### PR TITLE
Fix #152119 by using the runtime conversion in tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -704,9 +704,6 @@ tests:
 - class: org.elasticsearch.xpack.search.AsyncSearchActionIT
   method: testSearchPhaseFailureLeak
   issue: https://github.com/elastic/elasticsearch/issues/152117
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StIntersectionTests
-  method: testCrankyEvaluateBlockWithoutNulls {TestCase=geo_shape and geo_shape}
-  issue: https://github.com/elastic/elasticsearch/issues/152119
 - class: org.elasticsearch.index.engine.InternalEngineTests
   method: testLookupSeqNoByIdInLucene
   issue: https://github.com/elastic/elasticsearch/issues/152120

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialBinaryGeometryBlockProcessor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialBinaryGeometryBlockProcessor.java
@@ -129,7 +129,7 @@ class SpatialBinaryGeometryBlockProcessor {
      * For anything else (a true heterogeneous collection), pre-flatten to a supported type
      * using a self-union so the binary operation can proceed.
      */
-    private static Geometry flattenIfHeterogeneousCollection(Geometry geom) {
+    static Geometry flattenIfHeterogeneousCollection(Geometry geom) {
         if (geom instanceof MultiPoint || geom instanceof MultiLineString || geom instanceof MultiPolygon) {
             return geom;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/AbstractBinarySpatialGeometryFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/AbstractBinarySpatialGeometryFunctionTestCase.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.UNSPECIFIED;
+import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialBinaryGeometryBlockProcessor.flattenIfHeterogeneousCollection;
 
 /**
  * Base test case for spatial functions that take two geometry arguments and return a geometry
@@ -137,8 +138,8 @@ public abstract class AbstractBinarySpatialGeometryFunctionTestCase extends Abst
             return null;
         }
         try {
-            Geometry leftGeom = UNSPECIFIED.wkbToJtsGeometry(leftWkb);
-            Geometry rightGeom = UNSPECIFIED.wkbToJtsGeometry(rightWkb);
+            Geometry leftGeom = flattenIfHeterogeneousCollection(UNSPECIFIED.wkbToJtsGeometry(leftWkb));
+            Geometry rightGeom = flattenIfHeterogeneousCollection(UNSPECIFIED.wkbToJtsGeometry(rightWkb));
             Geometry result = jtsOp.apply(leftGeom, rightGeom);
             return UNSPECIFIED.jtsGeometryToWkb(result);
         } catch (Exception e) {


### PR DESCRIPTION
The core error was `GEOMETRYCOLLECTION EMPTY` was not equal to `LINESTRING EMPTY`.

Root cause: `StIntersectionTests.testCrankyEvaluateBlockWithoutNulls` for geo_shape and geo_shape failed because of a discrepancy in how the expected value and actual value were computed when a geo_shape input happened to be a GEOMETRYCOLLECTION(LINESTRING(...)).

- The evaluator (SpatialBinaryGeometryBlockProcessor.fromBytesRefBlock) called flattenIfHeterogeneousCollection to convert GEOMETRYCOLLECTION(LINESTRING) → LINESTRING before computing the intersection, resulting in LINESTRING EMPTY.
- The test's valueOf passed the raw GEOMETRYCOLLECTION directly to JTS, which returned GEOMETRYCOLLECTION EMPTY for a disjoint intersection.
- These mismatched WKB representations ([1 7 0...] vs [1 2 0...]) caused the assertion failure.

Fix:
1. Made flattenIfHeterogeneousCollection package-private in SpatialBinaryGeometryBlockProcessor (removed private)
2. Updated AbstractBinarySpatialGeometryFunctionTestCase.valueOf to apply the same flattenIfHeterogeneousCollection preprocessing before computing the expected result

This ensures the test's expected value is computed using the exact same input transformation as the actual evaluator, eliminating the discrepancy.

Fixes #152119
