### PR TITLE
Add elasticsearch-agentic-workflow pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -86,6 +86,74 @@ export BUILDKITE_API_TOKEN
 
 export GH_TOKEN="${VAULT_GITHUB_TOKEN:-}"
 
+# ── pi-agent ──────────────────────────────────────────────────────────────────
+# Bootstraps the self-contained pi-agent CLI (https://github.com/elastic/rene-bk-experiments)
+# so the elasticsearch-agentic-workflow pipeline can run pi sessions on this agent.
+#
+# Completely inert unless USE_PI_AGENT=true is set on the step. The required
+# secrets live in Vault at secret/ci/elastic-elasticsearch/agentic-workflows.
+if [[ "${USE_PI_AGENT:-}" == "true" ]]; then
+  # LiteLLM API key — the bundled models.json resolves it automatically.
+  ELASTIC_LITELLM_API_KEY=$(vault_with_retry read -field=litellm_token secret/ci/elastic-elasticsearch/agentic-workflows)
+  export ELASTIC_LITELLM_API_KEY
+
+  # Read-only Buildkite token for the agent's bk_* tools. The bundled
+  # buildkite-jobs extension reads BUILDKITE_API_TOKEN, so alias it here
+  # (scoped to this step's environment).
+  BUILDKITE_RO_API_TOKEN=$(vault_with_retry read -field=buildkite_ro_token secret/ci/elastic-elasticsearch/agentic-workflows)
+  export BUILDKITE_RO_API_TOKEN
+  export BUILDKITE_API_TOKEN="${BUILDKITE_RO_API_TOKEN}"
+
+  # Develocity API key for build-scan reads during analysis.
+  DEVELOCITY_API_KEY=$(vault_with_retry read -field=develocity_api_token secret/ci/elastic-elasticsearch/agentic-workflows)
+  export DEVELOCITY_API_KEY
+
+  export PATH="${HOME}/.local/bin:${PATH}"
+
+  # Bootstrap pi-agent if not already cached on this agent.
+  PI_AGENT_TAG="${PI_AGENT_TAG:-pi-agent-v1.0.2}"
+  PI_AGENT_DIR="${HOME}/.local/pi-agent"
+
+  if [[ ! -x "${PI_AGENT_DIR}/bin/pi-agent.js" ]]; then
+    echo "--- Bootstrapping pi-agent (${PI_AGENT_TAG})"
+
+    # The release repo is private — use the org-level gh_token from Vault.
+    GH_ADMIN_TOKEN=$(vault_with_retry read -field=gh_token secret/ci/elastic-elasticsearch/agentic-workflows)
+
+    # Resolve the pinned release's .tgz asset API URL.
+    PI_TARBALL_URL=$(curl -fsSL \
+      -H "Authorization: Bearer ${GH_ADMIN_TOKEN}" \
+      "https://api.github.com/repos/elastic/rene-bk-experiments/releases/tags/${PI_AGENT_TAG}" \
+      | node -e "
+          const r = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+          const a = r.assets.find(a => a.name.endsWith('.tgz') && !a.name.includes('sha256'));
+          if (!a) { process.stderr.write('No .tgz asset found in release\n'); process.exit(1); }
+          process.stdout.write(a.url);
+        ")
+
+    TMPDIR_DL="$(mktemp -d)"
+    curl -fsSL \
+      -H "Authorization: Bearer ${GH_ADMIN_TOKEN}" \
+      -H "Accept: application/octet-stream" \
+      "${PI_TARBALL_URL}" \
+      -o "${TMPDIR_DL}/pi-agent.tgz"
+
+    rm -rf "${PI_AGENT_DIR}"
+    mkdir -p "${PI_AGENT_DIR}"
+    tar -xzf "${TMPDIR_DL}/pi-agent.tgz" -C "${PI_AGENT_DIR}" --strip-components=1
+
+    # Install the bundled pi SDK dependency.
+    npm install --prefix "${PI_AGENT_DIR}" --omit=dev --no-audit --no-fund --silent
+
+    mkdir -p "${HOME}/.local/bin"
+    ln -sf "${PI_AGENT_DIR}/bin/pi-agent.js" "${HOME}/.local/bin/pi-agent"
+    chmod +x "${PI_AGENT_DIR}/bin/pi-agent.js"
+    rm -rf "${TMPDIR_DL}"
+    unset GH_ADMIN_TOKEN
+  fi
+fi
+# ── end pi-agent ──────────────────────────────────────────────────────────────
+
 if [[ "${USE_LUCENE_SNAPSHOT_CREDS:-}" == "true" ]]; then
   data=$(.buildkite/scripts/get-legacy-secret.sh aws-elastic/creds/lucene-snapshots)
 

--- a/.buildkite/pipelines/agentic-workflow.yml
+++ b/.buildkite/pipelines/agentic-workflow.yml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+#
+# elasticsearch-agentic-workflow
+#
+# On-demand agentic CI workflows powered by the self-contained pi-agent CLI
+# (https://github.com/elastic/rene-bk-experiments). pi runs directly on the
+# agent — no remote pipeline trigger and no .pi/ config in this repo. The
+# pre-command hook bootstraps pi-agent and injects secrets when USE_PI_AGENT=true.
+#
+# Supported workflows:
+#   test-analysis          — analyse a test-failure issue        (needs ISSUE_URL)
+#   pull-request-fix       — self-heal a failing pull request    (needs PR_URL)
+#   pull-request-creation  — implement a task and open a PR      (needs ISSUE_URL)
+#
+# Trigger from the UI (fill the input step) or via the Buildkite API with the
+# vars pre-set so the input step is skipped, e.g.:
+#   curl -X POST ".../pipelines/elasticsearch-agentic-workflow/builds" \
+#     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+#     -d '{"branch":"main","env":{
+#            "WORKFLOW":"test-analysis",
+#            "ISSUE_URL":"https://github.com/elastic/elasticsearch/issues/150989"}}'
+
+# Surface trigger vars at pipeline level so env() in step `if` conditions can
+# see them on API-triggered builds.
+env:
+  WORKFLOW:  "${WORKFLOW:-}"
+  ISSUE_URL: "${ISSUE_URL:-}"
+  PR_URL:    "${PR_URL:-}"
+
+steps:
+  # ── Optional input (skipped when WORKFLOW + a URL are already set) ───────────
+  - input: ":pencil: Pi — configure workflow"
+    key: pi-input
+    if: build.env("WORKFLOW") == null || build.env("WORKFLOW") == ""
+    fields:
+      - select: "Workflow"
+        key:     WORKFLOW
+        default: "test-analysis"
+        options:
+          - { label: "Test failure analysis", value: "test-analysis"         }
+          - { label: "Fix a pull request",    value: "pull-request-fix"       }
+          - { label: "Create a pull request", value: "pull-request-creation"  }
+      - text: "Issue URL"
+        key:  ISSUE_URL
+        hint: "https://github.com/elastic/elasticsearch/issues/N (test-analysis / pull-request-creation)"
+        required: false
+      - text: "Pull request URL"
+        key:  PR_URL
+        hint: "https://github.com/elastic/elasticsearch/pull/N (pull-request-fix)"
+        required: false
+
+  # ── Run pi-agent ─────────────────────────────────────────────────────────────
+  - label: ":robot_face: Pi — :workflow:"
+    key: pi-run
+    depends_on: pi-input
+    timeout_in_minutes: 60
+    env:
+      USE_PI_AGENT: "true"
+    agents:
+      provider:       gcp
+      image:          family/elasticsearch-ubuntu-2404
+      machineType:    n4-standard-16
+      diskType:       hyperdisk-balanced
+      buildDirectory: /dev/shm/bk
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+    command: |
+      set -euo pipefail
+
+      case "${WORKFLOW}" in
+        test-analysis)
+          [[ -n "${ISSUE_URL:-}" ]] || { echo "ISSUE_URL is required for test-analysis" >&2; exit 1; }
+          pi-agent analyze --issue-url "${ISSUE_URL}"
+          ;;
+        pull-request-fix)
+          [[ -n "${PR_URL:-}" ]] || { echo "PR_URL is required for pull-request-fix" >&2; exit 1; }
+          pi-agent fix-pr --pr-url "${PR_URL}"
+          ;;
+        pull-request-creation)
+          [[ -n "${ISSUE_URL:-}" ]] || { echo "ISSUE_URL is required for pull-request-creation" >&2; exit 1; }
+          pi-agent create --issue-url "${ISSUE_URL}"
+          ;;
+        *)
+          echo "Unknown or unset WORKFLOW: '${WORKFLOW:-}'" >&2
+          echo "Expected one of: test-analysis, pull-request-fix, pull-request-creation" >&2
+          exit 1
+          ;;
+      esac

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -482,3 +482,36 @@ spec:
           access_level: READ_ONLY
       provider_settings:
         trigger_mode: none
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-agentic-workflow
+  description: Run agentic workflows (test analysis, PR fix, PR creation)
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elasticsearch-agentic-workflow
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: group:elasticsearch-team
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: ":robot_face: Run pi agentic workflows (analysis / fix-pr / create)"
+      name: elasticsearch / agentic-workflow
+    spec:
+      repository: elastic/elasticsearch
+      pipeline_file: .buildkite/pipelines/agentic-workflow.yml
+      teams:
+        elasticsearch-team: {}
+        ml-core: {}
+        everyone:
+          access_level: READ_ONLY
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        trigger_mode: none


### PR DESCRIPTION
Add an on-demand Buildkite pipeline that runs pi agentic workflows
(test-analysis, pull-request-fix, pull-request-creation) via the
self-contained pi-agent CLI from elastic/rene-bk-experiments.

The pre-command hook bootstraps pi-agent (pinned to pi-agent-v1.0.2)
and injects the LiteLLM, read-only Buildkite, Develocity and GitHub
tokens from Vault, gated on USE_PI_AGENT so it stays inert for all
existing CI steps.