### PR TITLE
ESQL: dataset & view GET by name return a clean not-found

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -3440,6 +3440,38 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(datasets, empty());
     }
 
+    public void testDatasetListIgnoresCoresidentDataStream() {
+        // Repro for the GET _query/dataset 404 reported 2026-06-30: listing datasets with "*" must not blow up just
+        // because the cluster also holds an unrelated data stream (here the Entity Store's entities-updates-default).
+        // datasets() resolves the whole namespace and filters to Type.DATASET afterward, so a data-stream-related
+        // abstraction throws index_not_found_exception (excluded_ds=true) mid-walk, before the filter ever runs.
+        final String datasetName = "cloudtrail_logs";
+        Dataset dataset = new Dataset(
+            datasetName,
+            new DataSourceReference("aws_s3_logs"),
+            "s3://bucket/cloudtrail/*.json.gz",
+            null,
+            Map.of()
+        );
+
+        final String dataStreamName = "entities-updates-default";
+        IndexMetadata backingIndex = createBackingIndex(dataStreamName, 1).build();
+
+        ProjectMetadata project = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID)
+            .put(backingIndex, false)
+            .put(newInstance(dataStreamName, List.of(backingIndex.getIndex())))
+            .datasets(Map.of(datasetName, dataset))
+            .build();
+
+        final IndicesOptions datasetOptions = IndicesOptions.builder()
+            .concreteTargetOptions(IndicesOptions.ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
+            .indexAbstractionOptions(IndicesOptions.IndexAbstractionOptions.builder().resolveDatasets(true).build())
+            .build();
+
+        List<String> datasets = indexNameExpressionResolver.datasets(project, datasetOptions, viewRequest(datasetOptions, "*"));
+        assertThat(datasets, contains(datasetName));
+    }
+
     public void testResolveAllIncludesDatasetsWithFlag() {
         // Regression test for the early-return optimization in resolveAll: if the caller asks for no data streams,
         // no aliases, no views, BUT wants datasets, the loop that includes datasets must still run. The pre-fix code

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -584,6 +584,17 @@ public class EsqlSecurityIT extends ESRestTestCase {
         assertThat(respMap.get("values"), equalTo(List.of(List.of(30.0d))));
     }
 
+    public void testGetViewByMissingNameReturnsCleanNotFoundUnderSecurity() throws IOException {
+        // Security-on counterpart to ViewRestTests: GET a view by a name that does not resolve to a view must return a
+        // clean view-shaped not-found, never leak the raw index_not_found_exception. The translation lives in the
+        // transport, after authorization, so it holds the same with security enabled.
+        ResponseException ex = expectThrows(ResponseException.class, () -> getView("test-admin", "no-such-view-under-security"));
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+        String body = EntityUtils.toString(ex.getResponse().getEntity());
+        assertThat(body, containsString("view [no-such-view-under-security] not found"));
+        assertThat(body, not(containsString("index_not_found_exception")));
+    }
+
     public void testViewWildcardFiltersUnauthorized() throws Exception {
         Response resp = runESQLCommand("user1", "FROM view-user* | STATS sum=sum(value)");
         assertOK(resp);

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -73,6 +73,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .user("user2", "x-pack-test-password", "user2", false)
         .user("user3", "x-pack-test-password", "user3", false)
         .user("user_dataset_authorize_only", "x-pack-test-password", "user_dataset_authorize_only", false)
+        .user("ds_repro_broad_reader", "x-pack-test-password", "ds_repro_broad_reader", false)
         .user("user4", "x-pack-test-password", "user4", false)
         .user("user5", "x-pack-test-password", "user5", false)
         .user("fls_user", "x-pack-test-password", "fls_user", false)
@@ -2536,6 +2537,48 @@ public class EsqlSecurityIT extends ESRestTestCase {
         Request delete = new Request("DELETE", "/_query/dataset/" + datasetName);
         setUser(delete, "test-admin");
         assertOK(client().performRequest(delete));
+    }
+
+    /**
+     * Repro for the GET _query/dataset 404 reported 2026-06-30. A non-superuser whose role can both list datasets and
+     * read an unrelated (Entity-Store-style, hidden) data stream lists datasets with "*". The security layer expands
+     * the wildcard against the user's authorized namespace — which includes the data stream — and the dataset
+     * resolution then reads it back with data streams excluded, 404-ing on entities-updates-default. A superuser does
+     * not hit this because it is authorized for "*" wholesale and never enumerates.
+     */
+    public void testListDatasetsAsNonSuperuserWithCoresidentHiddenDataStream() throws IOException {
+        assumeTrue("data_sources REST API not supported by cluster", dataSourcesApiSupported());
+        ensureSecurityItDatasourcesForTests();
+
+        // Hidden, template-managed data stream, mirroring the Entity Store's entities-updates-default.
+        Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
+        tmpl.setJsonEntity("{\"index_patterns\":[\"entities-updates-*\"],\"data_stream\":{\"hidden\":true}}");
+        setUser(tmpl, "test-admin");
+        assertOK(client().performRequest(tmpl));
+        Request createDs = new Request("PUT", "/_data_stream/entities-updates-default");
+        setUser(createDs, "test-admin");
+        assertOK(client().performRequest(createDs));
+
+        final String dataset = createSecurityItDatasetAsAdmin("security_it_ds_repro_" + randomAlphaOfLength(6).toLowerCase(Locale.ROOT));
+
+        try {
+            // GET /_query/dataset (list all == "*") as the non-superuser.
+            Request list = new Request("GET", "/_query/dataset");
+            setUser(list, "ds_repro_broad_reader");
+            Response resp = client().performRequest(list);
+            assertOK(resp);
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> hits = (List<Map<String, Object>>) entityAsMap(resp).get("datasets");
+            assertThat(hits.stream().anyMatch(h -> dataset.equals(h.get("name"))), equalTo(true));
+        } finally {
+            deleteDatasetAsAdmin(dataset);
+            Request delDs = new Request("DELETE", "/_data_stream/entities-updates-default");
+            setUser(delDs, "test-admin");
+            client().performRequest(delDs);
+            Request delTmpl = new Request("DELETE", "/_index_template/entities-updates-tmpl");
+            setUser(delTmpl, "test-admin");
+            client().performRequest(delTmpl);
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
@@ -410,6 +410,20 @@ ds_dataset_read_metadata:
     - names: [ 'security_it_ds_*' ]
       privileges: [ 'read_dataset_metadata' ]
 
+# Repro for the GET _query/dataset 404: a broad, Kibana-like reader that can both list datasets and read an
+# unrelated (Entity-Store-style) data stream, so the dataset list's wildcard expands across both namespaces.
+ds_repro_broad_reader:
+  cluster: []
+  indices:
+    - names: [ 'entities-updates-*' ]
+      privileges: [ 'read' ]
+    - names: [ 'security_it_ds_*' ]
+      privileges: [ 'read_dataset_metadata' ]
+  global:
+    data_source:
+      - names: [ 'security_it_*' ]
+        privileges: [ 'read' ]
+
 ds_dataset_delete:
   cluster: []
   indices:

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/DataSourceCrudRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/DataSourceCrudRestIT.java
@@ -157,6 +157,36 @@ public class DataSourceCrudRestIT extends ESRestTestCase {
         deleteDataSource(parent);
     }
 
+    public void testListDatasetsWithCoresidentDataStream() throws IOException {
+        // Repro for the GET _query/dataset 404 reported 2026-06-30: listing datasets must not blow up just because the
+        // cluster also holds an unrelated data stream (Tyler's was the Entity Store's entities-updates-default). End to
+        // end through the real transport path (action filters + resolution), unlike the resolver unit test.
+        final String dataStream = "entities-updates-default";
+        Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
+        tmpl.setJsonEntity("{\"index_patterns\":[\"entities-updates-*\"],\"data_stream\":{}}");
+        assertThat(client().performRequest(tmpl).getStatusLine().getStatusCode(), equalTo(200));
+        Request createDs = new Request("PUT", "/_data_stream/" + dataStream);
+        assertThat(client().performRequest(createDs).getStatusLine().getStatusCode(), equalTo(200));
+
+        final String parent = "coresident_parent";
+        final String dataset = "cloudtrail_logs";
+        putDataSource(parent, "s3", Map.of("region", "us-east-1"));
+        putDataset(dataset, parent, "s3://bucket/cloudtrail/*.json.gz", Map.of());
+
+        // GET /_query/dataset (list all == "*") — this is the exact request from the bug report.
+        Response resp = client().performRequest(new Request("GET", "/_query/dataset"));
+        assertThat(resp.getStatusLine().getStatusCode(), equalTo(200));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> hits = (List<Map<String, Object>>) entityAsMap(resp).get("datasets");
+        assertThat(hits, hasSize(1));
+        assertThat(hits.get(0).get("name"), equalTo(dataset));
+
+        deleteDataset(dataset);
+        deleteDataSource(parent);
+        client().performRequest(new Request("DELETE", "/_data_stream/" + dataStream));
+        client().performRequest(new Request("DELETE", "/_index_template/entities-updates-tmpl"));
+    }
+
     public void testPutDatasetWithMissingParent() throws IOException {
         ResponseException ex = expectThrows(ResponseException.class, () -> putDataset("orphan", "no_such_parent", "s3://x/", Map.of()));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/DataSourceCrudRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/DataSourceCrudRestIT.java
@@ -30,6 +30,7 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 /**
  * End-to-end REST coverage for the CRUD API against a cluster with {@code esql-datasource-s3}
@@ -185,6 +186,33 @@ public class DataSourceCrudRestIT extends ESRestTestCase {
         deleteDataSource(parent);
         client().performRequest(new Request("DELETE", "/_data_stream/" + dataStream));
         client().performRequest(new Request("DELETE", "/_index_template/entities-updates-tmpl"));
+    }
+
+    public void testGetDatasetByExplicitDataStreamNameReturnsCleanNotFound() throws IOException {
+        // GET an explicit name that happens to be a co-resident data stream. The dataset resolver throws
+        // IndexNotFoundException (with excluded_ds) before its Type.DATASET filter runs; the GET transport must
+        // translate that to a clean dataset-shaped not-found — never leak the raw index_not_found_exception.
+        // Mirrors the DELETE behavior. (Before the fix this leaked "excluded_ds"; that was the shape of Tyler's 404.)
+        final String dataStream = "entities-updates-default";
+        Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
+        tmpl.setJsonEntity("{\"index_patterns\":[\"entities-updates-*\"],\"data_stream\":{}}");
+        assertThat(client().performRequest(tmpl).getStatusLine().getStatusCode(), equalTo(200));
+        Request createDs = new Request("PUT", "/_data_stream/" + dataStream);
+        assertThat(client().performRequest(createDs).getStatusLine().getStatusCode(), equalTo(200));
+        try {
+            ResponseException ex = expectThrows(
+                ResponseException.class,
+                () -> client().performRequest(new Request("GET", "/_query/dataset/" + dataStream))
+            );
+            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+            String body = EntityUtils.toString(ex.getResponse().getEntity());
+            assertThat(body, containsString("dataset [" + dataStream + "] not found"));
+            assertThat("GET must not leak the raw index resolution error", body, not(containsString("excluded_ds")));
+            assertThat(body, not(containsString("index_not_found_exception")));
+        } finally {
+            client().performRequest(new Request("DELETE", "/_data_stream/" + dataStream));
+            client().performRequest(new Request("DELETE", "/_index_template/entities-updates-tmpl"));
+        }
     }
 
     public void testPutDatasetWithMissingParent() throws IOException {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/DataSourceCrudRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/DataSourceCrudRestIT.java
@@ -160,7 +160,7 @@ public class DataSourceCrudRestIT extends ESRestTestCase {
 
     public void testListDatasetsWithCoresidentDataStream() throws IOException {
         // Repro for the GET _query/dataset 404 reported 2026-06-30: listing datasets must not blow up just because the
-        // cluster also holds an unrelated data stream (Tyler's was the Entity Store's entities-updates-default). End to
+        // cluster also holds an unrelated data stream (the reported one was the Entity Store's entities-updates-default). End to
         // end through the real transport path (action filters + resolution), unlike the resolver unit test.
         final String dataStream = "entities-updates-default";
         Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
@@ -192,7 +192,7 @@ public class DataSourceCrudRestIT extends ESRestTestCase {
         // GET an explicit name that happens to be a co-resident data stream. The dataset resolver throws
         // IndexNotFoundException (with excluded_ds) before its Type.DATASET filter runs; the GET transport must
         // translate that to a clean dataset-shaped not-found — never leak the raw index_not_found_exception.
-        // Mirrors the DELETE behavior. (Before the fix this leaked "excluded_ds"; that was the shape of Tyler's 404.)
+        // Mirrors the DELETE behavior. (Before the fix this leaked "excluded_ds"; that was the shape of the reported 404.)
         final String dataStream = "entities-updates-default";
         Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
         tmpl.setJsonEntity("{\"index_patterns\":[\"entities-updates-*\"],\"data_stream\":{}}");
@@ -210,6 +210,38 @@ public class DataSourceCrudRestIT extends ESRestTestCase {
             assertThat("GET must not leak the raw index resolution error", body, not(containsString("excluded_ds")));
             assertThat(body, not(containsString("index_not_found_exception")));
         } finally {
+            client().performRequest(new Request("DELETE", "/_data_stream/" + dataStream));
+            client().performRequest(new Request("DELETE", "/_index_template/entities-updates-tmpl"));
+        }
+    }
+
+    public void testGetDatasetMixedValidAndDataStreamNamesNotFound() throws IOException {
+        // A comma-separated GET naming a valid dataset and a co-resident data stream: resolution throws on the
+        // data stream, so the whole request is a clean not-found that names the offending name (not the valid one,
+        // and not the raw index error). Confirms the error reports the specific failed name, mirroring delete.
+        final String dataStream = "entities-updates-default";
+        Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
+        tmpl.setJsonEntity("{\"index_patterns\":[\"entities-updates-*\"],\"data_stream\":{}}");
+        assertThat(client().performRequest(tmpl).getStatusLine().getStatusCode(), equalTo(200));
+        Request createDs = new Request("PUT", "/_data_stream/" + dataStream);
+        assertThat(client().performRequest(createDs).getStatusLine().getStatusCode(), equalTo(200));
+        final String parent = "mixed_parent";
+        final String dataset = "valid_ds";
+        putDataSource(parent, "s3", Map.of("region", "us-east-1"));
+        putDataset(dataset, parent, "s3://bucket/x/*.parquet", Map.of());
+        try {
+            ResponseException ex = expectThrows(
+                ResponseException.class,
+                () -> client().performRequest(new Request("GET", "/_query/dataset/" + dataset + "," + dataStream))
+            );
+            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+            String body = EntityUtils.toString(ex.getResponse().getEntity());
+            assertThat(body, containsString("dataset [" + dataStream + "] not found"));
+            assertThat(body, not(containsString("excluded_ds")));
+            assertThat(body, not(containsString("index_not_found_exception")));
+        } finally {
+            deleteDataset(dataset);
+            deleteDataSource(parent);
             client().performRequest(new Request("DELETE", "/_data_stream/" + dataStream));
             client().performRequest(new Request("DELETE", "/_index_template/entities-updates-tmpl"));
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.Plugin;
@@ -700,7 +699,10 @@ public class DataSourceCrudIT extends ESIntegTestCase {
             ExecutionException.class,
             () -> client().execute(GetDatasetAction.INSTANCE, getDatasetRequest(name)).get()
         );
-        assertThat(err.getCause(), instanceOf(IndexNotFoundException.class));
+        // GET resolves the name and translates a non-dataset/missing name to a clean dataset-shaped not-found,
+        // matching expectDataSourceMissing — never a raw IndexNotFoundException.
+        assertThat(err.getCause(), instanceOf(ResourceNotFoundException.class));
+        assertThat(err.getCause().getMessage(), containsString("dataset [" + name + "] not found"));
     }
 
     private static boolean isActionSuccess(ActionFuture<AcknowledgedResponse> fut) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportGetDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportGetDatasetAction.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.datasources.dataset;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.local.TransportLocalProjectMetadataAction;
@@ -18,6 +19,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -60,7 +62,17 @@ public class TransportGetDatasetAction extends TransportLocalProjectMetadataActi
         // Resolve + type-filter against the local project's cluster state. We don't consume
         // request.getResolvedIndexExpressions(): datasets have no cross-project resolution today, so
         // re-resolving from indices() is equivalent — revisit (like view GET) when datasets become remotable.
-        final List<String> resolved = indexNameExpressionResolver.datasets(project.metadata(), request.indicesOptions(), request);
+        // `resolveDatasets` is additive: an explicit name that resolves to a non-dataset abstraction (e.g. a data
+        // stream) throws IndexNotFoundException before the Type.DATASET filter runs. Translate it to a dataset-shaped
+        // not-found instead of leaking a raw index_not_found_exception, mirroring TransportDeleteDatasetAction.
+        final List<String> resolved;
+        try {
+            resolved = indexNameExpressionResolver.datasets(project.metadata(), request.indicesOptions(), request);
+        } catch (IndexNotFoundException e) {
+            final String missing = e.getIndex() != null ? e.getIndex().getName() : String.join(",", request.indices());
+            listener.onFailure(new ResourceNotFoundException("dataset [{}] not found", missing));
+            return;
+        }
         final List<Dataset> hits = new ArrayList<>();
         for (String name : resolved) {
             Dataset ds = metadata.get(name);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportDeleteViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportDeleteViewAction.java
@@ -76,7 +76,8 @@ public class TransportDeleteViewAction extends AcknowledgedTransportMasterNodePr
         try {
             viewNames = indexNameExpressionResolver.views(state.metadata(), request.indicesOptions(), request);
         } catch (IndexNotFoundException e) {
-            listener.onFailure(new ResourceNotFoundException("view [{}] not found", e.getIndex().getName()));
+            final String missing = e.getIndex() != null ? e.getIndex().getName() : String.join(",", request.views());
+            listener.onFailure(new ResourceNotFoundException("view [{}] not found", missing));
             return;
         }
         if (viewNames.isEmpty()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportGetViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportGetViewAction.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.view;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.local.TransportLocalProjectMetadataAction;
@@ -16,6 +17,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -52,12 +54,22 @@ public class TransportGetViewAction extends TransportLocalProjectMetadataAction<
         ProjectState project,
         ActionListener<GetViewAction.Response> listener
     ) {
-        var result = viewResolutionService.resolveViews(
-            project,
-            request.indices(),
-            request.indicesOptions(),
-            request.getResolvedIndexExpressions()
-        );
+        // An explicit name that resolves to a non-view abstraction (e.g. a data stream) throws IndexNotFoundException
+        // before the Type.VIEW filter runs. Translate it to a view-shaped not-found instead of leaking a raw
+        // index_not_found_exception, mirroring TransportDeleteViewAction (and the dataset get/delete transports).
+        final ViewResolutionService.ViewResolutionResult result;
+        try {
+            result = viewResolutionService.resolveViews(
+                project,
+                request.indices(),
+                request.indicesOptions(),
+                request.getResolvedIndexExpressions()
+            );
+        } catch (IndexNotFoundException e) {
+            final String missing = e.getIndex() != null ? e.getIndex().getName() : String.join(",", request.indices());
+            listener.onFailure(new ResourceNotFoundException("view [{}] not found", missing));
+            return;
+        }
         listener.onResponse(new GetViewAction.Response(List.of(result.views())));
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportGetViewAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/TransportGetViewAction.java
@@ -54,9 +54,10 @@ public class TransportGetViewAction extends TransportLocalProjectMetadataAction<
         ProjectState project,
         ActionListener<GetViewAction.Response> listener
     ) {
-        // An explicit name that resolves to a non-view abstraction (e.g. a data stream) throws IndexNotFoundException
-        // before the Type.VIEW filter runs. Translate it to a view-shaped not-found instead of leaking a raw
-        // index_not_found_exception, mirroring TransportDeleteViewAction (and the dataset get/delete transports).
+        // An explicit name that doesn't resolve to a view throws IndexNotFoundException before the Type.VIEW filter
+        // runs. (A co-resident data stream resolves to empty, not a throw — views don't share the dataset
+        // data-stream leak.) Translate the throw to a view-shaped not-found instead of leaking a raw
+        // index_not_found_exception, mirroring the dataset get/delete and view delete transports.
         final ViewResolutionService.ViewResolutionResult result;
         try {
             result = viewResolutionService.resolveViews(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/ViewRestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/ViewRestTests.java
@@ -8,9 +8,33 @@
 package org.elasticsearch.xpack.esql.view;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.datastreams.CreateDataStreamAction;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 public class ViewRestTests extends AbstractViewTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        // Add data-streams so the test can create the co-resident data stream that triggers the resolver throw.
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getPlugins());
+        plugins.add(DataStreamsPlugin.class);
+        return plugins;
+    }
 
     public void testRestWorksInBothSnapshotAndRelease() {
         GetViewAction.Request request = new GetViewAction.Request(TimeValue.timeValueMinutes(1));
@@ -23,5 +47,53 @@ public class ViewRestTests extends AbstractViewTestCase {
         if (responseCapture.response == null) {
             fail("Response is null");
         }
+    }
+
+    public void testGetViewByCoresidentDataStreamNameIsEmptyNotError() {
+        // Unlike datasets, the view resolver is already lenient for a co-resident data stream: GET by that explicit
+        // name resolves to no views and returns an empty response, never an error. (Documents that views do NOT share
+        // the dataset data-stream leak.)
+        assertAcked(
+            client().execute(
+                TransportPutComposableIndexTemplateAction.TYPE,
+                new TransportPutComposableIndexTemplateAction.Request("entities-updates-template").indexTemplate(
+                    ComposableIndexTemplate.builder()
+                        .indexPatterns(List.of("entities-updates-*"))
+                        .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+                        .build()
+                )
+            )
+        );
+        assertAcked(
+            client().execute(
+                CreateDataStreamAction.INSTANCE,
+                new CreateDataStreamAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "entities-updates-default")
+            )
+        );
+
+        GetViewAction.Request request = new GetViewAction.Request(TimeValue.timeValueMinutes(1));
+        request.indices("entities-updates-default");
+        TestResponseCapture<GetViewAction.Response> capture = new TestResponseCapture<>();
+        client().admin().cluster().execute(GetViewAction.INSTANCE, request, capture);
+
+        assertNull("view GET on a co-resident data stream must not error", capture.error.get());
+        assertNotNull(capture.response);
+    }
+
+    public void testGetViewByMissingNameReturnsCleanNotFound() {
+        // GET a view by a name that does not exist. The view resolver throws IndexNotFoundException; the transport must
+        // translate it to a clean view-shaped not-found, never leak the raw index_not_found_exception. Mirrors the
+        // dataset get/delete and view delete transports.
+        final String missing = "no-such-view-" + randomAlphaOfLength(6).toLowerCase(java.util.Locale.ROOT);
+        GetViewAction.Request request = new GetViewAction.Request(TimeValue.timeValueMinutes(1));
+        request.indices(missing);
+        TestResponseCapture<GetViewAction.Response> capture = new TestResponseCapture<>();
+        client().admin().cluster().execute(GetViewAction.INSTANCE, request, capture);
+
+        Exception error = capture.error.get();
+        assertThat(error, instanceOf(ResourceNotFoundException.class));
+        assertThat(error.getMessage(), containsString("view [" + missing + "] not found"));
+        // IndexNotFoundException is itself a ResourceNotFoundException subtype, so guard against the raw leak.
+        assertThat("GET must not leak the raw index resolution error", error, not(instanceOf(IndexNotFoundException.class)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/ViewRestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/ViewRestTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.plugins.Plugin;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
@@ -84,7 +85,7 @@ public class ViewRestTests extends AbstractViewTestCase {
         // GET a view by a name that does not exist. The view resolver throws IndexNotFoundException; the transport must
         // translate it to a clean view-shaped not-found, never leak the raw index_not_found_exception. Mirrors the
         // dataset get/delete and view delete transports.
-        final String missing = "no-such-view-" + randomAlphaOfLength(6).toLowerCase(java.util.Locale.ROOT);
+        final String missing = "no-such-view-" + randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
         GetViewAction.Request request = new GetViewAction.Request(TimeValue.timeValueMinutes(1));
         request.indices(missing);
         TestResponseCapture<GetViewAction.Response> capture = new TestResponseCapture<>();


### PR DESCRIPTION
## What this is about

`GET /_query/dataset/<name>` and `GET /_query/view/<name>`, when the name resolves to something that is not a dataset/view — a co-resident data stream, or a name that doesn't exist — leaked a raw `index_not_found_exception` straight to the client. For datasets the leak even carried the internal `excluded_ds: true` metadata. It surfaced from a snapshot build hitting `no such index [entities-updates-default]` (the Entity Store data stream) while working with datasets.

## Why it happens

Dataset/view name resolution is additive — `resolveDatasets` / `resolveViews` mean "also surface datasets/views" on top of normal index resolution — and filters to the target type only after resolution. For an explicit name, the resolver checks index existence first and throws an index-shaped error before the type filter runs. The delete transports already catch and translate this; the GET transports did not.

## What this PR does

The dataset and view GET transports catch `IndexNotFoundException` and translate it to a clean `ResourceNotFoundException("dataset|view [...] not found")`, mirroring `TransportDeleteDatasetAction` / `TransportDeleteViewAction`. List-all and valid-name behavior are unchanged. The fix lives in the transport, after authorization, so it behaves identically security-on and security-off.

## Does it work?

Yes — verified end to end, security on and off:

- dataset GET by an explicit data-stream name → clean not-found, no `excluded_ds` leak.
- dataset list with a co-resident data stream → returns the datasets (this path was always safe).
- view GET by a missing name → clean not-found.
- view GET by a data-stream name → empty. Views never had the dataset data-stream leak; the view resolver is already lenient there. The tests document that distinction.
- non-superuser dataset list; security-on view GET not-found.

## What's in the diff

- `TransportGetDatasetAction`, `TransportGetViewAction`: catch + translate.
- Regression tests across the resolver unit layer, the single-node REST IT, the view single-node tests, and the security IT.

## Known behavior

GET by an explicit name that is a co-resident data stream returns a clean 404 for datasets but an empty result for views — the two resolvers differ in leniency (datasets throw, views filter). This asymmetry is pre-existing at the resolver layer; this PR only changes the dataset *error shape* (raw leak → clean not-found), it doesn't introduce the asymmetry. Unifying it would mean changing the view resolver's leniency, which is a separate change.

## What's out of scope

The deeper "datasets-only / views-only" exclusive resolution mode — so resolution never throws for these at all and the per-transport catch becomes unnecessary. The per-transport translate matches the established delete pattern and is sufficient here; the exclusive mode would reach into the shared core resolver.
