### PR TITLE
Backport #152127 to 9.4: Extend isPatchFrom to use 1000-slot patch space

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -349,7 +349,8 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
      * Returns {@code true} if this version is a patch version at or after {@code version}.
      */
     public boolean isPatchFrom(TransportVersion version) {
-        return id >= version.id && id < version.id + 100 - (version.id % 100);
+        // Two versions share the same patch space if they have the same base (id / 1000).
+        return id >= version.id && id / 1000 == version.id / 1000;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -133,13 +133,8 @@ public class TransportVersionTests extends ESTestCase {
 
     public void testPatchVersionsStillAvailable() {
         for (TransportVersion tv : TransportVersion.getAllVersions()) {
-            if (tv.id() >= 8_84_10_00 && (tv.id() % 100) > 90) {
-                fail(
-                    "Transport version "
-                        + tv
-                        + " is nearing the limit of available patch numbers."
-                        + " Please inform the Core/Infra team that isPatchFrom may need to be modified"
-                );
+            if (tv.id() >= 8_84_10_00 && (tv.id() % 1000) >= 999) {
+                fail("Transport version " + tv + " has exhausted the available patch numbers for its base. A new base is needed.");
             }
         }
     }
@@ -296,6 +291,14 @@ public class TransportVersionTests extends ESTestCase {
         assertThat(new TransportVersion(null, 3004000, null).supports(test4), is(true));
         assertThat(new TransportVersion(null, 100001000, null).supports(test4), is(true));
         assertThat(new TransportVersion(null, 100001001, null).supports(test4), is(true));
+
+        // Patch ids spanning past the hundred boundary within the same base: 1001002 is the backport,
+        // so 1001099-1001999 are all still on the same base and must be recognized as patches.
+        assertThat(new TransportVersion(null, 1001099, null).supports(test4), is(true));
+        assertThat(new TransportVersion(null, 1001100, null).supports(test4), is(true));
+        assertThat(new TransportVersion(null, 1001999, null).supports(test4), is(true));
+        // A different base (1002xxx) must not be recognized as a patch of 1001xxx.
+        assertThat(new TransportVersion(null, 1002000, null).supports(test4), is(false));
     }
 
     public void testComment() {


### PR DESCRIPTION
Backport of #152127 to 9.4.

The old formula limited patch versions to the same 100-id block as the origin version. The Gradle build tooling already defines the patch component as id % 1000, so this aligns the runtime check with that scheme and gives stateful patch ids up to 999 slots per base instead of ~99.