### PR TITLE
ESQL: dataset diffs left the indices lookup stale — rebuild it on apply

### DIFF
--- a/docs/changelog/152180.yaml
+++ b/docs/changelog/152180.yaml
@@ -1,0 +1,5 @@
+pr: 152180
+summary: Rebuild the indices lookup when a cluster-state diff changes only ES|QL datasets, so a newly created dataset resolves on every node
+area: ES|QL
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
@@ -2469,7 +2469,8 @@ public class ProjectMetadata implements Iterable<IndexMetadata>, Diffable<Projec
             builder.customs(customs.apply(part.customs));
             if (part.indices == updatedIndices
                 && builder.dataStreamMetadata() == part.custom(DataStreamMetadata.TYPE, DataStreamMetadata.EMPTY)
-                && builder.viewMetadata() == part.custom(ViewMetadata.TYPE, ViewMetadata.EMPTY)) {
+                && builder.viewMetadata() == part.custom(ViewMetadata.TYPE, ViewMetadata.EMPTY)
+                && builder.datasetMetadata() == part.custom(DatasetMetadata.TYPE, DatasetMetadata.EMPTY)) {
                 builder.previousIndicesLookup = part.indicesLookup;
             }
             return builder.build(true);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ProjectMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ProjectMetadataTests.java
@@ -80,6 +80,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -169,6 +170,46 @@ public class ProjectMetadataTests extends ESTestCase {
             Map<String, List<AliasMetadata>> aliases = project.findAllAliases(Strings.EMPTY_ARRAY);
             assertThat(aliases, anEmptyMap());
         }
+    }
+
+    /**
+     * Datasets are part of the indices lookup ({@code buildIndicesLookup}), so applying a published diff that changes
+     * only the dataset set must rebuild the lookup, exactly as index, data-stream, and view changes do (see
+     * {@link #testReuseIndicesLookup}). {@link ProjectMetadata.ProjectMetadataDiff#apply} previously reused the
+     * already-built, dataset-free lookup in that case, leaving the changed dataset missing from (or stale in) the lookup
+     * on the applying node until a later change rebuilt it. This guards that diff-apply path.
+     */
+    public void testDatasetChangeViaDiffRebuildsIndicesLookup() {
+        ProjectMetadata p0 = ProjectMetadata.builder(randomProjectIdOrDefault())
+            .put(
+                IndexMetadata.builder("index")
+                    .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+            )
+            .build();
+        // Prime the cached lookup so diff-apply has a non-null previous lookup it could (incorrectly) reuse.
+        assertThat(p0.getIndicesLookup(), hasKey("index"));
+        assertThat(p0.getIndicesLookup(), not(hasKey("ds")));
+
+        Dataset dataset = new Dataset("ds", new DataSourceReference("source"), "s3://bucket/key", null, Map.of());
+        ProjectMetadata withDataset = ProjectMetadata.builder(p0).datasets(Map.of("ds", dataset)).build();
+
+        // Applying the add-dataset diff mirrors cluster-state publication to another node.
+        ProjectMetadata appliedAdd = withDataset.diff(p0).apply(p0);
+        assertThat("dataset added via diff must appear in the rebuilt indices lookup", appliedAdd.getIndicesLookup(), hasKey("ds"));
+        assertThat(appliedAdd.getIndicesLookup().get("ds"), instanceOf(Dataset.class));
+        assertThat(appliedAdd.getIndicesLookup(), hasKey("index"));
+
+        // Symmetric removal: applying a remove-dataset diff must drop it from the lookup.
+        assertThat(appliedAdd.getIndicesLookup(), hasKey("ds")); // prime cache on the dataset-bearing state
+        ProjectMetadata appliedRemove = p0.diff(appliedAdd).apply(appliedAdd);
+        assertThat(
+            "dataset removed via diff must disappear from the rebuilt indices lookup",
+            appliedRemove.getIndicesLookup(),
+            not(hasKey("ds"))
+        );
+        assertThat(appliedRemove.getIndicesLookup(), hasKey("index"));
     }
 
     public void testFindDataStreamAliases() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -57,9 +57,8 @@ import static org.hamcrest.Matchers.not;
  * them. Proves that the parser → dataset rewriter → external-source resolver → analyzer →
  * execution pipeline wires up the way the PR description claims.
  *
- * <p>Single-node by design: multi-node dataset publication trips an unrelated
- * {@code ProjectMetadata.Builder} assertion already on {@code main}; coverage of that path is out
- * of scope for this PR.
+ * <p>Single-node by design; this exercises the {@code FROM <dataset>} pipeline, not cluster-state propagation across
+ * nodes (covered by {@code ProjectMetadataTests#testDatasetChangeViaDiffRebuildsIndicesLookup}).
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 public class FromDatasetIT extends AbstractEsqlIntegTestCase {


### PR DESCRIPTION
### What this is about

Applying a cluster-state diff must leave every node with the same self-consistent `ProjectMetadata` — its derived index-resolution lookup included. `ProjectMetadataDiff.apply` reuses the cached lookup when "nothing relevant changed", but that check left out datasets — it covers indices, data streams, and views — even though datasets are part of the lookup (`buildIndicesLookup`). A `PUT`/`DELETE` dataset publishes exactly such a diff, so a node applies it and ends up with a lookup that disagrees with its own metadata: the dataset is in cluster state but missing from the lookup (a deleted one lingers) until a later change rebuilds it. `FROM <dataset>` resolves through that lookup, so it can't find the dataset there — on serverless, the search node running the query. With assertions enabled the inconsistency trips `assertConsistent`, so the diff won't apply at all. Single-node clusters never hit it: nothing is published to another node.

### What this PR does

We rebuild the indices lookup when the dataset set changes, the same way we already do for indices, data streams, and views — one extra term in the lookup-reuse condition in `ProjectMetadataDiff.apply`. States with no datasets are untouched (both sides are the `DatasetMetadata.EMPTY` singleton). No wire-format change, so no transport version.

### Does it work?

`ProjectMetadataTests#testDatasetChangeViaDiffRebuildsIndicesLookup` builds a state, materializes its lookup, then applies a dataset-only diff and asserts the dataset is in the rebuilt lookup — and the symmetric removal. It fails without the fix. It guards the diff-apply path the bug lives in, alongside the existing `testReuseIndicesLookup`.

### What's in the diff

- `ProjectMetadata` — the dataset term in the diff-apply lookup-reuse condition. This is the fix.
- `ProjectMetadataTests` — the regression test.
- `FromDatasetIT` — its comment no longer claims multi-node datasets trip an assertion on main (that *was* this bug); it points at the new test.
- A changelog entry.

### What's out of scope

Nothing — this is the one correctness fix.
