### PR TITLE
Gracefully handle nested sandboxes on MacOS

### DIFF
--- a/docs/changelog/152443.yaml
+++ b/docs/changelog/152443.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 152443
+summary: Gracefully handle nested sandboxes on MacOS
+type: bug

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/MacNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/MacNativeAccess.java
@@ -124,6 +124,10 @@ public class MacNativeAccess extends PosixNativeAccess {
                 MemorySegment errorPtr = errorBuf.get(ValueLayout.ADDRESS, 0);
                 String message = MemorySegmentAdapter.getString(errorPtr.reinterpret(Long.MAX_VALUE), 0);
                 macLibc.sandbox_free_error(errorPtr);
+                if ("Operation not permitted".equals(message)) {
+                    logger.warn("sandbox_init: Operation not permitted. Already running in a sandbox?");
+                    return;
+                }
                 throw new UnsupportedOperationException("sandbox_init(): " + message);
             }
             logger.debug("OS X seatbelt initialization successful");


### PR DESCRIPTION
## What

Allow MacOS seatbelt creation to fail if the error message is `Operation not permitted`, indicating that the current process already runs in a sandbox.

Note that it started failing today after updating `main`, so it's probably related to the recent changes to `MacNativeAccess` although seatbelt creation is much older.

## Why

I run Claude on MacOS in a seatbelt sandbox using [nono.sh](https://nono.sh/). Tests run by Claude fail at startup because `BootstrapForTesting` (indirectly) tries to create a seatbelt sandbox, and it seems nested sandboxes aren't supported.

```
    java.lang.UnsupportedOperationException: sandbox_init(): Operation not permitted
        at org.elasticsearch.nativeaccess.MacNativeAccess.initMacSandbox(MacNativeAccess.java:131)
        at org.elasticsearch.nativeaccess.MacNativeAccess.tryInstallExecSandbox(MacNativeAccess.java:100)
        at org.elasticsearch.bootstrap.Elasticsearch.initializeNatives(Elasticsearch.java:497)
        at org.elasticsearch.bootstrap.BootstrapForTesting.<clinit>(BootstrapForTesting.java:57)
        at org.elasticsearch.test.ESTestCase.<clinit>(ESTestCase.java:368)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:560)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:631)
```

This can be reproduced on the command-line:

```
$ echo "(version 1) (allow default)" > rules1
$ echo "(version 1) (allow default) (deny process-fork) (deny process-exec)" > rules2
$ sandbox-exec -f rules1 bash
bash-5.3$ sandbox-exec -f rules2 bash
sandbox-exec: sandbox_apply: Operation not permitted
bash-5.3$
```
and with Gradle:

```
$ echo "(version 1) (allow default)" > rules1                                                                                                                     
bash-5.3$ ./gradlew :x-pack:plugin:esql-datasource-parquet:test                                                                                                                                              
                                                                                                                                                             
FAILURE: Build failed with an exception.                                                                                                                     

* What went wrong:
java.io.IOException: Operation not permitted
> Operation not permitted

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.
```