### PR TITLE
[8.19] Fix infinite loop in GeoLineDecomposer dateline crossing checks (#152096)

### DIFF
--- a/docs/changelog/152096.yaml
+++ b/docs/changelog/152096.yaml
@@ -1,0 +1,6 @@
+area: Geo
+issues:
+ - 152066
+pr: 152096
+summary: Fix infinite loop in `GeoLineDecomposer` dateline crossing checks
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoLineDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoLineDecomposer.java
@@ -76,6 +76,11 @@ class GeoLineDecomposer {
 
         double shift = 0;
         int i = 1;
+        // Tracks dateline crossings for the current segment (same i). Resets when i advances.
+        // A legitimate geographic line segment can cross the dateline at most once; allowing a generous
+        // limit here guards against extreme coordinate values causing effectively-infinite loops while
+        // still permitting deliberately-unwrapped multi-revolution paths in tests and edge cases.
+        int segmentCrossings = 0;
         while (i < lons.length) {
             // Check where the line is going east (+1), west (-1) or directly north/south (0)
             int direction = Double.compare(lons[i], lons[i - 1]);
@@ -94,6 +99,14 @@ class GeoLineDecomposer {
                 shift = newShift;
                 double t = intersection(lons[i - 1] + shift, lons[i] + shift);
                 if (Double.isNaN(t) == false) {
+                    segmentCrossings++;
+                    if (segmentCrossings > 10_000) {
+                        throw new IllegalArgumentException(
+                            "Longitude value ["
+                                + lons[i]
+                                + "] is out of valid range for geo_shape; consider normalizing coordinates to [-180, 180]"
+                        );
+                    }
                     // Found intersection, all previous segments are now part of the linestring
                     double[] partLons = Arrays.copyOfRange(lons, offset, i + 1);
                     double[] partLats = Arrays.copyOfRange(lats, offset, i + 1);
@@ -104,6 +117,7 @@ class GeoLineDecomposer {
                     collector.add(new Line(partLons, partLats));
                 } else {
                     // Didn't find intersection - just continue checking
+                    segmentCrossings = 0;
                     i++;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryNormalizerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryNormalizerTests.java
@@ -282,6 +282,17 @@ public class GeometryNormalizerTests extends ESTestCase {
         }
     }
 
+    /**
+     * Reproduces the infinite-loop OOM described in github issue #152066: a LineString whose second
+     * coordinate has an astronomically large longitude value (e.g. -4.14e19) drove
+     * GeoLineDecomposer.decompose into an effectively-infinite loop that exhausted the heap.
+     */
+    public void testExtremeLongitudeCausesTooManyCrossingsError() {
+        Line line = new Line(new double[] { 116.5037459137329, -4.142431633325595e19 }, new double[] { 39.793895444619, 71.0 });
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> GeometryNormalizer.apply(Orientation.CCW, line));
+        assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("out of valid range"));
+    }
+
     public void testMultiLine() {
         Line line = new Line(new double[] { 3, 4 }, new double[] { 1, 2 });
         MultiLine multiLine = new MultiLine(Collections.singletonList(line));


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix infinite loop in GeoLineDecomposer dateline crossing checks (#152096)