### PR TITLE
Update `X-Elastic-Product-Use-Case` header values

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceService.java
@@ -29,7 +29,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class InferenceService {
 
-    public static final String COMPLETION_PRODUCT_USE_CASE = "internal_completion";
+    /** Value of the {@code X-Elastic-Product-Use-Case} header for ESQL requests. */
+    public static final String ESQL_PRODUCT_USE_CASE = "ESQL";
 
     private InferenceSettings inferenceSettings;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIterator.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import static org.elasticsearch.xpack.esql.inference.InferenceService.COMPLETION_PRODUCT_USE_CASE;
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 
 /**
  * Iterator that converts a block of prompt strings into inference request items.
@@ -104,7 +104,7 @@ class CompletionRequestIterator implements BulkInferenceRequestItemIterator {
 
         InferenceAction.Request.Builder builder = InferenceAction.Request.builder(inferenceId, TaskType.COMPLETION)
             .setInput(List.of(prompt))
-            .setContext(new InferenceContext(COMPLETION_PRODUCT_USE_CASE));
+            .setContext(new InferenceContext(ESQL_PRODUCT_USE_CASE));
         if (timeout != null) {
             builder.setInferenceTimeout(timeout);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/embedding/EmbeddingRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/embedding/EmbeddingRequestIterator.java
@@ -18,6 +18,7 @@ import org.elasticsearch.inference.InferenceString;
 import org.elasticsearch.inference.InferenceStringGroup;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xpack.core.inference.InferenceContext;
 import org.elasticsearch.xpack.core.inference.action.BaseInferenceActionRequest;
 import org.elasticsearch.xpack.core.inference.action.EmbeddingAction;
 import org.elasticsearch.xpack.esql.inference.AbstractEmbeddingRequestIterator;
@@ -28,6 +29,8 @@ import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceReq
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 
 /**
  * Embedding request iterator for typed (DataType) inputs.
@@ -62,6 +65,7 @@ class EmbeddingRequestIterator extends AbstractEmbeddingRequestIterator {
                 inferenceId,
                 taskType,
                 embeddingRequest,
+                new InferenceContext(ESQL_PRODUCT_USE_CASE),
                 Objects.requireNonNullElse(timeout, BaseInferenceActionRequest.getDefaultTimeoutForTaskType(TaskType.TEXT_EMBEDDING))
             ),
             pvcs

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/rerank/RerankRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/rerank/RerankRequestIterator.java
@@ -17,6 +17,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceString;
 import org.elasticsearch.inference.RerankRequest;
+import org.elasticsearch.xpack.core.inference.InferenceContext;
 import org.elasticsearch.xpack.core.inference.action.RerankAction;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItem;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItemIterator;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.elasticsearch.inference.InferenceString.fromStringList;
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 
 /**
  * Iterator that converts a block of text strings into batched inference request items for reranking.
@@ -209,7 +211,7 @@ class RerankRequestIterator implements BulkInferenceRequestItemIterator {
         }
 
         var rerankRequest = new RerankRequest(fromStringList(inputs), InferenceString.ofText(queryText), null, null, null);
-        return new RerankAction.Request(inferenceId, rerankRequest, timeout);
+        return new RerankAction.Request(inferenceId, rerankRequest, new InferenceContext(ESQL_PRODUCT_USE_CASE), timeout);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingRequestIterator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xpack.core.inference.InferenceContext;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.esql.inference.AbstractEmbeddingRequestIterator;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItem;
@@ -20,6 +21,8 @@ import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceReq
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItemIterator;
 
 import java.util.List;
+
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 
 /**
  * Embedding request iterator for plain (untyped) text inputs.
@@ -41,7 +44,9 @@ class TextEmbeddingRequestIterator extends AbstractEmbeddingRequestIterator {
         if (text == null) {
             return new BulkInferenceRequestItem(null, pvcs);
         }
-        InferenceAction.Request.Builder builder = InferenceAction.Request.builder(inferenceId, taskType).setInput(List.of(text));
+        InferenceAction.Request.Builder builder = InferenceAction.Request.builder(inferenceId, taskType)
+            .setInput(List.of(text))
+            .setContext(new InferenceContext(ESQL_PRODUCT_USE_CASE));
         if (timeout != null) {
             builder.setInferenceTimeout(timeout);
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIteratorTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceReq
 
 import java.util.Map;
 
-import static org.elasticsearch.xpack.esql.inference.InferenceService.COMPLETION_PRODUCT_USE_CASE;
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -76,7 +76,7 @@ public class CompletionRequestIteratorTests extends ComputeTestCase {
             BulkInferenceRequestItem requestItem1 = requestIterator.next();
             assertThat(requestItem1.inferenceRequest().getInferenceEntityId(), equalTo(inferenceId));
             assertThat(requestItem1.inferenceRequest().getTaskType(), equalTo(TaskType.COMPLETION));
-            assertThat(requestItem1.inferenceRequest().getContext().productUseCase(), equalTo(COMPLETION_PRODUCT_USE_CASE));
+            assertThat(requestItem1.inferenceRequest().getContext().productUseCase(), equalTo(ESQL_PRODUCT_USE_CASE));
             assertThat(((InferenceAction.Request) requestItem1.inferenceRequest()).getInput().getFirst(), equalTo("prompt1"));
             assertThat(requestItem1.positionValueCounts(), equalTo(new int[] { 1, 0, 0 }));
             assertThat(
@@ -321,7 +321,7 @@ public class CompletionRequestIteratorTests extends ComputeTestCase {
 
                 assertThat(request.getInferenceEntityId(), equalTo(inferenceId));
                 assertThat(request.getTaskType(), equalTo(TaskType.COMPLETION));
-                assertThat(request.getContext().productUseCase(), equalTo(COMPLETION_PRODUCT_USE_CASE));
+                assertThat(request.getContext().productUseCase(), equalTo(ESQL_PRODUCT_USE_CASE));
                 assertThat(request.getInferenceTimeout(), equalTo(expectedTimeout(timeout)));
 
                 scratch = inputBlock.getBytesRef(inputBlock.getFirstValueIndex(iterationCount), scratch);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/embedding/EmbeddingRequestIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/embedding/EmbeddingRequestIteratorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceReq
 
 import java.util.Base64;
 
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
@@ -489,6 +490,26 @@ public class EmbeddingRequestIteratorTests extends ComputeTestCase {
 
     private static DataType randomDataType() {
         return randomFrom(DataType.TEXT, DataType.IMAGE);
+    }
+
+    public void testProductUseCase() throws Exception {
+        final String inferenceId = randomIdentifier();
+        final BytesRefBlock inputBlock = randomInputBlock(1);
+
+        try (
+            EmbeddingRequestIterator requestIterator = new EmbeddingRequestIterator(
+                inferenceId,
+                inputBlock,
+                DataType.TEXT,
+                BaseInferenceActionRequest.getDefaultTimeoutForTaskType(TaskType.EMBEDDING)
+            )
+        ) {
+            assertTrue(requestIterator.hasNext());
+            EmbeddingAction.Request request = (EmbeddingAction.Request) requestIterator.next().inferenceRequest();
+            assertThat(request.getContext().productUseCase(), equalTo(ESQL_PRODUCT_USE_CASE));
+        }
+
+        allBreakersEmpty();
     }
 
     private static String randomInputValue(DataType dataType) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/rerank/RerankRequestIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/rerank/RerankRequestIteratorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceReq
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -706,6 +707,21 @@ public class RerankRequestIteratorTests extends ComputeTestCase {
 
                 assertFalse(requestIterator.hasNext());
             }
+        }
+
+        allBreakersEmpty();
+    }
+
+    public void testProductUseCase() throws Exception {
+        final String inferenceId = randomIdentifier();
+        final int size = 25;
+        final int batchSize = 10;
+        final BytesRefBlock[] inputBlocks = new BytesRefBlock[] { randomInputBlock(size) };
+
+        try (RerankRequestIterator requestIterator = new RerankRequestIterator(inferenceId, QUERY_TEXT, inputBlocks, batchSize, null)) {
+            assertTrue(requestIterator.hasNext());
+            RerankAction.Request request = (RerankAction.Request) requestIterator.next().inferenceRequest();
+            assertThat(request.getContext().productUseCase(), equalTo(ESQL_PRODUCT_USE_CASE));
         }
 
         allBreakersEmpty();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingRequestIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingRequestIteratorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.inference.action.BaseInferenceActionRequest;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItem;
 
+import static org.elasticsearch.xpack.esql.inference.InferenceService.ESQL_PRODUCT_USE_CASE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -392,6 +393,19 @@ public class TextEmbeddingRequestIteratorTests extends ComputeTestCase {
             }
 
             assertThat(iterationCount, equalTo(size));
+        }
+
+        allBreakersEmpty();
+    }
+
+    public void testProductUseCase() throws Exception {
+        final String inferenceId = randomIdentifier();
+        final BytesRefBlock inputBlock = randomInputBlock(1);
+
+        try (TextEmbeddingRequestIterator requestIterator = new TextEmbeddingRequestIterator(inferenceId, inputBlock, null)) {
+            assertTrue(requestIterator.hasNext());
+            InferenceAction.Request request = (InferenceAction.Request) requestIterator.next().inferenceRequest();
+            assertThat(request.getContext().productUseCase(), equalTo(ESQL_PRODUCT_USE_CASE));
         }
 
         allBreakersEmpty();


### PR DESCRIPTION
Sends `X-Elastic-Product-Use-Case: ESQL` in all requests to the Inference Service from ESQL use cases.  Adds support for `RERANK`, `text_embedding`, and `embedding` requests alongside the existing support for completion requests.

Fixes #148505.
