### PR TITLE
Require columnar _id in strict columnar index modes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -17,6 +17,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
@@ -49,8 +50,29 @@ public abstract class IdFieldMapper extends MetadataFieldMapper {
             var indexMode = parserContext.getIndexSettings().getMode();
             if (indexMode == IndexMode.TIME_SERIES) {
                 throw new MapperParsingException(name + " is not configurable if index mode is time_series");
-            } else {
-                return super.parse(name, node, parserContext);
+            }
+            Builder builder = super.parse(name, node, parserContext);
+            requireColumnarIdInStrictColumnarMode(name, parserContext, builder);
+            return builder;
+        }
+
+        @Override
+        public Builder getDefaultBuilder(MappingParserContext parserContext) {
+            Builder builder = super.getDefaultBuilder(parserContext);
+            requireColumnarIdInStrictColumnarMode(NAME, parserContext, builder);
+            return builder;
+        }
+
+        private static void requireColumnarIdInStrictColumnarMode(String name, MappingParserContext parserContext, Builder builder) {
+            var indexSettings = parserContext.getIndexSettings();
+            // Columnar _id only became the strict-columnar default at MAPPING_ID_MODE_DEFAULT; indices created
+            // before that version may legitimately predate columnar _id support, so don't enforce it there.
+            if (indexSettings.getIndexVersionCreated().before(IndexVersions.MAPPING_ID_MODE_DEFAULT)) {
+                return;
+            }
+            var indexMode = indexSettings.getMode();
+            if (indexMode.isStrictColumnar() && ((IdFieldMapper) builder.build()).isColumnarMode() == false) {
+                throw new MapperParsingException(name + " mode [document] is not allowed in index using [" + indexMode + "] index mode");
             }
         }
     };

--- a/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.IndicesService;
@@ -186,5 +187,32 @@ public class ProvidedIdFieldMapperTests extends MapperServiceTestCase {
         MapperService mapperService = createMapperService(topMapping(b -> b.startObject("_id").field("mode", "document").endObject()));
         IdLoader idLoader = IdLoader.create(mapperService.getIndexSettings(), mapperService.mappingLookup());
         assertThat(idLoader, instanceOf(IdLoader.StoredIdLoader.class));
+    }
+
+    public void testStrictColumnarModesRejectExplicitDocumentId() {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            MapperParsingException e = expectThrows(
+                MapperParsingException.class,
+                () -> createMapperService(settings, topMapping(b -> b.startObject("_id").field("mode", "document").endObject()))
+            );
+            assertThat(e.getMessage(), containsString("_id mode [document] is not allowed in index using [" + indexMode + "]"));
+        }
+    }
+
+    public void testStrictColumnarModesRejectColumnarIdDisabledByDefault() {
+        assumeTrue("columnar index mode requires snapshot build", IndexMode.COLUMNAR_FEATURE_FLAG.isEnabled());
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder()
+                .put(IndexSettings.MODE.getKey(), indexMode.getName())
+                .put("index.mapping.use_columnar_id_mode_by_default", false)
+                .build();
+            MapperParsingException e = expectThrows(
+                MapperParsingException.class,
+                () -> createMapperService(settings, mapping(b -> {}))
+            );
+            assertThat(e.getMessage(), containsString("_id mode [document] is not allowed in index using [" + indexMode + "]"));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
@@ -208,10 +208,7 @@ public class ProvidedIdFieldMapperTests extends MapperServiceTestCase {
                 .put(IndexSettings.MODE.getKey(), indexMode.getName())
                 .put("index.mapping.use_columnar_id_mode_by_default", false)
                 .build();
-            MapperParsingException e = expectThrows(
-                MapperParsingException.class,
-                () -> createMapperService(settings, mapping(b -> {}))
-            );
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> createMapperService(settings, mapping(b -> {})));
             assertThat(e.getMessage(), containsString("_id mode [document] is not allowed in index using [" + indexMode + "]"));
         }
     }


### PR DESCRIPTION
## Summary
- Strict columnar index modes (`columnar`, `logsdb_columnar`) default `_id` to columnar storage (BINARY doc values, no stored field), but nothing enforced that default: a mapping could explicitly set `"_id": {"mode": "document"}`, or an index could set `index.mapping.use_columnar_id_mode_by_default: false`, and `_id` would silently end up as a stored field — undermining the "everything reconstructable from doc values, no stored fields" invariant these modes otherwise strictly enforce.
- `IdFieldMapper.PARSER` now rejects a resolved document-mode `_id` under strict columnar modes, in both the explicit-mapping (`parse`) and default (`getDefaultBuilder`) code paths, mirroring the existing rejection pattern for `subobjects`, `dynamic: runtime`, and `synthetic_source_keep` under the same modes.
- Indices created before `IndexVersions.MAPPING_ID_MODE_DEFAULT` are exempted, since columnar `_id` wasn't the default for strict columnar indices created on older versions.

Found while investigating test failures on #152481 — confirmed empirically that a real `index.mode=columnar` index with an explicit `_id.mode: document` mapping was previously accepted.

## Test plan
- [x] `ProvidedIdFieldMapperTests` (incl. 2 new tests covering both override paths, for both `COLUMNAR` and `LOGSDB_COLUMNAR`)
- [x] Full `org.elasticsearch.index.mapper.*` package sweep (8500+ tests), no failures