### PR TITLE
[9.4] ES|QL: treat empty list query parameters as null (#152098)

### DIFF
--- a/docs/changelog/152098.yaml
+++ b/docs/changelog/152098.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 152271
+pr: 152098
+summary: Treat empty list query parameters as null
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2625,6 +2625,14 @@ public class EsqlCapabilities {
          */
         APPROXIMATION_FIX_MV_FUNCTIONS,
 
+        /**
+         * An empty list passed as a query parameter (named or positional) is treated as null
+         * instead of producing an NPE. A defined-but-null param used in an identifier or pattern
+         * position produces a clean parsing error instead of silently yielding an empty column name.
+         * See <a href="https://github.com/elastic/elasticsearch/issues/147448">#147448</a>.
+         */
+        EMPTY_LIST_PARAM_AS_NULL,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RequestXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RequestXContent.java
@@ -201,6 +201,9 @@ final class RequestXContent {
                             classification = VALUE;
                             checkParamValueValidity(entry, classification, paramValue, loc, errors);
                         }
+                        if (classification == VALUE && paramValue instanceof List<?> list && list.isEmpty()) {
+                            paramValue = null;
+                        }
                         type = DataType.fromJava(paramValue);
                         currentParam = new QueryParam(
                             paramName,
@@ -230,7 +233,11 @@ final class RequestXContent {
                         } else if (mixedTypesFound) {
                             addMixedTypesError(errors, loc, null, paramValues);
                         }
-                        unNamedParams.add(new QueryParam(null, paramValues, arrayType, VALUE));
+                        if (paramValues.isEmpty()) {
+                            unNamedParams.add(new QueryParam(null, null, DataType.NULL, VALUE));
+                        } else {
+                            unNamedParams.add(new QueryParam(null, paramValues, arrayType, VALUE));
+                        }
                     } else {
                         ParamValueAndType valueAndDataType = parseSingleParamValue(p, errors);
                         unNamedParams.add(new QueryParam(null, valueAndDataType.value, valueAndDataType.type, VALUE));
@@ -422,19 +429,6 @@ final class RequestXContent {
                     new XContentParseException(
                         loc,
                         entry + " parameter is multivalued, only " + VALUE.name() + " parameters can be multivalued"
-                    )
-                );
-                return;
-            }
-            if (valueList.isEmpty()) {
-                errors.add(
-                    new XContentParseException(
-                        loc,
-                        "Empty lists are not allowed as named parameter values. Got parameter ["
-                            + entry.getKey()
-                            + "] with value ["
-                            + valueList
-                            + "]"
                     )
                 );
                 return;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -126,6 +126,19 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
      */
     public static final int MAX_EXPRESSION_DEPTH = 300;
 
+    /**
+     * Sentinel returned by {@link #visitInputNamedOrPositionalParam} when a named or positional
+     * parameter reference in the query has no matching entry in the request's parameter list.
+     * The "Unknown query parameter" parsing error is recorded at the return site; callers that
+     * receive this value should skip the segment rather than treating it as a real null literal.
+     * <p>
+     * This is intentionally distinct from {@link Literal#NULL} so that the two cannot be confused
+     * by reference equality: {@code Literal.NULL} is a general-purpose null literal that may
+     * appear legitimately in the expression tree, whereas {@code MISSING_PARAMETER} only ever
+     * comes from an unresolved parameter reference.
+     */
+    static final Literal MISSING_PARAMETER = new Literal(Source.EMPTY, null, DataType.NULL);
+
     protected final ParsingContext context;
 
     public record ParsingContext(
@@ -402,19 +415,8 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
                 unresolvedStar = true;
             }
             if (idCtx.parameter() != null || idCtx.doubleParameter() != null) {
-                ParseTree paramCtx = idCtx.parameter();
-                ParseTree doubleParamsCtx = idCtx.doubleParameter();
-                Expression exp = expression(paramCtx != null ? paramCtx : doubleParamsCtx);
-                if (exp instanceof Literal lit) {
-                    if (lit.value() != null) {
-                        throw new ParsingException(
-                            src,
-                            "Query parameter [{}] with value [{}] declared as a constant, cannot be used as an identifier or pattern",
-                            unqualifiedCtx.getText(),
-                            lit
-                        );
-                    }
-                } else if (exp instanceof UnresolvedNamePattern up) {
+                Expression exp = resolveParamInIdentifierPosition(idCtx, src, unqualifiedCtx.getText());
+                if (exp instanceof UnresolvedNamePattern up) {
                     if (up.name() != null && up.name().equals(WILDCARD)) {
                         unresolvedStar = true;
                     }
@@ -444,15 +446,8 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
             if (pattern.ID_PATTERN() != null) {
                 patternContext = pattern.ID_PATTERN().getText();
             } else if (pattern.parameter() != null || pattern.doubleParameter() != null) {
-                ParseTree paramCtx = pattern.parameter();
-                ParseTree doubleParamsCtx = pattern.doubleParameter();
-                Expression exp = expression(paramCtx != null ? paramCtx : doubleParamsCtx);
-                if (exp instanceof Literal lit) {
-                    // only Literal.NULL can happen with missing params, params for constants are not allowed
-                    if (lit.value() != null) {
-                        throw new ParsingException(src, "Constant [{}] is unsupported for [{}]", pattern, unqualifiedCtx.getText());
-                    }
-                } else if (exp instanceof UnresolvedAttribute ua) { // identifier provided in QueryParam is treated as unquoted string
+                Expression exp = resolveParamInIdentifierPosition(pattern, src, unqualifiedCtx.getText());
+                if (exp instanceof UnresolvedAttribute ua) { // identifier provided in QueryParam is treated as unquoted string
                     String unquotedIdentifier = ua.name();
                     String quotedIdentifier = ParserUtils.quoteIdString(unquotedIdentifier);
                     patternString.append(quotedIdentifier);
@@ -1065,6 +1060,43 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         return new Alias(src, newName.name(), oldName);
     }
 
+    /**
+     * Resolves a parameter from an identifier-pattern segment to an {@link Expression}, enforcing
+     * that it is not a bare constant or a defined-but-null value.
+     * <p>
+     * Three outcomes are possible without throwing:
+     * <ul>
+     *   <li>{@link #MISSING_PARAMETER} — the parameter is missing; a "Unknown query parameter"
+     *       parsing error has already been recorded by {@link #paramByNameOrPosition} and the
+     *       caller should skip the segment.</li>
+     *   <li>{@link UnresolvedAttribute} or {@link UnresolvedNamePattern} — the happy path;
+     *       the caller uses the resolved name or pattern.</li>
+     *   <li>A regular null-literal for defined-but-null query params.
+     *       Allowing this is a bug, but fixing it would break e.g. {@code RENAME foo AS ?bar}
+     *       when {@code ?bar} is null.</li>
+     * </ul>
+     *
+     * @param ctx          the single identifier-pattern segment that contains a {@code ?param} or {@code ??param}
+     * @param src          source location used for error reporting
+     * @param paramDisplay the display text of the enclosing qualified name, used in error messages
+     */
+    private Expression resolveParamInIdentifierPosition(EsqlBaseParser.IdentifierPatternContext ctx, Source src, String paramDisplay) {
+        ParseTree paramCtx = ctx.parameter();
+        ParseTree doubleParamsCtx = ctx.doubleParameter();
+        Expression exp = expression(paramCtx != null ? paramCtx : doubleParamsCtx);
+        if (exp instanceof Literal lit) {
+            if (lit.value() != null) {
+                throw new ParsingException(
+                    src,
+                    "Query parameter [{}] with value [{}] declared as a constant, cannot be used as an identifier or pattern",
+                    paramDisplay,
+                    lit
+                );
+            }
+        }
+        return exp;
+    }
+
     @Override
     public NamedExpression visitEnrichWithClause(EsqlBaseParser.EnrichWithClauseContext ctx) {
         Source src = source(ctx);
@@ -1189,7 +1221,7 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
     public Expression visitInputNamedOrPositionalParam(EsqlBaseParser.InputNamedOrPositionalParamContext ctx) {
         QueryParam param = paramByNameOrPosition(ctx.NAMED_OR_POSITIONAL_PARAM());
         if (param == null) {
-            return Literal.NULL;
+            return MISSING_PARAMETER;
         }
         return visitParam(source(ctx), param);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
@@ -437,12 +437,69 @@ public class EsqlQueryRequestTests extends ESTestCase {
         );
     }
 
-    public void testEmptyListNamedParamIsRejected() throws IOException {
-        // Empty lists as named parameters are rejected. See https://github.com/elastic/elasticsearch/issues/147448:
-        // they used to produce an NPE downstream because their inferred DataType was null.
+    /**
+     * An empty list passed as a named VALUE parameter is equivalent to null.
+     * See <a href="https://github.com/elastic/elasticsearch/issues/147448">#147448</a>.
+     */
+    public void testEmptyListNamedParamIsNull() throws IOException {
+        String query = randomAlphaOfLengthBetween(1, 100);
+        boolean columnar = randomBoolean();
+        ZoneId timeZone = randomZone();
+        Locale locale = randomLocale(random());
+        QueryBuilder filter = randomQueryBuilder();
+
+        String paramsString = """
+            ,"params":[
+             {"n1" : []},
+             {"n2" : null},
+             {"n3" : {"value" : []}},
+             {"n4" : "non-empty"},
+             {"n5" : []},
+             {"n6" : [1, 2, 3]}
+             ] }""";
+
+        List<QueryParam> expected = List.of(
+            new QueryParam("n1", null, NULL, ParserUtils.ParamClassification.VALUE),
+            new QueryParam("n2", null, NULL, ParserUtils.ParamClassification.VALUE),
+            new QueryParam("n3", null, NULL, ParserUtils.ParamClassification.VALUE),
+            paramAsConstant("n4", "non-empty"),
+            new QueryParam("n5", null, NULL, ParserUtils.ParamClassification.VALUE),
+            new QueryParam("n6", List.of(1, 2, 3), INTEGER, ParserUtils.ParamClassification.VALUE)
+        );
+        String json = String.format(Locale.ROOT, """
+            {
+                "query": "%s",
+                "columnar": %s,
+                "time_zone": "%s",
+                "locale": "%s",
+                "filter": %s
+                %s""", query, columnar, timeZone.getId(), locale.toLanguageTag(), filter, paramsString);
+
+        EsqlQueryRequest request = parseEsqlQueryRequestSync(json);
+
+        assertEquals(expected.size(), request.params().size());
+        for (int i = 0; i < expected.size(); i++) {
+            QueryParam expectedParam = expected.get(i);
+            QueryParam actualParam = request.params().get(i + 1);
+            assertEquals("param at index " + i, expectedParam, actualParam);
+        }
+
+        QueryParam bareEmpty = request.params().get("n1");
+        QueryParam explicitNull = request.params().get("n2");
+        QueryParam keyedEmpty = request.params().get("n3");
+        assertNull(bareEmpty.value());
+        assertNull(explicitNull.value());
+        assertNull(keyedEmpty.value());
+        assertEquals(NULL, bareEmpty.type());
+        assertEquals(NULL, explicitNull.type());
+        assertEquals(NULL, keyedEmpty.type());
+    }
+
+    public void testEmptyListNamedParamForIdentifierOrPatternIsRejected() throws IOException {
         String query = randomAlphaOfLengthBetween(1, 100);
         String paramsString = """
-            "params":[ {"_n1": []}, {"_n2": {"value": []}} ]""";
+            "params":[ {"n1" : {"identifier" : []}}, {"n2" : {"pattern" : []}},
+                        {"n3" : {"identifier" : null}}, {"n4" : {"pattern" : null}} ]""";
         String json = String.format(Locale.ROOT, """
             {
                 %s,
@@ -450,31 +507,43 @@ public class EsqlQueryRequestTests extends ESTestCase {
             }""", paramsString, query);
 
         Exception e = expectThrows(XContentParseException.class, () -> parseEsqlQueryRequestSync(json));
-        assertThat(
-            e.getCause().getMessage(),
-            containsString("Empty lists are not allowed as named parameter values. Got parameter [_n1] with value [[]]")
-        );
-        assertThat(
-            e.getCause().getMessage(),
-            containsString("Empty lists are not allowed as named parameter values. Got parameter [_n2] with value [[]]")
-        );
+        String message = e.getCause().getMessage();
+        // empty lists: rejected as multivalued (only VALUE params can be multivalued)
+        assertThat(message, containsString("n1={identifier=[]} parameter is multivalued, only VALUE parameters can be multivalued"));
+        assertThat(message, containsString("n2={pattern=[]} parameter is multivalued, only VALUE parameters can be multivalued"));
+        // explicit nulls: rejected because null is not a valid identifier/pattern string
+        assertThat(message, containsString("[null] is not a valid value for IDENTIFIER parameter"));
+        assertThat(message, containsString("[null] is not a valid value for PATTERN parameter"));
     }
 
-    public void testEmptyListUnnamedParamIsAccepted() throws IOException {
-        // Empty positional parameters are still accepted (they are treated as null downstream); the quickfix for
-        // https://github.com/elastic/elasticsearch/issues/147448 only targets named parameters.
+    /**
+     * Empty lists as unnamed/positional VALUE params are also coerced to null.
+     * See <a href="https://github.com/elastic/elasticsearch/issues/147448">#147448</a>.
+     */
+    public void testEmptyListPositionalParamIsNull() throws IOException {
         String query = randomAlphaOfLengthBetween(1, 100);
         String json = String.format(Locale.ROOT, """
             {
-                "params": [ [] ],
-                "query": "%s"
+                "query": "%s",
+                "params": [[], null, "non-empty", [1, 2, 3]]
             }""", query);
 
         EsqlQueryRequest request = parseEsqlQueryRequestSync(json);
-        assertThat(request.params().size(), is(1));
-        QueryParam param = request.params().get(1);
-        assertEquals(List.of(), param.value());
-        assertEquals(NULL, param.type());
+        assertEquals(4, request.params().size());
+
+        QueryParam emptyList = request.params().get(1);
+        QueryParam explicitNull = request.params().get(2);
+        assertNull(emptyList.value());
+        assertNull(explicitNull.value());
+        assertEquals(NULL, emptyList.type());
+        assertEquals(NULL, explicitNull.type());
+        assertEquals(ParserUtils.ParamClassification.VALUE, emptyList.classification());
+
+        assertEquals("non-empty", request.params().get(3).value());
+        assertEquals(KEYWORD, request.params().get(3).type());
+
+        assertEquals(List.of(1, 2, 3), request.params().get(4).value());
+        assertEquals(INTEGER, request.params().get(4).type());
     }
 
     public void testInvalidParamsString() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -2460,17 +2460,23 @@ public class StatementParserTests extends AbstractStatementParserTests {
                         : "Query parameter [?f1] with value [" + pattern + "] declared as a constant, cannot be used as an identifier"
                 );
             }
-            // nulls
-            if (invalidParamPosition.contains("rename")) {
-                // rename null as null is allowed, there is no ParsingException or VerificationException thrown
-                // named parameter doesn't change this behavior, it will need to be revisited
-                continue;
+            // null params: rejected via unresolvedAttributeNameInParam for eval/stats/mv_expand
+            // (those positions use visitIdentifierOrParameter, not visitQualifiedNamePattern).
+            // For RENAME, KEEP, DROP, and ENRICH, the null param goes through visitQualifiedNamePattern
+            // which silently skips the empty segment; see testNullParamInIdentifierPatternPosition.
+            if (invalidParamPosition.contains("rename") == false) {
+                expectError(
+                    "from test | " + invalidParamPosition,
+                    List.of(paramAsConstant("f1", null), paramAsConstant("f2", null)),
+                    "Query parameter [?f1] is null or undefined"
+                );
             }
-            expectError(
-                "from test | " + invalidParamPosition,
-                List.of(paramAsConstant("f1", null), paramAsConstant("f2", null)),
-                "Query parameter [?f1] is null or undefined"
-            );
+        }
+        // double-parameter markers (??): null param produces a "is null" error rather than an NPE or empty identifier
+        if (EsqlCapabilities.Cap.DOUBLE_PARAMETER_MARKERS_FOR_IDENTIFIERS.isEnabled()) {
+            for (String identifierPosition : List.of("drop ??f1", "keep ??f1", "rename ??f1 as color")) {
+                expectError("from test | " + identifierPosition, List.of(paramAsConstant("f1", null)), "Query parameter [??f1] is null");
+            }
         }
         // enrich with wildcard as pattern or constant is not supported
         String enrich = "ENRICH idx2 ON ?f1 WITH ?f2 = ?f3";
@@ -2486,6 +2492,32 @@ public class StatementParserTests extends AbstractStatementParserTests {
                 "Query parameter [?f1] with value [" + pattern + "] declared as a constant, cannot be used as an identifier or pattern"
             );
         }
+    }
+
+    /**
+     * Null params in RENAME/KEEP/DROP/ENRICH identifier-pattern positions are silently skipped
+     * by {@code visitQualifiedNamePattern}, so no {@code ParsingException} is thrown at parse time.
+     * This is a bug, but we can't fix it without breaking some queries.
+     * <p>
+     * Contrast with eval/stats/mv_expand which use {@code unresolvedAttributeNameInParam} and
+     * do produce a parse-time error for null params.
+     */
+    public void testNullParamInIdentifierPatternPosition() {
+        List<QueryParam> params = List.of(paramAsConstant("f1", null), paramAsConstant("f2", null));
+        for (String cmd : List.of(
+            "rename ?f1 as color",
+            "rename foo as ?f2",
+            "rename ?f1 as ?f2",
+            "keep ?f1",
+            "drop ?f1",
+            "enrich idx2 ON ?f1"
+        )) {
+            assertNotNull(query("from test | " + cmd, new QueryParams(params)));
+        }
+        // ENRICH WITH: null param as alias or field name
+        assertNotNull(query("from idx1 | enrich idx2 ON f1 WITH ?f2", new QueryParams(List.of(paramAsConstant("f2", null)))));
+        assertNotNull(query("from idx1 | enrich idx2 ON f1 WITH ?f2 = src_field", new QueryParams(List.of(paramAsConstant("f2", null)))));
+        assertNotNull(query("from idx1 | enrich idx2 ON f1 WITH dst = ?f3", new QueryParams(List.of(paramAsConstant("f3", null)))));
     }
 
     public void testMissingParam() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
@@ -881,3 +881,263 @@ version is not allowed:
   - length: { columns: 1 }
   - length: { values: 1 }
   - match: {values.0.0: 2}
+
+
+---
+"Empty list named param is treated as null":
+  # https://github.com/elastic/elasticsearch/issues/152271
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings_regex ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ empty_list_param_as_null ]
+      reason: "empty list named parameter is treated as null"
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row a = ?bare, b = ?keyed, c = ?explicit'
+          params: [{"bare": []}, {"keyed": {"value": []}}, {"explicit": null}]
+
+  - length: {columns: 3}
+  - match: {columns.0.name: "a"}
+  - match: {columns.0.type: "null"}
+  - match: {columns.1.name: "b"}
+  - match: {columns.1.type: "null"}
+  - match: {columns.2.name: "c"}
+  - match: {columns.2.type: "null"}
+  - length: {values: 1}
+  - match: {values.0: [null, null, null]}
+
+  # Reproducer from the issue: MV_CONTAINS with an empty-list named param must not NPE.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | where mv_contains(?x, [1, 2])'
+          params: [{"x": []}]
+
+  - length: {values: 0}
+
+  # IS NULL / IS NOT NULL: an empty-list named param must be considered null.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | eval is_null = ?x is null, is_not_null = ?x is not null'
+          params: [{"x": []}]
+
+  - length: {columns: 3}
+  - match: {columns.1.name: "is_null"}
+  - match: {columns.1.type: "boolean"}
+  - match: {columns.2.name: "is_not_null"}
+  - match: {columns.2.type: "boolean"}
+  - length: {values: 1}
+  - match: {values.0.1: true}
+  - match: {values.0.2: false}
+
+
+---
+"Empty list named param rejected for identifier or pattern":
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings_regex ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ empty_list_param_as_null ]
+      reason: "empty list named parameter is treated as null"
+
+  - do:
+      catch: /parameter is multivalued, only VALUE parameters can be multivalued/
+      esql.query:
+        body:
+          query: 'from test | keep ?f | limit 1'
+          params: [{"f" : {"identifier" : []}}]
+
+  - do:
+      catch: /parameter is multivalued, only VALUE parameters can be multivalued/
+      esql.query:
+        body:
+          query: 'from test | keep ?f | limit 1'
+          params: [{"f" : {"pattern" : []}}]
+
+
+---
+"Empty list positional param is treated as null":
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings_regex ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ empty_list_param_as_null ]
+      reason: "empty list positional parameter is treated as null"
+
+  # Anonymous params (`?`): empty list and explicit null are both treated as null.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row a = ?, b = ?, c = ?'
+          params: [[], null, []]
+
+  - length: {columns: 3}
+  - match: {columns.0.type: "null"}
+  - match: {columns.1.type: "null"}
+  - match: {columns.2.type: "null"}
+  - length: {values: 1}
+  - match: {values.0: [null, null, null]}
+
+  # Positional params (`?N`): same behavior as anonymous.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row a = ?1, b = ?2, c = ?3'
+          params: [[], null, []]
+
+  - length: {columns: 3}
+  - match: {columns.0.type: "null"}
+  - match: {columns.1.type: "null"}
+  - match: {columns.2.type: "null"}
+  - length: {values: 1}
+  - match: {values.0: [null, null, null]}
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | eval x = COALESCE(?1, v)'
+          params: [[]]
+
+  - length: {values: 1}
+  - match: {values.0.1: 1}
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | eval x = CASE(?1, 1, 2)'
+          params: [[]]
+
+  - length: {values: 1}
+  - match: {values.0.1: 2}
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | eval is_null = ?1 is null, is_not_null = ?1 is not null'
+          params: [[]]
+
+  - match: {values.0.1: true}
+  - match: {values.0.2: false}
+
+  # Reproducer from the issue: COALESCE(?, v) with anonymous positional empty-list param.
+  # Before the fix this threw index_out_of_bounds_exception.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | eval x = COALESCE(?, v)'
+          params: [[]]
+
+  - length: {values: 1}
+  - match: {values.0.1: 1}
+
+  # Reproducer from the issue: WHERE ? AND true with anonymous positional empty-list param.
+  # Before the fix this threw ClassCastException.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'row v = 1 | where ? and true'
+          params: [[]]
+
+  - length: {values: 0}
+
+  # Identifier-pattern positions with null positional params.
+  # This is actually a bug, but can't be fixed without breaking queries like the ones below.
+  #
+  # DROP: the empty column name is not found → verification error.
+  - do:
+      catch: /Unknown column \[\]/
+      esql.query:
+        body:
+          query: 'from test | drop ?1'
+          params: [[]]
+
+  # RENAME: the target column is renamed to "" — the query succeeds and the output column carries an empty name.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'from test | rename color as ?1 | limit 0'
+          params: [[]]
+
+  - length: {columns: 6}
+  - match: {columns.0.name: ""}
+  - match: {columns.0.type: "keyword"}
+
+  # RENAME then DROP the same null param: drops the renamed (empty-named) column — equivalent to DROP color.
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'from test | rename color as ?1 | drop ?1 | limit 0'
+          params: [[]]
+
+  - length: {columns: 5}
+  - match: {columns.0.name: "count"}
+
+---
+"Empty list param executes correctly with real index data":
+  # Verifies that empty-list params coerced to null are handled correctly at execution time,
+  # not just at parse time. See https://github.com/elastic/elasticsearch/issues/147448
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ empty_list_param_as_null ]
+      reason: "empty list parameter is treated as null"
+
+  # COALESCE with a null named param falls back to the real field value.
+  # Uses KEEP to get a deterministic single-column result.
+  - do:
+      esql.query:
+        body:
+          query: 'from test | eval x = COALESCE(?val, color) | keep x | sort x | limit 1'
+          params: [{"val": []}]
+
+  - length: {columns: 1}
+  - match: {columns.0.name: "x"}
+  - match: {values.0.0: "blue"}
+
+  # COALESCE with a null positional param falls back to the real field value.
+  - do:
+      esql.query:
+        body:
+          query: 'from test | eval x = COALESCE(?1, color) | keep x | sort x | limit 1'
+          params: [[]]
+
+  - length: {columns: 1}
+  - match: {values.0.0: "blue"}
+


### PR DESCRIPTION
This will backport the following commits from `main` to `9.4`:
 - [ES|QL: treat empty list query parameters as null (#152098)](https://github.com/elastic/elasticsearch/pull/152098)