### PR TITLE
Wire remaining  ES|QL HIGHLIGHT options through to the operator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HighlightConfig.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HighlightConfig.java
@@ -7,11 +7,20 @@
 
 package org.elasticsearch.compute.operator;
 
+import java.util.Locale;
+
 /**
  * Compute-side configuration handed straight to {@link HighlightOperator}.
  * The planner resolves the user-facing {@code WITH { ... }} options into the primitive values carried here, and the
  * operator builds its Lucene machinery from them. Keeping this record in the compute module (rather than referencing
  * the ES|QL planning-layer options type) means the operator depends only on plain primitives.
+ *
+ * @param wordBoundary       when {@code true} the unified highlighter breaks fragments on word boundaries instead of
+ *                           sentences (the {@code boundary_scanner=word} option).
+ * @param locale             locale used by the break iterator (the {@code boundary_scanner_locale} option).
+ * @param orderByScore       when {@code true} fragments are returned by descending score instead of document order
+ *                           (the {@code order=score} option).
+ * @param maxAnalyzedOffset  per-field analysis bound; a negative value means "use the index setting", matching Query DSL.
  */
 public record HighlightConfig(
     String queryText,
@@ -20,7 +29,11 @@ public record HighlightConfig(
     String encoder,
     int numberOfFragments,
     int fragmentSize,
-    int noMatchSize
+    int noMatchSize,
+    boolean wordBoundary,
+    Locale locale,
+    boolean orderByScore,
+    int maxAnalyzedOffset
 ) {
 
     /** Encoder name that escapes HTML markup in the highlighted text; any other value uses the default (no escaping). */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HighlightOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HighlightOperator.java
@@ -41,6 +41,7 @@ import org.elasticsearch.lucene.search.uhighlight.Snippet;
 import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
@@ -90,6 +91,8 @@ public class HighlightOperator extends AbstractPageMappingOperator {
                 + config.fragmentSize()
                 + ", no_match_size="
                 + config.noMatchSize()
+                + ", order_by_score="
+                + config.orderByScore()
                 + "]";
         }
     }
@@ -116,29 +119,42 @@ public class HighlightOperator extends AbstractPageMappingOperator {
         this.query = parsedQuery != null ? parsedQuery : new MatchNoDocsQuery("HIGHLIGHT query produced no terms");
         Encoder encoder = HighlightConfig.HTML_ENCODER.equals(config.encoder()) ? new SimpleHTMLEncoder() : new DefaultEncoder();
         this.formatter = new CustomPassageFormatter(config.preTag(), config.postTag(), encoder, config.numberOfFragments());
-        this.maxAnalyzedOffset = IndexSettings.MAX_ANALYZED_OFFSET_SETTING.get(Settings.EMPTY);
+        // A negative value means "use the index setting", matching Query DSL.
+        this.maxAnalyzedOffset = config.maxAnalyzedOffset() < 0
+            ? IndexSettings.MAX_ANALYZED_OFFSET_SETTING.get(Settings.EMPTY)
+            : config.maxAnalyzedOffset();
         // Ask Lucene for every passage and trim to number_of_fragments ourselves. Lucene would otherwise keep the
         // top passages by score, which loses document order when several sentences tie. We want document order.
         this.highlighterNumberOfFragments = Integer.MAX_VALUE - 1;
-        // TODO: honour boundary_scanner, boundary_scanner_locale, boundary_chars, boundary_max_scan, and order.
-        if (config.numberOfFragments() == 0) {
+        this.breakIteratorSupplier = breakIterator(
+            config.numberOfFragments(),
+            config.fragmentSize(),
+            config.wordBoundary(),
+            config.locale()
+        );
+    }
+
+    // Mirrors DefaultHighlighter getBreakIterator: word scanner ignores fragment_size, sentence scanner honours it.
+    private static Supplier<BreakIterator> breakIterator(int numberOfFragments, int fragmentSize, boolean wordBoundary, Locale locale) {
+        if (numberOfFragments == 0) {
             // One passage per (multi-)value: only break on the multi-value separator.
-            this.breakIteratorSupplier = () -> new CustomSeparatorBreakIterator(CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR);
-        } else {
-            // Fragment by sentence, bounded to fragment_size characters when a positive size is requested.
-            this.breakIteratorSupplier = () -> new SplittingBreakIterator(
-                sentenceBreakIterator(config.fragmentSize()),
-                CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR
-            );
+            return () -> new CustomSeparatorBreakIterator(CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR);
         }
+        return () -> {
+            BreakIterator passageIterator;
+            if (wordBoundary) {
+                passageIterator = BreakIterator.getWordInstance(locale);
+            } else {
+                passageIterator = sentenceBreakIterator(fragmentSize, locale);
+            }
+            return new SplittingBreakIterator(passageIterator, CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR);
+        };
     }
 
     // Break on sentences, capped to fragment_size chars when it's positive (long sentences get split, short ones may
     // share a fragment). A non-positive fragment_size drops the cap and just breaks on sentences.
-    private static BreakIterator sentenceBreakIterator(int fragmentSize) {
-        return fragmentSize > 0
-            ? BoundedBreakIteratorScanner.getSentence(Locale.ROOT, fragmentSize)
-            : BreakIterator.getSentenceInstance(Locale.ROOT);
+    private static BreakIterator sentenceBreakIterator(int fragmentSize, Locale locale) {
+        return fragmentSize > 0 ? BoundedBreakIteratorScanner.getSentence(locale, fragmentSize) : BreakIterator.getSentenceInstance(locale);
     }
 
     @Override
@@ -150,21 +166,24 @@ public class HighlightOperator extends AbstractPageMappingOperator {
         BytesRef scratch = new BytesRef();
         try {
             for (int f = 0; f < fieldEvaluators.length; f++) {
-                try (Block block = fieldEvaluators[f].eval(page)) {
-                    if (block instanceof BytesRefBlock fieldValues) {
-                        highlightedBlocks[f] = highlightField(fieldValues, rowCount, scratch);
-                    } else {
-                        throw new IllegalArgumentException(
-                            "HIGHLIGHT ON fields must evaluate to keyword/text values but got [" + block.getClass().getSimpleName() + "]"
-                        );
-                    }
-                }
+                highlightedBlocks[f] = highlightField(page, f, rowCount, scratch);
             }
             return page.appendBlocks(highlightedBlocks);
         } catch (Exception e) {
             // If we highlighted some fields but failed before appending them, we need to release them.
             Releasables.closeExpectNoException(highlightedBlocks);
             throw e;
+        }
+    }
+
+    private Block highlightField(Page page, int fieldIndex, int rowCount, BytesRef scratch) {
+        try (Block block = fieldEvaluators[fieldIndex].eval(page)) {
+            if (block instanceof BytesRefBlock fieldValues) {
+                return highlightField(fieldValues, rowCount, scratch);
+            }
+            throw new IllegalArgumentException(
+                "HIGHLIGHT ON fields must evaluate to keyword/text values but got [" + block.getClass().getSimpleName() + "]"
+            );
         }
     }
 
@@ -233,26 +252,43 @@ public class HighlightOperator extends AbstractPageMappingOperator {
 
     /**
      * Appends the highlighter output for one row: {@code null} when there is no snippet (no match and no
-     * {@code no_match_size}), a single value, or a multi-value entry when several fragments are returned. When
-     * {@code number_of_fragments > 0} the snippets, which arrive in document order, are capped to that many fragments.
+     * {@code no_match_size}), a single value, or a multi-value entry when several fragments are returned. Snippets
+     * arrive in document order; when {@code order} is {@code score} they are re-sorted by descending score first. When
+     * {@code number_of_fragments > 0} they are then capped to that many fragments.
      */
     private void appendSnippets(BytesRefBlock.Builder builder, Snippet[] snippets) {
-        int length = snippets == null ? 0 : snippets.length;
+        Snippet[] selectedSnippets = selectSnippets(snippets);
+        appendSelectedSnippets(builder, selectedSnippets);
+    }
+
+    private Snippet[] selectSnippets(Snippet[] snippets) {
+        if (snippets == null || snippets.length == 0) {
+            return new Snippet[0];
+        }
+        if (config.orderByScore() && snippets.length > 1) {
+            Arrays.sort(snippets, Comparator.comparingDouble(Snippet::getScore).reversed());
+        }
         int numberOfFragments = config.numberOfFragments();
-        if (numberOfFragments > 0) {
-            length = Math.min(length, numberOfFragments);
+        if (numberOfFragments > 0 && snippets.length > numberOfFragments) {
+            return Arrays.copyOf(snippets, numberOfFragments);
         }
-        if (length == 0) {
+        return snippets;
+    }
+
+    private static void appendSelectedSnippets(BytesRefBlock.Builder builder, Snippet[] selectedSnippets) {
+        if (selectedSnippets.length == 0) {
             builder.appendNull();
-        } else if (length == 1) {
-            builder.appendBytesRef(new BytesRef(snippets[0].getText()));
-        } else {
-            builder.beginPositionEntry();
-            for (int i = 0; i < length; i++) {
-                builder.appendBytesRef(new BytesRef(snippets[i].getText()));
-            }
-            builder.endPositionEntry();
+            return;
         }
+        if (selectedSnippets.length == 1) {
+            builder.appendBytesRef(new BytesRef(selectedSnippets[0].getText()));
+            return;
+        }
+        builder.beginPositionEntry();
+        for (Snippet snippet : selectedSnippets) {
+            builder.appendBytesRef(new BytesRef(snippet.getText()));
+        }
+        builder.endPositionEntry();
     }
 
     @Override
@@ -266,6 +302,8 @@ public class HighlightOperator extends AbstractPageMappingOperator {
             + config.fragmentSize()
             + ", no_match_size="
             + config.noMatchSize()
+            + ", order_by_score="
+            + config.orderByScore()
             + ", fields="
             + Arrays.toString(fieldEvaluators)
             + "]";

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HighlightOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HighlightOperatorTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.test.operator.blocksource.BytesRefBlockSourceOp
 import org.hamcrest.Matcher;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -44,12 +45,17 @@ public class HighlightOperatorTests extends OperatorTestCase {
 
     @Override
     protected Matcher<String> expectedDescriptionOfSimple() {
-        return equalTo("HighlightOperator[query=fox, fields=1, number_of_fragments=5, fragment_size=0, no_match_size=0]");
+        return equalTo(
+            "HighlightOperator[query=fox, fields=1, number_of_fragments=5, fragment_size=0, no_match_size=0, order_by_score=false]"
+        );
     }
 
     @Override
     protected Matcher<String> expectedToStringOfSimple() {
-        return equalTo("HighlightOperator[query=content:fox, number_of_fragments=5, fragment_size=0, no_match_size=0, fields=[identity]]");
+        return equalTo(
+            "HighlightOperator[query=content:fox, number_of_fragments=5, fragment_size=0, "
+                + "no_match_size=0, order_by_score=false, fields=[identity]]"
+        );
     }
 
     @Override
@@ -136,10 +142,47 @@ public class HighlightOperatorTests extends OperatorTestCase {
 
     public void testHtmlEncoderEscapesMarkup() {
         String text = "Use <b>bold</b> tags & special chars with the Ring.";
-        HighlightConfig config = new HighlightConfig("ring", DEFAULT_PRE_TAG, DEFAULT_POST_TAG, HighlightConfig.HTML_ENCODER, 5, 0, 0);
+        HighlightConfig config = new HighlightConfig(
+            "ring",
+            DEFAULT_PRE_TAG,
+            DEFAULT_POST_TAG,
+            HighlightConfig.HTML_ENCODER,
+            5,
+            0,
+            0,
+            false,
+            Locale.ROOT,
+            false,
+            -1
+        );
         BytesRefBlock result = highlightSingle(config, text);
         try {
             assertThat(value(result, 0), equalTo("Use &lt;b&gt;bold&lt;&#x2F;b&gt; tags &amp; special chars with the <em>Ring</em>."));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testWordBoundaryFragments() {
+        String text = "Elasticsearch powers fast search across very many documents and shards in a single cluster.";
+        BytesRefBlock result = highlight(config("elasticsearch", 5, 20, 0, true, false), bytesRefs(List.of(List.of(text))));
+        try {
+            // The word scanner ignores fragment_size and breaks on word boundaries, so the fragment is short.
+            assertThat(value(result, 0).contains("<em>Elasticsearch</em>"), equalTo(true));
+            assertThat(value(result, 0).length(), lessThan(text.length() + "<em></em>".length()));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testOrderByScoreReturnsBestFragmentFirst() {
+        // The second sentence has two matches, so it scores higher and must come first when ordering by score.
+        String text = "Search is fast. Fast search powers fast results. Indexing is simple.";
+        BytesRefBlock result = highlight(config("fast", 5, 0, 0, false, true), bytesRefs(List.of(List.of(text))));
+        try {
+            int first = result.getFirstValueIndex(0);
+            BytesRef scratch = new BytesRef();
+            assertThat(result.getBytesRef(first, scratch).utf8ToString(), startsWith("<em>Fast</em> search powers <em>fast</em> results."));
         } finally {
             result.close();
         }
@@ -201,7 +244,42 @@ public class HighlightOperatorTests extends OperatorTestCase {
     }
 
     private static HighlightConfig config(String queryText, int fragments, int fragmentSize, int noMatchSize) {
-        return new HighlightConfig(queryText, DEFAULT_PRE_TAG, DEFAULT_POST_TAG, DEFAULT_ENCODER, fragments, fragmentSize, noMatchSize);
+        return new HighlightConfig(
+            queryText,
+            DEFAULT_PRE_TAG,
+            DEFAULT_POST_TAG,
+            DEFAULT_ENCODER,
+            fragments,
+            fragmentSize,
+            noMatchSize,
+            false,
+            Locale.ROOT,
+            false,
+            -1
+        );
+    }
+
+    private static HighlightConfig config(
+        String queryText,
+        int fragments,
+        int fragmentSize,
+        int noMatchSize,
+        boolean wordBoundary,
+        boolean orderByScore
+    ) {
+        return new HighlightConfig(
+            queryText,
+            DEFAULT_PRE_TAG,
+            DEFAULT_POST_TAG,
+            DEFAULT_ENCODER,
+            fragments,
+            fragmentSize,
+            noMatchSize,
+            wordBoundary,
+            Locale.ROOT,
+            orderByScore,
+            -1
+        );
     }
 
     // Returns the input block unchanged, so the operator highlights channel 0 directly.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
@@ -1,6 +1,6 @@
 # Basic single-field highlight, default <em> tags, single short sentence.
 highlightSingleField
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "The quick brown fox jumps over the lazy dog."
 | HIGHLIGHT "fox" ON content
@@ -14,7 +14,7 @@ The quick brown <em>fox</em> jumps over the lazy dog.
 
 # Custom pre/post tags via WITH.
 highlightCustomTags
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "The quick brown fox jumps over the lazy dog."
 | HIGHLIGHT "fox" ON content WITH { "pre_tags": ["<b>"], "post_tags": ["</b>"] }
@@ -28,7 +28,7 @@ The quick brown <b>fox</b> jumps over the lazy dog.
 
 # Multiple query terms (OR'd) wrap independently within a single sentence.
 highlightMultipleTermsQuery
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Sauron forged the One Ring in the fires of Mount Doom."
 | HIGHLIGHT "ring sauron" ON content
@@ -42,7 +42,7 @@ highlight_content:keyword
 
 # Matching is case-insensitive; original casing preserved.
 highlightCaseInsensitive
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "The One Ring was forged by Sauron."
 | HIGHLIGHT "RING" ON content
@@ -56,7 +56,7 @@ The One <em>Ring</em> was forged by Sauron.
 
 # HTML encoder escapes markup and special characters while still wrapping matches.
 highlightHtmlEncoder
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Use <b>bold</b> tags & special chars with the Ring."
 | HIGHLIGHT "ring" ON content WITH { "encoder": "html" }
@@ -70,7 +70,7 @@ Use &lt;b&gt;bold&lt;&#x2F;b&gt; tags &amp; special chars with the <em>Ring</em>
 
 # No match in the field -> null (default no_match_size = 0).
 highlightNoMatch
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "A plain text with no matching terms."
 | HIGHLIGHT "nonexistent" ON content
@@ -82,9 +82,11 @@ null
 ;
 
 
-# no_match_size returns leading text even when nothing matches.
+# no_match_size > 0 makes a non-matching field fall back to its leading text instead of null. Contrast
+# with highlightNoMatch above, which returns null for the same kind of non-matching query when no_match_size
+# is left at its default of 0.
 highlightNoMatchSize
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Gardens and flowers bloom in spring."
 | HIGHLIGHT "elasticsearch" ON content WITH { "no_match_size": 200 }
@@ -98,7 +100,7 @@ Gardens and flowers bloom in spring.
 
 # Query text that analyzes to no terms still behaves as a no-match query.
 highlightEmptyQueryNoMatchSize
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Plain fallback text."
 | HIGHLIGHT "" ON content WITH { "no_match_size": 200 }
@@ -112,7 +114,7 @@ Plain fallback text.
 
 # Multiple ON fields each get their own highlight_<field> column.
 highlightMultipleFields
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
 | HIGHLIGHT "king tolkien" ON title, body
@@ -126,7 +128,7 @@ Return of the <em>King</em>      | <em>Tolkien</em> wrote the epic saga.
 
 # A field that the query does not match yields null while the other is populated.
 highlightFieldWithNoMatch
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW title = "Return of the King", body = "An ordinary description."
 | HIGHLIGHT "king" ON title, body
@@ -140,7 +142,7 @@ Return of the <em>King</em>   | null
 
 # Multi-valued field: every value is highlighted, order preserved.
 highlightMultivaluedField
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW positions = ["Senior Team Lead", "Lead Architect"]
 | HIGHLIGHT "lead" ON positions
@@ -154,7 +156,7 @@ highlight_positions:keyword
 
 # Sentence fragments over multi-valued fields must stay inside a single value.
 highlightMultivaluedFragmentsDoNotCrossValues
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW positions = ["Senior lead", "Lead architect"]
 | HIGHLIGHT "lead" ON positions WITH { "number_of_fragments": 1 }
@@ -169,7 +171,7 @@ Senior <em>lead</em>
 # number_of_fragments caps how many fragments are returned (document order, default order=none). A small fragment_size
 # bounds each passage to a single sentence so the three sentences become three candidate fragments, capped to two.
 highlightNumberOfFragments
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Elasticsearch is fast. Elasticsearch is scalable. Elasticsearch is open."
 | HIGHLIGHT "elasticsearch" ON content WITH { "number_of_fragments": 2, "fragment_size": 30 }
@@ -183,7 +185,7 @@ highlight_content:keyword
 
 # A single short sentence stays one fragment regardless of number_of_fragments.
 highlightSingleFragmentForShortText
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Elasticsearch powers fast search."
 | HIGHLIGHT "elasticsearch" ON content WITH { "number_of_fragments": 5 }
@@ -195,9 +197,24 @@ highlight_content:keyword
 ;
 
 
+# number_of_fragments = 0 disables fragmentation: the whole field value is returned as a single fragment
+# with the matches still wrapped, instead of being split into per-sentence fragments.
+highlightNumberOfFragmentsZero
+required_capability: highlight_v2
+
+ROW content = "Elasticsearch is fast. Elasticsearch is scalable. Elasticsearch is open."
+| HIGHLIGHT "elasticsearch" ON content WITH { "number_of_fragments": 0 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+<em>Elasticsearch</em> is fast. <em>Elasticsearch</em> is scalable. <em>Elasticsearch</em> is open.
+;
+
+
 # HIGHLIGHT over fields loaded from an index, after a full-text WHERE filter.
 highlightFromIndexAfterMatch
-required_capability: highlight_v1
+required_capability: highlight_v2
 required_capability: match_function
 
 FROM books
@@ -216,7 +233,7 @@ book_no:keyword | highlight_title:keyword
 # Sorting on a highlight_* column forces HIGHLIGHT to run before the final TopN, so it is
 # pushed down to the data nodes; this exercises HighlightExec serialization end-to-end.
 highlightPushedToDataNodes
-required_capability: highlight_v1
+required_capability: highlight_v2
 required_capability: match_function
 
 FROM books
@@ -235,7 +252,7 @@ book_no:keyword | highlight_title:keyword
 
 # HIGHLIGHT runs after the final SORT ... LIMIT (TopN), like Query DSL's post-fetch highlight.
 highlightAfterSortLimit
-required_capability: highlight_v1
+required_capability: highlight_v2
 required_capability: match_function
 
 FROM books METADATA _score
@@ -255,7 +272,7 @@ book_no:keyword | highlight_title:keyword
 
 # The original field is preserved alongside the appended highlight_<field> column.
 highlightKeepsOriginalColumn
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "The One Ring was forged by Sauron."
 | HIGHLIGHT "ring" ON content
@@ -267,9 +284,10 @@ The One Ring was forged by Sauron. | The One <em>Ring</em> was forged by Sauron.
 ;
 
 
-# A fragment_size larger than the whole text returns a single bounded fragment covering both sentences.
+# fragment_size bounds each sentence-based fragment to that many characters. A large value lets both
+# sentences share one fragment; the contrasting small-fragment_size test below splits them apart.
 highlightFragmentSizeLargerThanText
-required_capability: highlight_v1
+required_capability: highlight_v2
 
 ROW content = "Elasticsearch is fast. Elasticsearch is scalable."
 | HIGHLIGHT "elasticsearch" ON content WITH { "fragment_size": 100 }
@@ -278,4 +296,354 @@ ROW content = "Elasticsearch is fast. Elasticsearch is scalable."
 
 highlight_content:keyword
 <em>Elasticsearch</em> is fast. <em>Elasticsearch</em> is scalable.
+;
+
+
+# A small fragment_size keeps each sentence in its own fragment, so the two matching sentences become
+# two separate values instead of sharing one fragment as they do with the large fragment_size above.
+highlightSmallFragmentSizeSplitsSentences
+required_capability: highlight_v2
+
+ROW content = "Elasticsearch is fast. Elasticsearch is scalable."
+| HIGHLIGHT "elasticsearch" ON content WITH { "fragment_size": 25 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+[<em>Elasticsearch</em> is fast., <em>Elasticsearch</em> is scalable.]
+;
+
+
+# The default sentence boundary scanner breaks fragments on sentence boundaries: with a fragment_size that
+# spans both sentences, the match brings back the full surrounding text. Contrast with the word boundary
+# scanner test directly below, which scopes the fragment to the matched word instead.
+highlightSentenceBoundaryScanner
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron. Frodo carried it to Mount Doom."
+| HIGHLIGHT "ring" ON content WITH { "boundary_scanner": "sentence" }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+The One <em>Ring</em> was forged by Sauron. Frodo carried it to Mount Doom.
+;
+
+
+# The word boundary scanner breaks fragments on word boundaries instead of sentences, so the fragment is
+# scoped to the words around the match rather than the full sentence the sentence scanner returns above.
+highlightWordBoundaryScanner
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron. Frodo carried it to Mount Doom."
+| HIGHLIGHT "ring" ON content WITH { "boundary_scanner": "word" }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+<em>Ring</em>
+;
+
+
+# boundary_scanner_locale picks the Locale for the break iterator. For ROOT-equivalent English input it
+# breaks identically to the default locale, so the highlighted output is unchanged; this asserts the option
+# is accepted and applied without altering the result for this input.
+highlightBoundaryScannerLocale
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron."
+| HIGHLIGHT "ring" ON content WITH { "boundary_scanner_locale": "en-US" }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+The One <em>Ring</em> was forged by Sauron.
+;
+
+
+# order=none (the default) keeps fragments in document order, so the values come back in the order they
+# appear in the input regardless of how many matches each fragment has. Contrast with the order=score test
+# below, which reorders these same two values by descending score.
+highlightOrderNoneKeepsDocumentOrder
+required_capability: highlight_v2
+
+ROW content = ["fast search", "fast and fast results"]
+| HIGHLIGHT "fast" ON content WITH { "order": "none" }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+[<em>fast</em> search, <em>fast</em> and <em>fast</em> results]
+;
+
+
+# order=score reorders fragments by descending score: the second value has two matches so it scores higher
+# and is returned first, flipping the document order seen in the order=none test above.
+highlightOrderByScore
+required_capability: highlight_v2
+
+ROW content = ["fast search", "fast and fast results"]
+| HIGHLIGHT "fast" ON content WITH { "order": "score" }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+[<em>fast</em> and <em>fast</em> results, <em>fast</em> search]
+;
+
+
+# max_analyzed_offset caps how far into the field analysis runs: only terms whose offset is below the cap
+# are considered for matching. A match within the first 10 characters ("One" ends at offset 7) is still
+# highlighted under a cap of 10.
+highlightMaxAnalyzedOffsetWithinLimit
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron."
+| HIGHLIGHT "one" ON content WITH { "max_analyzed_offset": 10 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+The <em>One</em> Ring was forged by Sauron.
+;
+
+
+# A match that sits past the max_analyzed_offset cap is invisible to the highlighter: "Sauron" starts well
+# beyond offset 10, so analysis stops before reaching it, nothing matches, and (with the default
+# no_match_size = 0) the row is null.
+highlightMaxAnalyzedOffsetTruncatesMatch
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron."
+| HIGHLIGHT "sauron" ON content WITH { "max_analyzed_offset": 10 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+null
+;
+
+
+# boundary_chars, boundary_max_scan and phrase_limit only affect the FastVectorHighlighter. HIGHLIGHT
+# always uses the unified highlighter, so these are accepted for Query DSL parity but are no-ops: the
+# output is identical to running with default options.
+highlightUnifiedNoOpOptions
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron."
+| HIGHLIGHT "ring" ON content WITH { "boundary_chars": ".,!?", "boundary_max_scan": 10, "phrase_limit": 64 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+The One <em>Ring</em> was forged by Sauron.
+;
+
+
+# The query is a bag of words, so adjacent matched terms are each wrapped independently rather than being
+# merged into one span: "new york" matches "New" and "York" as two separate terms, producing two adjacent
+# <em>...</em> wraps. (Span merging in the formatter only kicks in for overlapping offsets, which a
+# term-based query does not produce.)
+highlightAdjacentMatchesWrappedIndependently
+required_capability: highlight_v2
+
+ROW content = "I love New York City in the spring."
+| HIGHLIGHT "new york" ON content
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+I love <em>New</em> <em>York</em> City in the spring.
+;
+
+
+# order=score combined with a number_of_fragments cap keeps the highest-scoring fragments, not the first in
+# document order. The third value has two matches so it scores highest and survives the cap of 1, even
+# though it is last in document order.
+highlightOrderByScoreWithFragmentCap
+required_capability: highlight_v2
+
+ROW content = ["one fast result", "a slow result", "fast and fast wins"]
+| HIGHLIGHT "fast" ON content WITH { "order": "score", "number_of_fragments": 1 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+<em>fast</em> and <em>fast</em> wins
+;
+
+
+# no_match_size bounds the leading text returned for a non-matching field. With a field longer than the
+# size, only the leading portion (the first sentence here, trimmed at the sentence boundary) is returned
+# rather than the whole multi-sentence value.
+highlightNoMatchSizeTruncatesLongText
+required_capability: highlight_v2
+
+ROW content = "Gardens and flowers bloom in spring. Bees hum across the meadow. Rain falls in autumn."
+| HIGHLIGHT "elasticsearch" ON content WITH { "no_match_size": 30 }
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+Gardens and flowers bloom in spring
+;
+
+
+# In a multi-valued field, only values that contain a match are highlighted and returned; values with no
+# match are dropped, so a single matching value comes back as a single value rather than a multi-value.
+highlightMultivaluedPartialMatch
+required_capability: highlight_v2
+
+ROW positions = ["Staff Engineer", "Team Lead", "Product Manager"]
+| HIGHLIGHT "lead" ON positions
+| KEEP highlight_positions
+;
+
+highlight_positions:keyword
+Team <em>Lead</em>
+;
+
+
+# An empty query analyzes to no terms and, with the default no_match_size = 0, yields null (the
+# MatchNoDocsQuery path) rather than echoing the field text back.
+highlightEmptyQueryDefaultNoMatchSizeIsNull
+required_capability: highlight_v2
+
+ROW content = "Plain fallback text."
+| HIGHLIGHT "" ON content
+| KEEP highlight_content
+;
+
+highlight_content:keyword
+null
+;
+
+
+# Column pruning: with two ON fields but only one highlight_<field> column kept downstream, the other
+# highlight column is pruned away by the KEEP without breaking the operator's block layout (the operator
+# always appends one block per ON field, so HIGHLIGHT itself is never partially pruned).
+highlightColumnPruningKeepsSingleHighlight
+required_capability: highlight_v2
+
+ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
+| HIGHLIGHT "king tolkien" ON title, body
+| KEEP highlight_body
+;
+
+highlight_body:keyword
+<em>Tolkien</em> wrote the epic saga.
+;
+
+
+# Column pruning also drops the original ON columns while keeping only the requested highlight column: the
+# title/body inputs are still read to compute the highlights, but neither survives in the final output.
+highlightColumnPruningDropsOriginalColumns
+required_capability: highlight_v2
+
+ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
+| HIGHLIGHT "king tolkien" ON title, body
+| KEEP highlight_title
+;
+
+highlight_title:keyword
+Return of the <em>King</em>
+;
+
+
+# Same column pruning over fields loaded from an index: two ON fields are highlighted but only
+# highlight_title is kept, so the unused highlight_description column is pruned downstream while both
+# ON fields are still extracted and highlighted by the operator.
+highlightColumnPruningFromIndex
+required_capability: highlight_v2
+required_capability: match_function
+
+FROM books
+| WHERE MATCH(title, "Return")
+| HIGHLIGHT "return" ON title, description
+| KEEP book_no, highlight_title
+| SORT book_no
+;
+
+book_no:keyword | highlight_title:keyword
+2714            | <em>Return</em> of the King Being the Third Part of The Lord of the Rings
+7350            | <em>Return</em> of the Shadow
+;
+
+
+# RENAME a single highlight column: HIGHLIGHT is a GeneratingPlan, so renaming a generated column flows
+# through withGeneratedNames and the renamed column carries the same highlighted value, while the
+# unrenamed highlight column keeps its default name.
+highlightRenameSingleColumn
+required_capability: highlight_v2
+
+ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
+| HIGHLIGHT "king tolkien" ON title, body
+| RENAME highlight_title AS h_title
+| KEEP h_title, highlight_body
+;
+
+h_title:keyword             | highlight_body:keyword
+Return of the <em>King</em> | <em>Tolkien</em> wrote the epic saga.
+;
+
+
+# RENAME both highlight columns: each generated column is renamed independently and keeps its own
+# highlighted value, confirming the ON-field-to-column alignment survives renaming.
+highlightRenameAllColumns
+required_capability: highlight_v2
+
+ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
+| HIGHLIGHT "king tolkien" ON title, body
+| RENAME highlight_title AS h_title, highlight_body AS h_body
+| KEEP h_title, h_body
+;
+
+h_title:keyword             | h_body:keyword
+Return of the <em>King</em> | <em>Tolkien</em> wrote the epic saga.
+;
+
+
+# DROP one highlight column: dropping highlight_title removes it from the output while the remaining
+# highlight_body column keeps its correct value, and the operator still appends one block per ON field.
+highlightDropSingleHighlightColumn
+required_capability: highlight_v2
+
+ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
+| HIGHLIGHT "king tolkien" ON title, body
+| DROP highlight_title, title, body
+;
+
+highlight_body:keyword
+<em>Tolkien</em> wrote the epic saga.
+;
+
+
+# DROP the original ON columns but keep both highlight columns: the inputs are consumed by HIGHLIGHT and
+# dropped from the output, leaving only the two highlighted columns.
+highlightDropOriginalColumns
+required_capability: highlight_v2
+
+ROW title = "Return of the King", body = "Tolkien wrote the epic saga."
+| HIGHLIGHT "king tolkien" ON title, body
+| DROP title, body
+;
+
+highlight_title:keyword     | highlight_body:keyword
+Return of the <em>King</em> | <em>Tolkien</em> wrote the epic saga.
+;
+
+
+# RENAME the original ON column before HIGHLIGHT references it: HIGHLIGHT highlights the renamed column and
+# names its generated output after the new column name.
+highlightRenameOnFieldBeforeHighlight
+required_capability: highlight_v2
+
+ROW content = "The One Ring was forged by Sauron."
+| RENAME content AS body
+| HIGHLIGHT "ring" ON body
+| KEEP highlight_body
+;
+
+highlight_body:keyword
+The One <em>Ring</em> was forged by Sauron.
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3190,7 +3190,7 @@ public class EsqlCapabilities {
          * Support for the {@code HIGHLIGHT} command: grammar, plan nodes, serialization, and execution that exposes the
          * generated {@code highlight_*} columns. Snapshot-only.
          */
-        HIGHLIGHT_V1(Build.current().isSnapshot()),
+        HIGHLIGHT_V2(Build.current().isSnapshot()),
 
         /**
          * Support for PromQL {@code histogram_quantile()} over classic histograms with {@code le} buckets.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Highlight.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Highlight.java
@@ -10,11 +10,15 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
@@ -29,13 +33,14 @@ import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-// TODO: add option-value verification (e.g. encoder must be default|html, order must be none|score).
 // TODO: carry an analyzer name here once the "analyzer" option is supported.
-public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPlan<Highlight> {
+public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPlan<Highlight>, PostAnalysisVerificationAware {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         LogicalPlan.class,
@@ -45,22 +50,22 @@ public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPl
 
     public static final String DEFAULT_PREFIX = "highlight_";
 
-    // Options honoured today by HighlightOptions and the operator.
+    // Options honoured by HighlightOptions and the unified highlighter.
     public static final String PRE_TAGS = "pre_tags";
     public static final String POST_TAGS = "post_tags";
     public static final String NUMBER_OF_FRAGMENTS = "number_of_fragments";
     public static final String FRAGMENT_SIZE = "fragment_size";
     public static final String ENCODER = "encoder";
     public static final String NO_MATCH_SIZE = "no_match_size";
-
-    // Options the parser accepts but that are not wired through yet. The feature is snapshot-only, so accepting them now
-    // keeps the grammar stable; each is honoured in a follow-up. TODO: wire these through HighlightOptions and the operator.
     public static final String BOUNDARY_SCANNER = "boundary_scanner";
     public static final String BOUNDARY_SCANNER_LOCALE = "boundary_scanner_locale";
-    public static final String BOUNDARY_CHARS = "boundary_chars";
-    public static final String BOUNDARY_MAX_SCAN = "boundary_max_scan";
     public static final String ORDER = "order";
     public static final String MAX_ANALYZED_OFFSET = "max_analyzed_offset";
+
+    // Accepted for Query DSL parity but only used by the FastVectorHighlighter, so they are no-ops for the unified
+    // highlighter that HIGHLIGHT always uses.
+    public static final String BOUNDARY_CHARS = "boundary_chars";
+    public static final String BOUNDARY_MAX_SCAN = "boundary_max_scan";
     public static final String PHRASE_LIMIT = "phrase_limit";
 
     private static final List<String> VALID_OPTION_NAMES = List.of(
@@ -222,6 +227,30 @@ public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPl
             }
         }
         return options == null || options.resolved();
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        verifyEnum(failures, ENCODER, HighlightOptions.ALLOWED_ENCODERS, false);
+        verifyEnum(failures, BOUNDARY_SCANNER, HighlightOptions.ALLOWED_BOUNDARY_SCANNERS, true);
+        verifyEnum(failures, ORDER, HighlightOptions.ALLOWED_ORDERS, true);
+    }
+
+    // Checks that a foldable string option is one of the allowed values.
+    private void verifyEnum(Failures failures, String name, List<String> allowed, boolean caseInsensitive) {
+        if (options == null) {
+            return;
+        }
+        Expression value = options.get(name);
+        if (value == null || value.foldable() == false) {
+            return;
+        }
+        String actual = BytesRefs.toString(value.fold(FoldContext.small()));
+        String valueToCheck = caseInsensitive ? actual.toLowerCase(Locale.ROOT) : actual;
+        if (allowed.contains(valueToCheck)) {
+            return;
+        }
+        failures.add(fail(this, "Invalid [{}] value [{}] in HIGHLIGHT, expected one of {}", name, actual, allowed));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptions.java
@@ -13,19 +13,29 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Resolved, plain-Java view of the {@code WITH { ... }} options of a {@link Highlight} command, with defaults applied.
  * Built once at local-execution-planning time from the (foldable) {@link MapExpression} so the operator factory only
  * deals with primitives.
+ * <p>
+ * {@code boundary_chars}, {@code boundary_max_scan} and {@code phrase_limit} are accepted for Query DSL parity but are
+ * only honoured by the FastVectorHighlighter. HIGHLIGHT always uses the unified highlighter, so they are no-ops here.
  */
-// TODO: extend this record to carry the remaining options so they reach the operator:
-// - boundary_scanner (sentence|word), boundary_scanner_locale, boundary_chars, boundary_max_scan -> break iterator
-// - order (none|score) -> passage sort comparator
-// - max_analyzed_offset -> QueryMaxAnalyzedOffset / re-analysis bound (currently always the index-setting default)
-// - phrase_limit -> phrase matching cap
-// TODO: add an analyzer name field here once the "analyzer" option is supported.
-public record HighlightOptions(String preTag, String postTag, String encoder, int numberOfFragments, int fragmentSize, int noMatchSize) {
+public record HighlightOptions(
+    String preTag,
+    String postTag,
+    String encoder,
+    int numberOfFragments,
+    int fragmentSize,
+    int noMatchSize,
+    String boundaryScanner,
+    Locale boundaryScannerLocale,
+    String order,
+    int maxAnalyzedOffset,
+    int phraseLimit
+) {
 
     public static final String DEFAULT_PRE_TAG = "<em>";
     public static final String DEFAULT_POST_TAG = "</em>";
@@ -35,16 +45,25 @@ public record HighlightOptions(String preTag, String postTag, String encoder, in
     public static final int DEFAULT_FRAGMENT_SIZE = 100;
     public static final int DEFAULT_NO_MATCH_SIZE = 0;
 
+    public static final String BOUNDARY_SCANNER_SENTENCE = "sentence";
+    public static final String BOUNDARY_SCANNER_WORD = "word";
+    public static final String ORDER_NONE = "none";
+    public static final String ORDER_SCORE = "score";
+
+    public static final String DEFAULT_BOUNDARY_SCANNER = BOUNDARY_SCANNER_SENTENCE;
+    public static final Locale DEFAULT_BOUNDARY_SCANNER_LOCALE = Locale.ROOT;
+    public static final String DEFAULT_ORDER = ORDER_NONE;
+
+    public static final List<String> ALLOWED_ENCODERS = List.of(DEFAULT_ENCODER, HTML_ENCODER);
+    public static final List<String> ALLOWED_BOUNDARY_SCANNERS = List.of(BOUNDARY_SCANNER_SENTENCE, BOUNDARY_SCANNER_WORD);
+    public static final List<String> ALLOWED_ORDERS = List.of(ORDER_NONE, ORDER_SCORE);
+    // -1 means "use the index setting", matching Query DSL.
+    public static final int DEFAULT_MAX_ANALYZED_OFFSET = -1;
+    public static final int DEFAULT_PHRASE_LIMIT = 256;
+
     public static HighlightOptions from(MapExpression options, FoldContext foldContext) {
         if (options == null) {
-            return new HighlightOptions(
-                DEFAULT_PRE_TAG,
-                DEFAULT_POST_TAG,
-                DEFAULT_ENCODER,
-                DEFAULT_NUMBER_OF_FRAGMENTS,
-                DEFAULT_FRAGMENT_SIZE,
-                DEFAULT_NO_MATCH_SIZE
-            );
+            return defaults();
         }
         return new HighlightOptions(
             string(options.get(Highlight.PRE_TAGS), foldContext, DEFAULT_PRE_TAG),
@@ -52,7 +71,28 @@ public record HighlightOptions(String preTag, String postTag, String encoder, in
             string(options.get(Highlight.ENCODER), foldContext, DEFAULT_ENCODER),
             integer(options.get(Highlight.NUMBER_OF_FRAGMENTS), foldContext, DEFAULT_NUMBER_OF_FRAGMENTS),
             integer(options.get(Highlight.FRAGMENT_SIZE), foldContext, DEFAULT_FRAGMENT_SIZE),
-            integer(options.get(Highlight.NO_MATCH_SIZE), foldContext, DEFAULT_NO_MATCH_SIZE)
+            integer(options.get(Highlight.NO_MATCH_SIZE), foldContext, DEFAULT_NO_MATCH_SIZE),
+            string(options.get(Highlight.BOUNDARY_SCANNER), foldContext, DEFAULT_BOUNDARY_SCANNER).toLowerCase(Locale.ROOT),
+            locale(options.get(Highlight.BOUNDARY_SCANNER_LOCALE), foldContext),
+            string(options.get(Highlight.ORDER), foldContext, DEFAULT_ORDER).toLowerCase(Locale.ROOT),
+            maxAnalyzedOffset(options.get(Highlight.MAX_ANALYZED_OFFSET), foldContext),
+            integer(options.get(Highlight.PHRASE_LIMIT), foldContext, DEFAULT_PHRASE_LIMIT)
+        );
+    }
+
+    private static HighlightOptions defaults() {
+        return new HighlightOptions(
+            DEFAULT_PRE_TAG,
+            DEFAULT_POST_TAG,
+            DEFAULT_ENCODER,
+            DEFAULT_NUMBER_OF_FRAGMENTS,
+            DEFAULT_FRAGMENT_SIZE,
+            DEFAULT_NO_MATCH_SIZE,
+            DEFAULT_BOUNDARY_SCANNER,
+            DEFAULT_BOUNDARY_SCANNER_LOCALE,
+            DEFAULT_ORDER,
+            DEFAULT_MAX_ANALYZED_OFFSET,
+            DEFAULT_PHRASE_LIMIT
         );
     }
 
@@ -76,6 +116,13 @@ public record HighlightOptions(String preTag, String postTag, String encoder, in
         return BytesRefs.toString(folded);
     }
 
+    private static Locale locale(Expression value, FoldContext foldContext) {
+        if (value == null) {
+            return DEFAULT_BOUNDARY_SCANNER_LOCALE;
+        }
+        return Locale.forLanguageTag(BytesRefs.toString(value.fold(foldContext)));
+    }
+
     private static int integer(Expression value, FoldContext foldContext, int defaultValue) {
         if (value == null) {
             return defaultValue;
@@ -85,6 +132,25 @@ public record HighlightOptions(String preTag, String postTag, String encoder, in
             int intValue = number.intValue();
             if (intValue < 0) {
                 throw new IllegalArgumentException("HIGHLIGHT option must be >= 0 but got [" + folded + "]");
+            }
+            return intValue;
+        }
+        throw new IllegalArgumentException("Expected a numeric HIGHLIGHT option but got [" + folded + "]");
+    }
+
+    /**
+     * {@code max_analyzed_offset} matches Query DSL semantics: a positive integer, or {@code -1} to fall back to the index
+     * setting. {@code 0} and any value below {@code -1} are rejected (see {@code AbstractHighlighterBuilder#maxAnalyzedOffset}).
+     */
+    private static int maxAnalyzedOffset(Expression value, FoldContext foldContext) {
+        if (value == null) {
+            return DEFAULT_MAX_ANALYZED_OFFSET;
+        }
+        Object folded = value.fold(foldContext);
+        if (folded instanceof Number number) {
+            int intValue = number.intValue();
+            if (intValue < -1 || intValue == 0) {
+                throw new IllegalArgumentException("[max_analyzed_offset] must be a positive integer, or -1 but got [" + folded + "]");
             }
             return intValue;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1269,7 +1269,6 @@ public class LocalExecutionPlanner {
             throw new EsqlIllegalArgumentException("HIGHLIGHT requires an explicit query string");
         }
         String queryText = BytesRefs.toString(queryExpr.fold(context.foldCtx));
-        // TODO: honour boundary_scanner*, order, max_analyzed_offset, and phrase_limit once HighlightOptions exposes them.
         HighlightOptions options = HighlightOptions.from(highlight.options(), context.foldCtx());
         HighlightConfig config = new HighlightConfig(
             queryText,
@@ -1278,7 +1277,11 @@ public class LocalExecutionPlanner {
             options.encoder(),
             options.numberOfFragments(),
             options.fragmentSize(),
-            options.noMatchSize()
+            options.noMatchSize(),
+            HighlightOptions.BOUNDARY_SCANNER_WORD.equals(options.boundaryScanner()),
+            options.boundaryScannerLocale(),
+            HighlightOptions.ORDER_SCORE.equals(options.order()),
+            options.maxAnalyzedOffset()
         );
 
         List<ExpressionEvaluator.Factory> fieldEvaluators = highlight.fields()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -4495,6 +4495,20 @@ public class VerifierTests extends ESTestCase {
         defaultAnalyzer().query("FROM test | EVAL x = TOP_SNIPPETS(first_name, CONCAT(\"search\", \" terms\"))");
     }
 
+    public void testHighlightRejectsInvalidEnumOptions() {
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
+        assertInvalidHighlightOption("encoder", "xml");
+        assertInvalidHighlightOption("boundary_scanner", "chars");
+        assertInvalidHighlightOption("order", "doc");
+    }
+
+    private void assertInvalidHighlightOption(String optionName, String optionValue) {
+        defaultAnalyzer().error(
+            "FROM test | HIGHLIGHT \"search\" ON first_name WITH { \"" + optionName + "\": \"" + optionValue + "\" }",
+            containsString("Invalid [" + optionName + "] value [" + optionValue + "] in HIGHLIGHT")
+        );
+    }
+
     /**
      * A second {@code STATS} on a time-series pipeline becomes a regular {@link org.elasticsearch.xpack.esql.plan.logical.Aggregate};
      * {@code WITHOUT} is only valid on {@link org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate} until non-TS support exists.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/HighlightGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/HighlightGoldenTests.java
@@ -23,7 +23,7 @@ public class HighlightGoldenTests extends GoldenTestCase {
      * whose generated {@code highlight_<field>} column is appended to the output layout.
      */
     public void testBasicHighlight() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         String query = """
             FROM employees
             | HIGHLIGHT "elasticsearch" ON first_name

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1252,7 +1252,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     public void testHighlightOnFields() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         LogicalPlan plan = query("FROM foo | HIGHLIGHT \"elasticsearch\" ON title, body");
         Highlight highlight = as(plan, Highlight.class);
         assertThat(highlight.prefix(), equalTo("highlight_"));
@@ -1267,7 +1267,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     public void testHighlightRequiresQueryAndOnClause() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         // Both query and ON are grammatically required in v1. The plan node keeps `query` nullable
         // and `fields` allowed-empty so the bare form can be enabled later without serialization changes.
         expectThrows(ParsingException.class, () -> query("FROM foo | HIGHLIGHT"));
@@ -1276,14 +1276,14 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     public void testHighlightRejectsPrefixSyntax() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         // The plan node still carries a prefix field (hard-coded to "highlight_") so a future
         // grammar extension can flip it on without breaking serialization.
         expectThrows(ParsingException.class, () -> query("FROM foo | HIGHLIGHT prefix = \"h_\" \"elasticsearch\" ON title"));
     }
 
     public void testHighlightWithOptions() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         LogicalPlan plan = query(
             "FROM foo | HIGHLIGHT \"elasticsearch\" ON title WITH { \"fragment_size\": 150, \"number_of_fragments\": 2 }"
         );
@@ -1292,8 +1292,21 @@ public class StatementParserTests extends AbstractStatementParserTests {
         assertThat(highlight.options().keyFoldedMap().keySet(), equalTo(Set.of("fragment_size", "number_of_fragments")));
     }
 
+    public void testHighlightAcceptsAllOptions() {
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
+        LogicalPlan plan = query("""
+            FROM foo | HIGHLIGHT "elasticsearch" ON title WITH {
+              "pre_tags": ["<b>"], "post_tags": ["</b>"], "encoder": "html",
+              "number_of_fragments": 2, "fragment_size": 150, "no_match_size": 100,
+              "boundary_scanner": "word", "boundary_scanner_locale": "en-US",
+              "boundary_chars": ".,!?", "boundary_max_scan": 10, "order": "score",
+              "max_analyzed_offset": 500, "phrase_limit": 64 }""");
+        Highlight highlight = as(plan, Highlight.class);
+        assertThat(highlight.options().keyFoldedMap().keySet(), equalTo(Set.copyOf(Highlight.validOptionNames())));
+    }
+
     public void testHighlightRejectsUnknownOption() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         expectThrows(
             ParsingException.class,
             containsString("Invalid option [bogus] in HIGHLIGHT"),
@@ -1302,17 +1315,17 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     public void testHighlightRejectsExpressionQuery() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         expectThrows(ParsingException.class, () -> query("FROM foo | HIGHLIGHT MATCH(title, \"x\") ON title"));
     }
 
     public void testHighlightRejectsWildcardFields() {
-        assumeTrue("requires HIGHLIGHT_V1 capability", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeTrue("requires HIGHLIGHT_V2 capability", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         expectThrows(ParsingException.class, () -> query("FROM foo | HIGHLIGHT \"elasticsearch\" ON *"));
     }
 
     public void testHighlightNotInReleaseBuild() {
-        assumeFalse("only runs on release build", EsqlCapabilities.Cap.HIGHLIGHT_V1.isEnabled());
+        assumeFalse("only runs on release build", EsqlCapabilities.Cap.HIGHLIGHT_V2.isEnabled());
         expectThrows(
             ParsingException.class,
             containsString("mismatched input 'HIGHLIGHT'"),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
@@ -34,6 +35,69 @@ public class HighlightOptionsTests extends ESTestCase {
         assertThat(options.numberOfFragments(), equalTo(HighlightOptions.DEFAULT_NUMBER_OF_FRAGMENTS));
         assertThat(options.fragmentSize(), equalTo(HighlightOptions.DEFAULT_FRAGMENT_SIZE));
         assertThat(options.noMatchSize(), equalTo(HighlightOptions.DEFAULT_NO_MATCH_SIZE));
+        assertThat(options.boundaryScanner(), equalTo(HighlightOptions.DEFAULT_BOUNDARY_SCANNER));
+        assertThat(options.boundaryScannerLocale(), equalTo(HighlightOptions.DEFAULT_BOUNDARY_SCANNER_LOCALE));
+        assertThat(options.order(), equalTo(HighlightOptions.DEFAULT_ORDER));
+        assertThat(options.maxAnalyzedOffset(), equalTo(HighlightOptions.DEFAULT_MAX_ANALYZED_OFFSET));
+        assertThat(options.phraseLimit(), equalTo(HighlightOptions.DEFAULT_PHRASE_LIMIT));
+    }
+
+    public void testBoundaryAndOrderOptionsAreParsed() {
+        MapExpression map = map(
+            Highlight.BOUNDARY_SCANNER,
+            keyword(HighlightOptions.BOUNDARY_SCANNER_WORD),
+            Highlight.BOUNDARY_SCANNER_LOCALE,
+            keyword("en-US"),
+            Highlight.ORDER,
+            keyword(HighlightOptions.ORDER_SCORE)
+        );
+        HighlightOptions options = HighlightOptions.from(map, FoldContext.small());
+        assertThat(options.boundaryScanner(), equalTo(HighlightOptions.BOUNDARY_SCANNER_WORD));
+        assertThat(options.boundaryScannerLocale(), equalTo(Locale.forLanguageTag("en-US")));
+        assertThat(options.order(), equalTo(HighlightOptions.ORDER_SCORE));
+    }
+
+    public void testBoundaryAndOrderOptionsAreNormalizedToLowerCase() {
+        MapExpression map = map(Highlight.BOUNDARY_SCANNER, keyword("WORD"), Highlight.ORDER, keyword("Score"));
+        HighlightOptions options = HighlightOptions.from(map, FoldContext.small());
+        assertThat(options.boundaryScanner(), equalTo(HighlightOptions.BOUNDARY_SCANNER_WORD));
+        assertThat(options.order(), equalTo(HighlightOptions.ORDER_SCORE));
+    }
+
+    public void testMaxAnalyzedOffsetAndPhraseLimitAreParsed() {
+        MapExpression map = map(Highlight.MAX_ANALYZED_OFFSET, integer(500), Highlight.PHRASE_LIMIT, integer(64));
+        HighlightOptions options = HighlightOptions.from(map, FoldContext.small());
+        assertThat(options.maxAnalyzedOffset(), equalTo(500));
+        assertThat(options.phraseLimit(), equalTo(64));
+    }
+
+    public void testMaxAnalyzedOffsetAllowsMinusOne() {
+        HighlightOptions options = HighlightOptions.from(map(Highlight.MAX_ANALYZED_OFFSET, integer(-1)), FoldContext.small());
+        assertThat(options.maxAnalyzedOffset(), equalTo(-1));
+    }
+
+    public void testMaxAnalyzedOffsetRejectsZero() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> HighlightOptions.from(map(Highlight.MAX_ANALYZED_OFFSET, integer(0)), FoldContext.small())
+        );
+        assertThat(e.getMessage(), containsString("[max_analyzed_offset] must be a positive integer, or -1"));
+    }
+
+    public void testMaxAnalyzedOffsetRejectsBelowMinusOne() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> HighlightOptions.from(map(Highlight.MAX_ANALYZED_OFFSET, integer(-2)), FoldContext.small())
+        );
+        assertThat(e.getMessage(), containsString("[max_analyzed_offset] must be a positive integer, or -1"));
+    }
+
+    public void testNegativePhraseLimitIsRejected() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> HighlightOptions.from(map(Highlight.PHRASE_LIMIT, integer(-1)), FoldContext.small())
+        );
+        assertThat(e.getMessage(), containsString("must be >= 0"));
     }
 
     public void testTagAsScalarString() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -67,7 +67,7 @@ setup:
             - fn_json_extract
             - esql_limit_by
             - dedup_command
-            - highlight_v1
+            - highlight_v2
       reason: "Test that should only be executed on snapshot versions"
 
   - do: { xpack.usage: { } }


### PR DESCRIPTION
HIGHLIGHT previously honoured only the tag/fragment/no_match options; the rest were parsed but ignored. This wires them through to the unified highlighter:
- boundary_scanner (sentence|word) and boundary_scanner_locale
- order (none|score)
- max_analyzed_offset (Query DSL semantics: -1 = index setting)

boundary_chars, boundary_max_scan and phrase_limit are FastVector-only, so they're now explicit no-ops kept for Query DSL parity. Option values are validated at analysis time, and the capability is bumped HIGHLIGHT_V1 -> HIGHLIGHT_V2 (snapshot-only).

Adds csv-spec coverage for column pruning, RENAME and DROP of the generated highlight_* columns.
