### PR TITLE
Add temporality to RandomizedTimeSeriesIT

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.compute.aggregation.Temporality;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.index.IndexMode;
@@ -35,6 +36,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -42,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -59,6 +62,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     private static final Long NUM_DOCS = 2000L;
     private static final Long TIME_RANGE_SECONDS = 3600L;
     private static final String DATASTREAM_NAME = "tsit_ds";
+    private static final String TEMPORALITY_FIELD = "temporality";
     private static final Integer SECONDS_IN_WINDOW = 60;
 
     record WindowOption(String label, int seconds) {}
@@ -614,6 +618,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         settingsBuilder.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, ESTestCase.randomIntBetween(1, 5));
         settingsBuilder.put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2025-07-31T00:00:00Z");
         settingsBuilder.put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2025-07-31T12:00:00Z");
+        settingsBuilder.put(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(), TEMPORALITY_FIELD);
         settingsBuilder.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
         CompressedXContent mappings = mappingString == null ? null : CompressedXContent.fromJSON(mappingString);
         TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request(
@@ -632,7 +637,8 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void populateIndex() throws IOException {
-        dataGenerationHelper = new TSDataGenerationHelper(NUM_DOCS, TIME_RANGE_SECONDS);
+        List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
+        dataGenerationHelper = new TSDataGenerationHelper(NUM_DOCS, TIME_RANGE_SECONDS, TEMPORALITY_FIELD, allowedTemporalities);
         final XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.map(dataGenerationHelper.mapping.raw());
         final String jsonMappings = Strings.toString(builder);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -207,6 +206,14 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
             }, Collectors.toList())));
     }
 
+    private static Temporality getCounterTemporality(String timeseriesId) {
+        String deltaLiteral = Temporality.DELTA.bytesRef().utf8ToString();
+        if (timeseriesId.contains(TSDataGenerationHelper.TEMPORALITY_ATTRIBUTE_NAME + ":" + deltaLiteral)) {
+            return Temporality.DELTA;
+        }
+        return Temporality.CUMULATIVE;
+    }
+
     /**
      * Two-level aggregation: first applies {@code timeseriesAgg} within each timeseries, then applies
      * {@code crossAgg} across all per-timeseries results.
@@ -350,15 +357,235 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     /** Aggregated rate statistics (count, max, avg, min, sum) computed across timeseries in a window. */
     record RateStats(Long count, RateRange max, RateRange avg, RateRange min, RateRange sum) {}
 
+
+    @Nullable
+    private static TimestampedValue findLastPoint(List<Map<String, List<TimestampedValue>>> allWindows, int idx, String tsId) {
+        if (idx < 0 || idx >= allWindows.size()) return null;
+        var pts = allWindows.get(idx).get(tsId);
+        if (pts == null) return null;
+        return pts.stream().max(Comparator.comparing(TimestampedValue::timestamp)).orElse(null);
+    }
+
+    @Nullable
+    private static TimestampedValue findFirstPoint(List<Map<String, List<TimestampedValue>>> allWindows, int idx, String tsId) {
+        if (idx < 0 || idx >= allWindows.size()) return null;
+        var pts = allWindows.get(idx).get(tsId);
+        if (pts == null) return null;
+        return pts.stream().min(Comparator.comparing(TimestampedValue::timestamp)).orElse(null);
+    }
+
     /**
-     * Calculates a delta-based aggregation (rate, irate, increase, delta, idelta) for a single time window,
-     * using adjacent windows for boundary interpolation.
-     *
-     * @param allWindows ordered list of time windows; each window is a map keyed by timeseries identifier
-     *                   to the data points in that window
-     * @param offset index into {@code allWindows} for the window to compute
-     * @param secondsInWindow time bucket width in seconds
-     * @param deltaAgg the delta aggregation type to compute
+     * Computes a reference rate or increase for a single timeseries within a time window, matching
+     * {@code RateDoubleGroupingAggregatorFunction#computeRate}.
+     */
+    static Double computeReferenceRateOrIncrease(
+        @Nullable TimestampedValue lastInPrevWindow,
+        List<TimestampedValue> currentWindow,
+        @Nullable TimestampedValue firstInNextWindow,
+        Temporality temporality,
+        int secondsInWindow,
+        boolean isRate
+    ) {
+        long millisInWindow = secondsInWindow * 1000L;
+        if (currentWindow.isEmpty()) {
+            return null;
+        }
+        TimestampedValue firstInWindow = currentWindow.getFirst();
+        TimestampedValue lastInWindow = currentWindow.getLast();
+
+        long startTs = firstInWindow.timestamp().toEpochMilli();
+        long endTs = lastInWindow.timestamp().toEpochMilli();
+
+        long timebucketStart = startTs / millisInWindow * millisInWindow;
+        long timebucketEnd = timebucketStart + millisInWindow;
+
+        double totalIncrease = computeCounterIncreaseBetween(currentWindow, temporality);
+
+        if (lastInPrevWindow != null) {
+            totalIncrease += getInterpolatedIncreaseBetween(lastInPrevWindow, firstInWindow, timebucketStart, temporality);
+            startTs = timebucketStart;
+        } else if (currentWindow.size() > 1) {
+            totalIncrease += getExtrapolatedIncreaseAtBorder(currentWindow, temporality, secondsInWindow,true);
+            startTs = timebucketStart;
+        }
+        if (firstInNextWindow != null) {
+            totalIncrease += getInterpolatedIncreaseBetween(lastInWindow, firstInNextWindow, timebucketEnd, temporality);
+            endTs = timebucketEnd;
+        } else if (currentWindow.size() > 1) {
+            totalIncrease += getExtrapolatedIncreaseAtBorder(currentWindow, temporality, secondsInWindow,false);
+            endTs = timebucketEnd;
+        }
+
+        if (startTs == endTs && lastInPrevWindow != null) {
+            // special case: The only value falsl exactly on the start border
+            // our rate implementation in this case returns the rate between the point in this window and the point in the last window
+            if (isRate) {
+                List<TimestampedValue> values = List.of(lastInPrevWindow, firstInWindow);
+                double rangeSeconds = (firstInWindow.timestamp().toEpochMilli() - lastInPrevWindow.timestamp().toEpochMilli()) * 1000.0;
+                return computeCounterIncreaseBetween(values, temporality) / rangeSeconds;
+            } else {
+                return null;
+            }
+        }
+        return isRate ? totalIncrease / ((endTs - startTs) / 1000.0) : totalIncrease;
+    }
+
+    private static double computeCounterIncreaseBetween(List<TimestampedValue> currentWindow, Temporality temporality) {
+        double increaseInWindow = 0.0;
+
+        for (int i = 1; i < currentWindow.size(); i++) {
+            if (temporality == Temporality.DELTA) {
+                increaseInWindow += currentWindow.get(i).value();
+            } else {
+                double prevValue = currentWindow.get(i-1).value();
+                double currValue = currentWindow.get(i).value();
+                if (currValue >= prevValue) {
+                    increaseInWindow += currValue - prevValue;
+                } else {
+                    // reset, don't subtract previous cumulative value
+                    increaseInWindow += currValue;
+                }
+            }
+        }
+        return increaseInWindow;
+    }
+
+    static double getInterpolatedIncreaseBetween(TimestampedValue left, TimestampedValue right, long targetTimestamp, Temporality temporality) {
+        long leftTs = left.timestamp().toEpochMilli();
+        long rightTs = right.timestamp().toEpochMilli();
+        assert targetTimestamp >= leftTs : "Target timestamp must be greater than or equal to left timestamp";
+        assert targetTimestamp <= rightTs : "Target timestamp must be less than or equal to right timestamp";
+        assert leftTs != rightTs : "Left and right timestamps must be different for interpolation";
+
+        long timespan = rightTs - leftTs;
+        double interpolationWeight = (targetTimestamp - leftTs) * 1.0 / timespan;
+
+        double totalIncrease;
+        if (temporality == Temporality.DELTA) {
+            // For delta, only the counter value of the right point matters. It represents the total increase between the two points
+            totalIncrease = right.value() ;
+        } else {
+            if (right.value() >= left.value()) {
+                // no reset
+                totalIncrease = right.value() - left.value();
+            } else {
+                // reset, absolute value of right point matters
+                totalIncrease = right.value();
+            }
+        }
+        return totalIncrease * interpolationWeight;
+    }
+
+    private static double getExtrapolatedIncreaseAtBorder(
+        List<TimestampedValue> values,
+        Temporality temporality,
+        long secondsInWindow,
+        boolean isLowerBoundary
+    ) {
+        assert values.size() >= 2 : "At least two points are required for extrapolation";
+
+        double increase = computeCounterIncreaseBetween(values, temporality);
+        long firstTs = values.getFirst().timestamp().toEpochMilli();
+        long lastTs = values.getLast().timestamp().toEpochMilli();
+
+        final long sampleTs = lastTs - firstTs;
+        final double averageSampleInterval = sampleTs * 1.0 / values.size();
+        final double slope = increase / sampleTs;
+
+        assert firstTs != lastTs;
+
+        long millisInWindow = secondsInWindow * 1000L;
+        long tbucketStart = firstTs / millisInWindow * millisInWindow;
+        long tbucketEnd = tbucketStart + millisInWindow;
+
+        double gap;
+        if (isLowerBoundary) {
+            gap = firstTs - tbucketStart;
+        } else {
+            gap = tbucketEnd - lastTs;
+        }
+        if (gap > 0) {
+            if (gap > averageSampleInterval * 1.1) {
+                gap = averageSampleInterval / 2.0;
+            }
+            return gap * slope;
+        }
+        return 0.0;
+    }
+
+    /**
+     * Computes a reference irate matching {@code IrateAggregator#evaluateFinal}.
+     * Uses only the last two samples; no adjacent-window data.
+     */
+    static Double computeReferenceIrate(List<TimestampedValue> currentWindow, Temporality temporality) {
+        if (currentWindow == null || currentWindow.size() < 2) {
+            return null;
+        }
+        var last = currentWindow.getLast();
+        var secondLast = currentWindow.get(currentWindow.size() - 2);
+        double ydiff;
+        if (temporality != Temporality.DELTA && last.value() >= secondLast.value()) {
+            ydiff = last.value() - secondLast.value();
+        } else {
+            ydiff = last.value();
+        }
+        long xdiff = last.timestamp().toEpochMilli() - secondLast.timestamp().toEpochMilli();
+        return ydiff / xdiff * 1000.0;
+    }
+
+    /**
+     * Computes a reference delta matching {@code DeltaAggregator#evaluateFinal} with PromQL-style
+     * in-bucket extrapolation to bucket boundaries. No adjacent-window data.
+     */
+    static Double computeReferenceDelta(List<TimestampedValue> currentWindow, int secondsInWindow) {
+        if (currentWindow == null || currentWindow.size() < 2) {
+            return null;
+        }
+        long firstTs = currentWindow.getFirst().timestamp().toEpochMilli();
+        double firstValue = currentWindow.getFirst().value();
+        long lastTs = currentWindow.getLast().timestamp().toEpochMilli();
+        double lastValue = currentWindow.getLast().value();
+        if (lastTs == firstTs) {
+            return null;
+        }
+
+        long bucketStartMs = (firstTs / (secondsInWindow * 1000L)) * (secondsInWindow * 1000L);
+        long bucketEndMs = bucketStartMs + secondsInWindow * 1000L;
+        double averageSampleInterval = (double) (lastTs - firstTs) / currentWindow.size();
+        double slope = (lastValue - firstValue) / (lastTs - firstTs);
+
+        double calculatedFirst = firstValue;
+        double startGap = firstTs - bucketStartMs;
+        if (startGap > 0) {
+            if (startGap > averageSampleInterval * 1.1) {
+                startGap = averageSampleInterval / 2.0;
+            }
+            calculatedFirst = firstValue - startGap * slope;
+        }
+        double calculatedLast = lastValue;
+        double endGap = bucketEndMs - lastTs;
+        if (endGap > 0) {
+            if (endGap > averageSampleInterval * 1.1) {
+                endGap = averageSampleInterval / 2.0;
+            }
+            calculatedLast = lastValue + endGap * slope;
+        }
+        return calculatedLast - calculatedFirst;
+    }
+
+    /**
+     * Computes a reference idelta matching {@code IdeltaAggregator#evaluateFinal}.
+     * Uses only the last two samples; no adjacent-window data, no temporality handling.
+     */
+    static Double computeReferenceIdelta(List<TimestampedValue> currentWindow) {
+        if (currentWindow == null || currentWindow.size() < 2) {
+            return null;
+        }
+        return currentWindow.getLast().value() - currentWindow.get(currentWindow.size() - 2).value();
+    }
+
+    /**
+     * Calculates a delta-based aggregation (rate, irate, increase, delta, idelta) for a single time window.
      */
     static RateStats calculateDeltaAggregation(
         List<Map<String, List<TimestampedValue>>> allWindows,
@@ -368,110 +595,30 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     ) {
         List<RateRange> allRates = allWindows.get(offset).entrySet().stream().map(entry -> {
             String timeseriesId = entry.getKey();
-            var timeseriesPointsInWindow = new ArrayList<>(entry.getValue());
-            timeseriesPointsInWindow.sort(Comparator.comparing(TimestampedValue::timestamp));
+            List<TimestampedValue> points = new ArrayList<>(entry.getValue());
+            points.sort(Comparator.comparing(TimestampedValue::timestamp));
+            Temporality temporality = getCounterTemporality(timeseriesId);
 
-            boolean addedLowerBoundary = false;
-            boolean addedUpperBoundary = false;
-            if (deltaAgg.equals(DeltaAgg.RATE) || deltaAgg.equals(DeltaAgg.INCREASE)) {
-                if (offset > 0) {
-                    var previousWindow = allWindows.get(offset - 1).get(timeseriesId);
-                    if (previousWindow != null && previousWindow.isEmpty() == false) {
-                        addedLowerBoundary = addBoundaryPoint(timeseriesPointsInWindow, previousWindow, secondsInWindow, true);
-                    }
-                }
-                if (offset < allWindows.size() - 1) {
-                    var nextWindow = allWindows.get(offset + 1).get(timeseriesId);
-                    if (nextWindow != null && nextWindow.isEmpty() == false) {
-                        addedUpperBoundary = addBoundaryPoint(timeseriesPointsInWindow, nextWindow, secondsInWindow, false);
-                    }
-                }
-            }
-            if (timeseriesPointsInWindow.size() < 2) {
-                if ((deltaAgg.equals(DeltaAgg.RATE) || deltaAgg.equals(DeltaAgg.INCREASE))
-                    && timeseriesPointsInWindow.size() == 1
-                    && timeseriesPointsInWindow.getFirst().timestamp().toEpochMilli() % (secondsInWindow * 1000L) == 0
-                    && offset > 0) {
-                    // Value at lower boundary is present, check if there's one in the previous window to use.
-                    addLastPointFromLowerWindow(timeseriesPointsInWindow, allWindows.get(offset - 1).get(timeseriesId), secondsInWindow);
-                    // For INCREASE, return 0 if there is a previous bucket because
-                    // the increase was already accounted for in the previous bucket.
-                    // For RATE, we still need to calculate the rate using interpolation from the previous bucket.
-                    if (timeseriesPointsInWindow.size() == 2 && deltaAgg.equals(DeltaAgg.INCREASE)) {
-                        return new RateRange(0.0, 0.0);
-                    }
-                }
-                if (timeseriesPointsInWindow.size() < 2) {
-                    return null;
-                }
-            }
-            var firstTs = timeseriesPointsInWindow.getFirst().timestamp();
-            var lastTs = timeseriesPointsInWindow.getLast().timestamp();
-            var tsDurationSeconds = (lastTs.toEpochMilli() - firstTs.toEpochMilli()) / 1000.0;
-            if (deltaAgg.equals(DeltaAgg.IRATE)) {
-                var lastVal = timeseriesPointsInWindow.getLast().value();
-                var secondLast = timeseriesPointsInWindow.get(timeseriesPointsInWindow.size() - 2);
-                var secondLastVal = secondLast.value();
-                var irate = (lastVal >= secondLastVal ? lastVal - secondLastVal : lastVal) / (lastTs.toEpochMilli() - secondLast.timestamp()
-                    .toEpochMilli()) * 1000;
-                return new RateRange(irate * 0.999, irate * 1.001); // Add 0.1% tolerance
-            } else if (deltaAgg.equals(DeltaAgg.DELTA)) {
-                var firstVal = timeseriesPointsInWindow.getFirst().value();
-                var lastVal = timeseriesPointsInWindow.getLast().value();
-                var delta = lastVal - firstVal;
-                var windowSizeFactor = secondsInWindow / tsDurationSeconds;
-                if (delta < 0) {
-                    return new RateRange(delta * windowSizeFactor * 1.001, delta * 0.999); // Add 0.1% tolerance
-                } else {
-                    return new RateRange(delta * 0.999, delta * windowSizeFactor * 1.001); // Add 0.1% tolerance
-                }
-            } else if (deltaAgg.equals(DeltaAgg.IDELTA)) {
-                var lastVal = timeseriesPointsInWindow.getLast().value();
-                var secondLastVal = timeseriesPointsInWindow.get(timeseriesPointsInWindow.size() - 2).value();
-                var idelta = lastVal - secondLastVal;
-                if (idelta < 0) {
-                    return new RateRange(idelta * 1.001, idelta * 0.999); // Add 0.1% tolerance
-                } else {
-                    return new RateRange(idelta * 0.999, idelta * 1.001); // Add 0.1% tolerance
-                }
-            }
-            assert deltaAgg == DeltaAgg.RATE || deltaAgg == DeltaAgg.INCREASE;
-            double lastValue = 0.0;
-            boolean first = true;
-            double counterGrowth = 0.0;
-            for (TimestampedValue point : timeseriesPointsInWindow) {
-                double currentValue = point.value();
-                if (first) {
-                    lastValue = currentValue;
-                    first = false;
-                    continue;
-                }
-                if (currentValue > lastValue) {
-                    counterGrowth += currentValue - lastValue;
-                } else if (currentValue < lastValue) {
-                    counterGrowth += currentValue;
-                }
-                lastValue = currentValue;
-            }
+            TimestampedValue lastInPrev = findLastPoint(allWindows, offset - 1, timeseriesId);
+            TimestampedValue firstInNext = findFirstPoint(allWindows, offset + 1, timeseriesId);
 
-            // Account for extrapolation in case there are no adjacent buckets.
-            if (timeseriesPointsInWindow.size() > 2) {
-                if (addedLowerBoundary && addedUpperBoundary == false) {
-                    firstTs = timeseriesPointsInWindow.get(1).timestamp();
-                } else if (addedLowerBoundary == false && addedUpperBoundary) {
-                    lastTs = timeseriesPointsInWindow.get(timeseriesPointsInWindow.size() - 2).timestamp();
-                }
-                tsDurationSeconds = (lastTs.toEpochMilli() - firstTs.toEpochMilli()) / 1000.0;
+            Double value = switch (deltaAgg) {
+                case RATE -> computeReferenceRateOrIncrease(lastInPrev, points, firstInNext, temporality, secondsInWindow, true);
+                case INCREASE -> computeReferenceRateOrIncrease(lastInPrev, points, firstInNext, temporality, secondsInWindow, false);
+                case IRATE -> computeReferenceIrate(points, temporality);
+                case DELTA -> computeReferenceDelta(points, secondsInWindow);
+                case IDELTA -> computeReferenceIdelta(points);
+            };
+            if (value == null || value.isNaN()) {
+                return null;
             }
-
-            if (deltaAgg.equals(DeltaAgg.INCREASE)) {
-                // TODO: get tighter bounds by applying interpolation instead of median between adjacent buckets
-                return new RateRange(counterGrowth * 0.9, counterGrowth * secondsInWindow / tsDurationSeconds * 1.1);
-            } else {
-                double lowBound = counterGrowth / secondsInWindow * 0.9;
-                double highBound = counterGrowth / tsDurationSeconds * 1.1;
-                return new RateRange(lowBound, highBound);
+            double tol = 0.001;
+            if (value == 0.0) {
+                return new RateRange(0.0, 0.0);
             }
+            double lo = value * (1 - tol);
+            double hi = value * (1 + tol);
+            return value < 0 ? new RateRange(hi, lo) : new RateRange(lo, hi);
         }).filter(Objects::nonNull).toList();
         if (allRates.isEmpty()) {
             return new RateStats(0L, null, null, null, null);
@@ -488,128 +635,6 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         );
     }
 
-    /**
-     * Adds an interpolated boundary point to a timeseries using data from the same timeseries in an
-     * adjacent window.
-     *
-     * @param currentWindow mutable list of data points for one timeseries in the current window (modified in place)
-     * @param adjacentWindow data points for the same timeseries in the adjacent window
-     * @return {@code true} if a boundary point was added or the reference point is already on the boundary
-     */
-    private static boolean addBoundaryPoint(
-        List<TimestampedValue> currentWindow,
-        List<TimestampedValue> adjacentWindow,
-        int secondsInWindow,
-        boolean isLowerBoundary
-    ) {
-        var referencePoint = isLowerBoundary ? currentWindow.getFirst() : currentWindow.getLast();
-        if (isLowerBoundary && referencePoint.timestamp().toEpochMilli() % (secondsInWindow * 1000L) == 0) {
-            return true;
-        }
-        if (instantsInAdjacentWindows(adjacentWindow.getFirst().timestamp(), referencePoint.timestamp(), secondsInWindow) == false) {
-            return false;
-        }
-        TimestampedValue otherValue = null;
-        long otherTimestamp = 0;
-        for (var point : adjacentWindow) {
-            long timestamp = point.timestamp().toEpochMilli();
-            if (otherValue == null
-                || (timestamp > otherTimestamp && isLowerBoundary)
-                || (timestamp < otherTimestamp && isLowerBoundary == false)) {
-                otherTimestamp = timestamp;
-                otherValue = point;
-            }
-        }
-        if (isLowerBoundary) {
-            currentWindow.addFirst(interpolateAtLowerBoundary(otherValue, referencePoint, secondsInWindow));
-        } else {
-            currentWindow.addLast(interpolateAtUpperBoundary(referencePoint, otherValue, secondsInWindow));
-        }
-        return true;
-    }
-
-    /**
-     * Prepends the latest data point from the same currentWindow in the lower (previous) window,
-     * used when only a single boundary-aligned point exists in the current window.
-     *
-     * @param currentWindow mutable list of data points for one currentWindow in the current window (modified in place)
-     * @param previousWindow data points for the same currentWindow in the previous window, or {@code null} if absent
-     */
-    private static void addLastPointFromLowerWindow(
-        List<TimestampedValue> currentWindow,
-        @Nullable List<TimestampedValue> previousWindow,
-        int secondsInWindow
-    ) {
-        if (previousWindow == null || previousWindow.isEmpty()) {
-            return;
-        }
-        Instant referenceTimestamp = currentWindow.getFirst().timestamp();
-        if (instantsInAdjacentWindows(previousWindow.getFirst().timestamp(), referenceTimestamp, secondsInWindow) == false) {
-            return;
-        }
-        TimestampedValue lowerPoint = null;
-        long lowerTimestampMs = 0;
-        for (var point : previousWindow) {
-            long timestamp = point.timestamp().toEpochMilli();
-            if (lowerPoint == null || timestamp > lowerTimestampMs) {
-                lowerTimestampMs = timestamp;
-                lowerPoint = point;
-            }
-        }
-        if (lowerPoint != null) {
-            currentWindow.addFirst(lowerPoint);
-        }
-    }
-
-    private static boolean instantsInAdjacentWindows(Instant first, Instant second, int secondsInWindow) {
-        long firstRounded = first.getEpochSecond() / secondsInWindow * secondsInWindow;
-        long secondRounded = second.getEpochSecond() / secondsInWindow * secondsInWindow;
-        long delta = Math.abs(firstRounded - secondRounded);
-        return delta == secondsInWindow;
-    }
-
-    private static TimestampedValue interpolateAtLowerBoundary(
-        TimestampedValue lowerPoint,
-        TimestampedValue upperPoint,
-        int secondsInWindow
-    ) {
-        final double valueDelta;
-        final double baseValue;
-        if (upperPoint.value() >= lowerPoint.value()) {
-            valueDelta = upperPoint.value() - lowerPoint.value();
-            baseValue = lowerPoint.value();
-        } else {
-            // Counter reset.
-            valueDelta = upperPoint.value();
-            baseValue = 0;
-        }
-        final double timeDelta = (upperPoint.timestamp().toEpochMilli() - lowerPoint.timestamp().toEpochMilli()) / 1000.0;
-        final double slope = valueDelta / timeDelta;
-        final long lowerBoundaryTimeSeconds = upperPoint.timestamp().getEpochSecond() / secondsInWindow * secondsInWindow;
-        final double lowerBoundaryValue = baseValue + slope * (lowerBoundaryTimeSeconds - lowerPoint.timestamp().toEpochMilli() / 1000.0);
-        return new TimestampedValue(Instant.ofEpochSecond(lowerBoundaryTimeSeconds), lowerBoundaryValue);
-    }
-
-    private static TimestampedValue interpolateAtUpperBoundary(
-        TimestampedValue lowerPoint,
-        TimestampedValue upperPoint,
-        int secondsInWindow
-    ) {
-        final double valueDelta;
-        if (upperPoint.value() >= lowerPoint.value()) {
-            valueDelta = upperPoint.value() - lowerPoint.value();
-        } else {
-            // Counter reset.
-            valueDelta = upperPoint.value();
-        }
-        final double timeDelta = (upperPoint.timestamp().toEpochMilli() - lowerPoint.timestamp().toEpochMilli()) / 1000.0;
-        final double slope = valueDelta / timeDelta;
-        final long upperBoundaryTimeSeconds = upperPoint.timestamp().getEpochSecond() / secondsInWindow * secondsInWindow;
-        final double upperBoundaryValue = lowerPoint.value() + slope * (upperBoundaryTimeSeconds - lowerPoint.timestamp().toEpochMilli()
-            / 1000.0);
-        return new TimestampedValue(Instant.ofEpochSecond(upperBoundaryTimeSeconds), upperBoundaryValue);
-    }
-
     void putTSDBIndexTemplate(List<String> patterns, @Nullable String mappingString) throws IOException {
         Settings.Builder settingsBuilder = Settings.builder();
         // Ensure it will be a TSDB data stream
@@ -617,7 +642,10 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         settingsBuilder.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, ESTestCase.randomIntBetween(1, 5));
         settingsBuilder.put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2025-07-31T00:00:00Z");
         settingsBuilder.put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2025-07-31T12:00:00Z");
-        settingsBuilder.put(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(), TSDataGenerationHelper.TEMPORALITY_FIELD_NAME);
+        settingsBuilder.put(
+            IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(),
+            "attributes." + TSDataGenerationHelper.TEMPORALITY_ATTRIBUTE_NAME
+        );
         settingsBuilder.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
         CompressedXContent mappings = mappingString == null ? null : CompressedXContent.fromJSON(mappingString);
         TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request(
@@ -636,7 +664,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void populateIndex() throws IOException {
-        //List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
+        // List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
         List<Temporality> allowedTemporalities = Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null);
         dataGenerationHelper = new TSDataGenerationHelper(NUM_DOCS, TIME_RANGE_SECONDS, allowedTemporalities);
         final XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -357,7 +357,6 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     /** Aggregated rate statistics (count, max, avg, min, sum) computed across timeseries in a window. */
     record RateStats(Long count, RateRange max, RateRange avg, RateRange min, RateRange sum) {}
 
-
     @Nullable
     private static TimestampedValue findLastPoint(List<Map<String, List<TimestampedValue>>> allWindows, int idx, String tsId) {
         if (idx < 0 || idx >= allWindows.size()) return null;
@@ -402,30 +401,29 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         double totalIncrease = computeCounterIncreaseBetween(currentWindow, temporality);
 
         if (lastInPrevWindow != null) {
-            totalIncrease += getInterpolatedIncreaseBetween(lastInPrevWindow, firstInWindow, timebucketStart, temporality);
+            totalIncrease += getInterpolatedIncreaseBetween(lastInPrevWindow, firstInWindow, timebucketStart, temporality, true);
             startTs = timebucketStart;
         } else if (currentWindow.size() > 1) {
-            totalIncrease += getExtrapolatedIncreaseAtBorder(currentWindow, temporality, secondsInWindow,true);
+            totalIncrease += getExtrapolatedIncreaseAtBorder(currentWindow, temporality, secondsInWindow, true);
             startTs = timebucketStart;
         }
         if (firstInNextWindow != null) {
-            totalIncrease += getInterpolatedIncreaseBetween(lastInWindow, firstInNextWindow, timebucketEnd, temporality);
+            totalIncrease += getInterpolatedIncreaseBetween(lastInWindow, firstInNextWindow, timebucketEnd, temporality, false);
             endTs = timebucketEnd;
         } else if (currentWindow.size() > 1) {
-            totalIncrease += getExtrapolatedIncreaseAtBorder(currentWindow, temporality, secondsInWindow,false);
+            totalIncrease += getExtrapolatedIncreaseAtBorder(currentWindow, temporality, secondsInWindow, false);
             endTs = timebucketEnd;
         }
 
-        if (startTs == endTs && lastInPrevWindow != null) {
-            // special case: The only value falsl exactly on the start border
-            // our rate implementation in this case returns the rate between the point in this window and the point in the last window
-            if (isRate) {
+        if (startTs == endTs) {
+            if (lastInPrevWindow != null && isRate) {
+                // special case: The only value falls exactly on the start border
+                // our rate implementation in this case returns the rate between the point in this window and the point in the last window
                 List<TimestampedValue> values = List.of(lastInPrevWindow, firstInWindow);
-                double rangeSeconds = (firstInWindow.timestamp().toEpochMilli() - lastInPrevWindow.timestamp().toEpochMilli()) * 1000.0;
+                double rangeSeconds = (firstInWindow.timestamp().toEpochMilli() - lastInPrevWindow.timestamp().toEpochMilli()) / 1000.0;
                 return computeCounterIncreaseBetween(values, temporality) / rangeSeconds;
-            } else {
-                return null;
             }
+            return null;
         }
         return isRate ? totalIncrease / ((endTs - startTs) / 1000.0) : totalIncrease;
     }
@@ -433,24 +431,36 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     private static double computeCounterIncreaseBetween(List<TimestampedValue> currentWindow, Temporality temporality) {
         double increaseInWindow = 0.0;
 
-        for (int i = 1; i < currentWindow.size(); i++) {
-            if (temporality == Temporality.DELTA) {
+        if (temporality == Temporality.DELTA) {
+            // Intentionally skip the first value: It's increase belongs to
+            // the timespan before the timestamp of the first value!
+            for (int i = 1; i < currentWindow.size(); i++) {
                 increaseInWindow += currentWindow.get(i).value();
-            } else {
-                double prevValue = currentWindow.get(i-1).value();
+            }
+        } else {
+            if (currentWindow.isEmpty()) {
+                return 0;
+            }
+            double resets = 0;
+            for (int i = 1; i < currentWindow.size(); i++) {
+                double prevValue = currentWindow.get(i - 1).value();
                 double currValue = currentWindow.get(i).value();
-                if (currValue >= prevValue) {
-                    increaseInWindow += currValue - prevValue;
-                } else {
-                    // reset, don't subtract previous cumulative value
-                    increaseInWindow += currValue;
+                if (currValue < prevValue) {
+                    resets += prevValue;
                 }
             }
+            increaseInWindow = currentWindow.getLast().value + resets - currentWindow.getFirst().value();
         }
         return increaseInWindow;
     }
 
-    static double getInterpolatedIncreaseBetween(TimestampedValue left, TimestampedValue right, long targetTimestamp, Temporality temporality) {
+    static double getInterpolatedIncreaseBetween(
+        TimestampedValue left,
+        TimestampedValue right,
+        long targetTimestamp,
+        Temporality temporality,
+        boolean isLowerBound
+    ) {
         long leftTs = left.timestamp().toEpochMilli();
         long rightTs = right.timestamp().toEpochMilli();
         assert targetTimestamp >= leftTs : "Target timestamp must be greater than or equal to left timestamp";
@@ -459,11 +469,14 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
 
         long timespan = rightTs - leftTs;
         double interpolationWeight = (targetTimestamp - leftTs) * 1.0 / timespan;
+        if (isLowerBound) {
+            interpolationWeight = 1.0 - interpolationWeight;
+        }
 
         double totalIncrease;
         if (temporality == Temporality.DELTA) {
             // For delta, only the counter value of the right point matters. It represents the total increase between the two points
-            totalIncrease = right.value() ;
+            totalIncrease = right.value();
         } else {
             if (right.value() >= left.value()) {
                 // no reset
@@ -508,7 +521,12 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
             if (gap > averageSampleInterval * 1.1) {
                 gap = averageSampleInterval / 2.0;
             }
-            return gap * slope;
+            // the extrapolated increase cannot exceed the first counter value for the lower boundary
+            double extrapolatedIncrease = gap * slope;
+            if (isLowerBoundary) {
+                extrapolatedIncrease = Math.min(extrapolatedIncrease, values.getFirst().value());
+            }
+            return extrapolatedIncrease;
         }
         return 0.0;
     }
@@ -534,43 +552,33 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     }
 
     /**
-     * Computes a reference delta matching {@code DeltaAggregator#evaluateFinal} with PromQL-style
-     * in-bucket extrapolation to bucket boundaries. No adjacent-window data.
+     * Computes a reference delta range for a single timeseries in a time window.
+     * The raw delta is {@code lastValue - firstValue}. The ES DeltaAggregator applies PromQL-style
+     * extrapolation that scales the delta up to cover the full bucket width, so the actual result
+     * falls between the raw delta and {@code delta * windowSizeFactor}.
+     *
+     * @return a {@code [lower, upper]} range, or {@code null} if fewer than 2 points
      */
-    static Double computeReferenceDelta(List<TimestampedValue> currentWindow, int secondsInWindow) {
+    static double[] computeReferenceDelta(List<TimestampedValue> currentWindow, int secondsInWindow) {
         if (currentWindow == null || currentWindow.size() < 2) {
             return null;
         }
-        long firstTs = currentWindow.getFirst().timestamp().toEpochMilli();
         double firstValue = currentWindow.getFirst().value();
-        long lastTs = currentWindow.getLast().timestamp().toEpochMilli();
         double lastValue = currentWindow.getLast().value();
+        long firstTs = currentWindow.getFirst().timestamp().toEpochMilli();
+        long lastTs = currentWindow.getLast().timestamp().toEpochMilli();
         if (lastTs == firstTs) {
             return null;
         }
 
-        long bucketStartMs = (firstTs / (secondsInWindow * 1000L)) * (secondsInWindow * 1000L);
-        long bucketEndMs = bucketStartMs + secondsInWindow * 1000L;
-        double averageSampleInterval = (double) (lastTs - firstTs) / currentWindow.size();
-        double slope = (lastValue - firstValue) / (lastTs - firstTs);
-
-        double calculatedFirst = firstValue;
-        double startGap = firstTs - bucketStartMs;
-        if (startGap > 0) {
-            if (startGap > averageSampleInterval * 1.1) {
-                startGap = averageSampleInterval / 2.0;
-            }
-            calculatedFirst = firstValue - startGap * slope;
+        double delta = lastValue - firstValue;
+        double tsDurationSeconds = (lastTs - firstTs) / 1000.0;
+        double windowSizeFactor = secondsInWindow / tsDurationSeconds;
+        if (delta < 0) {
+            return new double[] { delta * windowSizeFactor, delta };
+        } else {
+            return new double[] { delta, delta * windowSizeFactor };
         }
-        double calculatedLast = lastValue;
-        double endGap = bucketEndMs - lastTs;
-        if (endGap > 0) {
-            if (endGap > averageSampleInterval * 1.1) {
-                endGap = averageSampleInterval / 2.0;
-            }
-            calculatedLast = lastValue + endGap * slope;
-        }
-        return calculatedLast - calculatedFirst;
     }
 
     /**
@@ -599,15 +607,45 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
             points.sort(Comparator.comparing(TimestampedValue::timestamp));
             Temporality temporality = getCounterTemporality(timeseriesId);
 
+            long millisInWindow = secondsInWindow * 1000L;
+            long currentBucketStartMs = points.getFirst().timestamp().toEpochMilli() / millisInWindow * millisInWindow;
+
             TimestampedValue lastInPrev = findLastPoint(allWindows, offset - 1, timeseriesId);
             TimestampedValue firstInNext = findFirstPoint(allWindows, offset + 1, timeseriesId);
+
+            // The allWindows list only contains entries for non-empty buckets, so offset-1 / offset+1
+            // may point to a non-adjacent time bucket when there are gaps in the data. ES only
+            // interpolates with the immediately adjacent bucket, so discard points from distant buckets.
+            if (lastInPrev != null) {
+                long prevBucket = lastInPrev.timestamp().toEpochMilli() / millisInWindow * millisInWindow;
+                if (prevBucket != currentBucketStartMs - millisInWindow) {
+                    lastInPrev = null;
+                }
+            }
+            if (firstInNext != null) {
+                long nextBucket = firstInNext.timestamp().toEpochMilli() / millisInWindow * millisInWindow;
+                if (nextBucket != currentBucketStartMs + millisInWindow) {
+                    firstInNext = null;
+                }
+            }
+
+            if (deltaAgg == DeltaAgg.DELTA) {
+                double[] deltaRange = computeReferenceDelta(points, secondsInWindow);
+                if (deltaRange == null) {
+                    return null;
+                }
+                double tol = 0.001;
+                double lo = deltaRange[0] < 0 ? deltaRange[0] * (1 + tol) : deltaRange[0] * (1 - tol);
+                double hi = deltaRange[1] < 0 ? deltaRange[1] * (1 - tol) : deltaRange[1] * (1 + tol);
+                return new RateRange(lo, hi);
+            }
 
             Double value = switch (deltaAgg) {
                 case RATE -> computeReferenceRateOrIncrease(lastInPrev, points, firstInNext, temporality, secondsInWindow, true);
                 case INCREASE -> computeReferenceRateOrIncrease(lastInPrev, points, firstInNext, temporality, secondsInWindow, false);
                 case IRATE -> computeReferenceIrate(points, temporality);
-                case DELTA -> computeReferenceDelta(points, secondsInWindow);
                 case IDELTA -> computeReferenceIdelta(points);
+                default -> throw new IllegalStateException("Unexpected delta agg: " + deltaAgg);
             };
             if (value == null || value.isNaN()) {
                 return null;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -62,7 +62,6 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     private static final Long NUM_DOCS = 2000L;
     private static final Long TIME_RANGE_SECONDS = 3600L;
     private static final String DATASTREAM_NAME = "tsit_ds";
-    private static final String TEMPORALITY_FIELD = "temporality";
     private static final Integer SECONDS_IN_WINDOW = 60;
 
     record WindowOption(String label, int seconds) {}
@@ -618,7 +617,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
         settingsBuilder.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, ESTestCase.randomIntBetween(1, 5));
         settingsBuilder.put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2025-07-31T00:00:00Z");
         settingsBuilder.put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2025-07-31T12:00:00Z");
-        settingsBuilder.put(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(), TEMPORALITY_FIELD);
+        settingsBuilder.put(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(), TSDataGenerationHelper.TEMPORALITY_FIELD_NAME);
         settingsBuilder.put(IndexSettings.SYNTHETIC_ID.getKey(), randomBoolean());
         CompressedXContent mappings = mappingString == null ? null : CompressedXContent.fromJSON(mappingString);
         TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request(
@@ -637,8 +636,9 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void populateIndex() throws IOException {
-        List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
-        dataGenerationHelper = new TSDataGenerationHelper(NUM_DOCS, TIME_RANGE_SECONDS, TEMPORALITY_FIELD, allowedTemporalities);
+        //List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
+        List<Temporality> allowedTemporalities = Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null);
+        dataGenerationHelper = new TSDataGenerationHelper(NUM_DOCS, TIME_RANGE_SECONDS, allowedTemporalities);
         final XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.map(dataGenerationHelper.mapping.raw());
         final String jsonMappings = Strings.toString(builder);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -702,8 +702,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void populateIndex() throws IOException {
-        // List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
-        List<Temporality> allowedTemporalities = Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null);
+        List<Temporality> allowedTemporalities = randomNonEmptySubsetOf(Arrays.asList(Temporality.DELTA, Temporality.CUMULATIVE, null));
         dataGenerationHelper = new TSDataGenerationHelper(NUM_DOCS, TIME_RANGE_SECONDS, allowedTemporalities);
         final XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.map(dataGenerationHelper.mapping.raw());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TSDataGenerationHelper.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TSDataGenerationHelper.java
@@ -37,6 +37,9 @@ import java.util.stream.IntStream;
 
 class TSDataGenerationHelper {
 
+    private static final String TEMPORALITY_SUBFIELD_NAME = "temporality";
+    static final String TEMPORALITY_FIELD_NAME = "attributes." + TEMPORALITY_SUBFIELD_NAME;
+
     private static Object randomDimensionValue(String dimensionName) {
         // We use dimensionName to determine the type of the value.
         var isNumeric = dimensionName.hashCode() % 5 == 0;
@@ -52,7 +55,7 @@ class TSDataGenerationHelper {
         }
     }
 
-    TSDataGenerationHelper(long numDocs, long timeRangeSeconds, String temporalityFieldName, Collection<Temporality> allowedTemporalities) {
+    TSDataGenerationHelper(long numDocs, long timeRangeSeconds, Collection<Temporality> allowedTemporalities) {
         // Metrics coming into our system have a pre-set group of attributes.
         // Making a list-to-set-to-list to ensure uniqueness.
         this.numDocs = numDocs;
@@ -70,8 +73,8 @@ class TSDataGenerationHelper {
             ArrayList<Tuple<String, Object>> dimensions = dimensionsInMetric.stream().map(attr -> new Tuple<>(attr, randomDimensionValue(attr))).collect(Collectors.toCollection(ArrayList::new));
             Temporality temporality = ESTestCase.randomFrom(allowedTemporalities);
             if (temporality != null) {
-                usedAttributeNames.add(temporalityFieldName);
-                dimensions.add(new Tuple<>(temporalityFieldName, temporality.bytesRef().utf8ToString()));
+                usedAttributeNames.add(TEMPORALITY_SUBFIELD_NAME);
+                dimensions.add(new Tuple<>(TEMPORALITY_SUBFIELD_NAME, temporality.bytesRef().utf8ToString()));
             }
             return (List<Tuple<String, Object>>) dimensions;
         }).toList();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TSDataGenerationHelper.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TSDataGenerationHelper.java
@@ -37,8 +37,7 @@ import java.util.stream.IntStream;
 
 class TSDataGenerationHelper {
 
-    private static final String TEMPORALITY_SUBFIELD_NAME = "temporality";
-    static final String TEMPORALITY_FIELD_NAME = "attributes." + TEMPORALITY_SUBFIELD_NAME;
+    static final String TEMPORALITY_ATTRIBUTE_NAME = "temporality";
 
     private static Object randomDimensionValue(String dimensionName) {
         // We use dimensionName to determine the type of the value.
@@ -70,11 +69,13 @@ class TSDataGenerationHelper {
             List<String> dimensionsInMetric = ESTestCase.randomNonEmptySubsetOf(tempAttributeSet);
             // TODO: How do we handle the case when there are no dimensions? (i.e. regular randomSubsetof(...)
             usedAttributeNames.addAll(dimensionsInMetric);
-            ArrayList<Tuple<String, Object>> dimensions = dimensionsInMetric.stream().map(attr -> new Tuple<>(attr, randomDimensionValue(attr))).collect(Collectors.toCollection(ArrayList::new));
+            ArrayList<Tuple<String, Object>> dimensions = dimensionsInMetric.stream()
+                .map(attr -> new Tuple<>(attr, randomDimensionValue(attr)))
+                .collect(Collectors.toCollection(ArrayList::new));
             Temporality temporality = ESTestCase.randomFrom(allowedTemporalities);
             if (temporality != null) {
-                usedAttributeNames.add(TEMPORALITY_SUBFIELD_NAME);
-                dimensions.add(new Tuple<>(TEMPORALITY_SUBFIELD_NAME, temporality.bytesRef().utf8ToString()));
+                usedAttributeNames.add(TEMPORALITY_ATTRIBUTE_NAME);
+                dimensions.add(new Tuple<>(TEMPORALITY_ATTRIBUTE_NAME, temporality.bytesRef().utf8ToString()));
             }
             return (List<Tuple<String, Object>>) dimensions;
         }).toList();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TSDataGenerationHelper.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TSDataGenerationHelper.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.compute.aggregation.Temporality;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.datageneration.DocumentGenerator;
@@ -24,6 +25,8 @@ import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -49,7 +52,7 @@ class TSDataGenerationHelper {
         }
     }
 
-    TSDataGenerationHelper(long numDocs, long timeRangeSeconds) {
+    TSDataGenerationHelper(long numDocs, long timeRangeSeconds, String temporalityFieldName, Collection<Temporality> allowedTemporalities) {
         // Metrics coming into our system have a pre-set group of attributes.
         // Making a list-to-set-to-list to ensure uniqueness.
         this.numDocs = numDocs;
@@ -64,7 +67,13 @@ class TSDataGenerationHelper {
             List<String> dimensionsInMetric = ESTestCase.randomNonEmptySubsetOf(tempAttributeSet);
             // TODO: How do we handle the case when there are no dimensions? (i.e. regular randomSubsetof(...)
             usedAttributeNames.addAll(dimensionsInMetric);
-            return dimensionsInMetric.stream().map(attr -> new Tuple<>(attr, randomDimensionValue(attr))).collect(Collectors.toList());
+            ArrayList<Tuple<String, Object>> dimensions = dimensionsInMetric.stream().map(attr -> new Tuple<>(attr, randomDimensionValue(attr))).collect(Collectors.toCollection(ArrayList::new));
+            Temporality temporality = ESTestCase.randomFrom(allowedTemporalities);
+            if (temporality != null) {
+                usedAttributeNames.add(temporalityFieldName);
+                dimensions.add(new Tuple<>(temporalityFieldName, temporality.bytesRef().utf8ToString()));
+            }
+            return (List<Tuple<String, Object>>) dimensions;
         }).toList();
         attributesForMetrics = List.copyOf(usedAttributeNames);
 


### PR DESCRIPTION
Part of https://github.com/elastic/elasticsearch/issues/139189.

Updates RandomizedTimeSeriesIT to also use a randomized temporality per time series.
Unfortunately this involved some rafactorings to how we build the expected values in the tests to keep things maintainable: For interpolation / extrapolation at the borders, we would previously compute fake interpolated data points, add them to list of data points for a given time window and then compute the expected aggregation result based on that. This would have made to code very complex and hard to reason about when having to also take temporality into account: E.g. for interpolation of delta we wouldn't be able to just add another point, but rather we would have to adjust the value of the first data point and isnert some fake `0` into the data.

This PR changes the approach: We now provide the following input to functions which compute the expected value per aggregation:
 * All points in the time bucket
 * The last point in the bucket directly before the current bucket (if it exists)
 * The last point in the bucket directly after the current bucket (if it exists)
 * The temporality
 
 This makes the reference implementations hopefully easier to understand and moves the implementation close to what actually do in the aggregations.
 
 I ran the tests locally for 400 iterations without failures.