### PR TITLE
[ML] Add ingest model memory autoscaling SPI and service

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/IngestModelMemoryProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/IngestModelMemoryProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Extension point for reporting JVM heap bytes required to load DFA models referenced by ingest pipelines.
+ * Implemented by the ML plugin; consumed by serverless index-tier memory metrics without a compile dependency on ML.
+ */
+public interface IngestModelMemoryProvider {
+
+    record HeapRequirement(long heapBytes, boolean isExact) {}
+
+    AtomicReference<IngestModelMemoryProvider> REFERENCE = new AtomicReference<>(Noop.INSTANCE);
+
+    static IngestModelMemoryProvider getInstance() {
+        return REFERENCE.get();
+    }
+
+    static void setInstance(IngestModelMemoryProvider instance) {
+        Objects.requireNonNull(instance, "provider instance must not be null");
+        REFERENCE.set(instance);
+    }
+
+    /**
+     * Aggregate JVM heap bytes for DFA models referenced by ingest pipelines; no heap-to-container conversion.
+     */
+    HeapRequirement getRequiredHeapBytes();
+
+    final class Noop implements IngestModelMemoryProvider {
+
+        static final Noop INSTANCE = new Noop();
+
+        private Noop() {}
+
+        @Override
+        public HeapRequirement getRequiredHeapBytes() {
+            return new HeapRequirement(0L, true);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/IngestModelMemoryProviderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/IngestModelMemoryProviderTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class IngestModelMemoryProviderTests extends ESTestCase {
+
+    @Override
+    public void tearDown() throws Exception {
+        IngestModelMemoryProvider.setInstance(IngestModelMemoryProvider.Noop.INSTANCE);
+        super.tearDown();
+    }
+
+    public void testNoopProviderReturnsZeroExactBytes() {
+        IngestModelMemoryProvider provider = IngestModelMemoryProvider.getInstance();
+        IngestModelMemoryProvider.HeapRequirement requirement = provider.getRequiredHeapBytes();
+        assertThat(requirement.heapBytes(), equalTo(0L));
+        assertThat(requirement.isExact(), is(true));
+    }
+
+    public void testSetInstanceReplacesProvider() {
+        IngestModelMemoryProvider custom = () -> new IngestModelMemoryProvider.HeapRequirement(100L, false);
+        IngestModelMemoryProvider.setInstance(custom);
+        IngestModelMemoryProvider.HeapRequirement requirement = IngestModelMemoryProvider.getInstance().getRequiredHeapBytes();
+        assertThat(requirement.heapBytes(), equalTo(100L));
+        assertThat(requirement.isExact(), is(false));
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -187,6 +187,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.MlDataFrameAnalysisNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.dataframe.stats.AnalysisStatsNamedWriteablesProvider;
+import org.elasticsearch.xpack.core.ml.inference.IngestModelMemoryProvider;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.ModelAliasMetadata;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelCacheMetadata;
@@ -331,6 +332,7 @@ import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentClu
 import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentService;
 import org.elasticsearch.xpack.ml.inference.deployment.DeploymentManager;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
+import org.elasticsearch.xpack.ml.inference.ingest.IngestModelMemoryService;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.ltr.LearningToRankRescorerBuilder;
 import org.elasticsearch.xpack.ml.inference.ltr.LearningToRankService;
@@ -1281,6 +1283,14 @@ public class MachineLearning extends Plugin
         );
         this.modelLoadingService.set(modelLoadingService);
 
+        final IngestModelMemoryService ingestModelMemoryService = new IngestModelMemoryService(
+            clusterService,
+            trainedModelProvider,
+            threadPool
+        );
+        clusterService.addListener(ingestModelMemoryService);
+        IngestModelMemoryProvider.setInstance(ingestModelMemoryService);
+
         this.learningToRankService.set(
             new LearningToRankService(modelLoadingService, trainedModelProvider, services.scriptService(), services.xContentRegistry())
         );
@@ -1485,6 +1495,7 @@ public class MachineLearning extends Plugin
             dataFrameAnalyticsConfigProvider,
             nativeStorageProvider,
             modelLoadingService,
+            ingestModelMemoryService,
             trainedModelCacheMetadataService,
             trainedModelProvider,
             trainedModelAssignmentService,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryService.java
@@ -147,6 +147,15 @@ public class IngestModelMemoryService implements ClusterStateListener, IngestMod
             globalModelSizes.putIfAbsent(modelId, OptionalLong.empty());
             scheduleFetchIfNeeded(modelId);
         }
+        if (added.isEmpty() == false || removed.isEmpty() == false) {
+            logger.info(
+                "RFC 0007 ingest model references changed for project [{}]: added={}, removed={}, tracked_models={}",
+                projectId,
+                added,
+                removed,
+                perProject.size()
+            );
+        }
     }
 
     private void reconcileGlobalAfterProjectDrop(String modelId) {
@@ -193,6 +202,12 @@ public class IngestModelMemoryService implements ClusterStateListener, IngestMod
                 perProject.put(modelId, size);
             }
         }
+        logger.info(
+            "RFC 0007 ingest model heap size resolved for model [{}]: size_bytes={}, present={}",
+            modelId,
+            size.isPresent() ? size.getAsLong() : 0L,
+            size.isPresent()
+        );
     }
 
     // Visible for tests

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryService.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.ingest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
+import org.elasticsearch.xpack.core.ml.inference.IngestModelMemoryProvider;
+import org.elasticsearch.xpack.core.ml.inference.ModelAliasMetadata;
+import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+
+import java.util.HashSet;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Master-only service that tracks JVM heap bytes required to load DFA models referenced by ingest pipelines.
+ */
+public class IngestModelMemoryService implements ClusterStateListener, IngestModelMemoryProvider {
+
+    private static final Logger logger = LogManager.getLogger(IngestModelMemoryService.class);
+
+    private final TrainedModelProvider trainedModelProvider;
+    private final ThreadPool threadPool;
+
+    private final ConcurrentHashMap<ProjectId, ConcurrentHashMap<String, OptionalLong>> modelSizesByProject = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, OptionalLong> globalModelSizes = new ConcurrentHashMap<>();
+    private final Set<String> fetchScheduledModelIds = ConcurrentHashMap.newKeySet();
+
+    public IngestModelMemoryService(ClusterService clusterService, TrainedModelProvider trainedModelProvider, ThreadPool threadPool) {
+        this.trainedModelProvider = trainedModelProvider;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.state().nodes().isLocalNodeElectedMaster() == false) {
+            clearAllState();
+            return;
+        }
+
+        if (becameMaster(event)) {
+            repopulateAllProjects(event.state());
+            return;
+        }
+
+        handleRemovedProjects(event);
+        handleAddedProjects(event);
+        handleChangedProjects(event);
+    }
+
+    private static boolean becameMaster(ClusterChangedEvent event) {
+        return event.localNodeMaster() && event.previousState().nodes().isLocalNodeElectedMaster() == false;
+    }
+
+    private void repopulateAllProjects(ClusterState state) {
+        clearAllState();
+        for (ProjectMetadata project : state.metadata().projects().values()) {
+            refreshProjectFromFullScan(project.id(), state);
+        }
+    }
+
+    private void handleRemovedProjects(ClusterChangedEvent event) {
+        for (ProjectId removed : event.projectDelta().removed()) {
+            ConcurrentHashMap<String, OptionalLong> removedMap = modelSizesByProject.remove(removed);
+            if (removedMap != null) {
+                removedMap.keySet().forEach(this::reconcileGlobalAfterProjectDrop);
+            }
+        }
+    }
+
+    private void handleAddedProjects(ClusterChangedEvent event) {
+        for (ProjectId added : event.projectDelta().added()) {
+            if (ingestOrAliasRelevant(event, added)) {
+                refreshProjectFromFullScan(added, event.state());
+            }
+        }
+    }
+
+    private void handleChangedProjects(ClusterChangedEvent event) {
+        for (ProjectMetadata project : event.state().metadata().projects().values()) {
+            ProjectId projectId = project.id();
+            if (event.projectDelta().added().contains(projectId)) {
+                continue;
+            }
+            if (event.customMetadataChanged(projectId, IngestMetadata.TYPE)
+                || event.customMetadataChanged(projectId, ModelAliasMetadata.NAME)) {
+                refreshProjectFromFullScan(projectId, event.state());
+            }
+        }
+    }
+
+    @Override
+    public HeapRequirement getRequiredHeapBytes() {
+        long total = 0L;
+        boolean exact = true;
+        for (OptionalLong size : globalModelSizes.values()) {
+            if (size.isPresent()) {
+                total += size.getAsLong();
+            } else {
+                exact = false;
+            }
+        }
+        return new HeapRequirement(total, exact);
+    }
+
+    private void clearAllState() {
+        modelSizesByProject.clear();
+        globalModelSizes.clear();
+        fetchScheduledModelIds.clear();
+    }
+
+    private boolean ingestOrAliasRelevant(ClusterChangedEvent event, ProjectId projectId) {
+        return event.customMetadataChanged(projectId, IngestMetadata.TYPE)
+            || event.customMetadataChanged(projectId, ModelAliasMetadata.NAME)
+            || event.previousState().metadata().projects().get(projectId) == null;
+    }
+
+    private void refreshProjectFromFullScan(ProjectId projectId, ClusterState state) {
+        Set<String> nowReferenced = IngestPipelineModelReferences.resolveReferencedModelsForProject(state, projectId);
+        ConcurrentHashMap<String, OptionalLong> perProject = modelSizesByProject.computeIfAbsent(projectId, k -> new ConcurrentHashMap<>());
+        Set<String> current = new HashSet<>(perProject.keySet());
+        Set<String> added = Sets.difference(nowReferenced, current);
+        Set<String> removed = Sets.difference(current, nowReferenced);
+        removed.forEach(modelId -> {
+            perProject.remove(modelId);
+            reconcileGlobalAfterProjectDrop(modelId);
+        });
+        for (String modelId : added) {
+            perProject.put(modelId, OptionalLong.empty());
+            globalModelSizes.putIfAbsent(modelId, OptionalLong.empty());
+            scheduleFetchIfNeeded(modelId);
+        }
+    }
+
+    private void reconcileGlobalAfterProjectDrop(String modelId) {
+        boolean stillReferenced = modelSizesByProject.values().stream().anyMatch(map -> map.containsKey(modelId));
+        if (stillReferenced == false) {
+            globalModelSizes.remove(modelId);
+            fetchScheduledModelIds.remove(modelId);
+        }
+    }
+
+    private void scheduleFetchIfNeeded(String modelId) {
+        OptionalLong currentSize = globalModelSizes.get(modelId);
+        if (currentSize != null && currentSize.isPresent()) {
+            return;
+        }
+        if (fetchScheduledModelIds.add(modelId) == false) {
+            return;
+        }
+        threadPool.executor(ThreadPool.Names.MANAGEMENT)
+            .execute(
+                () -> trainedModelProvider.getTrainedModel(
+                    modelId,
+                    GetTrainedModelsAction.Includes.empty(),
+                    null,
+                    ActionListener.wrap(config -> {
+                        propagateModelSize(modelId, toStoredSize(config.getModelSize()));
+                        fetchScheduledModelIds.remove(modelId);
+                    }, e -> {
+                        logger.warn("Could not fetch config for ingest model [{}]: {}", modelId, e.getMessage());
+                        fetchScheduledModelIds.remove(modelId);
+                    })
+                )
+            );
+    }
+
+    private static OptionalLong toStoredSize(long modelSizeBytes) {
+        return modelSizeBytes > 0 ? OptionalLong.of(modelSizeBytes) : OptionalLong.empty();
+    }
+
+    private void propagateModelSize(String modelId, OptionalLong size) {
+        globalModelSizes.put(modelId, size);
+        for (ConcurrentHashMap<String, OptionalLong> perProject : modelSizesByProject.values()) {
+            if (perProject.containsKey(modelId)) {
+                perProject.put(modelId, size);
+            }
+        }
+    }
+
+    // Visible for tests
+    OptionalLong getGlobalModelSizeForTests(String modelId) {
+        return globalModelSizes.get(modelId);
+    }
+
+    boolean isTrackingModelForProjectForTests(ProjectId projectId, String modelId) {
+        ConcurrentHashMap<String, OptionalLong> perProject = modelSizesByProject.get(projectId);
+        return perProject != null && perProject.containsKey(modelId);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryService.java
@@ -196,6 +196,12 @@ public class IngestModelMemoryService implements ClusterStateListener, IngestMod
     }
 
     private void propagateModelSize(String modelId, OptionalLong size) {
+        boolean stillReferenced = modelSizesByProject.values().stream().anyMatch(map -> map.containsKey(modelId));
+        if (stillReferenced == false) {
+            globalModelSizes.remove(modelId);
+            fetchScheduledModelIds.remove(modelId);
+            return;
+        }
         globalModelSizes.put(modelId, size);
         for (ConcurrentHashMap<String, OptionalLong> perProject : modelSizesByProject.values()) {
             if (perProject.containsKey(modelId)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestPipelineModelReferences.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/IngestPipelineModelReferences.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.ingest;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.xpack.core.ml.inference.ModelAliasMetadata;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shared utilities for discovering model identifiers referenced by ingest pipeline inference processors.
+ */
+public final class IngestPipelineModelReferences {
+
+    private IngestPipelineModelReferences() {}
+
+    public static Set<String> resolveReferencedModelsForProject(ClusterState state, ProjectId projectId) {
+        IngestMetadata ingestMetadata = state.metadata().getProject(projectId).custom(IngestMetadata.TYPE);
+        Set<String> referencedKeys = collectReferencedModelKeys(ingestMetadata);
+        if (referencedKeys.isEmpty()) {
+            return referencedKeys;
+        }
+        ModelAliasMetadata modelAliasMetadata = modelAliasMetadataForProject(state, projectId);
+        Set<String> resolved = new HashSet<>(referencedKeys.size());
+        for (String modelKey : referencedKeys) {
+            String modelId = modelAliasMetadata.getModelId(modelKey);
+            resolved.add(modelId == null ? modelKey : modelId);
+        }
+        return resolved;
+    }
+
+    public static Set<String> collectReferencedModelKeys(IngestMetadata ingestMetadata) {
+        Set<String> referencedModelKeys = new HashSet<>();
+        if (ingestMetadata == null) {
+            return referencedModelKeys;
+        }
+        ingestMetadata.getPipelines()
+            .forEach((pipelineId, pipelineConfiguration) -> collectFromPipeline(pipelineConfiguration, referencedModelKeys));
+        return referencedModelKeys;
+    }
+
+    private static void collectFromPipeline(PipelineConfiguration pipelineConfiguration, Set<String> referencedModelKeys) {
+        Object processors = pipelineConfiguration.getConfig().get("processors");
+        if (processors instanceof List<?> processorList) {
+            for (Object processor : processorList) {
+                collectModelKeyFromProcessor(processor, referencedModelKeys);
+            }
+        }
+    }
+
+    private static void collectModelKeyFromProcessor(Object processor, Set<String> referencedModelKeys) {
+        if (processor instanceof Map<?, ?> processorMap) {
+            Object processorConfig = processorMap.get(InferenceProcessor.TYPE);
+            if (processorConfig instanceof Map<?, ?> inferenceConfig) {
+                Object modelId = inferenceConfig.get(InferenceResults.MODEL_ID_RESULTS_FIELD);
+                if (modelId != null) {
+                    assert modelId instanceof String;
+                    referencedModelKeys.add(modelId.toString());
+                }
+            }
+        }
+    }
+
+    private static ModelAliasMetadata modelAliasMetadataForProject(ClusterState state, ProjectId projectId) {
+        ModelAliasMetadata modelAliasMetadata = state.metadata().getProject(projectId).custom(ModelAliasMetadata.NAME);
+        return modelAliasMetadata == null ? ModelAliasMetadata.EMPTY : modelAliasMetadata;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
@@ -49,7 +48,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference.Inferenc
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.inference.TrainedModelStatsService;
-import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
+import org.elasticsearch.xpack.ml.inference.ingest.IngestPipelineModelReferences;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
 
@@ -59,7 +58,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -502,7 +500,12 @@ public class ModelLoadingService implements ClusterStateListener {
                 return;
             }
             auditNewReferencedModel(modelId);
-            trainedModelCircuitBreaker.addEstimateBytesAndMaybeBreak(trainedModelConfig.getModelSize(), modelId);
+            try {
+                trainedModelCircuitBreaker.addEstimateBytesAndMaybeBreak(trainedModelConfig.getModelSize(), modelId);
+            } catch (CircuitBreakingException ex) {
+                handleLoadFailure(modelId, ex);
+                return;
+            }
             provider.getTrainedModelForInference(modelId, consumer == Consumer.INTERNAL, ActionListener.wrap(inferenceDefinition -> {
                 try {
                     // Since we have used the previously stored estimate to help guard against OOM we need
@@ -723,6 +726,14 @@ public class ModelLoadingService implements ClusterStateListener {
     }
 
     private void handleLoadFailure(String modelId, Exception failure) {
+        if (failure instanceof CircuitBreakingException) {
+            logger.warn(
+                () -> "Model ["
+                    + modelId
+                    + "] could not be loaded because the inference circuit breaker limit was exceeded. "
+                    + "The ingest node will retry when memory becomes available. If this persists, the node may need to be resized."
+            );
+        }
         Queue<ActionListener<LocalModel>> listeners;
         synchronized (loadingListeners) {
             listeners = loadingListeners.remove(modelId);
@@ -802,7 +813,7 @@ public class ModelLoadingService implements ClusterStateListener {
         ClusterState state = event.state();
         IngestMetadata currentIngestMetadata = state.metadata().getProject().custom(IngestMetadata.TYPE);
         Set<String> allReferencedModelKeys = event.changedCustomProjectMetadataSet().contains(IngestMetadata.TYPE)
-            ? countInferenceProcessors(currentIngestMetadata)
+            ? IngestPipelineModelReferences.collectReferencedModelKeys(currentIngestMetadata)
             : new HashSet<>(referencedModels);
         Set<String> referencedModelsBeforeClusterState;
         Set<String> loadingModelBeforeClusterState = null;
@@ -1007,31 +1018,6 @@ public class ModelLoadingService implements ClusterStateListener {
     private static <T> Queue<T> addFluently(Queue<T> queue, T object) {
         queue.add(object);
         return queue;
-    }
-
-    private static Set<String> countInferenceProcessors(IngestMetadata ingestMetadata) {
-        Set<String> allReferencedModelKeys = new HashSet<>();
-        if (ingestMetadata == null) {
-            return allReferencedModelKeys;
-        }
-        ingestMetadata.getPipelines().forEach((pipelineId, pipelineConfiguration) -> {
-            Object processors = pipelineConfiguration.getConfig().get("processors");
-            if (processors instanceof List<?>) {
-                for (Object processor : (List<?>) processors) {
-                    if (processor instanceof Map<?, ?>) {
-                        Object processorConfig = ((Map<?, ?>) processor).get(InferenceProcessor.TYPE);
-                        if (processorConfig instanceof Map<?, ?>) {
-                            Object modelId = ((Map<?, ?>) processorConfig).get(InferenceResults.MODEL_ID_RESULTS_FIELD);
-                            if (modelId != null) {
-                                assert modelId instanceof String;
-                                allReferencedModelKeys.add(modelId.toString());
-                            }
-                        }
-                    }
-                }
-            }
-        });
-        return allReferencedModelKeys;
     }
 
     private static InferenceConfig inferenceConfigFromTargetType(TargetType targetType) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryServiceTests.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.ingest;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
+import org.elasticsearch.xpack.core.ml.inference.IngestModelMemoryProvider;
+import org.elasticsearch.xpack.core.ml.inference.ModelAliasMetadata;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class IngestModelMemoryServiceTests extends ESTestCase {
+
+    private static final ProjectId PROJECT_A = ProjectId.fromId("project-a");
+    private static final ProjectId PROJECT_B = ProjectId.fromId("project-b");
+
+    private TrainedModelProvider trainedModelProvider;
+    private ThreadPool threadPool;
+    private ClusterService clusterService;
+    private IngestModelMemoryService service;
+
+    @Before
+    public void setUpComponents() {
+        trainedModelProvider = mock(TrainedModelProvider.class);
+        threadPool = new TestThreadPool("IngestModelMemoryServiceTests");
+        clusterService = mock(ClusterService.class);
+        service = new IngestModelMemoryService(clusterService, trainedModelProvider, threadPool);
+    }
+
+    @After
+    public void tearDownComponents() throws Exception {
+        terminate(threadPool);
+    }
+
+    public void testMasterFetchPopulatesHeapRequirement() throws Exception {
+        stubModelConfig("model-a", 100L);
+        ClusterState previous = masterClusterState(ClusterState.EMPTY_STATE.metadata());
+        ClusterState current = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", current, previous));
+
+        assertBusy(() -> {
+            IngestModelMemoryProvider.HeapRequirement requirement = service.getRequiredHeapBytes();
+            assertThat(requirement.heapBytes(), equalTo(100L));
+            assertThat(requirement.isExact(), is(true));
+        });
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq("model-a"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+    }
+
+    public void testPipelineDeletionRemovesModelContribution() throws Exception {
+        stubModelConfig("model-a", 100L);
+        ClusterState withModel = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", withModel, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(100L)));
+
+        ClusterState withoutModel = masterClusterState(withIngestModels(Map.of()));
+        service.clusterChanged(new ClusterChangedEvent("test", withoutModel, withModel));
+
+        assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(0L));
+        assertThat(service.getRequiredHeapBytes().isExact(), is(true));
+    }
+
+    public void testProjectRemovalDropsTrackedModelsWithoutGlobalPipelineWalk() throws Exception {
+        stubModelConfig("model-a", 100L);
+        stubModelConfig("model-b", 200L);
+        ClusterState twoProjects = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a", PROJECT_B, "model-b")));
+        service.clusterChanged(new ClusterChangedEvent("test", twoProjects, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(300L)));
+
+        ClusterState projectRemoved = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", projectRemoved, twoProjects));
+
+        assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(100L));
+        assertThat(service.isTrackingModelForProjectForTests(PROJECT_B, "model-b"), is(false));
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq("model-b"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+    }
+
+    public void testUnchangedProjectsDoNotTriggerAdditionalFetches() throws Exception {
+        stubModelConfig("model-a", 100L);
+        stubModelConfig("model-b", 200L);
+        ClusterState initial = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a", PROJECT_B, "model-b")));
+        service.clusterChanged(new ClusterChangedEvent("test", initial, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(300L)));
+
+        ClusterState projectAOnlyChange = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a,model-a2", PROJECT_B, "model-b")));
+        stubModelConfig("model-a2", 50L);
+        service.clusterChanged(new ClusterChangedEvent("test", projectAOnlyChange, initial));
+
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(350L)));
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq("model-a2"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq("model-b"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+    }
+
+    public void testZeroModelSizeStoredAsInexact() throws Exception {
+        stubModelConfig("model-a", 0L);
+        ClusterState current = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", current, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        assertBusy(() -> {
+            IngestModelMemoryProvider.HeapRequirement requirement = service.getRequiredHeapBytes();
+            assertThat(requirement.heapBytes(), equalTo(0L));
+            assertThat(requirement.isExact(), is(false));
+        });
+    }
+
+    public void testNonMasterClearsTrackedState() throws Exception {
+        stubModelConfig("model-a", 100L);
+        ClusterState masterState = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", masterState, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(100L)));
+
+        ClusterState nonMasterState = nonMasterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", nonMasterState, masterState));
+
+        assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(0L));
+        assertThat(service.getRequiredHeapBytes().isExact(), is(true));
+    }
+
+    public void testWarmupReturnsInexactUntilFetchCompletes() throws Exception {
+        doAnswer(invocation -> null).when(trainedModelProvider)
+            .getTrainedModel(eq("model-a"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+
+        ClusterState current = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", current, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        IngestModelMemoryProvider.HeapRequirement warmup = service.getRequiredHeapBytes();
+        assertThat(warmup.heapBytes(), equalTo(0L));
+        assertThat(warmup.isExact(), is(false));
+    }
+
+    public void testAliasResolutionUsesCanonicalModelId() throws Exception {
+        stubModelConfig("canonical-model", 150L);
+        ClusterState current = masterClusterState(
+            withIngestModelsAndAliases(Map.of(PROJECT_A, "my-alias"), List.of(new Tuple<>("canonical-model", "my-alias")))
+        );
+        service.clusterChanged(new ClusterChangedEvent("test", current, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(150L)));
+        verify(trainedModelProvider).getTrainedModel(eq("canonical-model"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+    }
+
+    public void testDuplicateModelAcrossProjectsCountedOnce() throws Exception {
+        stubModelConfig("shared-model", 100L);
+        ClusterState current = masterClusterState(withIngestModels(Map.of(PROJECT_A, "shared-model", PROJECT_B, "shared-model")));
+        service.clusterChanged(new ClusterChangedEvent("test", current, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        assertBusy(() -> assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(100L)));
+        verify(trainedModelProvider, times(1)).getTrainedModel(
+            eq("shared-model"),
+            eq(GetTrainedModelsAction.Includes.empty()),
+            any(),
+            any()
+        );
+    }
+
+    private void stubModelConfig(String modelId, long modelSize) {
+        TrainedModelConfig trainedModelConfig = mock(TrainedModelConfig.class);
+        when(trainedModelConfig.getModelSize()).thenReturn(modelSize);
+        doAnswer(invocation -> {
+            ActionListener<TrainedModelConfig> listener = invocation.getArgument(3);
+            listener.onResponse(trainedModelConfig);
+            return null;
+        }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+    }
+
+    private static Metadata withIngestModels(Map<ProjectId, String> projectToModelId) throws IOException {
+        Metadata.Builder metadata = Metadata.builder();
+        for (Map.Entry<ProjectId, String> entry : projectToModelId.entrySet()) {
+            metadata.put(
+                ProjectMetadata.builder(entry.getKey()).putCustom(IngestMetadata.TYPE, ingestMetadataForModels(entry.getValue().split(",")))
+            );
+        }
+        return metadata.build();
+    }
+
+    private static Metadata withIngestModelsAndAliases(Map<ProjectId, String> projectToModelKey, List<Tuple<String, String>> aliases)
+        throws IOException {
+        Metadata.Builder metadata = Metadata.builder();
+        for (Map.Entry<ProjectId, String> entry : projectToModelKey.entrySet()) {
+            ProjectMetadata.Builder project = ProjectMetadata.builder(entry.getKey())
+                .putCustom(IngestMetadata.TYPE, ingestMetadataForModels(entry.getValue()));
+            if (entry.getKey().equals(PROJECT_A)) {
+                project.putCustom(
+                    ModelAliasMetadata.NAME,
+                    new ModelAliasMetadata(
+                        aliases.stream().collect(Collectors.toMap(Tuple::v2, t -> new ModelAliasMetadata.ModelAliasEntry(t.v1())))
+                    )
+                );
+            }
+            metadata.put(project);
+        }
+        return metadata.build();
+    }
+
+    private static IngestMetadata ingestMetadataForModels(String... modelIds) throws IOException {
+        Map<String, PipelineConfiguration> pipelines = Maps.newMapWithExpectedSize(modelIds.length);
+        for (String modelId : modelIds) {
+            pipelines.put("pipeline_" + modelId, pipelineWithModel(modelId));
+        }
+        return new IngestMetadata(pipelines);
+    }
+
+    private static PipelineConfiguration pipelineWithModel(String modelId) throws IOException {
+        try (
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .map(
+                    Collections.singletonMap(
+                        "processors",
+                        Collections.singletonList(
+                            Collections.singletonMap(
+                                InferenceProcessor.TYPE,
+                                Collections.singletonMap(InferenceResults.MODEL_ID_RESULTS_FIELD, modelId)
+                            )
+                        )
+                    )
+                )
+        ) {
+            return new PipelineConfiguration("pipeline_" + modelId, BytesReference.bytes(builder), XContentType.JSON);
+        }
+    }
+
+    private static ClusterState masterClusterState(Metadata metadata) {
+        DiscoveryNode masterNode = DiscoveryNodeUtils.create("master");
+        return ClusterState.builder(new ClusterName("test-cluster"))
+            .nodes(DiscoveryNodes.builder().add(masterNode).masterNodeId("master").localNodeId("master").build())
+            .metadata(metadata)
+            .build();
+    }
+
+    private static ClusterState nonMasterClusterState(Metadata metadata) {
+        DiscoveryNode masterNode = DiscoveryNodeUtils.create("master");
+        DiscoveryNode localNode = DiscoveryNodeUtils.create("data");
+        return ClusterState.builder(new ClusterName("test-cluster"))
+            .nodes(DiscoveryNodes.builder().add(masterNode).add(localNode).masterNodeId("master").localNodeId("data").build())
+            .metadata(metadata)
+            .build();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/IngestModelMemoryServiceTests.java
@@ -46,6 +46,8 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -103,6 +105,29 @@ public class IngestModelMemoryServiceTests extends ESTestCase {
 
         assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(0L));
         assertThat(service.getRequiredHeapBytes().isExact(), is(true));
+    }
+
+    public void testLateModelFetchAfterPipelineRemovalDoesNotRestoreHeap() throws Exception {
+        TrainedModelConfig trainedModelConfig = mock(TrainedModelConfig.class);
+        when(trainedModelConfig.getModelSize()).thenReturn(100L);
+        java.util.concurrent.atomic.AtomicReference<ActionListener<TrainedModelConfig>> pendingListener =
+            new java.util.concurrent.atomic.AtomicReference<>();
+        doAnswer(invocation -> {
+            pendingListener.set(invocation.getArgument(3));
+            return null;
+        }).when(trainedModelProvider).getTrainedModel(eq("model-a"), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+
+        ClusterState withModel = masterClusterState(withIngestModels(Map.of(PROJECT_A, "model-a")));
+        service.clusterChanged(new ClusterChangedEvent("test", withModel, masterClusterState(ClusterState.EMPTY_STATE.metadata())));
+
+        ClusterState withoutModel = masterClusterState(withIngestModels(Map.of()));
+        service.clusterChanged(new ClusterChangedEvent("test", withoutModel, withModel));
+
+        assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(0L));
+        assertThat(pendingListener.get(), notNullValue());
+        pendingListener.get().onResponse(trainedModelConfig);
+        assertThat(service.getRequiredHeapBytes().heapBytes(), equalTo(0L));
+        assertThat(service.getGlobalModelSizeForTests("model-a"), nullValue());
     }
 
     public void testProjectRemovalDropsTrackedModelsWithoutGlobalPipelineWalk() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -522,33 +522,34 @@ public class ModelLoadingServiceTests extends ESTestCase {
             mock(XPackLicenseState.class)
         );
 
-        MockLog mockLog = MockLog.capture(ModelLoadingService.class);
-        mockLog.addExpectation(
-            new MockLog.UnseenEventExpectation(
-                "circuit breaker load failure",
-                ModelLoadingService.class.getCanonicalName(),
-                Level.WARN,
-                "Model ["
-                    + modelId
-                    + "] could not be loaded because the inference circuit breaker limit was exceeded. "
-                    + "The ingest node will retry when memory becomes available. If this persists, the node may need to be resized."
-            )
-        );
+        try (var mockLog = MockLog.capture(ModelLoadingService.class)) {
+            mockLog.addExpectation(
+                new MockLog.SeenEventExpectation(
+                    "circuit breaker load failure",
+                    ModelLoadingService.class.getCanonicalName(),
+                    Level.WARN,
+                    "Model ["
+                        + modelId
+                        + "] could not be loaded because the inference circuit breaker limit was exceeded. "
+                        + "The ingest node will retry when memory becomes available. If this persists, the node may need to be resized."
+                )
+            );
 
-        modelLoadingService.addModelLoadedListener(modelId, ActionListener.wrap(r -> fail("expected circuit breaker failure"), e -> {
-            assertThat(e, instanceOf(CircuitBreakingException.class));
-            assertThat(((CircuitBreakingException) e).status(), equalTo(RestStatus.TOO_MANY_REQUESTS));
-        }));
-        modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
-        assertBusy(
-            () -> verify(trainedModelProvider, times(1)).getTrainedModel(
-                eq(modelId),
-                eq(GetTrainedModelsAction.Includes.empty()),
-                any(),
-                any()
-            )
-        );
-        mockLog.assertAllExpectationsMatched();
+            modelLoadingService.addModelLoadedListener(modelId, ActionListener.wrap(r -> fail("expected circuit breaker failure"), e -> {
+                assertThat(e, instanceOf(CircuitBreakingException.class));
+                assertThat(((CircuitBreakingException) e).status(), equalTo(RestStatus.TOO_MANY_REQUESTS));
+            }));
+            modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
+            assertBusy(
+                () -> verify(trainedModelProvider, times(1)).getTrainedModel(
+                    eq(modelId),
+                    eq(GetTrainedModelsAction.Includes.empty()),
+                    any(),
+                    any()
+                )
+            );
+            mockLog.awaitAllExpectationsMatched();
+        }
     }
 
     public void testExpiredModelsAreEvictedBeforeLoading() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.inference.loadingservice;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -31,7 +32,9 @@ import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -501,6 +504,51 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(model1));
 
         assertBusy(() -> assertThat(circuitBreaker.getUsed(), equalTo(5L)));
+    }
+
+    public void testCircuitBreakerFailureReturnsRetriableStatusAndLogsActionableMessage() throws Exception {
+        String modelId = "test-circuit-break-retriable";
+        withTrainedModel(modelId, 100L);
+        CircuitBreaker circuitBreaker = new CustomCircuitBreaker(10);
+        ModelLoadingService modelLoadingService = new ModelLoadingService(
+            trainedModelProvider,
+            auditor,
+            threadPool,
+            clusterService,
+            trainedModelStatsService,
+            Settings.EMPTY,
+            "test-node",
+            circuitBreaker,
+            mock(XPackLicenseState.class)
+        );
+
+        MockLog mockLog = MockLog.capture(ModelLoadingService.class);
+        mockLog.addExpectation(
+            new MockLog.UnseenEventExpectation(
+                "circuit breaker load failure",
+                ModelLoadingService.class.getCanonicalName(),
+                Level.WARN,
+                "Model ["
+                    + modelId
+                    + "] could not be loaded because the inference circuit breaker limit was exceeded. "
+                    + "The ingest node will retry when memory becomes available. If this persists, the node may need to be resized."
+            )
+        );
+
+        modelLoadingService.addModelLoadedListener(modelId, ActionListener.wrap(r -> fail("expected circuit breaker failure"), e -> {
+            assertThat(e, instanceOf(CircuitBreakingException.class));
+            assertThat(((CircuitBreakingException) e).status(), equalTo(RestStatus.TOO_MANY_REQUESTS));
+        }));
+        modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
+        assertBusy(
+            () -> verify(trainedModelProvider, times(1)).getTrainedModel(
+                eq(modelId),
+                eq(GetTrainedModelsAction.Includes.empty()),
+                any(),
+                any()
+            )
+        );
+        mockLog.assertAllExpectationsMatched();
     }
 
     public void testExpiredModelsAreEvictedBeforeLoading() throws Exception {


### PR DESCRIPTION
## Summary

Adds `IngestModelMemoryProvider` SPI in x-pack-core and master-only `IngestModelMemoryService` in the ML plugin to aggregate JVM heap bytes for DFA models referenced by ingest pipelines (per-project maps, global dedupe). Wires the provider into `MachineLearning.createComponents`, extracts shared pipeline model-reference scanning from `ModelLoadingService`, and improves circuit-breaker load-failure logging with a retriable 429 assertion test.