### PR TITLE
Disable memory mapping for ip-location DBs on Windows

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import org.elasticsearch.gradle.OS
+
 import static org.elasticsearch.gradle.util.PlatformUtils.normalize
 
 plugins {
@@ -190,6 +192,15 @@ tasks.named("internalClusterTest").configure {
   // Data sources require the project encryption key feature (EsqlPlugin fails fast otherwise); pair the flags.
   systemProperty 'es.project_encryption_key_feature_flag_enabled', 'true'
   systemProperty 'esql.kibana.docs.dir', "${rootDir}/docs/reference/query-languages/esql/kibana/generated"
+
+  // The IP_LOCATION csv-spec tests load geoip databases, which are memory-mapped by default.
+  // Windows cannot delete a memory-mapped file, so the per-suite temp directory cleanup fails there
+  // unless the databases are loaded on heap instead. Mirrors :modules:ip-location and
+  // :modules:ingest-ip-location.
+  // See https://github.com/maxmind/MaxMind-DB-Reader-java#file-lock-on-windows for more information
+  if (OS.current() == OS.WINDOWS) {
+    systemProperty 'es.geoip.load_db_on_heap', 'true'
+  }
 
   def injected = project.objects.newInstance(Injected)
   File snippetsFolder = file("build/testrun/internalClusterTest/temp/esql/_snippets")


### PR DESCRIPTION
Fixes #151935

## Root cause

Since the `IP_LOCATION` command (#149421), `CsvIT` copies the GeoLite2 databases into the test node's `config/ingest-geoip` directory, and the `ip_location` csv-spec tests memory-map them (the MaxMind reader defaults to `Reader.FileMode.MEMORY_MAPPED`). On Windows a memory-mapped file cannot be deleted, so the per-suite temp-directory cleanup (`TestRuleTemporaryFilesCleanup`) fails:

```
java.io.IOException: Could not remove the following files ... ...\config\ingest-geoip\GeoLite2-City.mmdb: The process cannot access the file because it is being used by another process at org.apache.lucene.tests.util.TestRuleTemporaryFilesCleanup.afterAlways(...)
```

The whole suite is then reported as `CsvIT > classMethod` (only `GeoLite2-City`/`GeoLite2-Country` are locked — `GeoLite2-ASN`, which no test looks up, deletes fine). This is why the reproduction line/message is `undefined` and the failure rate is dramatically higher on the `*_checkpart3_platform-support-windows` steps.

## Fix

Set `es.geoip.load_db_on_heap=true` for the esql `internalClusterTest` task on Windows, which makes the reader use `Reader.FileMode.MEMORY` instead of memory-mapping, so no file lock is held at cleanup time. The esql unit `test` task is intentionally left untouched — it uses a stubbed lookup, never a real `.mmdb`.

This mirrors the identical Windows-only workaround already [used](https://github.com/elastic/elasticsearch/blob/e27b4df662a6ecca783c77e820674ec9a64841df/modules/ingest-ip-location/build.gradle#L44-L52) by the geoip ingest processor module.

## Note

The linked issue bundled some unrelated `CsvIT` failures due to class-level triage grouping. Only the Windows suite-cleanup failure is addressed here; any unrelated failures will be tracked separately.