### PR TITLE
[9.4] Ignore OTLP number data points without a value (#152733)

### DIFF
--- a/docs/changelog/152733.yaml
+++ b/docs/changelog/152733.yaml
@@ -1,0 +1,5 @@
+area: TSDB
+issues: []
+pr: 152733
+summary: Ignore OTLP number data points without a value
+type: bug

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPoint.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPoint.java
@@ -142,6 +142,11 @@ public interface DataPoint {
             switch (dataPoint.getValueCase()) {
                 case AS_DOUBLE -> builder.value(dataPoint.getAsDouble());
                 case AS_INT -> builder.value(dataPoint.getAsInt());
+                // Value-less data points are rejected by isValid before reaching this point. Fail loudly rather than
+                // writing a field name with no value, which would corrupt the document.
+                case VALUE_NOT_SET -> throw new IllegalStateException(
+                    "number data point without a value should have been filtered out: " + metric.getName()
+                );
             }
         }
 
@@ -173,6 +178,10 @@ public interface DataPoint {
 
         @Override
         public boolean isValid(Set<String> errors) {
+            if (dataPoint.getValueCase() == NumberDataPoint.ValueCase.VALUE_NOT_SET) {
+                errors.add("number data point without a value, ignoring " + metric.getName());
+                return false;
+            }
             return true;
         }
     }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OtlpUtils.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OtlpUtils.java
@@ -179,6 +179,19 @@ public class OtlpUtils {
             .build();
     }
 
+    public static NumberDataPoint createNoValueDataPoint(long timestamp) {
+        return createNoValueDataPoint(timestamp, timestamp, List.of());
+    }
+
+    public static NumberDataPoint createNoValueDataPoint(long timeUnixNano, long startTimeUnixNano, List<KeyValue> attributes) {
+        // Neither as_double nor as_int is set, leaving the oneof value in the VALUE_NOT_SET state.
+        return NumberDataPoint.newBuilder()
+            .setTimeUnixNano(timeUnixNano)
+            .setStartTimeUnixNano(startTimeUnixNano)
+            .addAllAttributes(attributes)
+            .build();
+    }
+
     public static SummaryDataPoint createSummaryDataPoint(long timestamp, List<KeyValue> attributes) {
         return SummaryDataPoint.newBuilder()
             .setTimeUnixNano(timestamp)

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContextTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContextTests.java
@@ -27,6 +27,7 @@ import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createGaugeMetric;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createHistogramMetric;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createLongDataPoint;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createMetricsRequest;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createNoValueDataPoint;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createResourceMetrics;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createScopeMetrics;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createSumMetric;
@@ -141,6 +142,28 @@ public class DataPointGroupingContextTests extends ESTestCase {
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
         assertEquals(1, groupCount.get());
+    }
+
+    public void testGroupingIgnoresNumberDataPointWithoutValue() throws Exception {
+        // A NumberDataPoint whose oneof value is unset must be filtered out during grouping rather than
+        // reaching document building, where it would leave a dangling field name and corrupt the document.
+        ExportMetricsServiceRequest metricsRequest = createMetricsRequest(
+            List.of(
+                createGaugeMetric("system.cpu.usage", "", List.of(createDoubleDataPoint(nowUnixNanos))),
+                createGaugeMetric("system.memory.usage", "", List.of(createNoValueDataPoint(nowUnixNanos)))
+            )
+        );
+        context.groupDataPoints(metricsRequest);
+        assertEquals(2, context.totalDataPoints());
+        assertEquals(1, context.getIgnoredDataPoints());
+        assertThat(
+            context.getIgnoredDataPointsMessage(10),
+            containsString("number data point without a value, ignoring system.memory.usage")
+        );
+
+        List<String> metricNames = new ArrayList<>();
+        context.consume(dataPointGroup -> dataPointGroup.dataPoints().forEach(dp -> metricNames.add(dp.getMetricName())));
+        assertThat(metricNames, containsInAnyOrder("system.cpu.usage"));
     }
 
     public void testGroupingDuplicateNameDifferentTimeSeries() throws Exception {

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointNumberTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointNumberTests.java
@@ -10,15 +10,20 @@ package org.elasticsearch.xpack.oteldata.otlp.datapoint;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
 import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createDoubleDataPoint;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createGaugeMetric;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createLongDataPoint;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createNoValueDataPoint;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createSumMetric;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class DataPointNumberTests extends ESTestCase {
 
@@ -71,6 +76,16 @@ public class DataPointNumberTests extends ESTestCase {
             createSumMetric("http.requests.count", "", List.of(), false, AGGREGATION_TEMPORALITY_DELTA)
         );
         assertThat(longNonMonotonic.getDynamicTemplate(MappingHints.DEFAULT_TDIGEST), equalTo("gauge_long"));
+    }
+
+    public void testNoValueIsInvalid() {
+        DataPoint.Number noValue = new DataPoint.Number(
+            createNoValueDataPoint(nowUnixNanos),
+            createGaugeMetric("system.cpu.usage", "", List.of())
+        );
+        Set<String> errors = new HashSet<>();
+        assertThat(noValue.isValid(errors), is(false));
+        assertThat(errors, contains("number data point without a value, ignoring system.cpu.usage"));
     }
 
 }


### PR DESCRIPTION
Manual backport of #152733.

The automated backport failed with a cherry-pick conflict: `DataPoint.Number` on `9.4` doesn't yet have the `getTemporality()` method / `isValid(Set<String>, MappingHints)` overload that exist on `main`, which sit adjacent to this diff. Resolved by keeping 9.4's existing `isValid(Set<String>)` signature in place and applying only the `VALUE_NOT_SET` rejection logic from the original PR. Test file and changelog cherry-picked cleanly, aside from adapting to this branch's `isValid` signature and `DataPointGroupingContext` method names (`totalDataPoints`/`getIgnoredDataPoints`/`getIgnoredDataPointsMessage`).

Verified `DataPointNumberTests` and `DataPointGroupingContextTests` pass on this branch.