### PR TITLE
Use bulk scoring for knn vector rescoring

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.queries.function.FunctionScoreQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.ConjunctionUtils;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnByteVectorQuery;
@@ -201,6 +202,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
 
     private static class DirectRescoreKnnVectorQuery extends Query {
         private static final int PREFETCH_BUFFER_SIZE = 100;
+        private static final int BULK_SCORE_SIZE = 32;
 
         private final float[] floatTarget;
         private final String fieldName;
@@ -217,6 +219,94 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             return "DirectRescoreKnnVectorQuery[" + innerQuery + "]";
         }
 
+        /**
+         * A ring buffer that allows doc data to be prefetched, and then actually scored at a later point
+         * using a bulk scorer
+         */
+        private static class ScoringRing {
+            private final int[] docIds;
+            private final int[] docBases;
+            private final VectorScorer[] scorer;
+
+            /*
+             * Only one bulk scorer can be created for a VectorScorer at once,
+             * so we need to re-use any created bulk scorer in subsequent batches
+             * for the same scorer. Might as well store them here.
+             */
+            private VectorScorer previousScorer;
+            private VectorScorer.Bulk previousBulkScorer;
+
+            private int head;
+            private int size;
+
+            ScoringRing() {
+                this.docIds = new int[PREFETCH_BUFFER_SIZE];
+                this.docBases = new int[PREFETCH_BUFFER_SIZE];
+                this.scorer = new VectorScorer[PREFETCH_BUFFER_SIZE];
+            }
+
+            static int ringIdx(int head, int idx) {
+                return (head + idx) % PREFETCH_BUFFER_SIZE;
+            }
+
+            void advance(int count) {
+                head = ringIdx(head, count);
+                size -= count;
+            }
+
+            void append(int doc, int docBase, VectorScorer vecScorer) {
+                int idx = ringIdx(head, size);
+                docIds[idx] = doc;
+                docBases[idx] = docBase;
+                scorer[idx] = vecScorer;
+                size++;
+            }
+        }
+
+        /**
+         * A lazy docID iterator over {@link ScoringRing} for a specific scorer
+         */
+        static class RingIterator extends DocIdSetIterator {
+
+            private final ScoringRing ring;
+            private final VectorScorer scorer;
+            private final int startIdx;
+            private int idx = 0;    // just start on startIdx without needing an initial advance
+
+            RingIterator(ScoringRing ring, VectorScorer scorer, int startIdx) {
+                this.ring = ring;
+                this.scorer = scorer;
+                this.startIdx = startIdx;
+            }
+
+            @Override
+            public int docID() {
+                if (idx == NO_MORE_DOCS) {
+                    return idx;
+                }
+                return ring.docIds[ScoringRing.ringIdx(startIdx, idx)];
+            }
+
+            @Override
+            public int nextDoc() {
+                idx++;
+                if (ring.scorer[ScoringRing.ringIdx(startIdx, idx)] != scorer) {
+                    idx = NO_MORE_DOCS;
+                }
+                return docID();
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                return slowAdvance(target);
+            }
+
+            @Override
+            public long cost() {
+                return BULK_SCORE_SIZE;
+            }
+        }
+
         @Override
         public Query rewrite(IndexSearcher indexSearcher) throws IOException {
             Query innerRewritten = innerQuery.rewrite(indexSearcher);
@@ -225,12 +315,10 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             }
             assert innerRewritten.getClass() != MatchAllDocsQuery.class;
 
+            DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
             List<ScoreDoc> results = new ArrayList<>(10);
-            int[] ringDocIDs = new int[PREFETCH_BUFFER_SIZE];
-            int[] ringDocBases = new int[PREFETCH_BUFFER_SIZE];
-            VectorScorer[] ringScorers = new VectorScorer[PREFETCH_BUFFER_SIZE];
-            int ringHead = 0;
-            int ringCount = 0;
+
+            ScoringRing ring = new ScoringRing();
 
             for (var leaf : indexSearcher.getIndexReader().leaves()) {
                 var knnVectorValues = leaf.reader().getFloatVectorValues(fieldName);
@@ -253,7 +341,8 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                 final IndexInput input = getIndexSliceOrNull(knnVectorValues);
                 KnnVectorValues.DocIndexIterator vectorIter = knnVectorValues.iterator();
                 DocIdSetIterator conjunction = ConjunctionUtils.intersectIterators(List.of(vectorIter, filterIterator));
-                VectorScorer vecScorer = knnVectorValues.rescorer(floatTarget);
+                VectorScorer rescorer = knnVectorValues.rescorer(floatTarget);
+
                 int doc;
                 while ((doc = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                     assert doc == vectorIter.docID();
@@ -263,40 +352,71 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                         input.prefetch((long) ord * vectorByteSize, vectorByteSize);
                     }
 
-                    if (ringCount == PREFETCH_BUFFER_SIZE) {
-                        scoreEntry(ringDocIDs[ringHead], ringDocBases[ringHead], ringScorers[ringHead], results);
-                        ringHead = (ringHead + 1) % PREFETCH_BUFFER_SIZE;
-                        ringCount--;
+                    if (ring.size == PREFETCH_BUFFER_SIZE) {
+                        int scored = scoreEntries(ring, buffer, results);
+                        ring.advance(scored);
                     }
 
-                    int ringTail = (ringHead + ringCount) % PREFETCH_BUFFER_SIZE;
-                    ringDocIDs[ringTail] = doc;
-                    ringDocBases[ringTail] = leaf.docBase;
-                    ringScorers[ringTail] = vecScorer;
-                    ringCount++;
+                    ring.append(doc, leaf.docBase, rescorer);
                 }
             }
 
-            for (int i = 0; i < ringCount; i++) {
-                int idx = (ringHead + i) % PREFETCH_BUFFER_SIZE;
-                scoreEntry(ringDocIDs[idx], ringDocBases[idx], ringScorers[idx], results);
+            while (ring.size > 0) {
+                int scored = scoreEntries(ring, buffer, results);
+                ring.advance(scored);
             }
 
-            ScoreDoc[] arrayResults = results.toArray(new ScoreDoc[0]);
-            return new KnnScoreDocQuery(arrayResults, indexSearcher.getIndexReader());
+            return new KnnScoreDocQuery(results.toArray(ScoreDoc[]::new), indexSearcher.getIndexReader());
         }
 
         private static IndexInput getIndexSliceOrNull(KnnVectorValues vectorValues) {
             return vectorValues instanceof HasIndexSlice h ? h.getSlice() : null;
         }
 
-        private static void scoreEntry(int docID, int docBase, VectorScorer scorer, List<ScoreDoc> results) throws IOException {
-            int target = scorer.iterator().advance(docID);
-            assert target == docID;
-            float score = scorer.score();
-            if (Float.isNaN(score) == false) {
-                results.add(new ScoreDoc(docID + docBase, score));
+        private static int scoreEntries(
+            ScoringRing ring,
+            DocAndFloatFeatureBuffer buffer,
+            List<ScoreDoc> results
+        ) throws IOException {
+            int docBase = ring.docBases[ring.head];
+            VectorScorer scorer = ring.scorer[ring.head];
+
+            // create the bulk scorer from this scorer if it's not created already
+            VectorScorer.Bulk bulkScorer;
+            if (ring.previousScorer == scorer) {
+                // re-use the bulk scorer from the previous batch
+                bulkScorer = ring.previousBulkScorer;
+            } else {
+                // first use of this scorer - create a new bulk scorer
+                RingIterator iterator = new RingIterator(ring, scorer, ring.head);
+                scorer.iterator().advance(ring.docIds[ring.head]);
+                bulkScorer = scorer.bulk(iterator);
+
+                // and record it for any subsequent batches
+                ring.previousScorer = scorer;
+                ring.previousBulkScorer = bulkScorer;
             }
+
+            // find up to BULK_SCORE_SIZE docs for this scorer to score
+            int count = 0;
+            for (; count < BULK_SCORE_SIZE && count < ring.size; count++) {
+                int idx = ScoringRing.ringIdx(ring.head, count);
+                if (ring.scorer[idx] != scorer) break;    // scorer has changed - stop there
+            }
+            assert count > 0;
+
+            int maxDocId = ring.docIds[ScoringRing.ringIdx(ring.head, count - 1)] + 1; // upTo is EXCLUSIVE
+            bulkScorer.nextDocsAndScores(maxDocId, null, buffer);
+            assert buffer.size == count;
+
+            for (int d = 0; d < buffer.size; d++) {
+                if (!Float.isNaN(buffer.features[d])) {
+                    results.add(new ScoreDoc(buffer.docs[d] + docBase, buffer.features[d]));
+                }
+            }
+
+            // return the number of docs scored
+            return count;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -223,7 +223,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
          * A ring buffer that allows doc data to be prefetched, and then actually scored at a later point
          * using a bulk scorer
          */
-        private static class ScoringRing {
+        private static class PrefetchRing {
             private final int[] docIds;
             private final int[] docBases;
             private final VectorScorer[] scorer;
@@ -239,7 +239,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             private int head;
             private int size;
 
-            ScoringRing() {
+            PrefetchRing() {
                 this.docIds = new int[PREFETCH_BUFFER_SIZE];
                 this.docBases = new int[PREFETCH_BUFFER_SIZE];
                 this.scorer = new VectorScorer[PREFETCH_BUFFER_SIZE];
@@ -250,7 +250,18 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             }
 
             void advance(int count) {
-                head = ringIdx(head, count);
+                int newHead = ringIdx(head, count);
+
+                // clear the scorers so the RingIterator doesn't pick up stale entries
+                // if iteration over a single leaf loops all the way round
+                if (newHead > head) {
+                    Arrays.fill(scorer, head, newHead, null);
+                } else {
+                    Arrays.fill(scorer, head, PREFETCH_BUFFER_SIZE, null);
+                    Arrays.fill(scorer, 0, newHead, null);
+                }
+
+                head = newHead;
                 size -= count;
             }
 
@@ -264,16 +275,16 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
         }
 
         /**
-         * A lazy docID iterator over {@link ScoringRing} for a specific scorer
+         * A lazy docID iterator over {@link PrefetchRing} for a specific scorer
          */
         static class RingIterator extends DocIdSetIterator {
 
-            private final ScoringRing ring;
+            private final PrefetchRing ring;
             private final VectorScorer scorer;
             private final int startIdx;
             private int idx = 0;    // just start on startIdx without needing an initial advance
 
-            RingIterator(ScoringRing ring, VectorScorer scorer, int startIdx) {
+            RingIterator(PrefetchRing ring, VectorScorer scorer, int startIdx) {
                 this.ring = ring;
                 this.scorer = scorer;
                 this.startIdx = startIdx;
@@ -284,13 +295,13 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                 if (idx == NO_MORE_DOCS) {
                     return idx;
                 }
-                return ring.docIds[ScoringRing.ringIdx(startIdx, idx)];
+                return ring.docIds[PrefetchRing.ringIdx(startIdx, idx)];
             }
 
             @Override
             public int nextDoc() {
                 idx++;
-                if (ring.scorer[ScoringRing.ringIdx(startIdx, idx)] != scorer) {
+                if (ring.scorer[PrefetchRing.ringIdx(startIdx, idx)] != scorer) {
                     idx = NO_MORE_DOCS;
                 }
                 return docID();
@@ -318,7 +329,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
             List<ScoreDoc> results = new ArrayList<>(10);
 
-            ScoringRing ring = new ScoringRing();
+            PrefetchRing ring = new PrefetchRing();
 
             for (var leaf : indexSearcher.getIndexReader().leaves()) {
                 var knnVectorValues = leaf.reader().getFloatVectorValues(fieldName);
@@ -373,11 +384,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             return vectorValues instanceof HasIndexSlice h ? h.getSlice() : null;
         }
 
-        private static int scoreEntries(
-            ScoringRing ring,
-            DocAndFloatFeatureBuffer buffer,
-            List<ScoreDoc> results
-        ) throws IOException {
+        private static int scoreEntries(PrefetchRing ring, DocAndFloatFeatureBuffer buffer, List<ScoreDoc> results) throws IOException {
             int docBase = ring.docBases[ring.head];
             VectorScorer scorer = ring.scorer[ring.head];
 
@@ -400,12 +407,12 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             // find up to BULK_SCORE_SIZE docs for this scorer to score
             int count = 0;
             for (; count < BULK_SCORE_SIZE && count < ring.size; count++) {
-                int idx = ScoringRing.ringIdx(ring.head, count);
+                int idx = PrefetchRing.ringIdx(ring.head, count);
                 if (ring.scorer[idx] != scorer) break;    // scorer has changed - stop there
             }
             assert count > 0;
 
-            int maxDocId = ring.docIds[ScoringRing.ringIdx(ring.head, count - 1)] + 1; // upTo is EXCLUSIVE
+            int maxDocId = ring.docIds[PrefetchRing.ringIdx(ring.head, count - 1)] + 1; // upTo is EXCLUSIVE
             bulkScorer.nextDocsAndScores(maxDocId, null, buffer);
             assert buffer.size == count;
 


### PR DESCRIPTION
Have another go at #151875. Also encapsulate the references needed for the ring buffer into a single class.

Fixes https://github.com/elastic/elasticsearch/issues/134484

The issue with the first PR was that it was creating multiple bulk scorers from the same `VectorScorer`, which is a big no-no. This creates and keeps track of bulk scorers per vector scorer, so they can be re-used across bulk scoring batch calls