### PR TITLE
[Gradle] Make javadoc plugin variant-aware

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
@@ -9,30 +9,69 @@
 
 package org.elasticsearch.gradle.internal;
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin;
 
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
+import org.gradle.api.attributes.VerificationType;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePluginExtension;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.javadoc.Javadoc;
-import org.gradle.external.javadoc.JavadocOfflineLink;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
 
 import java.io.File;
 import java.util.Comparator;
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-// Handle javadoc dependencies across projects. Order matters: the linksOffline for
-// org.elasticsearch:elasticsearch must be the last one or all the links for the
-// other packages (e.g org.elasticsearch.client) will point to server rather than
-// their own artifacts.
+/**
+ * Wires inter-project javadoc linking using variant-aware dependency resolution rather than
+ * cross-project task wiring.
+ *
+ * <p>Each project that applies this plugin (together with the {@code java} plugin) <em>publishes</em>
+ * its javadoc output directory as a consumable variant ({@code javadocDirElements}). A consuming
+ * project then <em>resolves</em> that variant from its own {@code compileClasspath} project
+ * dependencies via an {@link org.gradle.api.artifacts.ArtifactView} with variant reselection. The
+ * resolved artifact files are registered as task inputs, so Gradle derives the producing
+ * {@code :upstream:javadoc} task dependency from the artifact's {@code builtBy} automatically. This
+ * removes the need for {@code Project#afterEvaluate}, {@code Project#evaluationDependsOn} and
+ * explicit cross-project {@code dependsOn(":upstream:javadoc")} wiring.
+ *
+ * <p>Order matters: the {@code linksOffline} entry for {@code org.elasticsearch:elasticsearch} must
+ * be the last one, otherwise all links for the other packages (e.g. {@code org.elasticsearch.client})
+ * would point to server rather than their own artifacts. We therefore sort the links by their
+ * published link path (which begins with the producer's group).
+ */
 public class ElasticsearchJavadocPlugin implements Plugin<Project> {
+
+    /**
+     * Marks the producer variant that exposes the javadoc <em>directory</em> (as opposed to the
+     * standard {@code javadocElements} variant which exposes the packaged javadoc jar). Requesting
+     * this attribute on the consumer side disambiguates the directory from any jar variant.
+     */
+    private static final Attribute<Boolean> JAVADOC_DIR_ATTRIBUTE = Attribute.of("elasticsearch.javadoc-dir", Boolean.class);
+
+    /**
+     * Carries the producer-computed offline-link path ({@code group/archivesName/version}). Publishing
+     * it as a (lazy) attribute lets the consumer build the external link URL without reading the
+     * upstream project's model, keeping resolution project-isolation friendly.
+     */
+    private static final Attribute<String> JAVADOC_LINK_PATH_ATTRIBUTE = Attribute.of("elasticsearch.javadoc-link-path", String.class);
 
     @Override
     public void apply(Project project) {
@@ -56,88 +95,156 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
         });
 
         // Relying on configurations introduced by the java plugin
-        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> project.afterEvaluate(project1 -> {
-            var withShadowPlugin = project1.getPlugins().hasPlugin(ShadowPlugin.class);
-            var compileClasspath = project.getConfigurations().getByName("compileClasspath");
+        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
+            registerJavadocDirVariant(project);
+            configureInterProjectJavadocLinks(project);
+            configureShadowedSources(project);
+        });
+    }
 
-            var copiedCompileClasspath = project.getConfigurations().create("copiedCompileClasspath");
-            copiedCompileClasspath.extendsFrom(compileClasspath);
-            if (withShadowPlugin) {
-                var shadowConfiguration = project.getConfigurations().getByName("shadow");
-                var shadowedDependencies = shadowConfiguration.getAllDependencies();
-                var nonShadowedCompileClasspath = copiedCompileClasspath.copyRecursive(
-                    dependency -> shadowedDependencies.contains(dependency) == false
-                );
-                configureJavadocForConfiguration(project, false, nonShadowedCompileClasspath);
-                configureJavadocForConfiguration(project, true, shadowConfiguration);
-            } else {
-                configureJavadocForConfiguration(project, false, compileClasspath);
+    /**
+     * Producer side: expose this project's javadoc output directory as a consumable variant so that
+     * dependent projects can resolve it through variant-aware dependency resolution.
+     */
+    private void registerJavadocDirVariant(Project project) {
+        ObjectFactory objects = project.getObjects();
+        TaskProvider<Javadoc> javadocTask = project.getTasks().named("javadoc", Javadoc.class);
+
+        // Lazily computed so that the build script's `version` and `archivesName` are picked up: the
+        // provider is only queried at resolution time, after the build script has run. This is the
+        // variant-aware replacement for the afterEvaluate hook the plugin used previously.
+        Provider<String> linkPath = project.getExtensions()
+            .getByType(BasePluginExtension.class)
+            .getArchivesName()
+            .map(
+                archivesName -> project.getGroup().toString().replace('.', '/') + '/' + archivesName.replace('.', '/') + '/' + project
+                    .getVersion()
+            );
+
+        project.getConfigurations().consumable("javadocDirElements", c -> {
+            c.attributes(a -> {
+                a.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
+                a.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, DocsType.JAVADOC));
+                a.attribute(JAVADOC_DIR_ATTRIBUTE, true);
+                a.attributeProvider(JAVADOC_LINK_PATH_ATTRIBUTE, linkPath);
+            });
+            // builtBy makes Gradle run :upstream:javadoc whenever a consumer resolves this artifact.
+            c.getOutgoing().artifact(javadocTask.map(Javadoc::getDestinationDir), artifact -> {
+                artifact.builtBy(javadocTask);
+                artifact.setType("javadoc-directory");
+            });
+        });
+    }
+
+    /**
+     * Consumer side: resolve the javadoc directory variant of every (non-shadowed) project dependency
+     * on the compile classpath and turn it into {@code linksOffline} entries.
+     */
+    private void configureInterProjectJavadocLinks(Project project) {
+        ObjectFactory objects = project.getObjects();
+        Configuration compileClasspath = project.getConfigurations().getByName("compileClasspath");
+        ResolvableDependencies incoming = compileClasspath.getIncoming();
+
+        // Shadowed project dependencies have their source inlined (see configureShadowedSources) and
+        // must therefore not be linked. Resolved lazily so no afterEvaluate / plugin probe is needed.
+        Provider<Set<String>> shadowedProjectPaths = project.provider(() -> {
+            Configuration shadow = project.getConfigurations().findByName(ShadowBasePlugin.SHADOW);
+            if (shadow == null) {
+                return Set.of();
             }
-        }));
-    }
+            return shadow.getAllDependencies()
+                .stream()
+                .filter(d -> d instanceof ProjectDependency)
+                .map(d -> ((ProjectDependency) d).getPath())
+                .collect(Collectors.toSet());
+        });
 
-    private void configureJavadocForConfiguration(Project project, boolean shadow, Configuration configuration) {
-        configuration.getAllDependencies()
-            .stream()
-            .sorted(Comparator.comparing(Dependency::getGroup))
-            .filter(d -> d instanceof ProjectDependency)
-            .map(d -> (ProjectDependency) d)
-            .forEach(projectDependency -> configureDependency(project, shadow, projectDependency));
-    }
-
-    private void configureDependency(Project project, boolean shadowed, ProjectDependency dep) {
-        // we should use variant aware dependency management to resolve artifacts required for javadoc here
-        Project upstreamProject = project.project(dep.getPath());
-        if (upstreamProject == null) {
-            return;
-        }
-        if (shadowed) {
-            /*
-             * Include the source of shadowed upstream projects so we don't
-             * have to publish their javadoc.
-             */
-            project.evaluationDependsOn(upstreamProject.getPath());
-            project.getTasks().named("javadoc", Javadoc.class).configure(javadoc -> {
-                Javadoc upstreamJavadoc = upstreamProject.getTasks().named("javadoc", Javadoc.class).get();
-                javadoc.setSource(javadoc.getSource().plus(upstreamJavadoc.getSource()));
-                javadoc.setClasspath(javadoc.getClasspath().plus(upstreamJavadoc.getClasspath()));
+        ArtifactCollection javadocDirs = incoming.artifactView(v -> {
+            // Reselect the javadoc-directory variant in place of the compile (jar) variant.
+            v.withVariantReselection();
+            // Tolerate dependencies that do not publish a javadoc variant or whose javadoc is disabled.
+            v.setLenient(true);
+            v.componentFilter(
+                id -> id instanceof ProjectComponentIdentifier pci && shadowedProjectPaths.get().contains(pci.getProjectPath()) == false
+            );
+            v.attributes(a -> {
+                a.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
+                a.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, DocsType.JAVADOC));
+                a.attribute(JAVADOC_DIR_ATTRIBUTE, true);
             });
-            /*
-             * Instead we need the upstream project's javadoc classpath so
-             * we don't barf on the classes that it references.
-             */
-        } else {
-            project.getTasks().named("javadoc", Javadoc.class).configure(javadoc -> {
-                // Link to non-shadowed dependant projects
-                javadoc.dependsOn(upstreamProject.getPath() + ":javadoc");
-                String externalLinkName = upstreamProject.getExtensions().getByType(BasePluginExtension.class).getArchivesName().get();
-                String artifactPath = dep.getGroup().replace('.', '/') + '/' + externalLinkName.replace('.', '/') + '/' + dep.getVersion();
-                var options = (StandardJavadocDocletOptions) javadoc.getOptions();
-                options.linksOffline(
-                    artifactHost(project) + "/javadoc/" + artifactPath,
-                    project.getProjectDir().toPath().relativize(upstreamProject.getBuildDir().toPath()) + "/docs/javadoc/"
-                );
-                /*
-                 *some dependent javadoc tasks are explicitly skipped. We need to ignore those external links as
-                 * javadoc would fail otherwise.
-                 * Using Action here instead of lambda to keep gradle happy and don't trigger deprecation
-                 */
-                File projectDir = project.getProjectDir();
-                javadoc.doFirst(new Action<Task>() {
-                    @Override
-                    public void execute(Task task) {
-                        List<JavadocOfflineLink> existingJavadocOfflineLinks = ((StandardJavadocDocletOptions) javadoc.getOptions())
-                            .getLinksOffline()
-                            .stream()
-                            .filter(javadocOfflineLink -> new File(projectDir, javadocOfflineLink.getPackagelistLoc()).exists())
-                            .toList();
-                        ((StandardJavadocDocletOptions) javadoc.getOptions()).setLinksOffline(existingJavadocOfflineLinks);
+        }).getArtifacts();
 
-                    }
+        File projectDir = project.getProjectDir();
+        String artifactHost = artifactHost(project);
+
+        project.getTasks().named("javadoc", Javadoc.class).configure(javadoc -> {
+            // Registering the resolved artifact files as inputs wires the producing :upstream:javadoc
+            // tasks via their builtBy metadata. This replaces dependsOn(":upstream:javadoc") and
+            // evaluationDependsOn(upstream).
+            javadoc.getInputs().files(javadocDirs.getArtifactFiles());
+
+            // linksOffline lives on StandardJavadocDocletOptions, which is read while the javadoc tool
+            // runs. doFirst is the safe point at which the resolved ArtifactCollection is available and
+            // the options still feed into the generated javadoc.options file.
+            javadoc.doFirst("configure inter-project javadoc links", new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    var options = (StandardJavadocDocletOptions) javadoc.getOptions();
+                    javadocDirs.getArtifacts()
+                        .stream()
+                        // Sort by the published link path (which begins with the producer's group) so
+                        // that org.elasticsearch:elasticsearch is linked last (see class javadoc).
+                        .sorted(Comparator.comparing(a -> a.getVariant().getAttributes().getAttribute(JAVADOC_LINK_PATH_ATTRIBUTE)))
+                        .forEach(artifact -> {
+                            String linkPath = artifact.getVariant().getAttributes().getAttribute(JAVADOC_LINK_PATH_ATTRIBUTE);
+                            if (linkPath == null) {
+                                return;
+                            }
+                            String relativeDir = projectDir.toPath().relativize(artifact.getFile().toPath()) + "/";
+                            options.linksOffline(artifactHost + "/javadoc/" + linkPath, relativeDir);
+                        });
+                    /*
+                     * Some dependent javadoc tasks are explicitly skipped. We need to ignore those
+                     * external links as javadoc would fail otherwise.
+                     */
+                    options.setLinksOffline(
+                        options.getLinksOffline().stream().filter(link -> new File(projectDir, link.getPackagelistLoc()).exists()).toList()
+                    );
+                }
+            });
+        });
+    }
+
+    /**
+     * Include the source of shadowed upstream projects so we don't have to publish their javadoc.
+     * Sources are pulled through the standard {@code mainSourceElements} variant and the shadowed
+     * classes/dependencies via the {@code shadow} configuration, both resolved lazily.
+     */
+    private void configureShadowedSources(Project project) {
+        ObjectFactory objects = project.getObjects();
+        project.getPlugins().withType(ShadowPlugin.class, shadowPlugin -> {
+            Configuration shadow = project.getConfigurations().getByName(ShadowBasePlugin.SHADOW);
+
+            FileCollection shadowedSources = shadow.getIncoming().artifactView(v -> {
+                v.withVariantReselection();
+                v.setLenient(true);
+                v.componentFilter(id -> id instanceof ProjectComponentIdentifier);
+                v.attributes(a -> {
+                    a.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.VERIFICATION));
+                    a.attribute(
+                        VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
+                        objects.named(VerificationType.class, VerificationType.MAIN_SOURCES)
+                    );
                 });
+            }).getFiles();
 
+            project.getTasks().named("javadoc", Javadoc.class).configure(javadoc -> {
+                // Inline the shadowed project's sources and put its classes/dependencies on the
+                // javadoc classpath so references resolve.
+                javadoc.source(shadowedSources);
+                javadoc.setClasspath(javadoc.getClasspath().plus(shadow));
             });
-        }
+        });
     }
 
     private String artifactHost(Project project) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
@@ -180,8 +180,9 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
         project.getTasks().named("javadoc", Javadoc.class).configure(javadoc -> {
             // Registering the resolved artifact files as inputs wires the producing :upstream:javadoc
             // tasks via their builtBy metadata. This replaces dependsOn(":upstream:javadoc") and
-            // evaluationDependsOn(upstream).
-            javadoc.getInputs().files(javadocDirs.getArtifactFiles());
+            // evaluationDependsOn(upstream). We bind to the public Task#getInputs() (rather than
+            // Javadoc's covariant override, which returns the internal TaskInputsInternal type).
+            ((Task) javadoc).getInputs().files(javadocDirs.getArtifactFiles());
 
             // linksOffline lives on StandardJavadocDocletOptions, which is read while the javadoc tool
             // runs. doFirst is the safe point at which the resolved ArtifactCollection is available and

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/GradlePluginConventionsArchUnitSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/GradlePluginConventionsArchUnitSpec.groovy
@@ -38,7 +38,6 @@ class GradlePluginConventionsArchUnitSpec extends AbstractArchUnitSpec {
      */
     private static final Set<String> KNOWN_AFTER_EVALUATE = [
         "org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin",
-        "org.elasticsearch.gradle.internal.ElasticsearchJavadocPlugin",
     ] as Set
 
     @Shared

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/IsolatedProjectsArchUnitSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/IsolatedProjectsArchUnitSpec.groovy
@@ -85,9 +85,7 @@ class IsolatedProjectsArchUnitSpec extends AbstractArchUnitSpec {
 
     private static final Set<String> KNOWN_ALL_SUB_PROJECTS_CALLBACK = [] as Set
 
-    private static final Set<String> KNOWN_EVALUATION_DEPENDS_ON = [
-        "org.elasticsearch.gradle.internal.ElasticsearchJavadocPlugin",
-    ] as Set
+    private static final Set<String> KNOWN_EVALUATION_DEPENDS_ON = [] as Set
 
     private static final Set<String> KNOWN_GET_PARENT = [
         "org.elasticsearch.gradle.internal.InternalDistributionArchiveCheckPlugin",


### PR DESCRIPTION
Rework ElasticsearchJavadocPlugin to resolve inter-project javadoc
through variant-aware artifact dependencies instead of cross-project
task wiring.

Each project now publishes its javadoc output directory as a
consumable variant, and consumers resolve it via an ArtifactView with
variant reselection. The producing javadoc task is derived from the
artifact builtBy, so afterEvaluate, evaluationDependsOn and explicit
dependsOn(":upstream:javadoc") wiring are no longer needed. The
offline-link path is published as a lazy attribute, removing the
afterEvaluate that previously waited for version and archivesName.

Drop the now-stale ArchUnit baseline entries for afterEvaluate and
evaluationDependsOn.