### PR TITLE
[9.4] ES|QL: fix UnsupportedOperationException for partially unmapped keyword fields with multi-fields (#150676)

### DIFF
--- a/docs/changelog/150676.yaml
+++ b/docs/changelog/150676.yaml
@@ -1,0 +1,7 @@
+area: ES|QL
+issues:
+ - 150667
+pr: 150676
+summary: Fix `UnsupportedOperationException` for partially unmapped keyword fields
+  with multi-fields
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -286,6 +286,14 @@ public class EsqlCapabilities {
         OPTIONAL_FIELDS_FIX_LOAD_PARTIALLY_MAPPED,
 
         /**
+         * Bugfix: {@code IndexResolver.mergedMappings} crashed with {@code UnsupportedOperationException} when a keyword
+         * field with multi-fields (e.g. {@code my_field.analyzed}) was partially unmapped across the queried indices and
+         * {@code SET unmapped_fields="load"} was active. {@code PotentiallyUnmappedKeywordEsField} was constructed with
+         * an immutable empty properties map, preventing child fields from being inserted.
+         */
+        OPTIONAL_FIELDS_FIX_LOAD_KEYWORD_WITH_MULTIFIELDS,
+
+        /**
          * Support specifically for *just* the _index METADATA field. Used by CsvTests, since that is the only metadata field currently
          * supported.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedKeywordEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedKeywordEsField.java
@@ -10,7 +10,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.HashMap;
 
 /**
  * This class is used as a marker for fields that may be unmapped, where an unmapped field is a field which exists in the _source but is not
@@ -19,7 +19,9 @@ import java.util.Collections;
  */
 public class PotentiallyUnmappedKeywordEsField extends KeywordEsField {
     public PotentiallyUnmappedKeywordEsField(String name) {
-        super(name, Collections.emptyMap(), true, Short.MAX_VALUE, false, false, TimeSeriesFieldType.UNKNOWN);
+        // Use a mutable map: IndexResolver may add child fields into the properties when the keyword field
+        // has multi-fields (e.g. "my_field.analyzed") that are also partially unmapped.
+        super(name, new HashMap<>(), true, Short.MAX_VALUE, false, false, TimeSeriesFieldType.UNKNOWN);
     }
 
     public PotentiallyUnmappedKeywordEsField(StreamInput in) throws IOException {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/292_unmapped_load_keyword_multifield.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/292_unmapped_load_keyword_multifield.yml
@@ -1,0 +1,73 @@
+---
+setup:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ optional_fields_fix_load_keyword_with_multifields ]
+      reason: 'Bugfix: IndexResolver crashed with UnsupportedOperationException when a partially unmapped keyword field had multi-fields'
+  #
+  # The table below represents the field mappings for the two indices created in this test.
+  # my_field is a keyword with a keyword multi-field in index-a only, making both partially
+  # unmapped when both indices are queried together.
+  # Using a keyword multi-field (rather than text) avoids an unrelated pre-existing bug where
+  # a type-conflicted multi-field cannot be transported in multi-node clusters (issue #152322).
+  #
+  # | Field         | index-a | index-b |
+  # |---------------|---------|---------|
+  # | my_field      | keyword | -       |
+  # | my_field.raw  | keyword | -       |
+  # | other_field   | -       | keyword |
+  #
+  - do:
+      indices.create:
+        index: index-a
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              my_field:
+                type: keyword
+                fields:
+                  raw:
+                    type: keyword
+  - do:
+      indices.create:
+        index: index-b
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              other_field:
+                type: keyword
+  - do:
+      index:
+        index: index-a
+        refresh: true
+        body:
+          my_field: hello
+  - do:
+      index:
+        index: index-b
+        refresh: true
+        body:
+          other_field: world
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: index-a,index-b
+
+---
+'keyword with multi-field partially unmapped does not crash':
+  - do:
+      esql.query:
+        body:
+          query: 'SET unmapped_fields="load"; FROM index-a,index-b | SORT my_field | LIMIT 2'
+  - match: { columns.0.name: my_field }
+  - match: { columns.0.type: keyword }
+  - match: { columns.1.name: my_field.raw }
+  - match: { columns.1.type: keyword }


### PR DESCRIPTION
This will backport the following commits from `main` to `9.4`:
 - [ES|QL: fix UnsupportedOperationException for partially unmapped keyword fields with multi-fields (#150676)](https://github.com/elastic/elasticsearch/pull/150676)