### PR TITLE
Handle wrapped MergeAbortedException in StatelessIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -773,9 +773,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SumSerializationTests
   method: testSerializeSumWithOverflowingLongSupplier
   issue: https://github.com/elastic/elasticsearch/issues/152506
-- class: org.elasticsearch.xpack.stateless.StatelessIT
-  method: testBackgroundMergeCommitAfterRelocationHasStartedDoesNotSendANewCommitNotification
-  issue: https://github.com/elastic/elasticsearch/issues/152516
 - class: org.elasticsearch.transport.RemoteClusterClientTests
   method: testConnectAndExecuteRequest
   issue: https://github.com/elastic/elasticsearch/issues/152518

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessIT.java
@@ -964,7 +964,9 @@ public class StatelessIT extends AbstractStatelessPluginIntegTestCase {
                 // Force merge checks if the engine is still open at the end, and sometimes it might
                 // throw an AlreadyClosedException even after the commit is already processed by ShardCommitState
             } catch (IOException e) {
-                fail(e);
+                if (e.getCause() instanceof MergePolicy.MergeAbortedException == false) {
+                    fail(e);
+                }
             }
         }, "force-merge-thread");
         forceMergeThread.start();


### PR DESCRIPTION
We were checking for a plain exception thrown from forceMerge, but it can also be wrapped by an IOException.

Fixes #152516