### PR TITLE
[Inference API] Fix ModelRegistryIT failures when endpoints are indexed

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -782,9 +782,6 @@ tests:
 - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
   method: testUpdatingFileBasedRoleAffectsAllProjects
   issue: https://github.com/elastic/elasticsearch/issues/152582
-- class: org.elasticsearch.xpack.inference.InferenceWithSecurityRestIT
-  method: test {p0=inference/80_region_policy_crud/Get region policy allowed with monitor_inference privilege}
-  issue: https://github.com/elastic/elasticsearch/issues/152587
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterWhere}
   issue: https://github.com/elastic/elasticsearch/issues/152591

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -1018,6 +1019,8 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
 
     private void storeModelDirectlyInIndexWithoutRegistry(Model model) {
         var listener = new PlainActionFuture<BulkResponse>();
+        var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        var featureService = getInstanceFromNode(FeatureService.class);
 
         client().prepareBulk()
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -1027,7 +1030,8 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
                     InferenceIndex.INDEX_NAME,
                     model.getConfigurations(),
                     false,
-                    true,
+                    clusterState,
+                    featureService,
                     client()
                 )
             )
@@ -1037,7 +1041,8 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
                     InferenceSecretsIndex.INDEX_NAME,
                     model.getSecrets(),
                     false,
-                    true,
+                    clusterState,
+                    featureService,
                     client()
                 )
             )
@@ -1258,6 +1263,8 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
 
     private void storeCorruptedModel(Model model, boolean storeSecrets) {
         var listener = new PlainActionFuture<BulkResponse>();
+        var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        var featureService = getInstanceFromNode(FeatureService.class);
 
         client().prepareBulk()
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -1267,7 +1274,8 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
                     storeSecrets ? InferenceSecretsIndex.INDEX_NAME : InferenceIndex.INDEX_NAME,
                     storeSecrets ? model.getSecrets() : model.getConfigurations(),
                     false,
-                    true,
+                    clusterState,
+                    featureService,
                     client()
                 )
             )

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
@@ -635,8 +635,7 @@ public class ModelRegistry implements ClusterStateListener {
             preventDeletionLock.add(inferenceEntityId);
         }
 
-        boolean includeDocType = InferencePlugin.INFERENCE_REGION_POLICY_FEATURE_FLAG.isEnabled()
-            && InferenceIndex.inferenceIndexHasV4Mappings(clusterService.state(), featureService);
+        var clusterState = clusterService.state();
         SubscribableListener.<BulkResponse>newForked((subListener) -> {
             // in this block, we try to update the stored model configurations
             var configRequestBuilder = createIndexRequestBuilder(
@@ -644,7 +643,8 @@ public class ModelRegistry implements ClusterStateListener {
                 InferenceIndex.INDEX_NAME,
                 newModel.getConfigurations(),
                 true,
-                includeDocType,
+                clusterState,
+                featureService,
                 client
             );
 
@@ -687,7 +687,8 @@ public class ModelRegistry implements ClusterStateListener {
                     InferenceSecretsIndex.INDEX_NAME,
                     newModel.getSecrets(),
                     true,
-                    includeDocType,
+                    clusterState,
+                    featureService,
                     client
                 );
 
@@ -711,7 +712,8 @@ public class ModelRegistry implements ClusterStateListener {
                     InferenceIndex.INDEX_NAME,
                     existingModel.getConfigurations(),
                     true,
-                    includeDocType,
+                    clusterState,
+                    featureService,
                     client
                 );
 
@@ -827,8 +829,7 @@ public class ModelRegistry implements ClusterStateListener {
         }
 
         var bulkRequestBuilder = client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-        boolean includeDocType = InferencePlugin.INFERENCE_REGION_POLICY_FEATURE_FLAG.isEnabled()
-            && InferenceIndex.inferenceIndexHasV4Mappings(clusterService.state(), featureService);
+        var clusterState = clusterService.state();
 
         for (var model : models) {
             bulkRequestBuilder.add(
@@ -837,7 +838,8 @@ public class ModelRegistry implements ClusterStateListener {
                     InferenceIndex.INDEX_NAME,
                     model.getConfigurations(),
                     allowOverwriting,
-                    includeDocType,
+                    clusterState,
+                    featureService,
                     client
                 )
             );
@@ -848,7 +850,8 @@ public class ModelRegistry implements ClusterStateListener {
                     InferenceSecretsIndex.INDEX_NAME,
                     model.getSecrets(),
                     allowOverwriting,
-                    includeDocType,
+                    clusterState,
+                    featureService,
                     client
                 )
             );
@@ -1247,9 +1250,13 @@ public class ModelRegistry implements ClusterStateListener {
         String indexName,
         ToXContentObject body,
         boolean allowOverwriting,
-        boolean includeDocType,
+        ClusterState clusterState,
+        FeatureService featureService,
         Client client
     ) {
+        boolean includeDocType = indexName.equals(InferenceIndex.INDEX_NAME)
+            && InferencePlugin.INFERENCE_REGION_POLICY_FEATURE_FLAG.isEnabled()
+            && InferenceIndex.inferenceIndexHasV4Mappings(clusterState, featureService);
         try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()) {
             Map<String, String> params = includeDocType
                 ? Map.of(


### PR DESCRIPTION
The ModelRegistryIT tests are indexing endpoints directly bypassing the guards for `doc_type`. This is fixing this by moving the guards in the method that is reused by the tests.

Closes #152560
Closes #152587
