### PR TITLE
Increase ES|QL csv-spec suite timeouts across the board

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -509,9 +509,6 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/151330
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:stats.maxOfHalfFloat}
-  issue: https://github.com/elastic/elasticsearch/issues/151357
 - class: org.elasticsearch.upgrades.MultiVersionRepositoryAccessIT
   method: testCreateAndRestoreSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/151388
@@ -545,9 +542,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:date_nanos.implicit casting to nanos, date plus time to millis, equality test}
-  issue: https://github.com/elastic/elasticsearch/issues/151536
 - class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
   method: testSyntheticSourceRuntimeFieldQueries
   issue: https://github.com/elastic/elasticsearch/issues/151546
@@ -563,21 +557,12 @@ tests:
 - class: org.elasticsearch.datastreams.lifecycle.ExplainDataStreamLifecycleIT
   method: testExplainFailuresLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/151602
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:metric_temporality.tdigestAggsByTBucket}
-  issue: https://github.com/elastic/elasticsearch/issues/151613
 - class: org.elasticsearch.gradle.internal.precommit.PomValidationPrecommitPluginFuncTest
   method: detects missing POM elements and reports structured problems
   issue: https://github.com/elastic/elasticsearch/issues/151636
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:lookup-join.byteEqualsLong}
-  issue: https://github.com/elastic/elasticsearch/issues/151650
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=scroll/10_basic/Basic scroll}
   issue: https://github.com/elastic/elasticsearch/issues/151698
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:string.mvAppendNull}
-  issue: https://github.com/elastic/elasticsearch/issues/151707
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/151709
@@ -587,9 +572,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.blob.SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests
   method: testCleanUpMigratedSystemIndexAfterIndicesAreDeleted
   issue: https://github.com/elastic/elasticsearch/issues/151732
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:in_subquery.inSubqueryWithEvalInsideInSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/151761
 - class: org.elasticsearch.xpack.stateless.CorruptionIT
   method: testConcurrentOperations
   issue: https://github.com/elastic/elasticsearch/issues/151779
@@ -599,24 +581,12 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasources.CompressionDelegatingFormatReaderTests
   method: testDelegatesMetadataAndReadZstd
   issue: https://github.com/elastic/elasticsearch/issues/151784
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:stats.minOfKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/151790
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=aggregations/terms/Double test}
   issue: https://github.com/elastic/elasticsearch/issues/151793
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:views.wildcardExcludeNestedEmployeeViewsNoFalseCircularReference}
-  issue: https://github.com/elastic/elasticsearch/issues/151811
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:ip.simpleProject}
-  issue: https://github.com/elastic/elasticsearch/issues/151818
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.blob.SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests
   method: testCleanUpAfterIndicesAreDeleted
   issue: https://github.com/elastic/elasticsearch/issues/151819
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:string.dissect}
-  issue: https://github.com/elastic/elasticsearch/issues/151831
 - class: org.elasticsearch.cluster.ClusterInfoServiceIT
   method: testMaxQueueLatenciesInClusterInfo
   issue: https://github.com/elastic/elasticsearch/issues/151837
@@ -626,18 +596,12 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testCloseWhileShardsAreHollowed
   issue: https://github.com/elastic/elasticsearch/issues/151861
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:string.convertFromUnsignedLong}
-  issue: https://github.com/elastic/elasticsearch/issues/151871
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testDeleteIndexAfterRecovery
   issue: https://github.com/elastic/elasticsearch/issues/151884
 - class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
   method: testSearchNodePrefetchesOnlyLatestGenerationOnFirstCommitNotification
   issue: https://github.com/elastic/elasticsearch/issues/151992
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:spatial-jts.stSimplifyCartesianShape}
-  issue: https://github.com/elastic/elasticsearch/issues/152004
 - class: org.elasticsearch.snapshots.SnapshotStressTestsIT
   method: testRandomActivities
   issue: https://github.com/elastic/elasticsearch/issues/152005
@@ -653,9 +617,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalParquetStringTopNSideChannelIT
   method: testNullsFirstEarlyTermination
   issue: https://github.com/elastic/elasticsearch/issues/152038
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:views.mixedIndexWithViewRowInFromSubquery}
-  issue: https://github.com/elastic/elasticsearch/issues/152040
 - class: org.elasticsearch.cluster.metadata.MetadataCreateIndexServiceIT
   method: testCreateIndexBatching
   issue: https://github.com/elastic/elasticsearch/issues/152041
@@ -707,15 +668,9 @@ tests:
 - class: org.elasticsearch.index.engine.InternalEngineTests
   method: testLookupSeqNoByIdInLucene
   issue: https://github.com/elastic/elasticsearch/issues/152120
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:views.notInSubqueryReferencingView}
-  issue: https://github.com/elastic/elasticsearch/issues/152126
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:mv_expand.keepStarMvExpand}
-  issue: https://github.com/elastic/elasticsearch/issues/152129
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
@@ -728,15 +683,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalSourceProfileIT
   method: testCsvCountStarScansColdThenSkipsWarm
   issue: https://github.com/elastic/elasticsearch/issues/152132
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:lookup-join.remoteEnrichBetweenLookupJoins}
-  issue: https://github.com/elastic/elasticsearch/issues/152137
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:in_subquery.inSubqueryWithIndexPatternMixedWithRow}
-  issue: https://github.com/elastic/elasticsearch/issues/152138
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:in_subquery.textInKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/152139
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:stats_sparkline.sparklineWithWeightedAvg}
   issue: https://github.com/elastic/elasticsearch/issues/152159
@@ -749,27 +695,12 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:stats_sparkline.weightedAvgAndSparklineWithSameWeightedAvg}
   issue: https://github.com/elastic/elasticsearch/issues/152162
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:keep.sortWithLimitFifteenAndProject}
-  issue: https://github.com/elastic/elasticsearch/issues/152238
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:bucket.docsBucketNumeric}
-  issue: https://github.com/elastic/elasticsearch/issues/152239
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/149746
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:highlight.highlightFieldWithNoMatch}
   issue: https://github.com/elastic/elasticsearch/issues/152240
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:views.tsMainQueryInSubqueryReferencingView}
-  issue: https://github.com/elastic/elasticsearch/issues/152253
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:bucket.bucketMonth}
-  issue: https://github.com/elastic/elasticsearch/issues/152256
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:grok.shadowingSubfields}
-  issue: https://github.com/elastic/elasticsearch/issues/152257
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
   method: testReshardWithDisruption
   issue: https://github.com/elastic/elasticsearch/issues/152259

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.qa.multi_node;
 
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
@@ -16,6 +19,7 @@ import org.junit.ClassRule;
 import java.io.IOException;
 import java.nio.file.Path;
 
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class EsqlSpecIT extends EsqlSpecTestCase {
     private static final Path CSV_DATA_PATH = CsvTestUtils.createCsvDataDirectory();
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -84,7 +84,7 @@ import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.assertNotPar
 import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.hasCapabilities;
 
 // This test can run very long in serverless configurations
-@TimeoutSuite(millis = 30 * TimeUnits.MINUTE)
+@TimeoutSuite(millis = 45 * TimeUnits.MINUTE)
 public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     @Rule(order = Integer.MIN_VALUE)

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -8,7 +8,9 @@
 package org.elasticsearch.xpack.esql;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -126,6 +128,7 @@ import static org.hamcrest.Matchers.hasSize;
  * InternalTestCluster` reuses current jvm. This enables debugging all scenarios from IDE.
  * Test data is loaded lazily in order to facilitate faster startup when running/debugging individual test cases.
  */
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class CsvIT extends ESTestCase {
 
     private static final Logger logger = LogManager.getLogger(CsvIT.class);


### PR DESCRIPTION
We have lots of failures due to timeouts, leading to arbitrary tests being muted. This causes a cyclical churn of mutes and unmutes, since these tests are not at fault.

This PR increases timeout across the board, but mostly for the multi-node EsqlSpecIT which had the highest failure rates.

| Class | Before | After | Note |
|---|---|---|---|
| `EsqlSpecTestCase` | 30 min | 45 min | Base class — all subclasses inherit unless they override |
| `multi_node.EsqlSpecIT` | 30 min | 60 min | Override added; most-affected suite with 10+ failures |
| `CsvIT` | 20 min | 40 min | Override added; inherits from `ESTestCase` not `EsqlSpecTestCase` |

All other `EsqlSpecTestCase` subclasses (`MixedClusterEsqlSpecIT`, `MultiClusterSpecIT`,
`single_node.EsqlSpecIT`, `EsqlSpecForceStoredLoadingIT`) pick up the 45 min bump via inheritance.

This PR also includes the unmutes from https://github.com/elastic/elasticsearch/pull/151848, but increases the timeout further. The multi-node suite was experiencing the highest failure rate.

----
For lovers of verbose AI descriptions, here is an analysis of how many failures per suite we were seeing, and how we decided which suites to increase the timeouts on.

## Background

Several ES|QL test suites have been timing out in CI, causing spurious failures.
Investigation of open `[CI]` issues assigned to me identified 19 distinct timeout failures
across 6 suites. All confirmed with `java.lang.Exception: Test abandoned because suite timeout was reached.`

### Suites and current timeouts

| Suite (fully-qualified class) | Gradle task | Current timeout | Source of timeout |
|---|---|---|---|
| `org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT` | `:x-pack:plugin:esql:qa:server:multi-node:javaRestTest` | 30 min | Inherited from `EsqlSpecTestCase` |
| `org.elasticsearch.xpack.esql.CsvIT` | `:x-pack:plugin:esql:internalClusterTest` | 20 min | Inherited from `ESTestCase` |
| `org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT` | `:x-pack:plugin:esql:qa:server:single-node:javaRestTest` | 30 min | Inherited via `EsqlSpecIT` → `EsqlSpecTestCase` |
| `org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT` | `:x-pack:plugin:esql:qa:server:mixed-cluster:javaRestTest` | 30 min | Inherited from `EsqlSpecTestCase` |
| `org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT` | `:x-pack:plugin:esql:qa:server:multi-clusters` | 30 min | Inherited from `EsqlSpecTestCase` |
| `org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StBufferTests` | `:x-pack:plugin:esql:test` | 20 min | Inherited from `ESTestCase` |

### Failures per suite (open CI issues)

| Suite | Open timeout issues | Issues |
|---|---|---|
| `multi_node.EsqlSpecIT` | 10 | #151357, #151536, #151613, #151650, #151761, #151790, #151811, #151818, #151831, #151871, #152004, #152137, #152138, #152253, #152257 |
| `CsvIT` | 3 | #151707, #152040, #152126 |
| `EsqlSpecForceStoredLoadingIT` | 2 | #152139, #152256 |
| `MixedClusterEsqlSpecIT` | 2 | #152129, #152238 |
| `MultiClusterSpecIT` | 1 | #152239 |
| `StBufferTests` | 1 | #146114 (to be addressed separately) |

`StBufferTests` will be addressed in a separate PR.

## Changes

### Timeout increases

| Class | Before | After | Note |
|---|---|---|---|
| `EsqlSpecTestCase` | 30 min | 45 min | Base class — all subclasses inherit unless they override |
| `multi_node.EsqlSpecIT` | 30 min | 60 min | Override added; most-affected suite with 10+ failures |
| `CsvIT` | 20 min | 40 min | Override added; inherits from `ESTestCase` not `EsqlSpecTestCase` |

All other `EsqlSpecTestCase` subclasses (`MixedClusterEsqlSpecIT`, `MultiClusterSpecIT`,
`single_node.EsqlSpecIT`, `EsqlSpecForceStoredLoadingIT`) pick up the 45 min bump via inheritance.

### Unmutes

23 entries removed from `muted-tests.yml`. These are all suite-timeout failures that should
now pass reliably with the increased timeouts above. Includes the 9 unmutes from #151848,
which this PR supersedes.

| Suite | Method | Issue |
|---|---|---|
| `multi_node.EsqlSpecIT` | `test {csv-spec:stats.maxOfHalfFloat}` | #151357 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:date_nanos.implicit casting to nanos, date plus time to millis, equality test}` | #151536 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:metric_temporality.tdigestAggsByTBucket}` | #151613 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:lookup-join.byteEqualsLong}` | #151650 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:in_subquery.inSubqueryWithEvalInsideInSubquery}` | #151761 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:stats.minOfKeyword}` | #151790 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:views.wildcardExcludeNestedEmployeeViewsNoFalseCircularReference}` | #151811 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:ip.simpleProject}` | #151818 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:string.dissect}` | #151831 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:string.convertFromUnsignedLong}` | #151871 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:spatial-jts.stSimplifyCartesianShape}` | #152004 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:lookup-join.remoteEnrichBetweenLookupJoins}` | #152137 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:in_subquery.inSubqueryWithIndexPatternMixedWithRow}` | #152138 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:views.tsMainQueryInSubqueryReferencingView}` | #152253 |
| `multi_node.EsqlSpecIT` | `test {csv-spec:grok.shadowingSubfields}` | #152257 |
| `CsvIT` | `test {csv-spec:string.mvAppendNull}` | #151707 |
| `CsvIT` | `test {csv-spec:views.mixedIndexWithViewRowInFromSubquery}` | #152040 |
| `CsvIT` | `test {csv-spec:views.notInSubqueryReferencingView}` | #152126 |
| `MixedClusterEsqlSpecIT` | `test {csv-spec:mv_expand.keepStarMvExpand}` | #152129 |
| `MixedClusterEsqlSpecIT` | `test {csv-spec:keep.sortWithLimitFifteenAndProject}` | #152238 |
| `EsqlSpecForceStoredLoadingIT` | `test {csv-spec:in_subquery.textInKeyword}` | #152139 |
| `EsqlSpecForceStoredLoadingIT` | `test {csv-spec:bucket.bucketMonth}` | #152256 |
| `MultiClusterSpecIT` | `test {csv-spec:bucket.docsBucketNumeric}` | #152239 |

