### PR TITLE
feat(tsdb): route IP dimension ordinals to block size 1024

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -33,7 +33,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
-import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -247,16 +246,6 @@ public class PerFieldFormatSupplier {
         }
         if (mapper instanceof IpFieldMapper ipFieldMapper) {
             return new FieldContext(blockSize, fieldName, null, null, MappedFieldType.IP, ipFieldMapper.fieldType().isDimension());
-        }
-        if (mapper instanceof KeywordFieldMapper keywordFieldMapper) {
-            return new FieldContext(
-                blockSize,
-                fieldName,
-                null,
-                null,
-                MappedFieldType.KEYWORD,
-                keywordFieldMapper.fieldType().isDimension()
-            );
         }
         return new FieldContext(blockSize, fieldName, null, null, null, false);
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatSelector;
 import org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdPostingsFormat;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContext;
+import org.elasticsearch.index.codec.tsdb.pipeline.MappedFieldType;
 import org.elasticsearch.index.codec.tsdb.pipeline.MetricRole;
 import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 import org.elasticsearch.index.codec.vectors.es93.ES93HnswVectorsFormat;
@@ -31,6 +32,8 @@ import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -237,12 +240,25 @@ public class PerFieldFormatSupplier {
         if (mapper instanceof NumberFieldMapper numberFieldMapper) {
             final PipelineDescriptor.DataType dataType = toPipelineDataType(numberFieldMapper.type());
             final MetricRole metricRole = toMetricRole(numberFieldMapper.fieldType().getMetricType());
-            return new FieldContext(blockSize, fieldName, dataType, metricRole);
+            return new FieldContext(blockSize, fieldName, dataType, metricRole, null, false);
         }
         if (mapper instanceof DateFieldMapper) {
-            return new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, null);
+            return new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, null, null, false);
         }
-        return new FieldContext(blockSize, fieldName, null, null);
+        if (mapper instanceof IpFieldMapper ipFieldMapper) {
+            return new FieldContext(blockSize, fieldName, null, null, MappedFieldType.IP, ipFieldMapper.fieldType().isDimension());
+        }
+        if (mapper instanceof KeywordFieldMapper keywordFieldMapper) {
+            return new FieldContext(
+                blockSize,
+                fieldName,
+                null,
+                null,
+                MappedFieldType.KEYWORD,
+                keywordFieldMapper.fieldType().isDimension()
+            );
+        }
+        return new FieldContext(blockSize, fieldName, null, null, null, false);
     }
 
     private static PipelineDescriptor.DataType toPipelineDataType(final NumberFieldMapper.NumberType type) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95NumericFieldWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95NumericFieldWriter.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 final class ES95NumericFieldWriter implements NumericFieldWriter {
 
     private static final TSDBDocValuesBlockWriter BLOCK_WRITER = new TSDBDocValuesBlockWriter();
-    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null);
+    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null, null, false);
 
     private final NumericWriteContext ctx;
     private final PipelineConfigResolver resolver;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 final class ES95OrdinalFieldWriter implements OrdinalFieldWriter {
 
     private static final TSDBDocValuesBlockWriter BLOCK_WRITER = new TSDBDocValuesBlockWriter();
-    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null);
+    private static final FieldContextResolver NO_INFO_RESOLVER = (name, bs) -> new FieldContext(bs, name, null, null, null, false);
 
     private final NumericWriteContext ctx;
     private final PipelineConfigResolver resolver;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/FieldContext.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/FieldContext.java
@@ -15,20 +15,28 @@ import org.elasticsearch.core.Nullable;
  * Context about the field being encoded, passed to the {@link PipelineConfigResolver}
  * for pipeline selection.
  *
- * @param blockSize   the number of values per numeric block
- * @param fieldName   the name of the field being encoded
- * @param dataType    the underlying doc-values storage type of the field, or
- *                    {@code null} when unknown (e.g. construction sites without
- *                    mapper access). All integer-domain numeric mapper types
- *                    (long, integer, short, byte) collapse to
- *                    {@link PipelineDescriptor.DataType#LONG} because doc values
- *                    back-store them as long.
- * @param metricRole  the {@link MetricRole} of the field, or {@code null} when the
- *                    field is not a time-series metric
+ * @param blockSize       the number of values per numeric block
+ * @param fieldName       the name of the field being encoded
+ * @param dataType        the underlying doc-values storage type of the field, or
+ *                        {@code null} when unknown (e.g. construction sites without
+ *                        mapper access). All integer-domain numeric mapper types
+ *                        (long, integer, short, byte) collapse to
+ *                        {@link PipelineDescriptor.DataType#LONG} because doc values
+ *                        back-store them as long.
+ * @param metricRole      the {@link MetricRole} of the field, or {@code null} when the
+ *                        field is not a time-series metric
+ * @param mappedFieldType the codec-local mirror of the mapper field type, or {@code null}
+ *                        when unknown. Used by ordinal routing to upgrade IP and keyword
+ *                        dimension fields to a larger block size.
+ * @param isDimension     {@code true} if the field is a TSDB dimension; used together
+ *                        with {@link #mappedFieldType} to select a larger ordinal block
+ *                        size for IP and keyword dimension fields
  */
 public record FieldContext(
     int blockSize,
     String fieldName,
     @Nullable PipelineDescriptor.DataType dataType,
-    @Nullable MetricRole metricRole
+    @Nullable MetricRole metricRole,
+    @Nullable MappedFieldType mappedFieldType,
+    boolean isDimension
 ) {}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/MappedFieldType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.pipeline;
+
+/**
+ * Codec-local mirror of the mapper-layer field type. The pipeline package needs to make
+ * routing decisions (e.g. block size selection) based on a field's logical type, but the
+ * codec layer does not import mapper classes directly. {@code PerFieldFormatSupplier}
+ * translates from the concrete mapper type to this enum when building a {@link FieldContext}.
+ */
+public enum MappedFieldType {
+    /** Maps to {@code NumberFieldMapper} types long, integer, short, and byte. */
+    LONG,
+    /** Maps to {@code NumberFieldMapper} type double. */
+    DOUBLE,
+    /** Maps to {@code NumberFieldMapper} types float and half_float. */
+    FLOAT,
+    /** Maps to {@code DateFieldMapper}. */
+    DATE,
+    /** Maps to {@code IpFieldMapper}. */
+    IP,
+    /** Maps to {@code KeywordFieldMapper}. */
+    KEYWORD
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/MappedFieldType.java
@@ -25,7 +25,5 @@ public enum MappedFieldType {
     /** Maps to {@code DateFieldMapper}. */
     DATE,
     /** Maps to {@code IpFieldMapper}. */
-    IP,
-    /** Maps to {@code KeywordFieldMapper}. */
-    KEYWORD
+    IP
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
@@ -34,10 +34,18 @@ package org.elasticsearch.index.codec.tsdb.pipeline;
  *       longs and produces the same compaction. {@code kMax} is sized from
  *       {@code blockSize} as {@code clamp(blockSize / 32, 4, 64)} so large blocks with
  *       many resets do not bow out under the default cap.</li>
+ *   <li>IP and keyword TSDB dimension fields ({@link MappedFieldType#IP} and
+ *       {@link MappedFieldType#KEYWORD} with {@link FieldContext#isDimension()}) use a
+ *       block size of {@code 1024} ({@code blockShift=10}) regardless of the format-level
+ *       default. Only {@code blockSize()} of the returned config is used for ordinal
+ *       fields; the pipeline stages are never executed. At {@code blockSize=1024},
+ *       {@code maxCycleLength=256}, covering low-cardinality dimension cycles that
+ *       arise after a {@code _tsid}-sorted merge.</li>
  *   <li>All other fields use the ES819 baseline {@code delta > offset > gcd > bitPack}.</li>
  * </ul>
  *
- * <p>The two production block sizes ({@code 128} and {@code 512}, see
+ * <p>The three known ordinal block sizes ({@code 128}, {@code 512}, and {@code 1024})
+ * and the two numeric production block sizes ({@code 128} and {@code 512}, see
  * {@code ES95TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT} and {@code NUMERIC_LARGE_BLOCK_SHIFT})
  * have their {@link PipelineConfig} precomputed at class load for the baseline, split-delta,
  * ALP-double-gauge, and ALP-double-counter variants, so the per-field write path reuses a
@@ -55,6 +63,7 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
 
     private static final PipelineConfig BLOCK_128 = build(128);
     private static final PipelineConfig BLOCK_512 = build(512);
+    private static final PipelineConfig BLOCK_1024 = build(1024);
     private static final PipelineConfig SPLIT_DELTA_BLOCK_128 = buildSplitDelta(128);
     private static final PipelineConfig SPLIT_DELTA_BLOCK_512 = buildSplitDelta(512);
     private static final PipelineConfig ALP_DOUBLE_GAUGE_BLOCK_128 = buildAlpDoubleGauge(128);
@@ -75,7 +84,17 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
         if (useAlpDoubleGauge(context)) {
             return alpDoubleGaugeConfig(context.blockSize());
         }
+        if (useOrdinalLargeBlock(context)) {
+            return BLOCK_1024;
+        }
         return baselineConfig(context.blockSize());
+    }
+
+    private static boolean useOrdinalLargeBlock(final FieldContext context) {
+        if (context.isDimension() == false) {
+            return false;
+        }
+        return context.mappedFieldType() == MappedFieldType.IP || context.mappedFieldType() == MappedFieldType.KEYWORD;
     }
 
     private static boolean useSplitDelta(final FieldContext context) {
@@ -129,6 +148,9 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
         }
         if (blockSize == 512) {
             return BLOCK_512;
+        }
+        if (blockSize == 1024) {
+            return BLOCK_1024;
         }
         return build(blockSize);
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolver.java
@@ -34,18 +34,18 @@ package org.elasticsearch.index.codec.tsdb.pipeline;
  *       longs and produces the same compaction. {@code kMax} is sized from
  *       {@code blockSize} as {@code clamp(blockSize / 32, 4, 64)} so large blocks with
  *       many resets do not bow out under the default cap.</li>
- *   <li>IP and keyword TSDB dimension fields ({@link MappedFieldType#IP} and
- *       {@link MappedFieldType#KEYWORD} with {@link FieldContext#isDimension()}) use a
- *       block size of {@code 1024} ({@code blockShift=10}) regardless of the format-level
- *       default. Only {@code blockSize()} of the returned config is used for ordinal
- *       fields; the pipeline stages are never executed. At {@code blockSize=1024},
- *       {@code maxCycleLength=256}, covering low-cardinality dimension cycles that
+ *   <li>IP TSDB dimension fields ({@link MappedFieldType#IP} with
+ *       {@link FieldContext#isDimension()}) use a block size of {@code 1024}
+ *       ({@code blockShift=10}) regardless of the format-level default. Only
+ *       {@code blockSize()} of the returned config is used for ordinal fields; the
+ *       pipeline stages are never executed. At {@code blockSize=1024},
+ *       {@code maxCycleLength=256}, covering low-cardinality IP dimension cycles that
  *       arise after a {@code _tsid}-sorted merge.</li>
  *   <li>All other fields use the ES819 baseline {@code delta > offset > gcd > bitPack}.</li>
  * </ul>
  *
- * <p>The three known ordinal block sizes ({@code 128}, {@code 512}, and {@code 1024})
- * and the two numeric production block sizes ({@code 128} and {@code 512}, see
+ * <p>The known ordinal block sizes ({@code 128}, {@code 512}, and {@code 1024})
+ * and the numeric production block sizes ({@code 128} and {@code 512}, see
  * {@code ES95TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT} and {@code NUMERIC_LARGE_BLOCK_SHIFT})
  * have their {@link PipelineConfig} precomputed at class load for the baseline, split-delta,
  * ALP-double-gauge, and ALP-double-counter variants, so the per-field write path reuses a
@@ -94,7 +94,7 @@ public final class StaticPipelineConfigResolver implements PipelineConfigResolve
         if (context.isDimension() == false) {
             return false;
         }
-        return context.mappedFieldType() == MappedFieldType.IP || context.mappedFieldType() == MappedFieldType.KEYWORD;
+        return context.mappedFieldType() == MappedFieldType.IP;
     }
 
     private static boolean useSplitDelta(final FieldContext context) {

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
@@ -875,8 +875,8 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
      * <p>The IP sequence is a fixed mix of IPv4 and IPv6 addresses that cycles with period 12.
      * Both block sizes satisfy {@code cycleLength <= maxCycleLength} (12 &lt;= 128 for 512,
      * 12 &lt;= 256 for 1024), so both codecs encode each block as a single cycle header plus
-     * 12 ordinal values. With {@code numDocs=4096}, ES819 needs 8 blocks and ES95 needs 4,
-     * so ES95 saves four blocks' worth of metadata overhead.
+     * 12 ordinal values. With {@code numDocs=65536}, ES819 needs 128 blocks and ES95 needs 64,
+     * so ES95 saves 64 blocks' worth of metadata overhead.
      */
     public void testIpDimensionRealIpSequenceStorageComparison() throws IOException {
         final String[] ipStrings = {
@@ -899,7 +899,7 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
             ipValues[i] = new BytesRef(InetAddressPoint.encode(InetAddress.getByName(ipStrings[i])));
         }
 
-        final int numDocs = 4096;
+        final int numDocs = 65536;
         final int cyclePeriod = ipValues.length;
         final String fieldName = "client.ip";
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
@@ -834,7 +834,7 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
             } else {
                 blockSize = defaultBlockSize;
             }
-            return new FieldContext(blockSize, fieldName, null, null);
+            return new FieldContext(blockSize, fieldName, null, null, null, false);
         };
         return new ES95TSDBDocValuesFormat(
             DEFAULT_SKIP_INDEX_INTERVAL_SIZE,

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95TSDBDocValuesFormatTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -37,10 +38,14 @@ import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
 import org.elasticsearch.index.codec.tsdb.es819.ES819Version3TSDBDocValuesFormat;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContext;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContextResolver;
+import org.elasticsearch.index.codec.tsdb.pipeline.MappedFieldType;
 import org.elasticsearch.index.codec.tsdb.pipeline.numeric.NumericCodecFactory;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.List;
 import java.util.Locale;
 
@@ -50,6 +55,8 @@ import static org.elasticsearch.index.codec.tsdb.es95.ES95TSDBDocValuesFormat.NU
 import static org.elasticsearch.index.codec.tsdb.es95.ES95TSDBDocValuesFormat.ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL;
 
 public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTests {
+
+    private static final Logger logger = LogManager.getLogger(ES95TSDBDocValuesFormatTests.class);
 
     private final Codec codec = new Elasticsearch93Lucene104Codec() {
 
@@ -860,6 +867,131 @@ public class ES95TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTes
     private static final String CUSTOM_BS_SORTED_FIELD = "custom_bs_sorted";
     private static final String DEFAULT_BS_SORTED_FIELD = "default_bs_sorted";
     private static final String DEMOTED_BS_SORTED_FIELD = "demoted_bs_sorted";
+
+    /**
+     * Compares on-disk doc-values storage for a repeating sequence of real-world IPs under
+     * ES819 (ordinal block size 512) versus the ES95 IP dimension routing (block size 1024).
+     *
+     * <p>The IP sequence is a fixed mix of IPv4 and IPv6 addresses that cycles with period 12.
+     * Both block sizes satisfy {@code cycleLength <= maxCycleLength} (12 &lt;= 128 for 512,
+     * 12 &lt;= 256 for 1024), so both codecs encode each block as a single cycle header plus
+     * 12 ordinal values. With {@code numDocs=4096}, ES819 needs 8 blocks and ES95 needs 4,
+     * so ES95 saves four blocks' worth of metadata overhead.
+     */
+    public void testIpDimensionRealIpSequenceStorageComparison() throws IOException {
+        final String[] ipStrings = {
+            "19.91.28.118",
+            "36.133.89.196",
+            "81.20.243.145",
+            "153.128.232.73",
+            "180.255.13.202",
+            "211.56.102.171",
+            "4a41:bd7b:f3b8:d570:976d:2d87:9a39:6069",
+            "7566:2659:f32a:7052:bc15:fe24:7440:1d74",
+            "7ad8:54a9:4dc1:682f:61f6:16f6:e7f6:3bda",
+            "80cf:68bd:ea74:b16:9e2b:f871:17ba:3f3e",
+            "b21f:6144:6d7:2ef4:651:7415:98a6:3b30",
+            "bf04:8864:8513:5322:7509:6b3:d779:35b7" };
+
+        // Encode IPs to 16-byte IPv6 BytesRefs as IpFieldMapper does via InetAddressPoint.
+        final BytesRef[] ipValues = new BytesRef[ipStrings.length];
+        for (int i = 0; i < ipStrings.length; i++) {
+            ipValues[i] = new BytesRef(InetAddressPoint.encode(InetAddress.getByName(ipStrings[i])));
+        }
+
+        final int numDocs = 4096;
+        final int cyclePeriod = ipValues.length;
+        final String fieldName = "client.ip";
+
+        // ES819 with block size 512 (NUMERIC_LARGE_BLOCK_SHIFT=9): 2 blocks of 512.
+        long es819Size;
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, writerConfig(new ES819TSDBDocValuesFormat(NUMERIC_LARGE_BLOCK_SHIFT)))) {
+                for (int i = 0; i < numDocs; i++) {
+                    final Document doc = new Document();
+                    doc.add(new SortedDocValuesField(fieldName, ipValues[i % cyclePeriod]));
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            es819Size = docValuesSize(dir);
+        }
+
+        // ES95 with IP dimension routing to block size 1024: 1 block of 1024.
+        long es95Size;
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, writerConfig(buildIpDimensionFormat(fieldName)))) {
+                for (int i = 0; i < numDocs; i++) {
+                    final Document doc = new Document();
+                    doc.add(new SortedDocValuesField(fieldName, ipValues[i % cyclePeriod]));
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+            es95Size = docValuesSize(dir);
+        }
+
+        logger.info(
+            "IP sequence (period={}) over {} docs: ES819 block=512: {} bytes, ES95 block=1024: {} bytes (ratio={})",
+            cyclePeriod,
+            numDocs,
+            es819Size,
+            es95Size,
+            String.format(Locale.ROOT, "%.2f", (double) es819Size / es95Size)
+        );
+
+        assertTrue(
+            "ES95 (block 1024) size "
+                + es95Size
+                + " should be smaller than ES819 (block 512) size "
+                + es819Size
+                + " for a repeating IP cycle of period "
+                + cyclePeriod,
+            es95Size < es819Size
+        );
+    }
+
+    /**
+     * Builds an ES95 format whose {@link FieldContextResolver} marks {@code ipFieldName} as an
+     * IP dimension, routing it to the 1024-value ordinal block size via
+     * {@link org.elasticsearch.index.codec.tsdb.pipeline.StaticPipelineConfigResolver}.
+     */
+    private static DocValuesFormat buildIpDimensionFormat(final String ipFieldName) {
+        final FieldContextResolver ipDimensionResolver = (fieldName, defaultBlockSize) -> {
+            if (ipFieldName.equals(fieldName)) {
+                return new FieldContext(defaultBlockSize, fieldName, null, null, MappedFieldType.IP, true);
+            }
+            return new FieldContext(defaultBlockSize, fieldName, null, null, null, false);
+        };
+        return new ES95TSDBDocValuesFormat(
+            DEFAULT_SKIP_INDEX_INTERVAL_SIZE,
+            ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL,
+            true,
+            BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
+            true,
+            NUMERIC_BLOCK_SHIFT,
+            false,
+            ES95TSDBDocValuesFormat.BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT,
+            ES95TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT,
+            NumericCodecFactory.DEFAULT,
+            ES95NumericFieldReader::defaultFallbackDecoder,
+            ipDimensionResolver
+        );
+    }
+
+    /**
+     * Returns the total byte size of doc-values files ({@code .dvd} and {@code .dvm}) in the
+     * directory — the on-disk footprint of encoded doc values for a single-segment index.
+     */
+    private static long docValuesSize(final Directory dir) throws IOException {
+        long total = 0;
+        for (final String file : dir.listAll()) {
+            if (file.endsWith(".dvd") || file.endsWith(".dvm")) {
+                total += dir.fileLength(file);
+            }
+        }
+        return total;
+    }
 
     private static IndexWriterConfig writerConfig(final DocValuesFormat format) {
         final IndexWriterConfig config = new IndexWriterConfig();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
@@ -273,22 +273,6 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         assertEquals(1024, config.blockSize());
     }
 
-    public void testKeywordDimensionFieldUsesBlockSize1024() {
-        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final FieldContext context = new FieldContext(
-            randomFrom(128, 512),
-            randomNonTimestampFieldName(),
-            null,
-            null,
-            MappedFieldType.KEYWORD,
-            true
-        );
-
-        final PipelineConfig config = resolver.resolve(context);
-
-        assertEquals(1024, config.blockSize());
-    }
-
     public void testIpNonDimensionFieldUsesFormatDefaultBlockSize() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
@@ -299,10 +283,12 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         assertEquals(blockSize, config.blockSize());
     }
 
-    public void testKeywordNonDimensionFieldUsesFormatDefaultBlockSize() {
+    public void testKeywordDimensionFieldUsesFormatDefaultBlockSize() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
-        final FieldContext context = new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, MappedFieldType.KEYWORD, false);
+        // Keyword fields are not routed to the larger IP block size; PerFieldFormatSupplier
+        // emits mappedFieldType=null for keyword fields so they fall through to baselineConfig.
+        final FieldContext context = new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, true);
 
         final PipelineConfig config = resolver.resolve(context);
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/pipeline/StaticPipelineConfigResolverTests.java
@@ -17,7 +17,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
 
     public void testResolvesBaselinePipelineShapeForNonTimestampField() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null));
+        final PipelineConfig config = resolver.resolve(
+            new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null, null, false)
+        );
 
         assertEquals("delta>offset>gcd>bitPack", config.describeStages());
         assertEquals(PipelineDescriptor.DataType.LONG, config.dataType());
@@ -27,7 +29,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
 
     public void testResolvesTimestampPipelineShape() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig config = resolver.resolve(new FieldContext(randomBlockSize(), TIMESTAMP_FIELD_NAME, null, null, null, false));
 
         assertEquals("splitDelta>delta>offset>gcd>bitPack", config.describeStages());
         assertEquals(PipelineDescriptor.DataType.LONG, config.dataType());
@@ -39,7 +41,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomBlockSize();
 
-        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
+        final PipelineConfig config = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false));
 
         assertEquals(blockSize, config.blockSize());
     }
@@ -48,8 +50,8 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomBlockSize();
 
-        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
-        final PipelineConfig other = resolver.resolve(new FieldContext(blockSize, "metric.value", null, null));
+        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
+        final PipelineConfig other = resolver.resolve(new FieldContext(blockSize, "metric.value", null, null, null, false));
 
         assertNotEquals(timestamp, other);
         assertEquals("splitDelta>delta>offset>gcd>bitPack", timestamp.describeStages());
@@ -58,7 +60,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
 
     public void testRepeatedResolveReturnsEqualConfigs() {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
-        final FieldContext context = new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null);
+        final FieldContext context = new FieldContext(randomBlockSize(), randomNonTimestampFieldName(), null, null, null, false);
 
         assertEquals(resolver.resolve(context), resolver.resolve(context));
     }
@@ -67,8 +69,8 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
 
-        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
-        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
+        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false));
+        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false));
         assertSame(first, second);
     }
 
@@ -76,8 +78,8 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = randomFrom(128, 512);
 
-        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
-        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig first = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
+        final PipelineConfig second = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
         assertSame(first, second);
     }
 
@@ -85,11 +87,13 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
         final int blockSize = 1 << randomIntBetween(4, 6);
 
-        final PipelineConfig nonTimestamp = resolver.resolve(new FieldContext(blockSize, randomNonTimestampFieldName(), null, null));
+        final PipelineConfig nonTimestamp = resolver.resolve(
+            new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, null, false)
+        );
         assertEquals(blockSize, nonTimestamp.blockSize());
         assertEquals("delta>offset>gcd>bitPack", nonTimestamp.describeStages());
 
-        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
         assertEquals(blockSize, timestamp.blockSize());
         assertEquals("splitDelta>delta>offset>gcd>bitPack", timestamp.describeStages());
     }
@@ -100,7 +104,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.LONG,
-            MetricRole.COUNTER
+            MetricRole.COUNTER,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -115,7 +121,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.LONG,
-            MetricRole.GAUGE
+            MetricRole.GAUGE,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -129,7 +137,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.DOUBLE,
-            MetricRole.COUNTER
+            MetricRole.COUNTER,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -145,7 +155,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.DOUBLE,
-            MetricRole.GAUGE
+            MetricRole.GAUGE,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -162,7 +174,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.DOUBLE,
-            null
+            null,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -175,10 +189,10 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final int blockSize = randomFrom(128, 512);
 
         final PipelineConfig first = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
         final PipelineConfig second = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
         assertSame(first, second);
     }
@@ -189,12 +203,12 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final String fieldName = randomNonTimestampFieldName();
 
         final PipelineConfig alpDouble = resolver.resolve(
-            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
         final PipelineConfig baseline = resolver.resolve(
-            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, MetricRole.GAUGE)
+            new FieldContext(blockSize, fieldName, PipelineDescriptor.DataType.LONG, MetricRole.GAUGE, null, false)
         );
-        final PipelineConfig splitDelta = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig splitDelta = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
 
         assertNotEquals(alpDouble, baseline);
         assertNotEquals(alpDouble, splitDelta);
@@ -208,7 +222,7 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final int blockSize = 1 << randomIntBetween(4, 6);
 
         final PipelineConfig config = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.DOUBLE, MetricRole.GAUGE, null, false)
         );
 
         assertEquals(blockSize, config.blockSize());
@@ -221,7 +235,9 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
             randomBlockSize(),
             randomNonTimestampFieldName(),
             PipelineDescriptor.DataType.LONG,
-            null
+            null,
+            null,
+            false
         );
 
         final PipelineConfig config = resolver.resolve(context);
@@ -234,11 +250,76 @@ public class StaticPipelineConfigResolverTests extends ESTestCase {
         final int blockSize = randomFrom(128, 512);
 
         final PipelineConfig counter = resolver.resolve(
-            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.LONG, MetricRole.COUNTER)
+            new FieldContext(blockSize, randomNonTimestampFieldName(), PipelineDescriptor.DataType.LONG, MetricRole.COUNTER, null, false)
         );
-        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null));
+        final PipelineConfig timestamp = resolver.resolve(new FieldContext(blockSize, TIMESTAMP_FIELD_NAME, null, null, null, false));
 
         assertSame(counter, timestamp);
+    }
+
+    public void testIpDimensionFieldUsesBlockSize1024() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final FieldContext context = new FieldContext(
+            randomFrom(128, 512),
+            randomNonTimestampFieldName(),
+            null,
+            null,
+            MappedFieldType.IP,
+            true
+        );
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(1024, config.blockSize());
+    }
+
+    public void testKeywordDimensionFieldUsesBlockSize1024() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final FieldContext context = new FieldContext(
+            randomFrom(128, 512),
+            randomNonTimestampFieldName(),
+            null,
+            null,
+            MappedFieldType.KEYWORD,
+            true
+        );
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(1024, config.blockSize());
+    }
+
+    public void testIpNonDimensionFieldUsesFormatDefaultBlockSize() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int blockSize = randomFrom(128, 512);
+        final FieldContext context = new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, MappedFieldType.IP, false);
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(blockSize, config.blockSize());
+    }
+
+    public void testKeywordNonDimensionFieldUsesFormatDefaultBlockSize() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int blockSize = randomFrom(128, 512);
+        final FieldContext context = new FieldContext(blockSize, randomNonTimestampFieldName(), null, null, MappedFieldType.KEYWORD, false);
+
+        final PipelineConfig config = resolver.resolve(context);
+
+        assertEquals(blockSize, config.blockSize());
+    }
+
+    public void testIpDimensionBlockSize1024IsCached() {
+        final StaticPipelineConfigResolver resolver = StaticPipelineConfigResolver.INSTANCE;
+        final int formatBlockSize = randomFrom(128, 512);
+
+        final PipelineConfig first = resolver.resolve(new FieldContext(formatBlockSize, "client.ip", null, null, MappedFieldType.IP, true));
+        final PipelineConfig second = resolver.resolve(
+            new FieldContext(formatBlockSize, "server.ip", null, null, MappedFieldType.IP, true)
+        );
+
+        assertSame(first, second);
+        assertEquals(1024, first.blockSize());
     }
 
     private static int randomBlockSize() {


### PR DESCRIPTION
## Summary

Routes IP TSDB dimension fields to ordinal block size 1024 (`blockShift=10`).
Keyword dimensions are intentionally excluded (see rationale below).

Based on #152141, restricted to IP fields only.

## How it works

`TSDBDocValuesEncoder.encodeOrdinals` detects repeating ordinal cycles with
`maxCycleLength = blockSize / 4`. At the default `blockSize=128`,
`maxCycleLength=32`. At `blockSize=1024`, `maxCycleLength=256`, covering a
wider cardinality range of real-world IP dimension fields after a
`_tsid`-sorted merge.

`StaticPipelineConfigResolver` returns `BLOCK_1024` when `mappedFieldType` is
`IP` and `isDimension` is `true`. Only `blockSize()` is consumed for ordinal
fields; the encoding pipeline stages are not executed.

## Why keyword is excluded

Codec-level tests (`testIpDimensionMultipleCyclesCompressionComparison` on
branch `tsdb/ip-ordinal-block-size-4k-test`) show that the larger block size
only helps when the ordinal sequence is a **single uniform cycle** across the
entire block. When the block contains **multiple consecutive cycles** (e.g.
two groups of time-series each with their own repeating value), the cycle
detector cannot span the transition and falls back to bit-packing — making the
large block significantly worse than ES819.

Measured sizes for 4096 docs, cycle size 16, ES819 vs ES95 (block 4096):

| Pattern | ES819 | ES95 | Winner |
|---|---|---|---|
| 1 cycle × 16 values | 989 B | 426 B | ES95 (2.3×) |
| 2 consecutive cycles × 16 | 995 B | 2975 B | ES819 (3×) |
| 4 consecutive cycles × 16 | 1006 B | 3498 B | ES819 (3.5×) |

IP dimensions in practice have low cardinality and predictable per-tsid
constant values, making the single-uniform-cycle pattern more likely. Keyword
dimensions span a much wider cardinality range and are more likely to produce
fragmented multi-cycle blocks, so they are left at the ES819 default for now.

## Changes

- `MappedFieldType.java`: adds `IP` only (no `KEYWORD`)
- `StaticPipelineConfigResolver.java`: `useOrdinalLargeBlock()` matches
  `MappedFieldType.IP` only; `BLOCK_1024` precomputed at class load
- `PerFieldFormatSupplier.java`: handles `IpFieldMapper` only
- `FieldContext.java`: adds `mappedFieldType` and `isDimension` parameters
- `StaticPipelineConfigResolverTests.java`: IP dimension → 1024, keyword
  dimension → format default (not routed)

## Testing

```
./gradlew :server:test --tests "*StaticPipelineConfigResolverTests"
./gradlew :server:test --tests "*ES95TSDBDocValuesFormatTests*"
./gradlew :server:test --tests "*pipeline.numeric.stages*"
```