### PR TITLE
Set columnar flag only on supported esql BWC nodes

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.qa.mixed;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
@@ -26,9 +27,14 @@ public class Clusters {
         boolean isDetachedVersion = System.getProperty("tests.bwc.refspec.main") != null;
         var cluster = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            // The columnar index mode is behind a snapshot-only feature flag and isn't supported across mixed node versions,
-            // so disable it here to keep its tests out of upgrade clusters. The property is ignored once the flag is removed.
-            .systemProperty("es.columnar_index_mode_feature_flag_enabled", "false")
+            // The columnar index mode is behind a feature flag and isn't supported across mixed node versions, so disable it here to
+            // keep its tests out of upgrade clusters. Only set it on nodes that know the flag: older BWC nodes predate it and would
+            // fail to start with an unknown property. The property is ignored once the flag is removed.
+            .systemProperty(
+                "es.columnar_index_mode_feature_flag_enabled",
+                () -> "false",
+                spec -> spec.getVersion().onOrAfter(FeatureFlag.COLUMNAR_INDEX_MODE_FEATURE_FLAG.from)
+            )
             .withNode(node -> node.version(oldVersionString, isDetachedVersion))
             .withNode(node -> node.version(Version.CURRENT))
             .withNode(node -> node.version(oldVersionString, isDetachedVersion))


### PR DESCRIPTION
Follow-up to #152457. It disabled the columnar feature flag cluster-wide in the esql mixed-cluster, so `es.columnar_index_mode_feature_flag_enabled` was also set on the old BWC node — which predates the flag and fails to boot with the unknown property, timing out cluster startup (`AllSupportedFieldsIT > classMethod`, BWC `v8.19.18`).

Only set it on nodes at or after the flag's version. Older nodes don't have columnar anyway, so the columnar tests still skip there.

Verified locally: `v8.19.18#javaRestTest` `AllSupportedFieldsIT` now starts — 168 tests, 125 skipped, 0 failures.