### PR TITLE
Fix flattened keyed block loader test: apply ignore_above to null_value

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldKeyedBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldKeyedBlockLoaderTests.java
@@ -96,15 +96,15 @@ public class FlattenedFieldKeyedBlockLoaderTests extends BinaryDVBlockLoaderTest
 
     @Override
     protected Object expected(Map<String, Object> fieldMapping, Object value, TestContext testContext) {
-        var nullValue = (String) fieldMapping.get("null_value");
-        if (value == null) {
-            return convert(null, nullValue, Integer.MAX_VALUE);
-        }
-
         boolean hasDocValues = hasDocValues(fieldMapping, true);
         int ignoreAbove = fieldMapping.get("ignore_above") != null && hasDocValues
             ? ((Number) fieldMapping.get("ignore_above")).intValue()
             : Integer.MAX_VALUE;
+
+        var nullValue = (String) fieldMapping.get("null_value");
+        if (value == null) {
+            return convert(null, nullValue, ignoreAbove);
+        }
 
         if (value instanceof List<?> valueList) {
             var valueStream = valueList.stream().map(v -> convert(v, nullValue, ignoreAbove)).filter(Objects::nonNull);


### PR DESCRIPTION
## Summary

When `null_value` exceeds `ignore_above`, the flattened field parser stores it in the fallback field rather than doc values. The `expected()` method in `FlattenedFieldKeyedBlockLoaderTests` was computing the expected value using `Integer.MAX_VALUE` instead of the actual `ignore_above` limit, causing a mismatch.

This issue was already fixed on main in #148900, but that change was not backported to 9.4.

Closes #152608

🤖 Generated with [Claude Code](https://claude.com/claude-code)