### PR TITLE
[9.4] trivial hardening of data uri validation (#152664)

### DIFF
--- a/docs/changelog/152664.yaml
+++ b/docs/changelog/152664.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 152664
+summary: Trivial hardening of data uri validation
+type: bug

--- a/server/src/main/java/org/elasticsearch/inference/InferenceString.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceString.java
@@ -31,7 +31,12 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * This class represents a String which may be raw text, or the String representation of some other data such as an image in base64
  */
 public record InferenceString(DataType dataType, DataFormat dataFormat, String value) implements Writeable, ToXContentObject {
-    private static final Pattern DATA_URI_PATTERN = Pattern.compile("^data:.*/.*;base64,");
+    // Caps regex cost regardless of total input size; real MIME types are well under this.
+    static final int MAX_DATA_URI_PREFIX_LENGTH = 256;
+
+    // Character classes stop at literal delimiters so matching is linear. RFC 2397 ";param=value" pairs get absorbed into the {subtype}
+    // class.
+    private static final Pattern DATA_URI_PATTERN = Pattern.compile("^data:[^/]+/[^,]+;base64,");
 
     static final String TYPE_FIELD = "type";
     static final String FORMAT_FIELD = "format";
@@ -89,7 +94,10 @@ public record InferenceString(DataType dataType, DataFormat dataFormat, String v
     private void validateDataURIFormat() {
         if (dataFormat == DataFormat.BASE64) {
             var endOfURIPart = value.indexOf(',');
-            if (endOfURIPart < 0 || DATA_URI_PATTERN.matcher(value.substring(0, endOfURIPart + 1)).matches() == false) {
+            // Fast-fail on missing or oversized URI part before the regex.
+            if (endOfURIPart < 0
+                || endOfURIPart >= MAX_DATA_URI_PREFIX_LENGTH
+                || DATA_URI_PATTERN.matcher(value).region(0, endOfURIPart + 1).matches() == false) {
                 throw new IllegalArgumentException(
                     "base64 inputs must be specified as data URIs with the format [data:{MIME-type};base64,...]"
                 );

--- a/server/src/test/java/org/elasticsearch/inference/InferenceStringTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/InferenceStringTests.java
@@ -75,6 +75,41 @@ public class InferenceStringTests extends AbstractBWCSerializationTestCase<Infer
         new InferenceString(DataType.IMAGE, DataFormat.BASE64, value);
     }
 
+    /** RFC 2397 parameters and MIME types containing {@code +} must still be accepted. */
+    public void testConstructorWithValidDataURIFormat_withMediaTypeParameters() {
+        new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/png;charset=utf-8;base64,abcd");
+        new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/png;p1=v1;p2=v2;base64,abcd");
+        new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/svg+xml;base64,abcd");
+    }
+
+    /** URI prefixes exceeding {@link InferenceString#MAX_DATA_URI_PREFIX_LENGTH} are rejected before the regex runs. */
+    public void testConstructorWithOversizedDataURIPrefix_throws() {
+        String oversizedPrefixValue = "data:image/" + "a".repeat(InferenceString.MAX_DATA_URI_PREFIX_LENGTH) + ";base64,abcd";
+
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new InferenceString(DataType.IMAGE, DataFormat.BASE64, oversizedPrefixValue)
+        );
+        assertThat(
+            exception.getMessage(),
+            is("base64 inputs must be specified as data URIs with the format [data:{MIME-type};base64,...]")
+        );
+    }
+
+    /** Adversarial input that would backtrack under the old {@code .*&#47;.*} regex must fail fast. */
+    public void testConstructorWithPathologicalDataURI_throwsAndCompletesQuickly() {
+        String pathological = "data:a" + "/a;".repeat(100) + ",";
+
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new InferenceString(DataType.IMAGE, DataFormat.BASE64, pathological)
+        );
+        assertThat(
+            exception.getMessage(),
+            is("base64 inputs must be specified as data URIs with the format [data:{MIME-type};base64,...]")
+        );
+    }
+
     public void testParserWithText() throws IOException {
         var requestJson = """
             {


### PR DESCRIPTION
Manual backport of #152664.

The automated backport failed with a cherry-pick conflict: `InferenceString.java` on `9.4` doesn't yet have the `TransportVersion` constant / public field visibility introduced by #152470, which sit adjacent to this diff. Resolved by keeping 9.4's existing structure in place and applying only the regex/validation hardening from the original PR. Test file and changelog cherry-picked cleanly with no changes needed.

Verified `InferenceStringTests` passes on this branch.