### PR TITLE
Fix query like FROM logs-*,-_origin:* | LIMIT 1 when there's no linked project

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ResolvedIndexExpressions.java
+++ b/server/src/main/java/org/elasticsearch/action/ResolvedIndexExpressions.java
@@ -92,7 +92,14 @@ public record ResolvedIndexExpressions(List<ResolvedIndexExpression> expressions
             for (int i = 0; i < expressions.size(); i++) {
                 ResolvedIndexExpression current = expressions.get(i);
                 if (current.localExpressions() != LocalExpressions.NONE) {
-                    expressions.set(i, new ResolvedIndexExpression(current.original(), LocalExpressions.NONE, current.remoteExpressions()));
+                    expressions.set(
+                        i,
+                        new ResolvedIndexExpression(
+                            current.original(),
+                            new LocalExpressions(Set.of(), LocalIndexResolutionResult.SUCCESS, null),
+                            current.remoteExpressions()
+                        )
+                    );
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-team/issues/4339