### PR TITLE
ESQL:DS: Enable local and HTTP provisioning

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -32,7 +32,9 @@ public enum FeatureFlag {
     PROMETHEUS_FEATURE_FLAG("es.prometheus_feature_flag_enabled=true", Version.fromString("9.4.0"), null),
     COLUMNAR_INDEX_MODE_FEATURE_FLAG("es.columnar_index_mode_feature_flag_enabled=true", Version.fromString("9.5.0"), null),
     ES95_CODEC_FEATURE_FLAG("es.es95_codec_feature_flag_enabled=true", Version.fromString("9.5.0"), null),
-    SLICE_INDEXING("es.slice_indexing_feature_flag_enabled=true", Version.fromString("9.5.0"), null);
+    SLICE_INDEXING("es.slice_indexing_feature_flag_enabled=true", Version.fromString("9.5.0"), null),
+    ESQL_EXTERNAL_DATASOURCES_LOCAL("es.esql_external_datasources_local_feature_flag_enabled=true", Version.fromString("9.5.0"), null),
+    ESQL_EXTERNAL_DATASOURCES_HTTP("es.esql_external_datasources_http_feature_flag_enabled=true", Version.fromString("9.5.0"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/esql-datasource-http/build.gradle
+++ b/x-pack/plugin/esql-datasource-http/build.gradle
@@ -32,6 +32,10 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(':libs:arrow')
   testImplementation project(xpackModule('esql:compute'))
+  // DataSourceSetting (loaded transitively when a validator stores settings) references EncryptedData
+  // from the encryption SPI. esql depends on it only as compileOnly, which is not transitive onto our
+  // test runtime classpath, so add it here to avoid a NoClassDefFoundError in validator unit tests.
+  testRuntimeOnly project(':x-pack:plugin:encryption:spi')
 }
 
 tasks.named("test").configure {

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePlugin.java
@@ -8,11 +8,15 @@
 package org.elasticsearch.xpack.esql.datasource.http;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasource.http.local.LocalStorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
+import org.elasticsearch.xpack.esql.datasources.spi.FileDataSourceValidator;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -33,8 +37,26 @@ import java.util.concurrent.ExecutorService;
  * <p>The executor for async HTTP I/O is injected via the
  * {@link DataSourcePlugin#storageProviders(Settings, ExecutorService)} SPI method,
  * backed by the ES GENERIC thread pool.
+ *
+ * <p>Provisioning these as {@code data_sources}/{@code datasets} (the CRUD path) is gated by two
+ * independent feature flags, {@link #ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG} and
+ * {@link #ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG}, which are enabled in snapshot/development
+ * builds and disabled in release builds. The storage providers below remain registered regardless,
+ * so the read path can resolve a provisioned dataset by its URI scheme without any extra wiring.
  */
 public class HttpDataSourcePlugin extends Plugin implements DataSourcePlugin {
+
+    /**
+     * Gates provisioning local-file ({@code file://}) data sources/datasets. Snapshot-on, release-off;
+     * override in release with {@code -Des.esql_external_datasources_local_feature_flag_enabled=true}.
+     */
+    public static final FeatureFlag ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG = new FeatureFlag("esql_external_datasources_local");
+
+    /**
+     * Gates provisioning HTTP/HTTPS ({@code http://}, {@code https://}) data sources/datasets. Snapshot-on,
+     * release-off; override in release with {@code -Des.esql_external_datasources_http_feature_flag_enabled=true}.
+     */
+    public static final FeatureFlag ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG = new FeatureFlag("esql_external_datasources_http");
 
     @Override
     public Set<String> supportedSchemes() {
@@ -43,13 +65,36 @@ public class HttpDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
     @Override
     public Map<String, StorageProviderFactory> storageProviders(Settings settings, ExecutorService executor) {
-        return Map.of(
-            "http",
-            StorageProviderFactory.noConfigKeys(() -> new HttpStorageProvider(HttpConfiguration.defaults(), executor)),
-            "https",
-            StorageProviderFactory.noConfigKeys(() -> new HttpStorageProvider(HttpConfiguration.defaults(), executor)),
-            "file",
-            StorageProviderFactory.noConfigKeys(LocalStorageProvider::new)
+        // http and https share one factory: the provider is scheme-agnostic and reads the scheme off each URI.
+        StorageProviderFactory httpFactory = StorageProviderFactory.noConfigKeys(
+            () -> new HttpStorageProvider(HttpConfiguration.defaults(), executor)
         );
+        return Map.of("http", httpFactory, "https", httpFactory, "file", StorageProviderFactory.noConfigKeys(LocalStorageProvider::new));
+    }
+
+    /**
+     * Registers CRUD validators for the unauthenticated {@code http} and {@code local} data source types,
+     * each only when its feature flag is enabled. Both reuse {@link FileDataSourceValidator}: it enforces
+     * the dataset resource scheme and (once {@code EsqlPlugin} attaches the format-config-key resolver)
+     * validates dataset-level format options, while {@link NoAuthDataSourceConfiguration} accepts only an
+     * explicit {@code auth=none} and rejects any other datasource-level setting since these sources carry
+     * no credentials or tunables.
+     *
+     * <p>The {@code http} type covers both {@code http://} and {@code https://}; the {@code local} type
+     * covers {@code file://}. When a flag is disabled the type is absent, so a PUT for it fails with the
+     * generic "unknown data source type" error from the CRUD layer.
+     */
+    @Override
+    public Map<String, DataSourceValidator> datasourceValidators(Settings settings) {
+        Map<String, DataSourceValidator> validators = new HashMap<>();
+        if (ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled()) {
+            DataSourceValidator http = new FileDataSourceValidator("http", NoAuthDataSourceConfiguration::fromMap, Set.of("http", "https"));
+            validators.put(http.type(), http);
+        }
+        if (ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled()) {
+            DataSourceValidator local = new FileDataSourceValidator("local", NoAuthDataSourceConfiguration::fromMap, Set.of("file"));
+            validators.put(local.type(), local);
+        }
+        return validators;
     }
 }

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/NoAuthDataSourceConfiguration.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/NoAuthDataSourceConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.http;
+
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfiguration;
+
+import java.util.Map;
+
+/**
+ * Minimal {@link DataSourceConfiguration} for unauthenticated sources (HTTP/HTTPS and local files).
+ *
+ * <p>It declares a single optional field, {@code auth}, whose only accepted value is {@code none} —
+ * letting a definition explicitly state "anonymous access" symmetrically with the file-based sources
+ * (S3/GCS/Azure), even though that is already the default. Every other datasource-level setting is
+ * rejected as an unknown field by the base-class constructor: these sources carry neither credentials
+ * nor tunable storage options today. The matching storage providers in {@link HttpDataSourcePlugin}
+ * are registered with {@code StorageProviderFactory.noConfigKeys(...)}, so there is nothing to thread
+ * from the stored datasource into the read path. Should authentication or per-source knobs (timeouts,
+ * headers) be added later, this is where their field definitions would live.
+ */
+public final class NoAuthDataSourceConfiguration extends DataSourceConfiguration {
+
+    private static final DataSourceConfigDefinition AUTH = DataSourceConfigDefinition.plaintext("auth").asCaseInsensitive();
+    private static final String AUTH_NONE = "none";
+    private static final Map<String, DataSourceConfigDefinition> FIELDS = DataSourceConfigDefinition.mapOf(AUTH);
+
+    private NoAuthDataSourceConfiguration(Map<String, Object> raw) {
+        super(raw, FIELDS);
+    }
+
+    @Override
+    protected void validate(ValidationException errors) {
+        String auth = get(AUTH.name());
+        if (auth != null && AUTH_NONE.equals(auth) == false) {
+            errors.addValidationError("Unsupported auth value [" + auth + "]; the only supported value is [none]");
+        }
+    }
+
+    /** Returns {@code null} for empty input so callers treat a settings-less datasource as "no configuration". */
+    public static NoAuthDataSourceConfiguration fromMap(Map<String, Object> raw) {
+        return raw == null || raw.isEmpty() ? null : new NoAuthDataSourceConfiguration(raw);
+    }
+}

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePluginTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.http;
+
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
+
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG;
+import static org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG;
+
+public class HttpDataSourcePluginTests extends ESTestCase {
+
+    private final HttpDataSourcePlugin plugin = new HttpDataSourcePlugin();
+
+    public void testHttpValidatorRegisteredWhenFlagEnabled() {
+        assumeTrue("requires http datasource feature flag", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
+        DataSourceValidator http = plugin.datasourceValidators(Settings.EMPTY).get("http");
+        assertNotNull("http validator should be registered when the flag is enabled", http);
+        assertEquals("http", http.type());
+    }
+
+    public void testLocalValidatorRegisteredWhenFlagEnabled() {
+        assumeTrue("requires local datasource feature flag", ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
+        DataSourceValidator local = plugin.datasourceValidators(Settings.EMPTY).get("local");
+        assertNotNull("local validator should be registered when the flag is enabled", local);
+        assertEquals("local", local.type());
+    }
+
+    public void testHttpValidatorAcceptsHttpAndHttpsSchemes() {
+        assumeTrue("requires http datasource feature flag", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
+        DataSourceValidator http = plugin.datasourceValidators(Settings.EMPTY).get("http");
+        // No dataset settings supplied, so the validated settings come back empty for both schemes.
+        assertTrue(http.validateDataset(Map.of(), "http://example.org/data.csv", Map.of()).isEmpty());
+        assertTrue(http.validateDataset(Map.of(), "https://example.org/data.csv", Map.of()).isEmpty());
+    }
+
+    public void testHttpValidatorRejectsNonHttpScheme() {
+        assumeTrue("requires http datasource feature flag", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
+        DataSourceValidator http = plugin.datasourceValidators(Settings.EMPTY).get("http");
+        expectThrows(ValidationException.class, () -> http.validateDataset(Map.of(), "file:///tmp/data.csv", Map.of()));
+        expectThrows(ValidationException.class, () -> http.validateDataset(Map.of(), "s3://bucket/data.csv", Map.of()));
+    }
+
+    public void testLocalValidatorAcceptsFileScheme() {
+        assumeTrue("requires local datasource feature flag", ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
+        DataSourceValidator local = plugin.datasourceValidators(Settings.EMPTY).get("local");
+        assertNotNull(local.validateDataset(Map.of(), "file:///tmp/data.csv", Map.of()));
+    }
+
+    public void testLocalValidatorRejectsNonFileScheme() {
+        assumeTrue("requires local datasource feature flag", ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
+        DataSourceValidator local = plugin.datasourceValidators(Settings.EMPTY).get("local");
+        expectThrows(ValidationException.class, () -> local.validateDataset(Map.of(), "http://example.org/data.csv", Map.of()));
+    }
+
+    public void testEmptyDatasourceSettingsAccepted() {
+        assumeTrue("requires http datasource feature flag", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
+        DataSourceValidator http = plugin.datasourceValidators(Settings.EMPTY).get("http");
+        assertTrue(http.validateDatasource(Map.of()).isEmpty());
+    }
+
+    public void testAuthNoneDatasourceSettingAccepted() {
+        assumeTrue("requires http datasource feature flag", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
+        DataSourceValidator http = plugin.datasourceValidators(Settings.EMPTY).get("http");
+        assertTrue(http.validateDatasource(Map.of("auth", "none")).containsKey("auth"));
+    }
+
+    public void testDatasourceSettingsRejected() {
+        assumeTrue("requires http datasource feature flag", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
+        DataSourceValidator http = plugin.datasourceValidators(Settings.EMPTY).get("http");
+        expectThrows(ValidationException.class, () -> http.validateDatasource(Map.of("region", "us-east-1")));
+    }
+}

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/NoAuthDataSourceConfigurationTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/NoAuthDataSourceConfigurationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.http;
+
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class NoAuthDataSourceConfigurationTests extends ESTestCase {
+
+    public void testNullReturnsNull() {
+        assertNull(NoAuthDataSourceConfiguration.fromMap(null));
+    }
+
+    public void testEmptyReturnsNull() {
+        assertNull(NoAuthDataSourceConfiguration.fromMap(Map.of()));
+    }
+
+    public void testAuthNoneAccepted() {
+        NoAuthDataSourceConfiguration config = NoAuthDataSourceConfiguration.fromMap(Map.of("auth", "none"));
+        assertNotNull(config);
+        assertEquals("none", config.get("auth"));
+    }
+
+    public void testAuthNoneIsCaseInsensitive() {
+        NoAuthDataSourceConfiguration config = NoAuthDataSourceConfiguration.fromMap(Map.of("auth", "NONE"));
+        assertNotNull(config);
+        assertEquals("none", config.get("auth"));
+    }
+
+    public void testUnsupportedAuthValueRejected() {
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> NoAuthDataSourceConfiguration.fromMap(Map.of("auth", "basic"))
+        );
+        assertThat(e.getMessage(), containsString("Unsupported auth value [basic]"));
+    }
+
+    public void testUnknownSettingIsRejected() {
+        // Only auth is declared, so any other datasource-level setting is an unknown field.
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> NoAuthDataSourceConfiguration.fromMap(Map.of("region", "us-east-1"))
+        );
+        assertThat(e.getMessage(), containsString("region"));
+    }
+
+    public void testMultipleUnknownSettingsAccumulateErrors() {
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("region", "us-east-1");
+        raw.put("access_key", "AKIA123");
+        ValidationException e = expectThrows(ValidationException.class, () -> NoAuthDataSourceConfiguration.fromMap(raw));
+        assertEquals(2, e.validationErrors().size());
+    }
+}


### PR DESCRIPTION
This allows defining datasources/sets for `file://` and `http(s)://`. These are behind individual feature flags.

The intention is to have them for dev/snapshot builds, not for release, allowing their (easy) use in testing. This'll help migrating away from `EXTERNAL .. WITH` to `FROM <dataset>`.
