### PR TITLE
[ESQL] Make external split discovery cancellable

### DIFF
--- a/docs/changelog/152391.yaml
+++ b/docs/changelog/152391.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152391
+summary: Make external split discovery cancellable
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -753,9 +753,14 @@ public class ExternalSourceResolver {
         List<Map.Entry<StoragePath, SourceMetadata>> entries = BoundedParallelGather.gather(indices, i -> {
             throwIfCancelled();
             StoragePath filePath = fileList.path(i);
-            SourceMetadata meta = cacheable
-                ? cachedResolveSingleSource(filePath, fileList.lastModifiedMillis(i), config)
-                : resolveSingleSource(filePath.toString(), config);
+            // Carry the cancellation signal across the synchronous footer read so a backoff sleep in
+            // the storage retry layer aborts promptly on cancel.
+            SourceMetadata meta = StorageRetryCancellation.callWithCancellation(
+                this::isCancelled,
+                () -> cacheable
+                    ? cachedResolveSingleSource(filePath, fileList.lastModifiedMillis(i), config)
+                    : resolveSingleSource(filePath.toString(), config)
+            );
             return Map.entry(filePath, meta);
         }, MAX_PARALLEL_METADATA_READS, executor);
 
@@ -819,7 +824,10 @@ public class ExternalSourceResolver {
         try {
             allMeta = BoundedParallelGather.gather(paths, filePath -> {
                 throwIfCancelled();
-                return resolveSingleSource(filePath.toString(), config);
+                return StorageRetryCancellation.callWithCancellation(
+                    this::isCancelled,
+                    () -> resolveSingleSource(filePath.toString(), config)
+                );
             }, MAX_PARALLEL_METADATA_READS, executor);
         } catch (TaskCancelledException e) {
             // Cancellation is not a "could not aggregate stats" condition — propagate it so the query
@@ -853,9 +861,13 @@ public class ExternalSourceResolver {
             String formatType = detectFormatType(filePath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
             try {
-                SchemaCacheEntry entry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                    return SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config));
-                });
+                SchemaCacheEntry entry = StorageRetryCancellation.callWithCancellation(
+                    this::isCancelled,
+                    () -> cacheService.getOrComputeSchema(
+                        schemaKey,
+                        k -> SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config))
+                    )
+                );
                 Map<String, Object> fileMeta = entry.safeMetadata();
                 if (fileMeta == null || fileMeta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false) {
                     // This file has no statistics — cannot produce accurate global stats.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -63,6 +64,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import java.util.function.BooleanSupplier;
 
 /**
  * Default {@link SplitProvider} for file-based sources.
@@ -135,6 +137,8 @@ public class FileSplitProvider implements SplitProvider {
 
     /** Maximum parallel per-file I/O tasks during split discovery (Parquet footer reads, etc.). */
     static final int MAX_PARALLEL_SPLIT_DISCOVERY = 16;
+
+    private static final String DISCOVERY_CANCELLED_MESSAGE = "ES|QL external split discovery cancelled";
 
     private final long targetSplitSizeBytes;
     private final DecompressionCodecRegistry codecRegistry;
@@ -227,6 +231,9 @@ public class FileSplitProvider implements SplitProvider {
         // still works, the on-wire cost is just slightly higher.
         ExternalSchema unifiedSchema = context.unifiedSchema();
 
+        // Bail before doing any per-file work if the originating query is already cancelled.
+        throwIfCancelled(context);
+
         // Phase 1: sequential filtering — cheap, in-memory predicates applied per file to
         // build the list of FileTask items that need I/O (footer reads, boundary scans).
         List<FileTask> tasks = new ArrayList<>(fileList.fileCount());
@@ -312,19 +319,20 @@ public class FileSplitProvider implements SplitProvider {
 
         // Phase 2: I/O-bound split discovery — parallelize when executor is available.
         final StorageProvider hoistedProvider = sharedProvider;
+        final BooleanSupplier isCancelled = context.isCancelled();
         List<List<ExternalSplit>> perFileSplits;
         try {
             if (executor != null && tasks.size() > 1) {
                 perFileSplits = BoundedParallelGather.gather(
                     tasks,
-                    task -> processFileForSplits(task, hoistedProvider),
+                    task -> processFileForSplits(task, hoistedProvider, isCancelled),
                     MAX_PARALLEL_SPLIT_DISCOVERY,
                     executor
                 );
             } else {
                 perFileSplits = new ArrayList<>(tasks.size());
                 for (FileTask task : tasks) {
-                    perFileSplits.add(processFileForSplits(task, hoistedProvider));
+                    perFileSplits.add(processFileForSplits(task, hoistedProvider, isCancelled));
                 }
             }
         } catch (IOException e) {
@@ -343,6 +351,20 @@ public class FileSplitProvider implements SplitProvider {
         // Each surviving task produces at least one split, so the task count is the number of
         // distinct files that are actually scanned after coordinator-side pruning.
         return new SplitDiscoveryResult(splits, tasks.size());
+    }
+
+    /**
+     * Throws {@link TaskCancelledException} when the originating query has been cancelled, so that a
+     * long-running split discovery (e.g. thousands of Parquet footer reads) aborts promptly. Mirrors
+     * {@code ExternalSourceResolver.throwIfCancelled}. Thrown from {@code processFileForSplits} it is
+     * the {@code fn} passed to {@link BoundedParallelGather#gather}, whose documented fast-fail
+     * short-circuits not-yet-started files and rethrows the exception, so cancel latency is bounded to
+     * the in-flight slots.
+     */
+    private static void throwIfCancelled(SplitDiscoveryContext context) {
+        if (context.isCancelled().getAsBoolean()) {
+            throw new TaskCancelledException(DISCOVERY_CANCELLED_MESSAGE);
+        }
     }
 
     /**
@@ -365,6 +387,16 @@ public class FileSplitProvider implements SplitProvider {
      * otherwise falls back to the registry for per-call provider resolution.
      * This method is safe to call concurrently from multiple threads.
      */
+    private List<ExternalSplit> processFileForSplits(FileTask task, @Nullable StorageProvider hoistedProvider, BooleanSupplier isCancelled)
+        throws IOException {
+        if (isCancelled.getAsBoolean()) {
+            throw new TaskCancelledException(DISCOVERY_CANCELLED_MESSAGE);
+        }
+        // Carry the cancellation signal as ambient thread-local state so the synchronous retry/throttle
+        // backoff inside the footer reads below can abort a parked sleep on cancel.
+        return StorageRetryCancellation.callWithCancellation(isCancelled, () -> processFileForSplits(task, hoistedProvider));
+    }
+
     private List<ExternalSplit> processFileForSplits(FileTask task, @Nullable StorageProvider hoistedProvider) throws IOException {
         List<ExternalSplit> fileSplits = new ArrayList<>();
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -257,9 +258,15 @@ class RetryPolicy {
                     decision.delayMillis(),
                     e.getMessage()
                 );
+                // Abort promptly if the originating query was already cancelled (skips the retry-count bump).
+                if (StorageRetryCancellation.isCancelled()) {
+                    throw new TaskCancelledException(StorageRetryCancellation.CANCELLED_MESSAGE);
+                }
                 onRetry.run();
                 try {
-                    Thread.sleep(decision.delayMillis());
+                    // Cancellation-aware sleep: polls during the delay so a cancel that flips mid-sleep aborts
+                    // within ~one poll interval rather than waiting out the full (up to 30s throttle) backoff.
+                    StorageRetryCancellation.sleepWithCancellationChecks(decision.delayMillis());
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     throw e;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObject.java
@@ -323,13 +323,13 @@ class RetryableStorageObject implements StorageObject {
                 throw rethrow(e);
             }
             closeQuietly(current);
-            if (decision.delayMillis() > 0) {
-                try {
-                    Thread.sleep(decision.delayMillis());
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    throw new IOException("interrupted while waiting to resume read of " + delegate.path(), ie);
-                }
+            try {
+                // Cancellation-aware sleep: aborts a parked backoff if the query is cancelled before or
+                // during the delay, rather than sleeping through the remaining per-episode retry budget.
+                StorageRetryCancellation.sleepWithCancellationChecks(decision.delayMillis());
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new IOException("interrupted while waiting to resume read of " + delegate.path(), ie);
             }
             retryCounters.addRetry();
             failuresSinceProgress++;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.splitAnd;
 
@@ -85,8 +86,22 @@ public final class SplitDiscoveryPhase {
         Map<String, ExternalSourceFactory> sourceFactories,
         int maxRecordBytes
     ) {
+        return resolveExternalSplitsWithStats(plan, sourceFactories, maxRecordBytes, () -> false);
+    }
+
+    /**
+     * Like {@link #resolveExternalSplitsWithStats(PhysicalPlan, Map, int)}, but threads a cancellation
+     * signal into each {@link SplitDiscoveryContext} so a long-running discovery (thousands of footer
+     * reads) aborts promptly when the originating query is cancelled.
+     */
+    public static Result resolveExternalSplitsWithStats(
+        PhysicalPlan plan,
+        Map<String, ExternalSourceFactory> sourceFactories,
+        int maxRecordBytes,
+        BooleanSupplier isCancelled
+    ) {
         ScanStats stats = new ScanStats();
-        PhysicalPlan resolved = resolveRecursive(plan, List.of(), sourceFactories, maxRecordBytes, stats);
+        PhysicalPlan resolved = resolveRecursive(plan, List.of(), sourceFactories, maxRecordBytes, stats, isCancelled);
         return new Result(resolved, stats.filesScanned, stats.splitsScanned, stats.bytesScanned);
     }
 
@@ -95,10 +110,11 @@ public final class SplitDiscoveryPhase {
         List<Expression> ancestorFilters,
         Map<String, ExternalSourceFactory> sourceFactories,
         int maxRecordBytes,
-        ScanStats stats
+        ScanStats stats,
+        BooleanSupplier isCancelled
     ) {
         if (plan instanceof ExternalSourceExec exec) {
-            return resolveExternalSource(exec, ancestorFilters, sourceFactories, maxRecordBytes, stats);
+            return resolveExternalSource(exec, ancestorFilters, sourceFactories, maxRecordBytes, stats, isCancelled);
         }
 
         List<Expression> filtersForChildren = ancestorFilters;
@@ -118,7 +134,7 @@ public final class SplitDiscoveryPhase {
         boolean changed = false;
         List<PhysicalPlan> newChildren = new ArrayList<>(children.size());
         for (PhysicalPlan child : children) {
-            PhysicalPlan resolved = resolveRecursive(child, filtersForChildren, sourceFactories, maxRecordBytes, stats);
+            PhysicalPlan resolved = resolveRecursive(child, filtersForChildren, sourceFactories, maxRecordBytes, stats, isCancelled);
             if (resolved != child) {
                 changed = true;
             }
@@ -140,7 +156,8 @@ public final class SplitDiscoveryPhase {
         List<Expression> ancestorFilters,
         Map<String, ExternalSourceFactory> sourceFactories,
         int maxRecordBytes,
-        ScanStats stats
+        ScanStats stats,
+        BooleanSupplier isCancelled
     ) {
         ExternalSourceFactory factory = sourceFactories.get(exec.sourceType());
         SplitProvider splitProvider = factory != null ? factory.splitProvider() : SplitProvider.SINGLE;
@@ -165,7 +182,8 @@ public final class SplitDiscoveryPhase {
             ancestorFilters,
             querySchema,
             exec.unifiedSchema(),
-            maxRecordBytes
+            maxRecordBytes,
+            isCancelled
         );
 
         SplitDiscoveryResult result;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
@@ -25,13 +25,27 @@ import java.util.function.BooleanSupplier;
  * discovery / resolution per-file lambda, so the signal is carried as thread-local state established
  * around that read via {@link #runWithCancellation}. Nested scopes restore the enclosing supplier on
  * exit; when no scope is active {@link #isCancelled()} returns {@code false}.
+ *
+ * <p><b>Scope.</b> Scopes are installed only around coordinator-side split-discovery and source-resolution
+ * footer reads. Data-node runtime scan reads hit the same backoff with no scope active and are
+ * intentionally not covered here: the driver already checks task cancellation between pages, so only the
+ * in-read backoff is uncovered on that path. Extending cancellation to the runtime read path is left as a
+ * separate, follow-up change.
+ *
+ * <p><b>Thread affinity.</b> The signal only reaches a backoff sleep that runs on the same thread the scope
+ * was installed on. This holds for every synchronous {@code StorageObject} footer read driven from the
+ * discovery / resolution worker. It does NOT reach reads outside that synchronous Java retry layer: the
+ * bzip2 parallel block-boundary scan runs chunk reads on a separate executor for large files (the
+ * thread-local does not propagate to those threads), and the parquet-rs reader performs footer I/O in a
+ * native runtime that bypasses the Java retry layer entirely. Both fall back to their own, non-cancellable
+ * backoff.
  */
-public final class StorageRetryCancellation {
+final class StorageRetryCancellation {
 
     private static final ThreadLocal<BooleanSupplier> CURRENT = new ThreadLocal<>();
 
     /** Message used for the {@link TaskCancelledException} thrown when a backoff sleep is cut short by cancellation. */
-    public static final String CANCELLED_MESSAGE = "ES|QL storage retry cancelled";
+    static final String CANCELLED_MESSAGE = "ES|QL storage retry cancelled";
 
     /**
      * Granularity of the cancellation-aware sleep: the requested delay is consumed in chunks no larger
@@ -46,7 +60,7 @@ public final class StorageRetryCancellation {
      * Runs {@code body} with {@code isCancelled} installed as the ambient cancellation signal for the
      * current thread, restoring any previously installed supplier on exit (so nested scopes compose).
      */
-    public static <E extends Exception> void runWithCancellation(BooleanSupplier isCancelled, CheckedRunnable<E> body) throws E {
+    static <E extends Exception> void runWithCancellation(BooleanSupplier isCancelled, CheckedRunnable<E> body) throws E {
         BooleanSupplier previous = CURRENT.get();
         CURRENT.set(isCancelled);
         try {
@@ -60,7 +74,7 @@ public final class StorageRetryCancellation {
      * As {@link #runWithCancellation(BooleanSupplier, CheckedRunnable)} but returns the value produced
      * by {@code body}.
      */
-    public static <T, E extends Exception> T callWithCancellation(BooleanSupplier isCancelled, CheckedSupplier<T, E> body) throws E {
+    static <T, E extends Exception> T callWithCancellation(BooleanSupplier isCancelled, CheckedSupplier<T, E> body) throws E {
         BooleanSupplier previous = CURRENT.get();
         CURRENT.set(isCancelled);
         try {
@@ -79,7 +93,7 @@ public final class StorageRetryCancellation {
     }
 
     /** Returns {@code true} when an ambient cancellation signal is installed and reports cancelled. */
-    public static boolean isCancelled() {
+    static boolean isCancelled() {
         BooleanSupplier current = CURRENT.get();
         return current != null && current.getAsBoolean();
     }
@@ -95,7 +109,7 @@ public final class StorageRetryCancellation {
      * @throws TaskCancelledException if the ambient signal reports cancelled before or during the sleep
      * @throws InterruptedException   if the thread is interrupted while sleeping (caller decides how to map it)
      */
-    public static void sleepWithCancellationChecks(long millis) throws InterruptedException {
+    static void sleepWithCancellationChecks(long millis) throws InterruptedException {
         if (isCancelled()) {
             throw new TaskCancelledException(CANCELLED_MESSAGE);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.core.CheckedSupplier;
+import org.elasticsearch.tasks.TaskCancelledException;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Ambient, thread-local cancellation signal consulted by the synchronous storage-retry backoff sites
+ * ({@link RetryPolicy#execute} and {@code RetryableStorageObject.ResumingInputStream.reopenOrThrow})
+ * so that a single in-flight footer read parked in retry/throttle backoff aborts promptly when the
+ * originating query is cancelled.
+ *
+ * <p>Providers and their {@link RetryPolicy} are cached per scheme in {@code StorageProviderRegistry},
+ * so the per-query cancellation signal cannot be bound at provider construction (it would leak across
+ * queries). Instead, the synchronous footer reads run on the same worker thread that runs the split
+ * discovery / resolution per-file lambda, so the signal is carried as thread-local state established
+ * around that read via {@link #runWithCancellation}. Nested scopes restore the enclosing supplier on
+ * exit; when no scope is active {@link #isCancelled()} returns {@code false}.
+ */
+public final class StorageRetryCancellation {
+
+    private static final ThreadLocal<BooleanSupplier> CURRENT = new ThreadLocal<>();
+
+    /** Message used for the {@link TaskCancelledException} thrown when a backoff sleep is cut short by cancellation. */
+    public static final String CANCELLED_MESSAGE = "ES|QL storage retry cancelled";
+
+    /**
+     * Granularity of the cancellation-aware sleep: the requested delay is consumed in chunks no larger
+     * than this so a cancel that arrives <em>after</em> the sleep has started is observed within roughly
+     * this bound instead of after the full (up to 30s throttle) delay.
+     */
+    static final long POLL_INTERVAL_MS = 50;
+
+    private StorageRetryCancellation() {}
+
+    /**
+     * Runs {@code body} with {@code isCancelled} installed as the ambient cancellation signal for the
+     * current thread, restoring any previously installed supplier on exit (so nested scopes compose).
+     */
+    public static <E extends Exception> void runWithCancellation(BooleanSupplier isCancelled, CheckedRunnable<E> body) throws E {
+        BooleanSupplier previous = CURRENT.get();
+        CURRENT.set(isCancelled);
+        try {
+            body.run();
+        } finally {
+            restore(previous);
+        }
+    }
+
+    /**
+     * As {@link #runWithCancellation(BooleanSupplier, CheckedRunnable)} but returns the value produced
+     * by {@code body}.
+     */
+    public static <T, E extends Exception> T callWithCancellation(BooleanSupplier isCancelled, CheckedSupplier<T, E> body) throws E {
+        BooleanSupplier previous = CURRENT.get();
+        CURRENT.set(isCancelled);
+        try {
+            return body.get();
+        } finally {
+            restore(previous);
+        }
+    }
+
+    private static void restore(BooleanSupplier previous) {
+        if (previous == null) {
+            CURRENT.remove();
+        } else {
+            CURRENT.set(previous);
+        }
+    }
+
+    /** Returns {@code true} when an ambient cancellation signal is installed and reports cancelled. */
+    public static boolean isCancelled() {
+        BooleanSupplier current = CURRENT.get();
+        return current != null && current.getAsBoolean();
+    }
+
+    /**
+     * Sleeps for {@code millis} while remaining responsive to the ambient cancellation signal. Rather than
+     * one blocking {@link Thread#sleep}, the delay is consumed in {@link #POLL_INTERVAL_MS} chunks; the
+     * cancellation signal is polled before each chunk and once more after the final wake, so a cancel that
+     * arrives <em>after</em> the sleep has begun (flipped from another thread) aborts within roughly one poll
+     * interval instead of after the whole delay. A non-positive {@code millis} still performs a single
+     * cancellation check and returns.
+     *
+     * @throws TaskCancelledException if the ambient signal reports cancelled before or during the sleep
+     * @throws InterruptedException   if the thread is interrupted while sleeping (caller decides how to map it)
+     */
+    public static void sleepWithCancellationChecks(long millis) throws InterruptedException {
+        if (isCancelled()) {
+            throw new TaskCancelledException(CANCELLED_MESSAGE);
+        }
+        if (millis <= 0) {
+            return;
+        }
+        long deadlineNanos = System.nanoTime() + millis * 1_000_000L;
+        while (true) {
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                break;
+            }
+            long remainingMs = (remainingNanos + 999_999L) / 1_000_000L;
+            Thread.sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+            if (isCancelled()) {
+                throw new TaskCancelledException(CANCELLED_MESSAGE);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 /**
  * Context passed to {@link SplitProvider#discoverSplits} containing all information
@@ -27,6 +28,10 @@ import java.util.Map;
  * @param unifiedSchema the pre-prune Unified schema, or {@code null} when not available. Together
  *        with {@code querySchema} and each file's schema this lets split providers narrow per-file
  *        {@link org.elasticsearch.xpack.esql.datasources.ColumnMapping}s on the coordinator.
+ * @param isCancelled polled during split discovery so a long-running enumeration (e.g. thousands of
+ *        Parquet footer reads) aborts promptly when the originating query is cancelled. Defaults to
+ *        {@code () -> false} ("never cancelled") for callers and SPI impls that do not carry a
+ *        {@code CancellableTask}.
  */
 public record SplitDiscoveryContext(
     SourceMetadata metadata,
@@ -37,7 +42,8 @@ public record SplitDiscoveryContext(
     List<Expression> filterHints,
     ExternalSchema querySchema,
     @Nullable ExternalSchema unifiedSchema,
-    int maxRecordBytes
+    int maxRecordBytes,
+    BooleanSupplier isCancelled
 ) {
     public SplitDiscoveryContext(
         SourceMetadata metadata,
@@ -55,7 +61,8 @@ public record SplitDiscoveryContext(
             filterHints,
             ExternalSchema.EMPTY,
             null,
-            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> false
         );
     }
 
@@ -76,7 +83,8 @@ public record SplitDiscoveryContext(
             filterHints,
             querySchema,
             null,
-            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> false
         );
     }
 
@@ -98,7 +106,8 @@ public record SplitDiscoveryContext(
             filterHints,
             querySchema,
             null,
-            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> false
         );
     }
 
@@ -113,5 +122,6 @@ public record SplitDiscoveryContext(
         if (maxRecordBytes <= 0) {
             throw new IllegalArgumentException("maxRecordBytes must be positive, got: " + maxRecordBytes);
         }
+        isCancelled = isCancelled != null ? isCancelled : () -> false;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -110,6 +110,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -242,7 +243,7 @@ public class ComputeService {
         return formatReaderRegistry;
     }
 
-    PhysicalPlan discoverSplits(PhysicalPlan plan, Configuration configuration, EsqlExecutionInfo execInfo) {
+    PhysicalPlan discoverSplits(PhysicalPlan plan, Configuration configuration, EsqlExecutionInfo execInfo, BooleanSupplier isCancelled) {
         if (operatorFactoryRegistry == null) {
             return plan;
         }
@@ -250,10 +251,14 @@ public class ComputeService {
             SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
                 plan,
                 operatorFactoryRegistry.sourceFactories(),
-                maxRecordBytes(configuration)
+                maxRecordBytes(configuration),
+                isCancelled
             );
             recordExternalScanStats(execInfo, result);
             return coalesceSplits(result.plan());
+        } catch (TaskCancelledException e) {
+            // Cancellation is not a discovery failure — propagate it without the warn.
+            throw e;
         } catch (Exception e) {
             LOGGER.warn("split discovery failed for external source", e);
             throw e;
@@ -302,9 +307,10 @@ public class ComputeService {
     ExternalDistributionResult applyExternalDistributionStrategy(
         PhysicalPlan plan,
         Configuration configuration,
-        EsqlExecutionInfo execInfo
+        EsqlExecutionInfo execInfo,
+        BooleanSupplier isCancelled
     ) {
-        List<ExternalSplit> externalSplits = collectExternalSplits(plan, configuration, execInfo);
+        List<ExternalSplit> externalSplits = collectExternalSplits(plan, configuration, execInfo, isCancelled);
         if (externalSplits.isEmpty()) {
             return new ExternalDistributionResult(collapseExternalSourceExchanges(plan), null, List.of());
         }
@@ -337,7 +343,12 @@ public class ComputeService {
         }
     }
 
-    private List<ExternalSplit> collectExternalSplits(PhysicalPlan plan, Configuration configuration, EsqlExecutionInfo execInfo) {
+    private List<ExternalSplit> collectExternalSplits(
+        PhysicalPlan plan,
+        Configuration configuration,
+        EsqlExecutionInfo execInfo,
+        BooleanSupplier isCancelled
+    ) {
         List<ExternalSplit> splits = new ArrayList<>();
         // A physical plan is produced by a single mapper, so top-level ExternalSourceExec nodes and
         // fragment-wrapped ExternalRelation nodes never coexist: the distributed Mapper wraps every
@@ -348,7 +359,7 @@ public class ComputeService {
         plan.forEachDown(ExternalSourceExec.class, exec -> splits.addAll(exec.splits()));
         if (splits.isEmpty()) {
             if (canSkipSplitDiscovery(plan, formatReaderRegistry) == false) {
-                discoverSplitsFromFragments(plan, splits, maxRecordBytes(configuration), execInfo);
+                discoverSplitsFromFragments(plan, splits, maxRecordBytes(configuration), execInfo, isCancelled);
                 if (splits.size() > SplitCoalescer.COALESCING_THRESHOLD) {
                     List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
                     if (coalesced != splits) {
@@ -450,7 +461,8 @@ public class ComputeService {
         PhysicalPlan plan,
         List<ExternalSplit> splits,
         int maxRecordBytes,
-        EsqlExecutionInfo execInfo
+        EsqlExecutionInfo execInfo,
+        BooleanSupplier isCancelled
     ) {
         if (operatorFactoryRegistry == null) {
             return;
@@ -461,7 +473,8 @@ public class ComputeService {
                 SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
                     tempExec,
                     operatorFactoryRegistry.sourceFactories(),
-                    maxRecordBytes
+                    maxRecordBytes,
+                    isCancelled
                 );
                 if (result.plan() instanceof ExternalSourceExec withSplits) {
                     splits.addAll(withSplits.splits());
@@ -745,8 +758,18 @@ public class ComputeService {
         Map<String, EsqlExecutionInfo.Cluster.Status> initialClusterStatuses,
         PlanTimeProfile planTimeProfile
     ) {
-        final PhysicalPlan splitPlan = discoverSplits(physicalPlan, configuration, execInfo);
-        final ExternalDistributionResult distributionResult = applyExternalDistributionStrategy(splitPlan, configuration, execInfo);
+        final PhysicalPlan splitPlan;
+        final ExternalDistributionResult distributionResult;
+        try {
+            // Phase 2 split discovery runs synchronously here and can be long (thousands of footer
+            // reads); thread the query's cancellation signal so a cancel aborts it promptly. A cancel
+            // (or any discovery failure) is surfaced through the listener rather than thrown raw.
+            splitPlan = discoverSplits(physicalPlan, configuration, execInfo, rootTask::isCancelled);
+            distributionResult = applyExternalDistributionStrategy(splitPlan, configuration, execInfo, rootTask::isCancelled);
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
         final PhysicalPlan resolvedPlan = distributionResult.plan();
         Tuple<PhysicalPlan, PhysicalPlan> coordinatorAndDataNodePlan = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
             resolvedPlan,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -69,6 +70,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
@@ -1972,6 +1975,62 @@ public class FileSplitProviderTests extends ESTestCase {
         public InputStream decompressRange(StorageObject object, long blockStart, long nextBlockStart) {
             return new ByteArrayInputStream(new byte[0]);
         }
+    }
+
+    public void testCancellationAbortsDiscoveryMidLoop() {
+        // Five files processed sequentially (no executor). The cancellation signal flips true partway
+        // through, so discovery must throw and stop polling rather than processing every file.
+        StorageEntry e1 = new StorageEntry(StoragePath.of("s3://b/a.parquet"), 100, Instant.EPOCH);
+        StorageEntry e2 = new StorageEntry(StoragePath.of("s3://b/b.parquet"), 100, Instant.EPOCH);
+        StorageEntry e3 = new StorageEntry(StoragePath.of("s3://b/c.parquet"), 100, Instant.EPOCH);
+        StorageEntry e4 = new StorageEntry(StoragePath.of("s3://b/d.parquet"), 100, Instant.EPOCH);
+        StorageEntry e5 = new StorageEntry(StoragePath.of("s3://b/e.parquet"), 100, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(e1, e2, e3, e4, e5), "s3://b/*.parquet");
+
+        // The supplier is polled once before the loop and once per file at the top of processFileForSplits.
+        // It reports cancelled starting at the 4th poll, so only the first two files are processed.
+        AtomicInteger polls = new AtomicInteger();
+        BooleanSupplier cancel = () -> polls.incrementAndGet() > 3;
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(
+            null,
+            fileList,
+            Map.of(),
+            Map.of(),
+            PartitionMetadata.EMPTY,
+            List.of(),
+            ExternalSchema.EMPTY,
+            null,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            cancel
+        );
+
+        expectThrows(TaskCancelledException.class, () -> provider.discoverSplits(ctx));
+        // Polling stopped as soon as cancellation was observed (4 polls), well short of the 6 it would take
+        // to process all five files, proving discovery short-circuited.
+        assertEquals(4, polls.get());
+    }
+
+    public void testNotCancelledProcessesAllFiles() {
+        StorageEntry e1 = new StorageEntry(StoragePath.of("s3://b/a.parquet"), 100, Instant.EPOCH);
+        StorageEntry e2 = new StorageEntry(StoragePath.of("s3://b/b.parquet"), 100, Instant.EPOCH);
+        StorageEntry e3 = new StorageEntry(StoragePath.of("s3://b/c.parquet"), 100, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(e1, e2, e3), "s3://b/*.parquet");
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(
+            null,
+            fileList,
+            Map.of(),
+            Map.of(),
+            PartitionMetadata.EMPTY,
+            List.of(),
+            ExternalSchema.EMPTY,
+            null,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> false
+        );
+
+        assertEquals(3, provider.discoverSplits(ctx).splits().size());
     }
 
     // -- helpers --

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -16,8 +17,16 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 
 public class RetryPolicyTests extends ESTestCase {
 
@@ -340,5 +349,113 @@ public class RetryPolicyTests extends ESTestCase {
         RetryPolicy policy = RetryPolicy.DEFAULT.withThrottleConfig(20, 1000, 60_000);
         assertEquals(20, policy.throttleMaxRetries());
         assertEquals(RetryPolicy.DEFAULT_MAX_RETRIES, policy.maxRetries());
+    }
+
+    // --- Cancellation-aware backoff tests ---
+
+    public void testExecuteAbortsBackoffWhenCancelled() {
+        // A high throttle budget with long delays would otherwise keep this thread sleeping for a long time;
+        // under an active cancellation scope the first scheduled retry must abort instead of sleeping.
+        RetryPolicy policy = new RetryPolicy(0, 0, 0, 10, 30_000, 30_000, RetryPolicy.NO_BUDGET, null);
+        AtomicInteger calls = new AtomicInteger();
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        TaskCancelledException ex = expectThrows(
+            TaskCancelledException.class,
+            () -> StorageRetryCancellation.runWithCancellation(() -> true, () -> policy.execute(() -> {
+                calls.incrementAndGet();
+                throw new ExternalUnavailableException(true, "throttled");
+            }, "test", path))
+        );
+
+        assertNotNull(ex.getMessage());
+        // Only the initial attempt ran; cancellation aborted before the first backoff sleep.
+        assertEquals(1, calls.get());
+    }
+
+    public void testExecuteDoesNotAbortWhenNotCancelled() throws IOException {
+        // With the cancellation supplier reporting false, behavior is unchanged: retries proceed to success.
+        RetryPolicy policy = new RetryPolicy(3, 1, 10);
+        AtomicInteger calls = new AtomicInteger();
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        String result = StorageRetryCancellation.callWithCancellation(() -> false, () -> policy.execute(() -> {
+            if (calls.incrementAndGet() < 3) {
+                throw new SocketTimeoutException("timeout");
+            }
+            return "ok";
+        }, "test", path));
+
+        assertEquals("ok", result);
+        assertEquals(3, calls.get());
+    }
+
+    public void testExecuteAbortsSleepWhenCancelledDuringBackoff() {
+        // Long throttle delays so a non-cancellable sleep would block this thread for ~30s. The signal is
+        // NOT cancelled at the pre-sleep check nor at the sleep start, then flips true during the sleep.
+        RetryPolicy policy = new RetryPolicy(0, 0, 0, 10, 30_000, 30_000, RetryPolicy.NO_BUDGET, null);
+        AtomicInteger calls = new AtomicInteger();
+        AtomicInteger polls = new AtomicInteger();
+        // poll 1 = execute() pre-sleep check, poll 2 = sleep start, poll 3+ = in-sleep -> cancelled.
+        BooleanSupplier cancel = () -> polls.incrementAndGet() > 2;
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        long startNanos = System.nanoTime();
+        expectThrows(TaskCancelledException.class, () -> StorageRetryCancellation.callWithCancellation(cancel, () -> policy.execute(() -> {
+            calls.incrementAndGet();
+            throw new ExternalUnavailableException(true, "throttled");
+        }, "test", path)));
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+
+        assertEquals("only the initial attempt ran", 1, calls.get());
+        assertThat("a cancel during the backoff must abort, not wait out the full delay", elapsedMs, lessThan(5_000L));
+    }
+
+    public void testExecuteAbortsSleepWhenCancelledFromAnotherThread() throws Exception {
+        RetryPolicy policy = new RetryPolicy(0, 0, 0, 10, 30_000, 30_000, RetryPolicy.NO_BUDGET, null);
+        StoragePath path = StoragePath.of("s3://bucket/key");
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        CountDownLatch sleeping = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        Thread worker = new Thread(() -> {
+            try {
+                StorageRetryCancellation.runWithCancellation(cancelled::get, () -> policy.execute(() -> {
+                    // Signal that we have entered the operation (which fails and parks in backoff next).
+                    sleeping.countDown();
+                    throw new ExternalUnavailableException(true, "throttled");
+                }, "test", path));
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        }, "retry-policy-cancellation-test");
+
+        long startNanos = System.nanoTime();
+        worker.start();
+        assertTrue("worker did not enter the operation", sleeping.await(5, TimeUnit.SECONDS));
+        cancelled.set(true);
+        worker.join(TimeUnit.SECONDS.toMillis(15));
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+
+        assertFalse("worker should have aborted the backoff and finished", worker.isAlive());
+        assertThat(thrown.get(), instanceOf(TaskCancelledException.class));
+        assertThat("a cross-thread cancel must not wait out the full throttle delay", elapsedMs, lessThan(15_000L));
+    }
+
+    public void testExecuteIgnoresCancellationOutsideScope() throws IOException {
+        // No ambient scope is active, so a cancelled-looking environment cannot affect the retry loop.
+        RetryPolicy policy = new RetryPolicy(3, 1, 10);
+        AtomicInteger calls = new AtomicInteger();
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        String result = policy.execute(() -> {
+            if (calls.incrementAndGet() < 3) {
+                throw new SocketTimeoutException("timeout");
+            }
+            return "ok";
+        }, "test", path);
+
+        assertEquals("ok", result);
+        assertEquals(3, calls.get());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageObjectTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -30,7 +31,9 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -450,6 +453,60 @@ public class RetryableStorageObjectTests extends ESTestCase {
         }
         // Initial open + 2 retries (the budget), then it gives up.
         assertEquals("re-opened up to the retry budget then gave up", 3, delegate.openCount());
+    }
+
+    /**
+     * A stuck stream under a long throttle backoff would otherwise sleep this thread for the full budget;
+     * under an active cancellation scope the mid-read resume must abort promptly instead of sleeping, and
+     * must not re-open the range.
+     */
+    public void testMidReadResumeAbortsBackoffWhenCancelled() throws IOException {
+        // Long throttle delays so a non-aborting resume would sleep for a long time.
+        RetryPolicy policy = new RetryPolicy(0, 0, 0, 10, 30_000, 30_000, RetryPolicy.NO_BUDGET, null);
+        byte[] payload = new byte[500];
+        MidReadFailingStorageObject delegate = new MidReadFailingStorageObject(
+            StoragePath.of("s3://bucket/key"),
+            payload,
+            0,
+            new ExternalUnavailableException(true, "throttled"),
+            true
+        );
+
+        RetryableStorageObject obj = new RetryableStorageObject(delegate, policy);
+        try (InputStream in = obj.newStream(0, payload.length)) {
+            expectThrows(TaskCancelledException.class, () -> StorageRetryCancellation.runWithCancellation(() -> true, in::readAllBytes));
+        }
+        assertEquals("cancellation aborted the resume before re-opening the range", 1, delegate.openCount());
+    }
+
+    /**
+     * Like {@link #testMidReadResumeAbortsBackoffWhenCancelled} but the signal flips true only <em>after</em>
+     * the backoff sleep has started (not cancelled at the pre-sleep poll), so it exercises the in-sleep
+     * cancellation polling rather than the immediate pre-sleep check.
+     */
+    public void testMidReadResumeAbortsBackoffWhenCancelledDuringSleep() throws IOException {
+        RetryPolicy policy = new RetryPolicy(0, 0, 0, 10, 30_000, 30_000, RetryPolicy.NO_BUDGET, null);
+        byte[] payload = new byte[500];
+        MidReadFailingStorageObject delegate = new MidReadFailingStorageObject(
+            StoragePath.of("s3://bucket/key"),
+            payload,
+            0,
+            new ExternalUnavailableException(true, "throttled"),
+            true
+        );
+
+        // false at the sleep start, true on the next in-sleep poll.
+        AtomicInteger polls = new AtomicInteger();
+        BooleanSupplier cancel = () -> polls.incrementAndGet() > 1;
+
+        RetryableStorageObject obj = new RetryableStorageObject(delegate, policy);
+        long startNanos = System.nanoTime();
+        try (InputStream in = obj.newStream(0, payload.length)) {
+            expectThrows(TaskCancelledException.class, () -> StorageRetryCancellation.runWithCancellation(cancel, in::readAllBytes));
+        }
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        assertEquals("cancellation aborted the resume before re-opening the range", 1, delegate.openCount());
+        assertThat("a cancel during the backoff must abort, not wait out the full delay", elapsedMs, lessThan(5_000L));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -208,6 +208,40 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         assertEquals(2, recorder.lastContext.filterHints().size());
     }
 
+    public void testCancellationSignalThreadedIntoContext() {
+        FileList fileList = createFileList(2);
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+
+        RecordingSplitProvider recorder = new RecordingSplitProvider();
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(recorder));
+
+        SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> true
+        );
+
+        assertNotNull(recorder.lastContext);
+        assertTrue(
+            "cancellation signal must be threaded into the split discovery context",
+            recorder.lastContext.isCancelled().getAsBoolean()
+        );
+    }
+
+    public void testDefaultContextIsNotCancelled() {
+        FileList fileList = createFileList(2);
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+
+        RecordingSplitProvider recorder = new RecordingSplitProvider();
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(recorder));
+
+        SplitDiscoveryPhase.resolveExternalSplits(exec, factories);
+
+        assertNotNull(recorder.lastContext);
+        assertFalse(recorder.lastContext.isCancelled().getAsBoolean());
+    }
+
     public void testNoFiltersWhenNoFilterExecInPlan() {
         FileList fileList = createFileList(2);
         ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellationTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
+
+public class StorageRetryCancellationTests extends ESTestCase {
+
+    public void testUnsetScopeIsNotCancelled() {
+        assertFalse(StorageRetryCancellation.isCancelled());
+    }
+
+    public void testScopeReflectsSupplier() throws Exception {
+        StorageRetryCancellation.runWithCancellation(() -> true, () -> assertTrue(StorageRetryCancellation.isCancelled()));
+        StorageRetryCancellation.runWithCancellation(() -> false, () -> assertFalse(StorageRetryCancellation.isCancelled()));
+        // The scope is cleared on exit.
+        assertFalse(StorageRetryCancellation.isCancelled());
+    }
+
+    public void testNestedScopesRestoreOuterSupplier() throws Exception {
+        StorageRetryCancellation.runWithCancellation(() -> true, () -> {
+            assertTrue(StorageRetryCancellation.isCancelled());
+            StorageRetryCancellation.runWithCancellation(() -> false, () -> assertFalse(StorageRetryCancellation.isCancelled()));
+            // Inner scope exited: the outer (cancelled) supplier is restored.
+            assertTrue(StorageRetryCancellation.isCancelled());
+        });
+        assertFalse(StorageRetryCancellation.isCancelled());
+    }
+
+    public void testCallWithCancellationReturnsValueAndRestores() throws Exception {
+        String result = StorageRetryCancellation.callWithCancellation(() -> true, () -> {
+            assertTrue(StorageRetryCancellation.isCancelled());
+            return "ok";
+        });
+        assertEquals("ok", result);
+        assertFalse(StorageRetryCancellation.isCancelled());
+    }
+
+    public void testScopeIsRestoredAfterException() {
+        expectThrows(RuntimeException.class, () -> StorageRetryCancellation.runWithCancellation(() -> true, () -> {
+            throw new RuntimeException("boom");
+        }));
+        // Even when the body throws, the thread-local is cleared.
+        assertFalse(StorageRetryCancellation.isCancelled());
+    }
+
+    public void testSleepReturnsNormallyWhenNotCancelled() throws Exception {
+        // No ambient scope: the sleep just elapses and returns.
+        StorageRetryCancellation.sleepWithCancellationChecks(10);
+        // Within a not-cancelled scope it also returns.
+        StorageRetryCancellation.runWithCancellation(() -> false, () -> StorageRetryCancellation.sleepWithCancellationChecks(10));
+    }
+
+    public void testSleepAbortsWhenAlreadyCancelled() {
+        long startNanos = System.nanoTime();
+        expectThrows(
+            TaskCancelledException.class,
+            () -> StorageRetryCancellation.runWithCancellation(
+                () -> true,
+                () -> StorageRetryCancellation.sleepWithCancellationChecks(60_000)
+            )
+        );
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        assertThat("an already-cancelled sleep must not block", elapsedMs, lessThan(5_000L));
+    }
+
+    public void testSleepAbortsWhenCancelledDuringSleep() {
+        // The signal is NOT cancelled at the first (pre-sleep) poll, then flips true on the next in-sleep
+        // poll — exercising the gap where a cancel arrives after the sleep has already started.
+        AtomicInteger polls = new AtomicInteger();
+        BooleanSupplier supplier = () -> polls.incrementAndGet() > 1;
+        long startNanos = System.nanoTime();
+        expectThrows(
+            TaskCancelledException.class,
+            () -> StorageRetryCancellation.runWithCancellation(supplier, () -> StorageRetryCancellation.sleepWithCancellationChecks(60_000))
+        );
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        assertThat("a cancel during the sleep must abort within ~one poll interval", elapsedMs, lessThan(5_000L));
+    }
+
+    public void testSleepAbortsWhenCancelledFromAnotherThread() throws Exception {
+        // Directly models the reviewer's case: the sleep starts, THEN another thread flips the signal.
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        CountDownLatch sleeping = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        Thread worker = new Thread(() -> {
+            try {
+                StorageRetryCancellation.runWithCancellation(cancelled::get, () -> {
+                    sleeping.countDown();
+                    StorageRetryCancellation.sleepWithCancellationChecks(60_000);
+                });
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        }, "storage-retry-cancellation-test");
+
+        long startNanos = System.nanoTime();
+        worker.start();
+        assertTrue("worker did not start sleeping", sleeping.await(5, TimeUnit.SECONDS));
+        // Flip the signal only after the sleep has begun.
+        cancelled.set(true);
+        worker.join(TimeUnit.SECONDS.toMillis(15));
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+
+        assertFalse("worker should have aborted the sleep and finished", worker.isAlive());
+        assertThat(thrown.get(), instanceOf(TaskCancelledException.class));
+        assertThat("a cross-thread cancel must not wait out the full delay", elapsedMs, lessThan(15_000L));
+    }
+}


### PR DESCRIPTION
Long-running queries that enter Phase 2 split discovery could not be stopped: the discovery path ran synchronously with no cancellation check, so thousands of footer reads ran to completion regardless of task cancellation. A single in-flight footer read could also park in retry/throttle backoff for the full budget (up to 30s per retry).

This threads the query cancellation signal into split discovery (checked before per-file work) and makes the storage retry backoff sleep itself cancellable by polling during the delay, so a cancelled query aborts footer reads and parked backoff promptly. Providers and their retry policy are cached per scheme, so the per-query signal is carried as ambient thread-local state consulted at the sleep rather than bound at provider construction.