### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/check-esql-generated-headers.yml
+++ b/.github/workflows/check-esql-generated-headers.yml
@@ -19,6 +19,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify generated-doc headers
         run: .ci/scripts/check-esql-generated-headers.sh

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,5 +10,5 @@ jobs:
     if: github.repository == 'elastic/elasticsearch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: gradle/actions/wrapper-validation@ac638b010cf58a27ee6c972d7336334ccaf61c96 # Release v4.4.1

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       branches: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: set-matrix
         run: |
           BRANCHES=$(jq -c '[.branches[].branch]' branches.json)
@@ -35,7 +35,7 @@ jobs:
       packages: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ matrix.branch }}
 


### PR DESCRIPTION
## Summary

Pin all unpinned GitHub Actions to immutable full-length commit SHAs.

**Why:** Mutable tags (`@v3`, `@main`) can be silently redirected to malicious commits. SHA-pinning ensures reviewed code runs in CI — defense-in-depth against supply-chain attacks.

**Changes:** 3 reference(s) across 3 workflow file(s). Version tags retained as inline comments.

**References:**
- [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [OpenSSF Scorecard: Pinned-Dependencies](https://securityscorecards.dev)

*Automated security hardening PR.*