### PR TITLE
[Inference API] Use new default 'regionless' EIS URL for CCM

### DIFF
--- a/docs/changelog/152339.yaml
+++ b/docs/changelog/152339.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues: []
+pr: 152339
+summary: "[DO NOT MERGE] [Inference API] Use new default 'regionless' EIS URL for\
+  \ CCM"
+type: enhancement

--- a/docs/changelog/152339.yaml
+++ b/docs/changelog/152339.yaml
@@ -1,6 +1,5 @@
 area: Inference
 issues: []
 pr: 152339
-summary: "[DO NOT MERGE] [Inference API] Use new default 'regionless' EIS URL for\
-  \ CCM"
+summary: "[Inference API] Use new default 'regionless' EIS URL for CCM"
 type: enhancement

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMInformedSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMInformedSettings.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * {@link ElasticInferenceServiceSettings#ELASTIC_INFERENCE_SERVICE_URL} setting.
  */
 public class CCMInformedSettings extends ElasticInferenceServiceSettings {
-    static final String DEFAULT_CCM_URL = "https://inference.us-east-1.aws.svc.elastic.cloud";
+    static final String DEFAULT_CCM_URL = "https://inference.svc.elastic.cloud";
 
     private final CCMFeature ccmFeature;
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequestTests.java
@@ -57,7 +57,7 @@ public class ElasticInferenceServiceAuthorizationRequestTests extends ESTestCase
     }
 
     public void testCreateUri_CreatesUri() throws URISyntaxException {
-        String url = "https://inference.us-east-1.aws.svc.elastic.cloud";
+        String url = "https://inference.svc.elastic.cloud";
 
         var request = new ElasticInferenceServiceAuthorizationRequest(
             url,


### PR DESCRIPTION
* updates the Elastic Inference Service (EIS) URL used by Cloud Connect (aka CCM)
* we will now use a 'regionless' URL by default
