### PR TITLE
[9.4]  Trip request breaker on big completion suggest size/shardSize (#152552)

### DIFF
--- a/docs/changelog/152552.yaml
+++ b/docs/changelog/152552.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 152552
+summary: Trip request breaker on big completion suggest size/shardSize
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.apache.lucene.analysis.TokenStreamToAutomaton;
 import org.apache.lucene.search.suggest.document.ContextSuggestField;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.indices.segments.IndexShardSegments;
 import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -22,6 +23,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.FieldMemoryStats;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Strings;
@@ -1552,5 +1554,49 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             this.contextMappings = mappings;
             return this;
         }
+    }
+
+    public void testBigSizeCircuitBreak() throws Exception {
+        final XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject(FIELD)
+            .field("type", "completion")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        assertAcked(prepareCreate(INDEX).setSettings(indexSettings(1, 0)).setMapping(mapping));
+        prepareIndex(INDEX).setId("1")
+            .setRefreshPolicy(IMMEDIATE)
+            .setSource(jsonBuilder().startObject().field(FIELD, new String[] { "Nevermind", "Nirvana" }).endObject())
+            .get();
+        ensureGreen(INDEX);
+
+        Exception exception = expectThrows(
+            Exception.class,
+            () -> prepareSearch(INDEX).setAllowPartialSearchResults(false)
+                .suggest(
+                    new SuggestBuilder().addSuggestion(
+                        "song-suggest",
+                        SuggestBuilders.completionSuggestion(FIELD).size(2_147_483_630).prefix("nir")
+                    )
+                )
+                .get()
+        );
+        assertThat(ExceptionsHelper.unwrap(exception, CircuitBreakingException.class), notNullValue());
+
+        exception = expectThrows(
+            Exception.class,
+            () -> prepareSearch(INDEX).setAllowPartialSearchResults(false)
+                .suggest(
+                    new SuggestBuilder().addSuggestion(
+                        "song-suggest",
+                        SuggestBuilders.completionSuggestion(FIELD).shardSize(2_147_483_630).prefix("nir")
+                    )
+                )
+                .get()
+        );
+        assertThat(ExceptionsHelper.unwrap(exception, CircuitBreakingException.class), notNullValue());
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -787,4 +787,18 @@ public class SearchExecutionContext extends QueryRewriteContext {
             circuitBreaker.addWithoutBreaking(-memoryToRelease);
         }
     }
+
+    /**
+     * Release {@code bytes} of accumulated query construction memory back to the circuit breaker.
+     *
+     * @param bytes the number of bytes to refund; must be {@code >= 0}
+     */
+    public void releaseQueryConstructionMemory(long bytes) {
+        assert bytes >= 0 : "negative refund: " + bytes;
+        if (circuitBreaker == null || bytes <= 0) {
+            return;
+        }
+        circuitBreaker.addWithoutBreaking(-bytes);
+        queryConstructionMemoryUsed.addAndGet(-bytes);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -19,7 +19,9 @@ import org.apache.lucene.search.suggest.document.CompletionQuery;
 import org.apache.lucene.search.suggest.document.TopSuggestDocs;
 import org.apache.lucene.search.suggest.document.TopSuggestDocsCollector;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.xcontent.Text;
@@ -47,31 +49,43 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
             final CompletionFieldMapper.CompletionFieldType fieldType = suggestionContext.getFieldType();
             CompletionSuggestion completionSuggestion = emptySuggestion(name, suggestionContext, spare);
             int shardSize = suggestionContext.getShardSize() != null ? suggestionContext.getShardSize() : suggestionContext.getSize();
-            TopSuggestGroupDocsCollector collector = new TopSuggestGroupDocsCollector(shardSize, suggestionContext.isSkipDuplicates());
-            suggest(searcher, suggestionContext.toQuery(), collector);
-            int numResult = 0;
-            for (TopSuggestDocs.SuggestScoreDoc suggestDoc : collector.get().scoreLookupDocs()) {
-                // collect contexts
-                Map<String, Set<String>> contexts = Collections.emptyMap();
-                if (fieldType.hasContextMappings()) {
-                    List<CharSequence> rawContexts = collector.getContexts(suggestDoc.doc);
-                    if (rawContexts.size() > 0) {
-                        contexts = fieldType.getContextMappings().getNamedContexts(rawContexts);
+            SearchExecutionContext searchExecutionContext = suggestionContext.getSearchExecutionContext();
+            // TopSuggestGroupDocsCollector uses a Lucene's SuggestScoreDocPriorityQueue
+            // which extends PriorityQueue and allocates a heap array of length shardSize + 1. This is the
+            // dominant cost so we make sure here we have enough heap to allocate it
+            long collectorBytes = RamUsageEstimator.alignObjectSize(
+                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (shardSize + 1L) * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            );
+            searchExecutionContext.addCircuitBreakerMemory(collectorBytes, "completion-suggest-collector");
+            try {
+                TopSuggestGroupDocsCollector collector = new TopSuggestGroupDocsCollector(shardSize, suggestionContext.isSkipDuplicates());
+                suggest(searcher, suggestionContext.toQuery(), collector);
+                int numResult = 0;
+                for (TopSuggestDocs.SuggestScoreDoc suggestDoc : collector.get().scoreLookupDocs()) {
+                    // collect contexts
+                    Map<String, Set<String>> contexts = Collections.emptyMap();
+                    if (fieldType.hasContextMappings()) {
+                        List<CharSequence> rawContexts = collector.getContexts(suggestDoc.doc);
+                        if (rawContexts.size() > 0) {
+                            contexts = fieldType.getContextMappings().getNamedContexts(rawContexts);
+                        }
+                    }
+                    if (numResult++ < suggestionContext.getSize()) {
+                        CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(
+                            suggestDoc.doc,
+                            new Text(suggestDoc.key.toString()),
+                            suggestDoc.score,
+                            contexts
+                        );
+                        completionSuggestion.getEntries().get(0).addOption(option);
+                    } else {
+                        break;
                     }
                 }
-                if (numResult++ < suggestionContext.getSize()) {
-                    CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(
-                        suggestDoc.doc,
-                        new Text(suggestDoc.key.toString()),
-                        suggestDoc.score,
-                        contexts
-                    );
-                    completionSuggestion.getEntries().get(0).addOption(option);
-                } else {
-                    break;
-                }
+                return completionSuggestion;
+            } finally {
+                searchExecutionContext.releaseQueryConstructionMemory(collectorBytes);
             }
-            return completionSuggestion;
         }
         return null;
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [ Trip request breaker on big completion suggest size/shardSize (#152552)](https://github.com/elastic/elasticsearch/pull/152552)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)