### PR TITLE
Add ES|QL federated data stub page

### DIFF
--- a/docs/reference/query-languages/esql/esql-federated-data.md
+++ b/docs/reference/query-languages/esql/esql-federated-data.md
@@ -1,0 +1,11 @@
+---
+navigation_title: "Federated data"
+description: "Overview of querying data stored outside Elasticsearch using {{esql}}, including key concepts, supported data sources, and file formats."
+applies_to:
+  stack: preview =9.5
+  serverless: preview
+products:
+  - id: elasticsearch
+---
+
+# {{esql}} federated data

--- a/docs/reference/query-languages/esql/esql-federated-data.md
+++ b/docs/reference/query-languages/esql/esql-federated-data.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Federated data"
-description: "Overview of querying data stored outside Elasticsearch using {{esql}}, including key concepts, supported data sources, and file formats."
+description: "Overview of querying data stored outside Elasticsearch using ES|QL, including key concepts, supported data sources, and file formats."
 applies_to:
   stack: preview =9.5
   serverless: preview

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -402,6 +402,7 @@ toc:
           - file: esql/esql-cross-serverless-projects.md
           - file: esql/esql-subquery.md
           - file: esql/esql-views.md
+      - hidden: esql/esql-federated-data.md
       - file: esql/esql-advanced.md
         children:
           - file: esql/esql-process-data-with-dissect-grok.md


### PR DESCRIPTION
Adds the ES|QL federated data URL as a stub containing only its frontmatter and H1. The page is registered in the query languages TOC with `hidden` so it is built but not displayed in navigation.