### PR TITLE
feat(tsdb): route IP/keyword dimension ordinals to block size 2048

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatSelector;
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.MappedFieldType;
 import org.elasticsearch.index.codec.tsdb.pipeline.MetricRole;
 import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 import org.elasticsearch.index.codec.vectors.es93.ES93HnswVectorsFormat;
@@ -31,6 +32,8 @@ import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -237,12 +240,25 @@ public class PerFieldFormatSupplier {
         if (mapper instanceof NumberFieldMapper numberFieldMapper) {
             final PipelineDescriptor.DataType dataType = toPipelineDataType(numberFieldMapper.type());
             final MetricRole metricRole = toMetricRole(numberFieldMapper.fieldType().getMetricType());
-            return new FieldContext(blockSize, fieldName, dataType, metricRole);
+            return new FieldContext(blockSize, fieldName, dataType, metricRole, null, false);
         }
         if (mapper instanceof DateFieldMapper) {
-            return new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, null);
+            return new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, null, null, false);
         }
-        return new FieldContext(blockSize, fieldName, null, null);
+        if (mapper instanceof IpFieldMapper ipFieldMapper) {
+            return new FieldContext(blockSize, fieldName, null, null, MappedFieldType.IP, ipFieldMapper.fieldType().isDimension());
+        }
+        if (mapper instanceof KeywordFieldMapper keywordFieldMapper) {
+            return new FieldContext(
+                blockSize,
+                fieldName,
+                null,
+                null,
+                MappedFieldType.KEYWORD,
+                keywordFieldMapper.fieldType().isDimension()
+            );
+        }
+        return new FieldContext(blockSize, fieldName, null, null, null, false);
     }
 
     private static PipelineDescriptor.DataType toPipelineDataType(final NumberFieldMapper.NumberType type) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -2188,8 +2188,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     private BlockDecoder blockDecoder(NumericEntry entry, long maxOrd) {
         if (maxOrd != AbstractTSDBDocValuesConsumer.NO_MAX_ORD) {
             final int bitsPerOrd = PackedInts.bitsRequired(maxOrd - 1);
-            var ordinalFieldReader = ordinalCodec.createReader(readContext);
-            final OrdinalFieldReader.Decoder decoder = ordinalFieldReader.decoder();
+            final OrdinalFieldReader.Decoder decoder = ordinalCodec.createReader(readContext).decoder(entry.blockSize);
             return (input, values) -> decoder.decodeOrdinals(input, values, bitsPerOrd);
         } else {
             var numericFieldReader = numericCodec.createReader(readContext);
@@ -2999,8 +2998,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         public PipelineDescriptor pipelineDescriptor;
         // NOTE: per-field block size. Equals pipelineDescriptor.blockSize() when present
         // (ES95 pipeline-encoded entries); otherwise the format-level default read from
-        // the numeric block shift header byte, used by ES819 entries and ordinal-stream
-        // entries that have no pipeline descriptor.
+        // the numeric block shift header byte, used by ES819 entries and ordinal entries.
         public int blockSize;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/NumericFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/NumericFieldReader.java
@@ -38,6 +38,13 @@ public interface NumericFieldReader {
     /**
      * Returns the per-block decoder used to decode the field's value blocks.
      *
+     * <p>Numeric encoding is pipeline-based and varies per field: the {@link PipelineDescriptor}
+     * carries the full stage description (delta, gcd, bitpack, ALP, etc.) written to metadata at
+     * encode time, which is needed to reconstruct the exact decoder chain. Contrast with
+     * {@link OrdinalFieldReader#decoder(int)}, which takes only a block size because ordinal
+     * encoding is always packed bits with no variable pipeline.
+     *
+     * @param pipelineDescriptor the field's pipeline descriptor, read from segment metadata
      * @return the block decoder
      */
     Decoder decoder(PipelineDescriptor pipelineDescriptor);

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/OrdinalFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/OrdinalFieldReader.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.codec.tsdb;
 
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 import java.io.IOException;
 
@@ -19,7 +20,7 @@ import java.io.IOException;
  *
  * <p>{@link #readFieldEntry} runs once per field at segment-open time and parses the field metadata
  * (value counts, block index, offsets, DISI metadata) into a
- * {@link AbstractTSDBDocValuesProducer.NumericEntry}. {@link #decoder()} returns the per-block
+ * {@link AbstractTSDBDocValuesProducer.NumericEntry}. {@link #decoder(int)} returns the per-block
  * {@link Decoder} that the iteration code drives during ordinal access; the same decoder may
  * be used for many blocks of the same field.
  */
@@ -37,9 +38,15 @@ public interface OrdinalFieldReader {
     /**
      * Returns the per-block decoder used to decode the field's ordinal blocks.
      *
+     * <p>Ordinal encoding is always packed bits via {@link TSDBDocValuesEncoder}; only the block
+     * size varies per field, so {@code blockSize} is the only input needed to construct the
+     * decoder. Contrast with {@link NumericFieldReader#decoder(PipelineDescriptor)}, which
+     * requires the full pipeline description because numeric encoding varies per field.
+     *
+     * @param blockSize the block size the field was encoded with
      * @return the block decoder
      */
-    Decoder decoder();
+    Decoder decoder(int blockSize);
 
     /**
      * Decodes one block of ordinal values.

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBOrdinalFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBOrdinalFieldReader.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * sorted-set fields from the TSDB block layout.
  *
  * <p>{@link #readFieldEntry} delegates to the shared metadata parsing in
- * {@link TSDBDocValuesBlockReader}. {@link #decoder()} returns the {@link Decoder} supplied at
+ * {@link TSDBDocValuesBlockReader}. {@link #decoder(int)} returns the {@link Decoder} supplied at
  * construction time, which the iteration code drives during ordinal access.
  */
 public final class TSDBOrdinalFieldReader implements OrdinalFieldReader {
@@ -41,7 +41,7 @@ public final class TSDBOrdinalFieldReader implements OrdinalFieldReader {
     }
 
     @Override
-    public Decoder decoder() {
+    public Decoder decoder(final int blockSize) {
         return decoder;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95NumericFieldWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95NumericFieldWriter.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 final class ES95NumericFieldWriter implements NumericFieldWriter {
 
     private static final TSDBDocValuesBlockWriter BLOCK_WRITER = new TSDBDocValuesBlockWriter();
-    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null);
+    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null, null, false);
 
     private final NumericWriteContext ctx;
     private final PipelineConfigResolver resolver;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalCodec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es95;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.tsdb.NumericReadContext;
+import org.elasticsearch.index.codec.tsdb.NumericWriteContext;
+import org.elasticsearch.index.codec.tsdb.OrdinalBlockCodec;
+import org.elasticsearch.index.codec.tsdb.OrdinalFieldReader;
+import org.elasticsearch.index.codec.tsdb.OrdinalFieldWriter;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldContextResolver;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfigResolver;
+
+/**
+ * {@link OrdinalBlockCodec} for the ES95 TSDB format.
+ *
+ * <p>Creates {@link ES95OrdinalFieldWriter} and {@link ES95OrdinalFieldReader} instances
+ * that carry a per-field {@code blockShift} byte in segment metadata. This lets the
+ * decoder always use the exact block size the field was encoded with, independent of
+ * the format-level default.
+ */
+final class ES95OrdinalCodec implements OrdinalBlockCodec {
+
+    private final PipelineConfigResolver resolver;
+    @Nullable
+    private final FieldContextResolver fieldContextResolver;
+
+    ES95OrdinalCodec(final PipelineConfigResolver resolver, @Nullable final FieldContextResolver fieldContextResolver) {
+        this.resolver = resolver;
+        this.fieldContextResolver = fieldContextResolver;
+    }
+
+    @Override
+    public OrdinalFieldReader createReader(final NumericReadContext ctx) {
+        return new ES95OrdinalFieldReader();
+    }
+
+    @Override
+    public OrdinalFieldWriter createWriter(final NumericWriteContext ctx) {
+        return new ES95OrdinalFieldWriter(ctx, resolver, fieldContextResolver);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldReader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es95;
+
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.NumericEntry;
+import org.elasticsearch.index.codec.tsdb.OrdinalFieldReader;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesBlockReader;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
+
+import java.io.IOException;
+
+/**
+ * {@link OrdinalFieldReader} implementation for the ES95 TSDB format.
+ *
+ * <p>{@link #readFieldEntry} delegates to {@link TSDBDocValuesBlockReader} with a
+ * per-field metadata callback that reads the {@code blockShift} byte written by
+ * {@link ES95OrdinalFieldWriter} and sets {@link NumericEntry#blockSize} from it.
+ * {@link #decoder(int)} creates a {@link TSDBDocValuesEncoder} sized to that block size,
+ * so the decoder is always correctly sized for the field it was encoded with.
+ */
+final class ES95OrdinalFieldReader implements OrdinalFieldReader {
+
+    private static final TSDBDocValuesBlockReader BLOCK_READER = new TSDBDocValuesBlockReader();
+
+    @Override
+    public void readFieldEntry(final IndexInput meta, final NumericEntry entry, int numericBlockShift) throws IOException {
+        BLOCK_READER.readFieldEntry(meta, entry, numericBlockShift, m -> {
+            final int blockShift = m.readByte() & 0xFF;
+            entry.blockSize = 1 << blockShift;
+        });
+    }
+
+    @Override
+    public Decoder decoder(final int blockSize) {
+        final TSDBDocValuesEncoder encoder = new TSDBDocValuesEncoder(blockSize);
+        return encoder::decodeOrdinals;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 final class ES95OrdinalFieldWriter implements OrdinalFieldWriter {
 
     private static final TSDBDocValuesBlockWriter BLOCK_WRITER = new TSDBDocValuesBlockWriter();
-    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null);
+    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null, null, false);
 
     private final NumericWriteContext ctx;
     private final PipelineConfigResolver resolver;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es95;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesConsumer;
+import org.elasticsearch.index.codec.tsdb.DocValueFieldCountStats;
+import org.elasticsearch.index.codec.tsdb.NumericWriteContext;
+import org.elasticsearch.index.codec.tsdb.OrdinalFieldWriter;
+import org.elasticsearch.index.codec.tsdb.SortedFieldObserver;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesBlockWriter;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
+import org.elasticsearch.index.codec.tsdb.TsdbDocValuesProducer;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.FieldContextResolver;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfigResolver;
+
+import java.io.IOException;
+
+/**
+ * {@link OrdinalFieldWriter} implementation for the ES95 TSDB format.
+ *
+ * <p>{@link #writeFieldEntry} resolves the block size once per field via
+ * {@link PipelineConfigResolver}, then writes a per-field {@code blockShift} byte to
+ * metadata immediately after the block-layout marker. This lets {@link ES95OrdinalFieldReader}
+ * reconstruct the exact block size the field was encoded with, so the ordinal decoder
+ * is always sized correctly regardless of the format-level default.
+ */
+final class ES95OrdinalFieldWriter implements OrdinalFieldWriter {
+
+    private static final TSDBDocValuesBlockWriter BLOCK_WRITER = new TSDBDocValuesBlockWriter();
+    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null);
+
+    private final NumericWriteContext ctx;
+    private final PipelineConfigResolver resolver;
+    private final FieldContextResolver fieldContextResolver;
+
+    ES95OrdinalFieldWriter(
+        final NumericWriteContext ctx,
+        final PipelineConfigResolver resolver,
+        @Nullable final FieldContextResolver fieldContextResolver
+    ) {
+        this.ctx = ctx;
+        this.resolver = resolver;
+        this.fieldContextResolver = fieldContextResolver != null ? fieldContextResolver : NO_INFO_RESOLVER;
+    }
+
+    @Override
+    public Encoder encoder() {
+        final TSDBDocValuesEncoder enc = new TSDBDocValuesEncoder(ctx.blockSize());
+        return enc::encodeOrdinals;
+    }
+
+    @Override
+    public DocValueFieldCountStats writeFieldEntry(
+        final FieldInfo field,
+        final TsdbDocValuesProducer valuesSource,
+        long maxOrd,
+        final AbstractTSDBDocValuesConsumer.DocValueCountConsumer docValueCountConsumer,
+        final SortedFieldObserver sortedFieldObserver
+    ) throws IOException {
+        final FieldContext context = fieldContextResolver.resolve(field.name, ctx.blockSize());
+        final int blockSize = resolver.resolve(context).blockSize();
+        final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+        final int bitsPerOrd = PackedInts.bitsRequired(Math.max(maxOrd - 1, 0));
+        final TSDBDocValuesEncoder encoder = new TSDBDocValuesEncoder(blockSize);
+        return BLOCK_WRITER.writeFieldEntry(
+            ctx,
+            field,
+            valuesSource,
+            maxOrd,
+            docValueCountConsumer,
+            sortedFieldObserver,
+            (buffer, data) -> encoder.encodeOrdinals(buffer, data, bitsPerOrd),
+            () -> ctx.meta().writeByte((byte) blockShift),
+            blockSize
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormat.java
@@ -25,7 +25,6 @@ import org.elasticsearch.index.codec.tsdb.SortedFieldObserver;
 import org.elasticsearch.index.codec.tsdb.SortedFieldObserverFactory;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.TermsDictConfig;
-import org.elasticsearch.index.codec.tsdb.TSDBOrdinalBlockCodec;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContextResolver;
 import org.elasticsearch.index.codec.tsdb.pipeline.PipelineConfigResolver;
 import org.elasticsearch.index.codec.tsdb.pipeline.StaticPipelineConfigResolver;
@@ -35,9 +34,9 @@ import java.io.IOException;
 
 /**
  * ES95 TSDB doc values format. Uses pipeline-based encoding for numeric fields via
- * {@link ES95NumericCodec} and reuses {@link TSDBOrdinalBlockCodec} for ordinals.
- * Non-numeric field types are handled identically to ES819 by the shared abstract
- * base classes. Each numeric field writes a self-describing
+ * {@link ES95NumericCodec} and per-field block size encoding for ordinals via
+ * {@link ES95OrdinalCodec}. Non-numeric field types are handled identically to
+ * ES819 by the shared abstract base classes. Each numeric field writes a self-describing
  * {@link org.elasticsearch.index.codec.tsdb.pipeline.FieldDescriptor} so decoders
  * reconstruct themselves from segment metadata.
  */
@@ -74,7 +73,6 @@ public class ES95TSDBDocValuesFormat extends DocValuesFormat {
     static final int ORDINAL_RANGE_ENCODING_BLOCK_SHIFT = 12;
 
     static final PipelineConfigResolver PIPELINE_CONFIG_RESOLVER = StaticPipelineConfigResolver.INSTANCE;
-    static final OrdinalBlockCodec ORDINAL_CODEC = new TSDBOrdinalBlockCodec();
 
     static final TermsDictConfig TERMS_DICT_CONFIG = new TermsDictConfig(
         TERMS_DICT_BLOCK_LZ4_MASK,
@@ -127,7 +125,7 @@ public class ES95TSDBDocValuesFormat extends DocValuesFormat {
         @Nullable final FieldContextResolver fieldContextResolver
     ) {
         super(CODEC_NAME);
-        assert numericBlockShift == NUMERIC_BLOCK_SHIFT || numericBlockShift == NUMERIC_LARGE_BLOCK_SHIFT : numericBlockShift;
+        assert numericBlockShift >= NUMERIC_BLOCK_SHIFT : numericBlockShift;
         if (skipIndexIntervalSize < 2) {
             throw new IllegalArgumentException("skipIndexIntervalSize must be > 1, got [" + skipIndexIntervalSize + "]");
         }
@@ -163,6 +161,7 @@ public class ES95TSDBDocValuesFormat extends DocValuesFormat {
             numericCodecFactory,
             fallbackDecoderFactory
         );
+        final OrdinalBlockCodec ordinalBlockCodec = new ES95OrdinalCodec(PIPELINE_CONFIG_RESOLVER, fieldContextResolver);
         return new ES95TSDBDocValuesConsumer(
             state,
             enableOptimizedMerge,
@@ -180,7 +179,7 @@ public class ES95TSDBDocValuesFormat extends DocValuesFormat {
                     : SortedFieldObserver.NOOP
                 : SortedFieldObserverFactory.NOOP,
             numericBlockCodec,
-            ORDINAL_CODEC
+            ordinalBlockCodec
         );
     }
 
@@ -192,6 +191,7 @@ public class ES95TSDBDocValuesFormat extends DocValuesFormat {
             numericCodecFactory,
             fallbackDecoderFactory
         );
+        final OrdinalBlockCodec ordinalBlockCodec = new ES95OrdinalCodec(PIPELINE_CONFIG_RESOLVER, fieldContextResolver);
         return new ES95TSDBDocValuesProducer(
             state,
             DATA_CODEC,
@@ -203,7 +203,7 @@ public class ES95TSDBDocValuesFormat extends DocValuesFormat {
             formatConfig,
             DocOffsetsCodec.BITPACKING.getDecoder(),
             numericBlockCodec,
-            ORDINAL_CODEC
+            ordinalBlockCodec
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/FieldContext.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/FieldContext.java
@@ -15,20 +15,28 @@ import org.elasticsearch.core.Nullable;
  * Context about the field being encoded, passed to the {@link PipelineConfigResolver}
  * for pipeline selection.
  *
- * @param blockSize   the number of values per numeric block
- * @param fieldName   the name of the field being encoded
- * @param dataType    the underlying doc-values storage type of the field, or
- *                    {@code null} when unknown (e.g. construction sites without
- *                    mapper access). All integer-domain numeric mapper types
- *                    (long, integer, short, byte) collapse to
- *                    {@link PipelineDescriptor.DataType#LONG} because doc values
- *                    back-store them as long.
- * @param metricRole  the {@link MetricRole} of the field, or {@code null} when the
- *                    field is not a time-series metric
+ * @param blockSize       the number of values per numeric block
+ * @param fieldName       the name of the field being encoded
+ * @param dataType        the underlying doc-values storage type of the field, or
+ *                        {@code null} when unknown (e.g. construction sites without
+ *                        mapper access). All integer-domain numeric mapper types
+ *                        (long, integer, short, byte) collapse to
+ *                        {@link PipelineDescriptor.DataType#LONG} because doc values
+ *                        back-store them as long.
+ * @param metricRole      the {@link MetricRole} of the field, or {@code null} when the
+ *                        field is not a time-series metric
+ * @param mappedFieldType the codec-local mirror of the mapper field type, or {@code null}
+ *                        when unknown. Used by ordinal routing to upgrade IP and keyword
+ *                        dimension fields to a larger block size.
+ * @param isDimension     {@code true} if the field is a TSDB dimension; used together
+ *                        with {@link #mappedFieldType} to select a larger ordinal block
+ *                        size for IP and keyword dimension fields
  */
 public record FieldContext(
     int blockSize,
     String fieldName,
     @Nullable PipelineDescriptor.DataType dataType,
-    @Nullable MetricRole metricRole
+    @Nullable MetricRole metricRole,
+    @Nullable MappedFieldType mappedFieldType,
+    boolean isDimension
 ) {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/MappedFieldType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline;
+
+/**
+ * Codec-local mirror of the mapper-layer field type. The pipeline package needs to make
+ * routing decisions (e.g. block size selection) based on a field's logical type, but the
+ * codec layer does not import mapper classes directly. {@code PerFieldFormatSupplier}
+ * translates from the concrete mapper type to this enum when building a {@link FieldContext}.
+ */
+public enum MappedFieldType {
+    /** Maps to {@code NumberFieldMapper} types long, integer, short, and byte. */
+    LONG,
+    /** Maps to {@code NumberFieldMapper} type double. */
+    DOUBLE,
+    /** Maps to {@code NumberFieldMapper} types float and half_float. */
+    FLOAT,
+    /** Maps to {@code DateFieldMapper}. */
+    DATE,
+    /** Maps to {@code IpFieldMapper}. */
+    IP,
+    /** Maps to {@code KeywordFieldMapper}. */
+    KEYWORD
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
@@ -34,10 +34,18 @@ package org.elasticsearch.index.codec.tsdb.pipeline;
  *       longs and produces the same compaction. {@code kMax} is sized from
  *       {@code blockSize} as {@code clamp(blockSize / 32, 4, 64)} so large blocks with
  *       many resets do not bow out under the default cap.</li>
+ *   <li>IP and keyword TSDB dimension fields ({@link MappedFieldType#IP} and
+ *       {@link MappedFieldType#KEYWORD} with {@link FieldContext#isDimension()}) use a
+ *       block size of {@code 2048} ({@code blockShift=11}) regardless of the format-level
+ *       default. Only {@code blockSize()} of the returned config is used for ordinal
+ *       fields; the pipeline stages are never executed. At {@code blockSize=2048},
+ *       {@code maxCycleLength=512}, covering low-cardinality dimension cycles that
+ *       arise after a {@code _tsid}-sorted merge.</li>
  *   <li>All other fields use the ES819 baseline {@code delta > offset > gcd > bitPack}.</li>
  * </ul>
  *
- * <p>The two production block sizes ({@code 128} and {@code 512}, see
+ * <p>The three known ordinal block sizes ({@code 128}, {@code 512}, and {@code 2048})
+ * and the two numeric production block sizes ({@code 128} and {@code 512}, see
  * {@code ES95TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT} and {@code NUMERIC_LARGE_BLOCK_SHIFT})
  * have their {@link PipelineConfig} precomputed at class load for the baseline, split-delta,
  * ALP-double-gauge, and ALP-double-counter variants, so the per-field write path reuses a
@@ -55,6 +63,7 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
 
     private static final PipelineConfig BLOCK_128 = build(128);
     private static final PipelineConfig BLOCK_512 = build(512);
+    private static final PipelineConfig BLOCK_2048 = build(2048);
     private static final PipelineConfig SPLIT_DELTA_BLOCK_128 = buildSplitDelta(128);
     private static final PipelineConfig SPLIT_DELTA_BLOCK_512 = buildSplitDelta(512);
     private static final PipelineConfig ALP_DOUBLE_GAUGE_BLOCK_128 = buildAlpDoubleGauge(128);
@@ -75,7 +84,17 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
         if (useAlpDoubleGauge(context)) {
             return alpDoubleGaugeConfig(context.blockSize());
         }
+        if (useOrdinalLargeBlock(context)) {
+            return BLOCK_2048;
+        }
         return baselineConfig(context.blockSize());
+    }
+
+    private static boolean useOrdinalLargeBlock(final FieldContext context) {
+        if (context.isDimension() == false) {
+            return false;
+        }
+        return context.mappedFieldType() == MappedFieldType.IP || context.mappedFieldType() == MappedFieldType.KEYWORD;
     }
 
     private static boolean useSplitDelta(final FieldContext context) {
@@ -129,6 +148,9 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
         }
         if (blockSize == 512) {
             return BLOCK_512;
+        }
+        if (blockSize == 2048) {
+            return BLOCK_2048;
         }
         return build(blockSize);
     }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
@@ -14,16 +14,21 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.codec.Elasticsearch93Lucene104Codec;
 import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesFormatTests;
 import org.elasticsearch.index.codec.tsdb.BinaryDVCompressionMode;
@@ -37,6 +42,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import static org.elasticsearch.index.codec.tsdb.es95.ES95TSDBDocValuesFormat.DEFAULT_SKIP_INDEX_INTERVAL_SIZE;
 import static org.elasticsearch.index.codec.tsdb.es95.ES95TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT;
@@ -350,6 +356,271 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
         }
     }
 
+    public void testSortedBlockSizeRoundTrip() throws IOException {
+        // blockSize*2 docs guarantees at least one full block at every block size.
+        for (int blockSize : BLOCK_SIZE_SWEEP) {
+            final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+            final int numDocs = blockSize * 2;
+            final String[] docTerms = new String[numDocs];
+            for (int i = 0; i < numDocs; i++) {
+                docTerms[i] = String.format(Locale.ROOT, "term-%05d", i);
+            }
+            try (Directory dir = newDirectory()) {
+                try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildOrdinalFormat(blockShift)))) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document doc = new Document();
+                        doc.add(new SortedDocValuesField(ORDINAL_FIELD, new BytesRef(docTerms[i])));
+                        writer.addDocument(doc);
+                    }
+                }
+                try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                    for (LeafReaderContext leaf : reader.leaves()) {
+                        assertSortedSequence(leaf, ORDINAL_FIELD, d -> docTerms[d]);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testSortedBlockSizePartialTrailingBlock() throws IOException {
+        // 100 docs leaves a partial trailing block at every block size in the sweep.
+        final int numDocs = 100;
+        final String[] terms = new String[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            terms[i] = String.format(Locale.ROOT, "term-%03d", i);
+        }
+        for (int blockSize : BLOCK_SIZE_SWEEP) {
+            final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+            try (Directory dir = newDirectory()) {
+                try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildOrdinalFormat(blockShift)))) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document doc = new Document();
+                        doc.add(new SortedDocValuesField(ORDINAL_FIELD, new BytesRef(terms[i])));
+                        writer.addDocument(doc);
+                    }
+                }
+                try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                    for (LeafReaderContext leaf : reader.leaves()) {
+                        assertSortedSequence(leaf, ORDINAL_FIELD, d -> terms[d]);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testSortedSetBlockSizeSweep() throws IOException {
+        // blockSize*2 docs guarantees at least one full block at every block size.
+        final int termsPerDoc = 3;
+        for (int blockSize : BLOCK_SIZE_SWEEP) {
+            final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+            final int numDocs = blockSize * 2;
+            final String[][] terms = new String[numDocs][termsPerDoc];
+            for (int i = 0; i < numDocs; i++) {
+                for (int j = 0; j < termsPerDoc; j++) {
+                    terms[i][j] = String.format(Locale.ROOT, "term-%05d-%d", i, j);
+                }
+            }
+            try (Directory dir = newDirectory()) {
+                try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildOrdinalFormat(blockShift)))) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document doc = new Document();
+                        for (int j = 0; j < termsPerDoc; j++) {
+                            doc.add(new SortedSetDocValuesField(ORDINAL_FIELD, new BytesRef(terms[i][j])));
+                        }
+                        writer.addDocument(doc);
+                    }
+                }
+                try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                    for (LeafReaderContext leaf : reader.leaves()) {
+                        assertSortedSetSequence(leaf, ORDINAL_FIELD, termsPerDoc, (d, j) -> terms[d][j]);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testSortedSetBlockSizePartialTrailingBlock() throws IOException {
+        // 100 docs leaves a partial trailing block for sorted-set at every block size in the sweep.
+        final int numDocs = 100;
+        final int termsPerDoc = 3;
+        final String[][] terms = new String[numDocs][termsPerDoc];
+        for (int i = 0; i < numDocs; i++) {
+            for (int j = 0; j < termsPerDoc; j++) {
+                terms[i][j] = String.format(Locale.ROOT, "term-%03d-%d", i, j);
+            }
+        }
+        for (int blockSize : BLOCK_SIZE_SWEEP) {
+            final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+            try (Directory dir = newDirectory()) {
+                try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildOrdinalFormat(blockShift)))) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document doc = new Document();
+                        for (int j = 0; j < termsPerDoc; j++) {
+                            doc.add(new SortedSetDocValuesField(ORDINAL_FIELD, new BytesRef(terms[i][j])));
+                        }
+                        writer.addDocument(doc);
+                    }
+                }
+                try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                    for (LeafReaderContext leaf : reader.leaves()) {
+                        assertSortedSetSequence(leaf, ORDINAL_FIELD, termsPerDoc, (d, j) -> terms[d][j]);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testSortedSetBlockSizeVariableTermsPerDoc() throws IOException {
+        for (int blockSize : BLOCK_SIZE_SWEEP) {
+            final int blockShift = Integer.numberOfTrailingZeros(blockSize);
+            final int numDocs = blockSize * 2;
+            final String[][] terms = new String[numDocs][];
+            for (int i = 0; i < numDocs; i++) {
+                final int count = ESTestCase.randomIntBetween(1, 4);
+                terms[i] = new String[count];
+                for (int j = 0; j < count; j++) {
+                    terms[i][j] = String.format(Locale.ROOT, "term-%05d-%d", i, j);
+                }
+            }
+            try (Directory dir = newDirectory()) {
+                try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildOrdinalFormat(blockShift)))) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document doc = new Document();
+                        for (final String term : terms[i]) {
+                            doc.add(new SortedSetDocValuesField(ORDINAL_FIELD, new BytesRef(term)));
+                        }
+                        writer.addDocument(doc);
+                    }
+                }
+                try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                    for (final LeafReaderContext leaf : reader.leaves()) {
+                        final SortedSetDocValues ssdv = leaf.reader().getSortedSetDocValues(ORDINAL_FIELD);
+                        assertNotNull(ssdv);
+                        int docCount = 0;
+                        while (ssdv.nextDoc() != SortedSetDocValues.NO_MORE_DOCS) {
+                            final int globalDoc = leaf.docBase + docCount;
+                            assertEquals(terms[globalDoc].length, ssdv.docValueCount());
+                            for (int j = 0; j < terms[globalDoc].length; j++) {
+                                assertEquals(new BytesRef(terms[globalDoc][j]), BytesRef.deepCopyOf(ssdv.lookupOrd(ssdv.nextOrd())));
+                            }
+                            docCount++;
+                        }
+                        assertEquals(leaf.reader().maxDoc(), docCount);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testPerFieldSortedBlockSizeRoundTrip() throws IOException {
+        for (int customBlockSize : BLOCK_SIZE_SWEEP) {
+            doTestPerFieldOrdinalBlockSizeRoundTrip(NUMERIC_BLOCK_SHIFT, customBlockSize, 4096);
+        }
+    }
+
+    public void testPerFieldSortedBlockSizePartialTrailingBlock() throws IOException {
+        for (int customBlockSize : BLOCK_SIZE_SWEEP) {
+            doTestPerFieldOrdinalBlockSizeRoundTrip(NUMERIC_BLOCK_SHIFT, customBlockSize, 100);
+        }
+    }
+
+    public void testPerFieldSortedSetBlockSizeMultiValue() throws IOException {
+        final int numDocs = 2048;
+        final int termsPerDoc = 3;
+        for (int customBlockSize : BLOCK_SIZE_SWEEP) {
+            try (Directory dir = newDirectory()) {
+                try (
+                    IndexWriter writer = new IndexWriter(
+                        dir,
+                        writerConfig(buildPerFieldBlockSizeFormat(NUMERIC_BLOCK_SHIFT, customBlockSize))
+                    )
+                ) {
+                    for (int i = 0; i < numDocs; i++) {
+                        final Document doc = new Document();
+                        for (int j = 0; j < termsPerDoc; j++) {
+                            doc.add(
+                                new SortedSetDocValuesField(
+                                    CUSTOM_BS_SORTED_FIELD,
+                                    new BytesRef(String.format(Locale.ROOT, "term-%05d-%d", i, j))
+                                )
+                            );
+                            doc.add(
+                                new SortedSetDocValuesField(
+                                    DEFAULT_BS_SORTED_FIELD,
+                                    new BytesRef(String.format(Locale.ROOT, "term-%05d-%d", i, j))
+                                )
+                            );
+                        }
+                        writer.addDocument(doc);
+                    }
+                }
+                try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                    for (LeafReaderContext leaf : reader.leaves()) {
+                        assertSortedSetSequence(
+                            leaf,
+                            CUSTOM_BS_SORTED_FIELD,
+                            termsPerDoc,
+                            (i, j) -> String.format(Locale.ROOT, "term-%05d-%d", i, j)
+                        );
+                        assertSortedSetSequence(
+                            leaf,
+                            DEFAULT_BS_SORTED_FIELD,
+                            termsPerDoc,
+                            (i, j) -> String.format(Locale.ROOT, "term-%05d-%d", i, j)
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    public void testPerFieldSortedBlockSizeOverridesFormatHeader() throws IOException {
+        final int numDocs = 4096;
+        final int promotedBlockSize = 1024;
+        try (Directory dir = newDirectory()) {
+            try (
+                IndexWriter writer = new IndexWriter(
+                    dir,
+                    writerConfig(buildPerFieldBlockSizeFormat(NUMERIC_LARGE_BLOCK_SHIFT, promotedBlockSize))
+                )
+            ) {
+                for (int i = 0; i < numDocs; i++) {
+                    final Document doc = new Document();
+                    doc.add(new SortedDocValuesField(CUSTOM_BS_SORTED_FIELD, new BytesRef(String.format(Locale.ROOT, "term-%05d", i))));
+                    doc.add(new SortedDocValuesField(DEMOTED_BS_SORTED_FIELD, new BytesRef(String.format(Locale.ROOT, "term-%05d", i))));
+                    doc.add(new SortedDocValuesField(DEFAULT_BS_SORTED_FIELD, new BytesRef(String.format(Locale.ROOT, "term-%05d", i))));
+                    writer.addDocument(doc);
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                for (LeafReaderContext leaf : reader.leaves()) {
+                    assertSortedSequence(leaf, CUSTOM_BS_SORTED_FIELD, i -> String.format(Locale.ROOT, "term-%05d", i));
+                    assertSortedSequence(leaf, DEMOTED_BS_SORTED_FIELD, i -> String.format(Locale.ROOT, "term-%05d", i));
+                    assertSortedSequence(leaf, DEFAULT_BS_SORTED_FIELD, i -> String.format(Locale.ROOT, "term-%05d", i));
+                }
+            }
+        }
+    }
+
+    private void doTestPerFieldOrdinalBlockSizeRoundTrip(int formatShift, int customBlockSize, int numDocs) throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildPerFieldBlockSizeFormat(formatShift, customBlockSize)))) {
+                for (int i = 0; i < numDocs; i++) {
+                    final Document doc = new Document();
+                    doc.add(new SortedDocValuesField(CUSTOM_BS_SORTED_FIELD, new BytesRef(String.format(Locale.ROOT, "term-%05d", i))));
+                    doc.add(new SortedDocValuesField(DEFAULT_BS_SORTED_FIELD, new BytesRef(String.format(Locale.ROOT, "term-%05d", i))));
+                    writer.addDocument(doc);
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                for (LeafReaderContext leaf : reader.leaves()) {
+                    assertSortedSequence(leaf, CUSTOM_BS_SORTED_FIELD, i -> String.format(Locale.ROOT, "term-%05d", i));
+                    assertSortedSequence(leaf, DEFAULT_BS_SORTED_FIELD, i -> String.format(Locale.ROOT, "term-%05d", i));
+                }
+            }
+        }
+    }
+
     public void testPerFieldBlockSizeRoundTrip() throws IOException {
         for (int customBlockSize : BLOCK_SIZE_SWEEP) {
             doTestPerFieldBlockSizeRoundTrip(NUMERIC_BLOCK_SHIFT, customBlockSize, 4096);
@@ -457,6 +728,16 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
         long at(int globalDocIndex, int valueIndex);
     }
 
+    @FunctionalInterface
+    private interface ExpectedTermAtDoc {
+        String at(int globalDocIndex);
+    }
+
+    @FunctionalInterface
+    private interface ExpectedTerm {
+        String at(int globalDocIndex, int valueIndex);
+    }
+
     private static void assertNumericSequence(LeafReaderContext leaf, String field, ExpectedValue expected) throws IOException {
         final NumericDocValues ndv = leaf.reader().getNumericDocValues(field);
         assertNotNull("missing doc values for " + field, ndv);
@@ -494,12 +775,61 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
         assertEquals(leaf.reader().maxDoc(), docCount);
     }
 
+    private static void assertSortedSequence(LeafReaderContext leaf, String field, ExpectedTermAtDoc expected) throws IOException {
+        final SortedDocValues sdv = leaf.reader().getSortedDocValues(field);
+        assertNotNull("missing sorted doc values for " + field, sdv);
+        int count = 0;
+        while (sdv.nextDoc() != SortedDocValues.NO_MORE_DOCS) {
+            final BytesRef actual = BytesRef.deepCopyOf(sdv.lookupOrd(sdv.ordValue()));
+            assertEquals("field " + field + " doc " + (leaf.docBase + count), new BytesRef(expected.at(leaf.docBase + count)), actual);
+            count++;
+        }
+        assertEquals(leaf.reader().maxDoc(), count);
+    }
+
+    private static void assertSortedSetSequence(LeafReaderContext leaf, String field, int termsPerDoc, ExpectedTerm expected)
+        throws IOException {
+        // Terms within each doc are stored and returned in lexicographic order.
+        // Test terms are formatted so that j=0..termsPerDoc-1 are already in sorted order.
+        final SortedSetDocValues ssdv = leaf.reader().getSortedSetDocValues(field);
+        assertNotNull("missing sorted-set doc values for " + field, ssdv);
+        int docCount = 0;
+        while (ssdv.nextDoc() != SortedSetDocValues.NO_MORE_DOCS) {
+            final int globalDoc = leaf.docBase + docCount;
+            assertEquals("doc value count for " + field + " doc " + globalDoc, termsPerDoc, ssdv.docValueCount());
+            for (int j = 0; j < termsPerDoc; j++) {
+                final long ord = ssdv.nextOrd();
+                final BytesRef actual = BytesRef.deepCopyOf(ssdv.lookupOrd(ord));
+                assertEquals("field " + field + " doc " + globalDoc + " term " + j, new BytesRef(expected.at(globalDoc, j)), actual);
+            }
+            docCount++;
+        }
+        assertEquals(leaf.reader().maxDoc(), docCount);
+    }
+
+    private static DocValuesFormat buildOrdinalFormat(int blockShift) {
+        return new ES95TSDBDocValuesFormat(
+            DEFAULT_SKIP_INDEX_INTERVAL_SIZE,
+            ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL,
+            true,
+            BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
+            true,
+            blockShift,
+            false,
+            ES95TSDBDocValuesFormat.BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT,
+            ES95TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT,
+            NumericCodecFactory.DEFAULT,
+            ES95NumericFieldReader::defaultFallbackDecoder,
+            null
+        );
+    }
+
     private static DocValuesFormat buildPerFieldBlockSizeFormat(int formatShift, int customBlockSize) {
         final FieldContextResolver perFieldResolver = (fieldName, defaultBlockSize) -> {
             final int blockSize;
-            if (CUSTOM_BS_FIELD.equals(fieldName)) {
+            if (CUSTOM_BS_FIELD.equals(fieldName) || CUSTOM_BS_SORTED_FIELD.equals(fieldName)) {
                 blockSize = customBlockSize;
-            } else if (DEMOTED_BS_FIELD.equals(fieldName)) {
+            } else if (DEMOTED_BS_FIELD.equals(fieldName) || DEMOTED_BS_SORTED_FIELD.equals(fieldName)) {
                 blockSize = 128;
             } else {
                 blockSize = defaultBlockSize;
@@ -526,6 +856,10 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
     private static final String CUSTOM_BS_FIELD = "custom_bs_field";
     private static final String DEFAULT_BS_FIELD = "default_bs_field";
     private static final String DEMOTED_BS_FIELD = "demoted_bs_field";
+    private static final String ORDINAL_FIELD = "keyword";
+    private static final String CUSTOM_BS_SORTED_FIELD = "custom_bs_sorted";
+    private static final String DEFAULT_BS_SORTED_FIELD = "default_bs_sorted";
+    private static final String DEMOTED_BS_SORTED_FIELD = "demoted_bs_sorted";
 
     private static IndexWriterConfig writerConfig(final DocValuesFormat format) {
         final IndexWriterConfig config = new IndexWriterConfig();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
@@ -834,7 +834,7 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
             } else {
                 blockSize = defaultBlockSize;
             }
-            return new FieldContext(blockSize, fieldName, null, null);
+            return new FieldContext(blockSize, fieldName, null, null, null, false);
         };
         return new ES95TSDBDocValuesFormat(
             DEFAULT_SKIP_INDEX_INTERVAL_SIZE,

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
@@ -17,7 +17,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
 
     public void testResolvesBaselinePipelineShapeForNonTimestampField() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null));
+        final PipelineConfig config = resolver.resolve(
+            new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null, null, false)
+        );
 
         assertEquals("delta>offset>gcd>bitPack", config.describeStages());
         assertEquals(PipelineDescriptor.DataType.LONG, config.dataType());
@@ -27,7 +29,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
 
     public void testResolvesTimestampPipelineShape() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), TIMESTAMP_FIELD_NAME, null, null, null, false));
 
         assertEquals("splitDelta>delta>offset>gcd>bitPack", config.describeStages());
         assertEquals(PipelineDescriptor.DataType.LONG, config.dataType());
@@ -39,7 +41,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomBlockSize();
 
-        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
+        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false));
 
         assertEquals(blockSize, config.blockSize());
     }
@@ -48,8 +50,8 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomBlockSize();
 
-        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
-        final PipelineConfig other = resolver.resolve(new FieldContext(blockSize, "metric.value", null, null));
+        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
+        final PipelineConfig other = resolver.resolve(new FieldContext(blockSize, "metric.value", null, null, null, false));
 
         assertNotEquals(timestamp, other);
         assertEquals("splitDelta>delta>offset>gcd>bitPack", timestamp.describeStages());
@@ -58,7 +60,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
 
     public void testRepeatedResolveReturnsEqualConfigs() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final FieldContext context = new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null);
+        final FieldContext context = new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null, null, false);
 
         assertEquals(resolver.resolve(context), resolver.resolve(context));
     }
@@ -67,8 +69,8 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
 
-        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
-        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
+        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false));
+        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false));
         assertSame(first, second);
     }
 
@@ -76,8 +78,8 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
 
-        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
-        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
+        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
         assertSame(first, second);
     }
 
@@ -85,11 +87,13 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = 1 << randomIntBetween(4, 6);
 
-        final PipelineConfig nonTimestamp = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
+        final PipelineConfig nonTimestamp = resolver.resolve(
+            new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false)
+        );
         assertEquals(blockSize, nonTimestamp.blockSize());
         assertEquals("delta>offset>gcd>bitPack", nonTimestamp.describeStages());
 
-        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
         assertEquals(blockSize, timestamp.blockSize());
         assertEquals("splitDelta>delta>offset>gcd>bitPack", timestamp.describeStages());
     }
@@ -100,7 +104,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.LONG,
-            MetricRole.COUNTER
+            MetricRole.COUNTER,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -115,7 +121,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.LONG,
-            MetricRole.GAUGE
+            MetricRole.GAUGE,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -129,7 +137,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.DOUBLE,
-            MetricRole.COUNTER
+            MetricRole.COUNTER,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -145,7 +155,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.DOUBLE,
-            MetricRole.GAUGE
+            MetricRole.GAUGE,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -162,7 +174,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.DOUBLE,
-            null
+            null,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -175,10 +189,10 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final int blockSize = randomFrom(128, 512);
 
         final PipelineConfig first = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
         final PipelineConfig second = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
         assertSame(first, second);
     }
@@ -189,12 +203,12 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final String fieldName = randomNonTimestampFieldName();
 
         final PipelineConfig alpDouble = resolver.resolve(
-            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
         final PipelineConfig baseline = resolver.resolve(
-            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, MetricRole.GAUGE)
+            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, MetricRole.GAUGE, null, false)
         );
-        final PipelineConfig splitDelta = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig splitDelta = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
 
         assertNotEquals(alpDouble, baseline);
         assertNotEquals(alpDouble, splitDelta);
@@ -208,7 +222,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final int blockSize = 1 << randomIntBetween(4, 6);
 
         final PipelineConfig config = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
 
         assertEquals(blockSize, config.blockSize());
@@ -221,7 +235,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.LONG,
-            null
+            null,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -234,11 +250,76 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final int blockSize = randomFrom(128, 512);
 
         final PipelineConfig counter = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.LONG, MetricRole.COUNTER)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.LONG, MetricRole.COUNTER, null, false)
         );
-        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
 
         assertSame(counter, timestamp);
+    }
+
+    public void testIpDimensionFieldUsesBlockSize2048() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final FieldContext context = new FieldContext(
+            randomFrom(128, 512),
+            randomNonTimestampFieldName(),
+            null,
+            null,
+            MappedFieldType.IP,
+            true
+        );
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(2048, config.blockSize());
+    }
+
+    public void testKeywordDimensionFieldUsesBlockSize2048() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final FieldContext context = new FieldContext(
+            randomFrom(128, 512),
+            randomNonTimestampFieldName(),
+            null,
+            null,
+            MappedFieldType.KEYWORD,
+            true
+        );
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(2048, config.blockSize());
+    }
+
+    public void testIpNonDimensionFieldUsesFormatDefaultBlockSize() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int blockSize = randomFrom(128, 512);
+        final FieldContext context = new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, MappedFieldType.IP, false);
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(blockSize, config.blockSize());
+    }
+
+    public void testKeywordNonDimensionFieldUsesFormatDefaultBlockSize() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int blockSize = randomFrom(128, 512);
+        final FieldContext context = new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, MappedFieldType.KEYWORD, false);
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(blockSize, config.blockSize());
+    }
+
+    public void testIpDimensionBlockSize2048IsCached() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int formatBlockSize = randomFrom(128, 512);
+
+        final PipelineConfig first = resolver.resolve(new FieldContext(formatBlockSize, "client.ip", null, null, MappedFieldType.IP, true));
+        final PipelineConfig second = resolver.resolve(
+            new FieldContext(formatBlockSize, "server.ip", null, null, MappedFieldType.IP, true)
+        );
+
+        assertSame(first, second);
+        assertEquals(2048, first.blockSize());
     }
 
     private static int randomBlockSize() {


### PR DESCRIPTION
> **NOTE:** This is one of three experimental PRs evaluating block sizes 1k, 2k, and 4k for IP and keyword TSDB dimension ordinals. The 1k variant is #152141 and the 4k variant is #152142. Results across all three will determine the block size that goes into the ES95 codec.

## TL;DR

Routes IP and keyword TSDB dimension fields to ordinal block size 2048 (`blockShift=11`). `FieldContext` gains `mappedFieldType` and `isDimension`; `PerFieldFormatSupplier` populates both from the mapper layer; `StaticPipelineConfigResolver` returns a precomputed `PipelineConfig` with `blockSize=2048` when the field is an IP or keyword dimension. Only `blockSize()` is consumed for ordinal fields: the ordinal encoding pipeline is not changed. Closes the IP/keyword dimension block size item from https://github.com/elastic/elasticsearch/issues/141118.

## Summary

`TSDBDocValuesEncoder.encodeOrdinals` detects repeating ordinal cycles with the threshold `maxCycleLength = blockSize / 4`. At the default `blockSize=128`, `maxCycleLength=32`, which covers only very short cycles. At `blockSize=2048`, `maxCycleLength=512`, covering the cardinality range of most real-world IP and keyword dimension fields after a `_tsid`-sorted merge. For example, a keyword dimension with 100 distinct values cycles with period 100: at `blockSize=128` the cycle detection fires only if `period <= 32`, so this field is not compressed; at `blockSize=2048` it fires at `period <= 512`, so the full block collapses to one cycle header plus 100 VLong values.

The infrastructure for per-field ordinal block sizes shipped in the previous commit on this branch (`e780b0dee294`), which added `ES95OrdinalFieldWriter`, wrote a per-field `blockShift` byte into `.dvm`, and updated `ES95OrdinalFieldReader` to read it back. `StaticPipelineConfigResolver` was left unchanged in that commit so on-disk bytes were identical to before. This PR completes the routing.

`FieldContext` gains two fields: `@Nullable MappedFieldType mappedFieldType` (already defined as a codec-local enum in the pipeline package) and `boolean isDimension`. The `isDimension` flag is necessary because keyword fields can appear as both dimensions and non-dimensions in a TSDB index, and only the dimension path benefits from the larger block size. `PerFieldFormatSupplier.resolveFieldContext` handles `IpFieldMapper` and `KeywordFieldMapper` by forwarding `fieldType().isDimension()`, keeping the mapper dependency confined to the codec bridge and out of the pipeline package.

`StaticPipelineConfigResolver` precomputes `BLOCK_2048` at class load alongside `BLOCK_128` and `BLOCK_512`, so the ordinal write path never allocates. `baselineConfig()` also caches `blockSize=2048` so a direct call with that size does not fall through to `build()`.

## Changes

- `FieldContext.java`: adds `@Nullable MappedFieldType mappedFieldType` and `boolean isDimension`; Javadoc updated to document both parameters.
- `StaticPipelineConfigResolver.java`: adds `BLOCK_2048` precomputed config, `useOrdinalLargeBlock()` predicate, and a routing branch in `resolve()` before the baseline fallback. `baselineConfig()` now caches `blockSize=2048`.
- `PerFieldFormatSupplier.java`: extends `resolveFieldContext()` to recognize `IpFieldMapper` and `KeywordFieldMapper`, populating `mappedFieldType` and `isDimension`.
- `ES95OrdinalFieldWriter.java`, `ES95NumericFieldWriter.java`: update `NO_INFO_RESOLVER` to pass `null, false` for the two new `FieldContext` parameters.
- `StaticPipelineConfigResolverTests.java`: updates all existing `FieldContext` construction sites to 6 args; adds `testIpDimensionFieldUsesBlockSize2048`, `testKeywordDimensionFieldUsesBlockSize2048`, `testIpNonDimensionFieldUsesFormatDefaultBlockSize`, `testKeywordNonDimensionFieldUsesFormatDefaultBlockSize`, and `testIpDimensionBlockSize2048IsCached`.
- `ES95TSDBDocValuesFormatTests.java`: updates one `FieldContext` construction site to 6 args.

## Testing

```
./gradlew :server:test --tests "*StaticPipelineConfigResolverTests"
./gradlew :server:test --tests "*ES95TSDBDocValuesFormatTests*"
./gradlew :server:test --tests "*pipeline.numeric.stages*"
```