### PR TITLE
feat(tsdb): run-length ordinal encoding for ES95

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/OrdinalBlockStrategy.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/OrdinalBlockStrategy.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * One strategy for encoding a block of sorted-field ordinals. Each strategy reports the exact size it
+ * would occupy for a block, so {@link RunLengthOrdinalEncoder} can pick the smallest without
+ * trial-encoding any candidate. The winner writes a header whose number of trailing one bits identifies
+ * it (single-run 0, run-length 1, cyclic 2, two-run 3, bit-packing 4), and {@link RunLengthOrdinalDecoder}
+ * dispatches back to it by that tag. Shorter tags go to the strategies whose header payload is small and
+ * common, so they stay one byte; bit-packing carries none, so it takes the longest tag.
+ * <p>
+ * Implementations are stateless singletons; the per-encoder {@link DocValuesForUtil} is passed in rather
+ * than held so a single instance can be reused across encoders and block sizes.
+ */
+sealed interface OrdinalBlockStrategy {
+
+    /** Returned by {@link #encodedSize} when a strategy cannot encode the block. */
+    long NOT_APPLICABLE = Long.MAX_VALUE;
+
+    /**
+     * Computes the exact number of bytes this strategy would write for the block, without encoding it.
+     *
+     * @param stats      the run structure of the block
+     * @param bitsPerOrd bits required to represent the largest ordinal in the block
+     * @param blockSize  number of ordinals in the block
+     * @return the byte size, or {@link #NOT_APPLICABLE} if this strategy cannot encode the block
+     */
+    long encodedSize(Stats stats, int bitsPerOrd, int blockSize);
+
+    /**
+     * Writes the block, including its strategy header, to {@code out}.
+     *
+     * @param values     the ordinals to encode
+     * @param stats      the run structure of the block
+     * @param bitsPerOrd bits required to represent the largest ordinal in the block
+     * @param forUtil    bit-packing helper, used only by {@link BitPacked}
+     * @param out        the output to write to
+     * @throws IOException if writing to {@code out} fails
+     */
+    void encode(long[] values, Stats stats, int bitsPerOrd, DocValuesForUtil forUtil, DataOutput out) throws IOException;
+
+    /**
+     * Reads a block previously written by {@link #encode} into {@code out}.
+     *
+     * @param headerPayload the block header with its trailing strategy bits already removed
+     * @param bitsPerOrd    bits required to represent the largest ordinal in the block
+     * @param in            the input positioned immediately after the header
+     * @param out           the array to fill with decoded ordinals
+     * @param forUtil       bit-packing helper, used only by {@link BitPacked}
+     * @throws IOException if reading from {@code in} fails
+     */
+    void decode(long headerPayload, int bitsPerOrd, DataInput in, long[] out, DocValuesForUtil forUtil) throws IOException;
+
+    /**
+     * Run and cycle structure of a block, computed once and shared across strategies to size them.
+     *
+     * @param runCount        number of runs of equal consecutive ordinals
+     * @param firstRunLength  length of the first run
+     * @param firstValue      ordinal of the first run
+     * @param lastValue       ordinal of the last run
+     * @param runBodyBytes    bytes the run-length body (every run's value and length) would occupy
+     * @param cyclicPeriod    smallest period that tiles the block, or {@code 0} if it is not cyclic
+     * @param cyclicBodyBytes bytes the {@code cyclicPeriod} cycle values would occupy
+     */
+    record Stats(
+        int runCount,
+        int firstRunLength,
+        long firstValue,
+        long lastValue,
+        long runBodyBytes,
+        int cyclicPeriod,
+        long cyclicBodyBytes
+    ) {
+
+        /**
+         * Scans a block once to compute its {@link Stats}, including a candidate cycle period that is
+         * then verified to tile the block. A repeated multi-valued set produces a cyclic block, so this
+         * is the multi-valued analog of a run.
+         *
+         * @param values the ordinals to analyze
+         * @return the run and cycle structure of {@code values}
+         */
+        static Stats of(final long[] values) {
+            final int length = values.length;
+            final long firstValue = values[0];
+
+            long constantCheck = 0;
+            for (int i = 1; i < length; i++) {
+                constantCheck |= values[i] ^ firstValue;
+            }
+            if (constantCheck == 0) {
+                return new Stats(1, length, firstValue, firstValue, zLongBytes(firstValue) + vIntBytes(length), 0, 0);
+            }
+
+            int runCount = 1;
+            int firstRunLength = length;
+            long runBodyBytes = 0;
+            long runValue = firstValue;
+            int runStart = 0;
+            long previousRunValue = 0;
+            int cycleCandidate = 0;
+            for (int i = 1; i <= length; i++) {
+                if (i == length || values[i] != runValue) {
+                    if (runStart == 0) {
+                        firstRunLength = i - runStart;
+                    }
+                    runBodyBytes += zLongBytes(runValue - previousRunValue) + vIntBytes(i - runStart);
+                    previousRunValue = runValue;
+                    if (i < length) {
+                        runCount++;
+                        runValue = values[i];
+                        runStart = i;
+                    }
+                }
+                if (cycleCandidate != -1 && i < length && values[i] == firstValue) {
+                    if (cycleCandidate == 0) {
+                        cycleCandidate = i;
+                    } else if (cycleCandidate == 1 || i % cycleCandidate != 0) {
+                        cycleCandidate = -1;
+                    }
+                }
+            }
+
+            int cyclicPeriod = 0;
+            long cyclicBodyBytes = 0;
+            if (cycleCandidate > 1 && tiles(values, cycleCandidate)) {
+                cyclicPeriod = cycleCandidate;
+                for (int i = 0; i < cycleCandidate; i++) {
+                    cyclicBodyBytes += vLongBytes(values[i]);
+                }
+            }
+            return new Stats(runCount, firstRunLength, firstValue, values[length - 1], runBodyBytes, cyclicPeriod, cyclicBodyBytes);
+        }
+
+        private static boolean tiles(final long[] values, int period) {
+            for (int i = period; i < values.length; i++) {
+                if (values[i] != values[i - period]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /** Single run: the whole block is one value. Header is {@code value << 1} (zero trailing ones). */
+    final class SingleRun implements OrdinalBlockStrategy {
+
+        static final SingleRun INSTANCE = new SingleRun();
+
+        private SingleRun() {}
+
+        @Override
+        public long encodedSize(final Stats stats, int bitsPerOrd, int blockSize) {
+            if (stats.runCount() != 1 || bitsPerOrd >= 63) {
+                return NOT_APPLICABLE;
+            }
+            return vLongBytes(stats.firstValue() << 1);
+        }
+
+        @Override
+        public void encode(final long[] values, final Stats stats, int bitsPerOrd, final DocValuesForUtil forUtil, final DataOutput out)
+            throws IOException {
+            out.writeVLong(stats.firstValue() << 1);
+        }
+
+        @Override
+        public void decode(long headerPayload, int bitsPerOrd, final DataInput in, final long[] out, final DocValuesForUtil forUtil) {
+            Arrays.fill(out, headerPayload);
+        }
+    }
+
+    /** Two runs: a first run of one value then a second run of another. Header sets three trailing ones. */
+    final class TwoRun implements OrdinalBlockStrategy {
+
+        static final TwoRun INSTANCE = new TwoRun();
+
+        private TwoRun() {}
+
+        @Override
+        public long encodedSize(final Stats stats, int bitsPerOrd, int blockSize) {
+            if (stats.runCount() != 2 || bitsPerOrd >= 60) {
+                return NOT_APPLICABLE;
+            }
+            return vLongBytes((stats.firstValue() << 4) | 0b0111) + vIntBytes(stats.firstRunLength()) + zLongBytes(
+                stats.lastValue() - stats.firstValue()
+            );
+        }
+
+        @Override
+        public void encode(final long[] values, final Stats stats, int bitsPerOrd, final DocValuesForUtil forUtil, final DataOutput out)
+            throws IOException {
+            out.writeVLong((stats.firstValue() << 4) | 0b0111);
+            out.writeVInt(stats.firstRunLength());
+            out.writeZLong(stats.lastValue() - stats.firstValue());
+        }
+
+        @Override
+        public void decode(long headerPayload, int bitsPerOrd, final DataInput in, final long[] out, final DocValuesForUtil forUtil)
+            throws IOException {
+            final int firstRunLength = in.readVInt();
+            final long secondValue = headerPayload + in.readZLong();
+            Arrays.fill(out, 0, firstRunLength, headerPayload);
+            Arrays.fill(out, firstRunLength, out.length, secondValue);
+        }
+    }
+
+    /** Bit-packing: the always-applicable fallback for high-entropy blocks. Sets four trailing ones. */
+    final class BitPacked implements OrdinalBlockStrategy {
+
+        static final BitPacked INSTANCE = new BitPacked();
+
+        private BitPacked() {}
+
+        @Override
+        public long encodedSize(final Stats stats, int bitsPerOrd, int blockSize) {
+            return 1 + (long) blockSize * bitsPerOrd / 8;
+        }
+
+        @Override
+        public void encode(final long[] values, final Stats stats, int bitsPerOrd, final DocValuesForUtil forUtil, final DataOutput out)
+            throws IOException {
+            out.writeVLong(0b01111);
+            forUtil.encode(values, bitsPerOrd, out);
+        }
+
+        @Override
+        public void decode(long headerPayload, int bitsPerOrd, final DataInput in, final long[] out, final DocValuesForUtil forUtil)
+            throws IOException {
+            forUtil.decode(bitsPerOrd, in, out);
+        }
+    }
+
+    /** Run-length: header carries the run count, then each run is a zigzag delta value and a length. */
+    final class RunLength implements OrdinalBlockStrategy {
+
+        static final RunLength INSTANCE = new RunLength();
+
+        private RunLength() {}
+
+        @Override
+        public long encodedSize(final Stats stats, int bitsPerOrd, int blockSize) {
+            return vLongBytes(((long) stats.runCount() << 2) | 0b01) + stats.runBodyBytes();
+        }
+
+        @Override
+        public void encode(final long[] values, final Stats stats, int bitsPerOrd, final DocValuesForUtil forUtil, final DataOutput out)
+            throws IOException {
+            out.writeVLong(((long) stats.runCount() << 2) | 0b01);
+            long previousValue = 0;
+            int i = 0;
+            while (i < values.length) {
+                final long value = values[i];
+                int next = i + 1;
+                while (next < values.length && values[next] == value) {
+                    next++;
+                }
+                out.writeZLong(value - previousValue);
+                out.writeVInt(next - i);
+                previousValue = value;
+                i = next;
+            }
+        }
+
+        @Override
+        public void decode(long headerPayload, int bitsPerOrd, final DataInput in, final long[] out, final DocValuesForUtil forUtil)
+            throws IOException {
+            final int runCount = (int) headerPayload;
+            long value = 0;
+            int position = 0;
+            for (int run = 0; run < runCount; run++) {
+                value += in.readZLong();
+                final int runLength = in.readVInt();
+                Arrays.fill(out, position, position + runLength, value);
+                position += runLength;
+            }
+            assert position == out.length : position;
+        }
+    }
+
+    /** Cyclic: the block tiles a short repeating set of values, as a repeated multi-valued set does. */
+    final class Cyclic implements OrdinalBlockStrategy {
+
+        static final Cyclic INSTANCE = new Cyclic();
+
+        private Cyclic() {}
+
+        @Override
+        public long encodedSize(final Stats stats, int bitsPerOrd, int blockSize) {
+            if (stats.cyclicPeriod() == 0) {
+                return NOT_APPLICABLE;
+            }
+            return vLongBytes(((long) stats.cyclicPeriod() << 3) | 0b011) + stats.cyclicBodyBytes();
+        }
+
+        @Override
+        public void encode(final long[] values, final Stats stats, int bitsPerOrd, final DocValuesForUtil forUtil, final DataOutput out)
+            throws IOException {
+            final int period = stats.cyclicPeriod();
+            out.writeVLong(((long) period << 3) | 0b011);
+            for (int i = 0; i < period; i++) {
+                out.writeVLong(values[i]);
+            }
+        }
+
+        @Override
+        public void decode(long headerPayload, int bitsPerOrd, final DataInput in, final long[] out, final DocValuesForUtil forUtil)
+            throws IOException {
+            final int period = (int) headerPayload;
+            for (int i = 0; i < period; i++) {
+                out[i] = in.readVLong();
+            }
+            int length = period;
+            while (length < out.length) {
+                final int copyLength = Math.min(length, out.length - length);
+                System.arraycopy(out, 0, out, length, copyLength);
+                length += copyLength;
+            }
+        }
+    }
+
+    static int vLongBytes(long value) {
+        int bytes = 1;
+        while ((value & ~0x7FL) != 0L) {
+            value >>>= 7;
+            bytes++;
+        }
+        return bytes;
+    }
+
+    static int zLongBytes(long value) {
+        return vLongBytes((value << 1) ^ (value >> 63));
+    }
+
+    static int vIntBytes(int value) {
+        int bytes = 1;
+        while ((value & ~0x7F) != 0) {
+            value >>>= 7;
+            bytes++;
+        }
+        return bytes;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/RunLengthOrdinalDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/RunLengthOrdinalDecoder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.DataInput;
+
+import java.io.IOException;
+
+/**
+ * Decodes a block written by {@link RunLengthOrdinalEncoder}, dispatching to the
+ * {@link OrdinalBlockStrategy} named by the header's trailing one bits.
+ * <p>
+ * This is injected into the ES95 ordinal reader for segments at the run-length format version or later;
+ * older ES95 segments are decoded with the legacy four-strategy decoder on {@link TSDBDocValuesEncoder}.
+ */
+public final class RunLengthOrdinalDecoder {
+
+    private final DocValuesForUtil forUtil;
+    private final int blockSize;
+
+    public RunLengthOrdinalDecoder(int blockSize) {
+        this.forUtil = new DocValuesForUtil(blockSize);
+        this.blockSize = blockSize;
+    }
+
+    /**
+     * Decodes a block written by {@link RunLengthOrdinalEncoder#encode}.
+     *
+     * @param in         the input positioned at the start of the block
+     * @param out        the array to fill with decoded ordinals
+     * @param bitsPerOrd bits required to represent the largest ordinal in the block
+     * @throws IOException if reading from {@code in} fails
+     */
+    public void decode(DataInput in, long[] out, int bitsPerOrd) throws IOException {
+        assert out.length == blockSize : out.length;
+        final long header = in.readVLong();
+        final int encoding = Long.numberOfTrailingZeros(~header);
+        final long payload = header >>> (encoding + 1);
+        // NOTE: switch on the concrete strategy instead of a shared call: with five implementations a
+        // single virtual call site is megamorphic, while each switch arm is monomorphic and inlinable.
+        switch (encoding) {
+            case 0 -> OrdinalBlockStrategy.SingleRun.INSTANCE.decode(payload, bitsPerOrd, in, out, forUtil);
+            case 1 -> OrdinalBlockStrategy.RunLength.INSTANCE.decode(payload, bitsPerOrd, in, out, forUtil);
+            case 2 -> OrdinalBlockStrategy.Cyclic.INSTANCE.decode(payload, bitsPerOrd, in, out, forUtil);
+            case 3 -> OrdinalBlockStrategy.TwoRun.INSTANCE.decode(payload, bitsPerOrd, in, out, forUtil);
+            case 4 -> OrdinalBlockStrategy.BitPacked.INSTANCE.decode(payload, bitsPerOrd, in, out, forUtil);
+            default -> throw new IllegalStateException("unexpected ordinal encoding " + encoding);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/RunLengthOrdinalEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/RunLengthOrdinalEncoder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.DataOutput;
+
+import java.io.IOException;
+
+/**
+ * Encodes a block of ES95 ordinals with the smallest {@link OrdinalBlockStrategy} chosen by exact byte
+ * size, writing a header whose trailing one bits tag the chosen strategy, which
+ * {@link RunLengthOrdinalDecoder} reads back.
+ * <p>
+ * This is injected into the ES95 ordinal writer in place of the legacy four-strategy encoding on
+ * {@link TSDBDocValuesEncoder}, which stays the default for ES87 and ES819.
+ */
+public final class RunLengthOrdinalEncoder {
+
+    private final DocValuesForUtil forUtil;
+    private final int blockSize;
+
+    public RunLengthOrdinalEncoder(int blockSize) {
+        this.forUtil = new DocValuesForUtil(blockSize);
+        this.blockSize = blockSize;
+    }
+
+    /**
+     * Encodes a block of ordinals with the smallest applicable strategy.
+     *
+     * @param in         the block of ordinals to encode
+     * @param out        the output to write the encoded block to
+     * @param bitsPerOrd bits required to represent the largest ordinal in the block
+     * @throws IOException if writing to {@code out} fails
+     */
+    public void encode(long[] in, DataOutput out, int bitsPerOrd) throws IOException {
+        assert in.length == blockSize;
+        final OrdinalBlockStrategy.Stats stats = OrdinalBlockStrategy.Stats.of(in);
+        final long singleRun = OrdinalBlockStrategy.SingleRun.INSTANCE.encodedSize(stats, bitsPerOrd, blockSize);
+        final long runLength = OrdinalBlockStrategy.RunLength.INSTANCE.encodedSize(stats, bitsPerOrd, blockSize);
+        final long cyclic = OrdinalBlockStrategy.Cyclic.INSTANCE.encodedSize(stats, bitsPerOrd, blockSize);
+        final long twoRun = OrdinalBlockStrategy.TwoRun.INSTANCE.encodedSize(stats, bitsPerOrd, blockSize);
+        final long bitPacked = OrdinalBlockStrategy.BitPacked.INSTANCE.encodedSize(stats, bitsPerOrd, blockSize);
+
+        int best = 0;
+        long bestBytes = singleRun;
+        if (runLength < bestBytes) {
+            best = 1;
+            bestBytes = runLength;
+        }
+        if (cyclic < bestBytes) {
+            best = 2;
+            bestBytes = cyclic;
+        }
+        if (twoRun < bestBytes) {
+            best = 3;
+            bestBytes = twoRun;
+        }
+        if (bitPacked < bestBytes) {
+            best = 4;
+        }
+
+        // NOTE: switch on the concrete strategy instead of a shared call: with five implementations a
+        // single virtual call site is megamorphic, while each switch arm is monomorphic and inlinable.
+        switch (best) {
+            case 0 -> OrdinalBlockStrategy.SingleRun.INSTANCE.encode(in, stats, bitsPerOrd, forUtil, out);
+            case 1 -> OrdinalBlockStrategy.RunLength.INSTANCE.encode(in, stats, bitsPerOrd, forUtil, out);
+            case 2 -> OrdinalBlockStrategy.Cyclic.INSTANCE.encode(in, stats, bitsPerOrd, forUtil, out);
+            case 3 -> OrdinalBlockStrategy.TwoRun.INSTANCE.encode(in, stats, bitsPerOrd, forUtil, out);
+            case 4 -> OrdinalBlockStrategy.BitPacked.INSTANCE.encode(in, stats, bitsPerOrd, forUtil, out);
+            default -> throw new AssertionError(best);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
@@ -141,5 +141,6 @@ public record TSDBDocValuesFormatConfig(
     public static final int VERSION_PREFIX_PARTITIONS = 4;
     public static final int VERSION_SEPARATE_SKIPLIST = 5;
     public static final int VERSION_ORDINAL_BLOCK_SHIFT = 6;
-    public static final int VERSION_CURRENT = VERSION_ORDINAL_BLOCK_SHIFT;
+    public static final int VERSION_ORDINAL_RUN_LENGTH = 7;
+    public static final int VERSION_CURRENT = VERSION_ORDINAL_RUN_LENGTH;
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldReader.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.codec.tsdb.es95;
 import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesProducer.NumericEntry;
 import org.elasticsearch.index.codec.tsdb.OrdinalFieldReader;
+import org.elasticsearch.index.codec.tsdb.RunLengthOrdinalDecoder;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesBlockReader;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
@@ -25,8 +26,12 @@ import java.io.IOException;
  * {@link #readFieldEntry} reads the per-field {@code blockShift} byte written by
  * {@link ES95OrdinalFieldWriter} and sets {@link NumericEntry#blockSize} from it.
  * For older segments (written before this version), no extra byte is present in the metadata,
- * so the format-level default {@code numericBlockShift} is used instead — preserving backward
+ * so the format-level default {@code numericBlockShift} is used instead, preserving backward
  * compatibility with segments written by earlier binaries.
+ *
+ * <p>For segments at {@link TSDBDocValuesFormatConfig#VERSION_ORDINAL_RUN_LENGTH} or later,
+ * {@link #decoder} returns the run-length decoder; older segments are decoded with the previous
+ * four-strategy ordinal decoder, so segments written by earlier binaries still decode correctly.
  */
 final class ES95OrdinalFieldReader implements OrdinalFieldReader {
 
@@ -52,7 +57,9 @@ final class ES95OrdinalFieldReader implements OrdinalFieldReader {
 
     @Override
     public Decoder decoder(final int blockSize) {
-        final TSDBDocValuesEncoder encoder = new TSDBDocValuesEncoder(blockSize);
-        return encoder::decodeOrdinals;
+        if (segmentVersion >= TSDBDocValuesFormatConfig.VERSION_ORDINAL_RUN_LENGTH) {
+            return new RunLengthOrdinalDecoder(blockSize)::decode;
+        }
+        return new TSDBDocValuesEncoder(blockSize)::decodeOrdinals;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldWriter.java
@@ -16,9 +16,9 @@ import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesConsumer;
 import org.elasticsearch.index.codec.tsdb.DocValueFieldCountStats;
 import org.elasticsearch.index.codec.tsdb.NumericWriteContext;
 import org.elasticsearch.index.codec.tsdb.OrdinalFieldWriter;
+import org.elasticsearch.index.codec.tsdb.RunLengthOrdinalEncoder;
 import org.elasticsearch.index.codec.tsdb.SortedFieldObserver;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesBlockWriter;
-import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
 import org.elasticsearch.index.codec.tsdb.TsdbDocValuesProducer;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContext;
 import org.elasticsearch.index.codec.tsdb.pipeline.FieldContextResolver;
@@ -56,8 +56,8 @@ final class ES95OrdinalFieldWriter implements OrdinalFieldWriter {
 
     @Override
     public Encoder encoder() {
-        final TSDBDocValuesEncoder enc = new TSDBDocValuesEncoder(ctx.blockSize());
-        return enc::encodeOrdinals;
+        final RunLengthOrdinalEncoder encoder = new RunLengthOrdinalEncoder(ctx.blockSize());
+        return encoder::encode;
     }
 
     @Override
@@ -72,7 +72,7 @@ final class ES95OrdinalFieldWriter implements OrdinalFieldWriter {
         final int blockSize = resolver.resolve(context).blockSize();
         final int blockShift = Integer.numberOfTrailingZeros(blockSize);
         final int bitsPerOrd = PackedInts.bitsRequired(Math.max(maxOrd - 1, 0));
-        final TSDBDocValuesEncoder encoder = new TSDBDocValuesEncoder(blockSize);
+        final RunLengthOrdinalEncoder encoder = new RunLengthOrdinalEncoder(blockSize);
         return BLOCK_WRITER.writeFieldEntry(
             ctx,
             field,
@@ -80,7 +80,7 @@ final class ES95OrdinalFieldWriter implements OrdinalFieldWriter {
             maxOrd,
             docValueCountConsumer,
             sortedFieldObserver,
-            (buffer, data) -> encoder.encodeOrdinals(buffer, data, bitsPerOrd),
+            (buffer, data) -> encoder.encode(buffer, data, bitsPerOrd),
             () -> ctx.meta().writeByte((byte) blockShift),
             blockSize
         );

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/OrdinalBlockStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/OrdinalBlockStrategyTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1";
+ */
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.index.codec.tsdb.OrdinalBlockStrategy.Stats;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class OrdinalBlockStrategyTests extends ESTestCase {
+
+    private static final int BLOCK_SIZE = 128;
+
+    private final DocValuesForUtil forUtil = new DocValuesForUtil(BLOCK_SIZE);
+
+    public void testSingleRunRoundTrips() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.fill(block, 63);
+        assertRoundTrips(OrdinalBlockStrategy.SingleRun.INSTANCE, block);
+    }
+
+    public void testSingleRunNotApplicableForTwoRuns() {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.fill(block, 5);
+        block[0] = 1;
+        assertEquals(OrdinalBlockStrategy.NOT_APPLICABLE, encodedSize(OrdinalBlockStrategy.SingleRun.INSTANCE, block));
+    }
+
+    public void testTwoRunRoundTrips() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.fill(block, 7);
+        block[0] = 3;
+        assertRoundTrips(OrdinalBlockStrategy.TwoRun.INSTANCE, block);
+    }
+
+    public void testTwoRunNotApplicableForSingleRun() {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.fill(block, 9);
+        assertEquals(OrdinalBlockStrategy.NOT_APPLICABLE, encodedSize(OrdinalBlockStrategy.TwoRun.INSTANCE, block));
+    }
+
+    public void testBitPackedRoundTrips() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            block[i] = i;
+        }
+        assertRoundTrips(OrdinalBlockStrategy.BitPacked.INSTANCE, block);
+    }
+
+    public void testRunLengthRoundTrips() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        final int runLength = BLOCK_SIZE / 4;
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            block[i] = i / runLength;
+        }
+        assertRoundTrips(OrdinalBlockStrategy.RunLength.INSTANCE, block);
+    }
+
+    public void testCyclicRoundTrips() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        final long[] set = { 100, 200, 300, 400, 480 };
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            block[i] = set[i % set.length];
+        }
+        assertRoundTrips(OrdinalBlockStrategy.Cyclic.INSTANCE, block);
+    }
+
+    public void testCyclicNotApplicableForRunBased() {
+        final long[] block = new long[BLOCK_SIZE];
+        final int runLength = BLOCK_SIZE / 4;
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            block[i] = i / runLength;
+        }
+        assertEquals(OrdinalBlockStrategy.NOT_APPLICABLE, encodedSize(OrdinalBlockStrategy.Cyclic.INSTANCE, block));
+    }
+
+    public void testRunLengthRoundTripsWithDecreasingRuns() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        final int runLength = BLOCK_SIZE / 4;
+        Arrays.fill(block, 0, runLength, 100);
+        Arrays.fill(block, runLength, 2 * runLength, 60);
+        Arrays.fill(block, 2 * runLength, 3 * runLength, 30);
+        Arrays.fill(block, 3 * runLength, BLOCK_SIZE, 10);
+        assertRoundTrips(OrdinalBlockStrategy.RunLength.INSTANCE, block);
+    }
+
+    private void assertRoundTrips(OrdinalBlockStrategy strategy, long[] block) throws IOException {
+        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd(block));
+        final Stats stats = Stats.of(block);
+        final long expectedSize = strategy.encodedSize(stats, bitsPerOrd, BLOCK_SIZE);
+        assertNotEquals("strategy should apply to this block", OrdinalBlockStrategy.NOT_APPLICABLE, expectedSize);
+
+        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        strategy.encode(block.clone(), stats, bitsPerOrd, forUtil, out);
+        assertEquals("encodedSize matches encoded length", expectedSize, out.size());
+
+        final DataInput in = out.toDataInput();
+        final long header = in.readVLong();
+        final int encoding = Long.numberOfTrailingZeros(~header);
+        final long[] decoded = new long[BLOCK_SIZE];
+        strategy.decode(header >>> (encoding + 1), bitsPerOrd, in, decoded, forUtil);
+        assertArrayEquals(block, decoded);
+    }
+
+    private long encodedSize(OrdinalBlockStrategy strategy, long[] block) {
+        return strategy.encodedSize(Stats.of(block), PackedInts.bitsRequired(maxOrd(block)), BLOCK_SIZE);
+    }
+
+    private static long maxOrd(long[] block) {
+        long max = 0;
+        for (long value : block) {
+            max = Math.max(max, value);
+        }
+        return max;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/OrdinalEncodingSizeComparisonTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/OrdinalEncodingSizeComparisonTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class OrdinalEncodingSizeComparisonTests extends ESTestCase {
+
+    private static final int BLOCK_SIZE = ES87TSDBDocValuesFormat.NUMERIC_BLOCK_SIZE;
+
+    private final RunLengthOrdinalEncoder encoder = new RunLengthOrdinalEncoder(BLOCK_SIZE);
+    private final TSDBDocValuesEncoder fourStrategyEncoder = new TSDBDocValuesEncoder(BLOCK_SIZE);
+
+    public void testFourRunsBeatsFourStrategy() throws IOException {
+        final long[] block = runs(new long[] { 10, 20, 30, 40 });
+        assertEncodedBytes(block, 9, 97);
+    }
+
+    public void testEightRunsBeatsFourStrategy() throws IOException {
+        final long[] block = runs(new long[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+        assertEncodedBytes(block, 17, 49);
+    }
+
+    public void testAllDistinctMatchesFourStrategy() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            block[i] = i;
+        }
+        final long bitPacked = 1 + (long) BLOCK_SIZE * PackedInts.bitsRequired(BLOCK_SIZE - 1) / 8;
+        assertEncodedBytes(block, bitPacked, bitPacked);
+    }
+
+    public void testSingleRunMatchesFourStrategy() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.fill(block, 63);
+        assertEncodedBytes(block, 1, 1);
+    }
+
+    public void testTwoRunMatchesFourStrategy() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.fill(block, 7);
+        block[0] = 3;
+        assertEncodedBytes(block, 3, 3);
+    }
+
+    public void testCyclicInterleaveMatchesFourStrategy() throws IOException {
+        final long[] block = new long[BLOCK_SIZE];
+        Arrays.setAll(block, i -> i % 4);
+        assertEncodedBytes(block, 5, 5);
+    }
+
+    public void testMultiValueSetMatchesFourStrategy() throws IOException {
+        final long[] set = { 100, 200, 300, 400, 480 };
+        final long[] block = new long[BLOCK_SIZE];
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            block[i] = set[i % set.length];
+        }
+        assertEncodedBytes(block, 10, 10);
+    }
+
+    private void assertEncodedBytes(long[] block, long expectedRunLengthBytes, long expectedFourStrategyBytes) throws IOException {
+        assertEquals("run-length bytes", expectedRunLengthBytes, encodedBytes(block, true));
+        assertEquals("four-strategy bytes", expectedFourStrategyBytes, encodedBytes(block, false));
+    }
+
+    private long encodedBytes(long[] block, boolean runLength) throws IOException {
+        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd(block));
+        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        // clone: the bit-packed branch mutates its input through `forUtil`
+        if (runLength) {
+            encoder.encode(block.clone(), out, bitsPerOrd);
+        } else {
+            fourStrategyEncoder.encodeOrdinals(block.clone(), out, bitsPerOrd);
+        }
+        return out.size();
+    }
+
+    private static long[] runs(long[] values) {
+        final long[] block = new long[BLOCK_SIZE];
+        final int runLength = BLOCK_SIZE / values.length;
+        for (int i = 0; i < values.length; i++) {
+            Arrays.fill(block, i * runLength, (i + 1) * runLength, values[i]);
+        }
+        return block;
+    }
+
+    private static long maxOrd(long[] block) {
+        long max = 0;
+        for (long value : block) {
+            max = Math.max(max, value);
+        }
+        return max;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/RunLengthOrdinalEncodingRoundTripTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/RunLengthOrdinalEncodingRoundTripTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class RunLengthOrdinalEncodingRoundTripTests extends ESTestCase {
+
+    public void testSingleRun() throws IOException {
+        final long[] block = new long[randomBlockSize()];
+        Arrays.fill(block, 63);
+        assertRoundTrips(block);
+    }
+
+    public void testTwoRuns() throws IOException {
+        final long[] block = new long[randomBlockSize()];
+        Arrays.fill(block, 7);
+        block[0] = 3;
+        assertRoundTrips(block);
+    }
+
+    public void testFourRuns() throws IOException {
+        final long[] block = new long[randomBlockSize()];
+        final int runLength = block.length / 4;
+        Arrays.fill(block, 0, runLength, 10);
+        Arrays.fill(block, runLength, 2 * runLength, 20);
+        Arrays.fill(block, 2 * runLength, 3 * runLength, 30);
+        Arrays.fill(block, 3 * runLength, block.length, 40);
+        assertRoundTrips(block);
+    }
+
+    public void testLargeValues() throws IOException {
+        final long[] block = new long[randomBlockSize()];
+        Arrays.fill(block, 0, block.length / 2, Long.MAX_VALUE >> 2);
+        Arrays.fill(block, block.length / 2, block.length, Long.MAX_VALUE >> 1);
+        assertRoundTrips(block);
+    }
+
+    public void testAllDistinct() throws IOException {
+        final long[] block = new long[randomBlockSize()];
+        for (int i = 0; i < block.length; i++) {
+            block[i] = i;
+        }
+        assertRoundTrips(block);
+    }
+
+    public void testMultiValueInterleave() throws IOException {
+        final long[] set = { 100, 200, 300, 400, 480 };
+        final long[] block = new long[randomBlockSize()];
+        for (int i = 0; i < block.length; i++) {
+            block[i] = set[i % set.length];
+        }
+        assertRoundTrips(block);
+    }
+
+    public void testRandomOrdinals() throws IOException {
+        final long[] block = new long[randomBlockSize()];
+        final int cardinality = randomIntBetween(1, 1 << 16);
+        for (int i = 0; i < block.length; i++) {
+            block[i] = randomIntBetween(0, cardinality - 1);
+        }
+        assertRoundTrips(block);
+    }
+
+    private void assertRoundTrips(long[] block) throws IOException {
+        final int blockSize = block.length;
+        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd(block));
+        final long[] expected = block.clone();
+        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        new RunLengthOrdinalEncoder(blockSize).encode(block, out, bitsPerOrd);
+        final long[] decoded = new long[blockSize];
+        new RunLengthOrdinalDecoder(blockSize).decode(out.toDataInput(), decoded, bitsPerOrd);
+        assertArrayEquals(expected, decoded);
+    }
+
+    // a power of two between 128 and 4096, the range of per-field ordinal block sizes
+    private static int randomBlockSize() {
+        return 1 << randomIntBetween(7, 12);
+    }
+
+    private static long maxOrd(long[] block) {
+        long max = 0;
+        for (long value : block) {
+            max = Math.max(max, value);
+        }
+        return max;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldReaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es95/ES95OrdinalFieldReaderTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es95;
+
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.index.codec.tsdb.OrdinalFieldReader;
+import org.elasticsearch.index.codec.tsdb.RunLengthOrdinalEncoder;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class ES95OrdinalFieldReaderTests extends ESTestCase {
+
+    private static final int BLOCK_SIZE = 128;
+
+    public void testRunLengthVersionDecodesRunLengthEncoding() throws IOException {
+        final long[] ordinals = runBased();
+        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd(ordinals));
+        final DataInput encoded = encodeRunLength(ordinals, bitsPerOrd);
+
+        final long[] decoded = new long[BLOCK_SIZE];
+        decoderAt(TSDBDocValuesFormatConfig.VERSION_ORDINAL_RUN_LENGTH).decodeOrdinals(encoded, decoded, bitsPerOrd);
+
+        assertArrayEquals(ordinals, decoded);
+    }
+
+    public void testPreRunLengthVersionDecodesFourStrategyEncoding() throws IOException {
+        final long[] ordinals = runBased();
+        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd(ordinals));
+        final DataInput encoded = encodeFourStrategy(ordinals, bitsPerOrd);
+
+        final long[] decoded = new long[BLOCK_SIZE];
+        decoderAt(TSDBDocValuesFormatConfig.VERSION_ORDINAL_BLOCK_SHIFT).decodeOrdinals(encoded, decoded, bitsPerOrd);
+
+        assertArrayEquals(ordinals, decoded);
+    }
+
+    private static OrdinalFieldReader.Decoder decoderAt(int segmentVersion) {
+        return new ES95OrdinalFieldReader(segmentVersion).decoder(BLOCK_SIZE);
+    }
+
+    // clone: the bit-packed branch mutates its input through `forUtil`, but the caller asserts on it
+    private static DataInput encodeRunLength(long[] ordinals, int bitsPerOrd) throws IOException {
+        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        new RunLengthOrdinalEncoder(BLOCK_SIZE).encode(ordinals.clone(), out, bitsPerOrd);
+        return out.toDataInput();
+    }
+
+    private static DataInput encodeFourStrategy(long[] ordinals, int bitsPerOrd) throws IOException {
+        final ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+        new TSDBDocValuesEncoder(BLOCK_SIZE).encodeOrdinals(ordinals.clone(), out, bitsPerOrd);
+        return out.toDataInput();
+    }
+
+    private static long[] runBased() {
+        final long[] ordinals = new long[BLOCK_SIZE];
+        final int runLength = BLOCK_SIZE / 4;
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            ordinals[i] = i / runLength;
+        }
+        return ordinals;
+    }
+
+    private static long maxOrd(long[] ordinals) {
+        long max = 0;
+        for (long ordinal : ordinals) {
+            max = Math.max(max, ordinal);
+        }
+        return max;
+    }
+}


### PR DESCRIPTION
TDB