### PR TITLE
Mute DiskBBQClientYamlTestSuiteIT slice test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -770,6 +770,9 @@ tests:
 - class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
   method: testSeqNoPartiallyRetainedByCcrLease
   issue: https://github.com/elastic/elasticsearch/issues/152498
+- class: org.elasticsearch.xpack.diskbbq.DiskBBQClientYamlTestSuiteIT
+  method: test {yaml=search.vectors/47_knn_search_bbq_disk_slice/KNN search with a different _slice returns that slice's nearest neighbor}
+  issue: https://github.com/elastic/elasticsearch/issues/152520
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SumSerializationTests
   method: testSerializeSumWithOverflowingLongSupplier
   issue: https://github.com/elastic/elasticsearch/issues/152506


### PR DESCRIPTION
Mutes `DiskBBQClientYamlTestSuiteIT` test `{yaml=search.vectors/47_knn_search_bbq_disk_slice/KNN search with a different _slice returns that slice's nearest neighbor}`, which is failing in CI.

Relates https://github.com/elastic/elasticsearch/issues/152520
