### PR TITLE
Fix for header settings not marked as secured and added headers …

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
@@ -211,7 +211,7 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
     @Override
     public List<String> getSettingsFilter() {
         final String exportersKey = "xpack.monitoring.exporters.";
-        return List.of(exportersKey + "*.auth.*", exportersKey + "*.ssl.*");
+        return List.of(exportersKey + "*.auth.*", exportersKey + "*.ssl.*", exportersKey + "*.headers.*");
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -293,7 +293,7 @@ public class HttpExporter extends Exporter {
                     throw new SettingsException("headers must have values, missing for setting [" + fullSetting + "]");
                 }
             }
-        }, Property.Dynamic, Property.NodeScope, Property.Deprecated),
+        }, Property.Dynamic, Property.NodeScope, Property.Filtered, Property.Deprecated),
         HTTP_TYPE_DEPENDENCY
     );
     /**


### PR DESCRIPTION
The fix addresses a security vulnerability where HTTP exporter headers (containing credentials like Bearer tokens and API keys) were exposed in the nodes info API response.
It required two changes :
Add Property.Filtered in HEADER_SETTINGS definition
Add headers to getSettingsFiltered to ensure they are redacted in responses