### PR TITLE
Add retries for TransportReshardSplitAction performed by split target shard

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -479,9 +479,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/estimate_model_memory/Test partition field with independent influencer}
   issue: https://github.com/elastic/elasticsearch/issues/151052
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
-  method: testMixedOperationsDuringSplitWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/151090
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testUnhollowOnUpdates
   issue: https://github.com/elastic/elasticsearch/issues/151100

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitTargetService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitTargetService.java
@@ -774,7 +774,7 @@ public class SplitTargetService {
         private final Split split;
         private final AtomicBoolean cancelled;
 
-        public InitiateSplitWithSourceShardAction(
+        InitiateSplitWithSourceShardAction(
             ClusterService clusterService,
             Client client,
             Split split,

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitTargetService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitTargetService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.stateless.reshard;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.FailedNodeException;
@@ -32,10 +33,13 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardClosedException;
+import org.elasticsearch.index.shard.IndexShardNotStartedException;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -477,9 +481,9 @@ public class SplitTargetService {
         }
 
         private void initiateSplitWithSourceShard(State.Clone state) {
-            client.execute(TransportReshardSplitAction.TYPE, new TransportReshardSplitAction.SplitRequest(split), new ActionListener<>() {
+            var action = new InitiateSplitWithSourceShardAction(clusterService, client, split, cancelled, new ActionListener<>() {
                 @Override
-                public void onResponse(ActionResponse ignored) {
+                public void onResponse(Void ignored) {
                     advance(new State.StartSplitRpcComplete(state.recoveryListener));
                 }
 
@@ -488,6 +492,7 @@ public class SplitTargetService {
                     advance(new State.FailedInRecovery(e, state.recoveryListener));
                 }
             });
+            action.run();
         }
 
         private void changeStateToHandoff(State.HandoffReceived handoffReceived) {
@@ -755,6 +760,74 @@ public class SplitTargetService {
                     timestamps.put(newState.getClass(), nowInMillis);
                 }
             }
+        }
+    }
+
+    // visible for tests
+    RetryableAction<Void> createInitiateSplitWithSourceShardAction(Split split, AtomicBoolean cancelled, ActionListener<Void> listener) {
+        return new InitiateSplitWithSourceShardAction(clusterService, client, split, cancelled, listener);
+    }
+
+    private static class InitiateSplitWithSourceShardAction extends RetryableAction<Void> {
+        private final Client client;
+
+        private final Split split;
+        private final AtomicBoolean cancelled;
+
+        public InitiateSplitWithSourceShardAction(
+            ClusterService clusterService,
+            Client client,
+            Split split,
+            AtomicBoolean cancelled,
+            ActionListener<Void> listener
+        ) {
+            super(
+                logger,
+                clusterService.threadPool(),
+                TimeValue.timeValueMillis(500),
+                TimeValue.timeValueSeconds(5),
+                // If we haven't made progress in this much time, fail back to allocator.
+                // Maybe the source shard is assigned to a different node now.
+                TimeValue.timeValueSeconds(60),
+                listener,
+                clusterService.threadPool().generic()
+            );
+            this.client = client;
+            this.split = split;
+            this.cancelled = cancelled;
+        }
+
+        @Override
+        public void tryAction(ActionListener<Void> listener) {
+            client.execute(
+                TransportReshardSplitAction.TYPE,
+                new TransportReshardSplitAction.SplitRequest(split),
+                listener.map(ignored -> null)
+            );
+        }
+
+        @Override
+        public boolean shouldRetry(Exception e) {
+            if (cancelled.get()) {
+                return false;
+            }
+
+            /// We apply internal retries if the source shard is not present/started.
+            /// This is because allocation only performs a limited number of retries (at the time of writing)
+            /// when a shard fails in recovery (which is what happens if start split RPC fails).
+            /// As such it is possible to exhaust this limited number of retries if f.e. source shard is relocating.
+            /// Recovering from this state requires manual intervention which is of course undesireable.
+            ///
+            /// Note that it is possible that we observe one of the *NotFound exceptions if the source shard
+            /// was moved from this node.
+            /// This is fine, eventually we'll stop retrying when we reach the retry timeout and retry the entire recovery sequence.
+            /// See corresponding source shard code in
+            /// [SplitSourceService#setupTargetShard(CancellableTask, ShardId, long, long, ActionListener)].
+            Throwable cause = ExceptionsHelper.unwrapCause(e);
+
+            return (cause instanceof IndexShardNotStartedException
+                || cause instanceof IndexNotFoundException
+                || cause instanceof ShardNotFoundException);
         }
     }
 

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/reshard/SplitTargetServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/reshard/SplitTargetServiceTests.java
@@ -20,8 +20,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardNotStartedException;
+import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -31,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.fail;
@@ -159,5 +164,90 @@ public class SplitTargetServiceTests extends ESTestCase {
             }
         });
         action.run();
+    }
+
+    public void testInitiateSplitWithSourceShardActionRetries() {
+        var time = new AtomicInteger(0);
+        var threadPool = new ThreadPool() {
+            @Override
+            public long relativeTimeInMillis() {
+                return time.getAndAdd(10 * 1000);
+            }
+
+            @Override
+            public ExecutorService generic() {
+                return EsExecutors.DIRECT_EXECUTOR_SERVICE;
+            }
+
+            @Override
+            public ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor) {
+                executor.execute(command);
+                // Only used for cancellation
+                return null;
+            }
+        };
+        var clusterService = mock(ClusterService.class);
+        when(clusterService.threadPool()).thenReturn(threadPool);
+
+        var reshardIndexService = mock(ReshardIndexService.class);
+
+        var sourceShardId = new ShardId("index", "uuid", 0);
+        var requests = new AtomicInteger(0);
+        var failingClient = new NoOpClient(threadPool) {
+            @Override
+            protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> action,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                if (action.name().equals(TransportReshardSplitAction.TYPE.name())) {
+                    requests.incrementAndGet();
+
+                    var exception = randomFrom(
+                        new IndexShardNotStartedException(sourceShardId, IndexShardState.RECOVERING),
+                        new IndexNotFoundException("", "index"),
+                        new ShardNotFoundException(sourceShardId)
+                    );
+                    listener.onFailure(exception);
+                }
+            }
+        };
+
+        var sts = new SplitTargetService(Settings.EMPTY, failingClient, clusterService, reshardIndexService);
+        var action = sts.createInitiateSplitWithSourceShardAction(dummySplit(), new AtomicBoolean(false), new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {
+                fail("Should never happen");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                // Should be 6 given the custom time implementation (6 times by 10 seconds exceeds 60 seconds timeout).
+                assertEquals(6, requests.get());
+            }
+        });
+
+        action.run();
+    }
+
+    private static SplitTargetService.Split dummySplit() {
+        var targetShardId = new ShardId("index", "1", 1);
+        var sourceNode = new DiscoveryNode(
+            "node1",
+            "node_1",
+            new TransportAddress(TransportAddress.META_ADDRESS, 10000),
+            Map.of(),
+            Set.of(),
+            null
+        );
+        var targetNode = new DiscoveryNode(
+            "node2",
+            "node_2",
+            new TransportAddress(TransportAddress.META_ADDRESS, 10001),
+            Map.of(),
+            Set.of(),
+            null
+        );
+        return new SplitTargetService.Split(targetShardId, sourceNode, targetNode, 2, 2);
     }
 }


### PR DESCRIPTION
See analysis in https://github.com/elastic/elasticsearch/issues/151090. I was not able to reproduce this failure so i haven't confirmed the fix outside of the unit test in the PR.  

Closes https://github.com/elastic/elasticsearch-team/issues/4218.
Closes https://github.com/elastic/elasticsearch/issues/151090.