### PR TITLE
ESQL:DS: Fix corss-file scalar/object conflicts under UNION_BY_NAME

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.metadata.DatasetMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.dataset.DeleteDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.datasource.DeleteDataSourceAction;
+import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceSetting;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.junit.After;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * End-to-end reproduction of elastic/esql-planning#1050, the cross-file completion of #1028: a
+ * field that is a scalar leaf in one file's schema and a nested object (dotted-prefix parent) in
+ * another's must reconcile to a single shape under the default {@code UNION_BY_NAME} schema
+ * resolution, with the losing file's records routed through the same {@code ErrorPolicy}
+ * machinery {@link NdJsonScalarObjectConflictIT} exercises for a single file. Runs through a real
+ * {@code FROM <dataset>} query (planner + execution + client response), mirroring
+ * {@code NdJsonScalarObjectConflictIT}'s dataset-registration pattern rather than the ad hoc
+ * {@code EXTERNAL} command, which is slated for removal.
+ */
+public class NdJsonCrossFileScalarObjectConflictIT extends AbstractEsqlIntegTestCase {
+
+    private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
+
+    /** Minimal pass-through validator registered for type {@code test}; accepts any resource scheme. */
+    public static final class TestDataSourcePlugin extends Plugin implements DataSourcePlugin {
+        @Override
+        public Map<String, DataSourceValidator> datasourceValidators(Settings settings) {
+            return Map.of("test", new TestValidator());
+        }
+    }
+
+    private static final class TestValidator implements DataSourceValidator {
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings) {
+            Map<String, DataSourceSetting> out = new HashMap<>();
+            for (Map.Entry<String, Object> e : datasourceSettings.entrySet()) {
+                out.put(e.getKey(), new DataSourceSetting(e.getValue(), e.getKey().startsWith("secret_")));
+            }
+            return out;
+        }
+
+        @Override
+        public Map<String, Object> validateDataset(
+            Map<String, DataSourceSetting> datasourceSettings,
+            String resource,
+            Map<String, Object> datasetSettings
+        ) {
+            return datasetSettings == null ? Map.of() : new HashMap<>(datasetSettings);
+        }
+    }
+
+    private Path fixtureDir;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(NdJsonDataSourcePlugin.class);
+        plugins.add(TestDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Before
+    public void requireFeatureFlag() {
+        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+    }
+
+    /**
+     * The exact repro shape from esql-planning#1050: {@code a.ndjson}'s {@code user} is a plain
+     * string, {@code b.ndjson}'s is a nested object. Lexicographic glob ordering (see
+     * {@code GlobExpander}) makes {@code a.ndjson} the first file, so first-shape-wins schema
+     * reconciliation resolves {@code user} to {@code KEYWORD} and {@code b.ndjson} is the one that
+     * hits the shape conflict at decode time. Registers a data source and two datasets over the
+     * same two-file directory — {@code strict_ds} with the default (strict) error policy and
+     * {@code lenient_ds} with {@code error_mode: skip_row} — so each test just picks the dataset
+     * matching the policy it exercises.
+     */
+    @Before
+    public void writeFixtureAndRegister() throws Exception {
+        fixtureDir = createTempDir().resolve("cross_file_shape_conflict");
+        Files.createDirectories(fixtureDir);
+        Files.writeString(fixtureDir.resolve("a.ndjson"), "{\"event\":1,\"user\":\"alice\"}\n", StandardCharsets.UTF_8);
+        Files.writeString(
+            fixtureDir.resolve("b.ndjson"),
+            "{\"event\":2,\"user\":{\"id\":\"bob\",\"tier\":\"gold\"}}\n",
+            StandardCharsets.UTF_8
+        );
+        String resource = StoragePath.fileUri(fixtureDir) + "/*.ndjson";
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertAcked(
+            client().execute(PutDatasetAction.INSTANCE, putDatasetRequest("strict_ds", "local_ds", resource, Map.of("format", "ndjson")))
+        );
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                putDatasetRequest("lenient_ds", "local_ds", resource, Map.of("format", "ndjson", "error_mode", "skip_row"))
+            )
+        );
+    }
+
+    @After
+    public void cleanupRegistry() throws Exception {
+        for (String dataset : List.of("strict_ds", "lenient_ds")) {
+            try {
+                client().execute(DeleteDatasetAction.INSTANCE, deleteDatasetRequest(dataset)).get(30, TimeUnit.SECONDS);
+            } catch (ResourceNotFoundException ignored) {
+                // already deleted
+            } catch (Exception e) {
+                logger.warn("dataset cleanup [{}] failed", dataset, e);
+            }
+        }
+        try {
+            client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest("local_ds")).get(30, TimeUnit.SECONDS);
+        } catch (ResourceNotFoundException ignored) {
+            // already deleted
+        } catch (Exception e) {
+            logger.warn("data source cleanup [local_ds] failed", e);
+        }
+        Files.walk(fixtureDir).sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+            try {
+                Files.deleteIfExists(p);
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        });
+    }
+
+    /**
+     * Default settings ({@code UNION_BY_NAME} schema resolution, strict error policy): before this
+     * fix, {@code a.ndjson}'s scalar {@code user} and {@code b.ndjson}'s {@code user.id}/
+     * {@code user.tier} would coexist in the fabricated unified schema and the query would
+     * silently return {@code with_user=1} rather than failing — the correctness bug this fix
+     * closes. With the fix, the family collapses to {@code a.ndjson}'s scalar shape, so
+     * {@code b.ndjson}'s now-pinned scalar {@code user} attribute hits its real object value and
+     * fails per elastic/esql-planning#1028's decode-time shape-conflict handling — mirroring
+     * {@link NdJsonScalarObjectConflictIT#testStrictPolicyFailsOnScalarObjectConflict}.
+     */
+    public void testDefaultSettingsFailsOnCrossFileScalarObjectConflict() {
+        String query = "FROM strict_ds | STATS total = COUNT(*), with_user = COUNT(user)";
+        Exception e = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest(query), TIMEOUT).close());
+        String trace = ExceptionsHelper.stackTrace(e);
+        assertTrue("must fail on the cross-file shape conflict, got: " + trace, trace.contains("user"));
+        assertTrue("error must explain the conflict, got: " + trace, trace.contains("resolved to scalar type"));
+    }
+
+    /**
+     * Non-strict policy ({@code error_mode: skip_row}, set on {@code lenient_ds}): {@code
+     * b.ndjson}'s {@code user} column is null-filled — not the row or the whole file dropped —
+     * {@code a.ndjson}'s row is unaffected, and the client receives a {@code Warning} naming the
+     * conflict. Nothing silently vanishes, end to end, not just at the reconciliation-unit level.
+     * The query runs through a chosen coordinator and we read that node's accumulated response
+     * {@code Warning} headers, proving the warning recorded by the reader propagates all the way
+     * to the client.
+     */
+    public void testSkipRowPolicyNullFillsAndWarnsClient() throws Exception {
+        EsqlQueryRequest request = syncEsqlQueryRequest("FROM lenient_ds | KEEP event, user | SORT event");
+
+        DiscoveryNode coordinator = randomFrom(clusterService().state().nodes().stream().toList());
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<List<List<Object>>> values = new AtomicReference<>();
+        AtomicReference<List<? extends ColumnInfo>> columns = new AtomicReference<>();
+        List<String> warnings = new CopyOnWriteArrayList<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        // ActionListener.wrap (not the run() helper) so we can also read the coordinator's
+        // response Warning headers; the transport client owns the response ref-count, so we must
+        // not close it here (that would double-decRef -- see ExternalCsvHivePartitionedIT).
+        client(coordinator.getName()).execute(EsqlQueryAction.INSTANCE, request, ActionListener.wrap(response -> {
+            try {
+                values.set(getValuesList(response));
+                columns.set(response.columns());
+                TransportService transportService = internalCluster().getInstance(TransportService.class, coordinator.getName());
+                warnings.addAll(
+                    transportService.getThreadPool().getThreadContext().getResponseHeaders().getOrDefault("Warning", List.of())
+                );
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            failure.set(e);
+            latch.countDown();
+        }));
+        assertTrue("query did not complete within 2 minutes", latch.await(2, TimeUnit.MINUTES));
+        if (failure.get() != null) {
+            throw new AssertionError("non-strict read must not fail, but did", failure.get());
+        }
+
+        assertThat(columns.get().size(), equalTo(2));
+        assertThat(columns.get().get(0).name(), equalTo("event"));
+        assertThat(columns.get().get(1).name(), equalTo("user"));
+
+        List<List<Object>> rows = values.get();
+        assertThat("both files' rows must still return, just [user] is null for the conflicting one", rows.size(), equalTo(2));
+        assertThat(((Number) rows.get(0).get(0)).intValue(), equalTo(1));
+        assertThat(rows.get(0).get(1), equalTo("alice"));
+        assertThat("b.ndjson's [event] sibling column must survive", ((Number) rows.get(1).get(0)).intValue(), equalTo(2));
+        assertThat("b.ndjson's [user] must be null-filled, not the whole row dropped", rows.get(1).get(1), nullValue());
+
+        assertTrue(
+            "client must receive a Warning naming the conflicting field, got: " + warnings,
+            warnings.stream().anyMatch(w -> w.contains("user"))
+        );
+    }
+
+    private static PutDataSourceAction.Request putDataSourceRequest(String name, Map<String, Object> settings) {
+        return new PutDataSourceAction.Request(TIMEOUT, TIMEOUT, name, "test", null, new HashMap<>(settings));
+    }
+
+    private static PutDatasetAction.Request putDatasetRequest(
+        String name,
+        String dataSource,
+        String resource,
+        Map<String, Object> settings
+    ) {
+        return new PutDatasetAction.Request(TIMEOUT, TIMEOUT, name, dataSource, resource, null, new HashMap<>(settings));
+    }
+
+    private static DeleteDataSourceAction.Request deleteDataSourceRequest(String name) {
+        return new DeleteDataSourceAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+
+    private static DeleteDatasetAction.Request deleteDatasetRequest(String name) {
+        return new DeleteDatasetAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -321,6 +322,13 @@ public final class SchemaReconciliation {
 
         emitKeywordFallbackWarnings(unified, contributions);
 
+        // Resolve esql-planning#1050 before the nullable-fill pass below: collapse any field that
+        // some files infer as a scalar leaf and others infer as a nested object (dotted-prefix
+        // parent) to a single shape, dropping the losing shape's entries from `unified` in place.
+        // The nullable-fill pass then naturally marks the surviving name nullable for the losing
+        // files (their original schema genuinely lacks it), which is exactly what we want.
+        Map<StoragePath, List<Attribute>> shapeConflictOverrides = resolveShapeConflicts(unified, fileMetadata);
+
         // Mark columns as nullable when missing from any file
         for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
             Set<String> fileColumnNames = new HashSet<>();
@@ -346,7 +354,11 @@ public final class SchemaReconciliation {
         for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
             StoragePath filePath = entry.getKey();
             SourceMetadata meta = entry.getValue();
-            List<Attribute> fileSchema = meta.schema();
+            // A file on the losing side of a shape conflict is pinned to the winning shape's
+            // attribute(s) instead of its own inferred sub-schema for that field — see
+            // resolveShapeConflicts for why this is what actually routes the file's real values
+            // through the per-file shape-conflict/ErrorPolicy handling at read time.
+            List<Attribute> fileSchema = shapeConflictOverrides.getOrDefault(filePath, meta.schema());
             SourceStatistics stats = meta.statistics().orElse(null);
 
             ColumnMapping mapping = computeMapping(unifiedSchema, fileSchema);
@@ -354,6 +366,276 @@ public final class SchemaReconciliation {
         }
 
         return new Result(new ExternalSchema(unifiedSchema), Map.copyOf(perFileInfo));
+    }
+
+    /**
+     * Detects and resolves esql-planning#1050: a field that some files infer as a scalar leaf and
+     * others infer as a nested object (a dotted-prefix parent, e.g. {@code user} vs
+     * {@code user.id}/{@code user.tier}) is a schema conflict across files, exactly like a
+     * within-file shape conflict is for a single file (elastic/esql-planning#1028).
+     * {@code UNION_BY_NAME} merges purely by exact name, so the two shapes never collide there and
+     * both get fabricated into the unified schema — this pass collapses each such family to a
+     * single shape: the first file (in {@code fileMetadata} iteration order) to contribute the
+     * family at all wins, mirroring both #1028's first-observed-shape rule and
+     * {@code FIRST_FILE_WINS}'s anchor semantics.
+     * <p>
+     * Mutates {@code unified} in place, removing the losing shape's entries so they never reach
+     * the unified schema. Returns a per-file override of {@link SourceMetadata#schema()} for the
+     * losing files: their own inferred sub-schema for the family is replaced by the winning
+     * attribute(s) taken straight from the (possibly widened) {@code unified} entries. That
+     * override becomes, via the caller, the losing file's {@link FileSchemaInfo#fileSchema()} —
+     * which is exactly what {@code FileSplitProvider} pins the reader's {@code readSchema} to. So
+     * when the reader for a losing file later hits that file's real, differently-shaped JSON
+     * value on the now-pinned winning attribute, the existing per-file shape-conflict handling
+     * (e.g. {@code NdJsonPageDecoder}'s {@code shapeConflict}, added for #1028) fires
+     * automatically and routes it through {@link org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy}
+     * — no format-specific code needed here.
+     * <p>
+     * A file that contributes <em>both</em> the bare name and a dotted child for the same root
+     * (a literal flat key such as {@code "user.tag"} coexisting with scalar {@code "user"} in one
+     * file) still fully participates in the vote above as a leaf-shaped contributor — presence of
+     * the bare name means its dotted column(s) are literal flat keys, not nested children (see
+     * {@code NdJsonPageDecoder#hasDottedPrefixConflict}), so only those unrelated dotted columns
+     * are excluded from the family; see {@link #resolveFamily} for why exempting the file's leaf
+     * contribution too would silently reopen the conflict.
+     */
+    private static Map<StoragePath, List<Attribute>> resolveShapeConflicts(
+        LinkedHashMap<String, MergeEntry> unified,
+        Map<StoragePath, SourceMetadata> fileMetadata
+    ) {
+        List<String> familyRoots = findFamilyRoots(unified.keySet());
+        if (familyRoots.isEmpty()) {
+            return Map.of();
+        }
+        // Shallowest roots first: once a shallower family is resolved its losing names are
+        // removed from `unified`, so a deeper candidate root re-derives its family membership
+        // from what's actually still there rather than from a stale upfront snapshot.
+        familyRoots.sort(Comparator.comparingInt(SchemaReconciliation::dotDepth));
+
+        Map<StoragePath, List<Attribute>> overrides = new LinkedHashMap<>();
+        List<FamilyConflict> conflicts = new ArrayList<>();
+        for (String root : familyRoots) {
+            FamilyConflict conflict = resolveFamily(root, unified, fileMetadata);
+            if (conflict == null) {
+                continue;
+            }
+            conflicts.add(conflict);
+            for (String droppedName : conflict.droppedNames()) {
+                unified.remove(droppedName);
+            }
+            for (Map.Entry<StoragePath, List<String>> losing : conflict.losingFileNames().entrySet()) {
+                StoragePath losingFile = losing.getKey();
+                List<String> ownFamilyNames = losing.getValue();
+                List<Attribute> override = overrides.computeIfAbsent(losingFile, f -> new ArrayList<>(fileMetadata.get(f).schema()));
+                override.removeIf(a -> ownFamilyNames.contains(a.name()));
+                override.addAll(conflict.winningAttributes());
+            }
+        }
+        emitShapeConflictWarnings(conflicts);
+        return overrides;
+    }
+
+    private static int dotDepth(String name) {
+        int depth = 0;
+        for (int i = 0; i < name.length(); i++) {
+            if (name.charAt(i) == '.') {
+                depth++;
+            }
+        }
+        return depth;
+    }
+
+    /**
+     * Returns every name in {@code names} that is a "family root": some other name in the set is
+     * {@code root + "." + suffix}. Quadratic in the (typically small, per-query-bounded) column
+     * count — the same trade-off {@link #validateNoDuplicateColumns} and the rest of this class
+     * already make for per-name work at reconciliation time.
+     */
+    private static List<String> findFamilyRoots(Set<String> names) {
+        List<String> roots = new ArrayList<>();
+        for (String candidate : names) {
+            String prefix = candidate + ".";
+            for (String other : names) {
+                if (other.startsWith(prefix)) {
+                    roots.add(candidate);
+                    break;
+                }
+            }
+        }
+        return roots;
+    }
+
+    /**
+     * Classifies every file's contribution to the {@code root} family as leaf-shaped (has the
+     * bare {@code root} name — even if it also carries unrelated {@code root.*} flat keys, see
+     * below), dotted-shaped (has some {@code root.*} name but not {@code root} itself) or absent,
+     * then resolves a conflict when both shapes are contributed by different files. Returns
+     * {@code null} when there is no actual cross-file conflict for this family (a single
+     * contributor, or every contributor agrees).
+     * <p>
+     * A file that has the bare {@code root} name always classifies as leaf-shaped for this
+     * family, full stop, regardless of whether it also happens to carry some unrelated
+     * {@code root.*} column: presence of {@code root} itself means any {@code root.*} names in
+     * that <em>same</em> file are literal flat keys, not nested children of {@code root} (see
+     * {@code NdJsonPageDecoder#hasDottedPrefixConflict}), so they take no part in this family
+     * either way — they are simply excluded from {@code familyNamesInFile} below and therefore
+     * never touched by the winning/losing overrides. The file's actual {@code root} value,
+     * though, is a real, ordinary leaf contribution and must fully participate in the cross-file
+     * win/loss vote like any other file's bare column — exempting it entirely (as an earlier
+     * version of this method did) let such a file's scalar {@code root} silently keep coexisting
+     * with a winning nested shape from another file, reopening the exact ambiguity this method
+     * exists to close.
+     */
+    @Nullable
+    private static FamilyConflict resolveFamily(
+        String root,
+        LinkedHashMap<String, MergeEntry> unified,
+        Map<StoragePath, SourceMetadata> fileMetadata
+    ) {
+        String dottedPrefix = root + ".";
+        Boolean winningShapeIsLeaf = null;
+        StoragePath winningFile = null;
+        // Every family-member name (the bare root, or a genuinely nested root.* child) mapped to
+        // the set of files whose own schema contributes it — used below so a name is only ever
+        // dropped from the unified schema when *every* one of its contributors is on the losing
+        // side; a name a kept (non-losing) file also relies on must survive untouched. Note this
+        // never contains a root.* name from a file that also has the bare root itself — see the
+        // class javadoc above for why those are excluded from the family entirely.
+        Map<String, Set<StoragePath>> contributorsByName = new LinkedHashMap<>();
+        // Losing files mapped to exactly the family-member names *they* contribute, so each
+        // file's override only ever removes its own columns, never another file's.
+        LinkedHashMap<StoragePath, List<String>> losingFileNames = new LinkedHashMap<>();
+
+        for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            boolean hasLeaf = false;
+            List<String> dottedNames = new ArrayList<>();
+            for (Attribute attr : entry.getValue().schema()) {
+                String name = attr.name();
+                if (name.equals(root)) {
+                    hasLeaf = true;
+                } else if (name.startsWith(dottedPrefix)) {
+                    dottedNames.add(name);
+                }
+            }
+
+            List<String> familyNamesInFile;
+            boolean fileShapeIsLeaf;
+            if (hasLeaf) {
+                familyNamesInFile = List.of(root);
+                fileShapeIsLeaf = true;
+            } else if (dottedNames.isEmpty() == false) {
+                familyNamesInFile = dottedNames;
+                fileShapeIsLeaf = false;
+            } else {
+                continue; // file doesn't touch this family at all
+            }
+
+            for (String name : familyNamesInFile) {
+                contributorsByName.computeIfAbsent(name, n -> new LinkedHashSet<>()).add(entry.getKey());
+            }
+            if (winningShapeIsLeaf == null) {
+                winningShapeIsLeaf = fileShapeIsLeaf;
+                winningFile = entry.getKey();
+            } else if (fileShapeIsLeaf != winningShapeIsLeaf) {
+                losingFileNames.put(entry.getKey(), familyNamesInFile);
+            }
+        }
+
+        if (losingFileNames.isEmpty()) {
+            return null;
+        }
+
+        // Restricted to contributorsByName's keys (true family members only) rather than a plain
+        // name/dottedPrefix match against `unified`: an unrelated root.* flat key owned by some
+        // other leaf-shaped file (excluded above) must never be pulled into the winning shape.
+        List<Attribute> winningAttributes = new ArrayList<>();
+        for (String name : unified.keySet()) {
+            if (contributorsByName.containsKey(name) == false) {
+                continue;
+            }
+            boolean isLeafName = name.equals(root);
+            if (isLeafName == winningShapeIsLeaf) {
+                MergeEntry me = unified.get(name);
+                Nullability nullability = me.nullable ? Nullability.TRUE : Nullability.FALSE;
+                winningAttributes.add(new ReferenceAttribute(Source.EMPTY, null, name, me.type, nullability, null, false));
+            }
+        }
+
+        Set<StoragePath> losingFiles = losingFileNames.keySet();
+        LinkedHashSet<String> droppedNames = new LinkedHashSet<>();
+        for (List<String> ownNames : losingFileNames.values()) {
+            for (String name : ownNames) {
+                if (losingFiles.containsAll(contributorsByName.get(name))) {
+                    droppedNames.add(name);
+                }
+            }
+        }
+
+        return new FamilyConflict(root, winningFile, winningShapeIsLeaf, winningAttributes, droppedNames, losingFileNames);
+    }
+
+    /**
+     * A resolved esql-planning#1050 conflict for one field family: {@code winningFile} kept its
+     * shape ({@code winningAttributes}, family root {@code root}); every file key in
+     * {@code losingFileNames} contributed the other shape and had its own listed family names
+     * removed from the unified schema (to the extent {@code droppedNames} allows — see
+     * {@link #resolveFamily}) and overridden to {@code winningAttributes} in its own
+     * {@code fileSchema()} pin.
+     */
+    private record FamilyConflict(
+        String root,
+        StoragePath winningFile,
+        boolean winningShapeIsLeaf,
+        List<Attribute> winningAttributes,
+        Set<String> droppedNames,
+        Map<StoragePath, List<String>> losingFileNames
+    ) {
+        String buildDetail() {
+            StoragePath losingExample = losingFileNames.keySet().iterator().next();
+            String winningShape = winningShapeIsLeaf ? "a scalar" : "an object";
+            String losingShape = winningShapeIsLeaf ? "an object" : "a scalar";
+            StringBuilder sb = new StringBuilder("Field [").append(root)
+                .append("] is ")
+                .append(winningShape)
+                .append(" in [")
+                .append(winningFile)
+                .append("] but ")
+                .append(losingShape)
+                .append(" in [")
+                .append(losingExample)
+                .append("]");
+            if (losingFileNames.size() > 1) {
+                sb.append(" (+").append(losingFileNames.size() - 1).append(" more)");
+            }
+            sb.append("; kept the [")
+                .append(winningFile)
+                .append("] shape [")
+                .append(String.join(", ", winningAttributes.stream().map(Attribute::name).toList()))
+                .append("], dropped [")
+                .append(String.join(", ", droppedNames))
+                .append("] from the unified schema. The conflicting file(s)' values for [")
+                .append(root)
+                .append("] are handled per the configured error policy at read time.");
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Fire-and-forget emit of one response {@code Warning} per resolved shape conflict, via the
+     * same {@link SkipWarnings} pattern as {@link #emitKeywordFallbackWarnings}.
+     */
+    private static void emitShapeConflictWarnings(List<FamilyConflict> conflicts) {
+        if (conflicts.isEmpty()) {
+            return;
+        }
+        SkipWarnings warnings = new SkipWarnings(
+            "Schema reconciliation resolved cross-file scalar/object shape conflicts (esql-planning#1050) by"
+                + " keeping the first file's shape; make the field's shape consistent across files, or declare it"
+                + " explicitly, to avoid this."
+        );
+        for (FamilyConflict conflict : conflicts) {
+            warnings.add(conflict.buildDetail());
+        }
     }
 
     static ColumnMapping computeMapping(List<Attribute> unifiedSchema, List<Attribute> fileSchema) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -21,12 +21,15 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -349,6 +352,270 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
         assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.LONG));
+    }
+
+    // === Cross-file scalar/object shape conflict tests (esql-planning#1050) ===
+    //
+    // A field that is a scalar leaf in one file's schema and a dotted-prefix parent in another's
+    // (an NDJSON field that is a scalar in one file and an object in the other) must reconcile to
+    // a single shape under UNION_BY_NAME — mirroring the per-file single-shape rule from
+    // esql-planning#1028 (first shape wins). Before this fix, [user] and [user.id]/[user.tier]
+    // never collided by name, so the unified schema fabricated both shapes and the losing file's
+    // values vanished silently. See SchemaReconciliation#resolveShapeConflicts.
+
+    public void testUnionByNameScalarVsObjectShapeConflictResolvesToScalar() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(
+            "expected exactly the first file's scalar [user] shape in the unified schema",
+            userFamily(result),
+            equalTo(List.of("user"))
+        );
+        drainWarningMessages();
+    }
+
+    /** Mirror of {@link #testUnionByNameScalarVsObjectShapeConflictResolvesToScalar}: object-shape file first. */
+    public void testUnionByNameObjectVsScalarShapeConflictResolvesToObject() {
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(objectFile), b, meta(scalarFile));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(
+            "expected exactly the first file's nested [user.*] shape in the unified schema",
+            userFamily(result),
+            equalTo(List.of("user.id", "user.tier"))
+        );
+        drainWarningMessages();
+    }
+
+    /**
+     * The unified schema shape is only half the fix: the losing (object-shaped) file's own
+     * {@code readSchema} pin must carry the winning scalar attribute, not its own
+     * [user.id]/[user.tier] sub-schema — that's what routes the file's real values through the
+     * existing per-file shape-conflict/{@code ErrorPolicy} handling (elastic/esql-planning#1028)
+     * at read time instead of silently vanishing.
+     */
+    public void testUnionByNameShapeConflictOverridesLosingFileReadSchema() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        List<Attribute> losingReadSchema = result.perFileInfo().get(b).fileSchema().attributes();
+        List<String> losingNames = losingReadSchema.stream().map(Attribute::name).toList();
+        assertThat(losingNames, equalTo(List.of("event", "user")));
+        assertThat(losingReadSchema.get(losingNames.indexOf("user")).dataType(), equalTo(DataType.KEYWORD));
+
+        // The winning file's own read schema is untouched.
+        assertThat(result.perFileInfo().get(a).fileSchema().attributes(), equalTo(scalarFile));
+        drainWarningMessages();
+    }
+
+    public void testUnionByNameShapeConflictEmitsWarning() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+        SchemaReconciliation.reconcileUnionByName(metadata);
+
+        List<String> warnings = drainWarningMessages();
+        assertWarningMentionsAll(warnings, "user", "a.ndjson", "b.ndjson", "scalar", "object");
+    }
+
+    /**
+     * Three files, two contributing the object shape: the winner is still "first file overall"
+     * (the anchor semantics from #1028/{@code FIRST_FILE_WINS}), and every losing file — not just
+     * the first one encountered — gets its own {@code readSchema} overridden.
+     */
+    public void testUnionByNameShapeConflictThreeFilesFirstFileWins() {
+        List<Attribute> objectFile1 = List.of(attr("event", DataType.INTEGER), attr("user.id", DataType.KEYWORD));
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile2 = List.of(attr("event", DataType.INTEGER), attr("user.id", DataType.KEYWORD));
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.ndjson");
+        StoragePath c = path("s3://b/c.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(a, meta(objectFile1));
+        metadata.put(b, meta(scalarFile));
+        metadata.put(c, meta(objectFile2));
+
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(userFamily(result), equalTo(List.of("user.id")));
+        assertThat(result.perFileInfo().get(a).fileSchema().attributes(), equalTo(objectFile1));
+        assertThat(result.perFileInfo().get(c).fileSchema().attributes(), equalTo(objectFile2));
+        assertThat(
+            result.perFileInfo().get(b).fileSchema().attributes().stream().map(Attribute::name).toList(),
+            equalTo(List.of("event", "user.id"))
+        );
+        drainWarningMessages();
+    }
+
+    /**
+     * A file that carries <em>both</em> the bare name and an unrelated dotted child for the same
+     * root in one file (e.g. a literal flat {@code "user.tag"} key coexisting with scalar
+     * {@code "user"}) has its dotted column excluded from the family — that column is already
+     * disambiguated per-file as a flat key, not a nested child (see
+     * {@code NdJsonPageDecoder#hasDottedPrefixConflict}) — but its bare {@code user} leaf still
+     * fully participates in the cross-file vote like any other file's. Here it happens to *agree*
+     * with the (scalar) winner, so both its columns stay untouched. See
+     * {@link #testUnionByNameShapeConflictFileWithBothShapesDisagreeingIsAlsoOverridden} for the
+     * disagreeing case.
+     */
+    public void testUnionByNameShapeConflictFileWithBothShapesAgreeingIsUnaffected() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+        List<Attribute> bothShapesFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user", DataType.KEYWORD),
+            attr("user.tag", DataType.KEYWORD)
+        );
+
+        StoragePath scalarPath = path("s3://b/a.ndjson");
+        StoragePath objectPath = path("s3://b/b.ndjson");
+        StoragePath bothPath = path("s3://b/c.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(scalarPath, meta(scalarFile));
+        metadata.put(objectPath, meta(objectFile));
+        metadata.put(bothPath, meta(bothShapesFile));
+
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(userFamily(result), equalTo(List.of("user", "user.tag")));
+        assertThat(result.perFileInfo().get(bothPath).fileSchema().attributes(), equalTo(bothShapesFile));
+        assertThat(
+            result.perFileInfo().get(objectPath).fileSchema().attributes().stream().map(Attribute::name).toList(),
+            equalTo(List.of("event", "user"))
+        );
+        drainWarningMessages();
+    }
+
+    /**
+     * Mirror of {@link #testUnionByNameShapeConflictFileWithBothShapesAgreeingIsUnaffected}: when
+     * the both-shapes file's own bare {@code user} *disagrees* with the winning shape (here the
+     * winner is the nested object, contributed by a different file), that leaf column is
+     * overridden exactly like any other losing file's — only the file's unrelated dotted column
+     * ({@code user.tag}, a literal flat key per {@code NdJsonPageDecoder#hasDottedPrefixConflict})
+     * stays untouched. Guards the fix to {@code resolveFamily}: an earlier version exempted a
+     * both-shapes file from the win/loss vote entirely, which let its scalar {@code user} value
+     * silently keep coexisting with the winning nested shape in the unified schema — reopening
+     * the exact scalar/object ambiguity this pass exists to close.
+     */
+    public void testUnionByNameShapeConflictFileWithBothShapesDisagreeingIsAlsoOverridden() {
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> bothShapesFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user", DataType.KEYWORD),
+            attr("user.tag", DataType.KEYWORD)
+        );
+
+        StoragePath objectPath = path("s3://b/a.ndjson");
+        StoragePath scalarPath = path("s3://b/b.ndjson");
+        StoragePath bothPath = path("s3://b/c.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        metadata.put(objectPath, meta(objectFile));
+        metadata.put(scalarPath, meta(scalarFile));
+        metadata.put(bothPath, meta(bothShapesFile));
+
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        // The scalar [user] shape is now fully gone from the unified schema -- both of its
+        // contributors (scalarFile and bothShapesFile) lost the vote -- while the unrelated
+        // [user.tag] flat key survives untouched.
+        assertThat(userFamily(result), equalTo(List.of("user.id", "user.tier", "user.tag")));
+
+        List<String> bothOverrideNames = result.perFileInfo()
+            .get(bothPath)
+            .fileSchema()
+            .attributes()
+            .stream()
+            .map(Attribute::name)
+            .toList();
+        assertThat("own unrelated [user.tag] column must survive untouched", bothOverrideNames, hasItem("user.tag"));
+        assertThat("own [user] leaf must be pinned to the winning nested shape", bothOverrideNames, hasItem("user.id"));
+        assertThat("own [user] leaf must no longer appear on its own", bothOverrideNames, not(hasItem("user")));
+
+        assertThat(
+            result.perFileInfo().get(scalarPath).fileSchema().attributes().stream().map(Attribute::name).toList(),
+            equalTo(List.of("event", "user.id", "user.tier"))
+        );
+        // The winning file's own read schema is untouched.
+        assertThat(result.perFileInfo().get(objectPath).fileSchema().attributes(), equalTo(objectFile));
+        drainWarningMessages();
+    }
+
+    /**
+     * Pins that {@code STRICT} still rejects the exact esql-planning#1050 repro shape outright
+     * (differing column counts) rather than ever attempting the UNION_BY_NAME-style resolution —
+     * the issue calls this out as already-correct behavior to guard, not change.
+     */
+    public void testStrictRejectsScalarVsObjectShapeConflict() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.ndjson");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(a, metadata));
+        assertThat(e.getMessage(), containsString("Schema mismatch"));
+    }
+
+    /** The {@code [user]}-family column names present in the unified schema, in schema order. */
+    private static List<String> userFamily(SchemaReconciliation.Result result) {
+        List<String> names = new ArrayList<>();
+        for (int i = 0; i < result.unifiedSchema().size(); i++) {
+            String n = result.unifiedSchema().get(i).name();
+            if (n.equals("user") || n.startsWith("user.")) {
+                names.add(n);
+            }
+        }
+        return names;
     }
 
     // === Config parsing tests ===


### PR DESCRIPTION
With the default UNION_BY_NAME, a field that's a scalar in one file and a nested object in another was merged by exact column name, so both shapes coexisted in the unified schema and the object file's values dissapeared.

This fixes this behavior while also respecting the conflict resolution strategy.

Closes https://github.com/elastic/esql-planning/issues/1050