### PR TITLE
Unmute TransportVersionValidationFuncTest on Windows

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,9 +248,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/151925
-- class: org.elasticsearch.gradle.internal.transport.TransportVersionValidationFuncTest
-  method: unreferable definitions can have primary ids that are patches
-  issue: https://github.com/elastic/elasticsearch/issues/152051
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testAverageWriteLoadMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/152064


### PR DESCRIPTION
Unmutes `TransportVersionValidationFuncTest#unreferable definitions can have primary ids that are patches` which failed once on a Windows CI host (9.4).

The failure produced an `IllegalStateException` wrapping a Gradle build error with no reproducible seed, suggesting a CI host communication issue rather than a real test bug.

Closes #152051