### PR TITLE
[8.19] [Gradle] Cleanup project usage in task implementations (#152445)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/FilePermissionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/FilePermissionsTask.java
@@ -54,11 +54,12 @@ public abstract class FilePermissionsTask extends DefaultTask {
         // exclude sh files that might have the executable bit set
         .exclude("**/*.sh");
 
-    private File outputMarker = new File(getProject().getBuildDir(), "markers/filePermissions");
+    private File outputMarker;
 
     @Inject
     public FilePermissionsTask(ProjectLayout projectLayout) {
         this.projectLayout = projectLayout;
+        this.outputMarker = new File(projectLayout.getBuildDirectory().getAsFile().get(), "markers/filePermissions");
         setDescription("Checks java source files for correct file permissions");
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
@@ -161,7 +161,13 @@ public class CopyRestApiTask extends DefaultTask {
                 }
             }
         } catch (IOException e) {
-            throw new IllegalStateException(String.format("Error determining if this project [%s] has rest tests.", getProject()), e);
+            throw new IllegalStateException(
+                String.format(
+                    "Error determining if this project [%s] has rest tests.",
+                    projectLayout.getProjectDirectory().getAsFile().getPath()
+                ),
+                e
+            );
         }
         return false;
     }

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/ConfigurationCacheArchUnitSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/ConfigurationCacheArchUnitSpec.groovy
@@ -38,8 +38,6 @@ class ConfigurationCacheArchUnitSpec extends AbstractArchUnitSpec {
      * removed as they are made configuration-cache safe (the staleness test enforces this).
      */
     private static final Set<String> KNOWN_GET_PROJECT_IN_TASKS = [
-        "org.elasticsearch.gradle.internal.precommit.FilePermissionsTask",
-        "org.elasticsearch.gradle.internal.test.rest.CopyRestApiTask",
     ] as Set
 
     @Shared


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Gradle] Cleanup project usage in task implementations (#152445)