### PR TITLE
Prevent BCC uploads when ObjectStoreService is stopped or closed

### DIFF
--- a/docs/changelog/152301.yaml
+++ b/docs/changelog/152301.yaml
@@ -1,0 +1,6 @@
+area: Distributed
+issues:
+ - 152259
+pr: 152301
+summary: Prevent BCC uploads when `ObjectStoreService` is stopped or closed
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -782,6 +782,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:grok.shadowingSubfields}
   issue: https://github.com/elastic/elasticsearch/issues/152257
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
-  method: testReshardWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/152259

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -779,7 +779,9 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
         }
 
         public boolean test(Exception e) {
-            if (commitState.isClosed()) {
+            if (commitState.isClosed()
+                || objectStoreService.lifecycleState() == Lifecycle.State.STOPPED
+                || objectStoreService.lifecycleState() == Lifecycle.State.CLOSED) {
                 return false;
             }
 


### PR DESCRIPTION
In the logs of a failed test, we can observe infinite retries of BCC upload:
```
  [2026-06-25T22:30:55,429][INFO ][o.e.x.s.c.BatchedCompoundCommitUploadTask][node_t1][stateless_shard_write][T#1] [index-jzwasrtsxe][2] failed attempt [256] to upload commit [4] to object store, will retry
   java.lang.IllegalStateException: Object store service is not running [STOPPED]
   	at org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService.ensureRunning(ObjectStoreService.java:654)
   	at org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService.enqueueTask(ObjectStoreService.java:732)
  	at org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService.uploadBatchedCompoundCommitFile(ObjectStoreService.java:686)
   	at org.elasticsearch.xpack.stateless.commits.BatchedCompoundCommitUploadTask.uploadBatchedCompoundCommitFile(BatchedCompoundCommitUploadTask.java:187)
 	at 
org.elasticsearch.xpack.stateless.commits.BatchedCompoundCommitUploadTask.lambda$executeUpload$5(BatchedCompoundCommitUploadTask.java:162)
```
This is caused by the retry condition is checking the `commitState.isClosed()` only


`org.elasticsearch.xpack.stateless.commits.StatelessCommitService.UploadRetryDecider` - line 781
```
if (commitState.isClosed()) { 
     return false; 
 }
```

When the `ObjectStoreService` stops (STOPPED or CLOSED state) it cannot start again. Checking for this service running state may prevent endless upload retry loops.

Closes: https://github.com/elastic/elasticsearch/issues/152259

