### PR TITLE
Fix in-flight search context leak in AsyncSearchActionIT after node restart

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -644,12 +644,6 @@ tests:
 - class: org.elasticsearch.upgrades.MlMappingsUpgradeIT
   method: testMappingsUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/152115
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testRestartAfterCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/152116
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testSearchPhaseFailureLeak
-  issue: https://github.com/elastic/elasticsearch/issues/152117
 - class: org.elasticsearch.index.engine.InternalEngineTests
   method: testLookupSeqNoByIdInLucene
   issue: https://github.com/elastic/elasticsearch/issues/152120

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -154,12 +154,13 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         ensureAllSearchContextsReleased();
 
         internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {});
-        // Ensure shards are ready before unpausing the maintenance service. If we unpaused first,
-        // the maintenance service could dispatch a DeleteByQueryRequest to a shard that is still
-        // INITIALIZING, hitting the waitForSearchReady path. The resulting reader context would be
-        // registered after ensureAllSearchContextsReleased() passes, causing a spurious
-        // assertNoInFlightContext() failure in subsequent-test teardown.
+        // The restarted node gets a new, unpaused maintenance service that the pre-restart pause did
+        // not cover. It can dispatch a DeleteByQueryRequest to a still-INITIALIZING shard, registering
+        // an async waitForSearchReady callback that opens a reader context only after the shard starts.
+        // Wait for shards to start, then pause and drain any such in-flight contexts before unpausing.
         ensureYellow(ASYNC_RESULTS_INDEX, indexName);
+        pauseMaintenanceService();
+        ensureAllSearchContextsReleased();
         unpauseMaintenanceService();
     }
 


### PR DESCRIPTION
The tests `AsyncSearchActionIT.testRestartAfterCompletion` and `AsyncSearchActionIT.testSearchPhaseFailureLeak` were failing intermittently with "There are still [1] in-flight contexts". This change fixes the leak and unmutes both tests.

The leak comes from `restartTaskNode` in `AsyncSearchIntegTestCase`. Before the restart we pause the maintenance service, but `internalCluster().restartNode(...)` creates a brand new `AsyncTaskMaintenanceService` on the restarted node, and that new instance starts unpaused. The pre-restart pause only covered the old instances, so it does not cover the new one. Because `tryStartCleanup()` only checks `lifecycle.stoppedOrClosed()` and not the paused flag, the new instance reacts to cluster state changes during recovery and dispatches a delete-by-query against the `.async-search` index.

If that request reaches a shard that is still initializing, `SearchService.rewriteAndFetchShardRequest` registers a `waitForSearchReady` callback that runs later on a background thread once the shard starts. That callback opens a reader context after our earlier `ensureAllSearchContextsReleased()` check already passed. The context is tracked in a static map shared across the whole suite, so it is still open when the next test tears down and that test fails instead. This is why `testSearchPhaseFailureLeak` failed even though the real cause was `testRestartAfterCompletion`.

The previous fix only moved `ensureYellow` before unpausing the old services, which does not help here because the new instance was never paused and acts on its own. The new instance is autonomous, so instead of trying to stop it from running we wait for things to settle. After `ensureYellow` returns and the deferred callbacks can run, we pause all services (now including the new one), call `ensureAllSearchContextsReleased()` to drain any context the callback opened, and only then unpause. `ensureAllSearchContextsReleased()` retries for up to ten seconds, so it waits for the asynchronous callback to finish and release its context before the test continues.

Verified by unmuting both tests and running them with the original failing seed (passes), then running 25 iterations of both tests with `--rerun-tasks` for a total of 50 runs with zero failures, zero errors, and zero skips.

Closes #152116
Closes #152117