### PR TITLE
[9.3] [Inference API] Adding tests to catch the requires failure for Custom service (#151901)

### DIFF
--- a/server/src/test/java/org/elasticsearch/module/BasicServerModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/module/BasicServerModuleTests.java
@@ -77,7 +77,7 @@ public class BasicServerModuleTests extends ESTestCase {
     }
 
     @SuppressForbidden(reason = "I need to convert URL's to Paths")
-    private static Path[] urlsToPaths(Set<URL> urls) {
+    public static Path[] urlsToPaths(Set<URL> urls) {
         return urls.stream().map(BasicServerModuleTests::uncheckedToURI).map(PathUtils::get).toArray(Path[]::new);
     }
 

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CustomServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CustomServiceIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import org.apache.http.HttpHeaders;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.test.http.MockResponse;
+import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.xpack.inference.common.ValidatingSubstitutor;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * End-to-end REST integration test for the Custom inference service.
+ *
+ * <p>Starts an in-process {@link MockWebServer} standing in for the upstream API.
+ * Creates a {@code text_embedding} inference endpoint pointing at the mock server,
+ * then runs inference and asserts that the request was built correctly.
+ *
+ * <p>Running inside a real default-distribution cluster means the inference plugin is loaded
+ * through {@code PluginsLoader.createModuleLayer} — the same JPMS module-layer path used in
+ * production. A missing {@code requires} directive in {@code module-info.java} (e.g. for
+ * {@code org.apache.commons.lang3}, which is a transitive runtime dependency of
+ * {@code org.apache.commons.text.StringSubstitutor} used by the Custom service's request
+ * template-substitution) would surface here as a {@code NoClassDefFoundError} at the point the
+ * first inference request is built, NOT in classpath-based unit tests where JPMS boundaries are
+ * not enforced.
+ */
+public class CustomServiceIT extends InferenceBaseRestTest {
+
+    private static final String ENDPOINT_ID = "custom-text-embedding";
+
+    /**
+     * OpenAI-compatible embedding response whose float array is extracted by the
+     * {@code json_parser} path {@code "$.data[*].embedding"} configured in the model below.
+     */
+    private static final String EMBEDDINGS_RESPONSE = """
+        {
+          "object": "list",
+          "data": [
+            {
+              "object": "embedding",
+              "index": 0,
+              "embedding": [0.1, 0.2, 0.3]
+            }
+          ],
+          "model": "text-embedding-3-small",
+          "usage": {"prompt_tokens": 1, "total_tokens": 1}
+        }
+        """;
+
+    private static final String INFERENCE_INPUT = "hello";
+
+    private static MockWebServer webServer;
+
+    @BeforeClass
+    public static void startWebServer() throws Exception {
+        webServer = new MockWebServer();
+        webServer.start();
+    }
+
+    @AfterClass
+    public static void stopWebServer() {
+        webServer.close();
+    }
+
+    @After
+    public void clearMockRequests() {
+        webServer.clearRequests();
+    }
+
+    /**
+     * Verifies that both the validation call during endpoint creation and the explicit inference
+     * call reach the mock upstream, and that the Custom service's template-substitution ran
+     * correctly (the {@code ${api_key}} placeholder in the Authorization header is replaced
+     * with the configured secret value before the outbound request is sent).
+     *
+     * <p>Custom endpoint creation triggers a validation inference call to the configured
+     * {@code url}, so two responses must be enqueued before calling {@code putModel}.
+     */
+    public void testCreate_AndInfer_SubstitutesTemplateVariables() throws Exception {
+        var url = Strings.format("http://localhost:%d/v1/embeddings", webServer.getPort());
+        // One response for the validation call fired during PUT, one for the explicit inference.
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDINGS_RESPONSE));
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDINGS_RESPONSE));
+
+        var apiKey = "test-key";
+
+        putModel(ENDPOINT_ID, customModelConfig(url, apiKey), TaskType.TEXT_EMBEDDING);
+        var result = infer(ENDPOINT_ID, TaskType.TEXT_EMBEDDING, List.of(INFERENCE_INPUT));
+
+        assertNonEmptyInferenceResults(result, 1, TaskType.TEXT_EMBEDDING);
+
+        // Confirm the upstream received exactly two calls: the validation call on PUT and the
+        // explicit inference call.
+        assertThat(webServer.requests(), hasSize(2));
+
+        // The Authorization header proves that ValidatingSubstitutor.replace() ran and resolved
+        // ${api_key} to "test-key" — this is the StringSubstitutor code path that depends on
+        // org.apache.commons.lang3 via org.apache.commons.text at runtime.
+        webServer.requests()
+            .forEach(req -> assertThat(req.getHeader(HttpHeaders.AUTHORIZATION), equalTo(Strings.format("Bearer %s", apiKey))));
+
+        // The request body must contain the substituted input.
+        assertThat(webServer.requests().get(1).getBody(), containsString(INFERENCE_INPUT));
+
+        deleteModel(ENDPOINT_ID, TaskType.TEXT_EMBEDDING);
+    }
+
+    /**
+     * Builds the PUT /_inference request body for a Custom text_embedding endpoint.
+     *
+     * <p>The {@code ${api_key}} placeholder in the Authorization header and the
+     * {@code ${input}} placeholder in the request body are substituted at inference time by
+     * {@code CustomRequest} via {@link ValidatingSubstitutor} (backed by
+     * {@code org.apache.commons.text.StringSubstitutor}, which uses
+     * {@code org.apache.commons.lang3} internally).
+     */
+    private static String customModelConfig(String url, String apiKey) {
+        return Strings.format("""
+            {
+              "service": "custom",
+              "service_settings": {
+                "secret_parameters": {
+                  "api_key": "%s"
+                },
+                "url": "%s",
+                "headers": {
+                  "Authorization": "Bearer ${api_key}",
+                  "Content-Type": "application/json;charset=utf-8"
+                },
+                "request": "{\\"input\\": ${input}, \\"model\\": \\"text-embedding-3-small\\"}",
+                "response": {
+                  "json_parser": {
+                    "text_embeddings": "$.data[*].embedding"
+                  }
+                }
+              }
+            }
+            """, apiKey, url);
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/InferenceModuleDescriptorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/InferenceModuleDescriptorTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import org.elasticsearch.jdk.JarHell;
+import org.elasticsearch.test.ESTestCase;
+
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+
+import static org.elasticsearch.module.BasicServerModuleTests.urlsToPaths;
+import static org.elasticsearch.test.hamcrest.ModuleDescriptorMatchers.requiresOf;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
+import static org.hamcrest.Matchers.hasItem;
+
+public class InferenceModuleDescriptorTests extends ESTestCase {
+
+    private static final String INFERENCE_MODULE_NAME = "org.elasticsearch.inference";
+
+    /**
+     * Pins the {@code requires} directives that exist only to satisfy a transitive runtime
+     * dependency that the inference plugin's own bytecode never references directly.
+     *
+     * <p>The dependency chain is:
+     * <pre>
+     *   CustomRequest
+     *     -> ValidatingSubstitutor
+     *          -> org.apache.commons.text.StringSubstitutor  (commons-text, an automatic module)
+     *               -> org.apache.commons.lang3.*            (loaded internally by StringSubstitutor)
+     * </pre>
+     *
+     * <p>{@code commons-text} is an <em>automatic</em> module (no {@code module-info.class}, only
+     * an {@code Automatic-Module-Name} manifest entry). Automatic modules carry no {@code requires}
+     * directives and therefore cannot pull any explicit module into the module graph on their own.
+     * {@code commons-lang3} is an <em>explicit</em> module (ships a {@code module-info.class}),
+     * so the "automatic module reads all other automatic modules" rule does not apply to it.
+     *
+     * <p>Consequently, without an explicit {@code requires org.apache.commons.lang3} in
+     * {@code module-info.java}, the lang3 module is never added to the inference plugin's module
+     * layer by {@code PluginsLoader.createModuleLayer}. Module layer resolution still succeeds
+     * (no error at resolve time), but the first call that causes {@code StringSubstitutor} to load
+     * a lang3 class throws a {@code NoClassDefFoundError} inside the running node.
+     *
+     * <p>This kind of failure is invisible to classpath-based unit tests (where JPMS {@code requires}
+     * is never enforced) and only manifests when the plugin is loaded as a named module inside a
+     * real Elasticsearch node — for example, during the validation inference call triggered by a
+     * {@code PUT _inference} request for the Custom service.
+     */
+    public void testRequiresCommonsTextAndLang3() {
+        var moduleDescriptor = getInferenceDescriptor();
+        assertThat(moduleDescriptor.requires(), hasItem(requiresOf("org.apache.commons.text")));
+        assertThat(moduleDescriptor.requires(), hasItem(requiresOf("org.apache.commons.lang3")));
+    }
+
+    private static ModuleDescriptor getInferenceDescriptor() {
+        var finder = ModuleFinder.of(urlsToPaths(JarHell.parseClassPath()));
+        var moduleReference = finder.find(INFERENCE_MODULE_NAME);
+        assertThat(moduleReference, isPresent());
+        return moduleReference.get().descriptor();
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Adding tests to catch the requires failure for Custom service (#151901)](https://github.com/elastic/elasticsearch/pull/151901)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)