### PR TITLE
[DOC]: Add 8.19.17 known issue for trained model input limits

### DIFF
--- a/docs/reference/release-notes/8.19.17.asciidoc
+++ b/docs/reference/release-notes/8.19.17.asciidoc
@@ -5,6 +5,12 @@ coming[8.19.17]
 
 Also see <<breaking-changes-8.19,Breaking changes in 8.19>>.
 
+[[known-issues-8.19.17]]
+[float]
+=== Known issues
+
+* The <<put-trained-models,create trained model API>> enforces overly restrictive input limits that may reject valid requests. A {es-pull}150227[change] in 8.19.17 introduced caps on `description`, `tags`, `prefix_strings.ingest_prefix`, `prefix_strings.search_prefix`, `input.field_names`, `default_field_map`, and `metadata`. These limits are too low for some existing use cases, including the Problemchild and DGA Security integrations, which require more than the 100-field cap on `input.field_names`.
+
 [[bug-8.19.17]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Document a known issue in the 8.19.17 release notes: the create trained model API enforces overly restrictive input limits (#150227), which can break existing use cases including the Problemchild and DGA Security integrations.