### PR TITLE
[ESQL] Async external source metadata discovery

### DIFF
--- a/docs/changelog/152691.yaml
+++ b/docs/changelog/152691.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152691
+summary: Async external source metadata discovery
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
@@ -34,6 +35,7 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -50,12 +52,15 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
 import org.elasticsearch.xpack.esql.datasources.cache.ParsedFooterCache;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
 import org.elasticsearch.xpack.esql.datasources.spi.DynamicThresholdAware;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
@@ -74,6 +79,7 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -88,6 +94,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 /**
  * FormatReader implementation for Parquet files.
@@ -131,6 +138,21 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     private final ParquetReaderCounters counters = new ParquetReaderCounters();
 
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
+
+    /**
+     * Bytes prefetched from the tail of a Parquet file by {@link #metadataAsync} to cover the footer
+     * in a single async read. The Parquet trailer is 8 bytes (4-byte little-endian footer length +
+     * 4-byte {@code PAR1} magic); footers for typical files fit comfortably within this window, so a
+     * single {@link StorageObject#readBytesAsync} suffices. When a footer exceeds this window a
+     * second exact-range read is issued (see {@link #metadataAsync}).
+     */
+    static final int FOOTER_TAIL_PREFETCH_BYTES = 64 * 1024;
+
+    /** The 4-byte magic that both opens and closes a (non-encrypted) Parquet file. */
+    private static final byte[] PARQUET_MAGIC = { 'P', 'A', 'R', '1' };
+
+    /** Length of the Parquet trailer: 4-byte footer length + 4-byte magic. */
+    private static final int PARQUET_TRAILER_BYTES = 8;
 
     static final String CONFIG_OPTIMIZED_READER = "optimized_reader";
     static final String CONFIG_LATE_MATERIALIZATION = "late_materialization";
@@ -529,13 +551,319 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         ParquetReadOptions options = readOptionsBuilder().build();
 
         try (ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, options)) {
-            FileMetaData fileMetaData = reader.getFileMetaData();
-            MessageType parquetSchema = fileMetaData.getSchema();
-            validateFooterIntegrity(object.path().toString(), parquetSchema, reader.getRowGroups());
-            List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
-            SourceStatistics statistics = extractStatistics(reader, schema);
-            return new SimpleSourceMetadata(schema, formatName(), object.path().toString(), statistics, null);
+            return buildFooterMetadata(object, reader.getFooter());
         }
+    }
+
+    /**
+     * Builds the {@link SourceMetadata} (schema + statistics) from an already-parsed Parquet
+     * {@link ParquetMetadata}. Shared by the synchronous {@link #metadata(StorageObject)} and the
+     * async {@link #metadataAsync} parse-from-buffer path so both produce identical results from the
+     * same footer, independent of how the footer bytes were obtained.
+     */
+    private SourceMetadata buildFooterMetadata(StorageObject object, ParquetMetadata footer) {
+        MessageType parquetSchema = footer.getFileMetaData().getSchema();
+        validateFooterIntegrity(object.path().toString(), parquetSchema, footer.getBlocks());
+        List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
+        SourceStatistics statistics = extractStatistics(footer.getBlocks(), schema);
+        return new SimpleSourceMetadata(schema, formatName(), object.path().toString(), statistics, null);
+    }
+
+    /**
+     * Async metadata resolution: prefetch the footer tail off the executor via
+     * {@link StorageObject#readBytesAsync} (native, non-blocking on S3), then run the (CPU-only)
+     * footer parse straight from the prefetched byte array (see {@link #parseFooterFromTail}). The
+     * executor thread is therefore released across the network round-trip and is touched only for the
+     * microsecond-scale parse, which is what makes a wide discovery fan-out safe to bound by an
+     * in-flight permit equal to the pool size. The prefetched bytes are additionally offered to the
+     * JVM-wide {@link FooterByteCache} best-effort so a later split-discovery pass can reuse them, but
+     * the parse never depends on that entry surviving.
+     * <p>
+     * On any anomaly (short file, absent/foreign magic, oversized footer that cannot be cached) the
+     * method falls back to running {@link #metadata(StorageObject)} on the executor, which performs
+     * its own I/O and produces the canonical error for invalid files. Correctness never depends on
+     * the prefetch succeeding.
+     * <p>
+     * Contract note: {@link StorageObject#length()} is read synchronously on the calling thread before
+     * the async prefetch is dispatched. This is I/O-free when {@code object} was built from a directory
+     * listing (the resolver always seeds it via a {@link org.elasticsearch.xpack.esql.datasources.spi.ListingHint},
+     * so {@code length()} returns the known size). A caller that constructs {@code object} without a
+     * known length makes this a blocking stat/HEAD on the calling thread — such callers should dispatch
+     * {@code metadataAsync} on an executor themselves.
+     */
+    @Override
+    public void metadataAsync(StorageObject object, Executor executor, ActionListener<SourceMetadata> listener) {
+        final long length;
+        final FooterByteCache.Key cacheKey;
+        try {
+            length = object.length();
+            cacheKey = FooterByteCache.Key.keyFor(object, length);
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        // Too small to hold a trailer, or the tail is already cached (warm) — the sync parse will
+        // not touch the network, so just run it on the executor.
+        if (length < PARQUET_TRAILER_BYTES || FooterByteCache.getInstance().get(cacheKey) != null) {
+            parseFooterOnExecutor(object, executor, listener);
+            return;
+        }
+
+        int tailLen = (int) Math.min(FOOTER_TAIL_PREFETCH_BYTES, length);
+        BufferAllocator allocator = blockFactory.arrowAllocator();
+        DirectBufferFactory factory = DirectBufferFactory.forAllocator(allocator);
+
+        object.readBytesAsync(length - tailLen, tailLen, factory, executor, ActionListener.wrap(tail -> {
+            final byte[] tailBytes;
+            try {
+                tailBytes = copyToArray(tail);
+            } finally {
+                tail.close();
+            }
+
+            int footerLength = footerLengthFromTrailer(tailBytes);
+            if (footerLength <= 0) {
+                // Missing/foreign magic or a nonsensical length — let the sync path produce the
+                // proper invalid-Parquet error (or handle an encrypted footer via its own I/O).
+                parseFooterOnExecutor(object, executor, listener);
+                return;
+            }
+
+            long footerRegion = (long) footerLength + PARQUET_TRAILER_BYTES;
+            if (footerRegion <= tailBytes.length) {
+                // The whole footer is already in the prefetched tail — parse straight from it.
+                parseTailOnExecutor(object, length, tailBytes, cacheKey, executor, listener);
+                return;
+            }
+
+            if (footerRegion > FooterByteCache.getInstance().maxEntryBytes()) {
+                // The footer is larger than the cache admits; the sync parse reads it directly.
+                parseFooterOnExecutor(object, executor, listener);
+                return;
+            }
+
+            // Large footer: a single exact-range read of [length - footerRegion, length) covers the
+            // whole footer, which is then parsed straight from the returned bytes.
+            int exactLen = (int) footerRegion;
+            object.readBytesAsync(length - exactLen, exactLen, factory, executor, ActionListener.wrap(footer -> {
+                final byte[] footerBytes;
+                try {
+                    footerBytes = copyToArray(footer);
+                } finally {
+                    footer.close();
+                }
+                parseTailOnExecutor(object, length, footerBytes, cacheKey, executor, listener);
+            }, listener::onFailure));
+        }, listener::onFailure));
+    }
+
+    /**
+     * Parses the footer directly from the prefetched {@code tailBytes} (a suffix of the file ending at
+     * {@code length}) on {@code executor}, completing {@code listener}. Parsing from the byte array is
+     * deliberate: it does not depend on the {@link FooterByteCache} surviving between the async read
+     * and the parse (a wide concurrent discovery could otherwise evict the tail against the cache's
+     * byte budget and force a blocking re-read on the executor thread). The bytes are additionally
+     * offered to the cache best-effort so a later split-discovery pass can reuse them, but correctness
+     * never depends on that.
+     */
+    private void parseTailOnExecutor(
+        StorageObject object,
+        long length,
+        byte[] tailBytes,
+        FooterByteCache.Key cacheKey,
+        Executor executor,
+        ActionListener<SourceMetadata> listener
+    ) {
+        executor.execute(() -> {
+            try {
+                FooterByteCache.getInstance().put(cacheKey, tailBytes);
+                listener.onResponse(parseFooterFromTail(object, length, tailBytes));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * Parses a Parquet {@link ParquetMetadata} footer from an in-memory suffix of the file
+     * ({@code tailBytes} covering {@code [length - tailBytes.length, length)}) and builds the
+     * corresponding {@link SourceMetadata}. Malformed footers surface as the same
+     * invalid-Parquet {@link IllegalArgumentException} the synchronous path produces.
+     */
+    private SourceMetadata parseFooterFromTail(StorageObject object, long length, byte[] tailBytes) throws IOException {
+        TailBackedInputFile inputFile = new TailBackedInputFile(length, tailBytes);
+        ParquetReadOptions options = readOptionsBuilder().build();
+        try (SeekableInputStream stream = inputFile.newStream()) {
+            ParquetMetadata footer;
+            try {
+                footer = ParquetFileReader.readFooter(inputFile, options, stream);
+            } catch (RuntimeException e) {
+                // parquet-mr signals a malformed footer with plain RuntimeExceptions; wrap them into
+                // the same shape as the synchronous read path so callers see consistent errors.
+                throw newInvalidParquetFileException(object.path().toString(), e);
+            }
+            return buildFooterMetadata(object, footer);
+        }
+    }
+
+    /** Runs the synchronous {@link #metadata(StorageObject)} on {@code executor}, completing {@code listener}. */
+    private void parseFooterOnExecutor(StorageObject object, Executor executor, ActionListener<SourceMetadata> listener) {
+        executor.execute(() -> {
+            try {
+                listener.onResponse(metadata(object));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * An {@link InputFile} whose bytes are an in-memory suffix of a larger file. It reports the true
+     * {@code fileLength} (so footer offsets computed from the trailer remain valid) but only serves
+     * reads that fall within the prefetched tail {@code [fileLength - tail.length, fileLength)}; any
+     * read below that throws, which for a footer-only parse never happens.
+     */
+    private static final class TailBackedInputFile implements org.apache.parquet.io.InputFile {
+        private final long fileLength;
+        private final byte[] tail;
+
+        TailBackedInputFile(long fileLength, byte[] tail) {
+            this.fileLength = fileLength;
+            this.tail = tail;
+        }
+
+        @Override
+        public long getLength() {
+            return fileLength;
+        }
+
+        @Override
+        public SeekableInputStream newStream() {
+            return new TailBackedSeekableInputStream(fileLength - tail.length, tail);
+        }
+    }
+
+    /** {@link SeekableInputStream} over a byte array positioned at file offset {@code tailStart}. */
+    private static final class TailBackedSeekableInputStream extends SeekableInputStream {
+        private final long tailStart;
+        private final byte[] tail;
+        private long pos;
+
+        TailBackedSeekableInputStream(long tailStart, byte[] tail) {
+            this.tailStart = tailStart;
+            this.tail = tail;
+            this.pos = tailStart;
+        }
+
+        private int index() throws IOException {
+            long rel = pos - tailStart;
+            if (rel < 0 || rel > tail.length) {
+                throw new IOException("Parquet footer read at " + pos + " outside prefetched tail of length " + tail.length);
+            }
+            return (int) rel;
+        }
+
+        @Override
+        public long getPos() {
+            return pos;
+        }
+
+        @Override
+        public void seek(long newPos) {
+            pos = newPos;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int i = index();
+            if (i >= tail.length) {
+                return -1;
+            }
+            pos++;
+            return tail[i] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int i = index();
+            if (i >= tail.length) {
+                return -1;
+            }
+            int n = Math.min(len, tail.length - i);
+            System.arraycopy(tail, i, b, off, n);
+            pos += n;
+            return n;
+        }
+
+        @Override
+        public int read(ByteBuffer buf) throws IOException {
+            int i = index();
+            int n = Math.min(buf.remaining(), tail.length - i);
+            if (n <= 0) {
+                return -1;
+            }
+            buf.put(tail, i, n);
+            pos += n;
+            return n;
+        }
+
+        @Override
+        public void readFully(byte[] bytes) throws IOException {
+            readFully(bytes, 0, bytes.length);
+        }
+
+        @Override
+        public void readFully(byte[] bytes, int start, int len) throws IOException {
+            int i = index();
+            if (i + len > tail.length) {
+                throw new java.io.EOFException("Parquet footer read past prefetched tail");
+            }
+            System.arraycopy(tail, i, bytes, start, len);
+            pos += len;
+        }
+
+        @Override
+        public void readFully(ByteBuffer buf) throws IOException {
+            int i = index();
+            int len = buf.remaining();
+            if (i + len > tail.length) {
+                throw new java.io.EOFException("Parquet footer read past prefetched tail");
+            }
+            buf.put(tail, i, len);
+            pos += len;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /** Copies the readable region ({@code position()}..{@code limit()}) of a direct buffer into a heap array. */
+    private static byte[] copyToArray(DirectReadBuffer buffer) {
+        ByteBuffer bb = buffer.buffer().duplicate();
+        byte[] bytes = new byte[bb.remaining()];
+        bb.get(bytes);
+        return bytes;
+    }
+
+    /**
+     * Reads the Parquet footer length from a byte array that ends at the file's final byte, i.e. the
+     * last 8 bytes are the trailer {@code [footerLength:int32-le][PAR1]}. Returns {@code -1} when the
+     * trailing magic is absent (foreign/encrypted footer, truncated file) so the caller can fall back
+     * to the synchronous path rather than trusting a bogus length.
+     */
+    private static int footerLengthFromTrailer(byte[] tail) {
+        int n = tail.length;
+        if (n < PARQUET_TRAILER_BYTES) {
+            return -1;
+        }
+        for (int i = 0; i < PARQUET_MAGIC.length; i++) {
+            if (tail[n - PARQUET_MAGIC.length + i] != PARQUET_MAGIC[i]) {
+                return -1;
+            }
+        }
+        int base = n - PARQUET_TRAILER_BYTES;
+        return (tail[base] & 0xFF) | ((tail[base + 1] & 0xFF) << 8) | ((tail[base + 2] & 0xFF) << 16) | ((tail[base + 3] & 0xFF) << 24);
     }
 
     /**
@@ -568,8 +896,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     }
 
     @SuppressWarnings("rawtypes")
-    private SourceStatistics extractStatistics(ParquetFileReader reader, List<Attribute> attributes) {
-        List<BlockMetaData> rowGroups = reader.getRowGroups();
+    private SourceStatistics extractStatistics(List<BlockMetaData> rowGroups, List<Attribute> attributes) {
         if (rowGroups.isEmpty()) {
             return null;
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -622,6 +622,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 tail.close();
             }
 
+            if (tailBytes.length != tailLen) {
+                // readBytesAsync's SPI contract permits a short read (fewer than the requested bytes). The parse path
+                // treats these bytes as a suffix ending at the file length (TailBackedInputFile offsets by
+                // length - tailBytes.length), so a short read would misalign every footer offset. Fall back to the
+                // synchronous parse, which reads the exact ranges it needs itself, rather than relying on the
+                // trailing-magic scan below happening to reject the misaligned bytes.
+                parseFooterOnExecutor(object, executor, listener);
+                return;
+            }
+
             int footerLength = footerLengthFromTrailer(tailBytes);
             if (footerLength <= 0) {
                 // Missing/foreign magic or a nonsensical length — let the sync path produce the
@@ -652,6 +662,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     footerBytes = copyToArray(footer);
                 } finally {
                     footer.close();
+                }
+                if (footerBytes.length != exactLen) {
+                    // Short read (see the tail-read guard above): the bytes would not align to the file suffix the
+                    // parse path assumes, so fall back to the synchronous exact-range read.
+                    parseFooterOnExecutor(object, executor, listener);
+                    return;
                 }
                 parseTailOnExecutor(object, length, footerBytes, cacheKey, executor, listener);
             }, listener::onFailure));

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -392,6 +392,115 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
     }
 
+    /**
+     * Short-read fallback: {@code readBytesAsync}'s SPI contract permits returning fewer bytes than
+     * requested. The async parse treats the prefetched bytes as a suffix ending at the file length, so a
+     * short read would misalign every footer offset. This mock returns a short buffer whose trailing 8
+     * bytes forge a valid-looking Parquet trailer (small footer length + {@code PAR1}) — enough to send
+     * the unguarded path straight into {@code parseTailOnExecutor} with a misaligned window (which then
+     * mis-parses or throws). {@code metadataAsync} must instead detect the short read and fall back to the
+     * synchronous parse, yielding metadata identical to the fully-synchronous path.
+     */
+    public void testMetadataAsyncShortReadFallsBackToSync() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("short_read_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("id", 42L);
+            g.add("name", "Bob");
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata syncMeta = reader.metadata(createStorageObject(parquetData));
+
+        // A deliberately short buffer with a forged trailer: footerLength=20 (LE int32) followed by PAR1.
+        // footerRegion (20 + 8) <= buffer length (40), so the unguarded path would parse straight from
+        // these misaligned bytes instead of the real file suffix.
+        byte[] shortBuffer = new byte[40];
+        int forgedFooterLength = 20;
+        int base = shortBuffer.length - 8;
+        shortBuffer[base] = (byte) (forgedFooterLength & 0xFF);
+        shortBuffer[base + 1] = (byte) ((forgedFooterLength >> 8) & 0xFF);
+        shortBuffer[base + 2] = (byte) ((forgedFooterLength >> 16) & 0xFF);
+        shortBuffer[base + 3] = (byte) ((forgedFooterLength >> 24) & 0xFF);
+        shortBuffer[base + 4] = 'P';
+        shortBuffer[base + 5] = 'A';
+        shortBuffer[base + 6] = 'R';
+        shortBuffer[base + 7] = '1';
+
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        try {
+            StorageObject asyncObject = new StorageObject() {
+                @Override
+                public InputStream newStream() {
+                    return new ByteArrayInputStream(parquetData);
+                }
+
+                @Override
+                public InputStream newStream(long position, long length) {
+                    int pos = (int) position;
+                    int len = (int) Math.min(length, parquetData.length - position);
+                    return new ByteArrayInputStream(parquetData, pos, len);
+                }
+
+                @Override
+                public void readBytesAsync(
+                    long position,
+                    long length,
+                    DirectBufferFactory factory,
+                    Executor ignored,
+                    ActionListener<DirectReadBuffer> listener
+                ) {
+                    asyncReadCount.incrementAndGet();
+                    probePool.execute(() -> listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(shortBuffer), () -> {})));
+                }
+
+                @Override
+                public long length() {
+                    return parquetData.length;
+                }
+
+                @Override
+                public Instant lastModified() {
+                    return Instant.ofEpochMilli(0);
+                }
+
+                @Override
+                public boolean exists() {
+                    return true;
+                }
+
+                @Override
+                public StoragePath path() {
+                    return StoragePath.of("memory://short-read-test.parquet");
+                }
+            };
+
+            PlainActionFuture<SourceMetadata> future = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, future);
+            SourceMetadata asyncMeta = future.actionGet(30, TimeUnit.SECONDS);
+
+            assertEquals("the tail prefetch must be attempted once before falling back", 1, asyncReadCount.get());
+            assertEquals(syncMeta.schema().size(), asyncMeta.schema().size());
+            for (int i = 0; i < syncMeta.schema().size(); i++) {
+                assertEquals(syncMeta.schema().get(i).name(), asyncMeta.schema().get(i).name());
+                assertEquals(syncMeta.schema().get(i).dataType(), asyncMeta.schema().get(i).dataType());
+            }
+            assertStatisticsEqual(syncMeta, asyncMeta);
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
     public void testReadDataFromSimpleParquet() throws Exception {
         MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT64)

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -26,6 +26,8 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.logging.HeaderWarning;
@@ -47,11 +49,14 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.junit.After;
@@ -76,10 +81,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -172,6 +183,213 @@ public class ParquetFormatReaderTests extends ESTestCase {
 
         assertEquals("active", attributes.get(3).name());
         assertEquals(DataType.BOOLEAN, attributes.get(3).dataType());
+    }
+
+    /**
+     * Parity: {@link ParquetFormatReader#metadataAsync} must resolve the same schema as the
+     * synchronous {@link ParquetFormatReader#metadata}. The async path prefetches the footer tail via
+     * {@code readBytesAsync} (completed here on a separate probe pool), seeds the footer-byte cache and
+     * then runs the CPU-only parse; the resulting {@link SourceMetadata} must be indistinguishable
+     * from the fully-synchronous path.
+     */
+    public void testMetadataAsyncMatchesSync() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("id", 7L);
+            g.add("name", "Alice");
+            g.add("age", 30);
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        // Synchronous baseline against its own (freshly cleared) object.
+        SourceMetadata syncMeta = reader.metadata(createStorageObject(parquetData));
+        List<Attribute> syncSchema = syncMeta.schema();
+
+        // Async path over an object whose reads complete on a separate pool.
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(parquetData, probePool, asyncReadCount, null);
+            PlainActionFuture<SourceMetadata> future = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, future);
+            SourceMetadata asyncMeta = future.actionGet(30, TimeUnit.SECONDS);
+
+            assertEquals("footer tail should be prefetched exactly once", 1, asyncReadCount.get());
+            List<Attribute> asyncSchema = asyncMeta.schema();
+            assertEquals(syncSchema.size(), asyncSchema.size());
+            for (int i = 0; i < syncSchema.size(); i++) {
+                assertEquals(syncSchema.get(i).name(), asyncSchema.get(i).name());
+                assertEquals(syncSchema.get(i).dataType(), asyncSchema.get(i).dataType());
+            }
+            // The async path parses via TailBackedInputFile, a different open path than the sync
+            // ParquetStorageObjectAdapter — statistics are part of the metadata contract, so assert
+            // row count, byte size and per-column stats match, not just the schema.
+            assertStatisticsEqual(syncMeta, asyncMeta);
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /** Asserts that two {@link SourceMetadata} carry identical row-count, byte-size and per-column statistics. */
+    private static void assertStatisticsEqual(SourceMetadata expected, SourceMetadata actual) {
+        assertEquals("statistics presence must match", expected.statistics().isPresent(), actual.statistics().isPresent());
+        if (expected.statistics().isPresent() == false) {
+            return;
+        }
+        SourceStatistics expectedStats = expected.statistics().get();
+        SourceStatistics actualStats = actual.statistics().get();
+        assertEquals("row count", expectedStats.rowCount(), actualStats.rowCount());
+        assertEquals("size in bytes", expectedStats.sizeInBytes(), actualStats.sizeInBytes());
+        assertEquals(
+            "column-statistics presence",
+            expectedStats.columnStatistics().isPresent(),
+            actualStats.columnStatistics().isPresent()
+        );
+        if (expectedStats.columnStatistics().isPresent() == false) {
+            return;
+        }
+        Map<String, SourceStatistics.ColumnStatistics> expectedCols = expectedStats.columnStatistics().get();
+        Map<String, SourceStatistics.ColumnStatistics> actualCols = actualStats.columnStatistics().get();
+        assertEquals("column-statistics keys", expectedCols.keySet(), actualCols.keySet());
+        for (Map.Entry<String, SourceStatistics.ColumnStatistics> entry : expectedCols.entrySet()) {
+            SourceStatistics.ColumnStatistics expectedCol = entry.getValue();
+            SourceStatistics.ColumnStatistics actualCol = actualCols.get(entry.getKey());
+            String col = entry.getKey();
+            assertEquals("null count [" + col + "]", expectedCol.nullCount(), actualCol.nullCount());
+            assertEquals("min value [" + col + "]", expectedCol.minValue(), actualCol.minValue());
+            assertEquals("max value [" + col + "]", expectedCol.maxValue(), actualCol.maxValue());
+            assertEquals("column size [" + col + "]", expectedCol.sizeInBytes(), actualCol.sizeInBytes());
+        }
+    }
+
+    /**
+     * Large footer: a file whose footer exceeds the {@link ParquetFormatReader#FOOTER_TAIL_PREFETCH_BYTES}
+     * tail window must trigger a second, exact-range {@code readBytesAsync} covering the whole footer,
+     * and still parse to the correct schema. A wide (many-column) schema inflates the footer well past
+     * the 64 KiB tail while staying under the footer-byte cache's per-entry cap.
+     */
+    public void testMetadataAsyncLargeFooterIssuesSecondRead() throws Exception {
+        int columns = 2000;
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < columns; i++) {
+            builder.optional(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + i);
+        }
+        MessageType schema = builder.named("wide_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("col_0", 1L);
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        List<Attribute> syncSchema = reader.metadata(createStorageObject(parquetData)).schema();
+
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger asyncReadCount = new AtomicInteger();
+        List<long[]> reads = new CopyOnWriteArrayList<>();
+        try {
+            StorageObject asyncObject = createAsyncStorageObject(parquetData, probePool, asyncReadCount, reads);
+            PlainActionFuture<SourceMetadata> future = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, future);
+            SourceMetadata asyncMeta = future.actionGet(30, TimeUnit.SECONDS);
+
+            assertEquals("footer larger than the tail window should trigger a second read", 2, asyncReadCount.get());
+            assertEquals("first read is the bounded tail prefetch", ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES, reads.get(0)[1]);
+            assertThat(
+                "second read must cover the full footer, larger than the tail window",
+                reads.get(1)[1],
+                greaterThan((long) ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES)
+            );
+            assertEquals(syncSchema.size(), asyncMeta.schema().size());
+            assertEquals(columns, asyncMeta.schema().size());
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /**
+     * No-buffer-leak (success): every {@link DirectReadBuffer} handed to {@code metadataAsync} —
+     * both the tail prefetch and the second full-footer read of a wide footer — must be closed by the
+     * reader once its bytes have been copied out. A file wide enough to force the two-read path
+     * exercises both allocations.
+     */
+    public void testMetadataAsyncReleasesBuffersOnSuccess() throws Exception {
+        int columns = 2000;
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < columns; i++) {
+            builder.optional(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + i);
+        }
+        byte[] parquetData = createParquetFile(builder.named("wide_schema"), factory -> {
+            Group g = factory.newGroup();
+            g.add("col_0", 1L);
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger openBuffers = new AtomicInteger();
+        AtomicInteger allocated = new AtomicInteger();
+        try {
+            StorageObject asyncObject = createBufferTrackingAsyncStorageObject(parquetData, probePool, openBuffers, allocated, -1);
+            PlainActionFuture<SourceMetadata> future = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, future);
+            future.actionGet(30, TimeUnit.SECONDS);
+
+            assertThat("both reads must allocate a buffer", allocated.get(), equalTo(2));
+            assertEquals("every prefetched buffer must be released after its bytes are copied", 0, openBuffers.get());
+        } finally {
+            probePool.shutdownNow();
+        }
+    }
+
+    /**
+     * No-buffer-leak (failure): when the second (full-footer) read fails, the reader must already have
+     * released the first (tail) buffer and must not leak any buffer, while surfacing the failure.
+     */
+    public void testMetadataAsyncReleasesBuffersOnReadFailure() throws Exception {
+        int columns = 2000;
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < columns; i++) {
+            builder.optional(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + i);
+        }
+        byte[] parquetData = createParquetFile(builder.named("wide_schema"), factory -> {
+            Group g = factory.newGroup();
+            g.add("col_0", 1L);
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        ExecutorService probePool = Executors.newFixedThreadPool(2);
+        AtomicInteger openBuffers = new AtomicInteger();
+        AtomicInteger allocated = new AtomicInteger();
+        try {
+            // Fail the second read (index 1): the full-footer fetch that follows the tail prefetch.
+            StorageObject asyncObject = createBufferTrackingAsyncStorageObject(parquetData, probePool, openBuffers, allocated, 1);
+            PlainActionFuture<SourceMetadata> future = new PlainActionFuture<>();
+            reader.metadataAsync(asyncObject, probePool, future);
+            expectThrows(Exception.class, () -> future.actionGet(30, TimeUnit.SECONDS));
+
+            assertEquals("the tail buffer must be released even though the follow-up read failed", 0, openBuffers.get());
+        } finally {
+            probePool.shutdownNow();
+        }
     }
 
     public void testReadDataFromSimpleParquet() throws Exception {
@@ -2816,6 +3034,156 @@ public class ParquetFormatReaderTests extends ESTestCase {
             @Override
             public String getPath() {
                 return "memory://test.parquet";
+            }
+        };
+    }
+
+    /**
+     * Builds a {@link StorageObject} that completes {@code readBytesAsync} on {@code pool} (never on
+     * the executor the caller passes in), so tests can assert the executor thread is released across
+     * the "network" read. {@code asyncReadCount} records the number of async dispatches; when
+     * {@code reads} is non-null each {@code readBytesAsync} appends a {@code [position, length]} pair
+     * so tests can inspect the exact ranges requested.
+     */
+    private static StorageObject createAsyncStorageObject(
+        byte[] data,
+        ExecutorService pool,
+        AtomicInteger asyncReadCount,
+        List<long[]> reads
+    ) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public void readBytesAsync(
+                long position,
+                long length,
+                DirectBufferFactory factory,
+                Executor ignored,
+                ActionListener<DirectReadBuffer> listener
+            ) {
+                asyncReadCount.incrementAndGet();
+                if (reads != null) {
+                    reads.add(new long[] { position, length });
+                }
+                pool.execute(() -> {
+                    try {
+                        int pos = (int) position;
+                        int len = (int) Math.min(length, data.length - position);
+                        byte[] slice = new byte[len];
+                        System.arraycopy(data, pos, slice, 0, len);
+                        listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(slice), () -> {}));
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                });
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.ofEpochMilli(0);
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://async-test.parquet");
+            }
+        };
+    }
+
+    /**
+     * Like {@link #createAsyncStorageObject} but tracks {@link DirectReadBuffer} lifecycle so leak
+     * tests can assert release: {@code allocated} counts buffers handed out and {@code openBuffers} is
+     * incremented on allocation and decremented on {@link DirectReadBuffer#close()}. When
+     * {@code failReadIndex >= 0} that (0-based) read completes with a failure and allocates no buffer.
+     */
+    private static StorageObject createBufferTrackingAsyncStorageObject(
+        byte[] data,
+        ExecutorService pool,
+        AtomicInteger openBuffers,
+        AtomicInteger allocated,
+        int failReadIndex
+    ) {
+        AtomicInteger readIndex = new AtomicInteger();
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public void readBytesAsync(
+                long position,
+                long length,
+                DirectBufferFactory factory,
+                Executor ignored,
+                ActionListener<DirectReadBuffer> listener
+            ) {
+                int idx = readIndex.getAndIncrement();
+                pool.execute(() -> {
+                    if (idx == failReadIndex) {
+                        listener.onFailure(new IOException("injected read failure at index " + idx));
+                        return;
+                    }
+                    try {
+                        int pos = (int) position;
+                        int len = (int) Math.min(length, data.length - position);
+                        byte[] slice = new byte[len];
+                        System.arraycopy(data, pos, slice, 0, len);
+                        allocated.incrementAndGet();
+                        openBuffers.incrementAndGet();
+                        listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(slice), openBuffers::decrementAndGet));
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                });
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.ofEpochMilli(0);
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://async-leak-test.parquet");
             }
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -582,61 +582,90 @@ public class ExternalSourceResolver {
         // Glob expansion / cache listing above can be slow on wide globs; re-check before the anchor footer read.
         throwIfCancelled();
 
-        ExternalSourceMetadata anchorMetadata;
-        if (cacheable) {
-            String formatType = detectFormatType(anchorPath);
-            SchemaCacheKey schemaKey = SchemaCacheKey.build(anchorPath.toString(), anchorMtime, formatType, config);
-            SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                return SchemaCacheEntry.from(resolveSingleSource(anchorPath.toString(), config));
-            });
-            List<Attribute> schema = schemaEntry.toAttributes();
-            anchorMetadata = buildMetadataFromCache(schemaEntry, schema, config);
-        } else {
-            SourceMetadata metadata = resolveSingleSource(anchorPath.toString(), config);
-            anchorMetadata = wrapAsExternalSourceMetadata(metadata, config);
-        }
-
+        // The anchor's length/mtime are already known from the listing, so seed a ListingHint and resolve it on the
+        // async footer-read path (like the fan-out) rather than a synchronous resolveSingleSource. This both skips
+        // the existence/HEAD + length probe and, more importantly, avoids pinning the metadata-read executor thread
+        // across the anchor footer read. Unlike the single-file getOrComputeSchema path this does not coalesce
+        // concurrent misses for the same anchor key; that matches the fan-out's peek/put trade-off and is safe
+        // because footer resolution is idempotent (see cachedResolveSingleSourceAsync).
+        ListingHint anchorHint = new ListingHint(listing.size(anchor), anchorMtime);
         final FileList finalListing = listing;
-        final ExternalSourceMetadata base = enrichWithFileCount(anchorMetadata, listing.fileCount());
-        if (listing.fileCount() > 1 && requiresStats) {
-            // For multi-file FIRST_FILE_WINS, read all files' metadata during Phase 1 to aggregate statistics
-            // across all files. This allows aggregate pushdown (COUNT/MIN/MAX) to use accurate global stats and
-            // to skip Phase 2 (split discovery) entirely for those queries.
-            //
-            // This eager all-file aggregation is gated on requiresStats: only query shapes that can consume the
-            // global stats — an ungrouped aggregate over the relation, detected by
-            // ExternalStatsRequirementExtractor#pathsRequiringEagerStats — pay the N footer reads. Every other
-            // shape (LIMIT, SELECT *, grouped STATS ... BY, INLINESTATS) takes the defer branch below: it keeps
-            // STATS_FILE_COUNT (from enrichWithFileCount above) but marks stats partial, so Phase 2 split discovery
-            // reads footers once instead of twice. Legacy callers pass requiresStats == true for every path (the
-            // resolve overload with a null pathsRequiringStats set), preserving the original eager-for-all behavior.
-            //
-            // For an eager (requiresStats) resolve the cost is acceptable because:
-            // - the cacheable path consults the schema cache, so repeat resolves are free;
-            // - the non-cacheable path reads footers with an async fan-out bounded by an in-flight permit
-            // (metadataReadConcurrency), releasing the pool thread across each footer read;
-            // - the aggregated stats unlock skipping Phase 2 entirely for pushable aggregates
-            // (see ComputeService#canSkipSplitDiscovery), which dominates the savings.
-            ActionListener<Map<String, Object>> statsListener = ActionListener.wrap(aggregatedStats -> {
-                try {
-                    listener.onResponse(finishFirstFileWins(finalListing, applyFirstFileWinsAggregatedStats(base, aggregatedStats)));
-                } catch (Exception e) {
-                    listener.onFailure(e);
-                }
-            }, listener::onFailure);
-            if (cacheable) {
-                readAndAggregateAllFileStatsWithCache(listing, config, statsListener);
-            } else {
-                readAndAggregateAllFileStats(listing, config, statsListener);
-            }
-        } else if (listing.fileCount() > 1) {
-            // Defer branch (requiresStats == false): skip the N footer reads. The anchor-only stats are not
-            // representative of the whole glob, so mark them partial — exactly the state the failed-aggregation
-            // path produces, which downstream already handles (SplitStats.resolveEffectiveStats returns null
-            // rather than consuming anchor stats as global). STATS_FILE_COUNT, stamped above, is preserved.
-            listener.onResponse(finishFirstFileWins(finalListing, markStatsAsPartial(base)));
+        ActionListener<ExternalSourceMetadata> anchorListener = ActionListener.wrap(
+            anchorMetadata -> completeFirstFileWins(anchorMetadata, finalListing, config, requiresStats, cacheable, listener),
+            listener::onFailure
+        );
+        if (cacheable) {
+            // cachedResolveSingleSourceAsync always completes with the ExternalSourceMetadata built by
+            // buildMetadataFromCache, so the cast is safe.
+            cachedResolveSingleSourceAsync(anchorPath, anchorHint, config, anchorListener.map(meta -> (ExternalSourceMetadata) meta));
         } else {
-            listener.onResponse(finishFirstFileWins(finalListing, base));
+            resolveSingleSourceAsync(
+                anchorPath.toString(),
+                anchorHint,
+                config,
+                anchorListener.map(meta -> wrapAsExternalSourceMetadata(meta, config))
+            );
+        }
+    }
+
+    /**
+     * Builds the FIRST_FILE_WINS result from the resolved anchor metadata and the discovered listing. Runs as the
+     * continuation of the async anchor footer read, so any synchronous failure here is funnelled to
+     * {@code listener::onFailure} rather than escaping onto the executor thread.
+     */
+    private void completeFirstFileWins(
+        ExternalSourceMetadata anchorMetadata,
+        FileList listing,
+        Map<String, Object> config,
+        boolean requiresStats,
+        boolean cacheable,
+        ActionListener<ExternalSourceResolution.ResolvedSource> listener
+    ) {
+        try {
+            final ExternalSourceMetadata base = enrichWithFileCount(anchorMetadata, listing.fileCount());
+            if (listing.fileCount() > 1 && requiresStats) {
+                // For multi-file FIRST_FILE_WINS, read all files' metadata during Phase 1 to aggregate statistics
+                // across all files. This allows aggregate pushdown (COUNT/MIN/MAX) to use accurate global stats and
+                // to skip Phase 2 (split discovery) entirely for those queries.
+                //
+                // This eager all-file aggregation is gated on requiresStats: only query shapes that can consume the
+                // global stats — an ungrouped aggregate over the relation, detected by
+                // ExternalStatsRequirementExtractor#pathsRequiringEagerStats — pay the N footer reads. Every other
+                // shape (LIMIT, SELECT *, grouped STATS ... BY, INLINESTATS) takes the defer branch below: it keeps
+                // STATS_FILE_COUNT (from enrichWithFileCount above) but marks stats partial, so Phase 2 split
+                // discovery reads footers once instead of twice. Legacy callers pass requiresStats == true for every
+                // path (the resolve overload with a null pathsRequiringStats set), preserving the original
+                // eager-for-all behavior.
+                //
+                // For an eager (requiresStats) resolve the cost is acceptable because:
+                // - the cacheable path consults the schema cache, so repeat resolves are free;
+                // - the non-cacheable path reads footers with an async fan-out bounded by an in-flight permit
+                // (metadataReadConcurrency), releasing the pool thread across each footer read;
+                // - the aggregated stats unlock skipping Phase 2 entirely for pushable aggregates
+                // (see ComputeService#canSkipSplitDiscovery), which dominates the savings.
+                ActionListener<Map<String, Object>> statsListener = ActionListener.wrap(aggregatedStats -> {
+                    try {
+                        listener.onResponse(finishFirstFileWins(listing, applyFirstFileWinsAggregatedStats(base, aggregatedStats)));
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                }, listener::onFailure);
+                if (cacheable) {
+                    readAndAggregateAllFileStatsWithCache(listing, config, statsListener);
+                } else {
+                    readAndAggregateAllFileStats(listing, config, statsListener);
+                }
+            } else if (listing.fileCount() > 1) {
+                // Defer branch (requiresStats == false): skip the N footer reads. The anchor-only stats are not
+                // representative of the whole glob, so mark them partial — exactly the state the failed-aggregation
+                // path produces, which downstream already handles (SplitStats.resolveEffectiveStats returns null
+                // rather than consuming anchor stats as global). STATS_FILE_COUNT, stamped above, is preserved.
+                listener.onResponse(finishFirstFileWins(listing, markStatsAsPartial(base)));
+            } else {
+                listener.onResponse(finishFirstFileWins(listing, base));
+            }
+        } catch (Exception e) {
+            listener.onFailure(e);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.util.concurrent.ThrottledIterator;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -28,18 +29,19 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.ListingHint;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
-import org.elasticsearch.xpack.esql.datasources.utils.BoundedParallelGather;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -47,6 +49,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -87,7 +91,14 @@ public class ExternalSourceResolver {
 
     public static final Set<String> CONFIG_KEYS = Set.of(CONFIG_SCHEMA_RESOLUTION, DATASOURCE_CONFIG_KEY);
 
-    private static final int MAX_PARALLEL_METADATA_READS = 16;
+    /**
+     * Default cap on in-flight per-file metadata reads during a multi-file discovery when a caller does not supply
+     * one. Production wires the {@code esql_worker} pool size here (via {@code TransportEsqlQueryAction}/{@code
+     * PlanExecutor}) so the fan-out is bounded by an in-flight permit equal to the pool size; because footer reads
+     * are async (released across the network round-trip) that permit does not translate into that many pinned
+     * threads. Kept as a fallback for the constructors used by tests and by callers that do not thread the pool size.
+     */
+    static final int DEFAULT_METADATA_READ_CONCURRENCY = 16;
 
     private static final String RESOLUTION_CANCELLED_MESSAGE = "ES|QL external source resolution cancelled";
 
@@ -140,6 +151,7 @@ public class ExternalSourceResolver {
     private final ExternalSourceCacheService cacheService;
     /** Node telemetry sink, taken from the module ({@link ExternalSourceMetrics#NOOP} when no module is wired, e.g. tests). */
     private final ExternalSourceMetrics metrics;
+    private final int metadataReadConcurrency;
 
     /**
      * Supplier consulted before each per-file footer read so that an in-flight resolution of a large
@@ -149,9 +161,30 @@ public class ExternalSourceResolver {
     @Nullable
     private final BooleanSupplier isCancelled;
 
+    /**
+     * The {@link #executor} decorated so that every task it runs has the query cancellation signal installed as the
+     * ambient {@link StorageRetryCancellation} scope. This is the executor handed to factories for the async footer
+     * reads: for storage backends whose {@code readBytesAsync} is an executor-backed synchronous read (local, GCS,
+     * S3-without-async-client) the blocking read — and its retry/throttle backoff — runs inside one of these tasks, so
+     * a query cancelled mid-backoff aborts promptly (the backoff polls the ambient signal). Backends with a native
+     * async client return from the executor task before the SDK callback and are not covered here (nor by the
+     * synchronous path), matching {@link StorageRetryCancellation}'s documented thread-affinity limits.
+     */
+    private final Executor metadataReadExecutor;
+
     /** Coordinator-side accessor used by EsqlSession to reconcile data-node-captured source stats post-query. */
     public ExternalSourceCacheService cacheService() {
         return cacheService;
+    }
+
+    /** Maximum in-flight per-file metadata reads for a multi-file discovery. Visible for wiring tests. */
+    public int metadataReadConcurrency() {
+        return metadataReadConcurrency;
+    }
+
+    /** Executor the discovery fan-out runs on. Visible for wiring/isolation tests. */
+    public Executor executor() {
+        return executor;
     }
 
     public ExternalSourceResolver(Executor executor, DataSourceModule dataSourceModule) {
@@ -168,7 +201,7 @@ public class ExternalSourceResolver {
         Settings settings,
         @Nullable ExternalSourceCacheService cacheService
     ) {
-        this(executor, dataSourceModule, settings, cacheService, null);
+        this(executor, dataSourceModule, settings, cacheService, (BooleanSupplier) null, DEFAULT_METADATA_READ_CONCURRENCY);
     }
 
     public ExternalSourceResolver(
@@ -178,12 +211,52 @@ public class ExternalSourceResolver {
         @Nullable ExternalSourceCacheService cacheService,
         @Nullable BooleanSupplier isCancelled
     ) {
+        this(executor, dataSourceModule, settings, cacheService, isCancelled, DEFAULT_METADATA_READ_CONCURRENCY);
+    }
+
+    /**
+     * @param metadataReadConcurrency maximum number of in-flight per-file metadata reads during a multi-file
+     *            discovery. Production passes the {@code esql_worker} pool size.
+     */
+    public ExternalSourceResolver(
+        Executor executor,
+        DataSourceModule dataSourceModule,
+        Settings settings,
+        @Nullable ExternalSourceCacheService cacheService,
+        int metadataReadConcurrency
+    ) {
+        this(executor, dataSourceModule, settings, cacheService, null, metadataReadConcurrency);
+    }
+
+    /**
+     * @param isCancelled consulted before each per-file footer read so a wide-glob discovery aborts promptly on
+     *            cancellation; {@code null} means "never cancelled".
+     * @param metadataReadConcurrency maximum number of in-flight per-file metadata reads during a multi-file
+     *            discovery. Production passes the {@code esql_worker} pool size.
+     */
+    public ExternalSourceResolver(
+        Executor executor,
+        DataSourceModule dataSourceModule,
+        Settings settings,
+        @Nullable ExternalSourceCacheService cacheService,
+        @Nullable BooleanSupplier isCancelled,
+        int metadataReadConcurrency
+    ) {
+        if (metadataReadConcurrency < 1) {
+            throw new IllegalArgumentException("metadataReadConcurrency must be >= 1, got: " + metadataReadConcurrency);
+        }
         this.executor = executor;
         this.dataSourceModule = dataSourceModule;
         this.settings = settings;
         this.cacheService = cacheService;
         this.isCancelled = isCancelled;
         this.metrics = dataSourceModule == null ? ExternalSourceMetrics.NOOP : dataSourceModule.externalSourceMetrics();
+        this.metadataReadConcurrency = metadataReadConcurrency;
+        // Install the query cancellation signal as the ambient StorageRetryCancellation scope for every footer read
+        // dispatched to the executor, so an executor-backed synchronous read's backoff aborts promptly on cancel.
+        this.metadataReadExecutor = command -> executor.execute(
+            () -> StorageRetryCancellation.runWithCancellation(this::isCancelled, command::run)
+        );
     }
 
     /**
@@ -274,93 +347,125 @@ public class ExternalSourceResolver {
             return;
         }
 
-        // Resolution runs on the caller-supplied executor (esql_worker in production, isolated from SEARCH
-        // so a wide wildcard cannot starve regular ES searches). A multi-file resolve pins one worker on
-        // the BoundedParallelGather latch while dispatching up to MAX_PARALLEL_METADATA_READS more tasks
-        // on the same pool (join pattern), for a peak of MAX_PARALLEL_METADATA_READS + 1 running slots.
-        // When the pool is smaller, ThrottledTaskRunner throttles submission rather than overflowing the
-        // queue; on saturation across concurrent ES|QL queries it fails fast per-slot via running-slot
-        // rejection rather than deadlocking. Splitting the coordinator from the footer fan-out onto a
-        // dedicated I/O pool would require a second executor here and is deferred until the
-        // esql_external_blocking_io pool's sizing and lifecycle are resolved; the caller-supplied
-        // executor is the current re-routing hook.
-        executor.execute(() -> {
-            try {
-                Map<String, ExternalSourceResolution.ResolvedSource> resolved = Maps.newHashMapWithExpectedSize(paths.size());
-
-                for (String path : paths) {
-                    Map<String, Object> config = pathConfigs.getOrDefault(path, Map.of());
-                    List<PartitionFilterHintExtractor.PartitionFilterHint> hints = filterHints != null ? filterHints.get(path) : null;
-                    boolean hivePartitioning = isHivePartitioningEnabled(config);
-                    // null => legacy eager for every path; non-null => eager only for listed paths.
-                    boolean requiresStats = pathsRequiringStats == null || pathsRequiringStats.contains(path);
-
-                    try {
-                        ExternalSourceResolution.ResolvedSource resolvedSource = resolveSource(
-                            path,
-                            config,
-                            hints,
-                            hivePartitioning,
-                            requiresStats
-                        );
-                        resolved.put(path, resolvedSource);
-                        LOGGER.debug("Successfully resolved external source: {}", path);
-                    } catch (TaskCancelledException e) {
-                        // Surface cancellation unwrapped so the client sees a clean cancellation (4xx) rather
-                        // than a generic "Failed to resolve external source" wrapper (500).
-                        LOGGER.debug("External source resolution cancelled for [{}]", path);
-                        listener.onFailure(e);
-                        return;
-                    } catch (IllegalArgumentException | UnsupportedOperationException e) {
-                        // A footer read (e.g. the FFW anchor or a single-file source) can fail because the query was
-                        // cancelled mid-read; surface that as cancellation rather than a bad-request/unsupported error.
-                        if (reportIfCancelled(path, listener)) {
-                            return;
-                        }
-                        recordDiscoveryFailure();
-                        LOGGER.error("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
-                        listener.onFailure(e);
-                        return;
-                    } catch (Exception e) {
-                        // Same guard for wrapped failures (e.g. the schema cache wraps a cancelled anchor read in
-                        // ExecutionException): a cancelled query must not surface as a generic 500.
-                        if (reportIfCancelled(path, listener)) {
-                            return;
-                        }
-                        recordDiscoveryFailure();
-                        LOGGER.error("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
-                        String exceptionMessage = e.getMessage();
-                        String errorDetail = exceptionMessage != null ? exceptionMessage : e.getClass().getSimpleName();
-                        String errorMessage = String.format(Locale.ROOT, "Failed to resolve external source [%s]: %s", path, errorDetail);
-                        listener.onFailure(new ElasticsearchException(errorMessage, e));
-                        return;
-                    }
-                }
-
-                listener.onResponse(new ExternalSourceResolution(resolved));
-            } catch (Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        // Resolution runs on the caller-supplied executor (esql_worker in production, isolated from SEARCH so a wide
+        // wildcard cannot starve regular ES searches). The initial dispatch performs the cheap synchronous prep (glob
+        // expansion, the FFW anchor / single-file footer read) and then hands the multi-file fan-out to async footer
+        // reads bounded by metadataReadConcurrency in-flight reads, so the executor thread is not held across the N
+        // network round-trips. Paths are resolved sequentially (see resolveNextPath) so the accumulation map needs no
+        // synchronization and the first failure short-circuits the rest — mirroring the previous synchronous loop.
+        //
+        // Dispatch on metadataReadExecutor (not the bare executor) so the query cancellation signal is installed as the
+        // ambient StorageRetryCancellation scope for the whole sequential prep: a cancelled wide-glob discovery then
+        // aborts its glob-expansion and anchor/single-file read backoff promptly, matching the per-read wrapping the
+        // async fan-out already gets.
+        Map<String, ExternalSourceResolution.ResolvedSource> resolved = Maps.newHashMapWithExpectedSize(paths.size());
+        metadataReadExecutor.execute(() -> resolveNextPath(paths, 0, pathConfigs, filterHints, pathsRequiringStats, resolved, listener));
     }
 
-    private ExternalSourceResolution.ResolvedSource resolveSource(
+    /**
+     * Resolves {@code paths[index]} asynchronously, then chains to the next path on success. Paths are resolved
+     * sequentially so the accumulation map needs no synchronization and the first failure short-circuits the rest.
+     */
+    private void resolveNextPath(
+        List<String> paths,
+        int index,
+        Map<String, Map<String, Object>> pathConfigs,
+        @Nullable Map<String, List<PartitionFilterHintExtractor.PartitionFilterHint>> filterHints,
+        @Nullable Set<String> pathsRequiringStats,
+        Map<String, ExternalSourceResolution.ResolvedSource> resolved,
+        ActionListener<ExternalSourceResolution> listener
+    ) {
+        if (index == paths.size()) {
+            listener.onResponse(new ExternalSourceResolution(resolved));
+            return;
+        }
+        String path = paths.get(index);
+        Map<String, Object> config = pathConfigs.getOrDefault(path, Map.of());
+        List<PartitionFilterHintExtractor.PartitionFilterHint> hints = filterHints != null ? filterHints.get(path) : null;
+        boolean hivePartitioning = isHivePartitioningEnabled(config);
+        // null => legacy eager for every path; non-null => eager only for listed paths.
+        boolean requiresStats = pathsRequiringStats == null || pathsRequiringStats.contains(path);
+
+        resolveSource(path, config, hints, hivePartitioning, requiresStats, ActionListener.wrap(resolvedSource -> {
+            resolved.put(path, resolvedSource);
+            LOGGER.debug("Successfully resolved external source: {}", path);
+            resolveNextPath(paths, index + 1, pathConfigs, filterHints, pathsRequiringStats, resolved, listener);
+        }, e -> listener.onFailure(mapResolveFailure(path, e))));
+    }
+
+    /**
+     * Reproduces the previous loop's error contract: a cancelled query surfaces {@link TaskCancelledException}
+     * unwrapped (so the client sees a clean 4xx rather than a generic 500), {@link IllegalArgumentException} and
+     * {@link UnsupportedOperationException} (client-caused) propagate unwrapped, and any other failure is wrapped in
+     * an {@link ElasticsearchException} carrying the path and detail. A footer read can fail <em>because</em> the
+     * query was cancelled mid-read and arrive wrapped (e.g. the schema cache wraps loader failures), so the
+     * cancellation state is consulted directly rather than matched on the exception type.
+     */
+    private RuntimeException mapResolveFailure(String path, Exception e) {
+        if (e instanceof TaskCancelledException tce) {
+            LOGGER.debug("External source resolution cancelled for [{}]", path);
+            return tce;
+        }
+        if (isCancelled()) {
+            LOGGER.debug("External source resolution cancelled for [{}]", path);
+            return new TaskCancelledException(RESOLUTION_CANCELLED_MESSAGE);
+        }
+        if (e instanceof IllegalArgumentException || e instanceof UnsupportedOperationException) {
+            recordDiscoveryFailure();
+            LOGGER.error("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
+            return (RuntimeException) e;
+        }
+        recordDiscoveryFailure();
+        LOGGER.error("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
+        String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+        return new ElasticsearchException(String.format(Locale.ROOT, "Failed to resolve external source [%s]: %s", path, detail), e);
+    }
+
+    private void resolveSource(
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
         boolean hivePartitioning,
-        boolean requiresStats
-    ) throws Exception {
+        boolean requiresStats,
+        ActionListener<ExternalSourceResolution.ResolvedSource> listener
+    ) {
         LOGGER.debug("Resolving external source: path=[{}]", path);
+        try {
+            resolveSourceInner(path, config, hints, hivePartitioning, requiresStats, listener);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
 
+    private void resolveSourceInner(
+        String path,
+        Map<String, Object> config,
+        @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
+        boolean hivePartitioning,
+        boolean requiresStats,
+        ActionListener<ExternalSourceResolution.ResolvedSource> listener
+    ) throws Exception {
         // A query cancelled before resolution starts must do no storage I/O at all: bail before glob
         // expansion, cache listing, or any footer read.
         throwIfCancelled();
 
         if (GlobExpander.isMultiFile(path)) {
-            return resolveMultiFileSource(path, config, hints, hivePartitioning, requiresStats);
+            resolveMultiFileSource(path, config, hints, hivePartitioning, requiresStats, listener);
+        } else {
+            resolveSingleFileSource(path, config, listener);
         }
+    }
 
+    /**
+     * Resolves a single, explicitly-referenced file. The footer read here is one bounded read on the resolver
+     * executor thread (not the fan-out), so it stays synchronous — matching the coordinator/anchor read cost. The
+     * multi-file fan-out is what goes async (see {@link #gatherPerFile}).
+     */
+    private void resolveSingleFileSource(
+        String path,
+        Map<String, Object> config,
+        ActionListener<ExternalSourceResolution.ResolvedSource> listener
+    ) throws Exception {
         /*
          * A concrete one-entry FileList is required so {@link org.elasticsearch.xpack.esql.datasources.FileSplitProvider}
          * can discover block-aligned splits for compressed files (e.g. .json.bz2). UNRESOLVED lists skip split discovery,
@@ -404,7 +509,7 @@ public class ExternalSourceResolver {
         );
         // Single-file: degenerate case of the general flow — one-entry schemaMap, identity mapping.
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = singleEntrySchemaMap(storagePath, fileSchema);
-        return new ExternalSourceResolution.ResolvedSource(extMetadata, singletonList, schemaMap);
+        listener.onResponse(new ExternalSourceResolution.ResolvedSource(extMetadata, singletonList, schemaMap));
     }
 
     private static Map<StoragePath, SchemaReconciliation.FileSchemaInfo> singleEntrySchemaMap(
@@ -418,12 +523,13 @@ public class ExternalSourceResolver {
         return Map.of(path, new SchemaReconciliation.FileSchemaInfo(new ExternalSchema(schema), identityMapping, null));
     }
 
-    private ExternalSourceResolution.ResolvedSource resolveMultiFileSource(
+    private void resolveMultiFileSource(
         String path,
         Map<String, Object> config,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
         boolean hivePartitioning,
-        boolean requiresStats
+        boolean requiresStats,
+        ActionListener<ExternalSourceResolution.ResolvedSource> listener
     ) throws Exception {
         StoragePath storagePath = StoragePath.of(path);
         StorageProvider provider = resolveProvider(storagePath, config);
@@ -442,7 +548,8 @@ public class ExternalSourceResolver {
             if (raw.fileCount() == 0) {
                 throw new IllegalArgumentException("Glob pattern matched no files: " + path);
             }
-            return resolveMultiFileWithReconciliation(raw, config, schemaResolution, cacheable);
+            resolveMultiFileWithReconciliation(raw, config, schemaResolution, cacheable, listener);
+            return;
         }
 
         FileList listing;
@@ -475,7 +582,7 @@ public class ExternalSourceResolver {
         // Glob expansion / cache listing above can be slow on wide globs; re-check before the anchor footer read.
         throwIfCancelled();
 
-        ExternalSourceMetadata extMetadata;
+        ExternalSourceMetadata anchorMetadata;
         if (cacheable) {
             String formatType = detectFormatType(anchorPath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(anchorPath.toString(), anchorMtime, formatType, config);
@@ -483,101 +590,130 @@ public class ExternalSourceResolver {
                 return SchemaCacheEntry.from(resolveSingleSource(anchorPath.toString(), config));
             });
             List<Attribute> schema = schemaEntry.toAttributes();
-            extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
+            anchorMetadata = buildMetadataFromCache(schemaEntry, schema, config);
         } else {
             SourceMetadata metadata = resolveSingleSource(anchorPath.toString(), config);
-            extMetadata = wrapAsExternalSourceMetadata(metadata, config);
+            anchorMetadata = wrapAsExternalSourceMetadata(metadata, config);
         }
 
-        extMetadata = enrichWithFileCount(extMetadata, listing.fileCount());
+        final FileList finalListing = listing;
+        final ExternalSourceMetadata base = enrichWithFileCount(anchorMetadata, listing.fileCount());
         if (listing.fileCount() > 1 && requiresStats) {
-            // For multi-file FIRST_FILE_WINS, read all files' metadata in parallel during Phase 1
-            // to aggregate statistics across all files. This allows aggregate pushdown
-            // (COUNT/MIN/MAX) to use accurate global stats and to skip Phase 2 (split discovery)
-            // entirely for those queries.
+            // For multi-file FIRST_FILE_WINS, read all files' metadata during Phase 1 to aggregate statistics
+            // across all files. This allows aggregate pushdown (COUNT/MIN/MAX) to use accurate global stats and
+            // to skip Phase 2 (split discovery) entirely for those queries.
             //
-            // This eager all-file aggregation is gated on requiresStats: only query shapes that can
-            // consume the global stats — an ungrouped aggregate over the relation, detected by
-            // ExternalStatsRequirementExtractor#pathsRequiringEagerStats — pay the N footer reads.
-            // Every other shape (LIMIT, SELECT *, grouped STATS ... BY, INLINESTATS) takes the
-            // defer branch below: it keeps STATS_FILE_COUNT (from enrichWithFileCount above) but
-            // marks stats partial, so Phase 2 split discovery reads footers once instead of twice.
-            // Legacy callers pass requiresStats == true for every path (the resolve overload with a
-            // null pathsRequiringStats set), preserving the original eager-for-all behavior.
+            // This eager all-file aggregation is gated on requiresStats: only query shapes that can consume the
+            // global stats — an ungrouped aggregate over the relation, detected by
+            // ExternalStatsRequirementExtractor#pathsRequiringEagerStats — pay the N footer reads. Every other
+            // shape (LIMIT, SELECT *, grouped STATS ... BY, INLINESTATS) takes the defer branch below: it keeps
+            // STATS_FILE_COUNT (from enrichWithFileCount above) but marks stats partial, so Phase 2 split discovery
+            // reads footers once instead of twice. Legacy callers pass requiresStats == true for every path (the
+            // resolve overload with a null pathsRequiringStats set), preserving the original eager-for-all behavior.
             //
             // For an eager (requiresStats) resolve the cost is acceptable because:
             // - the cacheable path consults the schema cache, so repeat resolves are free;
-            // - the non-cacheable path reads footers in parallel up to MAX_PARALLEL_METADATA_READS;
+            // - the non-cacheable path reads footers with an async fan-out bounded by an in-flight permit
+            // (metadataReadConcurrency), releasing the pool thread across each footer read;
             // - the aggregated stats unlock skipping Phase 2 entirely for pushable aggregates
             // (see ComputeService#canSkipSplitDiscovery), which dominates the savings.
-            Map<String, Object> aggregatedStats = cacheable
-                ? readAndAggregateAllFileStatsWithCache(listing, config)
-                : readAndAggregateAllFileStats(listing, config);
-            if (aggregatedStats != null) {
-                // Replace anchor-only stats with globally-aggregated stats.
-                // Preserve all non-stats keys from the current extMetadata (e.g. file_count, config).
-                Map<String, Object> current = extMetadata.sourceMetadata();
-                Map<String, Object> merged = current != null ? new HashMap<>(current) : new HashMap<>();
-                merged.putAll(aggregatedStats);
-                // Do NOT add STATS_PARTIAL — stats are now complete across all files.
-                merged.remove(SourceStatisticsSerializer.STATS_PARTIAL);
-                final Map<String, Object> finalMerged = Map.copyOf(merged);
-                final ExternalSourceMetadata baseMetadata = extMetadata;
-                extMetadata = new ExternalSourceMetadata() {
-                    @Override
-                    public String location() {
-                        return baseMetadata.location();
-                    }
-
-                    @Override
-                    public List<Attribute> schema() {
-                        return baseMetadata.schema();
-                    }
-
-                    @Override
-                    public String sourceType() {
-                        return baseMetadata.sourceType();
-                    }
-
-                    @Override
-                    public Map<String, Object> sourceMetadata() {
-                        return finalMerged;
-                    }
-
-                    @Override
-                    public Map<String, Object> config() {
-                        return baseMetadata.config();
-                    }
-                };
+            ActionListener<Map<String, Object>> statsListener = ActionListener.wrap(aggregatedStats -> {
+                try {
+                    listener.onResponse(finishFirstFileWins(finalListing, applyFirstFileWinsAggregatedStats(base, aggregatedStats)));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            }, listener::onFailure);
+            if (cacheable) {
+                readAndAggregateAllFileStatsWithCache(listing, config, statsListener);
             } else {
-                // Could not aggregate stats (some files lacked statistics) — mark as partial
-                // so the optimizer does not rely on incomplete sourceMetadata stats.
-                extMetadata = markStatsAsPartial(extMetadata);
+                readAndAggregateAllFileStats(listing, config, statsListener);
             }
         } else if (listing.fileCount() > 1) {
-            // Defer branch (requiresStats == false): skip the N footer reads. The anchor-only stats
-            // are not representative of the whole glob, so mark them partial — exactly the state the
-            // failed-aggregation path above produces, which downstream already handles
-            // (SplitStats.resolveEffectiveStats returns null rather than consuming anchor stats as
-            // global). STATS_FILE_COUNT, stamped by enrichWithFileCount above, is preserved.
-            extMetadata = markStatsAsPartial(extMetadata);
+            // Defer branch (requiresStats == false): skip the N footer reads. The anchor-only stats are not
+            // representative of the whole glob, so mark them partial — exactly the state the failed-aggregation
+            // path produces, which downstream already handles (SplitStats.resolveEffectiveStats returns null
+            // rather than consuming anchor stats as global). STATS_FILE_COUNT, stamped above, is preserved.
+            listener.onResponse(finishFirstFileWins(finalListing, markStatsAsPartial(base)));
+        } else {
+            listener.onResponse(finishFirstFileWins(finalListing, base));
         }
+    }
 
-        // The anchor's pre-enrichment schema is the physical read schema every file's reader parses.
-        // Partition columns are path-derived (injected by VirtualColumnIterator at read time), so they
-        // are never part of the physical read schema; the data-only view below drives the mapping
-        // output width.
+    /**
+     * Overlays globally-aggregated statistics onto the anchor metadata for the FIRST_FILE_WINS path. When
+     * {@code aggregatedStats} is {@code null} (some file lacked statistics or a read failed) the stats are marked
+     * partial so the optimizer does not rely on incomplete aggregations.
+     */
+    private static ExternalSourceMetadata applyFirstFileWinsAggregatedStats(
+        ExternalSourceMetadata base,
+        @Nullable Map<String, Object> aggregatedStats
+    ) {
+        if (aggregatedStats == null) {
+            // Could not aggregate stats (some files lacked statistics) — mark as partial so the optimizer does not
+            // rely on incomplete sourceMetadata stats.
+            return markStatsAsPartial(base);
+        }
+        // Replace anchor-only stats with globally-aggregated stats. Preserve all non-stats keys from base (e.g.
+        // file_count, config).
+        Map<String, Object> current = base.sourceMetadata();
+        Map<String, Object> merged = current != null ? new HashMap<>(current) : new HashMap<>();
+        merged.putAll(aggregatedStats);
+        // Do NOT add STATS_PARTIAL — stats are now complete across all files.
+        merged.remove(SourceStatisticsSerializer.STATS_PARTIAL);
+        return replaceSourceMetadata(base, Map.copyOf(merged));
+    }
+
+    /** Returns a wrapper that delegates to {@code base} but replaces {@code sourceMetadata()} with {@code replacement}. */
+    private static ExternalSourceMetadata replaceSourceMetadata(ExternalSourceMetadata base, Map<String, Object> replacement) {
+        return new ExternalSourceMetadata() {
+            @Override
+            public String location() {
+                return base.location();
+            }
+
+            @Override
+            public List<Attribute> schema() {
+                return base.schema();
+            }
+
+            @Override
+            public String sourceType() {
+                return base.sourceType();
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return replacement;
+            }
+
+            @Override
+            public Map<String, Object> config() {
+                return base.config();
+            }
+        };
+    }
+
+    /**
+     * Completes the FIRST_FILE_WINS path once per-file stats (if any) have been folded into {@code extMetadata}:
+     * applies Hive partition-key shadowing (the partition value wins over a same-named physical column), enriches the
+     * coordinator schema with partition columns, and pins the anchor's physical schema for every file via an
+     * (identity or narrowing) per-file mapping. Purely CPU-bound.
+     */
+    private ExternalSourceResolution.ResolvedSource finishFirstFileWins(FileList listing, ExternalSourceMetadata extMetadata) {
+        // The anchor's pre-enrichment schema is the physical read schema every file's reader parses. Partition
+        // columns are path-derived (injected by VirtualColumnIterator at read time), so they are never part of the
+        // physical read schema; the data-only view below drives the mapping output width.
         List<Attribute> physicalSchema = extMetadata.schema();
         List<Attribute> dataOnlySchema = physicalSchema;
 
         PartitionMetadata partitionMetadata = listing.partitionMetadata();
         if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
-            // Shadow same-named physical columns: when a physical column collides with a partition
-            // key, the partition (path-derived) value wins (Spark/DuckDB semantics). The reader still
-            // parses the physical column (CSV is positional), but the per-file mapping drops it from
-            // the output so the mapping width agrees with the data-only unified schema at
-            // ColumnMapping#pruneToPerFileQuery and with queryDataSchema at the SchemaAdaptingIterator
-            // guard. enrichSchemaWithPartitionColumns appends the partition column and warns.
+            // Shadow same-named physical columns: when a physical column collides with a partition key, the partition
+            // (path-derived) value wins (Spark/DuckDB semantics). The reader still parses the physical column (CSV is
+            // positional), but the per-file mapping drops it from the output so the mapping width agrees with the
+            // data-only unified schema at ColumnMapping#pruneToPerFileQuery and with queryDataSchema at the
+            // SchemaAdaptingIterator guard. enrichSchemaWithPartitionColumns appends the partition column and warns.
             dataOnlySchema = ExternalSchema.dataAttributesOf(physicalSchema, partitionMetadata.partitionColumns().keySet()).attributes();
             extMetadata = enrichSchemaWithPartitionColumns(extMetadata, partitionMetadata);
         }
@@ -585,9 +721,9 @@ public class ExternalSourceResolver {
         // _file.* columns are request-driven now; no auto-attach to the schema. See
         // ResolveExternalRelations / the EXTERNAL shim.
 
-        // FFW: every file's readSchema is the anchor's physical schema; the mapping is identity unless
-        // a partition key shadows a physical column, in which case it narrows the output to the
-        // data-only columns (the shadowed physical column is parsed but not emitted).
+        // FFW: every file's readSchema is the anchor's physical schema; the mapping is identity unless a partition
+        // key shadows a physical column, in which case it narrows the output to the data-only columns (the shadowed
+        // physical column is parsed but not emitted).
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap;
         if (physicalSchema != null && physicalSchema.isEmpty() == false) {
             Map<StoragePath, SchemaReconciliation.FileSchemaInfo> perFileInfo = Maps.newHashMapWithExpectedSize(listing.fileCount());
@@ -703,70 +839,76 @@ public class ExternalSourceResolver {
         };
     }
 
-    private ExternalSourceResolution.ResolvedSource resolveMultiFileWithReconciliation(
+    private void resolveMultiFileWithReconciliation(
         FileList fileList,
         Map<String, Object> config,
         FormatReader.SchemaResolution schemaResolution,
-        boolean cacheable
-    ) throws Exception {
+        boolean cacheable,
+        ActionListener<ExternalSourceResolution.ResolvedSource> listener
+    ) {
         long startNanos = System.nanoTime();
-        Map<StoragePath, SourceMetadata> allMetadata = readAllFileMetadata(fileList, config, cacheable);
-        long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
+        readAllFileMetadata(fileList, config, cacheable, ActionListener.wrap(allMetadata -> {
+            try {
+                long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
+                LOGGER.debug("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
 
-        LOGGER.debug("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
+                StoragePath firstFile = fileList.path(0);
+                SchemaReconciliation.Result result;
+                if (schemaResolution == FormatReader.SchemaResolution.STRICT) {
+                    result = SchemaReconciliation.reconcileStrict(firstFile, allMetadata);
+                } else {
+                    result = SchemaReconciliation.reconcileUnionByName(allMetadata);
+                }
 
-        StoragePath firstFile = fileList.path(0);
-        SchemaReconciliation.Result result;
-        if (schemaResolution == FormatReader.SchemaResolution.STRICT) {
-            result = SchemaReconciliation.reconcileStrict(firstFile, allMetadata);
-        } else {
-            result = SchemaReconciliation.reconcileUnionByName(allMetadata);
-        }
+                // Shadow physical columns that collide with Hive partition keys: the partition (path-derived)
+                // value wins (Spark/DuckDB semantics), so the unified schema and every per-file mapping's
+                // output must drop the physical column. The file (physical) schema is preserved so positional
+                // readers (CSV) still parse the column; enrichSchemaWithPartitionColumns re-adds the partition
+                // column to the coordinator-facing schema below. Keeping the mapping width data-only keeps it
+                // in agreement with the data-only unified schema at ColumnMapping#pruneToPerFileQuery and with
+                // queryDataSchema at the data-node SchemaAdaptingIterator guard.
+                //
+                // Ordering matters: shadowPartitionCollisions emits the single shadow warning and prunes the
+                // collision here, so the enrichSchemaWithPartitionColumns call below sees a data-only schema and
+                // does not warn again (the no-double-warning invariant, asserted at that call). Do not reorder.
+                PartitionMetadata partitionMetadata = fileList.partitionMetadata();
+                Set<String> partitionNames = partitionMetadata != null ? partitionMetadata.partitionColumns().keySet() : Set.of();
+                result = shadowPartitionCollisions(result, partitionNames);
 
-        // Shadow physical columns that collide with Hive partition keys: the partition (path-derived)
-        // value wins (Spark/DuckDB semantics), so the unified schema and every per-file mapping's
-        // output must drop the physical column. The file (physical) schema is preserved so positional
-        // readers (CSV) still parse the column; enrichSchemaWithPartitionColumns re-adds the partition
-        // column to the coordinator-facing schema below. Keeping the mapping width data-only keeps it
-        // in agreement with the data-only unified schema at ColumnMapping#pruneToPerFileQuery and with
-        // queryDataSchema at the data-node SchemaAdaptingIterator guard.
-        //
-        // Ordering matters: shadowPartitionCollisions emits the single shadow warning and prunes the
-        // collision here, so the enrichSchemaWithPartitionColumns call below sees a data-only schema and
-        // does not warn again (the no-double-warning invariant, asserted at that call). Do not reorder.
-        PartitionMetadata partitionMetadata = fileList.partitionMetadata();
-        Set<String> partitionNames = partitionMetadata != null ? partitionMetadata.partitionColumns().keySet() : Set.of();
-        result = shadowPartitionCollisions(result, partitionNames);
+                List<Attribute> unifiedSchema = result.unifiedSchema().attributes();
+                SourceMetadata firstMeta = allMetadata.get(firstFile);
+                // Aggregate from the per-file metadata already fetched by readAllFileMetadata —
+                // no second cache or storage hit per file.
+                Map<String, Object> aggregatedStats = aggregateFileStatistics(allMetadata.values());
+                ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config, aggregatedStats);
 
-        List<Attribute> unifiedSchema = result.unifiedSchema().attributes();
-        SourceMetadata firstMeta = allMetadata.get(firstFile);
-        // Aggregate from the per-file metadata already fetched by readAllFileMetadata —
-        // no second cache or storage hit per file.
-        Map<String, Object> aggregatedStats = aggregateFileStatistics(allMetadata.values());
-        ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config, aggregatedStats);
+                // Mirror the FFW invariants: file count enables canSkipSplitDiscovery; partial-stats
+                // marking is gated on fileCount > 1 (single-file globs have no "other file" missing stats).
+                extMetadata = enrichWithFileCount(extMetadata, fileList.fileCount());
+                if (aggregatedStats == null && fileList.fileCount() > 1) {
+                    extMetadata = markStatsAsPartial(extMetadata);
+                }
 
-        // Mirror the FFW invariants: file count enables canSkipSplitDiscovery; partial-stats
-        // marking is gated on fileCount > 1 (single-file globs have no "other file" missing stats).
-        extMetadata = enrichWithFileCount(extMetadata, fileList.fileCount());
-        if (aggregatedStats == null && fileList.fileCount() > 1) {
-            extMetadata = markStatsAsPartial(extMetadata);
-        }
+                if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
+                    // No-double-warning invariant: shadowPartitionCollisions above already pruned any physical
+                    // column that collides with a partition key (and emitted the one shadow warning), so the
+                    // post-shadow schema must be collision-free before enrich runs its own shadow detection.
+                    final ExternalSourceMetadata metaForAssert = extMetadata;
+                    assert metaForAssert.schema().stream().noneMatch(a -> partitionNames.contains(a.name()))
+                        : "shadowPartitionCollisions must run before enrichSchemaWithPartitionColumns: a physical "
+                            + "column still collides with a partition key, which would warn twice";
+                    extMetadata = enrichSchemaWithPartitionColumns(extMetadata, partitionMetadata);
+                }
 
-        if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
-            // No-double-warning invariant: shadowPartitionCollisions above already pruned any physical
-            // column that collides with a partition key (and emitted the one shadow warning), so the
-            // post-shadow schema must be collision-free before enrich runs its own shadow detection.
-            assert extMetadata.schema().stream().noneMatch(a -> partitionNames.contains(a.name()))
-                : "shadowPartitionCollisions must run before enrichSchemaWithPartitionColumns: a physical "
-                    + "column still collides with a partition key, which would warn twice";
-            extMetadata = enrichSchemaWithPartitionColumns(extMetadata, partitionMetadata);
-        }
+                // _file.* columns are request-driven now; no auto-attach to the schema. See
+                // ResolveExternalRelations / the EXTERNAL shim.
 
-        // _file.* columns are request-driven now; no auto-attach to the schema. See
-        // ResolveExternalRelations / the EXTERNAL shim.
-
-        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = result.perFileInfo();
-        return new ExternalSourceResolution.ResolvedSource(extMetadata, fileList, schemaMap);
+                Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = result.perFileInfo();
+                listener.onResponse(new ExternalSourceResolution.ResolvedSource(extMetadata, fileList, schemaMap));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, listener::onFailure));
     }
 
     /**
@@ -812,46 +954,142 @@ public class ExternalSourceResolver {
         return new SchemaReconciliation.Result(new ExternalSchema(dataOnlyUnified), Map.copyOf(perFileInfo));
     }
 
-    /** Per-file metadata, in parallel. When {@code cacheable} is true, each resolve goes through
-     *  the schema cache (keyed on path + mtime) so warm queries against the same paths hit cache. */
-    private Map<StoragePath, SourceMetadata> readAllFileMetadata(FileList fileList, Map<String, Object> config, boolean cacheable)
-        throws Exception {
+    /**
+     * Per-file metadata, read with an async fan-out bounded by {@link #metadataReadConcurrency} in-flight reads (see
+     * {@link #gatherPerFile}). When {@code cacheable} is true each resolve peeks the schema cache (keyed on path +
+     * mtime) and, on a miss, resolves asynchronously and stores the result so warm queries against the same paths hit
+     * cache. The result preserves the file order of {@code fileList}.
+     */
+    private void readAllFileMetadata(
+        FileList fileList,
+        Map<String, Object> config,
+        boolean cacheable,
+        ActionListener<Map<StoragePath, SourceMetadata>> listener
+    ) {
         int fileCount = fileList.fileCount();
-        List<Integer> indices = new ArrayList<>(fileCount);
-        for (int i = 0; i < fileCount; i++) {
-            indices.add(i);
-        }
-
-        List<Map.Entry<StoragePath, SourceMetadata>> entries = BoundedParallelGather.gather(indices, i -> {
-            throwIfCancelled();
-            StoragePath filePath = fileList.path(i);
-            // Carry the cancellation signal across the synchronous footer read so a backoff sleep in
-            // the storage retry layer aborts promptly on cancel.
-            SourceMetadata meta = StorageRetryCancellation.callWithCancellation(
-                this::isCancelled,
-                () -> cacheable
-                    ? cachedResolveSingleSource(filePath, fileList.lastModifiedMillis(i), config)
-                    : resolveSingleSource(filePath.toString(), config)
-            );
-            return Map.entry(filePath, meta);
-        }, MAX_PARALLEL_METADATA_READS, executor);
-
-        Map<StoragePath, SourceMetadata> result = new LinkedHashMap<>();
-        for (Map.Entry<StoragePath, SourceMetadata> entry : entries) {
-            result.put(entry.getKey(), entry.getValue());
-        }
-        return result;
+        gatherPerFile(fileList, config, cacheable, ActionListener.wrap(perFile -> {
+            Map<StoragePath, SourceMetadata> result = new LinkedHashMap<>();
+            for (int i = 0; i < fileCount; i++) {
+                result.put(fileList.path(i), perFile.get(i));
+            }
+            listener.onResponse(result);
+        }, listener::onFailure));
     }
 
-    /** Cache-aware single-file resolve. Mirrors the FFW path — exceptions propagate (no catch). */
-    private SourceMetadata cachedResolveSingleSource(StoragePath filePath, long mtime, Map<String, Object> config) throws Exception {
+    /**
+     * Runs an async, bounded fan-out over every file in {@code fileList}, resolving each file's {@link SourceMetadata}
+     * and returning results in file order. Concurrency is capped at {@link #metadataReadConcurrency} in-flight reads
+     * via {@link ThrottledIterator}; because the per-file resolve is itself async (the footer read is released across
+     * the network round-trip), that permit bounds in-flight reads rather than pinning that many executor threads. The
+     * cancellation signal is checked before each dispatch (a cancelled wide glob stops issuing reads promptly and
+     * surfaces {@link TaskCancelledException}), and the async reads run on {@link #metadataReadExecutor} so an
+     * executor-backed synchronous read's backoff aborts on cancel. The first failure is propagated to {@code listener}
+     * and short-circuits the remaining files.
+     */
+    private void gatherPerFile(
+        FileList fileList,
+        Map<String, Object> config,
+        boolean cacheable,
+        ActionListener<List<SourceMetadata>> listener
+    ) {
+        int fileCount = fileList.fileCount();
+        AtomicReferenceArray<SourceMetadata> results = new AtomicReferenceArray<>(fileCount);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        Iterator<Integer> indices = indexIterator(fileCount);
+        ThrottledIterator.run(indices, (releasable, i) -> {
+            if (failure.get() != null) {
+                // A previous file already failed (or the query was cancelled) — drain the remaining items
+                // without issuing reads.
+                releasable.close();
+                return;
+            }
+            ActionListener<SourceMetadata> itemListener = ActionListener.runAfter(
+                ActionListener.wrap(meta -> results.set(i, meta), e -> failure.compareAndSet(null, e)),
+                releasable::close
+            );
+            // ThrottledIterator's itemConsumer must not throw: an escaped exception would leave this item's ref
+            // permanently held (its releasable never closed) and onCompletion would never fire — a hang. A check-
+            // before-dispatch cancellation and any synchronous throw from the resolve dispatch (e.g. a factory that
+            // rejects the executor submission or throws before completing the listener) are therefore funnelled into
+            // itemListener.onFailure so runAfter(..., releasable::close) always runs.
+            try {
+                throwIfCancelled();
+                StoragePath filePath = fileList.path(i);
+                // Length + mtime come from the directory listing: thread them through so the factory can build the
+                // storage object without a synchronous existence/HEAD probe on the executor thread before the async
+                // footer read.
+                ListingHint hint = new ListingHint(fileList.size(i), fileList.lastModifiedMillis(i));
+                if (cacheable) {
+                    cachedResolveSingleSourceAsync(filePath, hint, config, itemListener);
+                } else {
+                    resolveSingleSourceAsync(filePath.toString(), hint, config, itemListener);
+                }
+            } catch (Exception e) {
+                itemListener.onFailure(e);
+            }
+        }, metadataReadConcurrency, () -> {
+            Exception e = failure.get();
+            if (e != null) {
+                listener.onFailure(e);
+                return;
+            }
+            List<SourceMetadata> out = new ArrayList<>(fileCount);
+            for (int i = 0; i < fileCount; i++) {
+                out.add(results.get(i));
+            }
+            listener.onResponse(out);
+        }, executor, e -> {
+            // A continuation was rejected/failed (e.g. executor shutdown): record it so onCompletion surfaces the
+            // failure rather than returning a partially-populated result.
+            failure.compareAndSet(null, e);
+        });
+    }
+
+    /**
+     * Cache-aware async single-file resolve for the multi-file fan-out. Peeks the schema cache and, on a miss,
+     * resolves asynchronously (without pinning a thread across the footer read) and stores the result. Unlike the
+     * single-file {@code getOrComputeSchema} path this does not coalesce concurrent misses for the same key: two
+     * concurrent misses may both fetch. That is acceptable here because each fan-out file is a distinct key and
+     * footer resolution is idempotent; see {@link ExternalSourceCacheService#getSchemaIfPresent}.
+     */
+    private void cachedResolveSingleSourceAsync(
+        StoragePath filePath,
+        ListingHint hint,
+        Map<String, Object> config,
+        ActionListener<SourceMetadata> listener
+    ) {
         String formatType = detectFormatType(filePath);
-        SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
-        SchemaCacheEntry entry = cacheService.getOrComputeSchema(
-            schemaKey,
-            k -> SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config))
-        );
-        return buildMetadataFromCache(entry, entry.toAttributes(), config);
+        SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), hint.lastModifiedMillis(), formatType, config);
+        SchemaCacheEntry cached = cacheService.getSchemaIfPresent(schemaKey);
+        if (cached != null) {
+            listener.onResponse(buildMetadataFromCache(cached, cached.toAttributes(), config));
+            return;
+        }
+        resolveSingleSourceAsync(filePath.toString(), hint, config, listener.map(meta -> {
+            SchemaCacheEntry entry = SchemaCacheEntry.from(meta);
+            cacheService.putSchema(schemaKey, entry);
+            return buildMetadataFromCache(entry, entry.toAttributes(), config);
+        }));
+    }
+
+    /** Sequential {@code 0..count} iterator for {@link ThrottledIterator}; avoids a stream in production code. */
+    private static Iterator<Integer> indexIterator(int count) {
+        return new Iterator<>() {
+            private int next = 0;
+
+            @Override
+            public boolean hasNext() {
+                return next < count;
+            }
+
+            @Override
+            public Integer next() {
+                if (next >= count) {
+                    throw new java.util.NoSuchElementException();
+                }
+                return next++;
+            }
+        };
     }
 
     /**
@@ -879,86 +1117,73 @@ public class ExternalSourceResolver {
     }
 
     /**
-     * Reads metadata from all files in {@code listing} in parallel (bounded concurrency)
-     * via {@link BoundedParallelGather}, then aggregates statistics across all files.
-     * Returns a merged flat stats map, or {@code null} if any file fails or lacks statistics.
-     * Errors reading individual files are logged at DEBUG and cause the method to return {@code null}
-     * (the caller will then mark stats as partial instead of using incomplete aggregations).
+     * Reads metadata from all files in {@code listing} with an async, bounded fan-out (see {@link #gatherPerFile}),
+     * then aggregates statistics across all files. Responds with a merged flat stats map, or {@code null} if any file
+     * lacks statistics (via {@link #aggregateFileStatistics}). A read failure is treated as "could not aggregate" and
+     * responds with {@code null} so the caller marks stats partial — except cancellation, which is surfaced as a
+     * failure so the query aborts promptly instead of silently degrading.
      */
-    @Nullable
-    private Map<String, Object> readAndAggregateAllFileStats(FileList listing, Map<String, Object> config) {
-        int fileCount = listing.fileCount();
-        List<StoragePath> paths = new ArrayList<>(fileCount);
-        for (int i = 0; i < fileCount; i++) {
-            paths.add(listing.path(i));
-        }
-        List<SourceMetadata> allMeta;
-        try {
-            allMeta = BoundedParallelGather.gather(paths, filePath -> {
-                throwIfCancelled();
-                return StorageRetryCancellation.callWithCancellation(
-                    this::isCancelled,
-                    () -> resolveSingleSource(filePath.toString(), config)
-                );
-            }, MAX_PARALLEL_METADATA_READS, executor);
-        } catch (TaskCancelledException e) {
-            // Cancellation is not a "could not aggregate stats" condition — propagate it so the query
-            // aborts promptly instead of silently degrading to partial stats and continuing.
-            throw e;
-        } catch (Exception e) {
-            // If the query was cancelled, a read may have failed for that reason; surface cancellation
-            // rather than masking it as partial stats.
-            throwIfCancelled();
-            LOGGER.debug(() -> "Failed to read per-file stats in parallel, will use partial stats: " + e.getMessage());
-            return null;
-        }
-        return aggregateFileStatistics(allMeta);
+    private void readAndAggregateAllFileStats(FileList listing, Map<String, Object> config, ActionListener<Map<String, Object>> listener) {
+        gatherPerFile(
+            listing,
+            config,
+            false,
+            ActionListener.wrap(allMeta -> { listener.onResponse(aggregateFileStatistics(allMeta)); }, e -> {
+                // Cancellation is not a "could not aggregate stats" condition — propagate it so the query aborts promptly
+                // instead of silently degrading to partial stats and continuing. A read that failed *because* the query
+                // was cancelled mid-flight can arrive wrapped (the schema cache wraps loader failures), so consult the
+                // cancellation state directly rather than matching only on the exception type.
+                if (e instanceof TaskCancelledException) {
+                    listener.onFailure(e);
+                    return;
+                }
+                if (isCancelled()) {
+                    listener.onFailure(new TaskCancelledException(RESOLUTION_CANCELLED_MESSAGE));
+                    return;
+                }
+                LOGGER.debug(() -> "Failed to read per-file stats in parallel, will use partial stats: " + e.getMessage());
+                listener.onResponse(null);
+            })
+        );
     }
 
     /**
-     * Cache-aware variant of {@link #readAndAggregateAllFileStats}.
-     * Uses the schema cache (keyed by path + mtime) for each file so that repeated
-     * multi-file resolves do not re-read footers unnecessarily.
-     * Returns {@code null} if any file cannot be resolved or lacks statistics.
+     * Cache-aware variant of {@link #readAndAggregateAllFileStats}. Peeks the schema cache (keyed by path + mtime) for
+     * each file so repeated multi-file resolves do not re-read footers. Responds with {@code null} if any file cannot
+     * be resolved or lacks statistics; a bare cancellation is surfaced as a failure so it is never masked as partial
+     * stats.
      */
-    @Nullable
-    private Map<String, Object> readAndAggregateAllFileStatsWithCache(FileList listing, Map<String, Object> config) {
-        int fileCount = listing.fileCount();
-        List<Map<String, Object>> perFileStats = new ArrayList<>(fileCount);
-        for (int i = 0; i < fileCount; i++) {
-            // Cancellation is checked before the per-file try so it is never swallowed as "partial stats".
-            throwIfCancelled();
-            StoragePath filePath = listing.path(i);
-            long mtime = listing.lastModifiedMillis(i);
-            String formatType = detectFormatType(filePath);
-            SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
-            try {
-                SchemaCacheEntry entry = StorageRetryCancellation.callWithCancellation(
-                    this::isCancelled,
-                    () -> cacheService.getOrComputeSchema(
-                        schemaKey,
-                        k -> SchemaCacheEntry.from(resolveSingleSource(filePath.toString(), config))
-                    )
-                );
-                Map<String, Object> fileMeta = entry.safeMetadata();
+    private void readAndAggregateAllFileStatsWithCache(
+        FileList listing,
+        Map<String, Object> config,
+        ActionListener<Map<String, Object>> listener
+    ) {
+        gatherPerFile(listing, config, true, ActionListener.wrap(allMeta -> {
+            List<Map<String, Object>> perFileStats = new ArrayList<>(allMeta.size());
+            for (SourceMetadata meta : allMeta) {
+                Map<String, Object> fileMeta = meta.sourceMetadata();
                 if (fileMeta == null || fileMeta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false) {
                     // This file has no statistics — cannot produce accurate global stats.
-                    return null;
+                    listener.onResponse(null);
+                    return;
                 }
                 perFileStats.add(fileMeta);
-            } catch (TaskCancelledException e) {
-                // A bare cancellation (e.g. from a cache wait point) must abort, not degrade to partial stats.
-                throw e;
-            } catch (Exception e) {
-                // The schema cache wraps loader failures in ExecutionException, so a cancellation observed
-                // while reading a footer can arrive wrapped here; re-check the supplier so it surfaces as
-                // cancellation rather than being masked as partial stats.
-                throwIfCancelled();
-                LOGGER.debug(() -> "Failed to get cached stats for [" + filePath + "], will use partial stats: " + e.getMessage());
-                return null;
             }
-        }
-        return SourceStatisticsSerializer.mergeStatistics(perFileStats);
+            listener.onResponse(SourceStatisticsSerializer.mergeStatistics(perFileStats));
+        }, e -> {
+            // A bare cancellation, or a read that failed because the query was cancelled mid-flight (the cache wraps
+            // loader failures, so consult the state directly), must abort rather than degrade to partial stats.
+            if (e instanceof TaskCancelledException) {
+                listener.onFailure(e);
+                return;
+            }
+            if (isCancelled()) {
+                listener.onFailure(new TaskCancelledException(RESOLUTION_CANCELLED_MESSAGE));
+                return;
+            }
+            LOGGER.debug(() -> "Failed to get cached stats, will use partial stats: " + e.getMessage());
+            listener.onResponse(null);
+        }));
     }
 
     private ExternalSourceMetadata buildUnifiedMetadata(
@@ -1087,6 +1312,93 @@ public class ExternalSourceResolver {
                 + sources
                 + "]."
         );
+    }
+
+    /**
+     * Async counterpart of {@link #resolveSingleSource}. Performs the cheap scheme validation synchronously (no I/O),
+     * then dispatches to the first factory that claims the path via {@link #resolveWithFactory}, falling through to
+     * the next candidate on failure exactly like the synchronous path. The async factory read runs on
+     * {@link #metadataReadExecutor} so the read's retry backoff aborts on cancellation.
+     */
+    private void resolveSingleSourceAsync(
+        String path,
+        @Nullable ListingHint hint,
+        Map<String, Object> config,
+        ActionListener<SourceMetadata> listener
+    ) {
+        try {
+            StoragePath parsed = StoragePath.of(path);
+            DataSourceCapabilities capabilities = dataSourceModule.capabilities();
+            if (capabilities != null && capabilities.supportsScheme(parsed.scheme()) == false) {
+                listener.onFailure(
+                    new UnsupportedSchemeException(
+                        "Unsupported storage scheme [" + parsed.scheme() + "]. Supported: " + capabilities.supportedSchemesString()
+                    )
+                );
+                return;
+            }
+        } catch (UnsupportedSchemeException e) {
+            listener.onFailure(e);
+            return;
+        } catch (IllegalArgumentException e) {
+            // Path parsing failed -- let the factory iteration handle it
+        }
+
+        List<ExternalSourceFactory> candidates = new ArrayList<>();
+        for (ExternalSourceFactory factory : dataSourceModule.sourceFactories().values()) {
+            if (factory.canHandle(path)) {
+                candidates.add(factory);
+            }
+        }
+        resolveWithFactory(path, hint, config, candidates, 0, null, listener);
+    }
+
+    /**
+     * Tries each claiming factory in order, asynchronously. On a factory failure (sync throw from dispatch or async
+     * {@code onFailure}) it records the failure and advances to the next candidate, mirroring the synchronous
+     * fall-through in {@link #resolveSingleSource}. When no candidate remains it fails with the last recorded error,
+     * or a "no handler" error if none claimed the path.
+     */
+    private void resolveWithFactory(
+        String path,
+        @Nullable ListingHint hint,
+        Map<String, Object> config,
+        List<ExternalSourceFactory> candidates,
+        int index,
+        @Nullable Exception lastFailure,
+        ActionListener<SourceMetadata> listener
+    ) {
+        if (index >= candidates.size()) {
+            if (lastFailure != null) {
+                listener.onFailure(new IllegalArgumentException("Failed to resolve metadata for [" + path + "]", lastFailure));
+                return;
+            }
+            var sources = String.join(", ", dataSourceModule.sourceFactories().keySet());
+            listener.onFailure(
+                new UnsupportedOperationException(
+                    "No handler found for source at path ["
+                        + path
+                        + "]. "
+                        + "Please ensure the appropriate data source plugin is installed. "
+                        + "Known handlers: ["
+                        + sources
+                        + "]."
+                )
+            );
+            return;
+        }
+        ExternalSourceFactory factory = candidates.get(index);
+        ActionListener<SourceMetadata> next = ActionListener.wrap(listener::onResponse, e -> {
+            LOGGER.debug("Factory [{}] claimed path [{}] but failed: {}", factory.type(), path, e.getMessage());
+            resolveWithFactory(path, hint, config, candidates, index + 1, e, listener);
+        });
+        try {
+            factory.resolveMetadataAsync(path, hint, config, metadataReadExecutor, next);
+        } catch (Exception e) {
+            // A factory that throws synchronously from dispatch (before invoking the listener) must not abort the
+            // whole resolve: fall through to the next candidate exactly as the async onFailure path does.
+            next.onFailure(e);
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -28,31 +28,33 @@ public final class ExternalSourceSettings {
 
     private ExternalSourceSettings() {}
 
-    /** Blob-store access concurrency per allocated processor — the {@code snapshot_meta} thread pool's slope. */
-    static final int BLOB_STORE_CONCURRENCY_PER_PROCESSOR = 3;
+    /** Metadata-discovery concurrency per allocated processor — the {@code snapshot_meta} thread pool's slope. */
+    static final int DISCOVERY_CONCURRENCY_PER_PROCESSOR = 3;
 
     /**
      * Ceiling for the CPU-derived metadata-discovery concurrency. Mirrors the {@code snapshot_meta} thread pool's
      * {@code min(processors * 3, 50)} shape but lifts the cap to 100: external metadata discovery fans out over many
      * small footer blobs, so it benefits from more in-flight requests than snapshot metadata does, while still
-     * bounding the total against a single store's tolerance.
+     * bounding the total against a single store's tolerance. This ceiling scopes discovery only; it does not bound
+     * the execution-time data-read path (see {@link #MAX_CONNECTIONS}).
      */
-    static final int BLOB_STORE_CONCURRENCY_CEILING = 100;
+    static final int DISCOVERY_CONCURRENCY_CEILING = 100;
 
     /**
-     * The default per-node in-flight concurrency for external metadata discovery, derived from the node's allocated
-     * processors using the {@code snapshot_meta} thread pool's sizing shape ({@code processors * 3}) with a 100
-     * ceiling. Discovery is latency-bound I/O against object stores, so it scales with node size rather than an
-     * ad-hoc constant. This is discovery's derived default only: production data reads are bounded separately by
-     * {@link #MAX_CONNECTIONS} (the SDK connection pools and the blocking-read thread pool), not this formula.
+     * The default per-node in-flight concurrency for external metadata discovery (the multi-file footer fan-out),
+     * derived from the node's allocated processors using the {@code snapshot_meta} thread pool's sizing shape
+     * ({@code processors * 3}) with a 100 ceiling. Discovery is latency-bound I/O against object stores, so it scales
+     * with node size rather than an ad-hoc constant. This bounds discovery only: production data reads are bounded
+     * separately by {@link #MAX_CONNECTIONS} (the SDK connection pools and the blocking-read thread pool), which is a
+     * distinct knob and is intentionally not capped by this discovery ceiling.
      */
-    public static int defaultBlobStoreConcurrency(int allocatedProcessors) {
-        return Math.min(allocatedProcessors * BLOB_STORE_CONCURRENCY_PER_PROCESSOR, BLOB_STORE_CONCURRENCY_CEILING);
+    public static int defaultDiscoveryConcurrency(int allocatedProcessors) {
+        return Math.min(allocatedProcessors * DISCOVERY_CONCURRENCY_PER_PROCESSOR, DISCOVERY_CONCURRENCY_CEILING);
     }
 
     /** Convenience overload resolving allocated processors from the given settings. */
-    public static int defaultBlobStoreConcurrency(Settings settings) {
-        return defaultBlobStoreConcurrency(EsExecutors.allocatedProcessors(settings));
+    public static int defaultDiscoveryConcurrency(Settings settings) {
+        return defaultDiscoveryConcurrency(EsExecutors.allocatedProcessors(settings));
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -56,6 +56,17 @@ public final class ExternalSourceSettings {
     }
 
     /**
+     * The effective per-node blob-store access concurrency that every external access path should read, so one knob
+     * governs metadata discovery and data reads alike. On this branch it resolves to the CPU-bound
+     * {@link #defaultBlobStoreConcurrency(Settings)} default; once the per-query concurrency work (PR B) lands its
+     * operator setting on top, this accessor becomes the override-aware value and both paths pick that up unchanged
+     * — the call sites do not move, only this body does.
+     */
+    public static int blobStoreConcurrency(Settings settings) {
+        return defaultBlobStoreConcurrency(settings);
+    }
+
+    /**
      * Maximum concurrent in-flight external-storage reads per backend, per node. Sizes the S3/Azure SDK connection
      * pools and the {@code esql_external_blocking_io} thread pool. Static (NodeScope): thread pools and SDK pools
      * are fixed at startup.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -28,33 +28,31 @@ public final class ExternalSourceSettings {
 
     private ExternalSourceSettings() {}
 
-    /** Metadata-discovery concurrency per allocated processor — the {@code snapshot_meta} thread pool's slope. */
-    static final int DISCOVERY_CONCURRENCY_PER_PROCESSOR = 3;
+    /** Blob-store access concurrency per allocated processor — the {@code snapshot_meta} thread pool's slope. */
+    static final int BLOB_STORE_CONCURRENCY_PER_PROCESSOR = 3;
 
     /**
-     * Ceiling for the CPU-derived metadata-discovery concurrency. Mirrors the {@code snapshot_meta} thread pool's
-     * {@code min(processors * 3, 50)} shape but lifts the cap to 100: external metadata discovery fans out over many
-     * small footer blobs, so it benefits from more in-flight requests than snapshot metadata does, while still
-     * bounding the total against a single store's tolerance. This ceiling scopes discovery only; it does not bound
-     * the execution-time data-read path (see {@link #MAX_CONNECTIONS}).
+     * Ceiling for the CPU-derived blob-store access concurrency. Mirrors the {@code snapshot_meta} thread pool's
+     * {@code min(processors * 3, 50)} shape but lifts the cap to 100: external metadata discovery and data reads
+     * fan out over many small blobs (footers, byte ranges), so they benefit from more in-flight requests than
+     * snapshot metadata does, while still bounding the total against a single store's tolerance.
      */
-    static final int DISCOVERY_CONCURRENCY_CEILING = 100;
+    static final int BLOB_STORE_CONCURRENCY_CEILING = 100;
 
     /**
-     * The default per-node in-flight concurrency for external metadata discovery (the multi-file footer fan-out),
-     * derived from the node's allocated processors using the {@code snapshot_meta} thread pool's sizing shape
-     * ({@code processors * 3}) with a 100 ceiling. Discovery is latency-bound I/O against object stores, so it scales
-     * with node size rather than an ad-hoc constant. This bounds discovery only: production data reads are bounded
-     * separately by {@link #MAX_CONNECTIONS} (the SDK connection pools and the blocking-read thread pool), which is a
-     * distinct knob and is intentionally not capped by this discovery ceiling.
+     * The default per-node concurrency for accessing an external blob store, derived from the node's allocated
+     * processors using the {@code snapshot_meta} thread pool's sizing shape ({@code processors * 3}) with a 100
+     * ceiling. This is the single source of truth for blob-store access concurrency so metadata discovery and
+     * data retrieval stay consistent: both are latency-bound I/O against object stores and should scale the same
+     * way with node size rather than each picking an ad-hoc constant.
      */
-    public static int defaultDiscoveryConcurrency(int allocatedProcessors) {
-        return Math.min(allocatedProcessors * DISCOVERY_CONCURRENCY_PER_PROCESSOR, DISCOVERY_CONCURRENCY_CEILING);
+    public static int defaultBlobStoreConcurrency(int allocatedProcessors) {
+        return Math.min(allocatedProcessors * BLOB_STORE_CONCURRENCY_PER_PROCESSOR, BLOB_STORE_CONCURRENCY_CEILING);
     }
 
     /** Convenience overload resolving allocated processors from the given settings. */
-    public static int defaultDiscoveryConcurrency(Settings settings) {
-        return defaultDiscoveryConcurrency(EsExecutors.allocatedProcessors(settings));
+    public static int defaultBlobStoreConcurrency(Settings settings) {
+        return defaultBlobStoreConcurrency(EsExecutors.allocatedProcessors(settings));
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -32,19 +32,19 @@ public final class ExternalSourceSettings {
     static final int BLOB_STORE_CONCURRENCY_PER_PROCESSOR = 3;
 
     /**
-     * Ceiling for the CPU-derived blob-store access concurrency. Mirrors the {@code snapshot_meta} thread pool's
-     * {@code min(processors * 3, 50)} shape but lifts the cap to 100: external metadata discovery and data reads
-     * fan out over many small blobs (footers, byte ranges), so they benefit from more in-flight requests than
-     * snapshot metadata does, while still bounding the total against a single store's tolerance.
+     * Ceiling for the CPU-derived metadata-discovery concurrency. Mirrors the {@code snapshot_meta} thread pool's
+     * {@code min(processors * 3, 50)} shape but lifts the cap to 100: external metadata discovery fans out over many
+     * small footer blobs, so it benefits from more in-flight requests than snapshot metadata does, while still
+     * bounding the total against a single store's tolerance.
      */
     static final int BLOB_STORE_CONCURRENCY_CEILING = 100;
 
     /**
-     * The default per-node concurrency for accessing an external blob store, derived from the node's allocated
+     * The default per-node in-flight concurrency for external metadata discovery, derived from the node's allocated
      * processors using the {@code snapshot_meta} thread pool's sizing shape ({@code processors * 3}) with a 100
-     * ceiling. This is the single source of truth for blob-store access concurrency so metadata discovery and
-     * data retrieval stay consistent: both are latency-bound I/O against object stores and should scale the same
-     * way with node size rather than each picking an ad-hoc constant.
+     * ceiling. Discovery is latency-bound I/O against object stores, so it scales with node size rather than an
+     * ad-hoc constant. This is discovery's derived default only: production data reads are bounded separately by
+     * {@link #MAX_CONNECTIONS} (the SDK connection pools and the blocking-read thread pool), not this formula.
      */
     public static int defaultBlobStoreConcurrency(int allocatedProcessors) {
         return Math.min(allocatedProcessors * BLOB_STORE_CONCURRENCY_PER_PROCESSOR, BLOB_STORE_CONCURRENCY_CEILING);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 
 import java.util.List;
 
@@ -25,6 +27,33 @@ import java.util.List;
 public final class ExternalSourceSettings {
 
     private ExternalSourceSettings() {}
+
+    /** Blob-store access concurrency per allocated processor — the {@code snapshot_meta} thread pool's slope. */
+    static final int BLOB_STORE_CONCURRENCY_PER_PROCESSOR = 3;
+
+    /**
+     * Ceiling for the CPU-derived blob-store access concurrency. Mirrors the {@code snapshot_meta} thread pool's
+     * {@code min(processors * 3, 50)} shape but lifts the cap to 100: external metadata discovery and data reads
+     * fan out over many small blobs (footers, byte ranges), so they benefit from more in-flight requests than
+     * snapshot metadata does, while still bounding the total against a single store's tolerance.
+     */
+    static final int BLOB_STORE_CONCURRENCY_CEILING = 100;
+
+    /**
+     * The default per-node concurrency for accessing an external blob store, derived from the node's allocated
+     * processors using the {@code snapshot_meta} thread pool's sizing shape ({@code processors * 3}) with a 100
+     * ceiling. This is the single source of truth for blob-store access concurrency so metadata discovery and
+     * data retrieval stay consistent: both are latency-bound I/O against object stores and should scale the same
+     * way with node size rather than each picking an ad-hoc constant.
+     */
+    public static int defaultBlobStoreConcurrency(int allocatedProcessors) {
+        return Math.min(allocatedProcessors * BLOB_STORE_CONCURRENCY_PER_PROCESSOR, BLOB_STORE_CONCURRENCY_CEILING);
+    }
+
+    /** Convenience overload resolving allocated processors from the given settings. */
+    public static int defaultBlobStoreConcurrency(Settings settings) {
+        return defaultBlobStoreConcurrency(EsExecutors.allocatedProcessors(settings));
+    }
 
     /**
      * Maximum concurrent in-flight external-storage reads per backend, per node. Sizes the S3/Azure SDK connection

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.core.Nullable;
@@ -21,6 +22,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.ListingHint;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
@@ -30,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -272,6 +275,72 @@ final class FileSourceFactory implements ExternalSourceFactory {
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to resolve metadata for [" + location + "]", e);
         }
+    }
+
+    /**
+     * Async metadata resolution. When {@code hint} is non-null the length/mtime came from a directory
+     * listing: the storage object is built with those values (so {@code length()} serves the cached
+     * value without I/O) and the existence probe is skipped, so no synchronous HEAD/range round-trip
+     * runs on the executor before the async footer read. When {@code hint} is null the object is
+     * created bare and its existence is verified up front, matching the synchronous path.
+     */
+    @Override
+    public void resolveMetadataAsync(
+        String location,
+        @Nullable ListingHint hint,
+        Map<String, Object> config,
+        Executor executor,
+        ActionListener<SourceMetadata> listener
+    ) {
+        final StorageObject storageObject;
+        final FormatReader reader;
+        try {
+            // Reject unknown configuration keys before any provider/reader work — same single source
+            // of truth as the synchronous resolveMetadata path.
+            validateConfig(location, config);
+            StoragePath storagePath = StoragePath.of(location);
+            String scheme = storagePath.scheme();
+
+            StorageProvider provider;
+            if (config != null && config.isEmpty() == false) {
+                provider = storageRegistry.createProviderTrackingConsumedKeys(
+                    scheme,
+                    settings,
+                    ExternalSourceResolver.storageConfig(config)
+                ).value();
+                reader = resolveFormatReader(storagePath.objectName(), config).withConfigTrackingConsumedKeys(config).value();
+            } else {
+                provider = storageRegistry.provider(storagePath);
+                reader = resolveFormatReader(storagePath.objectName(), config).withConfig(config);
+            }
+
+            if (hint != null) {
+                storageObject = provider.newObject(storagePath, hint.length(), Instant.ofEpochMilli(hint.lastModifiedMillis()));
+            } else {
+                storageObject = provider.newObject(storagePath);
+                if (storageObject.exists() == false) {
+                    listener.onFailure(
+                        new IllegalArgumentException(
+                            "Failed to resolve metadata for [" + location + "]",
+                            new IOException("File does not exist: " + location)
+                        )
+                    );
+                    return;
+                }
+            }
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        // Map an I/O failure from the async metadata read to the same IllegalArgumentException shape
+        // the synchronous path produces, so callers see identical exceptions regardless of path.
+        reader.metadataAsync(storageObject, executor, listener.delegateResponse((l, e) -> {
+            if (e instanceof IOException) {
+                l.onFailure(new IllegalArgumentException("Failed to resolve metadata for [" + location + "]", e));
+            } else {
+                l.onFailure(e);
+            }
+        }));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -92,6 +92,28 @@ public class ExternalSourceCacheService implements Closeable {
     }
 
     /**
+     * Returns a cached schema entry, or {@code null} on a miss (or when the cache is disabled).
+     * Unlike {@link #getOrComputeSchema}, this never invokes a loader — it is the peek half of the
+     * async resolve path, which fetches on a miss without holding an executor thread and then stores
+     * the result via {@link #putSchema}. This trades strict thundering-herd coalescing (two
+     * concurrent misses for the same key may both fetch) for the ability to resolve asynchronously.
+     */
+    public SchemaCacheEntry getSchemaIfPresent(SchemaCacheKey key) {
+        if (enabled == false) {
+            return null;
+        }
+        return schemaCache.get(key);
+    }
+
+    /** Stores a schema entry. No-op when the cache is disabled. Pairs with {@link #getSchemaIfPresent}. */
+    public void putSchema(SchemaCacheKey key, SchemaCacheEntry entry) {
+        if (enabled == false) {
+            return;
+        }
+        schemaCache.put(key, entry);
+    }
+
+    /**
      * Returns a cached file listing or stores the provided one. The loader is only invoked
      * on a cache miss. When the cache is disabled, the loader is called directly (bypassing the cache).
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalSourceFactory.java
@@ -7,7 +7,11 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.Nullable;
+
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * Common interface for complete external data source factories.
@@ -35,6 +39,38 @@ public interface ExternalSourceFactory {
     }
 
     SourceMetadata resolveMetadata(String location, Map<String, Object> config);
+
+    /**
+     * Asynchronously resolves metadata for the given location.
+     * <p>
+     * The default wraps the synchronous {@link #resolveMetadata(String, Map)} in the provided
+     * executor. File-based factories that can issue the footer/metadata read without pinning an
+     * executor thread across the network round-trip should override this to route through the
+     * format reader's {@link FormatReader#metadataAsync} path, so a multi-file discovery fan-out
+     * is bounded by an in-flight permit rather than by the executor's thread count.
+     * <p>
+     * When {@code hint} is non-null the caller already knows the object's length/mtime from a
+     * directory listing; overrides must build the storage object from it and skip any existence/HEAD
+     * probe, since that probe is a synchronous round-trip (e.g. an S3 HEAD) that would pin the
+     * executor thread before the async read and defeat the in-flight bound. A {@code null} hint means
+     * nothing is known (a single, explicitly-referenced path) and the override must verify existence
+     * itself.
+     */
+    default void resolveMetadataAsync(
+        String location,
+        @Nullable ListingHint hint,
+        Map<String, Object> config,
+        Executor executor,
+        ActionListener<SourceMetadata> listener
+    ) {
+        executor.execute(() -> {
+            try {
+                listener.onResponse(resolveMetadata(location, config));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
 
     /**
      * Reject configuration keys this factory doesn't recognize at the given location. Implementations

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -111,6 +111,25 @@ public interface FormatReader extends Closeable {
 
     SourceMetadata metadata(StorageObject object) throws IOException;
 
+    /**
+     * Asynchronously resolves metadata for the given storage object.
+     * <p>
+     * The default wraps the synchronous {@link #metadata(StorageObject)} in the provided executor,
+     * mirroring {@link #readAsync}. Formats whose footer/metadata read can be issued without holding
+     * an executor thread across the network round-trip (e.g. Parquet via
+     * {@link StorageObject#readBytesAsync}) should override this so that a wide discovery fan-out is
+     * bounded by an in-flight permit rather than by the number of executor threads it pins.
+     */
+    default void metadataAsync(StorageObject object, Executor executor, ActionListener<SourceMetadata> listener) {
+        executor.execute(() -> {
+            try {
+                listener.onResponse(metadata(object));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
     default List<Attribute> schema(StorageObject object) throws IOException {
         return metadata(object).schema();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ListingHint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ListingHint.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+/**
+ * Metadata about a file already known from a directory listing, passed to
+ * {@link ExternalSourceFactory#resolveMetadataAsync} so the factory can build the storage object
+ * without a synchronous existence/HEAD probe before the async metadata read. A {@code null} hint
+ * means nothing is known (e.g. a single, explicitly-referenced path) and the factory is responsible
+ * for verifying existence itself.
+ * <p>
+ * New listing-derived fields (etag/version-id, checksum, storage class, ...) should be added here
+ * rather than as extra parameters, so the async-resolution signature and its overrides stay stable.
+ *
+ * @param length the object's length in bytes
+ * @param lastModifiedMillis the object's last-modified time, in epoch milliseconds
+ */
+public record ListingHint(long length, long lastModifiedMillis) {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -105,7 +105,7 @@ public class PlanExecutor {
      * cancellation signal, and in-flight fan-out bound are supplied by the caller ({@link #esql}, ultimately
      * from {@code TransportEsqlQueryAction}) rather than hardcoded here, so the resolver keeps the
      * caller-owned executor/cancellation seam while the wiring — executor isolation (off {@code SEARCH}) and the
-     * caller-supplied {@code metadataReadConcurrency} (production: the {@code snapshot_meta}-shaped blob-store
+     * caller-supplied {@code metadataReadConcurrency} (production: the {@code snapshot_meta}-shaped discovery
      * default, capped at 100) — stays testable without standing up the full query path. See {@link #esql} for why
      * an in-flight bound that may exceed the pool size is safe.
      */
@@ -134,7 +134,7 @@ public class PlanExecutor {
      *                               wiring passes {@code esql_worker}.
      * @param externalSourceConcurrency maximum number of in-flight per-file metadata reads during a multi-file
      *                               resolve. Production wiring passes
-     *                               {@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)} (the
+     *                               {@link ExternalSourceSettings#defaultDiscoveryConcurrency(Settings)} (the
      *                               {@code snapshot_meta} shape, capped at 100): footer reads are async (the pool
      *                               thread is released across the network round-trip), so the bound caps concurrent
      *                               in-flight reads rather than pinning that many threads.
@@ -162,7 +162,7 @@ public class PlanExecutor {
         // Resolution (glob expansion, footer reads, schema reconciliation) runs on the caller-supplied
         // executor rather than the SEARCH pool, so a wildcard external query cannot starve regular ES
         // searches or other ES|QL queries. The per-query multi-file metadata fan-out is bounded by
-        // externalSourceConcurrency (production: the snapshot_meta-shaped blob-store default, capped at 100):
+        // externalSourceConcurrency (production: the snapshot_meta-shaped discovery default, capped at 100):
         // because footer reads are async (the pool thread is released across the network round-trip) the bound
         // caps in-flight reads rather than pinning that many threads, so a wide discovery cannot starve execution.
         // NOTE: this release-across-the-read guarantee holds for storage backends with native async

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -134,7 +134,7 @@ public class PlanExecutor {
      *                               wiring passes {@code esql_worker}.
      * @param externalSourceConcurrency maximum number of in-flight per-file metadata reads during a multi-file
      *                               resolve. Production wiring passes
-     *                               {@link ExternalSourceSettings#defaultDiscoveryConcurrency(Settings)} (the
+     *                               {@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)} (the
      *                               {@code snapshot_meta} shape, capped at 100): footer reads are async (the pool
      *                               thread is released across the network round-trip), so the bound caps concurrent
      *                               in-flight reads rather than pinning that many threads.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.indices.IndicesExpressionGrouper;
 import org.elasticsearch.license.XPackLicenseState;
@@ -99,10 +100,42 @@ public class PlanExecutor {
     }
 
     /**
+     * Builds the {@link ExternalSourceResolver} used for external (Iceberg/Parquet) discovery. The executor,
+     * cancellation signal, and in-flight fan-out bound are supplied by the caller ({@link #esql}, ultimately
+     * from {@code TransportEsqlQueryAction}) rather than hardcoded here, so the resolver keeps the
+     * caller-owned executor/cancellation seam while the wiring — executor isolation (off {@code SEARCH}) and
+     * {@code metadataReadConcurrency == esql_worker.getMax()} — stays testable without standing up the full
+     * query path. See {@link #esql} for why the pool size is a safe in-flight bound.
+     */
+    static ExternalSourceResolver createExternalSourceResolver(
+        Executor externalSourceExecutor,
+        DataSourceModule dataSourceModule,
+        Settings settings,
+        ExternalSourceCacheService cacheService,
+        BooleanSupplier cancellation,
+        int externalSourceConcurrency
+    ) {
+        return new ExternalSourceResolver(
+            externalSourceExecutor,
+            dataSourceModule,
+            settings,
+            cacheService,
+            cancellation,
+            externalSourceConcurrency
+        );
+    }
+
+    /**
      * @param externalSourceExecutor Executor for {@link ExternalSourceResolver} work — glob expansion, footer reads,
      *                               schema reconciliation. Must not be the SEARCH pool: a wildcard external query
      *                               would otherwise starve regular ES searches and other ES|QL queries. Production
      *                               wiring passes {@code esql_worker}.
+     * @param externalSourceConcurrency maximum number of in-flight per-file metadata reads during a multi-file
+     *                               resolve. Production wiring passes {@code esql_worker.getMax()}: footer reads are
+     *                               async (the pool thread is released across the network round-trip), so the bound
+     *                               caps concurrent in-flight reads rather than pinning that many threads.
+     * @param cancellation consulted before each per-file footer read so a wide-glob discovery aborts promptly when
+     *                               the originating query is cancelled.
      */
     public void esql(
         EsqlQueryRequest request,
@@ -117,19 +150,29 @@ public class PlanExecutor {
         EsqlSession.PlanRunner planRunner,
         TransportActionServices services,
         Executor externalSourceExecutor,
+        int externalSourceConcurrency,
         BooleanSupplier cancellation,
         ActionListener<Versioned<Result>> listener
     ) {
         final PlanTelemetry planTelemetry = new PlanTelemetry(functionRegistry);
         // Resolution (glob expansion, footer reads, schema reconciliation) runs on the caller-supplied
         // executor rather than the SEARCH pool, so a wildcard external query cannot starve regular ES
-        // searches or other ES|QL queries.
-        final ExternalSourceResolver externalSourceResolver = new ExternalSourceResolver(
+        // searches or other ES|QL queries. The per-query multi-file metadata fan-out is bounded by
+        // externalSourceConcurrency (production: esql_worker.getMax()): because footer reads are async
+        // (the pool thread is released across the network round-trip) the bound caps in-flight reads
+        // rather than pinning that many threads, so a wide discovery cannot starve execution.
+        // NOTE: this release-across-the-read guarantee holds for storage backends with native async
+        // reads (e.g. S3). Backends whose readBytesAsync is an executor-backed sync read (local, GCS)
+        // still occupy a worker thread for the duration of each footer read; the bound limits how
+        // many do so at once, and re-homing those blocking reads off esql_worker is handled by the
+        // follow-up concurrency-fairness work rather than here.
+        final ExternalSourceResolver externalSourceResolver = createExternalSourceResolver(
             externalSourceExecutor,
             dataSourceModule,
             services.clusterService().getSettings(),
             cacheService,
-            cancellation
+            cancellation,
+            externalSourceConcurrency
         );
         final var session = new EsqlSession(
             sessionId,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.datasources.DataSourceModule;
 import org.elasticsearch.xpack.esql.datasources.DatasetResolver;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
@@ -103,9 +104,10 @@ public class PlanExecutor {
      * Builds the {@link ExternalSourceResolver} used for external (Iceberg/Parquet) discovery. The executor,
      * cancellation signal, and in-flight fan-out bound are supplied by the caller ({@link #esql}, ultimately
      * from {@code TransportEsqlQueryAction}) rather than hardcoded here, so the resolver keeps the
-     * caller-owned executor/cancellation seam while the wiring — executor isolation (off {@code SEARCH}) and
-     * {@code metadataReadConcurrency == esql_worker.getMax()} — stays testable without standing up the full
-     * query path. See {@link #esql} for why the pool size is a safe in-flight bound.
+     * caller-owned executor/cancellation seam while the wiring — executor isolation (off {@code SEARCH}) and the
+     * caller-supplied {@code metadataReadConcurrency} (production: the {@code snapshot_meta}-shaped blob-store
+     * default, capped at 100) — stays testable without standing up the full query path. See {@link #esql} for why
+     * an in-flight bound that may exceed the pool size is safe.
      */
     static ExternalSourceResolver createExternalSourceResolver(
         Executor externalSourceExecutor,
@@ -131,9 +133,11 @@ public class PlanExecutor {
      *                               would otherwise starve regular ES searches and other ES|QL queries. Production
      *                               wiring passes {@code esql_worker}.
      * @param externalSourceConcurrency maximum number of in-flight per-file metadata reads during a multi-file
-     *                               resolve. Production wiring passes {@code esql_worker.getMax()}: footer reads are
-     *                               async (the pool thread is released across the network round-trip), so the bound
-     *                               caps concurrent in-flight reads rather than pinning that many threads.
+     *                               resolve. Production wiring passes
+     *                               {@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)} (the
+     *                               {@code snapshot_meta} shape, capped at 100): footer reads are async (the pool
+     *                               thread is released across the network round-trip), so the bound caps concurrent
+     *                               in-flight reads rather than pinning that many threads.
      * @param cancellation consulted before each per-file footer read so a wide-glob discovery aborts promptly when
      *                               the originating query is cancelled.
      */
@@ -158,9 +162,9 @@ public class PlanExecutor {
         // Resolution (glob expansion, footer reads, schema reconciliation) runs on the caller-supplied
         // executor rather than the SEARCH pool, so a wildcard external query cannot starve regular ES
         // searches or other ES|QL queries. The per-query multi-file metadata fan-out is bounded by
-        // externalSourceConcurrency (production: esql_worker.getMax()): because footer reads are async
-        // (the pool thread is released across the network round-trip) the bound caps in-flight reads
-        // rather than pinning that many threads, so a wide discovery cannot starve execution.
+        // externalSourceConcurrency (production: the snapshot_meta-shaped blob-store default, capped at 100):
+        // because footer reads are async (the pool thread is released across the network round-trip) the bound
+        // caps in-flight reads rather than pinning that many threads, so a wide discovery cannot starve execution.
         // NOTE: this release-across-the-read guarantee holds for storage backends with native async
         // reads (e.g. S3). Backends whose readBytesAsync is an executor-backed sync read (local, GCS)
         // still occupy a worker thread for the duration of each footer read; the bound limits how

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -134,7 +134,7 @@ public class PlanExecutor {
      *                               wiring passes {@code esql_worker}.
      * @param externalSourceConcurrency maximum number of in-flight per-file metadata reads during a multi-file
      *                               resolve. Production wiring passes
-     *                               {@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)} (the
+     *                               {@link ExternalSourceSettings#blobStoreConcurrency(Settings)} (the
      *                               {@code snapshot_meta} shape, capped at 100): footer reads are async (the pool
      *                               thread is released across the network round-trip), so the bound caps concurrent
      *                               in-flight reads rather than pinning that many threads.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -296,13 +296,13 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
      * outstanding, passed to {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver} as its fan-out
      * bound. Because footer reads are async (the {@code esql_worker} thread is released across the read), this caps
      * concurrent in-flight reads rather than pinning that many threads, so the bound may safely exceed the pool
-     * size. It is the {@link ExternalSourceSettings#defaultBlobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
-     * value, so discovery throttles blob-store access with a node-size-scaled formula ({@code snapshot_meta} shape,
-     * capped at 100) instead of the raw {@code esql_worker.getMax()} pool size. This is discovery's derived default
-     * only; production data reads are bounded separately by {@link ExternalSourceSettings#MAX_CONNECTIONS}.
+     * size. It is the {@link ExternalSourceSettings#defaultDiscoveryConcurrency(org.elasticsearch.common.settings.Settings)}
+     * value, so discovery throttles its footer fan-out with a node-size-scaled formula ({@code snapshot_meta} shape,
+     * capped at 100) instead of the raw {@code esql_worker.getMax()} pool size. This bounds discovery only;
+     * production data reads are bounded separately by {@link ExternalSourceSettings#MAX_CONNECTIONS}.
      */
     protected int externalSourceConcurrency() {
-        return ExternalSourceSettings.defaultBlobStoreConcurrency(clusterService.getSettings());
+        return ExternalSourceSettings.defaultDiscoveryConcurrency(clusterService.getSettings());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -296,13 +296,13 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
      * outstanding, passed to {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver} as its fan-out
      * bound. Because footer reads are async (the {@code esql_worker} thread is released across the read), this caps
      * concurrent in-flight reads rather than pinning that many threads, so the bound may safely exceed the pool
-     * size. It is the {@link ExternalSourceSettings#defaultDiscoveryConcurrency(org.elasticsearch.common.settings.Settings)}
-     * value, so discovery throttles its footer fan-out with a node-size-scaled formula ({@code snapshot_meta} shape,
-     * capped at 100) instead of the raw {@code esql_worker.getMax()} pool size. This bounds discovery only;
-     * production data reads are bounded separately by {@link ExternalSourceSettings#MAX_CONNECTIONS}.
+     * size. It is the shared {@link ExternalSourceSettings#defaultBlobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
+     * value, so discovery throttles its footer fan-out with the same node-size-scaled blob-store formula
+     * ({@code snapshot_meta} shape, capped at 100) the data-read path uses, instead of the raw
+     * {@code esql_worker.getMax()} pool size.
      */
     protected int externalSourceConcurrency() {
-        return ExternalSourceSettings.defaultDiscoveryConcurrency(clusterService.getSettings());
+        return ExternalSourceSettings.defaultBlobStoreConcurrency(clusterService.getSettings());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -296,13 +296,14 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
      * outstanding, passed to {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver} as its fan-out
      * bound. Because footer reads are async (the {@code esql_worker} thread is released across the read), this caps
      * concurrent in-flight reads rather than pinning that many threads, so the bound may safely exceed the pool
-     * size. It is the shared {@link ExternalSourceSettings#defaultBlobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
-     * value, so discovery throttles its footer fan-out with the same node-size-scaled blob-store formula
-     * ({@code snapshot_meta} shape, capped at 100) the data-read path uses, instead of the raw
-     * {@code esql_worker.getMax()} pool size.
+     * size. It is the shared {@link ExternalSourceSettings#blobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
+     * value — the single effective blob-store access concurrency that the data-read path also reads — so discovery
+     * throttles its footer fan-out with the same node-size-scaled formula ({@code snapshot_meta} shape, capped at
+     * 100, and any operator override once that setting lands) instead of the raw {@code esql_worker.getMax()} pool
+     * size.
      */
     protected int externalSourceConcurrency() {
-        return ExternalSourceSettings.defaultBlobStoreConcurrency(clusterService.getSettings());
+        return ExternalSourceSettings.blobStoreConcurrency(clusterService.getSettings());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -296,10 +296,10 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
      * outstanding, passed to {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver} as its fan-out
      * bound. Because footer reads are async (the {@code esql_worker} thread is released across the read), this caps
      * concurrent in-flight reads rather than pinning that many threads, so the bound may safely exceed the pool
-     * size. It is the shared {@link ExternalSourceSettings#defaultBlobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
-     * value so metadata
-     * discovery and data retrieval throttle blob-store access with one consistent, node-size-scaled formula
-     * ({@code snapshot_meta} shape, capped at 100) instead of the raw {@code esql_worker.getMax()} pool size.
+     * size. It is the {@link ExternalSourceSettings#defaultBlobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
+     * value, so discovery throttles blob-store access with a node-size-scaled formula ({@code snapshot_meta} shape,
+     * capped at 100) instead of the raw {@code esql_worker.getMax()} pool size. This is discovery's derived default
+     * only; production data reads are bounded separately by {@link ExternalSourceSettings#MAX_CONNECTIONS}.
      */
     protected int externalSourceConcurrency() {
         return ExternalSourceSettings.defaultBlobStoreConcurrency(clusterService.getSettings());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -62,6 +62,7 @@ import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
 import org.elasticsearch.xpack.esql.core.async.AsyncTaskManagementService;
 import org.elasticsearch.xpack.esql.core.expression.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.datasources.DatasetResolver;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
 import org.elasticsearch.xpack.esql.enrich.AbstractLookupService;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
@@ -293,13 +294,15 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     /**
      * Maximum number of in-flight per-file metadata (footer) reads a single multi-file resolution may have
      * outstanding, passed to {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver} as its fan-out
-     * bound. Sized to the {@link #externalSourceExecutor()} pool's max ({@code esql_worker.getMax()}) so that a wide
-     * wildcard discovery cannot exceed the pool it runs on: footer reads are async (the worker is released across the
-     * read), so this caps concurrent in-flight reads rather than pinning that many threads. Kept alongside
-     * {@link #externalSourceExecutor()} so the executor and its fan-out bound stay wired to the same pool.
+     * bound. Because footer reads are async (the {@code esql_worker} thread is released across the read), this caps
+     * concurrent in-flight reads rather than pinning that many threads, so the bound may safely exceed the pool
+     * size. It is the shared {@link ExternalSourceSettings#defaultBlobStoreConcurrency(org.elasticsearch.common.settings.Settings)}
+     * value so metadata
+     * discovery and data retrieval throttle blob-store access with one consistent, node-size-scaled formula
+     * ({@code snapshot_meta} shape, capped at 100) instead of the raw {@code esql_worker.getMax()} pool size.
      */
     protected int externalSourceConcurrency() {
-        return threadPool.info(externalSourceExecutorName()).getMax();
+        return ExternalSourceSettings.defaultBlobStoreConcurrency(clusterService.getSettings());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -291,12 +291,24 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     }
 
     /**
+     * Maximum number of in-flight per-file metadata (footer) reads a single multi-file resolution may have
+     * outstanding, passed to {@link org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver} as its fan-out
+     * bound. Sized to the {@link #externalSourceExecutor()} pool's max ({@code esql_worker.getMax()}) so that a wide
+     * wildcard discovery cannot exceed the pool it runs on: footer reads are async (the worker is released across the
+     * read), so this caps concurrent in-flight reads rather than pinning that many threads. Kept alongside
+     * {@link #externalSourceExecutor()} so the executor and its fan-out bound stay wired to the same pool.
+     */
+    protected int externalSourceConcurrency() {
+        return threadPool.info(externalSourceExecutorName()).getMax();
+    }
+
+    /**
      * Name of the thread pool backing {@link #externalSourceExecutor()}. Extracted so unit tests can pin the wiring
      * without needing a live {@link ThreadPool}. Must not resolve to {@link ThreadPool.Names#SEARCH}: a single
      * wildcard external query previously consumed nearly the entire SEARCH pool during resolution, starving unrelated
      * searches and other ES|QL queries.
      */
-    static String externalSourceExecutorName() {
+    public static String externalSourceExecutorName() {
         return ESQL_WORKER_THREAD_POOL_NAME;
     }
 
@@ -393,6 +405,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             planRunner,
             services,
             externalSourceExecutor(),
+            externalSourceConcurrency(),
             ((CancellableTask) task)::isCancelled,
             ActionListener.wrap(result -> {
                 recordCCSTelemetry(task, executionInfo, request, null);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.logging.HeaderWarning;
@@ -43,6 +44,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -56,6 +58,11 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
@@ -2493,6 +2500,244 @@ public class ExternalSourceResolverTests extends ESTestCase {
         return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, cacheService);
     }
 
+    // ===== Async fan-out tests =====
+
+    /**
+     * The multi-file fan-out must overlap per-file metadata reads up to the configured permit count
+     * even when the resolver executor is a single thread, and must never exceed it. A synchronous /
+     * thread-per-read resolver pinned to one thread could only ever have one read in flight; observing
+     * a max in-flight equal to the permit count therefore proves both the permit bound and that the
+     * pool thread is released across the (simulated) network read.
+     */
+    public void testAsyncFanOutRespectsPermitBoundBeyondResolverThreads() throws Exception {
+        int permits = 4;
+        int fileCount = 40;
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        List<StorageEntry> listing = new java.util.ArrayList<>();
+        List<Attribute> schema = List.of(attr("emp_no", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        for (int i = 0; i < fileCount; i++) {
+            String path = String.format(Locale.ROOT, "s3://bucket/data/file%02d.parquet", i);
+            schemasByPath.put(path, schema);
+            listing.add(entry(path, 100 + i));
+        }
+
+        ExecutorService resolverExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService readPool = Executors.newFixedThreadPool(permits);
+        CountDownLatch gate = new CountDownLatch(1);
+        AsyncStubFormatReader reader = new AsyncStubFormatReader(schemasByPath, readPool, gate, permits, null);
+        try {
+            String glob = "s3://bucket/data/*.parquet";
+            ExternalSourceResolution resolution = resolveWithAsyncReader(glob, schemasByPath, listing, reader, resolverExecutor, permits);
+
+            assertNotNull(resolution.resolvedSource(glob));
+            assertEquals("max in-flight reads must equal the permit count", permits, reader.maxInFlight.get());
+            assertEquals("all files must be read", fileCount, reader.totalReads.get());
+        } finally {
+            resolverExecutor.shutdownNow();
+            readPool.shutdownNow();
+        }
+    }
+
+    /**
+     * A single per-file read failure on the reconciliation path (UNION_BY_NAME) must fail the whole
+     * resolve promptly rather than hang or return a partial result. The failure originates in the
+     * async reader and must surface through the listener-driven gather.
+     */
+    public void testAsyncFanOutFailsFastOnReadError() throws Exception {
+        int fileCount = 12;
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        List<StorageEntry> listing = new java.util.ArrayList<>();
+        List<Attribute> schema = List.of(attr("emp_no", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        String failPath = null;
+        for (int i = 0; i < fileCount; i++) {
+            String path = String.format(Locale.ROOT, "s3://bucket/data/file%02d.parquet", i);
+            schemasByPath.put(path, schema);
+            listing.add(entry(path, 100 + i));
+            if (i == fileCount / 2) {
+                failPath = path;
+            }
+        }
+
+        ExecutorService resolverExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService readPool = Executors.newFixedThreadPool(4);
+        // gate == null: reads complete without a concurrency rendezvous so the fast-fail short-circuit
+        // (which drains the remaining files without issuing reads) cannot deadlock on an unmet barrier.
+        AsyncStubFormatReader reader = new AsyncStubFormatReader(schemasByPath, readPool, null, 0, failPath);
+        try {
+            String glob = "s3://bucket/data/*.parquet";
+            Map<String, Object> config = Map.of("schema_resolution", "union_by_name");
+
+            Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+            StoragePath sp = StoragePath.of(glob);
+            listingsByPrefix.put(sp.patternPrefix().toString(), listing);
+            ExternalSourceResolver resolver = createResolverWithAsyncReader(schemasByPath, listingsByPrefix, reader, resolverExecutor, 4);
+
+            PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+            resolver.resolve(List.of(glob), Map.of(glob, new HashMap<>(config)), future);
+
+            Exception e = expectThrows(Exception.class, () -> future.actionGet(30, TimeUnit.SECONDS));
+            assertThat(e.getMessage(), containsString("Failed to resolve metadata"));
+        } finally {
+            resolverExecutor.shutdownNow();
+            readPool.shutdownNow();
+        }
+    }
+
+    private ExternalSourceResolution resolveWithAsyncReader(
+        String glob,
+        Map<String, List<Attribute>> schemasByPath,
+        List<StorageEntry> listing,
+        FormatReader reader,
+        Executor resolverExecutor,
+        int permits
+    ) {
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        StoragePath sp = StoragePath.of(glob);
+        listingsByPrefix.put(sp.patternPrefix().toString(), listing);
+        ExternalSourceResolver resolver = createResolverWithAsyncReader(schemasByPath, listingsByPrefix, reader, resolverExecutor, permits);
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of(glob), Map.of(glob, new HashMap<>()), future);
+        return future.actionGet(30, TimeUnit.SECONDS);
+    }
+
+    private ExternalSourceResolver createResolverWithAsyncReader(
+        Map<String, List<Attribute>> schemasByPath,
+        Map<String, List<StorageEntry>> listingsByPrefix,
+        FormatReader formatReader,
+        Executor resolverExecutor,
+        int permits
+    ) {
+        StubStorageProvider storageProvider = new StubStorageProvider(listingsByPrefix, schemasByPath);
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", stubStorageProviderFactory(storageProvider));
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            new DataSourceCredentials(),
+            () -> false
+        );
+        return new ExternalSourceResolver(resolverExecutor, module, Settings.EMPTY, null, permits);
+    }
+
+    /**
+     * A {@link FormatReader} whose {@link #metadataAsync} completes on a dedicated read pool (never on
+     * the resolver executor passed to it), simulating a non-blocking footer read. It records the peak
+     * number of concurrently in-flight reads. When a {@code gate} is supplied, each read blocks on it
+     * until {@code permits} reads are concurrently in flight (the gate is released by the read that
+     * first observes that level), which makes the observed peak deterministic; when {@code gate} is
+     * {@code null} reads complete without rendezvous. A configured {@code failPath} fails that file's
+     * read with an {@link IOException}.
+     */
+    private static class AsyncStubFormatReader implements NoConfigFormatReader {
+        private final Map<String, List<Attribute>> schemasByPath;
+        private final ExecutorService readPool;
+        private final CountDownLatch gate;
+        private final int permits;
+        private final String failPath;
+        final AtomicInteger inFlight = new AtomicInteger();
+        final AtomicInteger maxInFlight = new AtomicInteger();
+        final AtomicInteger totalReads = new AtomicInteger();
+
+        AsyncStubFormatReader(
+            Map<String, List<Attribute>> schemasByPath,
+            ExecutorService readPool,
+            CountDownLatch gate,
+            int permits,
+            String failPath
+        ) {
+            this.schemasByPath = schemasByPath;
+            this.readPool = readPool;
+            this.gate = gate;
+            this.permits = permits;
+            this.failPath = failPath;
+        }
+
+        @Override
+        public void metadataAsync(StorageObject object, Executor executor, ActionListener<SourceMetadata> listener) {
+            readPool.execute(() -> {
+                String path = object.path().toString();
+                if (path.equals(failPath)) {
+                    listener.onFailure(new IOException("simulated read failure for " + path));
+                    return;
+                }
+                try {
+                    int cur = inFlight.incrementAndGet();
+                    maxInFlight.accumulateAndGet(cur, Math::max);
+                    totalReads.incrementAndGet();
+                    if (gate != null) {
+                        if (cur >= permits) {
+                            gate.countDown();
+                        }
+                        gate.await(30, TimeUnit.SECONDS);
+                    }
+                    inFlight.decrementAndGet();
+                    listener.onResponse(metadata(object));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            String path = object.path().toString();
+            List<Attribute> schema = schemasByPath.get(path);
+            if (schema == null) {
+                throw new IllegalArgumentException("No schema configured for path: " + path);
+            }
+            return new StubSourceMetadata(path, schema);
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatName() {
+            return "parquet";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public RowPositionStrategy rowPositionStrategy() {
+            return PassThroughRowPositionStrategy.INSTANCE;
+        }
+
+        @Override
+        public void close() {}
+    }
+
     // ===== Stub implementations =====
 
     private static class StubFormatReader implements NoConfigFormatReader {
@@ -2788,11 +3033,15 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         @Override
         public StorageObject newObject(StoragePath path, long length) {
+            // Listing-hinted construction is a schema-object creation too (the async multi-file path
+            // now builds the object from listing length/mtime instead of a bare newObject + exists()).
+            schemaCallCount.incrementAndGet();
             return delegate.newObject(path, length);
         }
 
         @Override
         public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            schemaCallCount.incrementAndGet();
             return delegate.newObject(path, length, lastModified);
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
@@ -29,7 +29,7 @@ public class PlanExecutorTests extends ESTestCase {
      * {@link TransportEsqlQueryAction} and {@link PlanExecutor#esql}: external discovery must run on the
      * {@code esql_worker} pool (isolated from {@code SEARCH}, so a wide wildcard cannot starve regular searches) and its
      * multi-file metadata fan-out must be bounded by discovery's derived default concurrency
-     * ({@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
+     * ({@link ExternalSourceSettings#defaultDiscoveryConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
      * 100) rather than the raw pool size. The fan-out may exceed the pool size because footer reads are async (the
      * worker is released across the read).
      * <p>
@@ -55,7 +55,7 @@ public class PlanExecutorTests extends ESTestCase {
         List<ExecutorBuilder<?>> builders = plugin.getExecutorBuilders(settings);
         ThreadPool threadPool = new TestThreadPool("test", settings, builders.toArray(new ExecutorBuilder<?>[0]));
         try {
-            int fanOut = ExternalSourceSettings.defaultBlobStoreConcurrency(settings);
+            int fanOut = ExternalSourceSettings.defaultDiscoveryConcurrency(settings);
             Executor esqlWorker = threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);
 
             ExternalSourceResolver resolver = PlanExecutor.createExternalSourceResolver(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
@@ -28,10 +28,10 @@ public class PlanExecutorTests extends ESTestCase {
      * Locks the PR-A wiring invariants that would otherwise only hold implicitly across
      * {@link TransportEsqlQueryAction} and {@link PlanExecutor#esql}: external discovery must run on the
      * {@code esql_worker} pool (isolated from {@code SEARCH}, so a wide wildcard cannot starve regular searches) and its
-     * multi-file metadata fan-out must be bounded by discovery's derived default concurrency
-     * ({@link ExternalSourceSettings#defaultDiscoveryConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
-     * 100) rather than the raw pool size. The fan-out may exceed the pool size because footer reads are async (the
-     * worker is released across the read).
+     * multi-file metadata fan-out must be bounded by the shared blob-store access concurrency
+     * ({@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
+     * 100 — the same formula the data-read path uses) rather than the raw pool size. The fan-out may exceed the pool
+     * size because footer reads are async (the worker is released across the read).
      * <p>
      * The pool selection and the fan-out bound live in {@link TransportEsqlQueryAction}
      * ({@code externalSourceExecutorName()} / {@code externalSourceConcurrency()}); this test pins both there and then
@@ -55,7 +55,7 @@ public class PlanExecutorTests extends ESTestCase {
         List<ExecutorBuilder<?>> builders = plugin.getExecutorBuilders(settings);
         ThreadPool threadPool = new TestThreadPool("test", settings, builders.toArray(new ExecutorBuilder<?>[0]));
         try {
-            int fanOut = ExternalSourceSettings.defaultDiscoveryConcurrency(settings);
+            int fanOut = ExternalSourceSettings.defaultBlobStoreConcurrency(settings);
             Executor esqlWorker = threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);
 
             ExternalSourceResolver resolver = PlanExecutor.createExternalSourceResolver(
@@ -67,7 +67,7 @@ public class PlanExecutorTests extends ESTestCase {
                 fanOut
             );
 
-            assertEquals("fan-out permit must be discovery's derived default concurrency", fanOut, resolver.metadataReadConcurrency());
+            assertEquals("fan-out permit must be the shared blob-store access concurrency", fanOut, resolver.metadataReadConcurrency());
             assertSame("discovery must run on the esql_worker executor", esqlWorker, resolver.executor());
             assertNotSame("discovery must not run on the SEARCH pool", threadPool.executor(ThreadPool.Names.SEARCH), resolver.executor());
         } finally {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
@@ -29,9 +29,9 @@ public class PlanExecutorTests extends ESTestCase {
      * {@link TransportEsqlQueryAction} and {@link PlanExecutor#esql}: external discovery must run on the
      * {@code esql_worker} pool (isolated from {@code SEARCH}, so a wide wildcard cannot starve regular searches) and its
      * multi-file metadata fan-out must be bounded by the shared blob-store access concurrency
-     * ({@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
-     * 100 — the same formula the data-read path uses) rather than the raw pool size. The fan-out may exceed the pool
-     * size because footer reads are async (the worker is released across the read).
+     * ({@link ExternalSourceSettings#blobStoreConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
+     * 100 — the same effective knob the data-read path uses) rather than the raw pool size. The fan-out may exceed
+     * the pool size because footer reads are async (the worker is released across the read).
      * <p>
      * The pool selection and the fan-out bound live in {@link TransportEsqlQueryAction}
      * ({@code externalSourceExecutorName()} / {@code externalSourceConcurrency()}); this test pins both there and then
@@ -55,7 +55,7 @@ public class PlanExecutorTests extends ESTestCase {
         List<ExecutorBuilder<?>> builders = plugin.getExecutorBuilders(settings);
         ThreadPool threadPool = new TestThreadPool("test", settings, builders.toArray(new ExecutorBuilder<?>[0]));
         try {
-            int fanOut = ExternalSourceSettings.defaultBlobStoreConcurrency(settings);
+            int fanOut = ExternalSourceSettings.blobStoreConcurrency(settings);
             Executor esqlWorker = threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);
 
             ExternalSourceResolver resolver = PlanExecutor.createExternalSourceResolver(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.execution;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ExecutorBuilder;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
+import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.TransportEsqlQueryAction;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
+
+public class PlanExecutorTests extends ESTestCase {
+
+    /**
+     * Locks the PR-A wiring invariants that would otherwise only hold implicitly across
+     * {@link TransportEsqlQueryAction} and {@link PlanExecutor#esql}: external discovery must run on the
+     * {@code esql_worker} pool (isolated from {@code SEARCH}, so a wide wildcard cannot starve regular searches) and its
+     * multi-file metadata fan-out must be bounded by exactly that pool's configured max, so a wide discovery cannot
+     * outrun the pool it shares with query execution.
+     * <p>
+     * The pool selection and the {@code getMax()} fan-out bound live in {@link TransportEsqlQueryAction}
+     * ({@code externalSourceExecutorName()} / {@code externalSourceConcurrency()}); this test pins both there and then
+     * confirms {@link PlanExecutor#createExternalSourceResolver} binds the supplied executor and concurrency onto the
+     * resolver verbatim (no silent re-homing back to a blocking or SEARCH pool).
+     */
+    public void testExternalSourceResolverWiredToEsqlWorkerPool() {
+        assertEquals(
+            "external discovery must target the esql_worker pool, isolated from SEARCH",
+            ESQL_WORKER_THREAD_POOL_NAME,
+            TransportEsqlQueryAction.externalSourceExecutorName()
+        );
+        assertNotEquals(
+            "esql_worker must not be the SEARCH pool",
+            ThreadPool.Names.SEARCH,
+            TransportEsqlQueryAction.externalSourceExecutorName()
+        );
+
+        EsqlPlugin plugin = new EsqlPlugin();
+        Settings settings = Settings.builder().put("node.name", "test").build();
+        List<ExecutorBuilder<?>> builders = plugin.getExecutorBuilders(settings);
+        ThreadPool threadPool = new TestThreadPool("test", settings, builders.toArray(new ExecutorBuilder<?>[0]));
+        try {
+            int esqlWorkerMax = threadPool.info(ESQL_WORKER_THREAD_POOL_NAME).getMax();
+            Executor esqlWorker = threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);
+
+            ExternalSourceResolver resolver = PlanExecutor.createExternalSourceResolver(
+                esqlWorker,
+                null,
+                Settings.EMPTY,
+                null,
+                () -> false,
+                esqlWorkerMax
+            );
+
+            assertEquals("fan-out permit must equal the esql_worker pool size", esqlWorkerMax, resolver.metadataReadConcurrency());
+            assertSame("discovery must run on the esql_worker executor", esqlWorker, resolver.executor());
+            assertNotSame("discovery must not run on the SEARCH pool", threadPool.executor(ThreadPool.Names.SEARCH), resolver.executor());
+        } finally {
+            terminate(threadPool);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
@@ -28,10 +28,10 @@ public class PlanExecutorTests extends ESTestCase {
      * Locks the PR-A wiring invariants that would otherwise only hold implicitly across
      * {@link TransportEsqlQueryAction} and {@link PlanExecutor#esql}: external discovery must run on the
      * {@code esql_worker} pool (isolated from {@code SEARCH}, so a wide wildcard cannot starve regular searches) and its
-     * multi-file metadata fan-out must be bounded by the shared blob-store access concurrency
-     * ({@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)}) — the same formula the data-read path
-     * uses — so discovery and data retrieval throttle object-store access consistently. The fan-out may exceed the
-     * pool size because footer reads are async (the worker is released across the read).
+     * multi-file metadata fan-out must be bounded by discovery's derived default concurrency
+     * ({@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)}, the {@code snapshot_meta} shape capped at
+     * 100) rather than the raw pool size. The fan-out may exceed the pool size because footer reads are async (the
+     * worker is released across the read).
      * <p>
      * The pool selection and the fan-out bound live in {@link TransportEsqlQueryAction}
      * ({@code externalSourceExecutorName()} / {@code externalSourceConcurrency()}); this test pins both there and then
@@ -67,7 +67,7 @@ public class PlanExecutorTests extends ESTestCase {
                 fanOut
             );
 
-            assertEquals("fan-out permit must be the shared blob-store access concurrency", fanOut, resolver.metadataReadConcurrency());
+            assertEquals("fan-out permit must be discovery's derived default concurrency", fanOut, resolver.metadataReadConcurrency());
             assertSame("discovery must run on the esql_worker executor", esqlWorker, resolver.executor());
             assertNotSame("discovery must not run on the SEARCH pool", threadPool.executor(ThreadPool.Names.SEARCH), resolver.executor());
         } finally {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/execution/PlanExecutorTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.TransportEsqlQueryAction;
 
@@ -27,10 +28,12 @@ public class PlanExecutorTests extends ESTestCase {
      * Locks the PR-A wiring invariants that would otherwise only hold implicitly across
      * {@link TransportEsqlQueryAction} and {@link PlanExecutor#esql}: external discovery must run on the
      * {@code esql_worker} pool (isolated from {@code SEARCH}, so a wide wildcard cannot starve regular searches) and its
-     * multi-file metadata fan-out must be bounded by exactly that pool's configured max, so a wide discovery cannot
-     * outrun the pool it shares with query execution.
+     * multi-file metadata fan-out must be bounded by the shared blob-store access concurrency
+     * ({@link ExternalSourceSettings#defaultBlobStoreConcurrency(Settings)}) — the same formula the data-read path
+     * uses — so discovery and data retrieval throttle object-store access consistently. The fan-out may exceed the
+     * pool size because footer reads are async (the worker is released across the read).
      * <p>
-     * The pool selection and the {@code getMax()} fan-out bound live in {@link TransportEsqlQueryAction}
+     * The pool selection and the fan-out bound live in {@link TransportEsqlQueryAction}
      * ({@code externalSourceExecutorName()} / {@code externalSourceConcurrency()}); this test pins both there and then
      * confirms {@link PlanExecutor#createExternalSourceResolver} binds the supplied executor and concurrency onto the
      * resolver verbatim (no silent re-homing back to a blocking or SEARCH pool).
@@ -52,7 +55,7 @@ public class PlanExecutorTests extends ESTestCase {
         List<ExecutorBuilder<?>> builders = plugin.getExecutorBuilders(settings);
         ThreadPool threadPool = new TestThreadPool("test", settings, builders.toArray(new ExecutorBuilder<?>[0]));
         try {
-            int esqlWorkerMax = threadPool.info(ESQL_WORKER_THREAD_POOL_NAME).getMax();
+            int fanOut = ExternalSourceSettings.defaultBlobStoreConcurrency(settings);
             Executor esqlWorker = threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);
 
             ExternalSourceResolver resolver = PlanExecutor.createExternalSourceResolver(
@@ -61,10 +64,10 @@ public class PlanExecutorTests extends ESTestCase {
                 Settings.EMPTY,
                 null,
                 () -> false,
-                esqlWorkerMax
+                fanOut
             );
 
-            assertEquals("fan-out permit must equal the esql_worker pool size", esqlWorkerMax, resolver.metadataReadConcurrency());
+            assertEquals("fan-out permit must be the shared blob-store access concurrency", fanOut, resolver.metadataReadConcurrency());
             assertSame("discovery must run on the esql_worker executor", esqlWorker, resolver.executor());
             assertNotSame("discovery must not run on the SEARCH pool", threadPool.executor(ThreadPool.Names.SEARCH), resolver.executor());
         } finally {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -245,6 +245,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     runPhase,
                     MOCK_TRANSPORT_ACTION_SERVICES,
                     EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                    1,
                     () -> false,
                     new ActionListener<>() {
                         @Override
@@ -285,6 +286,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                     runPhase,
                     MOCK_TRANSPORT_ACTION_SERVICES,
                     EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                    1,
                     () -> false,
                     new ActionListener<>() {
                         @Override
@@ -634,6 +636,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                 runPhase,
                 MOCK_TRANSPORT_ACTION_SERVICES,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                1,
                 () -> false,
                 listener
             );


### PR DESCRIPTION
Make external (Parquet/Iceberg) metadata discovery non-blocking so a
multi-file fan-out is bounded by an in-flight permit rather than by
pinned pool threads, and run it on esql_worker.

- FormatReader.metadataAsync and ExternalSourceFactory.resolveMetadataAsync
  add an async SPI seam; a nullable ListingHint carries listing length/mtime
  so listed files skip the exists()/length() HEAD round-trips.
- ParquetFormatReader.metadataAsync prefetches the footer tail via
  readBytesAsync and parses straight from the returned bytes
  (TailBackedInputFile), so the parse never depends on the footer-byte
  cache surviving; direct buffers are released even on a copy failure.
- ExternalSourceResolver replaces BoundedParallelGather with a
  listener-driven ThrottledIterator fan-out, guarded so a synchronous
  dispatch failure cannot leak a permit or hang completion.
- PlanExecutor wires the resolver to esql_worker with the fan-out permit
  equal to the pool size.