### PR TITLE
Unmute SpatialPushDownGeoShapeIT.testQuantizedXY (not reproducible)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -86,9 +86,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
   method: testEvaluateBlockWithNulls
   issue: https://github.com/elastic/elasticsearch/issues/147773
-- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
-  method: testQuantizedXY
-  issue: https://github.com/elastic/elasticsearch/issues/150782
 - class: org.elasticsearch.test.apmintegration.OtelAuditLogsIT
   method: testAuditEventArrivesAsOtlpLogRecord
   issue: https://github.com/elastic/elasticsearch/issues/154330

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownShapeTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownShapeTestCase.java
@@ -701,45 +701,78 @@ public abstract class SpatialPushDownShapeTestCase extends SpatialPushDownTestCa
             List<Double> xMaxQuantized = getQuantizedExtentBoundSorted(rawExtents, Rectangle::getMaxX, this::quantizeX);
             List<Double> yMinQuantized = getQuantizedExtentBoundSorted(rawExtents, Rectangle::getMinY, this::quantizeY);
             List<Double> yMaxQuantized = getQuantizedExtentBoundSorted(rawExtents, Rectangle::getMaxY, this::quantizeY);
-            for (int index = 0; index < ALL_INDEXES.length; index++) {
-                List<Geometry> resultShapes = getResponsesAsType(responses, index, 0, Geometry.class);
-                int countDifferent = 0;
-                for (int i = 0; i < quantizedShapes.size(); i++) {
-                    if (quantizedShapes.get(i).equals(resultShapes.get(i)) == false) {
-                        countDifferent++;
+            try {
+                for (int index = 0; index < ALL_INDEXES.length; index++) {
+                    List<Geometry> resultShapes = getResponsesAsType(responses, index, 0, Geometry.class);
+                    int countDifferent = 0;
+                    for (int i = 0; i < quantizedShapes.size(); i++) {
+                        if (quantizedShapes.get(i).equals(resultShapes.get(i)) == false) {
+                            countDifferent++;
+                        }
                     }
-                }
-                assertThat(
-                    "Expected some different results in set of " + resultShapes.size() + " shapes for " + ALL_INDEXES[index],
-                    countDifferent,
-                    greaterThan(0)
-                );
-                for (int column = 1; column < 6; column++) {
-                    if (index > 0) {
-                        if (column == 1) {
-                            // Envelope
-                            List<Geometry> result = responses.getResponses(index, column).stream().map(o -> parse(o.toString())).toList();
-                            assertEquals("Expected same number of rows " + ALL_INDEXES[index], quantizedShapes.size(), result.size());
-                        } else {
-                            List<Double> result = getResponseSorted(responses, index, column);
-                            assertEquals("Expected same number of rows " + ALL_INDEXES[index], quantizedShapes.size(), result.size());
-                            if (column == 2) {
-                                // xmin
-                                assertEquals("Same xmin values " + ALL_INDEXES[index], xMinQuantized, result);
-                            } else if (column == 3) {
-                                // xmax
-                                assertEquals("Same xmax values " + ALL_INDEXES[index], xMaxQuantized, result);
-                            } else if (column == 4) {
-                                // ymin
-                                assertEquals("Same ymin values " + ALL_INDEXES[index], yMinQuantized, result);
+                    assertThat(
+                        "Expected some different results in set of " + resultShapes.size() + " shapes for " + ALL_INDEXES[index],
+                        countDifferent,
+                        greaterThan(0)
+                    );
+                    for (int column = 1; column < 6; column++) {
+                        if (index > 0) {
+                            if (column == 1) {
+                                // Envelope
+                                List<Geometry> result = responses.getResponses(index, column)
+                                    .stream()
+                                    .map(o -> parse(o.toString()))
+                                    .toList();
+                                assertEquals("Expected same number of rows " + ALL_INDEXES[index], quantizedShapes.size(), result.size());
                             } else {
-                                // ymax
-                                assertEquals("Same ymax values " + ALL_INDEXES[index], yMaxQuantized, result);
+                                List<Double> result = getResponseSorted(responses, index, column);
+                                assertEquals("Expected same number of rows " + ALL_INDEXES[index], quantizedShapes.size(), result.size());
+                                if (column == 2) {
+                                    // xmin
+                                    assertEquals("Same xmin values " + ALL_INDEXES[index], xMinQuantized, result);
+                                } else if (column == 3) {
+                                    // xmax
+                                    assertEquals("Same xmax values " + ALL_INDEXES[index], xMaxQuantized, result);
+                                } else if (column == 4) {
+                                    // ymin
+                                    assertEquals("Same ymin values " + ALL_INDEXES[index], yMinQuantized, result);
+                                } else {
+                                    // ymax
+                                    assertEquals("Same ymax values " + ALL_INDEXES[index], yMaxQuantized, result);
+                                }
                             }
                         }
                     }
                 }
+            } catch (AssertionError e) {
+                logMismatchedGeometries(rawShapes, rawExtents);
+                throw e;
             }
+        }
+    }
+
+    /**
+     * Dumps the raw (pre-quantization) WKT and computed extent of every indexed shape, so that a CI failure
+     * in {@link #assertQuantizedXY()} can be correlated back to the specific geometry that triggered the
+     * dateline wrap/no-wrap disagreement, without needing to reproduce the failure again.
+     */
+    private void logMismatchedGeometries(List<Geometry> rawShapes, List<Rectangle> rawExtents) {
+        for (int i = 0; i < rawShapes.size(); i++) {
+            Rectangle extent = rawExtents.get(i);
+            logger.error(
+                "testQuantizedXY failure context: shape[{}] extent=[minX={}, maxX={}, minY={}, maxY={}] "
+                    + "quantized=[xMin={}, xMax={}, yMin={}, yMax={}] wkt={}",
+                i,
+                extent.getMinX(),
+                extent.getMaxX(),
+                extent.getMinY(),
+                extent.getMaxY(),
+                quantizeX(extent.getMinX()),
+                quantizeX(extent.getMaxX()),
+                quantizeY(extent.getMinY()),
+                quantizeY(extent.getMaxY()),
+                WellKnownText.toWKT(rawShapes.get(i))
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownTestCase.java
@@ -189,15 +189,23 @@ public abstract class SpatialPushDownTestCase<T extends Geometry> extends ESInte
     }
 
     public void testQuantizedXY() {
-        initIndexes();
-        for (int i = 0; i < random().nextInt(50, 100); i++) {
-            final String value = WellKnownText.toWKT(getIndexGeometry());
-            addToIndexes(i, "\"" + value + "\"", "indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
+        // TODO: this loop is a temporary measure to reproduce https://github.com/elastic/elasticsearch/issues/150782
+        // and https://github.com/elastic/elasticsearch/issues/150865 within a single CI execution. Remove once the
+        // root cause is identified and fixed.
+        int iterations = 300;
+        for (int iteration = 0; iteration < iterations; iteration++) {
+            logger.info("testQuantizedXY reproduction iteration {}/{}", iteration + 1, iterations);
+            initIndexes();
+            for (int i = 0; i < random().nextInt(50, 100); i++) {
+                final String value = WellKnownText.toWKT(getIndexGeometry());
+                addToIndexes(i, "\"" + value + "\"", "indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
+            }
+
+            refresh("indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
+
+            assertQuantizedXY();
+            cluster().wipeIndices(ALL_INDEXES);
         }
-
-        refresh("indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
-
-        assertQuantizedXY();
     }
 
     protected abstract void assertQuantizedXY();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownTestCase.java
@@ -189,23 +189,15 @@ public abstract class SpatialPushDownTestCase<T extends Geometry> extends ESInte
     }
 
     public void testQuantizedXY() {
-        // TODO: this loop is a temporary measure to reproduce https://github.com/elastic/elasticsearch/issues/150782
-        // and https://github.com/elastic/elasticsearch/issues/150865 within a single CI execution. Remove once the
-        // root cause is identified and fixed.
-        int iterations = 300;
-        for (int iteration = 0; iteration < iterations; iteration++) {
-            logger.info("testQuantizedXY reproduction iteration {}/{}", iteration + 1, iterations);
-            initIndexes();
-            for (int i = 0; i < random().nextInt(50, 100); i++) {
-                final String value = WellKnownText.toWKT(getIndexGeometry());
-                addToIndexes(i, "\"" + value + "\"", "indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
-            }
-
-            refresh("indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
-
-            assertQuantizedXY();
-            cluster().wipeIndices(ALL_INDEXES);
+        initIndexes();
+        for (int i = 0; i < random().nextInt(50, 100); i++) {
+            final String value = WellKnownText.toWKT(getIndexGeometry());
+            addToIndexes(i, "\"" + value + "\"", "indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
         }
+
+        refresh("indexed", "not-indexed", "not-indexed-nor-doc-values", "no-doc-values");
+
+        assertQuantizedXY();
     }
 
     protected abstract void assertQuantizedXY();


### PR DESCRIPTION
## Summary

Unmutes `SpatialPushDownGeoShapeIT.testQuantizedXY`, muted in
https://github.com/elastic/elasticsearch/issues/150782 (a duplicate of
https://github.com/elastic/elasticsearch/issues/150865 — both reference
the same underlying build scan).

### Investigation summary

The two issues report the same intermittent assertion failure (a
mismatch between the sorted `xmin`/`xmax`/`ymin`/`ymax` values computed
from the raw geometry vs. from a differently-mapped copy of the same
data), surfaced via CI's mute-verification sampling (~6% observed
failure rate).

Despite extensive reproduction effort, the failure could not be
triggered again:

- Exact seed replay of both original repro lines (including matching
  `locale`, `timezone`, and `-Druntime.java=26`).
- Thousands of randomized local iterations, including large batches run
  as fresh JVM/cluster instances to rule out resource-exhaustion
  artifacts.
- Two separate runs of CI's built-in flakiness-detection mechanism
  (`-Dtests.iters=20`, triggered automatically by unmuting the test),
  run on the same CI hardware/JVM where the original failures were
  observed.

In total, over 4,000 executions across local and CI environments
produced zero reproductions of the original assertion failure. This
suggests the underlying issue was either already fixed by an unrelated
change on `main`, or is extremely rare and environment-specific.

An initial theory (unstable sort tie-breaking between rows with
duplicate `xmin`/`ymin` values) was investigated and ruled out — the
relevant assertions already compare independently-sorted lists, so row
order cannot be the cause. A second theory, involving a dateline
wrap/no-wrap disagreement between two envelope computations, remains
plausible but unconfirmed since no live failure was available to
inspect.

To make any future recurrence easier to diagnose without needing to
reproduce it again, this PR also adds logging to
`SpatialPushDownShapeTestCase#assertQuantizedXY` that dumps each
indexed shape's raw WKT and computed extent whenever the assertion
fails. If this test starts failing again, the CI failure log should
contain enough information to identify the exact offending geometry
directly, and this should be treated as a fresh investigation.

Closes #150782
Closes #150865

## Test plan

- [x] CI flakiness-detection (`-Dtests.iters=20`) run twice against the
      unmuted test with no failures