### PR TITLE
Unmute TransportVersionTests.testPatchVersionsStillAvailable

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -254,9 +254,7 @@ tests:
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testAverageWriteLoadMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/152064
-- class: org.elasticsearch.TransportVersionTests
-  method: testPatchVersionsStillAvailable
-  issue: https://github.com/elastic/elasticsearch/issues/152122
+
 
 # Examples:
 #


### PR DESCRIPTION
Fixed by #152192 (backport of #152127 to 9.4). The test was muted in #152122 while the `isPatchFrom` fix was pending.