### PR TITLE
Update PromQL native histogram limitations docs

### DIFF
--- a/docs/reference/query-languages/promql/promql-limitations.md
+++ b/docs/reference/query-languages/promql/promql-limitations.md
@@ -48,7 +48,7 @@ The following constructs are not evaluated yet, so they return a client error (4
 
 ## Native histograms [promql-limitations-native-histograms]
 
-{applies_to}`stack: ga 9.5`
+{applies_to}`stack: ga 9.5` {applies_to}`serverless: ga`
 
 {{es}} provides basic support for Prometheus native histograms (the `exponential_histogram` type in {{es}}).
 The following query patterns work today:
@@ -60,11 +60,11 @@ The following query patterns work today:
 
 In particular, the following features are not available yet for native histograms:
 
-- **`rate`**: If possible, use `increase` instead. The `rate` function produces fractional bucket counts that native histograms do not support yet. Most queries that use `rate` can be rewritten with `increase` (for example, `histogram_quantile(0.99, sum by (job) (increase(metric[5m])))` instead of using `rate`).
-- **Native histograms as direct result types**: Queries that return a raw native histogram (such as a bare selector `my_histogram` or `increase(my_histogram[5m])` without wrapping in a histogram function) are not supported. Wrap selectors in `histogram_quantile`, `histogram_count`, `histogram_sum`, or `histogram_avg` to obtain scalar results.
-- **`irate`** and **`delta`**
-- **Arithmetic operators** on native histograms: `+`, `-`, `*`, `/`
-- **`histogram_fraction`** and **`histogram_stddev`**
+- `rate`: If possible, use `increase` instead. The `rate` function produces fractional bucket counts that native histograms do not support yet. Most queries that use `rate` can be rewritten with `increase` (for example, `histogram_quantile(0.99, sum by (job) (increase(metric[5m])))` instead of using `rate`).
+- Native histograms as direct result types**: Queries that return a raw native histogram (such as a bare selector `my_histogram` or `increase(my_histogram[5m])` without wrapping in a histogram function) are not supported. Wrap selectors in `histogram_quantile`, `histogram_count`, `histogram_sum`, or `histogram_avg` to obtain scalar results.
+- `irate` and `delta`
+- Arithmetic operators on native histograms: `+`, `-`, `*`, `/`
+- `histogram_fraction` and `histogram_stddev`
 
 ## Metric metadata `help` (HTTP API) [promql-limitations-metadata-help]
 

--- a/docs/reference/query-languages/promql/promql-limitations.md
+++ b/docs/reference/query-languages/promql/promql-limitations.md
@@ -48,8 +48,23 @@ The following constructs are not evaluated yet, so they return a client error (4
 
 ## Native histograms [promql-limitations-native-histograms]
 
-Prometheus native histograms are not supported yet.
-PromQL functions operate on float samples; series stored as native histograms are not evaluated.
+{applies_to}`stack: ga 9.5`
+
+{{es}} provides basic support for Prometheus native histograms (the `exponential_histogram` type in {{es}}).
+The following query patterns work today:
+
+- `histogram_quantile` on native histograms, including after aggregation: `histogram_quantile(0.9, sum by (job) (increase(metric[10m])))`
+- `histogram_count`, `histogram_sum`, and `histogram_avg` on native histograms
+- `increase` on native histograms
+- `sum` aggregation on native histograms to aggregate across series
+
+In particular, the following features are not available yet for native histograms:
+
+- **`rate`**: If possible, use `increase` instead. The `rate` function produces fractional bucket counts that native histograms do not support yet. Most queries that use `rate` can be rewritten with `increase` (for example, `histogram_quantile(0.99, sum by (job) (increase(metric[5m])))` instead of using `rate`).
+- **Native histograms as direct result types**: Queries that return a raw native histogram (such as a bare selector `my_histogram` or `increase(my_histogram[5m])` without wrapping in a histogram function) are not supported. Wrap selectors in `histogram_quantile`, `histogram_count`, `histogram_sum`, or `histogram_avg` to obtain scalar results.
+- **`irate`** and **`delta`**
+- **Arithmetic operators** on native histograms: `+`, `-`, `*`, `/`
+- **`histogram_fraction`** and **`histogram_stddev`**
 
 ## Metric metadata `help` (HTTP API) [promql-limitations-metadata-help]
 


### PR DESCRIPTION
Part of #150074

## Summary
- Update the native histograms section on the PromQL limitations page to document currently supported query patterns (`histogram_quantile`, `histogram_count`, `histogram_sum`, `histogram_avg`, `increase`, `sum` aggregation)
- List features not yet supported with workarounds (e.g. use `increase` instead of `rate`)