### PR TITLE
Mute InferenceRestMultiNodeIT rescore_chunks telemetry test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -770,6 +770,9 @@ tests:
 - class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
   method: testSeqNoPartiallyRetainedByCcrLease
   issue: https://github.com/elastic/elasticsearch/issues/152498
+- class: org.elasticsearch.xpack.inference.InferenceRestMultiNodeIT
+  method: test {p0=inference/10_retriever_extended_telemetry/Reranking based on rescore_chunks is reflected in extended search usage stats}
+  issue: https://github.com/elastic/elasticsearch/issues/152559
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SumSerializationTests
   method: testSerializeSumWithOverflowingLongSupplier
   issue: https://github.com/elastic/elasticsearch/issues/152506


### PR DESCRIPTION
Mutes the failing test.

Relates to https://github.com/elastic/elasticsearch/issues/152559
