### PR TITLE
[9.4] improve simulate bulk action authz (#152148)

### DIFF
--- a/docs/changelog/152148.yaml
+++ b/docs/changelog/152148.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 152148
+summary: Improve simulate bulk action authz
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/bulk/SimulateBulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/SimulateBulkRequest.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -98,7 +100,7 @@ import java.util.stream.Collectors;
  *   are the pipelineIds ("my-pipeline-1" and "my-pipeline-2" in the example above). The values are the Maps of "processors" to the List of
  *   processor definitions.
  */
-public class SimulateBulkRequest extends BulkRequest {
+public class SimulateBulkRequest extends BulkRequest implements IndicesRequest {
 
     private static final TransportVersion SIMULATE_INGEST_MAPPING_MERGE_TYPE = TransportVersion.fromName(
         "simulate_ingest_mapping_merge_type"
@@ -233,5 +235,15 @@ public class SimulateBulkRequest extends BulkRequest {
         bulkRequest.requireAlias(requireAlias());
         bulkRequest.requireDataStream(requireDataStream());
         return bulkRequest;
+    }
+
+    @Override
+    public String[] indices() {
+        return getIndices().toArray(new String[0]);
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.bulk.BulkShardRequest;
-import org.elasticsearch.action.bulk.SimulateBulkAction;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.get.TransportMultiGetAction;
@@ -284,7 +283,6 @@ public class RBACEngine implements AuthorizationEngine {
     private static boolean shouldAuthorizeIndexActionNameOnly(String action, TransportRequest request) {
         switch (action) {
             case TransportBulkAction.NAME:
-            case SimulateBulkAction.NAME:
             case TransportIndexAction.NAME:
             case TransportDeleteAction.NAME:
             case INDEX_SUB_REQUEST_PRIMARY:

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -50,6 +50,8 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.bulk.BulkShardResponse;
 import org.elasticsearch.action.bulk.MappingUpdatePerformer;
+import org.elasticsearch.action.bulk.SimulateBulkAction;
+import org.elasticsearch.action.bulk.SimulateBulkRequest;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.bulk.TransportShardBulkAction;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -3314,6 +3316,35 @@ public class AuthorizationServiceTests extends ESTestCase {
         assertThat(request.items()[1].getPrimaryResponse().isFailed(), is(true));
         assertThat(request.items()[2].getPrimaryResponse(), nullValue());
         assertThat(request.items()[3].getPrimaryResponse().isFailed(), is(true));
+    }
+
+    public void testSimulateBulkActionAuthorizesAllIncludedIndices() {
+        var bulkRequest = new SimulateBulkRequest(Map.of(), Map.of(), Map.of(), Map.of(), null);
+        bulkRequest.add(new IndexRequest("allowed-index"));
+        bulkRequest.add(new IndexRequest("unauthorised-index"));
+
+        var authentication = createAuthentication(new User("user", "my-role"));
+        var role = new RoleDescriptor(
+            "my-role",
+            null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("allowed-index").privileges("index").build() },
+            null
+        );
+        roleMap.put("my-role", role);
+        var requestId = AuditUtil.getOrGenerateRequestId(threadContext);
+        mockEmptyMetadata();
+
+        var ex = expectThrows(ElasticsearchSecurityException.class, () -> authorize(authentication, SimulateBulkAction.NAME, bulkRequest));
+        assertThat(ex.getMessage(), equalTo("""
+            action [indices:data/write/simulate/bulk] is unauthorized for user [user] with effective roles [my-role] \
+            on indices [unauthorised-index], this action is granted by the index privileges [create_doc,create,index,write,all]"""));
+        verify(auditTrail).accessDenied(
+            eq(requestId),
+            eq(authentication),
+            eq(SimulateBulkAction.NAME),
+            eq(bulkRequest),
+            authzInfoRoles(new String[] { role.getName() })
+        );
     }
 
     private BulkShardRequest createBulkShardRequest(String indexName, BiFunction<String, String, DocWriteRequest<?>> req) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - improve simulate bulk action authz (#152148)