### PR TITLE
[9.4] Fix reader context close race in markAsUsed (#152289)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.search.RescoreDocIds;
 import org.elasticsearch.search.SearchService;
+import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 import org.elasticsearch.transport.TransportRequest;
 
@@ -129,7 +130,9 @@ public class ReaderContext implements Releasable {
      * <code>keepAliveInMillis</code>.
      */
     public Releasable markAsUsed(long keepAliveInMillis) {
-        refCounted.incRef();
+        if (refCounted.tryIncRef() == false) {
+            throw new SearchContextMissingException(id);
+        }
         tryUpdateKeepAlive(keepAliveInMillis);
         return Releasables.releaseOnce(() -> {
             this.lastAccessTime.accumulateAndGet(nowInMillis(), Math::max);

--- a/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
@@ -17,8 +17,8 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.search.RescoreDocIds;
-import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.SearchContextMissingException;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 import org.elasticsearch.transport.TransportRequest;
 

--- a/server/src/test/java/org/elasticsearch/search/internal/ReaderContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ReaderContextTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.internal;
+
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.search.SearchContextMissingException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ReaderContextTests extends IndexShardTestCase {
+
+    public void testMarkAsUsedRacesWithClose() throws Exception {
+        IndexShard shard = newShard(true);
+        try {
+            final int racers = between(4, 8);
+            final int rounds = scaledRandomIntBetween(20, 100);
+            for (int round = 0; round < rounds; round++) {
+                final var context = newReaderContext(shard, new ShardSearchContextId(randomAlphaOfLength(8), round));
+                final List<Throwable> unexpected = Collections.synchronizedList(new ArrayList<>());
+                startInParallel(racers + 1, taskId -> {
+                    if (taskId == 0) {
+                        context.close();
+                        return;
+                    }
+                    try (Releasable ignored = context.markAsUsed(0L)) {
+                        // won the race; ref acquired and immediately released
+                    } catch (SearchContextMissingException expected) {
+                        // lost the race against close(); this is the expected, recoverable outcome
+                    } catch (Throwable other) {
+                        unexpected.add(other);
+                    }
+                });
+                assertThat("only SearchContextMissingException is allowed under the race", unexpected, empty());
+                SearchContextMissingException e = expectThrows(SearchContextMissingException.class, () -> context.markAsUsed(0L));
+                assertThat(e.contextId(), equalTo(context.id()));
+            }
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    private static ReaderContext newReaderContext(IndexShard shard, ShardSearchContextId id) {
+        return new ReaderContext(id, null, shard, null, 0L, randomBoolean(), 0L);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/internal/ReaderContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ReaderContextTests.java
@@ -54,6 +54,6 @@ public class ReaderContextTests extends IndexShardTestCase {
     }
 
     private static ReaderContext newReaderContext(IndexShard shard, ShardSearchContextId id) {
-        return new ReaderContext(id, null, shard, null, 0L, randomBoolean(), 0L);
+        return new ReaderContext(id, null, shard, null, 0L, randomBoolean());
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix reader context close race in markAsUsed (#152289)](https://github.com/elastic/elasticsearch/pull/152289)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)