### PR TITLE
Fix an infinite BCC upload retry-loop during disrupted reshard

### DIFF
--- a/docs/changelog/152278.yaml
+++ b/docs/changelog/152278.yaml
@@ -1,0 +1,6 @@
+area: Distributed
+issues:
+ - 152259
+pr: 152278
+summary: Fix an infinite BCC upload retry-loop during disrupted reshard
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -782,6 +782,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:grok.shadowingSubfields}
   issue: https://github.com/elastic/elasticsearch/issues/152257
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
-  method: testReshardWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/152259

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1463,10 +1463,18 @@ public class StatelessPlugin extends Plugin
                 }
 
                 @Override
+                public void beforeIndexShardClosed(ShardId shardId, IndexShard indexShard, Settings indexSettings) {
+                    if (indexShard != null) {
+                        // Must be called before engine.flushAndClose() to unblock any listeners waiting,
+                        // which would otherwise deadlock with drainForClose() waiting for ensureOpenRefs.
+                        statelessCommitService.closeShard(shardId);
+                    }
+                }
+
+                @Override
                 public void afterIndexShardClosed(ShardId shardId, IndexShard indexShard, Settings indexSettings) {
                     if (indexShard != null) {
                         statelessCommitService.unregisterCommitNotificationSuccessListener(shardId);
-                        statelessCommitService.closeShard(shardId);
                         // release snapshot commits after shardCommitState is closed
                         snapshotsCommitService.releaseCommitsAndRemoveShardAfterShardClosed(shardId);
                         hollowShardsService.get().removeHollowShard(indexShard, "index shard closed");


### PR DESCRIPTION
Unfortunately, I haven't found any commits that caused this behavior, so I focused on finding the race.

To me, it looks like a genuine issue.

In the logs, we can observe infinite retries of BCC upload:

```
  1> [2026-06-25T22:30:55,429][INFO ][o.e.x.s.c.BatchedCompoundCommitUploadTask][node_t1][stateless_shard_write][T#1] [index-jzwasrtsxe][2] failed attempt [256] to upload commit [4] to object store, will retry
  1> java.lang.IllegalStateException: Object store service is not running [STOPPED]
  1> 	at org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService.ensureRunning(ObjectStoreService.java:654)
  1> 	at org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService.enqueueTask(ObjectStoreService.java:732)
  1> 	at org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService.uploadBatchedCompoundCommitFile(ObjectStoreService.java:686)
  1> 	at org.elasticsearch.xpack.stateless.commits.BatchedCompoundCommitUploadTask.uploadBatchedCompoundCommitFile(BatchedCompoundCommitUploadTask.java:187)
  1> 	at org.elasticsearch.xpack.stateless.commits.BatchedCompoundCommitUploadTask.lambda$executeUpload$5(BatchedCompoundCommitUploadTask.java:162)
```

This is caused because the retry condition is checking the `commitState.isClosed()` only
https://github.com/elastic/elasticsearch/blob/54ab7884cfd8a31bafdfc2268f68948d677fcea1/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java#L782-L784

At the same time, `Engine#drainForClose` (called by `flushAndClose`) waits for closing the shard until the open refs are released. They are blocked by the upload task, though.


By moving the `statelessCommitService.closeShard(shardId);` from  `afterIndexShardClosed` to `beforeIndexShardClosed`, the upload task will stop retrying and finish, releasing the lock and unblocking the `drainForClose` method.

Closes: #152259