### PR TITLE
Text block loader and null_value

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1399,7 +1399,13 @@ public final class TextFieldMapper extends FieldMapper {
                 };
             }
             BlockLoader fallbackLoader = nonDelegateBlockLoader(blContext);
-            if (syntheticSourceDelegate.isPresent() && syntheticSourceDelegate.get().ignoreAbove().valuesPotentiallyIgnored()) {
+            // Use the keyword delegate only when ignore_above may drop values but null_value is not configured.
+            // A null_value substitution stores a synthetic value for null inputs, which would be incorrectly
+            // returned by the prefer loader for documents where the parent field is absent — the _ignore field
+            // only tracks values dropped by ignore_above, not null-value substitutions.
+            if (syntheticSourceDelegate.isPresent()
+                && syntheticSourceDelegate.get().ignoreAbove().valuesPotentiallyIgnored()
+                && syntheticSourceDelegate.get().hasNullValue() == false) {
                 DelegatingBlockLoader preferLoader = new DelegatingBlockLoader(syntheticSourceDelegate.get().blockLoader(blContext)) {
                     @Override
                     public String delegatingTo() {


### PR DESCRIPTION
- When a `text` field has a keyword multi-field configured with both `ignore_above` **and** `null_value`, `ConditionalBlockLoaderWithIgnoreField` incorrectly used the keyword delegate for documents where the parent field was absent.
- The keyword's `null_value` substitution stores a synthetic value in doc values even for null inputs, but the `_ignore` field only tracks values dropped by `ignore_above` — not null-value substitutions. So `canUsePreferLoaderForDoc()` returned `true` for null-input docs, causing the loader to return the `null_value` string instead of `null`.
- Fix: add a `hasNullValue() == false` guard to the `ConditionalBlockLoaderWithIgnoreField` path. When the keyword sub-field has `null_value` configured, always use the text field's own binary doc values (fallback loader), which correctly return `null` for absent fields.

Closes #152124