### PR TITLE
[9.4] rotate ms-graph-authz third party credentials (#152410)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -254,9 +254,6 @@ tests:
 - class: org.elasticsearch.gradle.internal.precommit.TestingConventionsPrecommitPluginFuncTest
   method: testing convention tasks are cacheable and uptodate
   issue: https://github.com/elastic/elasticsearch/issues/152371
-- class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
-  method: testAuthenticationSuccessful
-  issue: https://github.com/elastic/elasticsearch/issues/152375
 
 # Examples:
 #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [rotate ms-graph-authz third party credentials (#152410)](https://github.com/elastic/elasticsearch/pull/152410)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)