### PR TITLE
ESQL: fix NdJsonPageDecoderMaxRecordSizeTests ctor (after #152221)

### DIFF
--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderMaxRecordSizeTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderMaxRecordSizeTests.java
@@ -171,11 +171,33 @@ public class NdJsonPageDecoderMaxRecordSizeTests extends ESTestCase {
     }
 
     private NdJsonPageDecoder byteArrayDecoder(byte[] data, ErrorPolicy policy) throws IOException {
-        return new NdJsonPageDecoder(data, 0, data.length, SCHEMA, PROJECT_ID, 100, blockFactory, policy, "test", counters);
+        return new NdJsonPageDecoder(
+            data,
+            0,
+            data.length,
+            null /* DateFormatter */,
+            SCHEMA,
+            PROJECT_ID,
+            100,
+            blockFactory,
+            policy,
+            "test",
+            counters
+        );
     }
 
     private NdJsonPageDecoder streamingDecoder(byte[] data, ErrorPolicy policy) throws IOException {
-        return new NdJsonPageDecoder(new ByteArrayInputStream(data), SCHEMA, PROJECT_ID, 100, blockFactory, policy, "test", counters);
+        return new NdJsonPageDecoder(
+            new ByteArrayInputStream(data),
+            null /* DateFormatter */,
+            SCHEMA,
+            PROJECT_ID,
+            100,
+            blockFactory,
+            policy,
+            "test",
+            counters
+        );
     }
 
     private static void consumeAll(NdJsonPageDecoder decoder) throws IOException {


### PR DESCRIPTION
## What this is about

#152221 ([ESQL] NDJSON field-name identity cache) added a `DateFormatter` parameter to `NdJsonPageDecoder`'s constructors but didn't update `NdJsonPageDecoderMaxRecordSizeTests`, so `:x-pack:plugin:esql-datasource-ndjson:compileTestJava` is currently failing on `main` (it surfaces as a red `elasticsearch-ci/part-5` / `checkPart5`).

## What this PR does

Passes a `null` `DateFormatter` in the test's two decoder-construction helpers, matching how the sibling ndjson decoder tests (`NdJsonPageDecoderTests`, `NdJsonPageDecoderFieldNameCacheTests`, `NdJsonPageDecoderFastSkipTests`) construct it. Test-only — the max-record-size scenarios don't exercise datetime parsing, so `null` is the right value.

## Does it work?

`./gradlew :x-pack:plugin:esql-datasource-ndjson:test --tests "*NdJsonPageDecoderMaxRecordSizeTests"` compiles and passes.

Follow-up to #152221 — flagging for @costin as the author of that change.
