### PR TITLE
[ESQL] Route source resolver off SEARCH pool

### DIFF
--- a/docs/changelog/152627.yaml
+++ b/docs/changelog/152627.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152627
+summary: Route source resolver off SEARCH pool
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -255,11 +255,12 @@ public class ExternalSourceResolver {
             return;
         }
 
-        // Resolution runs on the SEARCH pool and a wide multi-file resolve pins this worker on the
-        // BoundedParallelGather latch while it dispatches up to MAX_PARALLEL_METADATA_READS more SEARCH
-        // tasks (join pattern). This is an accepted tradeoff: the rework bounds submission so a saturated
-        // pool now fails fast via running-slot rejection rather than deadlocking on a flooded queue.
-        // Moving resolution off SEARCH entirely is left as a possible follow-up.
+        // Resolution runs on the caller-supplied executor (esql_worker in production, isolated from
+        // SEARCH so a wide wildcard cannot starve regular ES searches). A multi-file resolve still pins
+        // this worker on the BoundedParallelGather latch while it dispatches up to
+        // MAX_PARALLEL_METADATA_READS more tasks on the same pool (join pattern). Submission is bounded,
+        // so a saturated pool fails fast via running-slot rejection rather than deadlocking on a
+        // flooded queue.
         executor.execute(() -> {
             try {
                 Map<String, ExternalSourceResolution.ResolvedSource> resolved = Maps.newHashMapWithExpectedSize(paths.size());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -255,12 +255,16 @@ public class ExternalSourceResolver {
             return;
         }
 
-        // Resolution runs on the caller-supplied executor (esql_worker in production, isolated from
-        // SEARCH so a wide wildcard cannot starve regular ES searches). A multi-file resolve still pins
-        // this worker on the BoundedParallelGather latch while it dispatches up to
-        // MAX_PARALLEL_METADATA_READS more tasks on the same pool (join pattern). Submission is bounded,
-        // so a saturated pool fails fast via running-slot rejection rather than deadlocking on a
-        // flooded queue.
+        // Resolution runs on the caller-supplied executor (esql_worker in production, isolated from SEARCH
+        // so a wide wildcard cannot starve regular ES searches). A multi-file resolve pins one worker on
+        // the BoundedParallelGather latch while dispatching up to MAX_PARALLEL_METADATA_READS more tasks
+        // on the same pool (join pattern), for a peak of MAX_PARALLEL_METADATA_READS + 1 running slots.
+        // When the pool is smaller, ThrottledTaskRunner throttles submission rather than overflowing the
+        // queue; on saturation across concurrent ES|QL queries it fails fast per-slot via running-slot
+        // rejection rather than deadlocking. Splitting the coordinator from the footer fan-out onto a
+        // dedicated I/O pool would require a second executor here and is deferred until the
+        // esql_external_blocking_io pool's sizing and lifecycle are resolved; the caller-supplied
+        // executor is the current re-routing hook.
         executor.execute(() -> {
             try {
                 Map<String, ExternalSourceResolution.ResolvedSource> resolved = Maps.newHashMapWithExpectedSize(paths.size());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.esql.telemetry.QueryMetric;
 import org.elasticsearch.xpack.esql.view.ViewResolver;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 
@@ -93,6 +94,12 @@ public class PlanExecutor {
         this.analysisRegistry = analysisRegistry;
     }
 
+    /**
+     * @param externalSourceExecutor Executor for {@link ExternalSourceResolver} work — glob expansion, footer reads,
+     *                               schema reconciliation. Must not be the SEARCH pool: a wildcard external query
+     *                               would otherwise starve regular ES searches and other ES|QL queries. Production
+     *                               wiring passes {@code esql_worker}.
+     */
     public void esql(
         EsqlQueryRequest request,
         String sessionId,
@@ -105,14 +112,16 @@ public class PlanExecutor {
         IndicesExpressionGrouper indicesExpressionGrouper,
         EsqlSession.PlanRunner planRunner,
         TransportActionServices services,
+        Executor externalSourceExecutor,
         BooleanSupplier cancellation,
         ActionListener<Versioned<Result>> listener
     ) {
         final PlanTelemetry planTelemetry = new PlanTelemetry(functionRegistry);
-        // Create ExternalSourceResolver for Iceberg/Parquet resolution
-        // Use the same executor as for searches to avoid blocking
+        // Resolution (glob expansion, footer reads, schema reconciliation) runs on the caller-supplied
+        // executor rather than the SEARCH pool, so a wildcard external query cannot starve regular ES
+        // searches or other ES|QL queries.
         final ExternalSourceResolver externalSourceResolver = new ExternalSourceResolver(
-            services.transportService().getThreadPool().executor(org.elasticsearch.threadpool.ThreadPool.Names.SEARCH),
+            externalSourceExecutor,
             dataSourceModule,
             services.clusterService().getSettings(),
             cacheService,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -520,7 +520,10 @@ public class ComputeService {
         assert ThreadPool.assertCurrentThreadPool(
             ThreadPool.Names.SYSTEM_READ,
             ThreadPool.Names.SEARCH,
-            ThreadPool.Names.SEARCH_COORDINATION
+            ThreadPool.Names.SEARCH_COORDINATION,
+            // execute() is invoked downstream of EsqlSession's analyzed-plan callback, which may complete on
+            // esql_worker after ExternalSourceResolver dispatches resolution there.
+            EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME
         );
         // Check if the plan contains subqueries (UnionAll) vs fork branches before breaking it apart.
         // Batching is only applied to subqueries, not fork branches.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
@@ -138,7 +138,10 @@ abstract class DataNodeRequestSender {
         assert ThreadPool.assertCurrentThreadPool(
             ThreadPool.Names.SYSTEM_READ,
             ThreadPool.Names.SEARCH,
-            ThreadPool.Names.SEARCH_COORDINATION
+            ThreadPool.Names.SEARCH_COORDINATION,
+            // Reached downstream of ComputeService.execute(), which itself may be invoked on esql_worker after
+            // ExternalSourceResolver completes on that pool.
+            EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME
         );
         final long startTimeInNanos = System.nanoTime();
         searchShards(concreteIndices, ActionListener.wrap(targetShards -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -266,14 +266,27 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     }
 
     /**
-     * Returns the executor used for external source coordination (e.g. connector handshakes and registry wiring).
+     * Returns the executor used for external source coordination: connector handshakes, registry wiring,
+     * and source resolution (glob expansion, footer reads, schema reconciliation performed by
+     * {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver}).
      * File-based async reads and slice-queue drain use the dedicated {@code esql_external_blocking_io} pool
      * ({@link EsqlPlugin#EXTERNAL_BLOCKING_IO_THREAD_POOL_NAME}) via {@link OperatorFactoryRegistry#fileReadExecutor},
      * so blocking external reads share neither the compute-driver pool nor the shared {@link ThreadPool.Names#GENERIC} pool.
-     * Isolated from {@link ThreadPool.Names#SEARCH} to prevent heavy external queries from starving regular ES operations.
+     * Isolated from {@link ThreadPool.Names#SEARCH} to prevent heavy external queries (glob expansion of thousands of
+     * S3 files, or long-running compute drivers) from starving regular ES operations.
      */
     protected Executor externalSourceExecutor() {
-        return threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);
+        return threadPool.executor(externalSourceExecutorName());
+    }
+
+    /**
+     * Name of the thread pool that backs {@link #externalSourceExecutor()}. Extracted so that unit tests can pin
+     * the wiring without needing a live {@link ThreadPool}. Must not resolve to {@link ThreadPool.Names#SEARCH}: a
+     * single wildcard external query previously consumed nearly the entire SEARCH pool during resolution, starving
+     * unrelated searches and other ES|QL queries.
+     */
+    static String externalSourceExecutorName() {
+        return ESQL_WORKER_THREAD_POOL_NAME;
     }
 
     /**
@@ -368,6 +381,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             remoteClusterService,
             planRunner,
             services,
+            externalSourceExecutor(),
             ((CancellableTask) task)::isCancelled,
             ActionListener.wrap(result -> {
                 recordCCSTelemetry(task, executionInfo, request, null);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -266,24 +266,35 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     }
 
     /**
-     * Returns the executor used for external source coordination: connector handshakes, registry wiring,
-     * and source resolution (glob expansion, footer reads, schema reconciliation performed by
+     * Executor for external source coordination: connector handshakes, registry wiring, and source resolution
+     * (glob expansion, footer reads, schema reconciliation performed by
      * {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver}).
-     * File-based async reads and slice-queue drain use the dedicated {@code esql_external_blocking_io} pool
-     * ({@link EsqlPlugin#EXTERNAL_BLOCKING_IO_THREAD_POOL_NAME}) via {@link OperatorFactoryRegistry#fileReadExecutor},
-     * so blocking external reads share neither the compute-driver pool nor the shared {@link ThreadPool.Names#GENERIC} pool.
-     * Isolated from {@link ThreadPool.Names#SEARCH} to prevent heavy external queries (glob expansion of thousands of
-     * S3 files, or long-running compute drivers) from starving regular ES operations.
+     * <p>
+     * Isolated from {@link ThreadPool.Names#SEARCH} to prevent heavy external queries (glob expansion over thousands
+     * of files, S3 footer reads) from starving regular ES searches — the reported production regression. Deliberately
+     * shares the compute-driver pool ({@code esql_worker}, default sizing {@code (1.5*cpu)+1} via
+     * {@link ThreadPool#searchOrGetThreadPoolSize} or the {@code esql.worker.thread_pool_size} setting override, with a
+     * heap-scaled queue). The resolver's join pattern needs up to {@code MAX_PARALLEL_METADATA_READS + 1} running slots;
+     * on nodes where that exceeds the pool size the {@link org.elasticsearch.xpack.esql.datasources.utils.BoundedParallelGather}
+     * runner throttles submission rather than overflowing the queue, and on saturation across concurrent ES|QL queries
+     * it fails fast per-slot rather than deadlocking. Blocking file-read fan-out uses the separate
+     * {@code esql_external_blocking_io} pool ({@link EsqlPlugin#EXTERNAL_BLOCKING_IO_THREAD_POOL_NAME}) via
+     * {@link OperatorFactoryRegistry#fileReadExecutor}.
+     * <p>
+     * This method is the coordinator-side hook: overriding it lets tests or a future re-routing move the resolver's
+     * coordinator and fan-out to a different pool without touching call sites. A true coordinator/footer split (two
+     * executors inside {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver}) is a larger change and
+     * is deferred until the {@code esql_external_blocking_io} pool's sizing and lifecycle are resolved.
      */
     protected Executor externalSourceExecutor() {
         return threadPool.executor(externalSourceExecutorName());
     }
 
     /**
-     * Name of the thread pool that backs {@link #externalSourceExecutor()}. Extracted so that unit tests can pin
-     * the wiring without needing a live {@link ThreadPool}. Must not resolve to {@link ThreadPool.Names#SEARCH}: a
-     * single wildcard external query previously consumed nearly the entire SEARCH pool during resolution, starving
-     * unrelated searches and other ES|QL queries.
+     * Name of the thread pool backing {@link #externalSourceExecutor()}. Extracted so unit tests can pin the wiring
+     * without needing a live {@link ThreadPool}. Must not resolve to {@link ThreadPool.Names#SEARCH}: a single
+     * wildcard external query previously consumed nearly the entire SEARCH pool during resolution, starving unrelated
+     * searches and other ES|QL queries.
      */
     static String externalSourceExecutorName() {
         return ESQL_WORKER_THREAD_POOL_NAME;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -151,6 +151,7 @@ import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.esql.session.SessionUtils.checkPagesBelowSize;
 
 /**
@@ -440,7 +441,10 @@ public class EsqlSession {
                     assert ThreadPool.assertCurrentThreadPool(
                         ThreadPool.Names.SEARCH,
                         ThreadPool.Names.SEARCH_COORDINATION,
-                        ThreadPool.Names.SYSTEM_READ
+                        ThreadPool.Names.SYSTEM_READ,
+                        // External source resolution ({@link ExternalSourceResolver}) dispatches through esql_worker
+                        // and this callback is reached on that thread.
+                        ESQL_WORKER_THREAD_POOL_NAME
                     );
 
                     LogicalPlan plan = analyzedPlan.inner();
@@ -530,7 +534,9 @@ public class EsqlSession {
         assert ThreadPool.assertCurrentThreadPool(
             ThreadPool.Names.SEARCH,
             ThreadPool.Names.SEARCH_COORDINATION,
-            ThreadPool.Names.SYSTEM_READ
+            ThreadPool.Names.SYSTEM_READ,
+            // Downstream of the analyzed-plan callback, which may complete on esql_worker after external source resolution.
+            ESQL_WORKER_THREAD_POOL_NAME
         );
         var physicalPlanOptimizer = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(configuration, minimumVersion));
 
@@ -1416,7 +1422,11 @@ public class EsqlSession {
         assert ThreadPool.assertCurrentThreadPool(
             ThreadPool.Names.SEARCH,
             ThreadPool.Names.SEARCH_COORDINATION,
-            ThreadPool.Names.SYSTEM_READ
+            ThreadPool.Names.SYSTEM_READ,
+            // Typically entered from a field-caps completion on SEARCH_COORDINATION, but on analyzer retry
+            // (analyzeWithRetry -> resolveIndicesAndAnalyze) with a synchronous main-index forAll (e.g. no FROM
+            // indices) the resolver's continuation reaches this on esql_worker.
+            ESQL_WORKER_THREAD_POOL_NAME
         );
         // No need to update the minimum transport version in the PreAnalysisResult,
         // it should already have been determined during the main index resolution.
@@ -1730,7 +1740,10 @@ public class EsqlSession {
         assert ThreadPool.assertCurrentThreadPool(
             ThreadPool.Names.SEARCH,
             ThreadPool.Names.SEARCH_COORDINATION,
-            ThreadPool.Names.SYSTEM_READ
+            ThreadPool.Names.SYSTEM_READ,
+            // On analyzer retry (analyzeWithRetry -> resolveIndicesAndAnalyze) this may be re-entered on esql_worker,
+            // the thread the external source resolver continued on.
+            ESQL_WORKER_THREAD_POOL_NAME
         );
         if (crossProjectModeDecider.crossProjectEnabled() == false) {
             EsqlCCSUtils.initCrossClusterState(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryActionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.plugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.EXTERNAL_BLOCKING_IO_THREAD_POOL_NAME;
 
 public class TransportEsqlQueryActionTests extends ESTestCase {
@@ -29,6 +30,23 @@ public class TransportEsqlQueryActionTests extends ESTestCase {
             "blocking external reads must not run on the shared generic pool",
             ThreadPool.Names.GENERIC,
             TransportEsqlQueryAction.fileReadExecutorName()
+        );
+    }
+
+    /**
+     * External source coordination — including {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver}
+     * glob expansion, footer reads, and schema reconciliation — must run on the dedicated {@code esql_worker} pool.
+     * A prior regression routed this work through {@link ThreadPool.Names#SEARCH}, where a single wildcard query
+     * over thousands of files consumed nearly the entire SEARCH pool for minutes, starving unrelated ES searches and
+     * other ES|QL queries. Pinning the returned name here locks the fix; the explicit not-{@code search} assertion
+     * catches any future re-introduction of that starvation.
+     */
+    public void testExternalSourceExecutorNameIsTheEsqlWorkerPool() {
+        assertEquals(ESQL_WORKER_THREAD_POOL_NAME, TransportEsqlQueryAction.externalSourceExecutorName());
+        assertNotEquals(
+            "external source coordination must not run on the shared search pool",
+            ThreadPool.Names.SEARCH,
+            TransportEsqlQueryAction.externalSourceExecutorName()
         );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -244,6 +244,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     groupIndicesByCluster,
                     runPhase,
                     MOCK_TRANSPORT_ACTION_SERVICES,
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
                     () -> false,
                     new ActionListener<>() {
                         @Override
@@ -283,6 +284,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     groupIndicesByCluster,
                     runPhase,
                     MOCK_TRANSPORT_ACTION_SERVICES,
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
                     () -> false,
                     new ActionListener<>() {
                         @Override
@@ -631,6 +633,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                 groupIndicesByCluster,
                 runPhase,
                 MOCK_TRANSPORT_ACTION_SERVICES,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 () -> false,
                 listener
             );


### PR DESCRIPTION
ExternalSourceResolver ran glob expansion, footer reads and schema
reconciliation on the SEARCH pool. A single wildcard query over
thousands of files consumed most SEARCH threads for minutes,
starving regular searches and other ES|QL queries.

Thread the caller-supplied executor through PlanExecutor.esql() and
wire it to esql_worker via a new static externalSourceExecutorName()
that mirrors fileReadExecutorName(). A pinning unit test locks the
pool name and asserts it is not SEARCH, matching the guard the file
read path already has.