### PR TITLE
[9.4] Fix flaky BWC DFA source indices unavailable during rolling upgrade (#144925)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/90_ml_data_frame_analytics_crud.yml
@@ -33,6 +33,21 @@ setup:
       indices.refresh:
         index: bwc_ml_*
 
+  # Ensure source indices are fully replicated so they remain available when a
+  # node is taken offline during the rolling-upgrade mixed-cluster phase.
+  - do:
+      indices.put_settings:
+        index: bwc_ml_*
+        body:
+          settings:
+            index.number_of_replicas: 2
+
+  - do:
+      cluster.health:
+        index: bwc_ml_*
+        wait_for_status: green
+        timeout: 30s
+
 ---
 "Put outlier_detection job on the old cluster":
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix flaky BWC DFA source indices unavailable during rolling upgrade (#144925)](https://github.com/elastic/elasticsearch/pull/144925)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)