### PR TITLE
[9.4] Extract build-logic checks into separate BK jobs (#152397)

### DIFF
--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -8,6 +8,14 @@ steps:
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
   - wait
+  - label: build-logic
+    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkBuildLogic
+    timeout_in_minutes: 120
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n1-standard-32
+      buildDirectory: /dev/shm/bk
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
     timeout_in_minutes: 300

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -9,6 +9,14 @@ steps:
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
   - wait
+  - label: build-logic
+    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkBuildLogic
+    timeout_in_minutes: 120
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n1-standard-32
+      buildDirectory: /dev/shm/bk
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
     timeout_in_minutes: 300

--- a/.buildkite/pipelines/pull-request/build-logic.yml
+++ b/.buildkite/pipelines/pull-request/build-logic.yml
@@ -1,0 +1,14 @@
+steps:
+  - label: build-logic
+    command: |
+      .buildkite/scripts/spotless.sh
+      .ci/scripts/run-gradle.sh -Dignore.tests.seed checkBuildLogic
+    timeout_in_minutes: 120
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-standard-32
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk
+      preemptible: true
+      spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/scripts/pull-request/pipeline.generate.ts
+++ b/.buildkite/scripts/pull-request/pipeline.generate.ts
@@ -5,21 +5,34 @@ import { generatePipelines } from "./pipeline.ts";
 
 const pipelines = generatePipelines();
 
+// Log each included pipeline for debugging
 for (const pipeline of pipelines) {
-  const yaml = stringify(pipeline.pipeline);
-
   console.log(`--- Generated pipeline: ${pipeline.name}`);
-  console.log(yaml);
+  console.log(stringify(pipeline.pipeline));
+}
 
-  // Only do the pipeline upload if we're actually in CI
-  // This lets us run the tool locally and see the output
-  if (process.env.CI) {
-    console.log("");
-    console.log("Uploading pipeline...");
+// Combine all pipelines into a single upload so that Buildkite preserves step
+// ordering.  When pipeline upload is called multiple times, each call inserts
+// its steps immediately after the currently-running step, which reverses the
+// intended order.  A single upload avoids that problem entirely.
+const combinedSteps = pipelines.flatMap((p) => p.pipeline.steps ?? []);
 
-    execSync(`buildkite-agent pipeline upload`, {
-      input: yaml,
-      stdio: ["pipe", "inherit", "inherit"],
-    });
-  }
+// Merge any top-level env blocks (individual pipelines may define pipeline-wide
+// env vars; merging them keeps those variables in scope for their steps).
+const combinedEnv = pipelines.reduce(
+  (acc, p) => ({ ...acc, ...(p.pipeline.env ?? {}) }),
+  {} as Record<string, string>,
+);
+
+const combined =
+  Object.keys(combinedEnv).length > 0 ? { env: combinedEnv, steps: combinedSteps } : { steps: combinedSteps };
+
+// Only do the pipeline upload if we're actually in CI
+// This lets us run the tool locally and see the output
+if (process.env.CI) {
+  console.log("--- Uploading combined pipeline");
+  execSync(`buildkite-agent pipeline upload`, {
+    input: stringify(combined),
+    stdio: ["pipe", "inherit", "inherit"],
+  });
 }

--- a/build.gradle
+++ b/build.gradle
@@ -288,6 +288,11 @@ def upgradeCompatibilityZip = tasks.register("upgradeCompatibilityZip", Zip) {
   from(generateUpgradeCompatibilityFile)
 }
 
+def isCiSplitTask = { String taskName ->
+  taskName.startsWith("checkPart") || taskName.startsWith("releaseTestCheck")
+    || taskName == 'functionalTests' || taskName == 'checkBuildLogic'
+}
+
 // TODO: This flag existed as a mechanism to disable bwc tests during a backport. It is no
 // longer used for that purpose, but instead a way to run only functional tests. We should
 // rework the functionalTests task to be more explicit about which tasks it wants to run
@@ -536,6 +541,9 @@ tasks.named("precommit") {
 }
 
 tasks.named("checkPart1").configure {
+}
+
+tasks.register("checkBuildLogic").configure {
   dependsOn gradle.includedBuild('build-tools').task(':check')
   dependsOn gradle.includedBuild('build-tools-internal').task(':check')
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Extract build-logic checks into separate BK jobs (#152397)](https://github.com/elastic/elasticsearch/pull/152397)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)