### PR TITLE
[Inference API] Fixing azure openai oauth2 tenant_id sensitivity

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiOAuth2Settings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiOAuth2Settings.java
@@ -188,7 +188,7 @@ public class AzureOpenAiOAuth2Settings implements ToXContentFragment, Writeable 
                 new SettingsConfiguration.Builder(supportedTaskTypes).setDescription(TENANT_ID_CONFIG_DESCRIPTION)
                     .setLabel("OAuth2 Tenant ID")
                     .setRequired(false)
-                    .setSensitive(true)
+                    .setSensitive(false)
                     .setUpdatable(true)
                     .setType(SettingsConfigurationFieldType.STRING)
                     .build()

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
@@ -1626,7 +1626,7 @@ public class AzureOpenAiServiceTests extends InferenceServiceTestCase {
                                       "description": "The directory tenant that you want to request permission from.",
                                       "label": "OAuth2 Tenant ID",
                                       "required": false,
-                                      "sensitive": true,
+                                      "sensitive": false,
                                       "updatable": true,
                                       "type": "str",
                                       "supported_task_types": [


### PR DESCRIPTION
This is a manual backport for the Azure OpenAI OAuth2 fix introduced in this PR: https://github.com/elastic/elasticsearch/pull/152525

The tenant_id isn't sensitive so fixing it so Kibana displays it appropriately.