### PR TITLE
[ESQL] Defer FFW footer reads when stats unneeded

### DIFF
--- a/docs/changelog/152328.yaml
+++ b/docs/changelog/152328.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152328
+summary: Defer FFW footer reads when stats unneeded
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceProfileIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceProfileIT.java
@@ -60,6 +60,7 @@ import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQuery
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -362,6 +363,57 @@ public class ExternalSourceProfileIT extends AbstractEsqlIntegTestCase {
             }
         } finally {
             Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    /**
+     * End-to-end correctness for the deferred-footer-read optimization across a real multi-file glob.
+     * Writes three Parquet files into one directory and exercises every {@code schema_resolution} path:
+     * <ul>
+     *   <li>{@code FIRST_FILE_WINS + LIMIT} — the <em>defer</em> path: no global stats are required, so
+     *       at planning time only the anchor file's footer is read, yet the query must still return a
+     *       correct page of rows.</li>
+     *   <li>{@code FIRST_FILE_WINS + COUNT(*)} (ungrouped) — the <em>eager</em> path: the planner still
+     *       aggregates every file's row count, so the result must span all files.</li>
+     *   <li>{@code UNION_BY_NAME} / {@code STRICT + COUNT(*)} — the reconciliation paths, which always
+     *       read every file's metadata; the count must stay correct (regression guard).</li>
+     * </ul>
+     * The per-file footer-read <em>count</em> reduction itself is asserted at the resolver layer in
+     * {@code ExternalSourceResolverTests} (the layer that issues the reads); there is no query-level
+     * metric exposing planning-time footer reads, so this IT proves correctness rather than GET counts.
+     */
+    public void testMultiFileFirstFileWinsDeferAndEagerProduceCorrectResults() throws Exception {
+        Path dir = createTempDir();
+        int files = 3;
+        int rowsPerFile = 100;
+        for (int i = 0; i < files; i++) {
+            writeParquetFileTo(dir.resolve("part_" + i + ".parquet"), rowsPerFile, 50);
+        }
+        String glob = StoragePath.fileUri(dir) + "/*.parquet";
+        long totalRows = (long) files * rowsPerFile;
+
+        // FFW + LIMIT: defer path. Only the anchor footer is needed at planning time, but the page must be correct.
+        try (var response = run(syncEsqlQueryRequest(externalQuery(glob, "first_file_wins", "| LIMIT 10")), TIMEOUT)) {
+            assertThat(getValuesList(response), hasSize(10));
+        }
+
+        // FFW + ungrouped COUNT(*): eager path — the global row count must span every file.
+        assertSingleLong(externalQuery(glob, "first_file_wins", "| STATS c = COUNT(*)"), totalRows);
+
+        // UNION_BY_NAME / STRICT still read every file for schema reconciliation; the count stays correct.
+        assertSingleLong(externalQuery(glob, "union_by_name", "| STATS c = COUNT(*)"), totalRows);
+        assertSingleLong(externalQuery(glob, "strict", "| STATS c = COUNT(*)"), totalRows);
+    }
+
+    private static String externalQuery(String glob, String schemaResolution, String tail) {
+        return "EXTERNAL \"" + glob + "\" WITH {\"schema_resolution\": \"" + schemaResolution + "\"} " + tail;
+    }
+
+    private void assertSingleLong(String query, long expected) {
+        try (var response = run(syncEsqlQueryRequest(query), TIMEOUT)) {
+            var rows = getValuesList(response);
+            assertThat(rows, hasSize(1));
+            assertThat((Long) rows.get(0).get(0), equalTo(expected));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -229,6 +229,27 @@ public class ExternalSourceResolver {
         @Nullable Map<String, List<PartitionFilterHintExtractor.PartitionFilterHint>> filterHints,
         ActionListener<ExternalSourceResolution> listener
     ) {
+        resolve(paths, pathConfigs, filterHints, null, listener);
+    }
+
+    /**
+     * Resolves external sources, gating the FIRST_FILE_WINS eager all-file stats aggregation on
+     * {@code pathsRequiringStats}.
+     *
+     * @param pathsRequiringStats paths whose multi-file FFW resolution must eagerly aggregate global
+     *        statistics across all files (the ungrouped-aggregate metadata fast path). A {@code null}
+     *        value selects legacy behavior — every path resolves eagerly — preserving existing call
+     *        sites and tests. When non-null, a path absent from the set defers the per-file footer
+     *        reads (keeping {@code STATS_FILE_COUNT}, marking stats partial). See
+     *        {@link ExternalStatsRequirementExtractor#pathsRequiringEagerStats}.
+     */
+    public void resolve(
+        List<String> paths,
+        Map<String, Map<String, Object>> pathConfigs,
+        @Nullable Map<String, List<PartitionFilterHintExtractor.PartitionFilterHint>> filterHints,
+        @Nullable Set<String> pathsRequiringStats,
+        ActionListener<ExternalSourceResolution> listener
+    ) {
         if (paths == null || paths.isEmpty()) {
             listener.onResponse(ExternalSourceResolution.EMPTY);
             return;
@@ -247,9 +268,17 @@ public class ExternalSourceResolver {
                     Map<String, Object> config = pathConfigs.getOrDefault(path, Map.of());
                     List<PartitionFilterHintExtractor.PartitionFilterHint> hints = filterHints != null ? filterHints.get(path) : null;
                     boolean hivePartitioning = isHivePartitioningEnabled(config);
+                    // null => legacy eager for every path; non-null => eager only for listed paths.
+                    boolean requiresStats = pathsRequiringStats == null || pathsRequiringStats.contains(path);
 
                     try {
-                        ExternalSourceResolution.ResolvedSource resolvedSource = resolveSource(path, config, hints, hivePartitioning);
+                        ExternalSourceResolution.ResolvedSource resolvedSource = resolveSource(
+                            path,
+                            config,
+                            hints,
+                            hivePartitioning,
+                            requiresStats
+                        );
                         resolved.put(path, resolvedSource);
                         LOGGER.debug("Successfully resolved external source: {}", path);
                     } catch (TaskCancelledException e) {
@@ -293,7 +322,8 @@ public class ExternalSourceResolver {
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning
+        boolean hivePartitioning,
+        boolean requiresStats
     ) throws Exception {
         LOGGER.debug("Resolving external source: path=[{}]", path);
 
@@ -302,7 +332,7 @@ public class ExternalSourceResolver {
         throwIfCancelled();
 
         if (GlobExpander.isMultiFile(path)) {
-            return resolveMultiFileSource(path, config, hints, hivePartitioning);
+            return resolveMultiFileSource(path, config, hints, hivePartitioning, requiresStats);
         }
 
         /*
@@ -366,7 +396,8 @@ public class ExternalSourceResolver {
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
-        boolean hivePartitioning
+        boolean hivePartitioning,
+        boolean requiresStats
     ) throws Exception {
         StoragePath storagePath = StoragePath.of(path);
         StorageProvider provider = resolveProvider(storagePath, config);
@@ -429,22 +460,26 @@ public class ExternalSourceResolver {
         }
 
         extMetadata = enrichWithFileCount(extMetadata, listing.fileCount());
-        if (listing.fileCount() > 1) {
+        if (listing.fileCount() > 1 && requiresStats) {
             // For multi-file FIRST_FILE_WINS, read all files' metadata in parallel during Phase 1
             // to aggregate statistics across all files. This allows aggregate pushdown
             // (COUNT/MIN/MAX) to use accurate global stats and to skip Phase 2 (split discovery)
             // entirely for those queries.
             //
-            // Tradeoff: this performs N footer reads up-front for *every* multi-file resolve,
-            // including queries that don't use the stats (e.g. SELECT *). For those queries,
-            // Phase 2 still runs, so the per-file footer is read twice (once here, once during
-            // split discovery). The cost is generally acceptable because:
+            // This eager all-file aggregation is gated on requiresStats: only query shapes that can
+            // consume the global stats — an ungrouped aggregate over the relation, detected by
+            // ExternalStatsRequirementExtractor#pathsRequiringEagerStats — pay the N footer reads.
+            // Every other shape (LIMIT, SELECT *, grouped STATS ... BY, INLINESTATS) takes the
+            // defer branch below: it keeps STATS_FILE_COUNT (from enrichWithFileCount above) but
+            // marks stats partial, so Phase 2 split discovery reads footers once instead of twice.
+            // Legacy callers pass requiresStats == true for every path (the resolve overload with a
+            // null pathsRequiringStats set), preserving the original eager-for-all behavior.
+            //
+            // For an eager (requiresStats) resolve the cost is acceptable because:
             // - the cacheable path consults the schema cache, so repeat resolves are free;
             // - the non-cacheable path reads footers in parallel up to MAX_PARALLEL_METADATA_READS;
             // - the aggregated stats unlock skipping Phase 2 entirely for pushable aggregates
             // (see ComputeService#canSkipSplitDiscovery), which dominates the savings.
-            // We don't gate this on the query (which isn't known here) — see issue #148086 for the
-            // design notes.
             Map<String, Object> aggregatedStats = cacheable
                 ? readAndAggregateAllFileStatsWithCache(listing, config)
                 : readAndAggregateAllFileStats(listing, config);
@@ -489,6 +524,13 @@ public class ExternalSourceResolver {
                 // so the optimizer does not rely on incomplete sourceMetadata stats.
                 extMetadata = markStatsAsPartial(extMetadata);
             }
+        } else if (listing.fileCount() > 1) {
+            // Defer branch (requiresStats == false): skip the N footer reads. The anchor-only stats
+            // are not representative of the whole glob, so mark them partial — exactly the state the
+            // failed-aggregation path above produces, which downstream already handles
+            // (SplitStats.resolveEffectiveStats returns null rather than consuming anchor stats as
+            // global). STATS_FILE_COUNT, stamped by enrichWithFileCount above, is preserved.
+            extMetadata = markStatsAsPartial(extMetadata);
         }
 
         // The anchor's pre-enrichment schema is the physical read schema every file's reader parses.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractor.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
 
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -66,7 +66,7 @@ public final class ExternalStatsRequirementExtractor {
      * @return the set of literal path strings whose resolution must eagerly aggregate global stats
      */
     public static Set<String> pathsRequiringEagerStats(LogicalPlan unresolvedPlan) {
-        Set<String> result = new LinkedHashSet<>();
+        Set<String> result = new HashSet<>();
         collect(unresolvedPlan, false, result);
         return result;
     }
@@ -96,10 +96,8 @@ public final class ExternalStatsRequirementExtractor {
             return; // leaf: no children below a relation
         }
 
-        for (Object child : node.children()) {
-            if (child instanceof Node<?> childNode) {
-                collect(childNode, ungroupedAggAbove, result);
-            }
+        for (Node<?> child : node.children()) {
+            collect(child, ungroupedAggAbove, result);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractor.java
@@ -106,9 +106,12 @@ public final class ExternalStatsRequirementExtractor {
     /**
      * Path-key derivation kept in lockstep with {@code PreAnalyzer#icebergPaths} and
      * {@code EsqlSession#extractExternalConfigs}: a non-null {@link Literal} {@code tablePath}
-     * rendered via {@code BytesRefs.toString}. Returns {@code null} for the (post-parse unexpected)
-     * non-literal case so detection never throws — the resolver simply stays eager (legacy) for a
-     * path it cannot key.
+     * rendered via {@code BytesRefs.toString}. Returns {@code null} for a non-literal {@code tablePath}
+     * so detection never throws; that path is then absent from the set and, since the resolver
+     * receives a non-null set, would <em>defer</em> rather than aggregate eagerly. In practice this
+     * branch is unreachable: {@code EsqlSession#extractExternalConfigs} runs first on the same plan
+     * and throws on a non-literal {@code tablePath}, so resolution never reaches a path this method
+     * could fail to key.
      */
     private static String extractPath(UnresolvedExternalRelation relation) {
         Expression tablePath = relation.tablePath();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractor.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Node;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Detects which external relations are read by a query shape that needs <em>eager</em> global
+ * statistics aggregated across <em>all</em> files of a multi-file glob during planning.
+ *
+ * <p>Eager global stats exist for exactly one optimization: the metadata-only fast path for an
+ * <b>ungrouped</b> aggregate ({@code COUNT}/{@code MIN}/{@code MAX} with no {@code BY}) directly over
+ * an external relation (see {@code ComputeService#canSkipSplitDiscovery}). Every other consumer
+ * (filter/aggregate pushdown, split-filter classification) runs after split discovery and prefers
+ * per-split stats over the global {@code sourceMetadata}. Therefore grouped {@code STATS ... BY} and
+ * {@code INLINESTATS} never benefit from the eager global aggregation and must not pay its
+ * per-file footer-read cost.
+ *
+ * <p>The result of {@link #pathsRequiringEagerStats(LogicalPlan)} is used by
+ * {@code ExternalSourceResolver} to gate the FIRST_FILE_WINS eager all-file stats aggregation: a
+ * path absent from the set defers the N footer reads (keeping {@code STATS_FILE_COUNT}, marking
+ * stats partial), so wide globs no longer block planning on thousands of object-store GETs for
+ * queries that do not consume the global stats (e.g. {@code LIMIT}, {@code SELECT *}, grouped
+ * {@code STATS ... BY}, {@code INLINESTATS}).
+ *
+ * <h2>Deliberate safety bias</h2>
+ * An ungrouped aggregate is matched <em>anywhere above</em> the relation, not only as its direct
+ * parent. A false <em>negative</em> would turn a metadata-only {@code COUNT(*)} over a huge glob
+ * into a full N-file scan (a severe regression); a false <em>positive</em> (e.g.
+ * {@code ... | WHERE x > 5 | STATS COUNT(*)}, which usually will not actually skip split discovery)
+ * only costs the over-read we already tolerate today. We bias toward eager for ungrouped aggregates.
+ *
+ * <h2>Per-path conservatism for mixed branches</h2>
+ * The result is a {@link Set}: if the same path appears under an ungrouped aggregate in one branch
+ * (e.g. a {@code FORK} arm) and under {@code LIMIT} in another, the union marks it as requiring eager
+ * stats. The single resolution of that path stays eager, which is correct because one resolution
+ * feeds both branches.
+ */
+public final class ExternalStatsRequirementExtractor {
+
+    private ExternalStatsRequirementExtractor() {}
+
+    /**
+     * Returns the literal {@code tablePath} of every {@link UnresolvedExternalRelation} that has an
+     * <b>ungrouped</b> {@link Aggregate} ancestor. The path-key derivation is identical to
+     * {@code PreAnalyzer} and {@code EsqlSession#extractExternalConfigs}
+     * ({@code BytesRefs.toString(literal.value())}), so the keys match the resolver's
+     * {@code icebergPaths} by construction.
+     *
+     * @param unresolvedPlan the root of the unresolved logical plan
+     * @return the set of literal path strings whose resolution must eagerly aggregate global stats
+     */
+    public static Set<String> pathsRequiringEagerStats(LogicalPlan unresolvedPlan) {
+        Set<String> result = new LinkedHashSet<>();
+        collect(unresolvedPlan, false, result);
+        return result;
+    }
+
+    private static void collect(Node<?> node, boolean ungroupedAggAbove, Set<String> result) {
+        // INLINESTATS wraps its embedded Aggregate as its child (UnaryPlan child). That embedded
+        // aggregate produces an InlineJoin, not the ungrouped-aggregate metadata fast path, so it
+        // must not flip the flag — skip the Aggregate node and walk below it with the flag unchanged.
+        if (node instanceof InlineStats inlineStats) {
+            collect(inlineStats.aggregate().child(), ungroupedAggAbove, result);
+            return;
+        }
+
+        if (node instanceof Aggregate aggregate && aggregate.groupings().isEmpty()) {
+            // Covers Aggregate and its subclass TimeSeriesAggregate; a grouped/TS aggregate has
+            // non-empty groupings, so it does not set the flag.
+            ungroupedAggAbove = true;
+        }
+
+        if (node instanceof UnresolvedExternalRelation relation) {
+            if (ungroupedAggAbove) {
+                String path = extractPath(relation);
+                if (path != null) {
+                    result.add(path);
+                }
+            }
+            return; // leaf: no children below a relation
+        }
+
+        for (Object child : node.children()) {
+            if (child instanceof Node<?> childNode) {
+                collect(childNode, ungroupedAggAbove, result);
+            }
+        }
+    }
+
+    /**
+     * Path-key derivation kept in lockstep with {@code PreAnalyzer#icebergPaths} and
+     * {@code EsqlSession#extractExternalConfigs}: a non-null {@link Literal} {@code tablePath}
+     * rendered via {@code BytesRefs.toString}. Returns {@code null} for the (post-parse unexpected)
+     * non-literal case so detection never throws — the resolver simply stays eager (legacy) for a
+     * path it cannot key.
+     */
+    private static String extractPath(UnresolvedExternalRelation relation) {
+        Expression tablePath = relation.tablePath();
+        if (tablePath instanceof Literal literal && literal.value() != null) {
+            return BytesRefs.toString(literal.value());
+        }
+        return null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -76,6 +76,7 @@ import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.datasources.DatasetResolver;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
+import org.elasticsearch.xpack.esql.datasources.ExternalStatsRequirementExtractor;
 import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
@@ -1478,10 +1479,16 @@ public class EsqlSession {
 
         var filterHints = PartitionFilterHintExtractor.extract(plan);
 
+        // Always non-null (empty when no ungrouped aggregate is present). A non-null set switches the
+        // resolver to selective eager stats: only the listed paths read every file's footer at
+        // planning time; the rest defer (see ExternalStatsRequirementExtractor).
+        Set<String> pathsRequiringStats = ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan);
+
         externalSourceResolver.resolve(
             preAnalysis.icebergPaths(),
             pathConfigs,
             filterHints.isEmpty() ? null : filterHints,
+            pathsRequiringStats,
             listener.map(result::withExternalSourceResolution)
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -1343,7 +1343,7 @@ public class EsqlSession {
                 executionInfo.queryProfile().indicesResolutionMarker().stop();
                 return r;
             })
-            .<PreAnalysisResult>andThen((l, r) -> preAnalyzeExternalSources(parsed, preAnalysis, r, l))
+            .<PreAnalysisResult>andThen((l, r) -> preAnalyzeExternalSources(externalSourceResolver, parsed, preAnalysis, r, l))
             .<PreAnalysisResult>andThen((l, r) -> {
                 // Do not update PreAnalysisResult.minimumTransportVersion, that's already been determined during main index resolution.
                 executionInfo.queryProfile().enrichResolutionMarker().start();
@@ -1464,7 +1464,10 @@ public class EsqlSession {
      * This runs in parallel with other resolution steps to avoid blocking.
      * Extracts partition filter hints from the WHERE clause for partition-aware glob rewriting.
      */
-    private void preAnalyzeExternalSources(
+    // package-private static so EsqlSessionTests can drive the wiring with a capturing
+    // ExternalSourceResolver and assert that the computed pathsRequiringStats set is forwarded.
+    static void preAnalyzeExternalSources(
+        ExternalSourceResolver externalSourceResolver,
         LogicalPlan plan,
         PreAnalyzer.PreAnalysis preAnalysis,
         PreAnalysisResult result,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -532,6 +532,265 @@ public class ExternalSourceResolverTests extends ESTestCase {
         }
     }
 
+    // ===== Deferred eager-stats (requiresStats gating) tests =====
+
+    /**
+     * Defer path (non-cacheable): a multi-file FFW resolve with an empty (non-null)
+     * {@code pathsRequiringStats} set reads only the anchor footer (1 metadata read), keeps
+     * {@code STATS_FILE_COUNT}, and marks stats partial — exactly the state the failed-aggregation
+     * fallback produces, so downstream consumers already handle it.
+     */
+    public void testFirstFileWinsDefersFooterReadsWhenStatsNotRequired() throws Exception {
+        AtomicInteger metadataReads = new AtomicInteger();
+        ExternalSourceResolution resolution = resolveFfwWithRequirement(threeFileStats(), metadataReads, Set.of(), null);
+
+        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(GLOB);
+        assertNotNull(resolved);
+        assertEquals("defer must read only the anchor footer", 1, metadataReads.get());
+        Map<String, Object> meta = resolved.metadata().sourceMetadata();
+        assertEquals("deferred stats must be partial", Boolean.TRUE, meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+        assertEquals("file count is preserved on defer", 3L, meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT));
+        // The anchor's own (single-file) stats remain embedded, but STATS_PARTIAL flags them as not
+        // representative of the whole glob, so downstream never consumes them as global stats
+        // (see testDeferredMetadataNeverConsumedAsGlobalStats). They are NOT the aggregated total.
+        assertEquals("anchor-only row count, not the 6000 aggregate", 1000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    /**
+     * Eager path (non-cacheable): when the path is in {@code pathsRequiringStats}, every file footer
+     * is read (anchor schema + N stats reads) and the aggregated global stats are complete
+     * (no {@code STATS_PARTIAL}).
+     */
+    public void testFirstFileWinsEagerlyReadsFootersWhenStatsRequired() throws Exception {
+        AtomicInteger metadataReads = new AtomicInteger();
+        ExternalSourceResolution resolution = resolveFfwWithRequirement(threeFileStats(), metadataReads, Set.of(GLOB), null);
+
+        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(GLOB);
+        assertNotNull(resolved);
+        // anchor schema read (1) + per-file stats reads across all 3 files (3) = 4.
+        assertEquals("eager must read the anchor footer plus all file footers", 4, metadataReads.get());
+        Map<String, Object> meta = resolved.metadata().sourceMetadata();
+        assertNull("eager stats are complete, not partial", meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+        assertEquals("aggregated row count across all files", 6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals("file count is stamped on eager too", 3L, meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT));
+    }
+
+    /**
+     * Legacy {@code null} overload: a {@code null} {@code pathsRequiringStats} keeps the original
+     * eager-for-every-path behavior, so all footers are read regardless of query shape.
+     */
+    public void testFirstFileWinsLegacyNullSetReadsAllFooters() throws Exception {
+        AtomicInteger metadataReads = new AtomicInteger();
+        ExternalSourceResolution resolution = resolveFfwWithRequirement(threeFileStats(), metadataReads, null, null);
+
+        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(GLOB);
+        assertNotNull(resolved);
+        assertEquals("legacy null set is eager for all paths", 4, metadataReads.get());
+        Map<String, Object> meta = resolved.metadata().sourceMetadata();
+        assertNull("legacy eager stats are complete", meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+        assertEquals(6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    /**
+     * Defer path (cacheable): only the anchor schema is loaded (1 cold load). The per-file stats
+     * loop is skipped entirely.
+     */
+    public void testFirstFileWinsDeferCacheableLoadsAnchorOnly() throws Exception {
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+            CountingStorageProvider provider = new CountingStorageProvider(Map.of(PREFIX, threeFileListing()), threeFileSchemas());
+            ExternalSourceResolver resolver = buildStatsResolver(provider, threeFileStats(), null, cacheService);
+
+            ExternalSourceResolution resolution = resolveFfw(resolver, Set.of());
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(GLOB);
+            assertNotNull(resolved);
+            assertEquals("defer loads only the anchor schema", 1, provider.schemaCallCount.get());
+            assertEquals(Boolean.TRUE, resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL));
+        }
+    }
+
+    /**
+     * Eager path (cacheable, cold): the anchor schema plus every other file is loaded once
+     * (N cold loads, anchor reused from cache in the stats loop). Aggregated stats are complete.
+     */
+    public void testFirstFileWinsEagerCacheableColdLoadsAllFiles() throws Exception {
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+            CountingStorageProvider provider = new CountingStorageProvider(Map.of(PREFIX, threeFileListing()), threeFileSchemas());
+            ExternalSourceResolver resolver = buildStatsResolver(provider, threeFileStats(), null, cacheService);
+
+            ExternalSourceResolution resolution = resolveFfw(resolver, Set.of(GLOB));
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(GLOB);
+            assertNotNull(resolved);
+            assertEquals("eager cold-loads all 3 file schemas exactly once", 3, provider.schemaCallCount.get());
+            Map<String, Object> meta = resolved.metadata().sourceMetadata();
+            assertNull(meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+            assertEquals(6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    /**
+     * Anchor-stats invariant: deferred metadata is {@code STATS_PARTIAL == true} and
+     * {@link SplitStats#resolveEffectiveStats} over empty splits returns {@code null} — proving the
+     * anchor-only stats are never consumed as global stats downstream.
+     */
+    public void testDeferredMetadataNeverConsumedAsGlobalStats() throws Exception {
+        AtomicInteger metadataReads = new AtomicInteger();
+        ExternalSourceResolution resolution = resolveFfwWithRequirement(threeFileStats(), metadataReads, Set.of(), null);
+
+        Map<String, Object> meta = resolution.resolvedSource(GLOB).metadata().sourceMetadata();
+        assertEquals(Boolean.TRUE, meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+        assertNull(
+            "deferred (partial) anchor stats must not resolve as global split stats",
+            SplitStats.resolveEffectiveStats(List.of(), meta)
+        );
+    }
+
+    /**
+     * Regression: the UNION_BY_NAME / STRICT reconciliation path must read every file regardless of
+     * {@code pathsRequiringStats} — it needs all schemas to build the unified schema and cannot
+     * defer. An empty (defer-everything) set must not change its behavior.
+     */
+    public void testReconciliationPathReadsAllFilesRegardlessOfStatsRequirement() throws Exception {
+        for (FormatReader.SchemaResolution strategy : List.of(
+            FormatReader.SchemaResolution.UNION_BY_NAME,
+            FormatReader.SchemaResolution.STRICT
+        )) {
+            AtomicInteger metadataReads = new AtomicInteger();
+            // empty pathsRequiringStats would defer under FFW; the reconciliation path ignores it.
+            ExternalSourceResolution resolution = resolveFfwWithRequirement(threeFileStats(), metadataReads, Set.of(), strategy);
+
+            ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(GLOB);
+            assertNotNull("[" + strategy + "] resolved source must not be null", resolved);
+            assertEquals("[" + strategy + "] reconciliation must read all files", 3, metadataReads.get());
+            Map<String, Object> meta = resolved.metadata().sourceMetadata();
+            assertNull("[" + strategy + "] reconciliation stats are complete", meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+            assertEquals("[" + strategy + "] aggregated row count", 6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    // ----- helpers for the requiresStats tests -----
+
+    private static final String GLOB = "s3://bucket/data/*.parquet";
+    private static final String PREFIX = "s3://bucket/data/";
+
+    private static Map<String, List<Attribute>> threeFileSchemas() {
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/a.parquet", schema);
+        schemasByPath.put("s3://bucket/data/b.parquet", schema);
+        schemasByPath.put("s3://bucket/data/c.parquet", schema);
+        return schemasByPath;
+    }
+
+    private static Map<String, Long> threeFileRowCounts() {
+        Map<String, Long> rowCounts = new HashMap<>();
+        rowCounts.put("s3://bucket/data/a.parquet", 1000L);
+        rowCounts.put("s3://bucket/data/b.parquet", 2000L);
+        rowCounts.put("s3://bucket/data/c.parquet", 3000L);
+        return rowCounts;
+    }
+
+    private record ThreeFileStats(Map<String, List<Attribute>> schemas, Map<String, Long> rowCounts) {}
+
+    private static ThreeFileStats threeFileStats() {
+        return new ThreeFileStats(threeFileSchemas(), threeFileRowCounts());
+    }
+
+    private static List<StorageEntry> threeFileListing() {
+        return List.of(
+            entry("s3://bucket/data/a.parquet", 100),
+            entry("s3://bucket/data/b.parquet", 200),
+            entry("s3://bucket/data/c.parquet", 300)
+        );
+    }
+
+    private static Settings cacheEnabledSettings() {
+        return Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+    }
+
+    /**
+     * Non-cacheable FFW resolve that counts footer reads (format-reader metadata calls) and threads a
+     * {@code pathsRequiringStats} set through the new 5-arg {@code resolve} overload.
+     */
+    private ExternalSourceResolution resolveFfwWithRequirement(
+        ThreeFileStats stats,
+        AtomicInteger metadataReadCounter,
+        Set<String> pathsRequiringStats,
+        FormatReader.SchemaResolution strategy
+    ) throws Exception {
+        StubStorageProvider storageProvider = new StubStorageProvider(Map.of(PREFIX, threeFileListing()), stats.schemas());
+        ExternalSourceResolver resolver = buildStatsResolver(storageProvider, stats, metadataReadCounter, null);
+        Map<String, Object> config = configFor(strategy == null ? FormatReader.SchemaResolution.FIRST_FILE_WINS : strategy);
+        return resolveFfwWithConfig(resolver, pathsRequiringStats, config);
+    }
+
+    private ExternalSourceResolution resolveFfw(ExternalSourceResolver resolver, Set<String> pathsRequiringStats) {
+        return resolveFfwWithConfig(resolver, pathsRequiringStats, configFor(FormatReader.SchemaResolution.FIRST_FILE_WINS));
+    }
+
+    private ExternalSourceResolution resolveFfwWithConfig(
+        ExternalSourceResolver resolver,
+        Set<String> pathsRequiringStats,
+        Map<String, Object> config
+    ) {
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of(GLOB), Map.of(GLOB, new HashMap<>(config)), null, pathsRequiringStats, future);
+        return future.actionGet();
+    }
+
+    /**
+     * Builds a resolver around a stats-returning format reader. When {@code metadataReadCounter} is
+     * non-null, every footer read (format-reader metadata call) is counted.
+     */
+    private ExternalSourceResolver buildStatsResolver(
+        StorageProvider storageProvider,
+        ThreeFileStats stats,
+        AtomicInteger metadataReadCounter,
+        ExternalSourceCacheService cacheService
+    ) {
+        StubFormatReaderWithStats formatReader = new StubFormatReaderWithStats(stats.schemas(), stats.rowCounts(), metadataReadCounter);
+
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", stubStorageProviderFactory(storageProvider));
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            new DataSourceCredentials(),
+            () -> false
+        );
+
+        return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, cacheService);
+    }
+
     // ===== GenericFileList threading tests =====
 
     public void testMultiFileResolutionReturnsGenericFileList() throws Exception {
@@ -2314,14 +2573,27 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         private final Map<String, List<Attribute>> schemasByPath;
         private final Map<String, Long> rowCountsByPath;
+        private final AtomicInteger metadataReadCounter;
 
         StubFormatReaderWithStats(Map<String, List<Attribute>> schemasByPath, Map<String, Long> rowCountsByPath) {
+            this(schemasByPath, rowCountsByPath, null);
+        }
+
+        StubFormatReaderWithStats(
+            Map<String, List<Attribute>> schemasByPath,
+            Map<String, Long> rowCountsByPath,
+            AtomicInteger metadataReadCounter
+        ) {
             this.schemasByPath = schemasByPath;
             this.rowCountsByPath = rowCountsByPath;
+            this.metadataReadCounter = metadataReadCounter;
         }
 
         @Override
         public SourceMetadata metadata(StorageObject object) {
+            if (metadataReadCounter != null) {
+                metadataReadCounter.incrementAndGet();
+            }
             String path = object.path().toString();
             List<Attribute> schema = schemasByPath.get(path);
             if (schema == null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractorTests.java
@@ -56,6 +56,18 @@ public class ExternalStatsRequirementExtractorTests extends ESTestCase {
         assertEquals(Set.of(PATH), ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan));
     }
 
+    public void testUngroupedStatsBelowOtherNodesStillRequiresEagerStats() {
+        // STATS COUNT(*) | LIMIT 5 — the ungrouped aggregate is not the plan root. The
+        // ancestor-anywhere walk still propagates the flag down to the relation. This mirrors what
+        // optimization can produce: nodes above the aggregate are irrelevant to detection, only the
+        // aggregate-to-relation ancestry matters, and that ancestry is preserved across the
+        // prune/pushdown rules that reshape the plan between parsing and the physical fast path.
+        LogicalPlan agg = ungroupedAggregate(externalRelation(PATH));
+        LogicalPlan plan = new Limit(SRC, intLiteral(5), agg);
+
+        assertEquals(Set.of(PATH), ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan));
+    }
+
     public void testGroupedStatsDoesNotRequireEagerStats() {
         // STATS COUNT(*) BY g -> grouped aggregate, path absent
         LogicalPlan plan = new Aggregate(SRC, externalRelation(PATH), List.of(unresolved("g")), List.<NamedExpression>of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalStatsRequirementExtractorTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.Fork;
+import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link ExternalStatsRequirementExtractor}. The detector marks a path only when an
+ * <b>ungrouped</b> aggregate is an ancestor of its {@link UnresolvedExternalRelation}; every other
+ * shape (grouped {@code STATS ... BY}, {@code INLINESTATS}, {@code LIMIT}, {@code SELECT *},
+ * {@code WHERE}-only) leaves the path absent so the resolver defers its per-file footer reads.
+ */
+public class ExternalStatsRequirementExtractorTests extends ESTestCase {
+
+    private static final Source SRC = Source.EMPTY;
+    private static final String PATH = "s3://bucket/data/*.parquet";
+
+    public void testUngroupedStatsRequiresEagerStats() {
+        // ungrouped STATS COUNT(*) -> path present
+        LogicalPlan plan = ungroupedAggregate(externalRelation(PATH));
+
+        Set<String> paths = ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan);
+        assertEquals(Set.of(PATH), paths);
+    }
+
+    public void testUngroupedStatsAboveIntermediateNodesStillRequiresEagerStats() {
+        // ... | WHERE x > 5 | LIMIT 10 | STATS COUNT(*) — the ancestor-anywhere safety bias keeps it eager
+        LogicalPlan relation = externalRelation(PATH);
+        LogicalPlan filter = new Filter(SRC, relation, new GreaterThan(SRC, unresolved("x"), intLiteral(5)));
+        LogicalPlan limit = new Limit(SRC, intLiteral(10), filter);
+        LogicalPlan plan = ungroupedAggregate(limit);
+
+        assertEquals(Set.of(PATH), ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan));
+    }
+
+    public void testGroupedStatsDoesNotRequireEagerStats() {
+        // STATS COUNT(*) BY g -> grouped aggregate, path absent
+        LogicalPlan plan = new Aggregate(SRC, externalRelation(PATH), List.of(unresolved("g")), List.<NamedExpression>of());
+
+        assertTrue(ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan).isEmpty());
+    }
+
+    public void testInlineStatsDoesNotRequireEagerStats() {
+        // INLINESTATS embeds an (ungrouped) aggregate as its child, but produces an InlineJoin that
+        // never reaches the ungrouped-aggregate metadata fast path, so the path must stay deferred.
+        Aggregate embedded = ungroupedAggregate(externalRelation(PATH));
+        LogicalPlan plan = new InlineStats(SRC, embedded);
+
+        assertTrue(ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan).isEmpty());
+    }
+
+    public void testLimitOnlyDoesNotRequireEagerStats() {
+        LogicalPlan plan = new Limit(SRC, intLiteral(10), externalRelation(PATH));
+
+        assertTrue(ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan).isEmpty());
+    }
+
+    public void testSelectStarDoesNotRequireEagerStats() {
+        // A bare relation (SELECT *) has no aggregate ancestor.
+        LogicalPlan plan = externalRelation(PATH);
+
+        assertTrue(ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan).isEmpty());
+    }
+
+    public void testWhereOnlyDoesNotRequireEagerStats() {
+        LogicalPlan plan = new Filter(SRC, externalRelation(PATH), new GreaterThan(SRC, unresolved("salary"), intLiteral(100)));
+
+        assertTrue(ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan).isEmpty());
+    }
+
+    public void testMixedBranchesUnionMarksPathEager() {
+        // Same path under an ungrouped aggregate in one FORK arm and under LIMIT in another: the
+        // union marks it eager because the single resolution feeds both branches.
+        LogicalPlan aggBranch = ungroupedAggregate(externalRelation(PATH));
+        LogicalPlan limitBranch = new Limit(SRC, intLiteral(10), externalRelation(PATH));
+        LogicalPlan plan = new Fork(SRC, List.of(aggBranch, limitBranch), List.of());
+
+        assertEquals(Set.of(PATH), ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan));
+    }
+
+    public void testDistinctPathsTrackedIndependently() {
+        String aggPath = "s3://bucket/agg/*.parquet";
+        String limitPath = "s3://bucket/limit/*.parquet";
+        LogicalPlan aggBranch = ungroupedAggregate(externalRelation(aggPath));
+        LogicalPlan limitBranch = new Limit(SRC, intLiteral(10), externalRelation(limitPath));
+        LogicalPlan plan = new Fork(SRC, List.of(aggBranch, limitBranch), List.of());
+
+        // Only the path under the ungrouped aggregate is marked eager.
+        assertEquals(Set.of(aggPath), ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan));
+    }
+
+    public void testNonLiteralTablePathIsSkipped() {
+        // Detection never throws on a non-literal tablePath; the path is simply not keyed (resolver
+        // stays eager by legacy default for paths it cannot match).
+        UnresolvedExternalRelation relation = new UnresolvedExternalRelation(SRC, unresolved("?param"), Map.of());
+        LogicalPlan plan = ungroupedAggregate(relation);
+
+        assertTrue(ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan).isEmpty());
+    }
+
+    private static Aggregate ungroupedAggregate(LogicalPlan child) {
+        return new Aggregate(SRC, child, List.of(), List.<NamedExpression>of());
+    }
+
+    private static UnresolvedExternalRelation externalRelation(String path) {
+        return new UnresolvedExternalRelation(SRC, Literal.keyword(SRC, path), Map.of());
+    }
+
+    private static UnresolvedAttribute unresolved(String name) {
+        return new UnresolvedAttribute(SRC, name);
+    }
+
+    private static Expression intLiteral(int value) {
+        return new Literal(SRC, value, DataType.INTEGER);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
@@ -8,18 +8,24 @@
 package org.elasticsearch.xpack.esql.session;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesFailure;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.InSubqueryResolver;
+import org.elasticsearch.xpack.esql.analysis.PreAnalyzer;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.datasources.ExternalStatsRequirementExtractor;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
+import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
 import org.elasticsearch.xpack.esql.index.MappingException;
@@ -34,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.stream.Collectors.toMap;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
@@ -232,35 +240,72 @@ public class EsqlSessionTests extends ESTestCase {
     }
 
     /**
-     * Wiring contract for {@code preAnalyzeExternalSources}: it computes
-     * {@link ExternalStatsRequirementExtractor#pathsRequiringEagerStats} and passes the result —
-     * always a non-null set — to the resolver. A {@code LIMIT}-shaped plan yields an empty (but
-     * non-null) set, switching the resolver to defer-everything for FFW multi-file globs.
+     * Wiring test: {@code preAnalyzeExternalSources} must forward the computed
+     * {@code pathsRequiringStats} set — always non-null — to {@code ExternalSourceResolver#resolve}.
+     * A {@code LIMIT}-shaped plan forwards an empty (defer-everything) set. Uses a capturing fake
+     * resolver to assert the argument actually reaches {@code resolve(...)}.
      */
-    public void testPathsRequiringEagerStatsEmptyForLimit() {
-        UnresolvedExternalRelation relation = new UnresolvedExternalRelation(
-            EMPTY,
-            Literal.keyword(EMPTY, "s3://bucket/data/*.parquet"),
-            Map.of()
-        );
+    public void testPreAnalyzeExternalSourcesForwardsEmptySetForLimit() {
+        String path = "s3://bucket/data/*.parquet";
+        UnresolvedExternalRelation relation = new UnresolvedExternalRelation(EMPTY, Literal.keyword(EMPTY, path), Map.of());
         LogicalPlan plan = new Limit(EMPTY, new Literal(EMPTY, 10, DataType.INTEGER), relation);
 
-        Set<String> paths = ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan);
-        assertNotNull("the wiring must always pass a non-null set", paths);
-        assertTrue("LIMIT does not consume eager global stats", paths.isEmpty());
+        Set<String> captured = capturePathsRequiringStats(plan, path);
+        assertNotNull("wiring must forward a non-null set", captured);
+        assertTrue("LIMIT forwards an empty set (defer everything)", captured.isEmpty());
     }
 
     /**
-     * Wiring contract: an ungrouped {@code STATS COUNT(*)} over an external relation yields a set
+     * Wiring test: an ungrouped {@code STATS COUNT(*)} over an external relation forwards a set
      * containing the relation's path, so the resolver keeps eager all-file stats aggregation for it.
      */
-    public void testPathsRequiringEagerStatsContainsPathForUngroupedStats() {
+    public void testPreAnalyzeExternalSourcesForwardsPathForUngroupedStats() {
         String path = "s3://bucket/data/*.parquet";
         UnresolvedExternalRelation relation = new UnresolvedExternalRelation(EMPTY, Literal.keyword(EMPTY, path), Map.of());
         LogicalPlan plan = new Aggregate(EMPTY, relation, List.of(), List.of());
 
-        Set<String> paths = ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan);
-        assertEquals(Set.of(path), paths);
+        assertEquals(Set.of(path), capturePathsRequiringStats(plan, path));
+    }
+
+    /**
+     * Drives {@code EsqlSession#preAnalyzeExternalSources} with a capturing {@link ExternalSourceResolver}
+     * and returns the {@code pathsRequiringStats} argument it forwarded to {@code resolve(...)}.
+     */
+    private static Set<String> capturePathsRequiringStats(LogicalPlan plan, String path) {
+        AtomicReference<Set<String>> captured = new AtomicReference<>();
+        AtomicBoolean resolveCalled = new AtomicBoolean();
+        ExternalSourceResolver capturingResolver = new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, null) {
+            @Override
+            public void resolve(
+                List<String> paths,
+                Map<String, Map<String, Object>> pathConfigs,
+                Map<String, List<PartitionFilterHintExtractor.PartitionFilterHint>> filterHints,
+                Set<String> pathsRequiringStats,
+                ActionListener<ExternalSourceResolution> listener
+            ) {
+                resolveCalled.set(true);
+                captured.set(pathsRequiringStats);
+                listener.onResponse(ExternalSourceResolution.EMPTY);
+            }
+        };
+
+        PreAnalyzer.PreAnalysis preAnalysis = new PreAnalyzer.PreAnalysis(
+            Map.of(),
+            List.of(),
+            List.of(),
+            Set.of(),
+            false,
+            false,
+            false,
+            List.of(path),
+            List.of()
+        );
+        EsqlSession.PreAnalysisResult result = new EsqlSession.PreAnalysisResult(Set.of(), Set.of());
+        PlainActionFuture<EsqlSession.PreAnalysisResult> future = new PlainActionFuture<>();
+        EsqlSession.preAnalyzeExternalSources(capturingResolver, plan, preAnalysis, result, future);
+        future.actionGet();
+        assertTrue("resolve must be invoked when icebergPaths is non-empty", resolveCalled.get());
+        return captured.get();
     }
 
     private static IndexResolution resolvedIndex(String indexName) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
@@ -18,10 +18,15 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.ExternalStatsRequirementExtractor;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
 import org.elasticsearch.xpack.esql.index.MappingException;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
 
 import java.util.Arrays;
@@ -224,6 +229,38 @@ public class EsqlSessionTests extends ESTestCase {
             var resolved = Map.of(RemoteClusterAware.splitIndexName(index).getClusterGroupingKey(), List.of(index));
             return IndexResolution.valid(new EsIndex(index, Map.of(), Map.of(), resolved, resolved));
         }));
+    }
+
+    /**
+     * Wiring contract for {@code preAnalyzeExternalSources}: it computes
+     * {@link ExternalStatsRequirementExtractor#pathsRequiringEagerStats} and passes the result —
+     * always a non-null set — to the resolver. A {@code LIMIT}-shaped plan yields an empty (but
+     * non-null) set, switching the resolver to defer-everything for FFW multi-file globs.
+     */
+    public void testPathsRequiringEagerStatsEmptyForLimit() {
+        UnresolvedExternalRelation relation = new UnresolvedExternalRelation(
+            EMPTY,
+            Literal.keyword(EMPTY, "s3://bucket/data/*.parquet"),
+            Map.of()
+        );
+        LogicalPlan plan = new Limit(EMPTY, new Literal(EMPTY, 10, DataType.INTEGER), relation);
+
+        Set<String> paths = ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan);
+        assertNotNull("the wiring must always pass a non-null set", paths);
+        assertTrue("LIMIT does not consume eager global stats", paths.isEmpty());
+    }
+
+    /**
+     * Wiring contract: an ungrouped {@code STATS COUNT(*)} over an external relation yields a set
+     * containing the relation's path, so the resolver keeps eager all-file stats aggregation for it.
+     */
+    public void testPathsRequiringEagerStatsContainsPathForUngroupedStats() {
+        String path = "s3://bucket/data/*.parquet";
+        UnresolvedExternalRelation relation = new UnresolvedExternalRelation(EMPTY, Literal.keyword(EMPTY, path), Map.of());
+        LogicalPlan plan = new Aggregate(EMPTY, relation, List.of(), List.of());
+
+        Set<String> paths = ExternalStatsRequirementExtractor.pathsRequiringEagerStats(plan);
+        assertEquals(Set.of(path), paths);
     }
 
     private static IndexResolution resolvedIndex(String indexName) {


### PR DESCRIPTION
The FIRST_FILE_WINS multi-file resolver eagerly read every file's footer during planning to aggregate global stats, regardless of query shape. Those stats are only consumed by the ungrouped-aggregate metadata fast path; LIMIT, SELECT *, grouped STATS ... BY and INLINESTATS pay N footer reads for zero benefit, blocking planning on wide globs.

Add `ExternalStatsRequirementExtractor` to mark only the paths under an ungrouped aggregate, thread the set through a new 5-arg `resolve` overload (null = legacy eager-for-all), and gate the eager all-file aggregation on it. Deferred paths reuse the existing `markStatsAsPartial` fallback, so there is no result or serialization change.

### Tests
- `ExternalStatsRequirementExtractorTests` — plan-shape detection (ungrouped/grouped STATS, INLINESTATS, LIMIT, SELECT *, WHERE-only, Fork branches, distinct paths).
- `ExternalSourceResolverTests` — defer vs eager footer-read counts (cached + non-cached), STATS_PARTIAL invariant, UNION_BY_NAME/STRICT regression.
- `EsqlSessionTests` — capturing resolver proves `pathsRequiringStats` is forwarded through `preAnalyzeExternalSources`.
- `ExternalSourceProfileIT` — multi-file FFW glob end-to-end: defer (LIMIT), eager (COUNT), UNION/STRICT reconciliation.