### PR TITLE
[ESQL] Encode external Parquet unsigned_long reads

### DIFF
--- a/docs/changelog/152551.yaml
+++ b/docs/changelog/152551.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152551
+summary: Encode external Parquet `unsigned_long` reads
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTestingIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTestingIT.java
@@ -652,8 +652,13 @@ public class ParquetTestingIT extends ESRestTestCase {
                 double epsilon = Math.abs(gtd) * 1e-6 + 1e-15;
                 assertEquals("Float mismatch at " + ctx, gtd, esqld, epsilon);
             } else if ("unsigned_long".equals(esqlType)) {
-                long esqlDecoded = esqlNum.longValue() ^ Long.MIN_VALUE;
-                assertEquals("Unsigned long mismatch at " + ctx, gtNum.longValue(), esqlDecoded);
+                // The ESQL response already holds the decoded unsigned value (the JSON output edge decodes
+                // unsigned_long blocks), so compare it directly against the ground truth. Both sides are compared
+                // as unsigned over the full [0, 2^64-1] range: the ground truth is the raw INT64 bits reinterpreted
+                // as unsigned, and the response value may be a Long (<= Long.MAX_VALUE) or a BigInteger (above it).
+                java.math.BigInteger gtUnsigned = new java.math.BigInteger(Long.toUnsignedString(gtNum.longValue()));
+                java.math.BigInteger esqlUnsigned = new java.math.BigInteger(esqlNum.toString());
+                assertEquals("Unsigned long mismatch at " + ctx, gtUnsigned, esqlUnsigned);
             } else {
                 assertEquals("Integer mismatch at " + ctx, gtNum.longValue(), esqlNum.longValue());
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -30,6 +30,7 @@ import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -158,14 +159,17 @@ final class PageColumnReader implements Releasable {
                         // TIME_MILLIS: physical INT32, widen to long (raw ms value, no unit conversion)
                         yield readInt32AsLongBatch(maxRows, blockFactory, true);
                     }
-                    yield readLongBatch(maxRows, blockFactory, ParquetColumnDecoding.timeNanoMultiplier(time));
+                    yield readLongBatch(maxRows, blockFactory, ParquetColumnDecoding.timeNanoMultiplier(time), false);
                 }
                 if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
                     var logicalType = (LogicalTypeAnnotation.IntLogicalTypeAnnotation) info.logicalType();
                     // A plain INT32 with no logical-type annotation is historically "signed"
                     yield readInt32AsLongBatch(maxRows, blockFactory, logicalType == null || logicalType.isSigned());
                 }
-                yield readLongBatch(maxRows, blockFactory, 1L);
+                // A 64-bit unsigned column maps to UNSIGNED_LONG, which ESQL stores sign-flip-encoded
+                // (value ^ 2^63) so signed-long ordering matches unsigned ordering. The output edge always
+                // decodes UNSIGNED_LONG blocks, so the read path must emit the encoded form here.
+                yield readLongBatch(maxRows, blockFactory, 1L, info.esqlType() == DataType.UNSIGNED_LONG);
             }
             case DOUBLE -> readDoubleBatch(maxRows, blockFactory);
             case KEYWORD, TEXT -> readBytesBatch(maxRows, blockFactory);
@@ -750,11 +754,24 @@ final class PageColumnReader implements Releasable {
 
     // --- Long ---
 
-    private Block readLongBatch(int maxRows, BlockFactory blockFactory, long multiplier) {
+    /**
+     * Reads a Parquet INT64 column into a {@code LONG}/{@code UNSIGNED_LONG} block.
+     *
+     * @param multiplier     factor applied to each value, used to normalize Parquet TIME_* units to nanoseconds
+     *                       ({@code 1L} when no conversion is needed).
+     * @param encodeUnsigned when {@code true} the column is an {@code unsigned_long}; the decoded values are sign-flip-encoded
+     *                       ({@code value ^ 2^63}) in place before constant detection and block creation, mirroring the indexing
+     *                       path so the always-decoding output edge produces the true unsigned value. Encoding before constant
+     *                       detection keeps a constant {@code unsigned_long} column correctly encoded. Mutually exclusive with a
+     *                       non-unit {@code multiplier} (a column is either a TIME type or {@code unsigned_long}).
+     */
+    private Block readLongBatch(int maxRows, BlockFactory blockFactory, long multiplier, boolean encodeUnsigned) {
         long[] values = UninitializedArrays.newLongArray(maxRows);
         if (maxDefLevel == 0) {
             int produced = readNonNullLongs(values, 0, maxRows);
-            if (multiplier != 1) {
+            if (encodeUnsigned) {
+                ParquetColumnDecoding.encodeUnsignedLongInPlace(values, produced);
+            } else if (multiplier != 1) {
                 for (int i = 0; i < produced; i++) {
                     values[i] *= multiplier;
                 }
@@ -775,7 +792,9 @@ final class PageColumnReader implements Releasable {
             produced += fromPage;
             remaining -= fromPage;
         }
-        if (multiplier != 1) {
+        if (encodeUnsigned) {
+            ParquetColumnDecoding.encodeUnsignedLongInPlace(values, produced);
+        } else if (multiplier != 1) {
             for (int i = 0; i < produced; i++) {
                 values[i] *= multiplier;
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -19,12 +19,13 @@ import org.apache.parquet.schema.Type;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 
 /**
  * Shared Parquet decode helpers used by both the baseline {@code ParquetColumnIterator}
  * and {@link OptimizedParquetColumnIterator}. Centralises list-column decoding,
- * timestamp conversion, UUID formatting, and other utilities so that bug fixes in one
- * decode path are automatically reflected in the other.
+ * timestamp conversion, UUID formatting, {@code unsigned_long} sign-flip encoding, and other utilities so that bug
+ * fixes in one decode path are automatically reflected in the other.
  */
 final class ParquetColumnDecoding {
 
@@ -52,6 +53,29 @@ final class ParquetColumnDecoding {
      */
     static long timeNanoMultiplier(LogicalTypeAnnotation.TimeLogicalTypeAnnotation time) {
         return time.getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS ? 1_000L : 1L;
+    }
+
+    // ---- Unsigned long encoding ----
+
+    /**
+     * Sign-flip-encodes a raw {@code unsigned_long} value ({@code value ^ 2^63}) into ESQL's sortable signed
+     * representation, mirroring the indexing path. ESQL stores {@code unsigned_long} inside a signed {@code LongBlock}
+     * in this form so signed-long ordering matches unsigned ordering, and every value-output surface decodes it back on
+     * the way out. Every Parquet read producer of an {@code unsigned_long} block must therefore route its INT64 values
+     * through this method. Shared so the baseline, optimized, and list read paths cannot drift.
+     */
+    static long encodeUnsignedLong(long value) {
+        return NumericUtils.asLongUnsigned(value);
+    }
+
+    /**
+     * Applies {@link #encodeUnsignedLong(long)} to the first {@code count} values in place. Null slots within the range
+     * hold undefined bits but are masked out by the caller, so encoding them is harmless.
+     */
+    static void encodeUnsignedLongInPlace(long[] values, int count) {
+        for (int i = 0; i < count; i++) {
+            values[i] = encodeUnsignedLong(values[i]);
+        }
     }
 
     // ---- UUID formatting ----
@@ -132,6 +156,7 @@ final class ParquetColumnDecoding {
                     : 1L;
                 yield readListLongColumn(cr, maxDef, rows, blockFactory, multiplier);
             }
+            case UNSIGNED_LONG -> readListUnsignedLongColumn(cr, maxDef, rows, blockFactory);
             case DOUBLE -> readListDoubleColumn(cr, maxDef, rows, blockFactory);
             case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows, blockFactory);
             case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows, blockFactory);
@@ -212,6 +237,21 @@ final class ParquetColumnDecoding {
     private static Block readListInt32AsLongColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
         try (var builder = blockFactory.newLongBlockBuilder(rows)) {
             Runnable appender = () -> builder.appendLong(cr.getInteger());
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Reads a LIST of {@code unsigned_long} (Parquet INT64 with {@code intType(64, false)}) into a {@code LongBlock}.
+     * Each element is sign-flip-encoded ({@code value ^ 2^63}) on the way in, mirroring the scalar read path and the
+     * indexing path, so the always-decoding output edge produces the true unsigned value.
+     */
+    private static Block readListUnsignedLongColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+            Runnable appender = () -> builder.appendLong(encodeUnsignedLong(cr.getLong()));
             for (int row = 0; row < rows; row++) {
                 readListRow(cr, maxDef, builder, appender);
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -2186,7 +2186,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                             // TIME_MILLIS: physical INT32, widen to long (raw ms value, no unit conversion)
                             yield readInt32WidenedToLongColumn(cr, info.maxDefLevel(), rowsToRead, true);
                         }
-                        yield readLongColumn(cr, info.maxDefLevel(), rowsToRead, ParquetColumnDecoding.timeNanoMultiplier(time));
+                        yield readLongColumn(cr, info.maxDefLevel(), rowsToRead, ParquetColumnDecoding.timeNanoMultiplier(time), false);
                     }
                     var logicalType = (LogicalTypeAnnotation.IntLogicalTypeAnnotation) info.logicalType();
                     if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
@@ -2198,7 +2198,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                             logicalType == null || logicalType.isSigned()
                         );
                     }
-                    yield readLongColumn(cr, info.maxDefLevel(), rowsToRead, 1L);
+                    // A 64-bit unsigned column maps to UNSIGNED_LONG, which ESQL stores sign-flip-encoded
+                    // (value ^ 2^63) so signed-long ordering matches unsigned ordering. The output edge always
+                    // decodes UNSIGNED_LONG blocks, so the read path must emit the encoded form here.
+                    yield readLongColumn(cr, info.maxDefLevel(), rowsToRead, 1L, info.esqlType() == DataType.UNSIGNED_LONG);
                 }
                 case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
                 case KEYWORD, TEXT -> {
@@ -2271,7 +2274,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull, false);
         }
 
-        private Block readLongColumn(ColumnReader cr, int maxDef, int rows, long multiplier) {
+        /**
+         * Reads a Parquet INT64 column into a {@code LONG}/{@code UNSIGNED_LONG} block.
+         *
+         * @param multiplier     factor applied to each value, used to normalize Parquet TIME_* units to nanoseconds
+         *                       ({@code 1L} when no conversion is needed).
+         * @param encodeUnsigned when {@code true} the column is an {@code unsigned_long}; each value is sign-flip-encoded
+         *                       ({@code value ^ 2^63}) before landing in the block, mirroring the indexing path so the
+         *                       always-decoding output edge produces the true unsigned value. Mutually exclusive with a
+         *                       non-unit {@code multiplier} (a column is either a TIME type or {@code unsigned_long}).
+         */
+        private Block readLongColumn(ColumnReader cr, int maxDef, int rows, long multiplier, boolean encodeUnsigned) {
             long[] values = UninitializedArrays.newLongArray(rows);
             BitSet isNull = maxDef > 0 ? new BitSet(rows) : null;
             boolean noNulls = true;
@@ -2280,7 +2293,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     isNull.set(i);
                     noNulls = false;
                 } else {
-                    values[i] = cr.getLong() * multiplier;
+                    long value = cr.getLong();
+                    values[i] = encodeUnsigned ? ParquetColumnDecoding.encodeUnsignedLong(value) : value * multiplier;
                 }
                 cr.consume();
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1671,6 +1671,91 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
     }
 
+    public void testReadListOfUnsignedLongColumn() throws Exception {
+        assertReadListOfUnsignedLongColumn(new ParquetFormatReader(blockFactory, false)); // baseline reader
+    }
+
+    public void testReadListOfUnsignedLongColumnOptimizedReader() throws Exception {
+        assertReadListOfUnsignedLongColumn(new ParquetFormatReader(blockFactory, true)); // optimized reader
+    }
+
+    /**
+     * A LIST of unsigned_long (Parquet INT64 with {@code intType(64, false)}) must sign-flip-encode each element
+     * ({@code value ^ 2^63}), just like the scalar path, so the always-decoding output edge produces the true unsigned
+     * value. Before the encode was added, list columns fell into the unsupported branch and read back as all-null.
+     * Both reader paths route list columns through the same shared decoder, so both are exercised here.
+     */
+    private void assertReadListOfUnsignedLongColumn(ParquetFormatReader reader) throws Exception {
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.intType(64, false)) // unsigned, bit-width 64
+            .named("values");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        long maxUnsigned = 0xFFFFFFFFFFFFFFFFL; // 2^64-1
+        // 2^63 + 100: as an unsigned value this is > Long.MAX_VALUE, so it encodes (^ 2^63) to a non-negative long --
+        // the opposite side of the sign boundary from 0 and 100, which encode to negative longs.
+        long aboveSignedMaxUnsigned = 0x8000000000000064L;
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            // Row 0: [0, 2^63+100, 2^64-1] -- spans both sides of the encoding's sign boundary
+            Group g1 = factory.newGroup();
+            Group list1 = g1.addGroup("values");
+            list1.addGroup("list").append("element", 0L);
+            list1.addGroup("list").append("element", aboveSignedMaxUnsigned);
+            list1.addGroup("list").append("element", maxUnsigned);
+
+            // Row 1: null list (no addGroup call)
+            Group g2 = factory.newGroup();
+
+            // Row 2: [100, null element, 200]
+            Group g3 = factory.newGroup();
+            Group list3 = g3.addGroup("values");
+            list3.addGroup("list").append("element", 100L);
+            list3.addGroup("list"); // element absent -> null within the list
+            list3.addGroup("list").append("element", 200L);
+
+            // Row 3: [] (empty, non-null list)
+            Group g4 = factory.newGroup();
+            g4.addGroup("values");
+
+            return List.of(g1, g2, g3, g4);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.UNSIGNED_LONG, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(4, page.getPositionCount());
+
+            LongBlock block = (LongBlock) page.getBlock(0);
+            // Row 0: [0, 2^63+100, 2^64-1] sign-flip-encoded
+            assertFalse(block.isNull(0));
+            assertEquals(3, block.getValueCount(0));
+            int start0 = block.getFirstValueIndex(0);
+            assertEquals(0L ^ Long.MIN_VALUE, block.getLong(start0));
+            assertEquals(aboveSignedMaxUnsigned ^ Long.MIN_VALUE, block.getLong(start0 + 1));
+            assertEquals(maxUnsigned ^ Long.MIN_VALUE, block.getLong(start0 + 2));
+
+            // Row 1: null list
+            assertTrue(block.isNull(1));
+
+            // Row 2: [100, 200] encoded; the null element is dropped (multivalue blocks do not hold null slots within a list)
+            assertFalse(block.isNull(2));
+            assertEquals(2, block.getValueCount(2));
+            int start2 = block.getFirstValueIndex(2);
+            assertEquals(100L ^ Long.MIN_VALUE, block.getLong(start2));
+            assertEquals(200L ^ Long.MIN_VALUE, block.getLong(start2 + 1));
+
+            // Row 3: [] empty list -> read back as null (the shared list decoder maps an empty list to a null position;
+            // ESQL multivalue blocks have no distinct empty-list representation). This is pre-existing list behavior,
+            // independent of the unsigned encoding, asserted here to document it for the unsigned_long path.
+            assertTrue(block.isNull(3));
+        }
+    }
+
     // --- UUID formatting unit test ---
 
     public void testFormatUuid() {
@@ -3455,8 +3540,95 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
-            assertEquals(unsignedBits, ((LongBlock) page.getBlock(0)).getLong(0));
+            // ESQL stores unsigned_long sign-flip-encoded (value ^ 2^63); the output edge decodes it back to the true value.
+            assertEquals(unsignedBits ^ Long.MIN_VALUE, ((LongBlock) page.getBlock(0)).getLong(0));
             assertFalse(iterator.hasNext());
+        }
+    }
+
+    public void testUnsignedLong64SignFlipEncoding() throws Exception {
+        assertUnsignedLong64SignFlipEncoding(new ParquetFormatReader(blockFactory, false)); // baseline reader
+    }
+
+    public void testUnsignedLong64SignFlipEncodingOptimizedReader() throws Exception {
+        assertUnsignedLong64SignFlipEncoding(new ParquetFormatReader(blockFactory, true)); // optimized reader
+    }
+
+    /**
+     * A 64-bit unsigned column maps to UNSIGNED_LONG, which ESQL stores in a signed LongBlock in sign-flip-encoded form
+     * ({@code value ^ 2^63}) so signed-long ordering matches unsigned ordering. The producer (this reader) must emit the
+     * encoded form because the output edge unconditionally decodes UNSIGNED_LONG blocks. This asserts the encode is applied
+     * across representative values, including {@code 0} and {@code 2^64-1}, on both reader paths.
+     */
+    private void assertUnsignedLong64SignFlipEncoding(ParquetFormatReader reader) throws Exception {
+        var schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.intType(64, false)) // unsigned, bit-width 64
+            .named("u64")
+            .named("test_schema");
+        // The encoding (v ^ 2^63) maps unsigned values in [0, 2^63-1] to negative longs and [2^63, 2^64-1] to non-negative
+        // longs. Cover both sides of that boundary: 0, small positive, 2^63-1 (largest value encoding to a negative long),
+        // 2^63 (smallest value encoding to a non-negative long), and 2^64-1.
+        long[] unsignedValues = { 0L, 100L, 0x7FFFFFFFFFFFFFFFL, 0x8000000000000000L, 0xFFFFFFFFFFFFFFFFL };
+        byte[] data = createParquetFile(schema, f -> {
+            List<Group> g = new ArrayList<>();
+            for (long bits : unsignedValues) {
+                g.add(f.newGroup().append("u64", bits));
+            }
+            return g;
+        });
+        var so = createStorageObject(data);
+        assertEquals(DataType.UNSIGNED_LONG, reader.metadata(so).schema().get(0).dataType());
+        try (CloseableIterator<Page> it = reader.read(so, null, 10)) {
+            LongBlock block = (LongBlock) it.next().getBlock(0);
+            for (int i = 0; i < unsignedValues.length; i++) {
+                // contract: a uint64 column is stored sign-flip-encoded (v ^ 2^63 == asLongUnsigned(v))
+                assertEquals(unsignedValues[i] ^ Long.MIN_VALUE, block.getLong(i));
+            }
+        }
+    }
+
+    public void testUnsignedLong64ConstantColumnEncoding() throws Exception {
+        assertUnsignedLong64ConstantColumnEncoding(new ParquetFormatReader(blockFactory, false), false); // baseline reader
+    }
+
+    public void testUnsignedLong64ConstantColumnEncodingOptimizedReader() throws Exception {
+        // The optimized reader collapses an all-equal column into a constant block; assert both the encoding and the collapse,
+        // which proves the encode is applied before constant detection rather than after.
+        assertUnsignedLong64ConstantColumnEncoding(new ParquetFormatReader(blockFactory, true), true);
+    }
+
+    /**
+     * A constant unsigned_long column must still be sign-flip-encoded. The encode is applied before constant detection,
+     * so a collapsed constant block holds the encoded value rather than the raw bits.
+     *
+     * @param expectConstantCollapse when {@code true} the block is additionally asserted to be a constant vector; only the
+     *                               optimized reader performs this collapse, so the baseline reader passes {@code false}.
+     */
+    private void assertUnsignedLong64ConstantColumnEncoding(ParquetFormatReader reader, boolean expectConstantCollapse) throws Exception {
+        var schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.intType(64, false)) // unsigned
+            .named("u64")
+            .named("test_schema");
+        long unsignedBits = 0xFFFFFFFFFFFFFFFFL; // 2^64-1, constant across all rows
+        byte[] data = createParquetFile(schema, f -> {
+            List<Group> g = new ArrayList<>();
+            for (int i = 0; i < 16; i++) {
+                g.add(f.newGroup().append("u64", unsignedBits));
+            }
+            return g;
+        });
+        var so = createStorageObject(data);
+        try (CloseableIterator<Page> it = reader.read(so, null, 100)) {
+            LongBlock block = (LongBlock) it.next().getBlock(0);
+            assertEquals(16, block.getPositionCount());
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                assertEquals(unsignedBits ^ Long.MIN_VALUE, block.getLong(i));
+            }
+            if (expectConstantCollapse) {
+                assertTrue("optimized reader should collapse an all-equal column into a constant vector", block.asVector().isConstant());
+            }
         }
     }
 


### PR DESCRIPTION
External Parquet `uint64` columns were read back transformed by `XOR 2^63` on every output path (projection, sort, aggregate, group-by), silently corrupting a common type with no error.

ESQL stores `unsigned_long` inside a signed `LongBlock` in sign-flip-encoded form (`value ^ 2^63`) so signed-long ordering matches unsigned ordering. Every value-output surface decodes unconditionally on the way out, so any producer of an `unsigned_long` block must emit the encoded form. The Parquet reader is such a producer but skipped the encode for the 64-bit unsigned case, so the output decode undid an encode that never happened.

This applies the sign-flip encode when the resolved type is `unsigned_long` across all three read producers: the baseline scalar reader, the optimized batch reader (before constant detection so a constant column still encodes), and the shared list/repeated-column decoder (which previously dropped `uint64` lists entirely as an unsupported type, reading them back as all null). Smaller unsigned widths are unaffected: Parquet `uint32` maps to `LONG`, not `unsigned_long`, so it needs no sign-flip.