### PR TITLE
Do not demote cache regions of closed shard if node is shutting down

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -968,7 +968,6 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
      * The predicate is evaluated when the task runs; demotion is skipped when it returns {@code false}.
      */
     public void demoteAllAsync(ShardId shard, Predicate<ShardId> shouldDemote) {
-        // TODO do not submit task if shutting down
         asyncEvictionsRunner.enqueueTask(new ActionListener<>() {
             @Override
             public void onResponse(Releasable releasable) {

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -955,7 +955,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
      * Demotes all active cache regions for the given shard to frequency 0.
      * Demoted entries are inserted at the front of the frequency-0 list so they are evicted before
      * other frequency-0 entries. {@code lastAccessedEpoch} is set to {@code -1} so demoted entries
-     * are promoted again if they are accessed due to shard relocating back while demoting.
+     * are promoted again if they are accessed due to shard relocating back after demotion.
      *
      * @return the number of regions demoted
      */

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -955,7 +955,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
      * Demotes all active cache regions for the given shard to frequency 0.
      * Demoted entries are inserted at the front of the frequency-0 list so they are evicted before
      * other frequency-0 entries. {@code lastAccessedEpoch} is set to {@code -1} so demoted entries
-     * are not frequency-promoted before the next epoch.
+     * are promoted again if they are accessed due to shard relocating back while demoting.
      *
      * @return the number of regions demoted
      */

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -241,15 +241,13 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
 
         internalCluster().awaitNodeVacated(indexName, shutdownNode);
 
-        assertBusy(() -> {
-            long regionCount = cacheService.countCachedRegions(shardPredicate(shardId));
-            assertThat(regionCount, greaterThan(0L));
-            assertThat(
-                "cache regions should not be demoted when node is shutting down",
-                SharedBlobCacheServiceTestUtils.countCachedRegionsByFreq(cacheService, shardPredicate(shardId)),
-                equalTo(freqsBeforeShutdown)
-            );
-        });
+        long regionCount = cacheService.countCachedRegions(shardPredicate(shardId));
+        assertThat(regionCount, greaterThan(0L));
+        assertThat(
+            "cache regions should not be demoted when node is shutting down",
+            SharedBlobCacheServiceTestUtils.countCachedRegionsByFreq(cacheService, shardPredicate(shardId)),
+            equalTo(freqsBeforeShutdown)
+        );
     }
 
     private static Settings cacheBoostPreferenceTestSettings() {

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.stateless.lucene.SearchDirectory;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -89,7 +90,7 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         final var plugins = new ArrayList<>(super.nodePlugins());
         plugins.add(InternalSettingsPlugin.class);
         plugins.add(ShutdownPlugin.class);
-        return plugins;
+        return Collections.unmodifiableList(plugins);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTestUtils;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
@@ -25,6 +26,8 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.xpack.shutdown.PutShutdownNodeAction;
+import org.elasticsearch.xpack.shutdown.ShutdownPlugin;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
 import org.elasticsearch.xpack.stateless.TestUtils;
 import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
@@ -33,8 +36,10 @@ import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 import org.elasticsearch.xpack.stateless.lucene.SearchDirectory;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import static java.util.stream.IntStream.range;
@@ -42,7 +47,6 @@ import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_C
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING;
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX;
-import static org.elasticsearch.common.util.CollectionUtils.appendToCopy;
 import static org.elasticsearch.core.TimeValue.MINUS_ONE;
 import static org.elasticsearch.search.sort.SortOrder.ASC;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -82,7 +86,10 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return appendToCopy(super.nodePlugins(), InternalSettingsPlugin.class);
+        final var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(InternalSettingsPlugin.class);
+        plugins.add(ShutdownPlugin.class);
+        return plugins;
     }
 
     @Override
@@ -187,6 +194,61 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
         internalCluster().awaitNodesInclude(indexName, nodes -> nodes.contains(searchNodeA) == false && nodes.contains(searchNodeB));
 
         assertDemotedToFrequencyZero(cacheServiceA, shardId);
+    }
+
+    public void testCacheNotDemotedWhenNodeIsShuttingDown() throws Exception {
+        final Settings cacheSettings = cacheBoostPreferenceTestSettings();
+        startMasterAndIndexNode(cacheSettings);
+        final String searchNodeA = startSearchNode(cacheSettings);
+        final String searchNodeB = startSearchNode(cacheSettings);
+        final String indexName = randomIdentifier();
+        createIndex(indexName, indexSettings(1, 1).build());
+        ensureGreen(indexName);
+
+        indexAndSearch(indexName, randomIntBetween(10, 100));
+
+        final ShardId shardId = new ShardId(resolveIndex(indexName), 0);
+        final Set<String> nodesWithShard = internalCluster().nodesInclude(indexName);
+        final String shutdownNode = nodesWithShard.stream()
+            .filter(n -> n.equals(searchNodeA) || n.equals(searchNodeB))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no search node has a shard for [" + indexName + "]"));
+
+        final StatelessSharedBlobCacheService cacheService = getCacheService(shutdownNode);
+        assertNonZeroFrequencies(cacheService, shardId);
+
+        final Map<Integer, Integer> freqsBeforeShutdown = SharedBlobCacheServiceTestUtils.countCachedRegionsByFreq(
+            cacheService,
+            shardPredicate(shardId)
+        );
+
+        assertAcked(
+            client().execute(
+                PutShutdownNodeAction.INSTANCE,
+                new PutShutdownNodeAction.Request(
+                    TEST_REQUEST_TIMEOUT,
+                    TEST_REQUEST_TIMEOUT,
+                    getNodeId(shutdownNode),
+                    SingleNodeShutdownMetadata.Type.SIGTERM,
+                    "test shutdown to verify cache demotion is skipped",
+                    null,
+                    null,
+                    TimeValue.timeValueMinutes(5)
+                )
+            )
+        );
+
+        internalCluster().awaitNodeVacated(indexName, shutdownNode);
+
+        assertBusy(() -> {
+            long regionCount = cacheService.countCachedRegions(shardPredicate(shardId));
+            assertThat(regionCount, greaterThan(0L));
+            assertThat(
+                "cache regions should not be demoted when node is shutting down",
+                SharedBlobCacheServiceTestUtils.countCachedRegionsByFreq(cacheService, shardPredicate(shardId)),
+                equalTo(freqsBeforeShutdown)
+            );
+        });
     }
 
     private static Settings cacheBoostPreferenceTestSettings() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1516,6 +1516,7 @@ public class StatelessPlugin extends Plugin
             });
         }
         if (hasSearchRole) {
+            final var commitService = this.commitService.get();
             final var collector = searchShardSizeCollector.get();
             indexModule.addIndexEventListener(new IndexEventListener() {
 
@@ -1529,9 +1530,11 @@ public class StatelessPlugin extends Plugin
                     getClosedShardService().onStoreClose(shardId);
                     final var cacheService = sharedBlobCacheService.get();
                     // TODO consider removing the flag guard once performance is verified
-                    if (cacheService.isCacheBoostPreferenceEnabled()) {
-                        final Predicate<ShardId> hasShard = indicesService.get().hasShardPredicate();
-                        cacheService.demoteAllAsync(shardId, id -> hasShard.test(id) == false);
+                    if (cacheService.isCacheBoostPreferenceEnabled() && commitService.isNodeShuttingDown() == false) {
+                        final var shouldDemote = indicesService.get()
+                            .hasShardPredicate()
+                            .and(shardId1 -> commitService.isNodeShuttingDown() == false);
+                        cacheService.demoteAllAsync(shardId, id -> shouldDemote.test(id) == false);
                     }
                 }
             });

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -1531,10 +1531,10 @@ public class StatelessPlugin extends Plugin
                     final var cacheService = sharedBlobCacheService.get();
                     // TODO consider removing the flag guard once performance is verified
                     if (cacheService.isCacheBoostPreferenceEnabled() && commitService.isNodeShuttingDown() == false) {
-                        final var shouldDemote = indicesService.get()
-                            .hasShardPredicate()
-                            .and(shardId1 -> commitService.isNodeShuttingDown() == false);
-                        cacheService.demoteAllAsync(shardId, id -> shouldDemote.test(id) == false);
+                        final var hasShard = indicesService.get().hasShardPredicate();
+                        final Predicate<ShardId> shouldDemote = id -> hasShard.test(id) == false
+                            && commitService.isNodeShuttingDown() == false;
+                        cacheService.demoteAllAsync(shardId, shouldDemote);
                     }
                 }
             });

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -3328,7 +3328,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         try {
-            if(event.state().metadata().nodeShutdowns().contains(event.state().nodes().getLocalNodeId())) {
+            if (event.state().metadata().nodeShutdowns().contains(event.state().nodes().getLocalNodeId())) {
                 isNodeShuttingDown.compareAndSet(false, true);
             }
             if (event.nodesDelta().removed()) {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -251,7 +251,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
      * as the header and replicated content, in which case there is no need to replicate content for that file.
      */
     private final int estimatedMaxHeaderSizeInBytes;
-    private final AtomicBoolean isNodeShuttingDown = new AtomicBoolean(false);
+    private volatile boolean isNodeShuttingDown;
 
     public StatelessCommitService(
         Settings settings,
@@ -1039,7 +1039,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
     }
 
     public boolean isNodeShuttingDown() {
-        return isNodeShuttingDown.get();
+        return isNodeShuttingDown;
     }
 
     public void unregister(ShardId shardId) {
@@ -3329,7 +3329,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
     public void clusterChanged(ClusterChangedEvent event) {
         try {
             if (event.state().metadata().nodeShutdowns().contains(event.state().nodes().getLocalNodeId())) {
-                isNodeShuttingDown.compareAndSet(false, true);
+                isNodeShuttingDown = true;
             }
             if (event.nodesDelta().removed()) {
                 var removedNodeIds = event.nodesDelta().removedNodes().stream().map(node -> node.getId()).collect(Collectors.toSet());

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -251,6 +251,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
      * as the header and replicated content, in which case there is no need to replicate content for that file.
      */
     private final int estimatedMaxHeaderSizeInBytes;
+    private final AtomicBoolean isNodeShuttingDown = new AtomicBoolean(false);
 
     public StatelessCommitService(
         Settings settings,
@@ -1035,6 +1036,10 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
 
     public boolean isShardDeletingIndex(ShardId shardId) {
         return getSafe(shardsCommitsStates, shardId).isDeletingIndex();
+    }
+
+    public boolean isNodeShuttingDown() {
+        return isNodeShuttingDown.get();
     }
 
     public void unregister(ShardId shardId) {
@@ -3323,6 +3328,9 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         try {
+            if(event.state().metadata().nodeShutdowns().contains(event.state().nodes().getLocalNodeId())) {
+                isNodeShuttingDown.compareAndSet(false, true);
+            }
             if (event.nodesDelta().removed()) {
                 var removedNodeIds = event.nodesDelta().removedNodes().stream().map(node -> node.getId()).collect(Collectors.toSet());
                 for (var shardCommitState : shardsCommitsStates.values()) {


### PR DESCRIPTION
This change prevent cache regions eviction tasks to be submitted if we know the node is shutting down. Goal here is to avoid unnecessary work.

Follow up #151986

Note: I added a isNodeShuttingDown flag in the commit service as it seems to be the most centralized place for such a thing (actually I expected such flag to already exist there). The onStoreClosed method can be called by the cluster state applier thread so no possible usage of ClusterService#state() there.