### PR TITLE
[8.19] Fix assertion (#152476) | Fix summary in change log (#152519)

### DIFF
--- a/docs/changelog/152476.yaml
+++ b/docs/changelog/152476.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 152476
+summary: Fix assertion
+type: bug

--- a/docs/changelog/152476.yaml
+++ b/docs/changelog/152476.yaml
@@ -1,5 +1,5 @@
 area: Search
 issues: []
 pr: 152476
-summary: Fix assertion
+summary: Return a 400 (Bad Request) for invalid tokens in a `script` query
 type: bug

--- a/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -109,7 +109,7 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
                 }
             } else {
                 if (token != XContentParser.Token.START_ARRAY) {
-                    throw new AssertionError("Impossible token received: " + token.name());
+                    throw new ParsingException(parser.getTokenLocation(), "[script] query does not support token [" + token + "]");
                 }
                 throw new ParsingException(
                     parser.getTokenLocation(),

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -127,4 +127,15 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
         ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> queryBuilder.toQuery(searchExecutionContext));
         assertEquals("[script] queries cannot be executed when 'search.allow_expensive_queries' is set to false.", e.getMessage());
     }
+
+    public void testNullScript() {
+        String json = """
+            {
+              "script" : {
+                "script" : null
+              }
+            }""";
+        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
+        assertThat(e.getMessage(), containsString("[script] query does not support token [VALUE_NULL]"));
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix assertion (#152476)](https://github.com/elastic/elasticsearch/pull/152476)
 - [Fix summary in change log (#152519)](https://github.com/elastic/elasticsearch/pull/152519)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)