### PR TITLE
[9.4] Add details of RFC support to uri_parts processor documentation (#152609)

### DIFF
--- a/docs/reference/enrich-processor/uri-parts-processor.md
+++ b/docs/reference/enrich-processor/uri-parts-processor.md
@@ -9,6 +9,8 @@ mapped_pages:
 
 Parses a Uniform Resource Identifier (URI) string and extracts its components as an object. This URI object includes properties for the URI’s domain, path, fragment, port, query, scheme, user info, username, and password.
 
+The processor uses [java.net.URI](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/net/URI.html) to parse the URI string, which as of Java 24 supports [RFC 2396](https://datatracker.ietf.org/doc/html/rfc2396), amended by [RFC 2732](https://datatracker.ietf.org/doc/html/rfc2732). The most recent URI syntax RFC is [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), meaning this processor might not parse URIs that depend on [features specific to RFC 3986](https://www.rfc-editor.org/info/rfc3986/#appendix-D) as expected.
+
 $$$uri-parts-options$$$
 
 | Name | Required | Default | Description |

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
@@ -151,6 +151,15 @@ public class UriPartsProcessorTests extends ESTestCase {
         );
     }
 
+    /**
+     * If this test starts failing, it means that {@link java.net.URI#URI(String)} has started supporting RFC 3986, or we've
+     * moved to an implementation that does. If so, we must update the public documentation for the processor accordingly.
+     */
+    public void testUriWithUnderscoresInDomain() throws Exception {
+        // Note that domain is null, this is because of the unsupported underscores in RFC 2396
+        testUriParsing("https://www.unsupported_by_rfc2396.com/foobar", Map.of("scheme", "https", "path", "/foobar"));
+    }
+
     public void testUrlWithCharactersNotToleratedByUri() throws Exception {
         testUriParsing(
             "http://www.google.com/path with spaces",


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Add details of RFC support to uri_parts processor documentation (#152609)