### PR TITLE
Fix unmapped dense_vector conversion in ESQL

### DIFF
--- a/docs/changelog/152213.yaml
+++ b/docs/changelog/152213.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 152184
+pr: 152213
+summary: Fix partially unmapped dense_vector conversion in ES|QL
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2832,9 +2832,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         return convertExpression;
                     }
 
-                    Expression potentiallyUnmappedConversion = tcf.isPotentiallyUnmapped()
-                        ? ResolveUnionTypes.typeSpecificConvert(convert, fa.source(), KEYWORD, tcf)
-                        : null;
+                    Expression potentiallyUnmappedConversion = null;
+                    // Unmapped dense_vector values come from _source arrays, not the hex strings accepted by TO_DENSE_VECTOR.
+                    if (tcf.isPotentiallyUnmapped() && ((Expression) convert).dataType() != DENSE_VECTOR) {
+                        potentiallyUnmappedConversion = ResolveUnionTypes.typeSpecificConvert(convert, fa.source(), KEYWORD, tcf);
+                    }
                     EsField resolvedField = resolvedUnionTypeFields(fa, tcf, typeResolutions, potentiallyUnmappedConversion, context);
                     return createIfDoesNotAlreadyExist(fa, resolvedField, unionFieldAttributes);
                 }
@@ -3224,12 +3226,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         Map<ResolveUnionTypes.TypeResolutionKey, Expression> typeResolutions = new HashMap<>();
                         typeResolutions(convert, mappedType, fa, tcf, typeResolutions);
 
-                        Expression potentiallyUnmappedConversion = ResolveUnionTypes.typeSpecificConvert(
-                            convert,
-                            fa.source(),
-                            KEYWORD,
-                            tcf
-                        );
+                        Expression potentiallyUnmappedConversion = null;
+                        // Unmapped dense_vector values come from _source arrays, not the hex strings accepted by TO_DENSE_VECTOR.
+                        if (mappedType != DENSE_VECTOR) {
+                            potentiallyUnmappedConversion = ResolveUnionTypes.typeSpecificConvert(convert, fa.source(), KEYWORD, tcf);
+                        }
 
                         EsField resolvedField = ResolveUnionTypes.resolvedUnionTypeFields(
                             fa,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1279,6 +1280,23 @@ public class AnalyzerUnmappedTests extends AnalyzerUnmappedTestBase {
         assertThat(limit.output().getFirst().dataType(), is(DataType.KEYWORD));
     }
 
+    public void testAllowLoadWithPartiallyMappedDenseVectorCastNullifiesUnmappedBranch() {
+        assumeTrue("Requires OPTIONAL_FIELDS_V5", EsqlCapabilities.Cap.OPTIONAL_FIELDS_V5.isEnabled());
+
+        var esIndex = partialIndex(Map.of("partial_dense", denseVectorField("partial_dense")), Set.of("partial_dense"));
+        LogicalPlan plan = analyzer().addIndex(esIndex)
+            .statement(setUnmappedLoad("FROM idx* | EVAL vector = partial_dense::dense_vector | KEEP vector"));
+
+        Set<UnionTypeEsField> unionFields = Collections.newSetFromMap(new IdentityHashMap<>());
+        plan.forEachExpressionDown(FieldAttribute.class, fa -> {
+            if (fa.field() instanceof UnionTypeEsField unionField && unionField.getDataType() == DataType.DENSE_VECTOR) {
+                unionFields.add(unionField);
+            }
+        });
+        assertThat(unionFields, hasSize(1));
+        assertThat(unionFields.iterator().next().getUnmappedConversionExpression(), nullValue());
+    }
+
     /**
      * Comma-separated {@code FROM} resolves to one merged {@link EsIndex} named {@code idx_a,idx_b}; partial-field checks must use that
      * resolution (see {@link IndexResolution#matches}).
@@ -1655,6 +1673,10 @@ public class AnalyzerUnmappedTests extends AnalyzerUnmappedTestBase {
                 is(DataType.KEYWORD)
             );
         }
+    }
+
+    private static EsField denseVectorField(String name) {
+        return new EsField(name, DataType.DENSE_VECTOR, emptyMap(), true, EsField.TimeSeriesFieldType.NONE);
     }
 
     /**


### PR DESCRIPTION
Closes #152184

## Summary
- avoid applying the unmapped keyword-to-dense-vector conversion path to partially unmapped dense_vector fields
- leave the unmapped branch without a conversion so `unmapped_fields="nullify"` produces nulls instead of trying to parse dense vectors from keyword hex strings
- add analyzer coverage for the generated union field metadata

## Tests
- `GRADLE_USER_HOME=/tmp/gradle JAVA_HOME=/tmp/jdk-25 RUNTIME_JAVA_HOME=/tmp/jdk-25 ./gradlew :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.analysis.AnalyzerUnmappedTests`