### PR TITLE
provide default jwt_audience

### DIFF
--- a/docs/changelog/152362.yaml
+++ b/docs/changelog/152362.yaml
@@ -1,0 +1,5 @@
+area: Authentication
+issues: []
+pr: 152362
+summary: Provide default `jwt_audience`
+type: feature

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureConfiguration.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureConfiguration.java
@@ -27,7 +27,7 @@ import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefin
  * <ul>
  *   <li>{@code auth=static_credentials} — a connection string, account + key (SharedKey auth), or account + SAS token</li>
  *   <li>{@code auth=federated_identity} — workload identity federation via {@code tenant_id}, {@code client_id},
- *       and {@code jwt_audience}</li>
+ *       and optionally {@code jwt_audience}</li>
  *   <li>{@code auth=anonymous} — anonymous access to public containers</li>
  *   <li>{@code auth=managed_identity} — the node's managed identity via Azure IMDS. Requires the
  *       {@code esql.datasource.managed_identity.enabled} cluster setting.</li>
@@ -68,9 +68,6 @@ public class AzureConfiguration extends FileDataSourceConfiguration {
             }
             if (clientId() == null) {
                 errors.addValidationError("client_id is required when keyless authentication settings are configured");
-            }
-            if (jwtAudience() == null) {
-                errors.addValidationError("jwt_audience is required when keyless authentication settings are configured");
             }
         }
     }
@@ -155,7 +152,7 @@ public class AzureConfiguration extends FileDataSourceConfiguration {
 
     /**
      * Audience passed to the workload-identity issuer {@code IssueTokenRequest} when minting the JWT that
-     * is presented to Azure AD as a client assertion (typically {@code api://AzureADTokenExchange}).
+     * is presented to Azure AD as a client assertion (defaults to {@code api://AzureADTokenExchange}).
      */
     public String jwtAudience() {
         return get(JWT_AUDIENCE.name());

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProvider.java
@@ -97,6 +97,7 @@ public final class AzureStorageProvider implements StorageProvider {
 
     /** Operator-managed AKS Workload Identity token symlink, relative to {@code ${ES_PATH_CONF}}. */
     public static final String AKS_FEDERATED_TOKEN_FILE_LOCATION = "esql-datasource-azure/azure-federated-token";
+    private static final String DEFAULT_JWT_AUDIENCE = "api://AzureADTokenExchange";
 
     /**
      * Test-only system property that disables Microsoft Entra instance discovery on the Azure SDK
@@ -421,7 +422,7 @@ public final class AzureStorageProvider implements StorageProvider {
             // back to ForkJoinPool.commonPool, which we deliberately keep token acquisition off of.
             throw new IllegalStateException("Azure keyless authentication requires a non-null executor for token acquisition");
         }
-        String jwtAudience = config.jwtAudience();
+        String jwtAudience = Strings.hasText(config.jwtAudience()) ? config.jwtAudience() : DEFAULT_JWT_AUDIENCE;
         // The synchronous clientAssertion supplier the delegate reads is wired by FederatedAssertionCredential itself;
         // we only configure the identity and the MSAL executor here.
         ClientAssertionCredentialBuilder delegateBuilder = new ClientAssertionCredentialBuilder().tenantId(config.tenantId())

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureConfigurationTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureConfigurationTests.java
@@ -285,10 +285,18 @@ public class AzureConfigurationTests extends ESTestCase {
         assertFalse(config.hasCredentials());
     }
 
-    public void testKeylessAuthRequiresAllFields() {
+    public void testKeylessAuthRequiresClientId() {
         ValidationException e = expectThrows(ValidationException.class, () -> AzureConfiguration.fromMap(Map.of("tenant_id", "my-tenant")));
         assertThat(e.getMessage(), containsString("client_id is required when keyless authentication settings are configured"));
-        assertThat(e.getMessage(), containsString("jwt_audience is required when keyless authentication settings are configured"));
+    }
+
+    public void testKeylessAuthAllowsOmittingJwtAudience() {
+        AzureConfiguration config = AzureConfiguration.fromMap(Map.of("tenant_id", "my-tenant", "client_id", "my-client"));
+        assertNotNull(config);
+        assertEquals("my-tenant", config.tenantId());
+        assertEquals("my-client", config.clientId());
+        assertNull(config.jwtAudience());
+        assertTrue(config.hasKeylessAuth());
     }
 
     public void testKeylessAuthConflictsWithExplicitCredentials() {

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProviderTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProviderTests.java
@@ -266,6 +266,23 @@ public class AzureStorageProviderTests extends ESTestCase {
             // The issuer fails the assertion, so resolution short-circuits before any Azure AD token exchange.
             TokenRequestContext request = new TokenRequestContext().addScopes("https://storage.azure.com/.default");
             expectThrows(CredentialUnavailableException.class, () -> credential.getToken(request).block());
+            assertEquals("overridden-audience", issuer.requestedAudience);
+        } finally {
+            WorkloadIdentityRegistry.reset();
+        }
+    }
+
+    public void testBuildClientAssertionCredentialRequestsDefaultAudienceWhenOmitted() {
+        RecordingIssuerClient issuer = new RecordingIssuerClient(true, false);
+        WorkloadIdentityRegistry.setIssuerClient(issuer);
+        try {
+            TokenCredential credential = AzureStorageProvider.buildClientAssertionCredential(
+                AzureConfiguration.fromMap(Map.of("tenant_id", "test-tenant-id", "client_id", "test-client-id")),
+                EsExecutors.DIRECT_EXECUTOR_SERVICE
+            );
+            // The issuer fails the assertion, so resolution short-circuits before any Azure AD token exchange.
+            TokenRequestContext request = new TokenRequestContext().addScopes("https://storage.azure.com/.default");
+            expectThrows(CredentialUnavailableException.class, () -> credential.getToken(request).block());
             assertEquals("api://AzureADTokenExchange", issuer.requestedAudience);
         } finally {
             WorkloadIdentityRegistry.reset();
@@ -274,7 +291,7 @@ public class AzureStorageProviderTests extends ESTestCase {
 
     private static AzureConfiguration keylessConfig() {
         return AzureConfiguration.fromMap(
-            Map.of("tenant_id", "test-tenant-id", "client_id", "test-client-id", "jwt_audience", "api://AzureADTokenExchange")
+            Map.of("tenant_id", "test-tenant-id", "client_id", "test-client-id", "jwt_audience", "overridden-audience")
         );
     }
 

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfiguration.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfiguration.java
@@ -25,8 +25,8 @@ import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefin
  * {@code auto}, which infers the mode from the fields present. Supported modes:
  * <ul>
  *   <li>{@code auth=static_credentials} — service account JSON credentials (inline) or a short-lived OAuth2 access token</li>
- *   <li>{@code auth=federated_identity} — workload identity federation via {@code sts_audience},
- *       and optionally {@code service_account_impersonation_url}, and {@code jwt_audience}</li>
+ *   <li>{@code auth=federated_identity} — workload identity federation via {@code sts_audience}
+ *       (and optionally {@code service_account_impersonation_url}, and {@code jwt_audience})</li>
  *   <li>{@code auth=anonymous} — anonymous access to public buckets</li>
  *   <li>{@code auth=managed_identity} — the node's own GCE/GKE metadata-server credentials,
  *       gated by the {@code esql.datasource.managed_identity.enabled} cluster setting</li>

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfiguration.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfiguration.java
@@ -25,8 +25,8 @@ import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefin
  * {@code auto}, which infers the mode from the fields present. Supported modes:
  * <ul>
  *   <li>{@code auth=static_credentials} — service account JSON credentials (inline) or a short-lived OAuth2 access token</li>
- *   <li>{@code auth=federated_identity} — workload identity federation via {@code jwt_audience}, {@code sts_audience},
- *       and {@code service_account_impersonation_url}</li>
+ *   <li>{@code auth=federated_identity} — workload identity federation via {@code sts_audience},
+ *       and optionally {@code service_account_impersonation_url}, and {@code jwt_audience}</li>
  *   <li>{@code auth=anonymous} — anonymous access to public buckets</li>
  *   <li>{@code auth=managed_identity} — the node's own GCE/GKE metadata-server credentials,
  *       gated by the {@code esql.datasource.managed_identity.enabled} cluster setting</li>
@@ -69,9 +69,6 @@ public class GcsConfiguration extends FileDataSourceConfiguration {
         // service_account_impersonation_url is optional: direct workload-identity federation maps the
         // federated identity straight to a principal without impersonating a service account.
         if (hasKeylessAuth()) {
-            if (jwtAudience() == null) {
-                errors.addValidationError("jwt_audience is required when keyless authentication settings are configured");
-            }
             if (stsAudience() == null) {
                 errors.addValidationError("sts_audience is required when keyless authentication settings are configured");
             }
@@ -161,7 +158,8 @@ public class GcsConfiguration extends FileDataSourceConfiguration {
     }
 
     /**
-     * Audience passed to the workload-identity issuer {@code IssueTokenRequest} when minting a JWT.
+     * Audience override passed to the workload-identity issuer {@code IssueTokenRequest} when minting a JWT.
+     * By default, it mirrors the value of {@link #stsAudience()}.
      */
     public String jwtAudience() {
         return get(JWT_AUDIENCE.name());

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageProvider.java
@@ -191,10 +191,11 @@ public class GcsStorageProvider implements StorageProvider {
             throw new IllegalStateException("GCS keyless authentication requires the workload-identity feature to be enabled on this node");
         }
 
+        String jwtAudience = Strings.hasText(config.jwtAudience()) ? config.jwtAudience() : config.stsAudience();
         IdentityPoolCredentials.Builder credentialsBuilder = IdentityPoolCredentials.newBuilder()
             .setAudience(config.stsAudience())
             .setSubjectTokenType(ExternalAccountCredentials.SubjectTokenTypes.JWT)
-            .setSubjectTokenSupplier(new GcsWorkloadIdentitySubjectTokenSupplier(issuerClient, config.jwtAudience()));
+            .setSubjectTokenSupplier(new GcsWorkloadIdentitySubjectTokenSupplier(issuerClient, jwtAudience));
 
         // Optional: when absent, the federated identity maps directly to a principal without impersonation.
         if (config.serviceAccountImpersonationUrl() != null) {

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfigurationTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfigurationTests.java
@@ -227,12 +227,19 @@ public class GcsConfigurationTests extends ESTestCase {
         assertFalse(config.hasCredentials());
     }
 
-    public void testPartialKeylessAuthRequiresBothAudiences() {
+    public void testKeylessAuthRequiresStsAudience() {
         ValidationException e = expectThrows(
             ValidationException.class,
             () -> GcsConfiguration.fromFields(null, null, null, null, null, "jwt-audience", null, null)
         );
         assertThat(e.getMessage(), containsString("sts_audience is required"));
+    }
+
+    public void testKeylessAuthAllowsOmittingJwtAudience() {
+        GcsConfiguration config = GcsConfiguration.fromFields(null, null, null, null, null, null, "sts-audience", null);
+        assertTrue(config.hasKeylessAuth());
+        assertNull(config.jwtAudience());
+        assertEquals("sts-audience", config.stsAudience());
     }
 
     public void testKeylessAuthAllowsOmittingServiceAccountImpersonationUrl() {

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageProviderTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageProviderTests.java
@@ -78,6 +78,27 @@ public class GcsStorageProviderTests extends ESTestCase {
         assertNotNull(new GcsStorageProvider(config));
     }
 
+    public void testKeylessAuthBuildsWithDefaultJwtAudience() {
+        WorkloadIdentityRegistry.setIssuerClient((request, listener) -> fail("token request is not expected during client construction"));
+        GcsConfiguration config = GcsConfiguration.fromFields(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+            null
+        );
+        assertNotNull(new GcsStorageProvider(config));
+    }
+
+    public void testKeylessAuthBuildsWithOverriddenJwtAudience() {
+        WorkloadIdentityRegistry.setIssuerClient((request, listener) -> fail("token request is not expected during client construction"));
+        GcsConfiguration config = keylessConfiguration();
+        assertNotNull(new GcsStorageProvider(config));
+    }
+
     private static GcsConfiguration keylessConfiguration() {
         return GcsConfiguration.fromFields(
             null,

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3Configuration.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3Configuration.java
@@ -25,8 +25,8 @@ import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefin
  * {@code auto}, which infers the mode from the fields present. Supported modes:
  * <ul>
  *   <li>{@code auth=static_credentials} — access_key + secret_key (optionally session_token for STS temporary credentials)</li>
- *   <li>{@code auth=federated_identity} — keyless workload-identity federation via {@code role_arn} and
- *       {@code jwt_audience} (optionally {@code role_session_name} and {@code sts_endpoint})</li>
+ *   <li>{@code auth=federated_identity} — keyless workload-identity federation via {@code role_arn} (and optionally
+ *       {@code jwt_audience}, {@code role_session_name} and {@code sts_endpoint})</li>
  *   <li>{@code auth=anonymous} — anonymous access to public buckets</li>
  *   <li>{@code auth=managed_identity} — the node's instance credentials via the IMDS-family chain
  *       (ECS task role, then EC2 instance profile). Requires the
@@ -66,14 +66,11 @@ public class S3Configuration extends FileDataSourceConfiguration {
 
     @Override
     protected void validateCredentials(ValidationException errors) {
-        // role_session_name and sts_endpoint are optional; role_arn and jwt_audience are the minimum
+        // role_session_name, sts_endpoint, and jwt_audience are optional; role_arn is the minimum
         // needed to mint an OIDC token and exchange it for credentials via STS AssumeRoleWithWebIdentity.
         if (hasKeylessAuth()) {
             if (roleArn() == null) {
                 errors.addValidationError("role_arn is required when keyless authentication settings are configured");
-            }
-            if (jwtAudience() == null) {
-                errors.addValidationError("jwt_audience is required when keyless authentication settings are configured");
             }
         }
     }
@@ -186,7 +183,8 @@ public class S3Configuration extends FileDataSourceConfiguration {
         return get(ROLE_SESSION_NAME.name());
     }
 
-    /** Audience passed to the workload-identity issuer when minting the OIDC token presented to STS. */
+    /** Optional override for audience passed to the workload-identity issuer when minting the OIDC token
+     *  presented to STS; defaults to {@code sts.amazonaws.com}. */
     public String jwtAudience() {
         return get(JWT_AUDIENCE.name());
     }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
@@ -509,7 +509,7 @@ public class S3StorageProvider implements StorageProvider {
         if (config == null || config.resolveAuthModeOrNull() == null) {
             return ". If accessing a public bucket, set auth=anonymous. "
                 + "Otherwise, provide credentials via access_key and secret_key, "
-                + "or configure keyless authentication with role_arn and jwt_audience";
+                + "or configure keyless authentication with role_arn";
         }
         return "";
     }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
@@ -92,6 +92,7 @@ import java.util.NoSuchElementException;
 public class S3StorageProvider implements StorageProvider {
     private static final Logger LOGGER = LogManager.getLogger(S3StorageProvider.class);
     private static final String DEFAULT_ROLE_SESSION_NAME = "elasticsearch-esql-datasource";
+    private static final String DEFAULT_JWT_AUDIENCE = "sts.amazonaws.com";
 
     private static final Duration CONNECTION_ACQUISITION_TIMEOUT = Duration.ofSeconds(60);
 
@@ -377,10 +378,11 @@ public class S3StorageProvider implements StorageProvider {
         StsAsyncClient stsAsyncClient
     ) {
         String roleSessionName = Strings.hasText(config.roleSessionName()) ? config.roleSessionName() : DEFAULT_ROLE_SESSION_NAME;
+        String jwtAudience = Strings.hasText(config.jwtAudience()) ? config.jwtAudience() : DEFAULT_JWT_AUDIENCE;
         return AsyncWebIdentityCredentialsProvider.builder()
             .roleArn(config.roleArn())
             .roleSessionName(roleSessionName)
-            .tokenSupplier(new S3WorkloadIdentityTokenSupplier(issuerClient, config.jwtAudience()))
+            .tokenSupplier(new S3WorkloadIdentityTokenSupplier(issuerClient, jwtAudience))
             .stsAsyncClient(stsAsyncClient)
             .build();
     }

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3ConfigurationTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3ConfigurationTests.java
@@ -334,12 +334,12 @@ public class S3ConfigurationTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("role_arn is required when keyless authentication settings are configured"));
     }
 
-    public void testKeylessAuthRequiresJwtAudience() {
-        ValidationException e = expectThrows(
-            ValidationException.class,
-            () -> S3Configuration.fromKeylessFields("role-arn", null, null, null, null, null, null)
-        );
-        assertThat(e.getMessage(), containsString("jwt_audience is required when keyless authentication settings are configured"));
+    public void testKeylessAuthAllowsOmittingJwtAudience() {
+        S3Configuration config = S3Configuration.fromKeylessFields("role-arn", null, null, null, null, null, null);
+        assertNotNull(config);
+        assertTrue(config.hasKeylessAuth());
+        assertEquals("role-arn", config.roleArn());
+        assertNull(config.jwtAudience());
     }
 
     public void testKeylessAuthConflictsWithCredentials() {

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3WorkloadIdentityCredentialsProviderTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3WorkloadIdentityCredentialsProviderTests.java
@@ -83,6 +83,27 @@ public class S3WorkloadIdentityCredentialsProviderTests extends ESTestCase {
         assertEquals("custom-session", captured.get().roleSessionName());
     }
 
+    public void testUsesDefaultJwtAudienceWhenOmitted() throws Exception {
+        AtomicReference<String> requestedAudience = new AtomicReference<>();
+        WorkloadIdentityIssuerClient issuerClient = (request, listener) -> {
+            requestedAudience.set(request.audience());
+            listener.onResponse(new WorkloadIdentityIssuerClient.IssueTokenResponse("signed.jwt", Instant.now().plusSeconds(300)));
+        };
+        AtomicReference<AssumeRoleWithWebIdentityRequest> captured = new AtomicReference<>();
+        StubStsAsyncClient sts = new StubStsAsyncClient(captured, "AK-1");
+
+        S3Configuration config = S3Configuration.fromKeylessFields(ROLE_ARN, null, null, null, null, null, null);
+        AsyncWebIdentityCredentialsProvider provider = S3StorageProvider.buildWorkloadIdentityCredentialsProvider(
+            config,
+            issuerClient,
+            sts
+        );
+
+        provider.resolveIdentity(ResolveIdentityRequest.builder().build()).get();
+        assertEquals("sts.amazonaws.com", requestedAudience.get());
+        assertEquals("signed.jwt", captured.get().webIdentityToken());
+    }
+
     public void testConstructionFailsWhenWorkloadIdentityDisabled() {
         WorkloadIdentityRegistry.setIssuerClient(new WorkloadIdentityIssuerClient() {
             @Override


### PR DESCRIPTION
Each CSP has their own default
audience claim. Each allows
overriding too. This change
brings the defaults, as earlier
we required them to be provided
explicitly. This way, user may
leave the UI parameters blank to
use sensible defaults.
