### PR TITLE
Fix empty DocIdSetIterator behaviour for exponential_histogram field type

### DIFF
--- a/docs/changelog/152405.yaml
+++ b/docs/changelog/152405.yaml
@@ -1,0 +1,7 @@
+area: Mapping
+issues:
+ - 152318
+pr: 152405
+summary: Fix empty `DocIdSetIterator` behaviour for `exponential_histogram` field
+  type
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -725,9 +725,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:folding.dateNanos_GreaterThan_MultiValueConstant}
   issue: https://github.com/elastic/elasticsearch/issues/152314
-- class: org.elasticsearch.xpack.analytics.mapper.ExponentialHistogramFieldMapperTests
-  method: testExponentialHistogramValuesReader
-  issue: https://github.com/elastic/elasticsearch/issues/152318
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StUnionTests
   method: testFold {TestCase=geo_shape and geo_shape}
   issue: https://github.com/elastic/elasticsearch/issues/152323

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
@@ -822,13 +822,9 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
         private final NumericDocValues valueMinima;
         private final NumericDocValues valueMaxima;
 
+        private int currentDocId = -1;
         private final CompressedExponentialHistogram tempHistogram = new CompressedExponentialHistogram();
-
-        /**
-         * If advanceExact(docId) returns false, we remember the docId for which it failed to prevent
-         * calling any of the accessor methods, such as {@link #histogramValue()}
-         */
-        private int advanceExactFailedDoc = -1;
+        private final DocIdSetIterator docIdSetIterator;
 
         DocValuesReader(LeafReader leafReader, String fullPath) throws IOException {
             histoDocValues = leafReader.getBinaryDocValues(fullPath);
@@ -837,6 +833,38 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             valueSums = leafReader.getNumericDocValues(valuesSumSubFieldName(fullPath));
             valueMinima = leafReader.getNumericDocValues(valuesMinSubFieldName(fullPath));
             valueMaxima = leafReader.getNumericDocValues(valuesMaxSubFieldName(fullPath));
+            docIdSetIterator = new DocIdSetIterator() {
+
+                @Override
+                public int docID() {
+                    return currentDocId;
+                }
+
+                @Override
+                public int nextDoc() throws IOException {
+                    if (valueCounts != null) {
+                        currentDocId = valueCounts.nextDoc();
+                    } else {
+                        currentDocId = DocIdSetIterator.NO_MORE_DOCS;
+                    }
+                    return currentDocId;
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    if (valueCounts != null) {
+                        currentDocId = valueCounts.advance(target);
+                    } else {
+                        currentDocId = DocIdSetIterator.NO_MORE_DOCS;
+                    }
+                    return currentDocId;
+                }
+
+                @Override
+                public long cost() {
+                    return valueCounts != null ? valueCounts.cost() : 0;
+                }
+            };
         }
 
         boolean hasAnyValues() {
@@ -845,30 +873,18 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public boolean advanceExact(int docId) throws IOException {
-            if (valueCounts == null) {
-                return false;
-            }
-            boolean present = valueCounts.advanceExact(docId);
-            advanceExactFailedDoc = present ? -1 : docId;
-            return present;
-        }
-
-        private int currentDocId() {
-            if (valueCounts == null) {
-                throw new IllegalStateException("No histogram present for current document id");
-            }
-            int docId = valueCounts.docID();
-            if (docId < 0 || docId == DocIdSetIterator.NO_MORE_DOCS || docId == advanceExactFailedDoc) {
-                throw new IllegalStateException("No histogram present for current document id");
-            }
-            return docId;
+            boolean isPresent = valueCounts != null && valueCounts.advanceExact(docId);
+            currentDocId = isPresent ? docId : -1;
+            return isPresent;
         }
 
         @Override
         public ExponentialHistogram histogramValue() throws IOException {
-            int docId = currentDocId();
-            boolean histoPresent = histoDocValues.advanceExact(docId);
-            boolean zeroThresholdPresent = zeroThresholds.advanceExact(docId);
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
+            }
+            boolean histoPresent = histoDocValues.advanceExact(currentDocId);
+            boolean zeroThresholdPresent = zeroThresholds.advanceExact(currentDocId);
             assert zeroThresholdPresent && histoPresent;
 
             BytesRef encodedHistogram = histoDocValues.binaryValue();
@@ -876,20 +892,20 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             long valueCount = valueCounts.longValue();
             double valueSum;
             if (valueCount > 0) {
-                boolean valueSumsPresent = valueSums.advanceExact(docId);
+                boolean valueSumsPresent = valueSums.advanceExact(currentDocId);
                 assert valueSumsPresent;
                 valueSum = NumericUtils.sortableLongToDouble(valueSums.longValue());
             } else {
                 valueSum = 0.0;
             }
             double valueMin;
-            if (valueMinima != null && valueMinima.advanceExact(docId)) {
+            if (valueMinima != null && valueMinima.advanceExact(currentDocId)) {
                 valueMin = NumericUtils.sortableLongToDouble(valueMinima.longValue());
             } else {
                 valueMin = Double.NaN;
             }
             double valueMax;
-            if (valueMaxima != null && valueMaxima.advanceExact(docId)) {
+            if (valueMaxima != null && valueMaxima.advanceExact(currentDocId)) {
                 valueMax = NumericUtils.sortableLongToDouble(valueMaxima.longValue());
             } else {
                 valueMax = Double.NaN;
@@ -905,8 +921,10 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double sumValue() throws IOException {
-            int docId = currentDocId();
-            if (valueSums == null || valueSums.advanceExact(docId) == false) {
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
+            }
+            if (valueSums == null || valueSums.advanceExact(currentDocId) == false) {
                 return 0.0;
             }
             return NumericUtils.sortableLongToDouble(valueSums.longValue());
@@ -914,8 +932,10 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double minValue() throws IOException {
-            int docId = currentDocId();
-            if (valueMinima == null || valueMinima.advanceExact(docId) == false) {
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
+            }
+            if (valueMinima == null || valueMinima.advanceExact(currentDocId) == false) {
                 return Double.POSITIVE_INFINITY;
             }
             return NumericUtils.sortableLongToDouble(valueMinima.longValue());
@@ -923,8 +943,10 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double maxValue() throws IOException {
-            int docId = currentDocId();
-            if (valueMaxima == null || valueMaxima.advanceExact(docId) == false) {
+            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new IllegalStateException("No histogram present for current document id");
+            }
+            if (valueMaxima == null || valueMaxima.advanceExact(currentDocId) == false) {
                 return Double.NEGATIVE_INFINITY;
             }
             return NumericUtils.sortableLongToDouble(valueMaxima.longValue());
@@ -932,7 +954,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public DocIdSetIterator docIdIterator() {
-            return valueCounts != null ? valueCounts : DocIdSetIterator.empty();
+            return docIdSetIterator;
         }
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
@@ -925,6 +925,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
                 throw new IllegalStateException("No histogram present for current document id");
             }
             if (valueSums == null || valueSums.advanceExact(currentDocId) == false) {
+                // empty histogram, must have sum of 0.0
                 return 0.0;
             }
             return NumericUtils.sortableLongToDouble(valueSums.longValue());
@@ -936,6 +937,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
                 throw new IllegalStateException("No histogram present for current document id");
             }
             if (valueMinima == null || valueMinima.advanceExact(currentDocId) == false) {
+                // empty histogram
                 return Double.POSITIVE_INFINITY;
             }
             return NumericUtils.sortableLongToDouble(valueMinima.longValue());
@@ -947,6 +949,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
                 throw new IllegalStateException("No histogram present for current document id");
             }
             if (valueMaxima == null || valueMaxima.advanceExact(currentDocId) == false) {
+                // empty histogram
                 return Double.NEGATIVE_INFINITY;
             }
             return NumericUtils.sortableLongToDouble(valueMaxima.longValue());

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
@@ -822,9 +822,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
         private final NumericDocValues valueMinima;
         private final NumericDocValues valueMaxima;
 
-        private int currentDocId = -1;
         private final CompressedExponentialHistogram tempHistogram = new CompressedExponentialHistogram();
-        private final DocIdSetIterator docIdSetIterator;
+        private int advanceExactFailedDoc = -2;
 
         DocValuesReader(LeafReader leafReader, String fullPath) throws IOException {
             histoDocValues = leafReader.getBinaryDocValues(fullPath);
@@ -833,37 +832,6 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             valueSums = leafReader.getNumericDocValues(valuesSumSubFieldName(fullPath));
             valueMinima = leafReader.getNumericDocValues(valuesMinSubFieldName(fullPath));
             valueMaxima = leafReader.getNumericDocValues(valuesMaxSubFieldName(fullPath));
-            if (valueCounts == null) {
-                currentDocId = DocIdSetIterator.NO_MORE_DOCS;
-            }
-            docIdSetIterator = new DocIdSetIterator() {
-
-                @Override
-                public int docID() {
-                    return currentDocId;
-                }
-
-                @Override
-                public int nextDoc() throws IOException {
-                    if (valueCounts != null) {
-                        currentDocId = valueCounts.nextDoc();
-                    }
-                    return currentDocId;
-                }
-
-                @Override
-                public int advance(int target) throws IOException {
-                    if (valueCounts != null) {
-                        currentDocId = valueCounts.advance(target);
-                    }
-                    return currentDocId;
-                }
-
-                @Override
-                public long cost() {
-                    return valueCounts != null ? valueCounts.cost() : 0;
-                }
-            };
         }
 
         boolean hasAnyValues() {
@@ -872,18 +840,30 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public boolean advanceExact(int docId) throws IOException {
-            boolean isPresent = valueCounts != null && valueCounts.advanceExact(docId);
-            currentDocId = isPresent ? docId : -1;
-            return isPresent;
+            if (valueCounts == null) {
+                return false;
+            }
+            boolean present = valueCounts.advanceExact(docId);
+            advanceExactFailedDoc = present ? -2 : docId;
+            return present;
+        }
+
+        private int currentDocId() {
+            if (valueCounts == null) {
+                throw new IllegalStateException("No histogram present for current document id");
+            }
+            int docId = valueCounts.docID();
+            if (docId < 0 || docId == DocIdSetIterator.NO_MORE_DOCS || docId == advanceExactFailedDoc) {
+                throw new IllegalStateException("No histogram present for current document id");
+            }
+            return docId;
         }
 
         @Override
         public ExponentialHistogram histogramValue() throws IOException {
-            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
-                throw new IllegalStateException("No histogram present for current document id");
-            }
-            boolean histoPresent = histoDocValues.advanceExact(currentDocId);
-            boolean zeroThresholdPresent = zeroThresholds.advanceExact(currentDocId);
+            int docId = currentDocId();
+            boolean histoPresent = histoDocValues.advanceExact(docId);
+            boolean zeroThresholdPresent = zeroThresholds.advanceExact(docId);
             assert zeroThresholdPresent && histoPresent;
 
             BytesRef encodedHistogram = histoDocValues.binaryValue();
@@ -891,20 +871,20 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             long valueCount = valueCounts.longValue();
             double valueSum;
             if (valueCount > 0) {
-                boolean valueSumsPresent = valueSums.advanceExact(currentDocId);
+                boolean valueSumsPresent = valueSums.advanceExact(docId);
                 assert valueSumsPresent;
                 valueSum = NumericUtils.sortableLongToDouble(valueSums.longValue());
             } else {
-                valueSum = 0.0; // empty histogram has sum of 0.0, but we store null in the doc values
+                valueSum = 0.0;
             }
             double valueMin;
-            if (valueMinima != null && valueMinima.advanceExact(currentDocId)) {
+            if (valueMinima != null && valueMinima.advanceExact(docId)) {
                 valueMin = NumericUtils.sortableLongToDouble(valueMinima.longValue());
             } else {
                 valueMin = Double.NaN;
             }
             double valueMax;
-            if (valueMaxima != null && valueMaxima.advanceExact(currentDocId)) {
+            if (valueMaxima != null && valueMaxima.advanceExact(docId)) {
                 valueMax = NumericUtils.sortableLongToDouble(valueMaxima.longValue());
             } else {
                 valueMax = Double.NaN;
@@ -920,11 +900,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double sumValue() throws IOException {
-            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
-                throw new IllegalStateException("No histogram present for current document id");
-            }
-            if (valueSums == null || valueSums.advanceExact(currentDocId) == false) {
-                // empty histogram, must have sum of 0.0
+            int docId = currentDocId();
+            if (valueSums == null || valueSums.advanceExact(docId) == false) {
                 return 0.0;
             }
             return NumericUtils.sortableLongToDouble(valueSums.longValue());
@@ -932,11 +909,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double minValue() throws IOException {
-            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
-                throw new IllegalStateException("No histogram present for current document id");
-            }
-            if (valueMinima == null || valueMinima.advanceExact(currentDocId) == false) {
-                // empty histogram
+            int docId = currentDocId();
+            if (valueMinima == null || valueMinima.advanceExact(docId) == false) {
                 return Double.POSITIVE_INFINITY;
             }
             return NumericUtils.sortableLongToDouble(valueMinima.longValue());
@@ -944,11 +918,8 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public double maxValue() throws IOException {
-            if (currentDocId == -1 || currentDocId == DocIdSetIterator.NO_MORE_DOCS) {
-                throw new IllegalStateException("No histogram present for current document id");
-            }
-            if (valueMaxima == null || valueMaxima.advanceExact(currentDocId) == false) {
-                // empty histogram
+            int docId = currentDocId();
+            if (valueMaxima == null || valueMaxima.advanceExact(docId) == false) {
                 return Double.NEGATIVE_INFINITY;
             }
             return NumericUtils.sortableLongToDouble(valueMaxima.longValue());
@@ -956,7 +927,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
 
         @Override
         public DocIdSetIterator docIdIterator() {
-            return docIdSetIterator;
+            return valueCounts != null ? valueCounts : DocIdSetIterator.empty();
         }
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
@@ -823,7 +823,12 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
         private final NumericDocValues valueMaxima;
 
         private final CompressedExponentialHistogram tempHistogram = new CompressedExponentialHistogram();
-        private int advanceExactFailedDoc = -2;
+
+        /**
+         * If advanceExact(docId) returns false, we remember the docId for which it failed to prevent
+         * calling any of the accessor methods, such as {@link #histogramValue()}
+         */
+        private int advanceExactFailedDoc = -1;
 
         DocValuesReader(LeafReader leafReader, String fullPath) throws IOException {
             histoDocValues = leafReader.getBinaryDocValues(fullPath);
@@ -844,7 +849,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
                 return false;
             }
             boolean present = valueCounts.advanceExact(docId);
-            advanceExactFailedDoc = present ? -2 : docId;
+            advanceExactFailedDoc = present ? -1 : docId;
             return present;
         }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramFieldMapper.java
@@ -896,7 +896,7 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
                 assert valueSumsPresent;
                 valueSum = NumericUtils.sortableLongToDouble(valueSums.longValue());
             } else {
-                valueSum = 0.0;
+                valueSum = 0.0; // empty histogram has sum of 0.0, but we store null in the doc values
             }
             double valueMin;
             if (valueMinima != null && valueMinima.advanceExact(currentDocId)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/exponentialhistogram/fielddata/ExponentialHistogramValuesReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/exponentialhistogram/fielddata/ExponentialHistogramValuesReader.java
@@ -74,6 +74,7 @@ public interface ExponentialHistogramValuesReader {
 
     /**
      * @return a doc id iterator over the doc values when available, otherwise null.
+     *         Moving the returned iterator also moves the position of the {@link ExponentialHistogramValuesReader} instance.
      */
     @Nullable
     default DocIdSetIterator docIdIterator() {


### PR DESCRIPTION
Closes #152318

The `DocValuesReader` constructor in `ExponentialHistogramFieldMapper` eagerly set `currentDocId` to `NO_MORE_DOCS` when `valueCounts` was null (i.e. a leaf segment has no documents with the histogram field). This violates the Lucene `DocIdSetIterator` contract which requires `docID()` to return `-1` before `nextDoc()` or `advance()` have been called.

The failure was non-deterministic because it only triggered when `RandomIndexWriter` happened to create a segment containing only documents without the histogram field.

~This fix comes with a refactor: Instead of maintaining an additional `currentDocId` ourselves, we simply reuse `valueCounts.docId()` and just return `valueCounts` as the `DocIdSetIterator()`. The only state we then have to keep in addition is if a `advanceExact` call failed, to prevent calling the accessor methods in that case.~

As it turns out `docId()` is unreliable, as some implementations (`ColumnarSourceWriter.NumericSlot.docID()`) don't obey the `docId()` contract. So I've switched the PR back to the explicit `currentDocId` tracking.