### PR TITLE
[9.4] Replace Project.getRootDir() with ProjectLayout.getSettingsDirectory() (#152511)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -524,7 +524,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 if (project.getGradle().getStartParameter().isBuildCacheEnabled()) {
                     c.getArgs().add("--build-cache");
                 }
-                File rootDir = project.getRootDir();
+                File rootDir = project.getLayout().getSettingsDirectory().getAsFile();
                 c.doLast(new Action<Task>() {
                     @Override
                     public void execute(Task task) {
@@ -604,7 +604,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             : effectiveMavenGroup + ":" + effectiveMavenModule + ":" + versionString + ":" + gradleClassifier + "@" + extension;
         project.getDependencies().add(draConfigName, dependencyNotation);
 
-        File rootDir = project.getRootDir();
+        File rootDir = project.getLayout().getSettingsDirectory().getAsFile();
         if (mavenModule.isEmpty() == false) {
             // Maven JAR artifacts (JDBC, stable API): use a dedicated task type so that
             // getOutputs().getFiles() contains exactly the downloaded JAR. A Copy task's

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportPlugin.java
@@ -12,11 +12,13 @@ import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.provider.Provider;
 
-import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.inject.Inject;
 
 import static org.elasticsearch.gradle.internal.util.ParamsUtils.loadBuildParams;
 
@@ -27,6 +29,13 @@ import static org.elasticsearch.gradle.internal.util.ParamsUtils.loadBuildParams
 public class DockerSupportPlugin implements Plugin<Project> {
     public static final String DOCKER_SUPPORT_SERVICE_NAME = "dockerSupportService";
     public static final String DOCKER_ON_LINUX_EXCLUSIONS_FILE = ".ci/dockerOnLinuxExclusions";
+
+    private final ProjectLayout projectLayout;
+
+    @Inject
+    public DockerSupportPlugin(ProjectLayout projectLayout) {
+        this.projectLayout = projectLayout;
+    }
 
     @Override
     public void apply(Project project) {
@@ -39,7 +48,7 @@ public class DockerSupportPlugin implements Plugin<Project> {
         Provider<DockerSupportService> dockerSupportServiceProvider = project.getGradle()
             .getSharedServices()
             .registerIfAbsent(DOCKER_SUPPORT_SERVICE_NAME, DockerSupportService.class, spec -> spec.parameters(params -> {
-                params.setExclusionsFile(new File(project.getRootDir(), DOCKER_ON_LINUX_EXCLUSIONS_FILE));
+                params.setExclusionsFile(projectLayout.getSettingsDirectory().file(DOCKER_ON_LINUX_EXCLUSIONS_FILE).getAsFile());
                 params.getIsCI().set(buildParams.getCi());
             }));
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/esql/EsqlFunctionPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/esql/EsqlFunctionPlugin.java
@@ -99,11 +99,15 @@ public class EsqlFunctionPlugin implements Plugin<Project> {
             File tempDir = project.file("build/testrun/test/temp/" + folder);
             File commandsExamplesFile = new File(tempDir, "commands.examples");
             FileTree mdFiles = project.fileTree(
-                new File(project.getRootDir(), "docs/reference/query-languages/" + folder + "/_snippets/commands/examples/"),
+                new File(
+                    project.getLayout().getSettingsDirectory().getAsFile(),
+                    "docs/reference/query-languages/" + folder + "/_snippets/commands/examples/"
+                ),
                 tree -> tree.include("**/*.csv-spec/*.md")
             );
 
-            Path docFolder = new File(project.getRootDir(), "docs/reference/query-languages/" + folder).toPath();
+            Path docFolder = new File(project.getLayout().getSettingsDirectory().getAsFile(), "docs/reference/query-languages/" + folder)
+                .toPath();
             File snippetsDocFolder = docFolder.resolve("_snippets").toFile();
             File imagesDocFolder = docFolder.resolve("images").toFile();
             File kibanaDocFolder = docFolder.resolve("kibana").toFile();

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsPrecommitPlugin.java
@@ -45,7 +45,7 @@ public class ForbiddenPatternsPrecommitPlugin extends PrecommitPlugin {
                     .map(sourceSet -> sourceSet.getProcessResourcesTaskName())
                     .collect(Collectors.toList())
             );
-            forbiddenPatternsTask.getRootDir().set(project.getRootDir());
+            forbiddenPatternsTask.getRootDir().set(project.getLayout().getSettingsDirectory().getAsFile());
         });
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateRestSpecPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ValidateRestSpecPlugin.java
@@ -29,7 +29,9 @@ public class ValidateRestSpecPlugin implements Plugin<Project> {
                 }));
                 // This must always be specified precisely, so that
                 // projects other than `rest-api-spec` can use this task.
-                task.setJsonSchema(new File(project.getRootDir(), "rest-api-spec/src/main/resources/schema.json"));
+                task.setJsonSchema(
+                    project.getLayout().getSettingsDirectory().file("rest-api-spec/src/main/resources/schema.json").getAsFile()
+                );
                 task.setReport(new File(project.getBuildDir(), "reports/validateJson.txt"));
             });
 
@@ -39,7 +41,7 @@ public class ValidateRestSpecPlugin implements Plugin<Project> {
                     filter.include(DOUBLE_STAR + "/rest-api-spec/api/" + DOUBLE_STAR + "/*.json");
                     filter.exclude(DOUBLE_STAR + "/_common.json");
                 }));
-                task.setJsonKeywords(new File(project.getRootDir(), "rest-api-spec/keywords.json"));
+                task.setJsonKeywords(project.getLayout().getSettingsDirectory().file("rest-api-spec/keywords.json").getAsFile());
                 task.setReport(new File(project.getBuildDir(), "reports/validateKeywords.txt"));
                 // There's no point running this task if the schema validation fails
                 task.mustRunAfter(validateRestSpecTask);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/PruneChangelogsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/PruneChangelogsTask.java
@@ -14,8 +14,8 @@ import com.google.common.annotations.VisibleForTesting;
 import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
@@ -48,10 +48,10 @@ public class PruneChangelogsTask extends DefaultTask {
     private final Path rootDir;
 
     @Inject
-    public PruneChangelogsTask(Project project, ObjectFactory objectFactory, ExecOperations execOperations) {
+    public PruneChangelogsTask(ProjectLayout projectLayout, ObjectFactory objectFactory, ExecOperations execOperations) {
         changelogs = objectFactory.fileCollection();
         gitWrapper = new GitWrapper(execOperations);
-        rootDir = project.getRootDir().toPath();
+        rootDir = projectLayout.getSettingsDirectory().getAsFile().toPath();
     }
 
     @Internal

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
@@ -72,7 +72,7 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
                 task.setGroup("Documentation");
                 task.setDescription("Validate that the changelog YAML files comply with the changelog schema");
                 task.setInputFiles(yamlFiles);
-                task.setJsonSchema(new File(project.getRootDir(), RESOURCES + "changelog-schema.json"));
+                task.setJsonSchema(projectLayout.getSettingsDirectory().file(RESOURCES + "changelog-schema.json").getAsFile());
                 task.setReport(new File(project.getBuildDir(), "reports/validateYaml.txt"));
             });
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
@@ -52,7 +52,9 @@ public class SnykDependencyMonitoringGradlePlugin implements Plugin<Project> {
                 generateSnykDependencyGraph.getTargetReference()
                     .set(providerFactory.gradleProperty("snykTargetReference").orElse(projectVersion));
                 generateSnykDependencyGraph.getRemoteUrl()
-                    .convention(providerFactory.provider(() -> GitInfo.gitInfo(project.getRootDir()).urlFromOrigin()));
+                    .convention(
+                        providerFactory.provider(() -> GitInfo.gitInfo(projectLayout.getSettingsDirectory().getAsFile()).urlFromOrigin())
+                    );
                 generateSnykDependencyGraph.getOutputFile().set(projectLayout.getBuildDirectory().file("snyk/dependencies.json"));
             });
 

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/IsolatedProjectsArchUnitSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/archunit/IsolatedProjectsArchUnitSpec.groovy
@@ -46,6 +46,8 @@ class IsolatedProjectsArchUnitSpec extends AbstractArchUnitSpec {
     // Baselines
     // -------------------------------------------------------------------------
 
+    private static final Set<String> KNOWN_GET_ROOT_DIR = [] as Set
+
     private static final Set<String> KNOWN_GET_ROOT_PROJECT = [
         "org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin",
         "org.elasticsearch.gradle.internal.BuildPlugin",
@@ -97,6 +99,20 @@ class IsolatedProjectsArchUnitSpec extends AbstractArchUnitSpec {
     // -------------------------------------------------------------------------
     // Rules
     // -------------------------------------------------------------------------
+
+    def "production code does not call Project.getRootDir()"() {
+        given:
+        ArchRule rule = noClasses()
+            .that(notInBaseline(KNOWN_GET_ROOT_DIR))
+            .should().callMethodWhere(projectMethodNamed("getRootDir"))
+            .because("Project.getRootDir() returns the root project directory as a raw File and is incompatible "
+                + "with project isolation and the configuration cache; use "
+                + "ProjectLayout.getSettingsDirectory() instead, which returns a lazy Directory "
+                + "that is cache-safe")
+
+        expect:
+        rule.check(productionClasses)
+    }
 
     def "production code does not call Project.getRootProject()"() {
         given:
@@ -186,6 +202,14 @@ class IsolatedProjectsArchUnitSpec extends AbstractArchUnitSpec {
     // -------------------------------------------------------------------------
     // Staleness checks
     // -------------------------------------------------------------------------
+
+    def "the getRootDir baseline contains no stale entries"() {
+        expect:
+        List<String> stale = staleBaselineEntries(KNOWN_GET_ROOT_DIR, productionClasses) { JavaClass c ->
+            callsProjectMethod(c, "getRootDir")
+        }
+        assert stale.isEmpty(), "Stale entries (migrated or removed) — delete them:\n  " + stale.join("\n  ")
+    }
 
     def "the getRootProject baseline contains no stale entries"() {
         expect:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Replace Project.getRootDir() with ProjectLayout.getSettingsDirectory() (#152511)](https://github.com/elastic/elasticsearch/pull/152511)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)