### PR TITLE
Fix over-strict stored-fields check for columnar _id

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -391,8 +392,10 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
             for (int i = 0; i < documents.size(); i++) {
                 var document = reader.storedFields().document(i);
                 List<String> storedFieldNames = document.getFields().stream().map(IndexableField::name).toList();
+                // This scenario falls back to _ignored_source (no native offsets, see the assertion below), which is
+                // stored independently of _id's storage mode, so only assert on _id's own presence here.
                 if (isUseColumnarId(reader)) {
-                    assertThat(storedFieldNames, empty());
+                    assertThat(storedFieldNames, not(hasItem("_id")));
                 } else {
                     assertThat(storedFieldNames, hasItem("_id"));
                 }


### PR DESCRIPTION
## Summary
- `NativeArrayIntegrationTestCase#verifySyntheticObjectArray` asserted that a document has **no** stored fields at all when `_id` uses columnar storage (BINARY doc values instead of a stored field). But this scenario (an array of sub-objects, each holding an array field, with no native offsets support) legitimately falls back to `_ignored_source` regardless of `_id`'s storage mode — `_ignored_source` and columnar `_id` are unrelated mechanisms.
- Confirmed this is test-only: real columnar index mode (`COLUMNAR`/`LOGSDB_COLUMNAR`) explicitly forbids `index.mapping.synthetic_source_keep` (see `Mapper.java`'s validator) specifically because it would write to `_ignored_source`, which strict-columnar modes must never do. This test never sets a columnar index mode — only columnar `_id`, a narrower, orthogonal feature — so that invariant doesn't apply here.
- Fix: assert `_id`'s own absence (`not(hasItem("_id"))`) instead of asserting the whole stored-fields collection is empty.

Found while investigating test failures on #152481.

## Test plan
- [x] `LongSyntheticSourceNativeArrayIntegrationTests#testSynthesizeObjectArray` with the originally-failing seed now passes
- [x] Same test run 40x with fresh random seeds (exercises both columnar and non-columnar `_id` branches), no failures