### PR TITLE
Account remote reindex HTTP response buffer

### DIFF
--- a/docs/changelog/152444.yaml
+++ b/docs/changelog/152444.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 152444
+summary: Account remote reindex HTTP response buffer
+type: bug

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactory.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.elasticsearch.client.HttpAsyncResponseConsumerFactory;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+
+import java.util.Objects;
+
+/**
+ * Creates one breaker-aware response consumer per remote reindex request attempt.
+ */
+final class BreakerAwareConsumerFactory implements HttpAsyncResponseConsumerFactory {
+
+    /** Matches the default response buffer limit used by the low-level REST client. */
+    static final int DEFAULT_BUFFER_LIMIT_BYTES = 100 * 1024 * 1024;
+
+    private final CircuitBreaker breaker;
+    private final int bufferLimitBytes;
+
+    BreakerAwareConsumerFactory(CircuitBreaker breaker) {
+        this(breaker, DEFAULT_BUFFER_LIMIT_BYTES);
+    }
+
+    BreakerAwareConsumerFactory(CircuitBreaker breaker, int bufferLimitBytes) {
+        this.breaker = Objects.requireNonNull(breaker, "breaker");
+        if (bufferLimitBytes <= 0) {
+            throw new IllegalArgumentException("bufferLimitBytes must be > 0, was " + bufferLimitBytes);
+        }
+        this.bufferLimitBytes = bufferLimitBytes;
+    }
+
+    @Override
+    public HttpAsyncResponseConsumer<HttpResponse> createHttpAsyncResponseConsumer() {
+        return new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, bufferLimitBytes);
+    }
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.ContentTooLongException;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.HttpEntityWrapper;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.entity.ContentBufferEntity;
+import org.apache.http.nio.protocol.AbstractAsyncResponseConsumer;
+import org.apache.http.nio.util.ByteBufferAllocator;
+import org.apache.http.nio.util.ContentInputBuffer;
+import org.apache.http.nio.util.SimpleInputBuffer;
+import org.apache.http.protocol.HttpContext;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.core.Releasable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Heap-buffered async response consumer that charges the raw Apache HTTP response buffer to the
+ * {@link CircuitBreaker#REQUEST} circuit breaker.
+ *
+ * <p>The low-level REST client buffers each async response in a {@link SimpleInputBuffer} before
+ * invoking the application callback. For remote reindex search responses that means heap can be
+ * exhausted before {@link RemoteParseContext} sees any bytes. This consumer accounts the actual
+ * {@link ByteBuffer} allocations used by that Apache buffer, including growth for responses without
+ * a {@code Content-Length} header.
+ *
+ * <p>On a successful response, Apache calls {@link #releaseResources()} before the reindex callback
+ * reads the returned entity. For that reason the breaker reservation is attached to the response
+ * entity and must be released after the entity content has been consumed. Failed or cancelled
+ * requests release directly from {@link #releaseResources()}.
+ */
+final class BreakerAwareHeapBufferedAsyncResponseConsumer extends AbstractAsyncResponseConsumer<HttpResponse> {
+
+    /** Label used when charging the REQUEST breaker for the raw HTTP response buffer. */
+    static final String REMOTE_RESPONSE_BUFFER_BREAKER_LABEL = "reindex_remote_response_buffer";
+
+    private final int bufferLimitBytes;
+    private final AccountingByteBufferAllocator allocator;
+
+    private volatile HttpResponse response;
+    private volatile ContentInputBuffer contentBuffer;
+    private volatile boolean responseDelivered;
+
+    BreakerAwareHeapBufferedAsyncResponseConsumer(CircuitBreaker breaker, int bufferLimitBytes) {
+        if (bufferLimitBytes <= 0) {
+            throw new IllegalArgumentException("bufferLimitBytes must be > 0, was " + bufferLimitBytes);
+        }
+        this.bufferLimitBytes = bufferLimitBytes;
+        this.allocator = new AccountingByteBufferAllocator(Objects.requireNonNull(breaker, "breaker"));
+    }
+
+    int getBufferLimit() {
+        return bufferLimitBytes;
+    }
+
+    long currentReservation() {
+        return allocator.currentReservation();
+    }
+
+    @Override
+    protected void onResponseReceived(HttpResponse httpResponse) throws HttpException, IOException {
+        this.response = httpResponse;
+    }
+
+    @Override
+    protected void onEntityEnclosed(HttpEntity entity, ContentType contentType) throws IOException {
+        long len = entity.getContentLength();
+        if (len > bufferLimitBytes) {
+            throw contentTooLong(len);
+        }
+        int initialBufferSize = len < 0 ? 4096 : Math.toIntExact(len);
+        try {
+            contentBuffer = new AccountingSimpleInputBuffer(initialBufferSize, bufferLimitBytes, allocator);
+            this.response.setEntity(new ReleasableContentBufferEntity(new ContentBufferEntity(entity, contentBuffer), allocator));
+        } catch (CircuitBreakingException cbe) {
+            throw new IOException(cbe);
+        }
+    }
+
+    @Override
+    protected void onContentReceived(ContentDecoder decoder, IOControl ioctrl) throws IOException {
+        try {
+            contentBuffer.consumeContent(decoder);
+        } catch (ContentTooLongRuntimeException e) {
+            throw e.asIOException();
+        } catch (CircuitBreakingException cbe) {
+            throw new IOException(cbe);
+        }
+    }
+
+    @Override
+    protected HttpResponse buildResult(HttpContext context) {
+        responseDelivered = true;
+        return response;
+    }
+
+    @Override
+    protected void releaseResources() {
+        try {
+            if (responseDelivered == false) {
+                allocator.close();
+            }
+        } finally {
+            response = null;
+            contentBuffer = null;
+        }
+    }
+
+    private ContentTooLongException contentTooLong(long contentLength) {
+        return new ContentTooLongException(
+            "entity content is too long [" + contentLength + "] for the configured buffer limit [" + bufferLimitBytes + "]"
+        );
+    }
+
+    private final class AccountingSimpleInputBuffer extends SimpleInputBuffer {
+        private final int bufferLimitBytes;
+        private final AccountingByteBufferAllocator allocator;
+
+        private AccountingSimpleInputBuffer(int bufferSize, int bufferLimitBytes, AccountingByteBufferAllocator allocator) {
+            super(bufferSize, allocator);
+            this.bufferLimitBytes = bufferLimitBytes;
+            this.allocator = allocator;
+        }
+
+        @Override
+        protected void expand() {
+            int oldCapacity = buffer.capacity();
+            if (oldCapacity >= bufferLimitBytes) {
+                throw new ContentTooLongRuntimeException(contentTooLong((long) bufferLimitBytes + 1));
+            }
+            long doubledCapacity = ((long) oldCapacity + 1) << 1;
+            int newCapacity = Math.toIntExact(Math.min(doubledCapacity, (long) bufferLimitBytes));
+
+            ByteBuffer oldBuffer = buffer;
+            ByteBuffer newBuffer = allocator.allocate(newCapacity);
+            boolean success = false;
+            try {
+                oldBuffer.flip();
+                newBuffer.put(oldBuffer);
+                success = true;
+            } finally {
+                if (success) {
+                    buffer = newBuffer;
+                    allocator.release(oldCapacity);
+                } else {
+                    allocator.release(newCapacity);
+                }
+            }
+        }
+    }
+
+    private static final class AccountingByteBufferAllocator implements ByteBufferAllocator, Releasable {
+        private final CircuitBreaker breaker;
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private long reservedBytes;
+
+        private AccountingByteBufferAllocator(CircuitBreaker breaker) {
+            this.breaker = breaker;
+        }
+
+        @Override
+        public ByteBuffer allocate(int size) {
+            if (size < 0) {
+                throw new IllegalArgumentException("size must be >= 0, was " + size);
+            }
+            if (size > 0) {
+                breaker.addEstimateBytesAndMaybeBreak(size, REMOTE_RESPONSE_BUFFER_BREAKER_LABEL);
+                reservedBytes += size;
+            }
+            try {
+                return ByteBuffer.allocate(size);
+            } catch (RuntimeException | Error e) {
+                release(size);
+                throw e;
+            }
+        }
+
+        void release(long bytes) {
+            if (bytes > 0) {
+                reservedBytes -= bytes;
+                breaker.addWithoutBreaking(-bytes);
+            }
+        }
+
+        long currentReservation() {
+            return reservedBytes;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                long bytes = reservedBytes;
+                reservedBytes = 0;
+                if (bytes > 0) {
+                    breaker.addWithoutBreaking(-bytes);
+                }
+            }
+        }
+    }
+
+    private static final class ReleasableContentBufferEntity extends HttpEntityWrapper implements Releasable {
+        private final Releasable releasable;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private ReleasableContentBufferEntity(HttpEntity wrappedEntity, Releasable releasable) {
+            super(wrappedEntity);
+            this.releasable = releasable;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                releasable.close();
+            }
+        }
+    }
+
+    private static final class ContentTooLongRuntimeException extends RuntimeException {
+        private final ContentTooLongException contentTooLongException;
+
+        private ContentTooLongRuntimeException(ContentTooLongException cause) {
+            super(cause);
+            this.contentTooLongException = cause;
+        }
+
+        private ContentTooLongException asIOException() {
+            return contentTooLongException;
+        }
+    }
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
@@ -27,7 +27,10 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.core.Releasable;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -225,6 +228,29 @@ final class BreakerAwareHeapBufferedAsyncResponseConsumer extends AbstractAsyncR
         private ReleasableContentBufferEntity(HttpEntity wrappedEntity, Releasable releasable) {
             super(wrappedEntity);
             this.releasable = releasable;
+        }
+
+        @Override
+        public InputStream getContent() throws IOException {
+            return new FilterInputStream(super.getContent()) {
+                @Override
+                public void close() throws IOException {
+                    try {
+                        super.close();
+                    } finally {
+                        ReleasableContentBufferEntity.this.close();
+                    }
+                }
+            };
+        }
+
+        @Override
+        public void writeTo(OutputStream outStream) throws IOException {
+            try {
+                super.writeTo(outStream);
+            } finally {
+                close();
+            }
         }
 
         @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumer.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Heap-buffered async response consumer that charges the raw Apache HTTP response buffer to the
@@ -144,7 +145,9 @@ final class BreakerAwareHeapBufferedAsyncResponseConsumer extends AbstractAsyncR
         protected void expand() {
             int oldCapacity = buffer.capacity();
             if (oldCapacity >= bufferLimitBytes) {
-                throw new ContentTooLongRuntimeException(contentTooLong((long) bufferLimitBytes + 1));
+                throw new ContentTooLongRuntimeException(
+                    new ContentTooLongException("response buffer exceeded limit [" + bufferLimitBytes + "] bytes")
+                );
             }
             long doubledCapacity = ((long) oldCapacity + 1) << 1;
             int newCapacity = Math.toIntExact(Math.min(doubledCapacity, (long) bufferLimitBytes));
@@ -170,7 +173,7 @@ final class BreakerAwareHeapBufferedAsyncResponseConsumer extends AbstractAsyncR
     private static final class AccountingByteBufferAllocator implements ByteBufferAllocator, Releasable {
         private final CircuitBreaker breaker;
         private final AtomicBoolean closed = new AtomicBoolean();
-        private long reservedBytes;
+        private final AtomicLong reservedBytes = new AtomicLong();
 
         private AccountingByteBufferAllocator(CircuitBreaker breaker) {
             this.breaker = breaker;
@@ -183,7 +186,7 @@ final class BreakerAwareHeapBufferedAsyncResponseConsumer extends AbstractAsyncR
             }
             if (size > 0) {
                 breaker.addEstimateBytesAndMaybeBreak(size, REMOTE_RESPONSE_BUFFER_BREAKER_LABEL);
-                reservedBytes += size;
+                reservedBytes.addAndGet(size);
             }
             try {
                 return ByteBuffer.allocate(size);
@@ -195,20 +198,19 @@ final class BreakerAwareHeapBufferedAsyncResponseConsumer extends AbstractAsyncR
 
         void release(long bytes) {
             if (bytes > 0) {
-                reservedBytes -= bytes;
+                reservedBytes.addAndGet(-bytes);
                 breaker.addWithoutBreaking(-bytes);
             }
         }
 
         long currentReservation() {
-            return reservedBytes;
+            return reservedBytes.get();
         }
 
         @Override
         public void close() {
             if (closed.compareAndSet(false, true)) {
-                long bytes = reservedBytes;
-                reservedBytes = 0;
+                long bytes = reservedBytes.getAndSet(0L);
                 if (bytes > 0) {
                     breaker.addWithoutBreaking(-bytes);
                 }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteReindexingUtils.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteReindexingUtils.java
@@ -215,6 +215,11 @@ public class RemoteReindexingUtils {
         CircuitBreaker breaker,
         long memoryAccountingThresholdBytes
     ) {
+        // Account the raw Apache HTTP response buffer against the REQUEST breaker before the
+        // response reaches this callback. RemoteParseContext accounts parsed hits later.
+        request.setOptions(
+            request.getOptions().toBuilder().setHttpAsyncResponseConsumerFactory(new BreakerAwareConsumerFactory(breaker)).build()
+        );
         // Preserve the thread context so headers survive after the call
         Supplier<ThreadContext.StoredContext> contextSupplier = threadPool.getThreadContext().newRestorableContext(true);
         try {
@@ -229,8 +234,12 @@ public class RemoteReindexingUtils {
                         // Armed with the parseContext while we own it; nulled out once handed off to the Response.
                         // The finally always closes whatever this points at (null is safe).
                         Releasable toCloseOnFailure = null;
+                        Releasable responseEntityReleasable = null;
                         try {
                             HttpEntity responseEntity = response.getEntity();
+                            if (responseEntity instanceof Releasable releasable) {
+                                responseEntityReleasable = releasable;
+                            }
                             InputStream content = responseEntity.getContent();
                             XContentType xContentType = null;
                             if (responseEntity.getContentType() != null) {
@@ -290,7 +299,7 @@ public class RemoteReindexingUtils {
                                 e
                             );
                         } finally {
-                            Releasables.closeWhileHandlingException(toCloseOnFailure);
+                            Releasables.closeWhileHandlingException(toCloseOnFailure, responseEntityReleasable);
                         }
                         listener.onResponse(parsedResponse);
                     }
@@ -302,11 +311,19 @@ public class RemoteReindexingUtils {
                         assert ctx != null; // eliminates compiler warning
                         if (e instanceof ResponseException re) {
                             int statusCode = re.getResponse().getStatusLine().getStatusCode();
-                            e = wrapExceptionToPreserveStatus(statusCode, re.getResponse().getEntity(), re);
+                            HttpEntity responseEntity = re.getResponse().getEntity();
+                            try {
+                                e = wrapExceptionToPreserveStatus(statusCode, responseEntity, re);
+                            } finally {
+                                closeIfReleasable(responseEntity);
+                            }
                             if (RestStatus.TOO_MANY_REQUESTS.getStatus() == statusCode) {
                                 listener.onRejection(e);
                                 return;
                             }
+                        } else if (ExceptionsHelper.unwrap(e, CircuitBreakingException.class) instanceof CircuitBreakingException cbe) {
+                            listener.onFailure(cbe);
+                            return;
                         } else if (e instanceof ContentTooLongException) {
                             e = new IllegalArgumentException(
                                 "Remote responded with a chunk that was too large. Use a smaller batch size.",
@@ -319,6 +336,12 @@ public class RemoteReindexingUtils {
             });
         } catch (Exception e) {
             listener.onFailure(e);
+        }
+    }
+
+    private static void closeIfReleasable(@Nullable HttpEntity entity) {
+        if (entity instanceof Releasable releasable) {
+            releasable.close();
         }
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactoryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareConsumerFactoryTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.reindex.remote.BreakerAwareConsumerFactory.DEFAULT_BUFFER_LIMIT_BYTES;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class BreakerAwareConsumerFactoryTests extends ESTestCase {
+
+    public void testCreateReturnsNewConsumerEachCall() {
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+        HttpAsyncResponseConsumer<HttpResponse> first = factory.createHttpAsyncResponseConsumer();
+        HttpAsyncResponseConsumer<HttpResponse> second = factory.createHttpAsyncResponseConsumer();
+
+        assertThat(first, not(sameInstance(second)));
+        assertThat(first, instanceOf(BreakerAwareHeapBufferedAsyncResponseConsumer.class));
+        assertThat(second, instanceOf(BreakerAwareHeapBufferedAsyncResponseConsumer.class));
+    }
+
+    public void testDefaultBufferLimitMatchesRestClientDefault() {
+        assertThat(DEFAULT_BUFFER_LIMIT_BYTES, equalTo(100 * 1024 * 1024));
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) factory
+            .createHttpAsyncResponseConsumer();
+
+        assertThat(consumer.getBufferLimit(), equalTo(DEFAULT_BUFFER_LIMIT_BYTES));
+    }
+
+    public void testCustomBufferLimitIsUsed() {
+        int customLimit = between(1, 10_000);
+        BreakerAwareConsumerFactory factory = new BreakerAwareConsumerFactory(new NoopCircuitBreaker(CircuitBreaker.REQUEST), customLimit);
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) factory
+            .createHttpAsyncResponseConsumer();
+
+        assertThat(consumer.getBufferLimit(), equalTo(customLimit));
+    }
+
+    public void testConstructorValidation() {
+        NoopCircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
+
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareConsumerFactory(breaker, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareConsumerFactory(breaker, -1));
+        expectThrows(NullPointerException.class, () -> new BreakerAwareConsumerFactory(null));
+        expectThrows(NullPointerException.class, () -> new BreakerAwareConsumerFactory(null, 1));
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex.remote;
+
+import org.apache.http.ContentTooLongException;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.nio.ContentDecoder;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.elasticsearch.reindex.remote.BreakerAwareHeapBufferedAsyncResponseConsumer.REMOTE_RESPONSE_BUFFER_BREAKER_LABEL;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class BreakerAwareHeapBufferedAsyncResponseConsumerTests extends ESTestCase {
+
+    private static class TrackingBreaker extends NoopCircuitBreaker {
+        private final AtomicLong net = new AtomicLong();
+        private final long limit;
+
+        TrackingBreaker() {
+            this(Long.MAX_VALUE);
+        }
+
+        TrackingBreaker(long limit) {
+            super(CircuitBreaker.REQUEST);
+            this.limit = limit;
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+            long projected = net.get() + bytes;
+            if (projected > limit) {
+                throw new CircuitBreakingException(
+                    "[" + label + "] tracking breaker tripped",
+                    bytes,
+                    limit,
+                    CircuitBreaker.Durability.TRANSIENT
+                );
+            }
+            net.addAndGet(bytes);
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            net.addAndGet(bytes);
+        }
+
+        @Override
+        public long getUsed() {
+            return net.get();
+        }
+    }
+
+    private static class FixedBytesContentDecoder implements ContentDecoder {
+        private int remainingBytes;
+        private boolean completed;
+
+        FixedBytesContentDecoder(int bytes) {
+            this.remainingBytes = bytes;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) {
+            if (remainingBytes == 0) {
+                completed = true;
+                return -1;
+            }
+            if (dst.hasRemaining() == false) {
+                return 0;
+            }
+            int bytes = Math.min(dst.remaining(), remainingBytes);
+            dst.position(dst.position() + bytes);
+            remainingBytes -= bytes;
+            return bytes;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return completed || remainingBytes == 0;
+        }
+    }
+
+    public void testKnownContentLengthReservationIsReleasedWhenEntityIsClosed() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 1024);
+
+        consumer.responseReceived(responseWithContentLength(512));
+        assertThat(breaker.getUsed(), equalTo(512L));
+        assertThat(consumer.currentReservation(), equalTo(512L));
+
+        consumer.responseCompleted(null);
+        assertThat("successful response remains buffered for the caller to parse", breaker.getUsed(), equalTo(512L));
+
+        HttpResponse result = consumer.getResult();
+        assertThat(result.getEntity(), instanceOf(Releasable.class));
+        ((Releasable) result.getEntity()).close();
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testChunkedResponseGrowthIsAccountedAndReleasedWhenEntityIsClosed() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 20_000);
+
+        consumer.responseReceived(responseWithContentLength(-1));
+        assertThat("unknown-length responses start with the REST client default initial buffer", breaker.getUsed(), equalTo(4096L));
+
+        consumer.consumeContent(new FixedBytesContentDecoder(10_000), null);
+        assertThat("buffer growth is accounted by current capacity", breaker.getUsed(), equalTo(16_390L));
+
+        consumer.responseCompleted(null);
+        ((Releasable) consumer.getResult().getEntity()).close();
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testBreakerTripDuringChunkedGrowthIsReleasedOnFailure() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker(10_000L);
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 20_000);
+
+        consumer.responseReceived(responseWithContentLength(-1));
+        assertThat(breaker.getUsed(), equalTo(4096L));
+
+        IOException thrown = expectThrows(IOException.class, () -> consumer.consumeContent(new FixedBytesContentDecoder(10_000), null));
+        assertThat(thrown.getCause(), instanceOf(CircuitBreakingException.class));
+        assertThat(thrown.getCause().getMessage(), containsString(REMOTE_RESPONSE_BUFFER_BREAKER_LABEL));
+
+        consumer.failed(thrown);
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testChunkedResponseIsCappedAtBufferLimit() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 8194);
+
+        consumer.responseReceived(responseWithContentLength(-1));
+        ContentTooLongException thrown = expectThrows(
+            ContentTooLongException.class,
+            () -> consumer.consumeContent(new FixedBytesContentDecoder(10_000), null)
+        );
+        assertThat(thrown.getMessage(), containsString("configured buffer limit [8194]"));
+
+        consumer.failed(thrown);
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testKnownContentLengthTooLongDoesNotReserveBytes() {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 1024);
+
+        expectThrows(ContentTooLongException.class, () -> consumer.responseReceived(responseWithContentLength(1025)));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testFailureBeforeResponseCompletionReleasesReservation() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 1024);
+
+        consumer.responseReceived(responseWithContentLength(512));
+        assertThat(breaker.getUsed(), equalTo(512L));
+
+        consumer.failed(new IOException("boom"));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testEntityCloseIsIdempotent() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 1024);
+
+        consumer.responseReceived(responseWithContentLength(512));
+        consumer.responseCompleted(null);
+        Releasable releasable = (Releasable) consumer.getResult().getEntity();
+
+        releasable.close();
+        releasable.close();
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testNoopBreakerDoesNotTrip() throws Exception {
+        CircuitBreaker noop = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(noop, 1024);
+
+        consumer.responseReceived(responseWithContentLength(1024));
+        assertThat(noop.getUsed(), equalTo(0L));
+        assertThat(consumer.currentReservation(), equalTo(1024L));
+
+        consumer.responseCompleted(null);
+        ((Releasable) consumer.getResult().getEntity()).close();
+        assertThat(consumer.currentReservation(), equalTo(0L));
+    }
+
+    public void testConstructorValidation() {
+        TrackingBreaker breaker = new TrackingBreaker();
+
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, -1));
+        expectThrows(NullPointerException.class, () -> new BreakerAwareHeapBufferedAsyncResponseConsumer(null, 1024));
+    }
+
+    private static BasicHttpResponse responseWithContentLength(long len) {
+        ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+        StatusLine statusLine = new BasicStatusLine(protocolVersion, 200, "OK");
+        BasicHttpResponse response = new BasicHttpResponse(statusLine);
+        response.setEntity(new StringEntity("", ContentType.APPLICATION_JSON) {
+            @Override
+            public long getContentLength() {
+                return len;
+            }
+        });
+        return response;
+    }
+}

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
@@ -13,6 +13,7 @@ import org.apache.http.ContentTooLongException;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
+import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHttpResponse;
@@ -116,6 +117,22 @@ public class BreakerAwareHeapBufferedAsyncResponseConsumerTests extends ESTestCa
         HttpResponse result = consumer.getResult();
         assertThat(result.getEntity(), instanceOf(Releasable.class));
         ((Releasable) result.getEntity()).close();
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testBufferingNonRepeatableEntityReleasesReservation() throws Exception {
+        TrackingBreaker breaker = new TrackingBreaker();
+        BreakerAwareHeapBufferedAsyncResponseConsumer consumer = new BreakerAwareHeapBufferedAsyncResponseConsumer(breaker, 1024);
+
+        consumer.responseReceived(responseWithContentLength(512));
+        consumer.consumeContent(new FixedBytesContentDecoder(512), null);
+        consumer.responseCompleted(null);
+
+        HttpResponse result = consumer.getResult();
+        assertThat(breaker.getUsed(), equalTo(512L));
+
+        BufferedHttpEntity buffered = new BufferedHttpEntity(result.getEntity());
+        assertThat(buffered.getContentLength(), equalTo(512L));
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/BreakerAwareHeapBufferedAsyncResponseConsumerTests.java
@@ -158,7 +158,7 @@ public class BreakerAwareHeapBufferedAsyncResponseConsumerTests extends ESTestCa
             ContentTooLongException.class,
             () -> consumer.consumeContent(new FixedBytesContentDecoder(10_000), null)
         );
-        assertThat(thrown.getMessage(), containsString("configured buffer limit [8194]"));
+        assertThat(thrown.getMessage(), containsString("response buffer exceeded limit [8194] bytes"));
 
         consumer.failed(thrown);
         assertThat(breaker.getUsed(), equalTo(0L));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSourceTests.java
@@ -27,7 +27,6 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.HeapBufferedAsyncResponseConsumer;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.ParsingException;
@@ -511,7 +510,8 @@ public class RemotePitPaginatedHitSourceTests extends ESTestCase {
                 any(FutureCallback.class)
             )
         ).then((Answer<Future<HttpResponse>>) invocationOnMock -> {
-            HeapBufferedAsyncResponseConsumer consumer = (HeapBufferedAsyncResponseConsumer) invocationOnMock.getArguments()[1];
+            BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) invocationOnMock
+                .getArguments()[1];
             FutureCallback callback = (FutureCallback) invocationOnMock.getArguments()[3];
             assertEquals(ByteSizeValue.of(100, ByteSizeUnit.MB).bytesAsInt(), consumer.getBufferLimit());
             callback.failed(tooLong);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteReindexingUtilsTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteReindexingUtilsTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.RejectAwareActionListener;
@@ -80,6 +81,23 @@ public class RemoteReindexingUtilsTests extends ESTestCase {
             t = t.getCause();
         }
         return sb.toString();
+    }
+
+    private static class ReleasableStringEntity extends StringEntity implements Releasable {
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        ReleasableStringEntity(String string, ContentType contentType) {
+            super(string, contentType);
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+
+        boolean isClosed() {
+            return closed.get();
+        }
     }
 
     private ThreadPool threadPool;
@@ -837,6 +855,58 @@ public class RemoteReindexingUtilsTests extends ESTestCase {
             1024L
         );
         assertTrue("onFailure should have been called", failed.get());
+    }
+
+    public void testExecuteInstallsBreakerAwareConsumerFactoryAndClosesResponseEntityOnSuccess() {
+        ReleasableStringEntity entity = new ReleasableStringEntity("{\"version\":{\"number\":\"1.7.5\"}}", ContentType.APPLICATION_JSON);
+        Response response = mock(Response.class);
+        when(response.getEntity()).thenReturn(entity);
+        mockSuccess(response);
+
+        AtomicBoolean success = new AtomicBoolean(false);
+        RemoteReindexingUtils.lookupRemoteVersion(
+            RejectAwareActionListener.wrap(v -> success.set(true), e -> fail("unexpected failure"), e -> fail("unexpected rejection")),
+            threadPool,
+            client,
+            new NoopCircuitBreaker(CircuitBreaker.REQUEST),
+            1024L
+        );
+
+        assertTrue("listener should have received success", success.get());
+        assertTrue("response entity should have been closed after parsing", entity.isClosed());
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(client).performRequestAsync(requestCaptor.capture(), any());
+        assertTrue(
+            requestCaptor.getValue()
+                .getOptions()
+                .getHttpAsyncResponseConsumerFactory()
+                .createHttpAsyncResponseConsumer() instanceof BreakerAwareHeapBufferedAsyncResponseConsumer
+        );
+    }
+
+    public void testExecuteClosesResponseEntityOnHttpError() throws Exception {
+        ReleasableStringEntity entity = new ReleasableStringEntity("bad request", ContentType.TEXT_PLAIN);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(RestStatus.BAD_REQUEST.getStatus());
+        Response response = mock(Response.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(response.getEntity()).thenReturn(entity);
+        RequestLine requestLine = mock(RequestLine.class);
+        when(requestLine.getMethod()).thenReturn("GET");
+        when(response.getRequestLine()).thenReturn(requestLine);
+        mockFailure(new ResponseException(response));
+
+        AtomicBoolean failed = new AtomicBoolean(false);
+        RemoteReindexingUtils.lookupRemoteVersion(
+            RejectAwareActionListener.wrap(v -> fail("unexpected success"), e -> failed.set(true), e -> fail("unexpected rejection")),
+            threadPool,
+            client,
+            new NoopCircuitBreaker(CircuitBreaker.REQUEST),
+            1024L
+        );
+
+        assertTrue("listener should have received failure", failed.get());
+        assertTrue("response entity should have been closed after error extraction", entity.isClosed());
     }
 
     private Response successResponse(String resource) throws Exception {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
@@ -27,7 +27,6 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.HeapBufferedAsyncResponseConsumer;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.BackoffPolicy;
@@ -385,7 +384,8 @@ public class RemoteScrollablePaginatedHitSourceTests extends ESTestCase {
         ).then(new Answer<Future<HttpResponse>>() {
             @Override
             public Future<HttpResponse> answer(InvocationOnMock invocationOnMock) {
-                HeapBufferedAsyncResponseConsumer consumer = (HeapBufferedAsyncResponseConsumer) invocationOnMock.getArguments()[1];
+                BreakerAwareHeapBufferedAsyncResponseConsumer consumer = (BreakerAwareHeapBufferedAsyncResponseConsumer) invocationOnMock
+                    .getArguments()[1];
                 FutureCallback callback = (FutureCallback) invocationOnMock.getArguments()[3];
                 assertEquals(ByteSizeValue.of(100, ByteSizeUnit.MB).bytesAsInt(), consumer.getBufferLimit());
                 callback.failed(tooLong);


### PR DESCRIPTION
## Summary
- account Apache HTTP response buffer allocations for reindex-from-remote against the REQUEST breaker
- cover both known Content-Length responses and chunked/unknown-length SimpleInputBuffer growth
- release the reservation after RemoteReindexingUtils consumes the buffered entity, and unwrap breaker failures from async HTTP callbacks

## Testing
- ./gradlew :modules:reindex:spotlessJavaCheck
- ./gradlew :modules:reindex:test --tests org.elasticsearch.reindex.remote.BreakerAwareConsumerFactoryTests --tests org.elasticsearch.reindex.remote.BreakerAwareHeapBufferedAsyncResponseConsumerTests --tests org.elasticsearch.reindex.remote.RemoteReindexingUtilsTests --tests org.elasticsearch.reindex.remote.RemoteScrollablePaginatedHitSourceTests.testTooLargeResponse --tests org.elasticsearch.reindex.remote.RemotePitPaginatedHitSourceTests.testTooLargeResponse

Relates #148916