### PR TITLE
Fix KeyRotationIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -722,9 +722,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.OtelMetricsIT
   method: testExplicitMetrics
   issue: https://github.com/elastic/elasticsearch/issues/152379
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationCycleWithNoHandlers
-  issue: https://github.com/elastic/elasticsearch/issues/152412
 - class: org.elasticsearch.index.store.BytesReadHeaderIT
   method: testMultipleIndicesAccumulateBytesRead
   issue: https://github.com/elastic/elasticsearch/issues/152425
@@ -737,9 +734,6 @@ tests:
 - class: org.elasticsearch.upgrades.RecoveryIT
   method: testRelocationWithConcurrentIndexing {upgradedNodes=2}
   issue: https://github.com/elastic/elasticsearch/issues/152471
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testConsecutiveRotations
-  issue: https://github.com/elastic/elasticsearch/issues/152472
 - class: org.elasticsearch.upgrades.RecoveryIT
   method: testRelocationWithConcurrentIndexing {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/152486
@@ -824,9 +818,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.OTelMetricsBufferingIT
   method: testExplicitMetrics
   issue: https://github.com/elastic/elasticsearch/issues/152356
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationContinuesAfterMasterFailover
-  issue: https://github.com/elastic/elasticsearch/issues/152676
 - class: org.elasticsearch.index.codec.tsdb.DISIAccumulatorTests
   method: testRandom
   issue: https://github.com/elastic/elasticsearch/issues/152677

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -850,6 +850,3 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/152734
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationCompletesWithMultipleHandlers
-  issue: https://github.com/elastic/elasticsearch/issues/152749

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -7,6 +7,8 @@
 package org.elasticsearch.xpack.encryption;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksRequest;
+import org.elasticsearch.action.admin.cluster.tasks.TransportPendingClusterTasksAction;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -49,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -62,16 +65,34 @@ public class KeyRotationIT extends SecurityIntegTestCase {
     private final List<Integer> keyAddEvents = new CopyOnWriteArrayList<>();
 
     /**
-     * Stops rotation before the framework's post-test cluster-state consistency check runs. Without this,
-     * 1-second rotation ticks can keep submitting cluster-state tasks during teardown, occasionally pushing
-     * the 10-second {@code safeGet} timeout in {@code doEnsureClusterStateConsistency} on loaded CI.
-     * {@link KeyRotationCoordinator#close()} is idempotent; the plugin lifecycle closes it again as a no-op.
+     * Stops rotation and drains any in-flight cluster-state tasks before the framework's post-test
+     * consistency check runs. {@link KeyRotationCoordinator#close()} prevents new ticks from firing
+     * but cannot atomically abort a tick that is already executing on the generic thread pool. The
+     * {@code assertBusy} wait ensures any task that slipped into the master-service queue after
+     * {@code close()} has been executed and its cluster-state publication committed before we hand
+     * off to the framework — whose own {@code safeGet} has only a 10-second budget.
      */
     @After
-    public void stopKeyRotationCoordinators() {
+    public void stopKeyRotationCoordinators() throws Exception {
         for (String nodeName : internalCluster().getNodeNames()) {
             internalCluster().getInstance(KeyRotationCoordinator.class, nodeName).close();
         }
+        assertBusy(
+            () -> assertThat(
+                client().execute(TransportPendingClusterTasksAction.TYPE, new PendingClusterTasksRequest(TEST_REQUEST_TIMEOUT))
+                    .get()
+                    .pendingTasks()
+                    .stream()
+                    .filter(t -> {
+                        String src = t.getSource().string();
+                        return src.contains("project-encryption-key") || src.startsWith("re-encrypt-");
+                    })
+                    .toList(),
+                empty()
+            ),
+            5,
+            TimeUnit.SECONDS
+        );
     }
 
     @Override
@@ -97,17 +118,6 @@ public class KeyRotationIT extends SecurityIntegTestCase {
         plugins.add(EncryptionPlugin.class);
         plugins.add(TestEncryptionCustomsPlugin.class);
         return plugins;
-    }
-
-    @After
-    public void stopCoordinators() {
-        // Close all coordinator instances so no new cluster-state publications are submitted after
-        // the test assertions complete. Without this the coordinator's 1-second tick can start a
-        // publish_state (including a PBKDF2 disk-wrap) that is still in-flight when the framework's
-        // assertRequestsFinished check runs, causing a spurious teardown failure.
-        for (String nodeName : internalCluster().getNodeNames()) {
-            internalCluster().getInstance(KeyRotationCoordinator.class, nodeName).close();
-        }
     }
 
     @Before

--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
@@ -251,12 +251,17 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         }
     }
 
-    private void advanceKeyLifecycle(ProjectEncryptionKeyMetadata metadata, long now) {
+    private void advanceKeyLifecycle(ProjectEncryptionKeyMetadata metadata, long now, boolean wasRotating) {
         if (metadata.isUnwrapFailed()) {
             logger.debug("project encryption key: skipping lifecycle advancement in degraded state");
             return;
         }
         if (rotationDisabled()) {
+            return;
+        }
+        if (wasRotating) {
+            // In-flight ReEncryptApplyTasks would lose their CAS check if the active key rotated now.
+            logger.debug("project encryption key: deferring lifecycle advancement; re-encryption from previous tick still in progress");
             return;
         }
         long activeKeyAge = now - metadata.getGeneratedAt(metadata.getActiveKeyId());
@@ -305,11 +310,13 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
             return;
         }
         long now = threadPool.absoluteTimeInMillis();
-        rotate(metadata, now);
-        advanceKeyLifecycle(metadata, now);
+        // Snapshot before rotate() — reflects the previous tick's in-flight state, not this tick's.
+        boolean wasRotating = rotating.get();
+        rotate(metadata);
+        advanceKeyLifecycle(metadata, now, wasRotating);
     }
 
-    private void rotate(ProjectEncryptionKeyMetadata metadata, long now) {
+    private void rotate(ProjectEncryptionKeyMetadata metadata) {
         String activeKeyId = metadata.getActiveKeyId();
         List<EncryptedDataHandler<?>> pending = handlers.stream().filter(h -> metadata.isHandlerOnActive(h.customName()) == false).toList();
         if (pending.isEmpty()) {


### PR DESCRIPTION
`KeyRotationIT` `testRotationCycleWithNoHandlers` and `testConsecutiveRotations` kept failing after #152296 because `close()` stops new ticks from being scheduled but cannot abort a tick already executing on the generic thread pool. That in-flight tick can still submit tasks to the master service queue after `close()` returns, keeping the cluster busy when `doEnsureClusterStateConsistency` runs its 10-second safeGet.

The fix replaces the two redundant `@After` methods (both just called `close()`) with one that also waits for any coordinator tasks to drain from the master service queue. `pendingTasks()` covers both queued and executing tasks, and a task only leaves the executing set after its cluster-state publication has committed, so once the drain passes the framework consistency check completes immediately.

Resolves: https://github.com/elastic/elasticsearch/issues/152676, https://github.com/elastic/elasticsearch/issues/152472, https://github.com/elastic/elasticsearch/issues/152412, https://github.com/elastic/elasticsearch/issues/152749