### PR TITLE
[ESQL] Fix NDJSON NPE on null nested objects

### DIFF
--- a/docs/changelog/152635.yaml
+++ b/docs/changelog/152635.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152635
+summary: Fix NDJSON NPE on null nested objects
+type: bug

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -770,12 +770,24 @@ public class NdJsonPageDecoder implements Closeable {
                 // Note: the `inArray` flag is needed because blockBuilder.beginPositionEntry() is not idempotent.
                 // Calling it twice implicitly calls endPositionEntry().
                 if (!inArray) {
-                    // Decide the multi-value shape from the first non-null element. Leading JSON nulls must be
-                    // skipped first: for an array of objects, `includeChildren` gates opening the child MV entries,
-                    // and inferring it from a leading null (e.g. [null, {"type":"a"}]) would leave the child columns
-                    // without an open MV while later objects still append values, misaligning rows across columns.
+                    // `includeChildren` gates opening the child MV entries and must reflect whether the array
+                    // actually contains an object: otherwise later objects append into never-opened child builders,
+                    // misaligning rows across columns. Skip leading elements that cannot open this node's MV entry:
+                    // - a leaf node only skips leading JSON nulls (its scalars are real values);
+                    // - a structural (prefix) node carries no scalar values of its own, so it also skips leading
+                    // stray scalars (e.g. [null, "x", {"type":"a"}]) until the first object or the array end.
                     JsonToken first = parser.nextToken();
-                    while (first == JsonToken.VALUE_NULL) {
+                    while (first == JsonToken.VALUE_NULL
+                        || (blockBuilder == null && first != null && first != JsonToken.START_OBJECT && first != JsonToken.END_ARRAY)) {
+                        if (blockBuilder == null && first != JsonToken.VALUE_NULL && logger.isDebugEnabled()) {
+                            logger.debug(
+                                "Expected object in array for nested field [{}] but got {} at {}",
+                                parser.getParsingContext().pathAsPointer(),
+                                first,
+                                parser.getTokenLocation()
+                            );
+                        }
+                        parser.skipChildren(); // no-op for scalar/null tokens; safe to call here
                         first = parser.nextToken();
                     }
                     if (first == JsonToken.END_ARRAY) {
@@ -808,9 +820,11 @@ public class NdJsonPageDecoder implements Closeable {
                 // scalar where an object was expected. Leave the leaf descendants untracked so the end-of-row fill
                 // assigns them null, mirroring how missing fields and empty arrays are handled. This keeps datasets
                 // with occasionally-null nested objects (e.g. CloudTrail "responseElements": null) queryable.
-                if (token != JsonToken.VALUE_NULL) {
+                if (token != JsonToken.VALUE_NULL && logger.isDebugEnabled()) {
                     // Structural nodes never receive setAttribute(), so `name` is null here; derive the JSON path
                     // (e.g. /userIdentity/sessionContext) from the parser context so large files can be diagnosed.
+                    // Guarded by isDebugEnabled() so the JsonPointer/JsonLocation allocations are skipped when DEBUG
+                    // is off, since this can fire per-row across millions of records.
                     logger.debug(
                         "Expected object for nested field [{}] but got {} at {}",
                         parser.getParsingContext().pathAsPointer(),

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -741,6 +741,20 @@ public class NdJsonPageDecoder implements Closeable {
             }
         }
 
+        /**
+         * Decodes the current JSON value into this decoder's block (or, for a structural prefix node, recurses into
+         * its children). NDJSON is schema-on-read: the inferred/bound schema flattens nested objects to dotted leaf
+         * columns, so a value whose shape does not match the schema is not a hard error. Type mismatches are
+         * null-filled for the affected column(s) rather than failing the query:
+         * <ul>
+         *   <li>a JSON {@code null} (or a scalar) where an object was expected on a structural prefix node leaves its
+         *       leaf columns null for that row;</li>
+         *   <li>a scalar of the wrong primitive type is reported via {@link #unexpectedValue} and null-filled.</li>
+         * </ul>
+         * These mismatches are logged at {@code DEBUG} only, never {@code WARN}: they are per-row data-shape quirks
+         * (e.g. an intermittently-null nested object across millions of records), so surfacing them at a
+         * default-enabled level would flood the log without giving the cluster admin an actionable signal.
+         */
         private void decodeValue(JsonParser parser, boolean inArray) throws IOException {
             JsonToken token = parser.currentToken();
 
@@ -756,7 +770,14 @@ public class NdJsonPageDecoder implements Closeable {
                 // Note: the `inArray` flag is needed because blockBuilder.beginPositionEntry() is not idempotent.
                 // Calling it twice implicitly calls endPositionEntry().
                 if (!inArray) {
+                    // Decide the multi-value shape from the first non-null element. Leading JSON nulls must be
+                    // skipped first: for an array of objects, `includeChildren` gates opening the child MV entries,
+                    // and inferring it from a leading null (e.g. [null, {"type":"a"}]) would leave the child columns
+                    // without an open MV while later objects still append values, misaligning rows across columns.
                     JsonToken first = parser.nextToken();
+                    while (first == JsonToken.VALUE_NULL) {
+                        first = parser.nextToken();
+                    }
                     if (first == JsonToken.END_ARRAY) {
                         appendNullsForEmptyArray();
                         return;
@@ -778,6 +799,26 @@ public class NdJsonPageDecoder implements Closeable {
 
             if (token == JsonToken.START_OBJECT) {
                 decodeObject(parser, inArray);
+                return;
+            }
+
+            if (blockBuilder == null) {
+                // Structural (prefix) node with no scalar builder of its own: the schema only knows dotted leaf
+                // columns for this field (e.g. "address.city"/"address.zip"), but this row holds a JSON null or a
+                // scalar where an object was expected. Leave the leaf descendants untracked so the end-of-row fill
+                // assigns them null, mirroring how missing fields and empty arrays are handled. This keeps datasets
+                // with occasionally-null nested objects (e.g. CloudTrail "responseElements": null) queryable.
+                if (token != JsonToken.VALUE_NULL) {
+                    // Structural nodes never receive setAttribute(), so `name` is null here; derive the JSON path
+                    // (e.g. /userIdentity/sessionContext) from the parser context so large files can be diagnosed.
+                    logger.debug(
+                        "Expected object for nested field [{}] but got {} at {}",
+                        parser.getParsingContext().pathAsPointer(),
+                        token,
+                        parser.getTokenLocation()
+                    );
+                }
+                parser.skipChildren();
                 return;
             }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
@@ -220,6 +221,92 @@ public class NdJsonPageDecoderTests extends ESTestCase {
                 out.add(BytesRef.deepCopyOf(ref));
             }
             return out;
+        }
+    }
+
+    /**
+     * A dotted-prefix column such as {@code address.city} builds a structural (intermediate) decoder node with no
+     * scalar block builder of its own. When a row provides a JSON {@code null} or a scalar where an object was
+     * expected, the leaf columns must be filled with null for that row instead of throwing a
+     * {@link NullPointerException}. Regression test for https://github.com/elastic/elasticsearch/issues/152574.
+     * <p>
+     * This drives the decoder with an explicit dotted schema, i.e. the planner-resolved (bound) read-schema path
+     * where {@code address} exists only as a nested-object prefix. It deliberately does not go through per-file
+     * schema inference: when a mixed object/scalar field is <em>sampled</em>, inference additionally emits a flat
+     * {@code address} column, and {@code hasDottedPrefixConflict} then routes the dotted keys differently. That
+     * inference interaction is a separate schema-resolution concern, exercised end-to-end in the iterator tests.
+     */
+    public void testNullOrScalarWhereNestedObjectExpected() throws IOException {
+        String ndjson = "{\"address\": {\"city\": \"NYC\", \"zip\": \"10001\"}}\n"
+            + "{\"address\": null}\n"
+            + "{\"address\": \"unstructured\"}\n"
+            + "{\"address\": {\"city\": \"London\", \"zip\": \"SW1A\"}}\n";
+
+        try (
+            Page page = decodePage(ndjson, List.of(attribute("address.city", DataType.KEYWORD), attribute("address.zip", DataType.KEYWORD)))
+        ) {
+            assertNotNull(page);
+            assertEquals(4, page.getPositionCount());
+            BytesRefBlock city = page.getBlock(0);
+            BytesRefBlock zip = page.getBlock(1);
+            BytesRef scratch = new BytesRef();
+            assertEquals(new BytesRef("NYC"), BytesRef.deepCopyOf(city.getBytesRef(0, scratch)));
+            assertEquals(new BytesRef("10001"), BytesRef.deepCopyOf(zip.getBytesRef(0, scratch)));
+            assertTrue("null object row -> city null", city.isNull(1));
+            assertTrue("null object row -> zip null", zip.isNull(1));
+            assertTrue("scalar-where-object row -> city null", city.isNull(2));
+            assertTrue("scalar-where-object row -> zip null", zip.isNull(2));
+            assertEquals(new BytesRef("London"), BytesRef.deepCopyOf(city.getBytesRef(3, scratch)));
+            assertEquals(new BytesRef("SW1A"), BytesRef.deepCopyOf(zip.getBytesRef(3, scratch)));
+        }
+    }
+
+    /**
+     * A {@code null} element inside a JSON array of objects (e.g. {@code "events": [{"type":"a"}, null]}) reaches a
+     * structural decoder node with {@code inArray == true}. The null element must be ignored (nulls in arrays are not
+     * supported) without throwing on the null {@code blockBuilder}, leaving the surrounding multi-value entry intact.
+     * Companion to {@link #testNullOrScalarWhereNestedObjectExpected} for the in-array path (#152574).
+     */
+    public void testNullElementInArrayOfObjects() throws IOException {
+        String ndjson = "{\"events\": [{\"type\": \"click\"}, {\"type\": \"view\"}]}\n" + "{\"events\": [{\"type\": \"scroll\"}, null]}\n";
+
+        try (Page page = decodePage(ndjson, List.of(attribute("events.type", DataType.KEYWORD)))) {
+            assertNotNull(page);
+            assertEquals(2, page.getPositionCount());
+            BytesRefBlock type = page.getBlock(0);
+            BytesRef scratch = new BytesRef();
+            assertMvAt(type, 0, scratch, List.of("click", "view"));
+            assertMvAt(type, 1, scratch, List.of("scroll"));
+        }
+    }
+
+    /**
+     * An array of objects with a leading (or all-)null element must still align with sibling columns. The MV shape is
+     * decided from the first non-null element; a leading null previously left the child columns without an open
+     * multi-value entry while later objects appended values, misaligning rows across columns (#152574). Covers
+     * leading-null, mid-null, and all-null arrays against a scalar {@code id} column that pins the expected row count.
+     */
+    public void testArrayOfObjectsWithNullElements() throws IOException {
+        String ndjson = "{\"events\": [{\"type\": \"a\"}, {\"type\": \"b\"}], \"id\": 1}\n"
+            + "{\"events\": [null, {\"type\": \"c\"}, {\"type\": \"d\"}], \"id\": 2}\n"
+            + "{\"events\": [{\"type\": \"e\"}, null, {\"type\": \"f\"}], \"id\": 3}\n"
+            + "{\"events\": [null, null], \"id\": 4}\n";
+
+        try (Page page = decodePage(ndjson, List.of(attribute("events.type", DataType.KEYWORD), attribute("id", DataType.INTEGER)))) {
+            assertNotNull(page);
+            assertEquals(4, page.getPositionCount());
+            BytesRefBlock type = page.getBlock(0);
+            IntBlock id = page.getBlock(1);
+            assertEquals(type.getPositionCount(), id.getPositionCount());
+            BytesRef scratch = new BytesRef();
+            assertMvAt(type, 0, scratch, List.of("a", "b"));
+            assertMvAt(type, 1, scratch, List.of("c", "d"));
+            assertMvAt(type, 2, scratch, List.of("e", "f"));
+            assertTrue("all-null array -> type null", type.isNull(3));
+            for (int p = 0; p < 4; p++) {
+                assertFalse("id must be present for row " + p, id.isNull(p));
+                assertEquals(p + 1, id.getInt(id.getFirstValueIndex(p)));
+            }
         }
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -310,6 +310,38 @@ public class NdJsonPageDecoderTests extends ESTestCase {
         }
     }
 
+    /**
+     * An array of objects on a structural node whose leading element(s) are stray scalars (e.g.
+     * {@code ["x", {"type":"a"}, {"type":"b"}]}) must still align with sibling columns. A structural prefix carries
+     * no scalar values of its own, so leading scalars are skipped when deciding the multi-value shape; otherwise
+     * {@code includeChildren} stayed false and the later objects appended into never-opened child builders,
+     * reproducing the same cross-column misalignment as the leading-null case (#152574). Covers leading-scalar,
+     * mid-scalar, and all-scalar arrays against a scalar {@code id} column that pins the expected row count.
+     */
+    public void testArrayOfObjectsWithScalarElements() throws IOException {
+        String ndjson = "{\"events\": [\"x\", {\"type\": \"a\"}, {\"type\": \"b\"}], \"id\": 1}\n"
+            + "{\"events\": [{\"type\": \"c\"}, \"y\", {\"type\": \"d\"}], \"id\": 2}\n"
+            + "{\"events\": [null, \"z\", {\"type\": \"e\"}], \"id\": 3}\n"
+            + "{\"events\": [\"only-scalars\", \"more\"], \"id\": 4}\n";
+
+        try (Page page = decodePage(ndjson, List.of(attribute("events.type", DataType.KEYWORD), attribute("id", DataType.INTEGER)))) {
+            assertNotNull(page);
+            assertEquals(4, page.getPositionCount());
+            BytesRefBlock type = page.getBlock(0);
+            IntBlock id = page.getBlock(1);
+            assertEquals(type.getPositionCount(), id.getPositionCount());
+            BytesRef scratch = new BytesRef();
+            assertMvAt(type, 0, scratch, List.of("a", "b"));
+            assertMvAt(type, 1, scratch, List.of("c", "d"));
+            assertMvAt(type, 2, scratch, List.of("e"));
+            assertTrue("all-scalar array -> type null", type.isNull(3));
+            for (int p = 0; p < 4; p++) {
+                assertFalse("id must be present for row " + p, id.isNull(p));
+                assertEquals(p + 1, id.getInt(id.getFirstValueIndex(p)));
+            }
+        }
+    }
+
     private Page decodePage(String ndjson, List<Attribute> attributes) throws IOException {
         try (
             NdJsonPageDecoder decoder = new NdJsonPageDecoder(

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasource.ndjson;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
@@ -1109,6 +1110,115 @@ public class NdJsonPageIteratorTests extends ESTestCase {
             assertEquals(2, page.getPositionCount());
             assertEquals(2, page.getBlockCount());
         }
+    }
+
+    public void testNestedObjectSometimesNull() throws IOException {
+        var blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+
+        // "address" is a nested-object prefix in the schema (address.city / address.zip), but in one row it is a JSON null.
+        // Reproduces https://github.com/elastic/elasticsearch/issues/152574 (NPE on structural decoder nodes).
+        String ndjson = """
+            {"address": {"city": "NYC", "zip": "10001"}}
+            {"address": null}
+            {"address": {"city": "London", "zip": "SW1A"}}
+            """;
+
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var object = new BytesStorageObject("file:///test.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+
+        try (var iterator = reader.read(object, List.of("address.city", "address.zip"), 100)) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertPage(page, """
+                   BYTES_REF   |   BYTES_REF  \s
+                ---------------+---------------
+                NYC            |10001         \s
+                null           |null          \s
+                London         |SW1A          \s
+                """);
+            assertEquals(3, page.getPositionCount());
+        }
+    }
+
+    public void testDeeplyNestedObjectSometimesNull() throws IOException {
+        var blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+
+        // Intermediate prefix "user.sessionContext" is an object in one row and JSON null in another.
+        String ndjson = """
+            {"user": {"type": "Root", "sessionContext": {"creationDate": "2017"}}}
+            {"user": {"type": "IAMUser", "sessionContext": null}}
+            {"user": null}
+            """;
+
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var object = new BytesStorageObject("file:///test.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+
+        try (var iterator = reader.read(object, List.of("user.type", "user.sessionContext.creationDate"), 100)) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertPage(page, """
+                   BYTES_REF   |   BYTES_REF  \s
+                ---------------+---------------
+                Root           |2017          \s
+                IAMUser        |null          \s
+                null           |null          \s
+                """);
+            assertEquals(3, page.getPositionCount());
+        }
+    }
+
+    /**
+     * Issue-faithful regression for https://github.com/elastic/elasticsearch/issues/152574: AWS CloudTrail-shaped
+     * NDJSON read through full per-file schema inference (null projection), with a nested {@code userIdentity} object
+     * that is sometimes {@code null} and an arbitrary {@code responseElements} object that is intermittently
+     * {@code null}. The previous code NPE'd on the structural decoder nodes; here the whole file must decode with the
+     * mismatched rows null-filled and every column staying row-aligned.
+     */
+    public void testCloudTrailNestedObjectsWithInferredSchema() throws IOException {
+        var blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+
+        String ndjson = """
+            {"eventSource":"s3.amazonaws.com","userIdentity":{"type":"Root","arn":"arn:1"},"responseElements":{"code":"200"}}
+            {"eventSource":"ec2.amazonaws.com","userIdentity":{"type":"IAMUser","arn":"arn:2"},"responseElements":null}
+            {"eventSource":"iam.amazonaws.com","userIdentity":null,"responseElements":{"code":"403"}}
+            """;
+
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var object = new BytesStorageObject("file:///cloudtrail.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var schema = reader.metadata(object).schema();
+
+        try (var iterator = reader.read(object, null, 100)) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            for (int b = 0; b < page.getBlockCount(); b++) {
+                assertEquals("column " + b + " row-misaligned", 3, page.getBlock(b).getPositionCount());
+            }
+
+            BytesRef scratch = new BytesRef();
+            BytesRefBlock eventSource = page.getBlock(indexOf(schema, "eventSource"));
+            assertEquals("s3.amazonaws.com", eventSource.getBytesRef(eventSource.getFirstValueIndex(0), scratch).utf8ToString());
+            assertEquals("iam.amazonaws.com", eventSource.getBytesRef(eventSource.getFirstValueIndex(2), scratch).utf8ToString());
+
+            BytesRefBlock userType = page.getBlock(indexOf(schema, "userIdentity.type"));
+            assertEquals("Root", userType.getBytesRef(userType.getFirstValueIndex(0), scratch).utf8ToString());
+            assertEquals("IAMUser", userType.getBytesRef(userType.getFirstValueIndex(1), scratch).utf8ToString());
+            assertTrue("userIdentity null row -> userIdentity.type null", userType.isNull(2));
+
+            BytesRefBlock respCode = page.getBlock(indexOf(schema, "responseElements.code"));
+            assertEquals("200", respCode.getBytesRef(respCode.getFirstValueIndex(0), scratch).utf8ToString());
+            assertTrue("responseElements null row -> responseElements.code null", respCode.isNull(1));
+            assertEquals("403", respCode.getBytesRef(respCode.getFirstValueIndex(2), scratch).utf8ToString());
+        }
+    }
+
+    private static int indexOf(List<Attribute> schema, String name) {
+        for (int i = 0; i < schema.size(); i++) {
+            if (schema.get(i).name().equals(name)) {
+                return i;
+            }
+        }
+        throw new AssertionError("column [" + name + "] not found in schema " + schema);
     }
 
     public void testArrayOfObjects() throws IOException {


### PR DESCRIPTION
Querying NDJSON external sources whose nested objects are sometimes a JSON `null` (or a scalar) instead of an object threw a `NullPointerException` in the block builder, failing the whole query. Such prefix columns now null-fill the affected row instead of crashing, and array-of-objects multi-value shape is decided from the first non-null element so a leading null no longer misaligns columns.

Closes elastic/elasticsearch#152574