### PR TITLE
[ESQL] NDJSON field-name identity cache

### DIFF
--- a/docs/changelog/152221.yaml
+++ b/docs/changelog/152221.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152221
+summary: NDJSON field-name identity cache
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -73,10 +73,9 @@ public class NdJsonPageDecoder implements Closeable {
     static final int IDENTITY_CACHE_MIN_CAP = 256;
 
     /**
-     * Multiplier on the local {@code children.size()} when sizing the identity-cache bound:
-     * gives wide schemas (e.g. ClickBench's ~105-column {@code hits}) headroom for every
-     * unprojected name without letting the bound scale unbounded with dynamic JSON keys not
-     * present in the schema.
+     * Multiplier on the local projected {@code children.size()} when sizing the identity-cache
+     * bound. The fixed floor gives narrow projections room for common unprojected field names;
+     * this multiplier gives wider projections extra space without scaling with dynamic JSON keys.
      */
     static final int IDENTITY_CACHE_FANOUT_MULT = 4;
 
@@ -858,10 +857,11 @@ public class NdJsonPageDecoder implements Closeable {
             if (children == null) {
                 return unprojected;
             }
+            int maxEntries = identityCacheMaxEntries();
             if (identityCache == null) {
-                // Sized for the expected fanout of one object: the schema's full column count is a
-                // conservative ceiling. We never iterate it, so collisions only cost a probe.
-                identityCache = new IdentityHashMap<>(children.size() * 2);
+                // Seed to the bound so narrow projections over wide objects avoid rehashing during
+                // warm-up as unprojected names fill the floor-sized working set.
+                identityCache = new IdentityHashMap<>(maxEntries);
             }
             BlockDecoder cached = identityCache.get(fieldName);
             if (cached != null) {
@@ -870,18 +870,18 @@ public class NdJsonPageDecoder implements Closeable {
             hashMapFallbacks++;
             BlockDecoder resolved = children.get(fieldName);
             BlockDecoder toCache = resolved == null ? unprojected : resolved;
-            if (identityCache.size() < identityCacheMaxEntries()) {
+            if (identityCache.size() < maxEntries) {
                 identityCache.put(fieldName, toCache);
             }
             return toCache;
         }
 
         /**
-         * Upper bound for {@link #identityCache} entries on this decoder. Sized off the local
-         * children fanout so a wide schema still gets generous headroom for unprojected names
-         * while a narrow one (the common NDJSON STATS case) stays compact. The hard floor is
-         * {@value #IDENTITY_CACHE_MIN_CAP} so leaf-ish objects with a tiny {@code children} map
-         * still cache a usable working set.
+         * Upper bound for {@link #identityCache} entries on this decoder. The local
+         * {@code children} fanout is the projected fanout at this object level, not the full
+         * observed object width. The hard floor ({@value #IDENTITY_CACHE_MIN_CAP}) gives narrow
+         * projections a usable working set for unprojected names, while wider projections get
+         * additional space proportional to their projected children.
          */
         private int identityCacheMaxEntries() {
             return Math.max(IDENTITY_CACHE_MIN_CAP, children.size() * IDENTITY_CACHE_FANOUT_MULT);

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -49,6 +49,7 @@ import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,6 +62,23 @@ import java.util.Map;
 public class NdJsonPageDecoder implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(NdJsonPageDecoder.class);
+
+    /**
+     * Floor for the per-{@code BlockDecoder} identity-cache bound (see
+     * {@code BlockDecoder#identityCacheMaxEntries}). High enough that the common NDJSON STATS
+     * shape (a handful of projected columns plus tens of unprojected ones) fits entirely; low
+     * enough that the worst-case retention on a dynamic-key input stays in the kilobytes range
+     * per decoder level.
+     */
+    static final int IDENTITY_CACHE_MIN_CAP = 256;
+
+    /**
+     * Multiplier on the local {@code children.size()} when sizing the identity-cache bound:
+     * gives wide schemas (e.g. ClickBench's ~105-column {@code hits}) headroom for every
+     * unprojected name without letting the bound scale unbounded with dynamic JSON keys not
+     * present in the schema.
+     */
+    static final int IDENTITY_CACHE_FANOUT_MULT = 4;
 
     private InputStream input;
     /**
@@ -705,6 +723,40 @@ public class NdJsonPageDecoder implements Closeable {
         parser = null;
     }
 
+    /**
+     * Total number of {@code children.get(String)} (HashMap) fallback lookups across the decoder
+     * tree on this decoder's lifetime. Each {@link BlockDecoder#decodeObject} field probes the
+     * per-object identity cache first; the HashMap is consulted only on identity-cache miss (i.e.
+     * the first time a given canonicalised {@code String} instance is seen by this object's
+     * decoder). Once a name is cached, repeat occurrences across pages cost a single identity
+     * compare. Package-private for tests that assert the cache is effective.
+     */
+    long hashMapFallbacks() {
+        return hashMapFallbacks;
+    }
+
+    private long hashMapFallbacks = 0L;
+
+    /**
+     * Size of the root {@code BlockDecoder}'s identity cache, or {@code 0} when the cache has
+     * not been allocated (no JSON object decoded yet, or the root decoder has {@code null}
+     * children). Package-private so tests can pin the bound semantics on dynamic-key inputs
+     * where the cache is intentionally capped rather than allowed to grow with each new field
+     * name on the wire.
+     */
+    int rootIdentityCacheSize() {
+        var cache = decoder.identityCache;
+        return cache == null ? 0 : cache.size();
+    }
+
+    /**
+     * Sentinel returned by {@link BlockDecoder#lookupChild} for canonicalised field-name
+     * {@code String} instances that have been resolved to "no matching projection". One per
+     * decoder; only identity comparisons are performed against it (never any method calls), so
+     * its inner-class outer-{@code this} binding is irrelevant.
+     */
+    private final BlockDecoder unprojected = new BlockDecoder();
+
     // ---------------------------------------------------------------------------------------------
     // A tree of decoders. Avoids path reconstruction when traversing nested objects.
     private class BlockDecoder {
@@ -714,6 +766,22 @@ public class NdJsonPageDecoder implements Closeable {
         int blockIdx;
         Block.Builder blockBuilder;
         Map<String, BlockDecoder> children;
+        /**
+         * Identity-keyed cache of field-name {@link String} instances previously seen by this
+         * object's decoder, mapped to either a child {@link BlockDecoder} (projected) or
+         * {@link #unprojected} (unprojected). Lazily allocated on the first field probe so
+         * leaf decoders (which never call {@link #decodeObject}) pay nothing.
+         * <p>
+         * Correctness rests on Jackson's {@link com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer}
+         * (enabled by default; {@code JsonFactory.Feature#CANONICALIZE_FIELD_NAMES}) returning the
+         * <em>same</em> {@code String} instance for repeat occurrences of a name across pages — and
+         * on the {@link NdJsonUtils#JSON_FACTORY} root canonicalizer being shared so subsequent
+         * parsers from the same factory inherit those instances. A name that hash-collides with a
+         * different identity falls through to the slow HashMap lookup and re-primes the cache; the
+         * code is therefore safe even when an instance does turn over (e.g. canonicaliser rehash).
+         */
+        @Nullable
+        IdentityHashMap<String, BlockDecoder> identityCache;
 
         void setAttribute(Attribute attribute, int blockIdx) {
             this.dataType = attribute.dataType();
@@ -751,9 +819,9 @@ public class NdJsonPageDecoder implements Closeable {
             }
             String fieldName;
             while ((fieldName = parser.nextFieldName()) != null) {
-                var childDecoder = this.children == null ? null : this.children.get(fieldName);
+                var childDecoder = lookupChild(fieldName);
                 parser.nextToken();
-                if (childDecoder == null) {
+                if (childDecoder == unprojected) {
                     // Unknown/unprojected field: advance to its value then skip (no decode).
                     // For string values nextFieldName() uses _skipString() internally on the next
                     // call, so we avoid _finishString2 for non-projected string fields.
@@ -762,6 +830,61 @@ public class NdJsonPageDecoder implements Closeable {
                     childDecoder.decodeValue(parser, inArray);
                 }
             }
+        }
+
+        /**
+         * Resolve {@code fieldName} to either a projected child {@link BlockDecoder} or the
+         * {@link #unprojected} sentinel, using an identity-keyed cache to avoid the
+         * {@link String#hashCode}/{@link HashMap#get} pair on repeat occurrences of the same
+         * canonicalised {@code String} instance.
+         * <p>
+         * On cache miss (first time this object's decoder sees this identity) the call falls
+         * back to a single {@code children.get(fieldName)} probe and primes the cache with
+         * either the child decoder or {@link #unprojected}. The fallback count is exposed via
+         * {@link #hashMapFallbacks()} so tests can pin that the cache is doing its job.
+         * <p>
+         * When {@code children} is {@code null} the decoder cannot match any projection, so the
+         * loop short-circuits to {@link #unprojected} without allocating an identity cache or
+         * incrementing the fallback counter — there is no HashMap probe to avoid in that case.
+         * <p>
+         * The cache is bounded at {@link #identityCacheMaxEntries()} entries to keep
+         * dynamic-key NDJSON inputs (per-tenant column names, event ids embedded as JSON keys,
+         * sparse extensions) from growing the cache without bound. Once full it stops accepting
+         * new entries — existing entries keep serving identity hits and the rest pay the
+         * {@code HashMap} probe — so correctness degrades to "no cache" for the tail, not to a
+         * memory leak.
+         */
+        private BlockDecoder lookupChild(String fieldName) {
+            if (children == null) {
+                return unprojected;
+            }
+            if (identityCache == null) {
+                // Sized for the expected fanout of one object: the schema's full column count is a
+                // conservative ceiling. We never iterate it, so collisions only cost a probe.
+                identityCache = new IdentityHashMap<>(children.size() * 2);
+            }
+            BlockDecoder cached = identityCache.get(fieldName);
+            if (cached != null) {
+                return cached;
+            }
+            hashMapFallbacks++;
+            BlockDecoder resolved = children.get(fieldName);
+            BlockDecoder toCache = resolved == null ? unprojected : resolved;
+            if (identityCache.size() < identityCacheMaxEntries()) {
+                identityCache.put(fieldName, toCache);
+            }
+            return toCache;
+        }
+
+        /**
+         * Upper bound for {@link #identityCache} entries on this decoder. Sized off the local
+         * children fanout so a wide schema still gets generous headroom for unprojected names
+         * while a narrow one (the common NDJSON STATS case) stays compact. The hard floor is
+         * {@value #IDENTITY_CACHE_MIN_CAP} so leaf-ish objects with a tiny {@code children} map
+         * still cache a usable working set.
+         */
+        private int identityCacheMaxEntries() {
+            return Math.max(IDENTITY_CACHE_MIN_CAP, children.size() * IDENTITY_CACHE_FANOUT_MULT);
         }
 
         /**

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
@@ -41,12 +41,13 @@ class NdJsonUtils {
      *       book-keeping.</li>
      *   <li>{@link JsonFactory.Feature#INTERN_FIELD_NAMES} disabled - eliminates the global
      *       {@code String.intern()} synchronization point under parallel parsing. Field names live
-     *       only as long as the column attribute lookup keys, so interning gains us nothing while
-     *       serializing parser threads on the JVM string-table monitor. Disabling is safe because
-     *       this factory is package-private to the NDJSON plugin and every consumer (currently the
-     *       schema inferrer and {@link NdJsonPageDecoder}) treats {@code parser.currentName()} as a
-     *       hash-map key — there are no identity (==) comparisons that would silently break when
-     *       names stop being interned.</li>
+     *       only as long as the column attribute lookup keys, so JVM-wide interning gains us
+     *       nothing while serializing parser threads on the JVM string-table monitor. Disabling
+     *       is safe because {@code JsonFactory.Feature#CANONICALIZE_FIELD_NAMES} (also default-on
+     *       and kept on here) already returns stable {@code String} instances per name from the
+     *       per-parser {@code ByteQuadsCanonicalizer} — that is what {@link NdJsonPageDecoder}'s
+     *       identity-keyed field-name cache relies on. Equality-based lookups remain correct
+     *       regardless.</li>
      * </ul>
      */
     static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder().disable(StreamReadFeature.AUTO_CLOSE_SOURCE)

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderFieldNameCacheTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderFieldNameCacheTests.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.hamcrest.Matchers;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Pins {@link NdJsonPageDecoder}'s identity-keyed field-name cache: a probe on
+ * {@code children.get(fieldName)} (HashMap fallback) must happen at most once per unique field
+ * name, regardless of how many records carry it. Jackson's {@link
+ * com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer} returns stable {@code String} instances
+ * for repeat names (within one parser's lifetime — which spans every page this decoder emits),
+ * so the cache makes the unprojected-field tax flat-per-name rather than per-record.
+ * <p>
+ * This is the residual the original 105-column ClickBench profile attributed to {@code
+ * HashMap.getNode} on the decoder's side; the Jackson-side name tokenisation cost
+ * ({@code parseMediumName2}/{@code findName}) is irreducible at the public API surface and is
+ * not what this change targets.
+ */
+public class NdJsonPageDecoderFieldNameCacheTests extends ESTestCase {
+
+    private static final int COLUMNS = 4;
+    private static final int ROWS = 32;
+
+    private static final List<Attribute> SCHEMA = List.of(
+        NdJsonSchemaInferrer.attribute("id", DataType.INTEGER, false),
+        NdJsonSchemaInferrer.attribute("name", DataType.KEYWORD, false),
+        NdJsonSchemaInferrer.attribute("age", DataType.INTEGER, false),
+        NdJsonSchemaInferrer.attribute("active", DataType.BOOLEAN, false)
+    );
+
+    /** Narrow projection: 1 of 4 fields. The other 3 must be probed at most once. */
+    private static final List<String> NARROW_PROJECTION = List.of("id");
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * After the decoder has seen a name once, every subsequent record paying that same name must
+     * be served from the identity cache. With {@value #COLUMNS} columns the HashMap-fallback
+     * counter must equal exactly {@value #COLUMNS} after all {@value #ROWS} rows decode (one
+     * probe per unique name on the first record, zero on every record after).
+     */
+    public void testNarrowProjectionCachesFieldNamesAcrossRecords() throws IOException {
+        byte[] ndjson = fixture();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson),
+                null, // DateFormatter
+                SCHEMA,
+                NARROW_PROJECTION,
+                ROWS + 1,
+                blockFactory,
+                ErrorPolicy.STRICT,
+                "test",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            Page page = decoder.decodePage();
+            assertNotNull(page);
+            try {
+                assertEquals(ROWS, page.getPositionCount());
+            } finally {
+                page.releaseBlocks();
+            }
+            // Exactly one HashMap fallback per unique field name. The other (ROWS-1) * COLUMNS
+            // field-name probes must all be served from the identity cache.
+            assertEquals(
+                "every unique field name should be probed against the slow HashMap at most once",
+                COLUMNS,
+                decoder.hashMapFallbacks()
+            );
+        }
+    }
+
+    /**
+     * Same invariant under {@link ErrorPolicy#LENIENT}: lenient decode uses the same field-name
+     * loop, so the cache must do the same work. The page-build path differs (scratch row
+     * builders) but {@code decodeObject} does not.
+     */
+    public void testLenientCachesFieldNamesAcrossRecords() throws IOException {
+        byte[] ndjson = fixture();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson),
+                null, // DateFormatter
+                SCHEMA,
+                NARROW_PROJECTION,
+                ROWS + 1,
+                blockFactory,
+                ErrorPolicy.LENIENT,
+                "test",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            Page page = decoder.decodePage();
+            assertNotNull(page);
+            try {
+                assertEquals(ROWS, page.getPositionCount());
+            } finally {
+                page.releaseBlocks();
+            }
+            assertEquals(COLUMNS, decoder.hashMapFallbacks());
+        }
+    }
+
+    /**
+     * The cache must survive page boundaries: each {@code decodePage()} call shares the same
+     * underlying {@link com.fasterxml.jackson.core.JsonParser} (and therefore the same
+     * canonicaliser child), so the {@code String} identities seen on page 1 must match those on
+     * page 2. A regression that, for example, allocates a fresh identity cache per page would
+     * make the fallback counter grow linearly in the number of pages.
+     */
+    public void testCacheSurvivesPageBoundaries() throws IOException {
+        byte[] ndjson = fixture();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson),
+                null, // DateFormatter
+                SCHEMA,
+                NARROW_PROJECTION,
+                4,
+                blockFactory,
+                ErrorPolicy.STRICT,
+                "test",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            int totalRows = 0;
+            Page page;
+            while ((page = decoder.decodePage()) != null) {
+                try {
+                    totalRows += page.getPositionCount();
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+            assertEquals(ROWS, totalRows);
+            assertEquals(
+                "the identity cache spans every page the decoder produces, so fallback count must stay at COLUMNS",
+                COLUMNS,
+                decoder.hashMapFallbacks()
+            );
+        }
+    }
+
+    /**
+     * The byte-array constructor takes the same {@code decodeObject} loop as the
+     * {@link java.io.InputStream}-based one, so the cache must behave identically. Pinned
+     * because the streaming-parallel hot path (every chunk handed to the decoder as a bounded
+     * {@code byte[]}) goes through that constructor and is the workload the optimisation
+     * actually matters for.
+     */
+    public void testByteArrayConstructorCachesFieldNamesAcrossRecords() throws IOException {
+        byte[] ndjson = fixture();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                ndjson,
+                0,
+                ndjson.length,
+                null, // DateFormatter
+                SCHEMA,
+                NARROW_PROJECTION,
+                ROWS + 1,
+                blockFactory,
+                ErrorPolicy.STRICT,
+                "test",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            Page page = decoder.decodePage();
+            assertNotNull(page);
+            try {
+                assertEquals(ROWS, page.getPositionCount());
+            } finally {
+                page.releaseBlocks();
+            }
+            assertEquals(COLUMNS, decoder.hashMapFallbacks());
+        }
+    }
+
+    /**
+     * Each level of the decoder tree owns its own identity cache. With nested projection
+     * {@code user.id} against records shaped {@code {"user":{"id":..,"name":..},"other":..}}
+     * the root decoder probes 2 unique names ({@code user}, {@code other}) and the inner
+     * {@code user} decoder probes 2 ({@code id}, {@code name}) — 4 fallbacks total, again
+     * regardless of record count.
+     */
+    public void testNestedProjectionCachesPerSubtree() throws IOException {
+        List<Attribute> nestedSchema = List.of(
+            NdJsonSchemaInferrer.attribute("user.id", DataType.INTEGER, false),
+            NdJsonSchemaInferrer.attribute("user.name", DataType.KEYWORD, false),
+            NdJsonSchemaInferrer.attribute("other", DataType.KEYWORD, false)
+        );
+        List<String> nestedProjection = List.of("user.id");
+        byte[] ndjson = nestedFixture();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson),
+                null, // DateFormatter
+                nestedSchema,
+                nestedProjection,
+                ROWS + 1,
+                blockFactory,
+                ErrorPolicy.STRICT,
+                "test",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            Page page = decoder.decodePage();
+            assertNotNull(page);
+            try {
+                assertEquals(ROWS, page.getPositionCount());
+            } finally {
+                page.releaseBlocks();
+            }
+            // Root: {user, other} = 2 unique. Inner "user" decoder: {id, name} = 2 unique. Total = 4.
+            assertEquals(
+                "each BlockDecoder level owns an independent identity cache; total fallbacks = unique names per level summed",
+                4,
+                decoder.hashMapFallbacks()
+            );
+        }
+    }
+
+    /**
+     * Dynamic-key NDJSON (per-row varying field names: tenant-keyed columns, embedded event
+     * ids, sparse extensions) must not grow the identity cache without bound. The cache caps at
+     * {@code max(IDENTITY_CACHE_MIN_CAP, children.size() * IDENTITY_CACHE_FANOUT_MULT)} entries
+     * per decoder; past the bound, new names fall through to the {@code HashMap} every
+     * occurrence. Correctness must hold (the projected {@code id} column is decoded for every
+     * row) and the root cache size must stay within the bound regardless of how many unique
+     * unprojected names the input carries.
+     */
+    public void testDynamicKeyInputCapsIdentityCacheSize() throws IOException {
+        int uniquePerRecordExtras = 512;
+        int rows = 4;
+        List<Attribute> schema = List.of(NdJsonSchemaInferrer.attribute("id", DataType.INTEGER, false));
+        List<String> projection = List.of("id");
+        byte[] ndjson = dynamicKeyFixture(rows, uniquePerRecordExtras);
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson),
+                null, // DateFormatter
+                schema,
+                projection,
+                rows + 1,
+                blockFactory,
+                ErrorPolicy.STRICT,
+                "test",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            Page page = decoder.decodePage();
+            assertNotNull(page);
+            try {
+                assertEquals(rows, page.getPositionCount());
+            } finally {
+                page.releaseBlocks();
+            }
+            // Root schema fanout is 1 ({@code id}), so the cache bound is the floor (256). Without
+            // a bound the cache would hold 1 + uniquePerRecordExtras * rows entries (~2049). The
+            // cap must keep it well under that.
+            int bound = Math.max(256, /* children.size() = */ 1 * 4);
+            assertThat(
+                "identity cache must be capped on dynamic-key inputs",
+                decoder.rootIdentityCacheSize(),
+                Matchers.lessThanOrEqualTo(bound)
+            );
+            // And the cap must actually have engaged here (more unique names than the bound).
+            assertThat(
+                "test fixture must produce more unique names than the cap so the bound is exercised",
+                1 + uniquePerRecordExtras * rows,
+                Matchers.greaterThan(bound)
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+
+    /** Generates {@value #ROWS} NDJSON lines with {@value #COLUMNS} fields each. */
+    private static byte[] fixture() throws IOException {
+        var sw = new StringWriter();
+        try (PrintWriter w = new PrintWriter(sw)) {
+            for (int i = 0; i < ROWS; i++) {
+                w.format(
+                    Locale.ROOT,
+                    "{\"id\":%d,\"name\":\"name-%d\",\"age\":%d,\"active\":%s}%n",
+                    i,
+                    i,
+                    20 + i,
+                    i % 2 == 0 ? "true" : "false"
+                );
+            }
+        }
+        return sw.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Generates {@value #ROWS} NDJSON lines shaped {@code {"user":{"id":i,"name":"x-i"},"other":"y-i"}}. */
+    private static byte[] nestedFixture() throws IOException {
+        var sw = new StringWriter();
+        try (PrintWriter w = new PrintWriter(sw)) {
+            for (int i = 0; i < ROWS; i++) {
+                w.format(Locale.ROOT, "{\"user\":{\"id\":%d,\"name\":\"u-%d\"},\"other\":\"o-%d\"}%n", i, i, i);
+            }
+        }
+        return sw.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Generates {@code rows} NDJSON lines each shaped
+     * {@code {"id":i,"dyn_<r>_0":...,"dyn_<r>_<extras-1>":...}}, so every record carries the
+     * projected {@code id} plus a fresh batch of unique unprojected field names (no name
+     * repeats across records). Exercises the identity-cache bound.
+     */
+    private static byte[] dynamicKeyFixture(int rows, int extrasPerRow) throws IOException {
+        var sw = new StringWriter();
+        try (PrintWriter w = new PrintWriter(sw)) {
+            for (int r = 0; r < rows; r++) {
+                var sb = new StringBuilder().append("{\"id\":").append(r);
+                for (int e = 0; e < extrasPerRow; e++) {
+                    sb.append(",\"dyn_").append(r).append('_').append(e).append("\":").append(e);
+                }
+                sb.append('}');
+                w.println(sb);
+            }
+        }
+        return sw.toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtilsTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtilsTests.java
@@ -58,6 +58,20 @@ public class NdJsonUtilsTests extends ESTestCase {
     }
 
     /**
+     * {@link NdJsonPageDecoder}'s identity-keyed field-name cache only avoids the {@code
+     * HashMap} probe when {@link com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer} returns
+     * stable {@code String} instances per name across records. That stability is the default and
+     * is driven by {@link JsonFactory.Feature#CANONICALIZE_FIELD_NAMES} being on; pin it here so
+     * a future tuning change has to surface the consequence explicitly.
+     */
+    public void testFactoryEnablesCanonicalizeFieldNames() {
+        assertTrue(
+            "CANONICALIZE_FIELD_NAMES must be on; NdJsonPageDecoder's identity-keyed field-name cache depends on it",
+            NdJsonUtils.JSON_FACTORY.isEnabled(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES)
+        );
+    }
+
+    /**
      * Behavioural check for {@code AUTO_CLOSE_SOURCE = false}: closing the parser must not
      * close the underlying stream. Schema inference and parse-error recovery rely on this.
      */


### PR DESCRIPTION
NdJsonPageDecoder previously paid String.hashCode plus a HashMap
probe on every field name of every record, including the unprojected
fields a narrow projection skips. Jacksons canonicaliser already
returns stable String instances per name, so an IdentityHashMap on
each BlockDecoder turns the lookup into a single reference compare
after the first occurrence; the slow HashMap fallback runs at most
once per unique name. A sentinel decoder marks known-unprojected
names so the cache covers both projected and skip paths.

The cache is bounded per decoder at max(256, children.size() * 4)
entries so dynamic-key NDJSON (per-tenant column names, embedded
event ids, sparse extensions) cannot grow it without bound; past
the bound, new names fall through to the HashMap on every probe
and correctness degrades to no cache rather than to a memory leak.

This is the part of issue 966 the public Jackson API actually
permits. The headline name-tokenisation cost is irreducible without
forking UTF8StreamJsonParser; the HashMap residual is small but
free and the fix is local.

A factory pin in NdJsonUtilsTests catches accidental drift on
CANONICALIZE_FIELD_NAMES, which the cache depends on.