### PR TITLE
Continuation of deduplicating content for plugins

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -20,6 +20,16 @@ redirects:
   # Custom plugins and bundles moved to docs-content (narrative ECH deployment docs)
   'reference/elasticsearch-plugins/cloud/ec-custom-bundles.md': 'docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md'
 
+  # ECE and ECH plugin management procedures moved to docs-content (see elastic/docs-content#7101)
+  'reference/elasticsearch-plugins/plugin-management.md':
+    to: 'reference/elasticsearch-plugins/plugin-management.md'
+    anchors: {}
+    many:
+      - to: 'docs-content://deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md'
+        anchors: {'ec-adding-plugins', 'managing-plugins-for-ech', 'ec-adding-elastic-plugins', 'ec_before_you_begin_6'}
+      - to: 'docs-content://deploy-manage/deploy/cloud-enterprise/add-plugins.md'
+        anchors: {'ece-adding-plugins', 'managing-plugins-for-ece'}
+
   # https://github.com/elastic/elasticsearch/pull/131385
   'reference/elasticsearch/rest-apis/retrievers.md':
     to: 'reference/elasticsearch/rest-apis/retrievers.md'

--- a/docs/reference/elasticsearch-plugins/plugin-management.md
+++ b/docs/reference/elasticsearch-plugins/plugin-management.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugin-management.html
 applies_to:
-  stack: all
+  stack: ga
   serverless: unavailable
 ---
 
@@ -24,7 +24,7 @@ How you add and manage plugins depends on where {{es}} runs:
 * On [{{eck}}](#managing-plugins-for-eck) deployments you install plugins by building a custom container image or using init containers.
 
 ::::{note} {{serverless-full}} projects
-{{serverless-full}} projects do not support custom plugin or bundle uploads. For how {{ech}} and {{serverless-short}} differ on plugins, bundles, and dictionary options, see [Compare {{ech}} and Serverless](docs-content://deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md#elasticsearch-differences-custom-plugins-and-bundles).
+{{serverless-full}} projects do not support installing plugins or uploading custom plugins and bundles. {{serverless-short}} includes [core analysis plugins](./analysis-plugins.md#_core_analysis_plugins) by default. To manage synonyms, use the [synonyms API]({{es-serverless-apis}}group/endpoint-synonyms). For other differences between {{ech}} and {{serverless-short}} on plugins, bundles, and custom dictionaries, see [Compare {{ech}} and Serverless](docs-content://deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md#elasticsearch-differences-custom-plugins-and-bundles).
 ::::
 
 ## Managing plugins for {{ech}} [managing-plugins-for-ech]
@@ -59,7 +59,9 @@ To add plugins to an {{ece}} deployment, refer to:
     self: ga
 ```
 
-Use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which {{es}} package you installed. For more information, see [](_plugins_directory.md)
+If you run {{es}} using the [official {{es}} Docker image](https://www.docker.elastic.co/), manage plugins with a declarative [configuration file](manage-plugins-using-configuration-file.md). When {{es}} starts, it installs, upgrades, or removes plugins to match the file.
+
+For all other installation methods, use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which {{es}} package you installed. For more information, see [](_plugins_directory.md).
 
 Run the following command to get usage instructions:
 
@@ -73,13 +75,12 @@ If {{es}} was installed using the deb or rpm package then run `/usr/share/elasti
 
 For detailed instructions on installing, managing, and configuring plugins, see the following:
 
-* [Installing Plugins](./installation.md)
+* [](./installation.md)
 * [Custom URL or file system](./plugin-management-custom-url.md)
 * [Installing multiple plugins](./installing-multiple-plugins.md)
 * [Mandatory plugins](./mandatory-plugins.md)
 * [Listing, removing and updating installed plugins](./listing-removing-updating.md)
 * [Other command line parameters](./_other_command_line_parameters.md)
-* [Manage plugins using a configuration file](./manage-plugins-using-configuration-file.md)
 
 ### Managing plugins for Docker deployments
 

--- a/docs/reference/elasticsearch-plugins/plugin-management.md
+++ b/docs/reference/elasticsearch-plugins/plugin-management.md
@@ -1,9 +1,6 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugin-management.html
-  - https://www.elastic.co/guide/en/cloud/current/ec-adding-plugins.html
-  - https://www.elastic.co/guide/en/cloud/current/ec-adding-elastic-plugins.html
-  - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-add-plugins.html
 applies_to:
   deployment:
     ess: ga
@@ -14,95 +11,49 @@ applies_to:
 
 # Plugin management
 
-Plugins extend Elasticsearch’s core functionality and can be managed differently depending on the deployment type. While {{ece}} (ECE) and {{ech}} (ECH) provide built-in plugin management, self-managed deployments require manual installation.
-
-{{ece}} and {{ech}} deployments simplify plugin management by offering compatible plugins for your Elasticsearch version. These plugins are automatically upgraded with your deployment, except in cases of breaking changes.
-
-In ECE and ECH deployments, you can add plugins by selecting them from the available list. However, plugin availability depends on the Elasticsearch version.
+Plugins extend {{es}}'s core functionality and can be managed differently depending on the deployment type. While {{ece}} (ECE) and {{ech}} 
+(ECH) provide built-in plugin management, self-managed deployments require manual installation.
 
 Plugins serve various purposes, including:
 
 * National language support, phonetic analysis, and extended unicode support
 * Ingesting attachments in common formats and ingesting information about the geographic location of IP addresses
-* Adding new field datatypes to Elasticsearch
-* Discovery plugins, such as the cloud AWS plugin that allows discovering nodes on EC2 instances.
-* Analysis plugins, to provide analyzers targeted at languages other than English.
-* Scripting plugins, to provide additional scripting languages.
+* Adding new field datatypes to {{es}}
+* Discovery plugins, such as the cloud AWS plugin that allows discovering nodes on EC2 instances
+* Analysis plugins, to provide analyzers targeted at languages other than English
+* Scripting plugins, to provide additional scripting languages
 
-## Managing plugins for ECE
-```{applies_to}
-    ece: ga
-```
-
-### Add plugins when creating a new ECE deployment
-
-1. [Log into the Cloud UI](docs-content://deploy-manage/deploy/cloud-enterprise/log-into-cloud-ui.md) and select **Create deployment**.
-2. Make your initial deployment selections, then select **Customize Deployment**.
-3. Beneath the Elasticsearch master node, expand the **Manage plugins and settings** caret.
-4. Select the plugins you want.
-5. Select **Create deployment**.
-
-The deployment spins up with the plugins installed.
-
-### Add plugins to an existing ECE deployment
-
-1. [Log into the Cloud UI](docs-content://deploy-manage/deploy/cloud-enterprise/log-into-cloud-ui.md).
-2. On the **Deployments** page, select your deployment.
-
-    Narrow the list by name, ID, or choose from several other filters. To further define the list, use a combination of filters.
-
-3. From your deployment menu, go to the **Edit** page.
-4. Beneath the Elasticsearch master node, expand the **Manage plugins and settings** caret.
-5. Select the plugins that you want.
-6. Select **Save changes**.
-
-There is no downtime when adding plugins to highly available deployments. The deployment is updated with new nodes that have the plugins installed.
-
-## Managing plugins for ECH
+## Managing plugins for {{ech}}
 ```{applies_to}
     ess: ga
 ```
 
-There are two ways to add plugins to {{ech}} deployments:
+{{ech}} simplifies plugin management by offering compatible plugins for your {{es}} version. These plugins are automatically upgraded with your deployment, except when there are breaking changes.
 
-* Enable one of the official plugins already available in ECH
-* [Upload a custom plugin and then enable it per deployment](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md).
+To add plugins to a hosted deployment, refer to:
 
-Custom plugins can include the official {{es}} plugins not provided with ECH, any of the community-sourced plugins, or [plugins that you write yourself](/extend/index.md). Uploading custom plugins is available only to Gold, Platinum, and Enterprise subscriptions. For more information, check [Upload custom plugins and bundles](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md).
+* [Add plugins and extensions in {{ech}}](docs-content://deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md)
+* [Upload custom plugins and bundles](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md)
+* [Manage plugins and extensions through the API](docs-content://deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md)
 
-To learn more about the official and community-sourced plugins, refer to [{{es}} Plugins and Integrations](index.md).
+## Managing plugins for {{ece}}
+```{applies_to}
+    ece: ga
+```
 
-For a detailed guide with examples of using the Elasticsearch Service API to create, get information about, update, and delete extensions and plugins, check [Manage plugins and extensions through the API](docs-content://deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md).
+{{ece}} provides built-in plugins that work with your version of {{es}} and are upgraded along with your deployment, unless there are breaking changes.
 
-### Add plugins provided with ECH [ec-adding-elastic-plugins]
+To add plugins to an {{ece}} deployment, refer to:
 
-You can use a variety of official plugins that are compatible with your version of {{es}}. When you upgrade to a new {{es}} version, these plugins are simply upgraded with the rest of your deployment.
-
-#### Before you begin [ec_before_you_begin_6]
-
-Some restrictions apply when adding plugins. To learn more, check [Restrictions for {{es}} and {{kib}} plugins](cloud://release-notes/cloud-hosted/known-issues.md#ec-restrictions-plugins).
-
-Only Gold, Platinum, Enterprise and Private subscriptions have access to uploading custom plugins. All subscription levels, including Standard, can upload scripts and dictionaries.
-
-### Enabling plugins for a deployment
-
-1. Log in to the [{{ecloud}} Console](https://cloud.elastic.co?page=docs&placement=docs-body).
-2. Find your deployment On the home page and select **Manage** next to it, or go to the **Deployments** page to view all deployments.
-
-    On the **Deployments** page you can narrow your deployments by name, ID, or choose from several other filters. To customize your view, use a combination of filters, or change the format from a grid to a list.
-
-3. From the **Actions** dropdown, select **Edit deployment**.
-4. Select **Manage user settings and extensions**.
-5. Select the **Extensions** tab.
-6. Select the plugins that you want to enable.
-7. Select **Back**.
-8. Select **Save**. The {{es}} cluster is then updated with new nodes that have the plugin installed.
+* [Add plugins and extensions in {{ece}}](docs-content://deploy-manage/deploy/cloud-enterprise/add-plugins.md)
+* [Add custom bundles and plugins](docs-content://deploy-manage/deploy/cloud-enterprise/add-custom-bundles-plugins.md)
 
 ## Managing plugins for self-managed deployments
 ```{applies_to}
     self: ga
 ```
-Use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which Elasticsearch package you installed. For more information, see [Plugins directory](_plugins_directory.md)
+
+Use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which {{es}} package you installed. For more information, see [Plugins directory](_plugins_directory.md)
 
 Run the following command to get usage instructions:
 
@@ -111,7 +62,7 @@ sudo bin/elasticsearch-plugin -h
 ```
 
 :::{important} Running as root
-If Elasticsearch was installed using the deb or rpm package then run `/usr/share/elasticsearch/bin/elasticsearch-plugin` as `root` so it can write to the appropriate files on disk. Otherwise run `bin/elasticsearch-plugin` as the user that owns all of the Elasticsearch files.
+If {{es}} was installed using the deb or rpm package then run `/usr/share/elasticsearch/bin/elasticsearch-plugin` as `root` so it can write to the appropriate files on disk. Otherwise run `bin/elasticsearch-plugin` as the user that owns all of the {{es}} files.
 :::
 
 For detailed instructions on installing, managing, and configuring plugins, see the following:
@@ -124,13 +75,12 @@ For detailed instructions on installing, managing, and configuring plugins, see 
 * [Other command line parameters](./_other_command_line_parameters.md)
 * [Manage plugins using a configuration file](./manage-plugins-using-configuration-file.md)
 
-## Managing plugins for docker deployments
-```{applies_to}
-    self: ga
-```
-If you run Elasticsearch using Docker, you can manage plugins using a [configuration file](manage-plugins-using-configuration-file.md).
+### Managing plugins for Docker deployments
+
+If you run {{es}} using the [official {{es}} Docker image](https://www.docker.elastic.co/), you can manage plugins using a declarative [configuration file](manage-plugins-using-configuration-file.md). This approach applies to self-managed Docker deployments only.
 
 
-
-
-
+:::{admonition} Running {{es}} with plugins on {{eck}}
+:applies_to: eck: ga
+On {{eck}}, install plugins by building a custom container image or using init containers. For details, see [Custom configuration files and plugins](docs-content://deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md).
+:::

--- a/docs/reference/elasticsearch-plugins/plugin-management.md
+++ b/docs/reference/elasticsearch-plugins/plugin-management.md
@@ -2,19 +2,13 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugin-management.html
 applies_to:
-  deployment:
-    ess: ga
-    ece: ga
-    self: ga
+  stack: all
   serverless: unavailable
 ---
 
 # Plugin management
 
-Plugins extend {{es}}'s core functionality and can be managed differently depending on the deployment type. While {{ece}} (ECE) and {{ech}} 
-(ECH) provide built-in plugin management, self-managed deployments require manual installation.
-
-Plugins serve various purposes, including:
+Plugins extend {{es}}'s core functionality and can serve various purposes, including:
 
 * National language support, phonetic analysis, and extended unicode support
 * Ingesting attachments in common formats and ingesting information about the geographic location of IP addresses
@@ -23,7 +17,17 @@ Plugins serve various purposes, including:
 * Analysis plugins, to provide analyzers targeted at languages other than English
 * Scripting plugins, to provide additional scripting languages
 
-## Managing plugins for {{ech}}
+
+How you add and manage plugins depends on where {{es}} runs:
+* Hosted Cloud deployments such as [{{ech}}](#managing-plugins-for-ech) and [{{ece}}](#managing-plugins-for-ece) expose plugin and extension management in the Cloud console and API.
+* [Self-managed deployments](#managing-plugins-for-self-managed) use the `elasticsearch-plugin` CLI to install, list, and remove plugins on each node, while for Docker, you can also declare plugins in a [configuration file](manage-plugins-using-configuration-file.md).
+* On [{{eck}}](#managing-plugins-for-eck) deployments you install plugins by building a custom container image or using init containers.
+
+::::{note} {{serverless-full}} projects
+{{serverless-full}} projects do not support custom plugin or bundle uploads. For how {{ech}} and {{serverless-short}} differ on plugins, bundles, and dictionary options, see [Compare {{ech}} and Serverless](docs-content://deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md#elasticsearch-differences-custom-plugins-and-bundles).
+::::
+
+## Managing plugins for {{ech}} [managing-plugins-for-ech]
 ```{applies_to}
     ess: ga
 ```
@@ -33,10 +37,11 @@ Plugins serve various purposes, including:
 To add plugins to a hosted deployment, refer to:
 
 * [Add plugins and extensions in {{ech}}](docs-content://deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md)
+% * [Add plugins provided with {{ech}}](docs-content://deploy-manage/deploy/elastic-cloud/add-plugins-provided-with-ech.md)
 * [Upload custom plugins and bundles](docs-content://deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md)
 * [Manage plugins and extensions through the API](docs-content://deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md)
 
-## Managing plugins for {{ece}}
+## Managing plugins for {{ece}} [managing-plugins-for-ece]
 ```{applies_to}
     ece: ga
 ```
@@ -48,12 +53,13 @@ To add plugins to an {{ece}} deployment, refer to:
 * [Add plugins and extensions in {{ece}}](docs-content://deploy-manage/deploy/cloud-enterprise/add-plugins.md)
 * [Add custom bundles and plugins](docs-content://deploy-manage/deploy/cloud-enterprise/add-custom-bundles-plugins.md)
 
-## Managing plugins for self-managed deployments
+
+## Managing plugins for self-managed deployments [managing-plugins-for-self-managed]
 ```{applies_to}
     self: ga
 ```
 
-Use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which {{es}} package you installed. For more information, see [Plugins directory](_plugins_directory.md)
+Use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which {{es}} package you installed. For more information, see [](_plugins_directory.md)
 
 Run the following command to get usage instructions:
 
@@ -80,7 +86,17 @@ For detailed instructions on installing, managing, and configuring plugins, see 
 If you run {{es}} using the [official {{es}} Docker image](https://www.docker.elastic.co/), you can manage plugins using a declarative [configuration file](manage-plugins-using-configuration-file.md). This approach applies to self-managed Docker deployments only.
 
 
-:::{admonition} Running {{es}} with plugins on {{eck}}
-:applies_to: eck: ga
-On {{eck}}, install plugins by building a custom container image or using init containers. For details, see [Custom configuration files and plugins](docs-content://deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md).
+
+## Managing plugins for {{eck}} [managing-plugins-for-eck]
+```{applies_to}
+    eck: ga
+```
+
+On {{eck}}, {{es}} runs in Kubernetes pods. Plugins must be on disk before the main {{es}} container starts. The two supported approaches are:
+
+* [Using a custom container image](docs-content://deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md): You build a custom image from the official Elastic image with the required plugins pre-installed. This option is reproducible, works without internet access at runtime, and starts quickly, but requires a container registry and a new image for each {{es}} version upgrade.
+* [Using init containers](docs-content://deploy-manage/deploy/cloud-on-k8s/init-containers-for-plugin-downloads.md): You use an init container to run `elasticsearch-plugin install` before the main {{es}} container starts. This option is easier to get started with, but requires pod internet access and repeats the download on each new node.
+
+:::{note}
+You can inject configuration files, such as synonym dictionaries, SAML metadata, or TLS certificates by [mounting them with ConfigMaps or Secrets](docs-content://deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md#use-a-volume-and-volume-mount-together-with-a-configmap-or-secret). However, mounting plugin files into a pod does not run `elasticsearch-plugin install`, so {{es}} will not load them at startup. Instead, to install plugins, use a custom container image or init container. 
 :::

--- a/docs/reference/elasticsearch-plugins/plugin-management.md
+++ b/docs/reference/elasticsearch-plugins/plugin-management.md
@@ -73,20 +73,16 @@ sudo bin/elasticsearch-plugin -h
 If {{es}} was installed using the deb or rpm package then run `/usr/share/elasticsearch/bin/elasticsearch-plugin` as `root` so it can write to the appropriate files on disk. Otherwise run `bin/elasticsearch-plugin` as the user that owns all of the {{es}} files.
 :::
 
-For detailed instructions on installing, managing, and configuring plugins, see the following:
+The following pages document plugin management for self-managed deployments. Use the column that matches how you install {{es}}.
 
-* [](./installation.md)
-* [Custom URL or file system](./plugin-management-custom-url.md)
-* [Installing multiple plugins](./installing-multiple-plugins.md)
-* [Mandatory plugins](./mandatory-plugins.md)
-* [Listing, removing and updating installed plugins](./listing-removing-updating.md)
-* [Other command line parameters](./_other_command_line_parameters.md)
-
-### Managing plugins for Docker deployments
-
-If you run {{es}} using the [official {{es}} Docker image](https://www.docker.elastic.co/), you can manage plugins using a declarative [configuration file](manage-plugins-using-configuration-file.md). This approach applies to self-managed Docker deployments only.
-
-
+| Documentation page | Package and archive installs (`elasticsearch-plugin`) | Official Docker image (`elasticsearch-plugins.yml`) |
+| --- | --- | --- |
+| [](./installation.md) | Install core plugins by name with `elasticsearch-plugin install`. | Add plugins by `id` in the [configuration file](manage-plugins-using-configuration-file.md) and restart the container. |
+| [](./plugin-management-custom-url.md) | Install from an HTTP URL or local ZIP path. | Set the `location` field for each plugin in the config file. |
+| [](./installing-multiple-plugins.md) | Install several plugins in one CLI invocation. | List each plugin as a separate entry in the config file. |
+| [](./mandatory-plugins.md) | Set `plugin.mandatory` in `elasticsearch.yml`. | This applies to all self-managed deployments, including Docker. |
+| [](./listing-removing-updating.md) | List, remove, or reinstall plugins with the CLI. | Edit the config file and restart to add or remove plugins; the `list` command and [node-info API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-info) still work for inspection. |
+| [](./_other_command_line_parameters.md) | Options for `install`, such as batch mode, proxy settings, and a custom config path. | Set `proxy` in the config file instead. |
 
 ## Managing plugins for {{eck}} [managing-plugins-for-eck]
 ```{applies_to}

--- a/docs/reference/elasticsearch-plugins/plugin-management.md
+++ b/docs/reference/elasticsearch-plugins/plugin-management.md
@@ -20,7 +20,7 @@ Plugins extend {{es}}'s core functionality and can serve various purposes, inclu
 
 How you add and manage plugins depends on where {{es}} runs:
 * Hosted Cloud deployments such as [{{ech}}](#managing-plugins-for-ech) and [{{ece}}](#managing-plugins-for-ece) expose plugin and extension management in the Cloud console and API.
-* [Self-managed deployments](#managing-plugins-for-self-managed) use the `elasticsearch-plugin` CLI to install, list, and remove plugins on each node, while for Docker, you can also declare plugins in a [configuration file](manage-plugins-using-configuration-file.md).
+* [Self-managed deployments](#managing-plugins-for-self-managed) — use a [configuration file](manage-plugins-using-configuration-file.md) with the official Docker image, or the `elasticsearch-plugin` CLI for package and archive installs.
 * On [{{eck}}](#managing-plugins-for-eck) deployments you install plugins by building a custom container image or using init containers.
 
 ::::{note} {{serverless-full}} projects
@@ -59,9 +59,25 @@ To add plugins to an {{ece}} deployment, refer to:
     self: ga
 ```
 
-If you run {{es}} using the [official {{es}} Docker image](https://www.docker.elastic.co/), manage plugins with a declarative [configuration file](manage-plugins-using-configuration-file.md). When {{es}} starts, it installs, upgrades, or removes plugins to match the file.
+How you manage plugins depends on how you install {{es}}:
 
-For all other installation methods, use the `elasticsearch-plugin` command line tool to install, list, and remove plugins. It is located in the `$ES_HOME/bin` directory by default but it may be in a different location depending on which {{es}} package you installed. For more information, see [](_plugins_directory.md).
+* If you run {{es}} using the [official {{es}} Docker image](https://www.docker.elastic.co/), manage plugins with a declarative [configuration file](manage-plugins-using-configuration-file.md).
+* For all [other installation methods](#manage-plugins-with-package-and-archive-installs), use the `elasticsearch-plugin` command-line tool to install, list, and remove plugins.
+
+### Manage plugins with the Docker image
+
+List the plugins you want in `elasticsearch-plugins.yml` in your config directory. Each time the container starts, {{es}} syncs installed plugins to match that list: installing missing plugins, removing ones you deleted from the file, and upgrading official plugins when you upgrade {{es}}.
+
+To add or remove a plugin, edit the file and restart the container. Do not use `elasticsearch-plugin install` or `remove` as those commands are disabled when `elasticsearch-plugins.yml` is present.
+
+Refer to the following pages:
+
+* [Manage plugins using a configuration file](./manage-plugins-using-configuration-file.md)
+* [Mandatory plugins](./mandatory-plugins.md)
+
+### Manage plugins with package and archive installs [manage-plugins-with-package-and-archive-installs]
+
+Use the `elasticsearch-plugin` command-line tool. It is located in the `$ES_HOME/bin` directory by default, but it might be in a different location depending on which {{es}} package you installed. For more information, see [Plugins directory](_plugins_directory.md).
 
 Run the following command to get usage instructions:
 
@@ -69,21 +85,18 @@ Run the following command to get usage instructions:
 sudo bin/elasticsearch-plugin -h
 ```
 
-:::{important} Running as root
-If {{es}} was installed using the deb or rpm package then run `/usr/share/elasticsearch/bin/elasticsearch-plugin` as `root` so it can write to the appropriate files on disk. Otherwise run `bin/elasticsearch-plugin` as the user that owns all of the {{es}} files.
+:::{important} - Running as root
+If {{es}} was installed using the deb or rpm package, then run `/usr/share/elasticsearch/bin/elasticsearch-plugin` as `root` so it can write to the appropriate files on disk. Otherwise, run `bin/elasticsearch-plugin` as the user that owns all of the {{es}} files.
 :::
 
-The following pages document plugin management for self-managed deployments. Use the column that matches how you install {{es}}.
+Refer to the following pages:
 
-| Documentation page | Package and archive installs (`elasticsearch-plugin`) | Official Docker image (`elasticsearch-plugins.yml`) |
-| --- | --- | --- |
-| [](./installation.md) | Install core plugins by name with `elasticsearch-plugin install`. | Add plugins by `id` in the [configuration file](manage-plugins-using-configuration-file.md) and restart the container. |
-| [](./plugin-management-custom-url.md) | Install from an HTTP URL or local ZIP path. | Set the `location` field for each plugin in the config file. |
-| [](./installing-multiple-plugins.md) | Install several plugins in one CLI invocation. | List each plugin as a separate entry in the config file. |
-| [](./mandatory-plugins.md) | Set `plugin.mandatory` in `elasticsearch.yml`. | This applies to all self-managed deployments, including Docker. |
-| [](./listing-removing-updating.md) | List, remove, or reinstall plugins with the CLI. | Edit the config file and restart to add or remove plugins; the `list` command and [node-info API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-info) still work for inspection. |
-| [](./_other_command_line_parameters.md) | Options for `install`, such as batch mode, proxy settings, and a custom config path. | Set `proxy` in the config file instead. |
-
+* [Installing plugins](./installation.md)
+* [Custom URL or file system](./plugin-management-custom-url.md)
+* [Installing multiple plugins](./installing-multiple-plugins.md)
+* [Mandatory plugins](./mandatory-plugins.md)
+* [Listing, removing and updating installed plugins](./listing-removing-updating.md)
+* [Other command line parameters](./_other_command_line_parameters.md)
 ## Managing plugins for {{eck}} [managing-plugins-for-eck]
 ```{applies_to}
     eck: ga


### PR DESCRIPTION
Part of [#423](https://github.com/elastic/docs-projects/issues/423) and this is the counterpart PR to https://github.com/elastic/docs-content/pull/7101 which moves the content that's deleted here into its respective home in the narrative docs.

I've also made a tiny change to the [Managing plugins for docker deployments](https://www.elastic.co/docs/reference/elasticsearch/plugins/plugin-management#managing-plugins-for-docker-deployments) section and brought it in as a child of the self-managed section (which it is). I added an admonition to the [Custom configuration files and plugins](https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins) page for ECK, just in case someone lands on this page and needs that connecting link.


Reviewers, please disregard my branch naming skills 😶‍🌫️ we're experiencing a heatwave and words are hard🫣 