### PR TITLE
Fix scheduled-refresh race in relocation test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -710,9 +710,6 @@ tests:
 - class: org.elasticsearch.xpack.encryption.spi.test.EncryptedDataHandlerProviderSpiIT
   method: testProviderIsDiscoveredAndHandlerIsInvoked
   issue: https://github.com/elastic/elasticsearch/issues/152303
-- class: org.elasticsearch.xpack.stateless.StatelessConcurrentRefreshIT
-  method: testWaitUntilShouldNotWaitForUpload
-  issue: https://github.com/elastic/elasticsearch/issues/152304
 - class: org.elasticsearch.blobcache.common.SparseFileTrackerTests
   method: testThreadSafety
   issue: https://github.com/elastic/elasticsearch/issues/152305

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessConcurrentRefreshIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessConcurrentRefreshIT.java
@@ -282,7 +282,7 @@ public class StatelessConcurrentRefreshIT extends AbstractStatelessPluginIntegTe
             + "org.elasticsearch.indices.recovery:debug",
         reason = "ensure detailed shard relocation information"
     )
-    public void testWaitUntilShouldNotWaitForUpload() throws InterruptedException {
+    public void testWaitUntilShouldNotWaitForUpload() throws Exception {
         startMasterOnlyNode();
         final String indexNode = startIndexNode();
         startSearchNode();
@@ -292,11 +292,12 @@ public class StatelessConcurrentRefreshIT extends AbstractStatelessPluginIntegTe
         createIndex(
             indexName,
             indexSettings(1, 1).put(INDEX_TRANSLOG_FLUSH_THRESHOLD_AGE_SETTING.getKey(), "1h")
-                // The test should pass with scheduled refresh disabled. Randomly enable it for closer resemblance to production
-                .put(
-                    IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(),
-                    randomFrom(TimeValue.MINUS_ONE, IndexSettings.STATELESS_MIN_NON_FAST_REFRESH_INTERVAL)
-                )
+                // Scheduled refresh must stay disabled: this test relies on the relocation's forceRefreshes() being the
+                // refresh that notifies the wait_until refresh listener and counts down afterRefreshLatch (via the overridden
+                // 1-arg refresh(String)). A periodic refresh goes through Engine.maybeRefresh() -> the 3-arg refresh(), which
+                // notifies/consumes the listener WITHOUT counting the latch; the relocation would then find no pending listener
+                // (refreshNeeded() == false), never force a refresh, and afterRefreshLatch would never reach zero.
+                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE)
                 .build()
         );
         ensureGreen(indexName);
@@ -313,6 +314,14 @@ public class StatelessConcurrentRefreshIT extends AbstractStatelessPluginIntegTe
         logger.info("--> Starting the bulk indexing thread with wait_until");
         final var indexingThread = new Thread(() -> bulkIndexDocsWithRefresh(indexName, 20, WriteRequest.RefreshPolicy.WAIT_UNTIL));
         indexingThread.start();
+
+        // Establish the happens-before the rest of the test relies on: wait until all docs have been written on the source
+        // primary (20 immediate + 20 immediate + 20 wait_until = 60). By then the wait_until bulk holds its operation permit
+        // and has registered (or is about to register) its refresh listener on the source, so the relocation's forceRefreshes()
+        // is guaranteed to observe a pending listener (refreshNeeded() == true) and fire the latch-counting refresh. Without
+        // this, under load the relocation could drain all permits before the bulk registers, the bulk would reroute to the new
+        // primary, and afterRefreshLatch would never count down.
+        assertBusy(() -> assertThat(testStateless.indexCounter.get(), equalTo(60)));
 
         // 2. Start the relocation and block it right after the pre-flush. The pre-flush creates and uploads generation N.
         // afterRealFlushCompletedBarrierReference is used so that only this real flush (IS_FLUSH_BY_REFRESH=false) can


### PR DESCRIPTION
testWaitUntilShouldNotWaitForUpload relied on the relocation's `forceRefreshes()` being the refresh that notifies the `wait_until` listener and counts the latch. A randomly-enabled scheduled refresh could notify the listener first via `maybeRefresh()`, so `forceRefreshes()` found no pending listener and the latch timed out.

Disable scheduled refresh, and wait for the wait_until bulk to register its listener before relocating so `forceRefreshes()` always notifies it.

Closes #152304