### PR TITLE
[qVec] Implement #intoBitSet in non cached filters

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
@@ -1074,7 +1074,18 @@ public class KnnSearcher {
                     var bitSet = segmentDocs[context.ord];
                     var cardinality = cardinalities[context.ord];
                     final DocIdSetIterator bitSetIterator = new BitSetIterator(bitSet, cardinality);
-                    final DocIdSetIterator iterator = filterCached ? bitSetIterator : new FilterDocIdSetIterator(bitSetIterator);
+                    final DocIdSetIterator iterator = filterCached ? bitSetIterator : new FilterDocIdSetIterator(bitSetIterator) {
+
+                        @Override
+                        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                            bitSetIterator.intoBitSet(upTo, bitSet, offset);
+                        }
+
+                        @Override
+                        public int docIDRunEnd() throws IOException {
+                            return bitSetIterator.docIDRunEnd();
+                        }
+                    };
 
                     var scorer = new ConstantScoreScorer(score(), scoreMode, iterator);
                     return new ScorerSupplier() {


### PR DESCRIPTION
We are currently materializing the filters one document at a time which make the comparison unfair with the cached case. Lets implement the methods  #intoBitSet and @docIDRunEnd() so it  gives a better understanding on the benefits.