### PR TITLE
Small optimization for DocumentParser#getSourceKeepMode(...)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -244,7 +244,7 @@ public final class DocumentParser {
     }
 
     private static Mapper.SourceKeepMode getSourceKeepMode(DocumentParserContext context, Optional<Mapper.SourceKeepMode> mapperMode) {
-        return mapperMode.orElseGet(context::sourceKeepModeFromIndexSettings);
+        return mapperMode.isPresent() ? mapperMode.get() : context.sourceKeepModeFromIndexSettings();
     }
 
     private static void throwNotAtEnd(XContentParser.Token token) {


### PR DESCRIPTION
`DocumentParser.getSourceKeepMode` is called once per leaf field (and once per object) during
`DocumentMapper.parse`. Its current body allocates a capturing `Supplier` on every call via
`orElseGet(context::sourceKeepModeFromIndexSettings)`, including the common case where `mapperMode`
is already present and the supplier is never invoked.

This change replaces it with an explicit `isPresent()`/`get()` ternary:
