### PR TITLE
Avoid HttpServer assertion in APM tracing test

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/ConsumingTestServer.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/ConsumingTestServer.java
@@ -80,11 +80,14 @@ class ConsumingTestServer extends ExternalResource {
                         received.addAll(read);
                     }
                 }
-
+                // Respond only after a successful read. A request severed mid-stream (e.g. a node and its APM agent
+                // shutting down during an in-flight export) can leave the JDK HttpServer connection in REQUEST state, and
+                // responding then trips its dispatcher-thread assertion ("State is not RESPONSE"). On failure we instead
+                // fall through to the catch and let the connection close without a response.
+                exchange.sendResponseHeaders(201, 0);
             } catch (RuntimeException e) {
                 logger.warn("failed to parse request", e);
             }
-            exchange.sendResponseHeaders(201, 0);
         }
     }
 


### PR DESCRIPTION
`ConsumingTestServer` (the mock APM endpoint used by `RemoteClusterSecurityWithApmTracingRestIT`) replied 201 even when reading the request body had failed. When a cluster node and its APM agent shut down mid-export, a chunked intake request can be severed in its terminating CRLF, which makes the JDK `HttpServer` skip its internal REQUEST->RESPONSE transition. Responding on that connection then trips an assertion ("State is not RESPONSE") on the server's dispatcher thread, killing it and failing the suite at the class level.

Send the 201 only after the request body has been fully read. On a read failure we now fall through to the existing catch and let the exchange close without a response, which tears the connection down without completing a response and avoids the assertion.

Closes #148784

## Root cause (OpenJDK `com.sun.net.httpserver`)

The fixture uses the JDK's built-in `HttpServer`, whose connection state machine transitions `REQUEST -> RESPONSE` lazily, from inside the request-body stream. In [`ChunkedInputStream.readImpl`](https://github.com/openjdk/jdk/blob/jdk-25+36/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedInputStream.java#L117-L124) the only place `eof` is set is the zero-chunk, immediately followed by `consumeCRLF()` and then `requestCompleted()`:

```java
if (remaining == 0) {
    eof = true;
    consumeCRLF();                                          // throws if the trailing CRLF was cut off
    t.getServerImpl().requestCompleted(t.getConnection());  // skipped -> connection stays in REQUEST
    return -1;
}
```

If the stream ends after `0\r\n` but before the trailing CRLF, `consumeCRLF()` throws, so `eof == true` while `requestCompleted()` never runs. When the handler then responds, the deferred write completion hits the assertion in [`ServerImpl.responseCompleted`](https://github.com/openjdk/jdk/blob/jdk-25+36/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java#L1050-L1055):

```java
void responseCompleted (HttpConnection c) {
    State s = c.getState();
    assert s == State.RESPONSE : "State is not RESPONSE ("+s+")";  // s == REQUEST
    ...
}
```
