### PR TITLE
Tolerate histogram over-counting in testExplicitMetrics

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -749,9 +749,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testWatcherWithApiKey {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/152355
-- class: org.elasticsearch.test.apmintegration.OTelMetricsBufferingIT
-  method: testExplicitMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/152356
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=indices.create/21_synthetic_source_stored/index param - field ordering}
   issue: https://github.com/elastic/elasticsearch/issues/152364

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/AbstractMetricsIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/AbstractMetricsIT.java
@@ -91,7 +91,10 @@ public abstract class AbstractMetricsIT extends AbstractTelemetryIT {
                     if (histogramExpected != null && sampleValue instanceof ReceivedTelemetry.HistogramSample(var counts)) {
                         int total = counts.stream().mapToInt(Integer::intValue).sum();
                         int remaining = histogramExpected - total;
-                        if (remaining == 0) {
+                        // Pass once we have observed at least the expected number of counts. The retry loop below
+                        // re-records the histogram on each iteration, so cumulative counts can exceed the expectation
+                        // and drive remaining negative; requiring exactly 0 would then never be satisfiable again.
+                        if (remaining <= 0) {
                             logger.info("{} assertion PASSED", key);
                             histogramAssertions.remove(key);
                         } else {


### PR DESCRIPTION
Follow-up to #152325, which introduced a regression in the inherited `AbstractMetricsIT.testExplicitMetrics`.

That PR wrapped the body in an `assertBusy` retry that re-calls `/_use_apm_metrics` on each iteration (needed to recover from genuinely dropped exports in the no-buffer `OtelMetricsIT` configuration). The histogram assertions, however, use a subtractive matcher — `remaining -= total`, pass only when `remaining == 0`. Re-recording the histogram on each retry pushes cumulative counts past the expected value, driving `remaining` negative, after which `== 0` is never satisfiable again. The test then times out with both histogram assertions remaining:

```
Timeout when waiting for assertions to complete. Remaining assertions to match: es.test.long_histogram.histogram,es.test.double_histogram.histogram
```

This surfaced on `OTelMetricsBufferingIT.testExplicitMetrics` (#152356) — the buffering-enabled subclass, where exports are buffered and replayed rather than dropped, so the retry re-records without any compensating loss. The counter assertions were unaffected because they use a stateless per-sample predicate (`closeTo(1.0)`) that passes on the first clean export.

Fix: pass the histogram assertion once at least the expected number of counts has been observed (`remaining <= 0`), matching the tolerance the counter assertions already have. Over-counting from retries is benign for this smoke-level check.

Fixes #152356