### PR TITLE
Convert framework setUp/tearDown overrides to @Before/@After

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,10 +38,13 @@ public class InternalExtendedStatsTests extends InternalAggregationTestCase<Inte
 
     private double sigma;
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUpSigma() {
         this.sigma = randomDoubleBetween(0, 10, true);
+    }
+
+    public final void setUp() throws Exception {
+        super.setUp();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractColumnarArrayOrderFieldDataTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractColumnarArrayOrderFieldDataTestCase.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,10 +37,13 @@ public abstract class AbstractColumnarArrayOrderFieldDataTestCase extends Mapper
 
     protected abstract String fieldTypeName();
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void assumeColumnarFeatureEnabled() {
         assumeTrue("columnar index mode requires a snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+    }
+
+    public final void setUp() throws Exception {
+        super.setUp();
     }
 
     private MapperService columnarMapperService() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractColumnarArrayOrderSyntheticSourceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractColumnarArrayOrderSyntheticSourceTestCase.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
@@ -40,11 +41,14 @@ public abstract class AbstractColumnarArrayOrderSyntheticSourceTestCase extends 
      */
     protected abstract String fieldTypeName();
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void assumeColumnarFeatureEnabled() {
         assumeTrue("columnar index mode requires a snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
         assumeTrue("in-order binary doc values require the columnar feature flag", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+    }
+
+    public final void setUp() throws Exception {
+        super.setUp();
     }
 
     protected MapperService columnarMapperService() throws IOException {

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AbstractClientYamlTestFragmentParserTestCase.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AbstractClientYamlTestFragmentParserTestCase.java
@@ -22,10 +22,8 @@ import static org.hamcrest.Matchers.nullValue;
 public abstract class AbstractClientYamlTestFragmentParserTestCase extends ESTestCase {
     protected XContentParser parser;
 
-    @Override
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void verifyParserClosed() throws Exception {
         // test may be skipped so we did not create a parser instance
         if (parser != null) {
             // next token can be null even in the middle of the document (e.g. with "---"), but not too many consecutive times
@@ -34,6 +32,10 @@ public abstract class AbstractClientYamlTestFragmentParserTestCase extends ESTes
             assertThat(parser.nextToken(), nullValue());
             parser.close();
         }
+    }
+
+    public final void tearDown() throws Exception {
+        super.tearDown();
     }
 
     @Override


### PR DESCRIPTION
Part of the ongoing migration to replace setUp/tearDown overrides with
@Before/@After annotated methods in intermediate framework classes. Each
converted class retains a public final setUp()/tearDown() stub that
delegates to super, preventing future subclass overrides.
