### PR TITLE
Revert "Remove legacy single-arg IndexResolver constructor"

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -106,10 +106,14 @@ public class IndexResolver {
     private final Client client;
     /**
      * Whether the {@code flattened} data type is currently enabled, backing the {@code esql.query.flattened.enabled}
-     * kill switch. Read at field-caps resolution time so a runtime change takes effect on the next query. Tests that
-     * don't exercise the kill switch pass an always-enabled supplier ({@code () -> true}).
+     * kill switch. Read at field-caps resolution time so a runtime change takes effect on the next query. Defaults to
+     * always-enabled for the test/legacy constructor.
      */
     private final BooleanSupplier flattenedDataTypeEnabled;
+
+    public IndexResolver(Client client) {
+        this(client, () -> true);
+    }
 
     public IndexResolver(Client client, BooleanSupplier flattenedDataTypeEnabled) {
         this.client = client;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
@@ -428,7 +428,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
             super(
                 mockClusterService(projectId, policies),
                 transports.get(cluster),
-                new IndexResolver(new FieldCapsClient(threadPool, aliases, mappings), () -> true),
+                new IndexResolver(new FieldCapsClient(threadPool, aliases, mappings)),
                 TestProjectResolvers.singleProject(projectId)
             );
             this.policies = policies;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -185,7 +185,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         String[] indices = new String[] { "test" };
 
         Client qlClient = mock(Client.class);
-        IndexResolver idxResolver = new IndexResolver(qlClient, () -> true);
+        IndexResolver idxResolver = new IndexResolver(qlClient);
         // simulate a valid field_caps response so we can parse and correctly analyze de query
         FieldCapabilitiesResponse fieldCapabilitiesResponse = mock(FieldCapabilitiesResponse.class);
         when(fieldCapabilitiesResponse.getIndices()).thenReturn(indices);
@@ -199,7 +199,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         }).when(qlClient).execute(eq(EsqlResolveFieldsAction.TYPE), any(), any());
 
         Client esqlClient = mock(Client.class);
-        IndexResolver indexResolver = new IndexResolver(esqlClient, () -> true);
+        IndexResolver indexResolver = new IndexResolver(esqlClient);
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<EsqlResolveFieldsResponse> listener = (ActionListener<EsqlResolveFieldsResponse>) invocation.getArguments()[2];
@@ -312,7 +312,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         String[] indices = new String[] { "test" };
 
         Client esqlClient = mock(Client.class);
-        IndexResolver indexResolver = new IndexResolver(esqlClient, () -> true);
+        IndexResolver indexResolver = new IndexResolver(esqlClient);
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<EsqlResolveFieldsResponse> listener = (ActionListener<EsqlResolveFieldsResponse>) invocation.getArguments()[2];
@@ -416,7 +416,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         String[] indices = new String[] { "test" };
 
         Client esqlClient = mock(Client.class);
-        IndexResolver indexResolver = new IndexResolver(esqlClient, () -> true);
+        IndexResolver indexResolver = new IndexResolver(esqlClient);
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<EsqlResolveFieldsResponse> listener = (ActionListener<EsqlResolveFieldsResponse>) invocation.getArguments()[2];
@@ -494,7 +494,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         String[] indices = new String[] { "test" };
 
         Client esqlClient = mock(Client.class);
-        IndexResolver indexResolver = new IndexResolver(esqlClient, () -> true);
+        IndexResolver indexResolver = new IndexResolver(esqlClient);
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<EsqlResolveFieldsResponse> listener = (ActionListener<EsqlResolveFieldsResponse>) invocation.getArguments()[2];
@@ -558,7 +558,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         String[] indices = new String[] { "test" };
 
         Client esqlClient = mock(Client.class);
-        IndexResolver indexResolver = new IndexResolver(esqlClient, () -> true);
+        IndexResolver indexResolver = new IndexResolver(esqlClient);
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<EsqlResolveFieldsResponse> listener = (ActionListener<EsqlResolveFieldsResponse>) invocation.getArguments()[2];


### PR DESCRIPTION
## Summary

This reverts commit 90222642013b347740d4fcd1a234e9eb7aa55b4d ("Remove legacy single-arg IndexResolver constructor"), which reached `main` via a direct push without going through a pull request / review.

The change itself was a reasonable follow-up (removing the legacy `IndexResolver(Client)` constructor in favor of the canonical `IndexResolver(Client, BooleanSupplier)`), but it should go through the normal review + CI process rather than landing on `main` unreviewed. This revert restores `main` to the prior state so the change can be re-proposed properly.

Restores:
- the `IndexResolver(Client)` convenience constructor, and
- the corresponding single-arg call sites in `PlanExecutorMetricsTests` and `EnrichPolicyResolverTests`.

## Test plan

- [x] `./gradlew :x-pack:plugin:esql:compileTestJava` passes locally
- [ ] CI green

Made with [Cursor](https://cursor.com)