### PR TITLE
[ESQL] Sanitize external UTF-8 at source boundary

### DIFF
--- a/docs/changelog/152783.yaml
+++ b/docs/changelog/152783.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152783
+summary: Sanitize external UTF-8 at source boundary
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -41,6 +41,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
@@ -814,7 +815,11 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
             case DATE -> DataType.DATETIME;
             case DECIMAL -> DataType.DOUBLE;
             case LIST -> convertOrcTypeToEsql(orcType.getChildren().get(0));
-            default -> DataType.UNSUPPORTED;
+            // BINARY holds arbitrary bytes (KEYWORD would assume valid UTF-8), and MAP/STRUCT/UNION and the
+            // geospatial types have no scalar ESQL equivalent, so all map to UNSUPPORTED. They are enumerated
+            // explicitly so that default is reserved for a genuinely unexpected ORC category (a future enum constant).
+            case BINARY, MAP, STRUCT, UNION, Geometry, Geography -> DataType.UNSUPPORTED;
+            default -> throw new IllegalArgumentException("Unexpected ORC type category: " + orcType.getCategory());
         };
     }
 
@@ -1491,7 +1496,9 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                                 builder.appendBytesRef(new org.apache.lucene.util.BytesRef());
                             } else {
                                 builder.appendBytesRef(
-                                    new org.apache.lucene.util.BytesRef(child.vector[idx], child.start[idx], child.length[idx])
+                                    Utf8Sanitizer.sanitize(
+                                        new org.apache.lucene.util.BytesRef(child.vector[idx], child.start[idx], child.length[idx])
+                                    )
                                 );
                             }
                         }
@@ -1765,7 +1772,9 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                     return blockFactory.newConstantNullBlock(rowCount);
                 }
                 return blockFactory.newConstantBytesRefBlockWith(
-                    new org.apache.lucene.util.BytesRef(bytesVector.vector[0], bytesVector.start[0], bytesVector.length[0]),
+                    Utf8Sanitizer.sanitize(
+                        new org.apache.lucene.util.BytesRef(bytesVector.vector[0], bytesVector.start[0], bytesVector.length[0])
+                    ),
                     rowCount
                 );
             }
@@ -1779,7 +1788,13 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                     } else {
                         int idx = readFromZero ? 0 : i;
                         builder.appendBytesRef(
-                            new org.apache.lucene.util.BytesRef(bytesVector.vector[idx], bytesVector.start[idx], bytesVector.length[idx])
+                            Utf8Sanitizer.sanitize(
+                                new org.apache.lucene.util.BytesRef(
+                                    bytesVector.vector[idx],
+                                    bytesVector.start[idx],
+                                    bytesVector.length[idx]
+                                )
+                            )
                         );
                     }
                 }

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -179,7 +179,7 @@ public class OrcFormatReaderTests extends ESTestCase {
      * ORC's {@code TypeDescription} encodes no non-null guarantee at the schema level — per-file non-null observations live
      * only in footer statistics — so defaulting attributes to non-nullable would cause planner rules (e.g. {@code COALESCE}
      * simplification, {@code IS NULL}/{@code IS NOT NULL} rewriting) to drop legitimate null rows. The schema below covers
-     * every branch of {@code convertOrcTypeToEsql}, including the {@code UNSUPPORTED} fallback (binary).
+     * the representative scalar, list and {@code UNSUPPORTED} (binary) mappings of {@code convertOrcTypeToEsql}.
      */
     public void testSchemaAttributesAreAlwaysNullable() throws Exception {
         TypeDescription schema = TypeDescription.createStruct()
@@ -250,6 +250,38 @@ public class OrcFormatReaderTests extends ESTestCase {
             assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(2));
             assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(2, new BytesRef()));
             assertEquals(92.1, ((DoubleBlock) page.getBlock(2)).getDouble(2), 0.001);
+        });
+    }
+
+    public void testBinaryColumnMapsToUnsupported() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("payload", TypeDescription.createBinary());
+        byte[] orcData = createOrcFile(schema, batch -> { batch.size = 0; });
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+        List<Attribute> attributes = reader.metadata(createStorageObject(orcData)).schema();
+        assertEquals(1, attributes.size());
+        assertEquals(DataType.UNSUPPORTED, attributes.get(0).dataType());
+    }
+
+    public void testStringColumnWithInvalidUtf8IsSanitized() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("name", TypeDescription.createString());
+
+        byte[] orcData = createOrcFile(schema, batch -> {
+            batch.size = 2;
+            BytesColumnVector nameCol = (BytesColumnVector) batch.cols[0];
+            // 0xF8..0xFF is never a valid UTF-8 lead byte; it is exactly what crashes the TopN Utf8 encoder.
+            nameCol.setVal(0, new byte[] { (byte) 0xFF, (byte) 0xF8 });
+            nameCol.setVal(1, "ok".getBytes(StandardCharsets.UTF_8));
+        });
+
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+        StorageObject storageObject = createStorageObject(orcData);
+        assertEquals(DataType.KEYWORD, reader.metadata(storageObject).schema().get(0).dataType());
+
+        readFirstPage(reader, storageObject, null, page -> {
+            BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
+            // Two invalid lead bytes -> two U+FFFD.
+            assertEquals(new BytesRef("\uFFFD\uFFFD"), block.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("ok"), block.getBytesRef(1, new BytesRef()));
         });
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -236,6 +236,9 @@ final class DictionaryValueDecoder {
             BytesRef[] entries = new BytesRef[size];
             for (int i = 0; i < size; i++) {
                 byte[] bytes = dict.decodeToBinary(i).getBytes();
+                // Note: this decoder is type-agnostic; the same dictionary bytes back INT96 timestamps,
+                // decimals and float16 (read via readBinaries), so UTF-8 sanitization must NOT happen here.
+                // KEYWORD callers sanitize in PageColumnReader's ordinal/fallback paths instead.
                 entries[i] = new BytesRef(bytes, 0, bytes.length);
             }
             cachedDictBytesRefs = entries;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -28,6 +28,7 @@ import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.UninitializedArrays;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -1145,7 +1146,7 @@ final class PageColumnReader implements Releasable {
                 for (int i = 0; i < fromPage; i++) {
                     allValues[produced + i] = isUuid
                         ? new BytesRef(ParquetColumnDecoding.formatUuid(vals[i].bytes, vals[i].offset, vals[i].length))
-                        : vals[i];
+                        : Utf8Sanitizer.sanitize(vals[i]);
                 }
                 advancePosition(fromPage);
                 produced += fromPage;
@@ -1174,7 +1175,7 @@ final class PageColumnReader implements Releasable {
                     BytesRef uuidRef = vals[valIdx++];
                     allValues[produced + i] = new BytesRef(ParquetColumnDecoding.formatUuid(uuidRef.bytes, uuidRef.offset, uuidRef.length));
                 } else {
-                    allValues[produced + i] = vals[valIdx++];
+                    allValues[produced + i] = Utf8Sanitizer.sanitize(vals[valIdx++]);
                 }
             }
             advancePosition(fromPage);
@@ -1272,7 +1273,7 @@ final class PageColumnReader implements Releasable {
         if (nulls == null || nulls.isEmpty()) {
             int constantOrdinal = detectConstantOrdinal(ordinals, produced);
             if (constantOrdinal >= 0) {
-                return blockFactory.newConstantBytesRefBlockWith(dict[constantOrdinal], produced);
+                return blockFactory.newConstantBytesRefBlockWith(Utf8Sanitizer.sanitize(dict[constantOrdinal]), produced);
             }
         }
         IntBlock ordinalsBlock = null;
@@ -1346,7 +1347,9 @@ final class PageColumnReader implements Releasable {
         boolean success = false;
         try {
             for (BytesRef entry : entries) {
-                array.append(entry);
+                // KEYWORD ordinal dictionary path only (buildDictionaryVector -> here); sanitize each
+                // dictionary entry once per chunk so the OrdinalBytesRefBlock never exposes malformed UTF-8.
+                array.append(Utf8Sanitizer.sanitize(entry));
             }
             cachedDictArray = array;
             cachedDictArraySource = dictionary;
@@ -1410,6 +1413,15 @@ final class PageColumnReader implements Releasable {
             Block allNull = ConstantBlockDetection.tryAllNull(combinedNulls.toBitSet(), filled, blockFactory);
             if (allNull != null) {
                 return allNull;
+            }
+        }
+        // KEYWORD materialized fallback: {@code all} mixes raw dictionary entries with scalar values read
+        // after the chunk fell off dictionary encoding (this path is never taken for UUID, see readBytesBatch),
+        // so sanitize each position once before building. sanitize returns the input unchanged when it is
+        // already well-formed, so shared dictionary entries are not copied or mutated.
+        for (int i = 0; i < filled; i++) {
+            if (combinedNulls == null || combinedNulls.get(i) == false) {
+                all[i] = Utf8Sanitizer.sanitize(all[i]);
             }
         }
         return buildBytesRefBlock(all, combinedNulls, filled, blockFactory);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 
@@ -311,7 +312,7 @@ final class ParquetColumnDecoding {
             case UNSIGNED_LONG -> readListUnsignedLongColumn(cr, maxDef, rows, blockFactory);
             case DOUBLE -> readListDoubleColumn(cr, maxDef, rows, blockFactory);
             case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows, blockFactory);
-            case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows, blockFactory);
+            case KEYWORD, TEXT -> readListBytesRefColumn(cr, info, rows, blockFactory);
             case DATETIME -> readListDatetimeColumn(cr, info, rows, blockFactory);
             case DATE_NANOS -> readListDateNanosColumn(cr, info, rows, blockFactory);
             default -> {
@@ -432,9 +433,15 @@ final class ParquetColumnDecoding {
         }
     }
 
-    private static Block readListBytesRefColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+    private static Block readListBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        int maxDef = info.maxDefLevel();
+        // UUID-annotated bytes are raw 16-byte payloads: format them as hex (matching the scalar path)
+        // rather than sanitizing, which would mangle valid UUID bytes into replacement characters.
+        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
         try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
-            Runnable appender = () -> builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+            Runnable appender = isUuid
+                ? () -> builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())))
+                : () -> builder.appendBytesRef(Utf8Sanitizer.sanitize(new BytesRef(cr.getBinary().getBytes())));
             for (int row = 0; row < rows; row++) {
                 readListRow(cr, maxDef, builder, appender);
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -41,6 +41,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.UninitializedArrays;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
@@ -2175,6 +2176,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     yield DataType.DOUBLE;
                 }
                 if (logical instanceof LogicalTypeAnnotation.BsonLogicalTypeAnnotation) {
+                    // BSON is a binary document container, not UTF-8 text, so it is not KEYWORD-safe.
                     yield DataType.UNSUPPORTED;
                 }
                 if (logical instanceof LogicalTypeAnnotation.IntervalLogicalTypeAnnotation) {
@@ -2182,6 +2184,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     // DATE_PERIOD is year/quarter/months/week/days, and TIME_DURATION is hours/minutes/secs/millis.
                     yield DataType.UNSUPPORTED;
                 }
+                // Everything else maps to KEYWORD: string/enum/json annotations, UUID (rendered as a hex
+                // string), and un-annotated BINARY/FIXED_LEN_BYTE_ARRAY. Legacy writers (Impala, older Spark)
+                // and much real-world data store strings as un-annotated BINARY, so mapping those to
+                // UNSUPPORTED would silently drop legitimate string columns. ES|QL requires KEYWORD bytes to
+                // be valid UTF-8 (the TopN Utf8 encoders index a table by the raw lead byte), so the reader
+                // sanitizes malformed bytes to U+FFFD on read, keeping KEYWORD operations total even when a
+                // column genuinely holds arbitrary bytes.
                 yield DataType.KEYWORD;
             }
             default -> DataType.UNSUPPORTED;
@@ -2781,7 +2790,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     } else if (isUuid) {
                         builder.appendBytesRef(new BytesRef(ParquetColumnDecoding.formatUuid(cr.getBinary().getBytes())));
                     } else {
-                        builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+                        builder.appendBytesRef(Utf8Sanitizer.sanitize(new BytesRef(cr.getBinary().getBytes())));
                     }
                     cr.consume();
                 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -76,6 +76,7 @@ import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -1964,6 +1965,147 @@ public class ParquetFormatReaderTests extends ESTestCase {
             BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
             assertEquals(uuid1.toString(), block.getBytesRef(0, new BytesRef()).utf8ToString());
             assertEquals(uuid2.toString(), block.getBytesRef(1, new BytesRef()).utf8ToString());
+        }
+    }
+
+    // --- Raw binary / malformed UTF-8 tests ---
+
+    public void testRawBinaryColumnsMapToKeywordAndAreSanitized() throws Exception {
+        // Un-annotated BINARY/FIXED_LEN_BYTE_ARRAY is how legacy writers (Impala, older Spark) store strings,
+        // so it maps to KEYWORD rather than UNSUPPORTED to avoid dropping legitimate string columns. Because
+        // the bytes may be arbitrary, the reader sanitizes them to well-formed UTF-8 so KEYWORD ops stay total.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .named("raw_binary")
+            .required(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+            .length(4)
+            .named("raw_fixed")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("raw_binary", Binary.fromConstantByteArray(new byte[] { (byte) 0xFF, (byte) 0xFE, 0x00 }));
+            g.add("raw_fixed", Binary.fromConstantByteArray(new byte[] { (byte) 0xF8, (byte) 0xFF, 0x01, 0x02 }));
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        StorageObject storageObject = createStorageObject(parquetData);
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(2, metadata.schema().size());
+        assertEquals(DataType.KEYWORD, metadata.schema().get(0).dataType());
+        assertEquals(DataType.KEYWORD, metadata.schema().get(1).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            BytesRefBlock rawBinary = (BytesRefBlock) page.getBlock(0);
+            BytesRefBlock rawFixed = (BytesRefBlock) page.getBlock(1);
+            // 0xFF and 0xFE are invalid lead bytes -> one U+FFFD each; 0x00/0x01/0x02 are valid ASCII.
+            assertEquals(new BytesRef("\uFFFD\uFFFD\u0000"), rawBinary.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("\uFFFD\uFFFD\u0001\u0002"), rawFixed.getBytesRef(0, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    public void testStringColumnWithInvalidUtf8IsSanitized() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("s")
+            .named("test_schema");
+
+        // 0xFF is never a valid UTF-8 lead byte (it is exactly what crashes the TopN Utf8 encoder).
+        byte[] invalid = { (byte) 0xFF };
+        byte[] valid = "ok".getBytes(StandardCharsets.UTF_8);
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("s", Binary.fromConstantByteArray(invalid));
+            Group g2 = factory.newGroup();
+            g2.add("s", Binary.fromConstantByteArray(valid));
+            return List.of(g1, g2);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        StorageObject storageObject = createStorageObject(parquetData);
+        assertEquals(DataType.KEYWORD, reader.metadata(storageObject).schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
+            assertEquals(new BytesRef("\uFFFD"), block.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("ok"), block.getBytesRef(1, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    public void testStringListWithInvalidUtf8IsSanitized() throws Exception {
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("tags");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            Group list = g.addGroup("tags");
+            list.addGroup("list").append("element", Binary.fromConstantByteArray(new byte[] { (byte) 0xC3, (byte) 0x28 }));
+            list.addGroup("list").append("element", Binary.fromConstantByteArray("valid".getBytes(StandardCharsets.UTF_8)));
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        StorageObject storageObject = createStorageObject(parquetData);
+        assertEquals(DataType.KEYWORD, reader.metadata(storageObject).schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
+            assertEquals(2, block.getValueCount(0));
+            int start = block.getFirstValueIndex(0);
+            // 0xC3 0x28: 0xC3 is a 2-byte lead but 0x28 is not a continuation -> one U+FFFD then '('.
+            assertEquals(new BytesRef("\uFFFD("), block.getBytesRef(start, new BytesRef()));
+            assertEquals(new BytesRef("valid"), block.getBytesRef(start + 1, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    public void testUuidListIsFormattedNotSanitized() throws Exception {
+        // A UUID-annotated list element is a raw 16-byte payload (usually not valid UTF-8). It must be
+        // hex-formatted like the scalar UUID path, never fed through the UTF-8 sanitizer.
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+            .length(16)
+            .as(LogicalTypeAnnotation.uuidType())
+            .named("ids");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        UUID uuid1 = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        UUID uuid2 = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            Group list = g.addGroup("ids");
+            list.addGroup("list").append("element", Binary.fromConstantByteArray(toUuidBytes(uuid1)));
+            list.addGroup("list").append("element", Binary.fromConstantByteArray(toUuidBytes(uuid2)));
+            return List.of(g);
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        StorageObject storageObject = createStorageObject(parquetData);
+        assertEquals(DataType.KEYWORD, reader.metadata(storageObject).schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            BytesRefBlock block = (BytesRefBlock) page.getBlock(0);
+            assertEquals(2, block.getValueCount(0));
+            int start = block.getFirstValueIndex(0);
+            assertEquals(uuid1.toString(), block.getBytesRef(start, new BytesRef()).utf8ToString());
+            assertEquals(uuid2.toString(), block.getBytesRef(start + 1, new BytesRef()).utf8ToString());
+            page.releaseBlocks();
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Utf8Sanitizer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Utf8Sanitizer.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.util.Arrays;
+
+/**
+ * Validates and, if necessary, repairs UTF-8 byte sequences that enter ES|QL as {@code KEYWORD}
+ * values from external sources (Parquet, ORC, Arrow).
+ * <p>
+ * ES|QL assumes every {@code KEYWORD}/{@code TEXT} {@link BytesRef} holds well-formed UTF-8: for
+ * example {@code Utf8AscTopNEncoder}/{@code Utf8DescTopNEncoder} index a 248-entry code-length table
+ * by the raw lead byte, so a byte in {@code 0xF8..0xFF} throws {@link ArrayIndexOutOfBoundsException}
+ * on the sort path. External writers (notably Spark) can emit malformed UTF-8 in string-annotated
+ * columns, so the byte hygiene ES|QL relies on cannot be assumed at the source boundary.
+ * <p>
+ * {@link #sanitize(BytesRef)} returns the input unchanged when it is already well-formed (the common,
+ * fast path with no allocation) and otherwise returns a copy in which each maximal ill-formed
+ * subsequence is replaced by a single Unicode replacement character {@code U+FFFD} ({@code EF BF BD}).
+ * The "substitution of maximal subparts" behaviour matches the Unicode recommendation and the output
+ * of ICU / Spark, so downstream {@code KEYWORD} operations become total without silently dropping or
+ * merging distinct malformed inputs.
+ */
+public final class Utf8Sanitizer {
+
+    private Utf8Sanitizer() {}
+
+    /** {@code U+FFFD} REPLACEMENT CHARACTER encoded as UTF-8. */
+    private static final byte[] REPLACEMENT = { (byte) 0xEF, (byte) 0xBF, (byte) 0xBD };
+
+    /**
+     * Allocation-free scan reporting whether {@code [off, off+len)} is well-formed UTF-8.
+     */
+    public static boolean isWellFormed(byte[] bytes, int off, int len) {
+        int i = off;
+        int end = off + len;
+        while (i < end) {
+            int b0 = bytes[i] & 0xFF;
+            if (b0 < 0x80) {
+                // ASCII
+                i++;
+                continue;
+            }
+            int consumed = sequenceLength(bytes, i, end);
+            if (consumed < 0) {
+                return false;
+            }
+            i += consumed;
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code in} unchanged when it is well-formed UTF-8, otherwise a new {@link BytesRef}
+     * (offset 0) with every maximal ill-formed subsequence replaced by {@code U+FFFD}.
+     */
+    public static BytesRef sanitize(BytesRef in) {
+        if (in == null) {
+            return null;
+        }
+        if (isWellFormed(in.bytes, in.offset, in.length)) {
+            return in;
+        }
+        return new BytesRef(repair(in.bytes, in.offset, in.length));
+    }
+
+    /**
+     * Length of the well-formed UTF-8 sequence starting at {@code i}, or the negated length of the
+     * maximal ill-formed subpart (always {@code <= -1}) when the sequence is malformed. The negated
+     * length lets {@link #repair} advance by exactly the maximal subpart, emitting one {@code U+FFFD}
+     * per Unicode's substitution recommendation.
+     */
+    private static int sequenceLength(byte[] bytes, int i, int end) {
+        int b0 = bytes[i] & 0xFF;
+        if (b0 < 0x80) {
+            return 1;
+        }
+        // Continuation byte or C0/C1 (always overlong) as a lead: ill-formed, maximal subpart is one byte.
+        if (b0 < 0xC2) {
+            return -1;
+        }
+        if (b0 < 0xE0) {
+            // 2-byte sequence C2..DF 80..BF
+            if (i + 1 >= end || isCont(bytes[i + 1]) == false) {
+                return -1;
+            }
+            return 2;
+        }
+        if (b0 < 0xF0) {
+            // 3-byte sequence; the second byte range excludes overlong (E0) and surrogates (ED).
+            int lo = (b0 == 0xE0) ? 0xA0 : 0x80;
+            int hi = (b0 == 0xED) ? 0x9F : 0xBF;
+            if (i + 1 >= end || inRange(bytes[i + 1], lo, hi) == false) {
+                return -1;
+            }
+            if (i + 2 >= end || isCont(bytes[i + 2]) == false) {
+                // Maximal subpart is the two valid leading bytes.
+                return -2;
+            }
+            return 3;
+        }
+        if (b0 < 0xF5) {
+            // 4-byte sequence; the second byte range excludes overlong (F0) and > U+10FFFF (F4).
+            int lo = (b0 == 0xF0) ? 0x90 : 0x80;
+            int hi = (b0 == 0xF4) ? 0x8F : 0xBF;
+            if (i + 1 >= end || inRange(bytes[i + 1], lo, hi) == false) {
+                return -1;
+            }
+            if (i + 2 >= end || isCont(bytes[i + 2]) == false) {
+                return -2;
+            }
+            if (i + 3 >= end || isCont(bytes[i + 3]) == false) {
+                return -3;
+            }
+            return 4;
+        }
+        // 0xF5..0xFF: never a valid lead byte.
+        return -1;
+    }
+
+    private static byte[] repair(byte[] bytes, int off, int len) {
+        // Worst case each input byte becomes a 3-byte replacement; grow-on-demand keeps the common
+        // "few bad bytes" case compact without a second pass.
+        byte[] out = new byte[len + 8];
+        int outLen = 0;
+        int i = off;
+        int end = off + len;
+        while (i < end) {
+            int consumed = sequenceLength(bytes, i, end);
+            if (consumed > 0) {
+                out = ensureCapacity(out, outLen + consumed);
+                System.arraycopy(bytes, i, out, outLen, consumed);
+                outLen += consumed;
+                i += consumed;
+            } else {
+                out = ensureCapacity(out, outLen + REPLACEMENT.length);
+                System.arraycopy(REPLACEMENT, 0, out, outLen, REPLACEMENT.length);
+                outLen += REPLACEMENT.length;
+                i += -consumed;
+            }
+        }
+        return outLen == out.length ? out : Arrays.copyOf(out, outLen);
+    }
+
+    private static byte[] ensureCapacity(byte[] out, int needed) {
+        if (needed <= out.length) {
+            return out;
+        }
+        return Arrays.copyOf(out, Math.max(needed, out.length + (out.length >> 1)));
+    }
+
+    private static boolean isCont(byte b) {
+        return (b & 0xC0) == 0x80;
+    }
+
+    private static boolean inRange(byte b, int lo, int hi) {
+        int v = b & 0xFF;
+        return v >= lo && v <= hi;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/ArrowToBlockConverters.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/ArrowToBlockConverters.java
@@ -49,7 +49,10 @@ public class ArrowToBlockConverters {
         map.put(Types.MinorType.UINT2, UInt16ArrowBufBlock::of);
         map.put(Types.MinorType.UINT4, UInt32ArrowBufBlock::of);
         map.put(Types.MinorType.BIT, BooleanArrowBlock::of);
-        map.put(Types.MinorType.VARCHAR, BytesRefArrowBlock::of);
+        // VARCHAR is nominally UTF-8 but external producers can emit malformed bytes; sanitize to U+FFFD so
+        // downstream KEYWORD ops (e.g. the TopN Utf8 encoders) stay total regardless of which reader feeds this
+        // registry. sanitize is a no-op (zero-copy) for well-formed data.
+        map.put(Types.MinorType.VARCHAR, BytesRefArrowBlock::ofSanitizedUtf8);
         map.put(Types.MinorType.VARBINARY, BytesRefArrowBlock::of);
         map.put(Types.MinorType.TIMESTAMPSEC, LongMul1kArrowBufBlock::of);
         map.put(Types.MinorType.TIMESTAMPSECTZ, LongMul1kArrowBufBlock::of);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBlock.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.data.arrow;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -14,6 +15,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 
 /**
  * Converts Arrow VARCHAR/VARBINARY vectors to ESQL BytesRefBlocks.
@@ -35,6 +37,122 @@ public final class BytesRefArrowBlock {
             return ofList(listVector, blockFactory);
         }
         return BytesRefArrowBufBlock.of(vector, blockFactory);
+    }
+
+    /**
+     * Converts an Arrow {@code VARCHAR} vector to a KEYWORD {@link BytesRefBlock}, repairing malformed
+     * UTF-8 to {@code U+FFFD} so downstream {@code KEYWORD} operations (e.g. the TopN Utf8 encoders)
+     * stay total. Arrow {@code VARCHAR} is nominally UTF-8, but external producers (e.g. Spark) can
+     * still emit ill-formed bytes.
+     * <p>
+     * The common, well-formed case is validated in a single pass and then returned as the zero-copy
+     * {@link BytesRefArrowBufBlock}; only when a malformed value is found does the block get rebuilt
+     * with sanitized values. UTF-8 well-formedness is checked per value because a multi-byte sequence
+     * can never span two logical Arrow values.
+     */
+    public static Block ofSanitizedUtf8(ValueVector vector, BlockFactory blockFactory) {
+        if (vector instanceof ListVector listVector) {
+            // Lists always go through the copying builder path (like ofList): it is the canonical
+            // ArrowListSupport multi-value mapping and lets each emitted value be sanitized.
+            return ofSanitizedList(listVector, blockFactory);
+        }
+        if (vector instanceof BaseVariableWidthVector base && allWellFormed(base) == false) {
+            return ofSanitizedFlat(base, blockFactory);
+        }
+        return BytesRefArrowBufBlock.of(vector, blockFactory);
+    }
+
+    private static boolean allWellFormed(BaseVariableWidthVector base) {
+        int valueCount = base.getValueCount();
+        ArrowBuf offsets = base.getOffsetBuffer();
+        ArrowBuf data = base.getDataBuffer();
+        byte[] scratch = null;
+        for (int i = 0; i < valueCount; i++) {
+            if (base.isNull(i)) {
+                continue;
+            }
+            int start = offsets.getInt((long) i * Integer.BYTES);
+            int end = offsets.getInt((long) (i + 1) * Integer.BYTES);
+            int len = end - start;
+            if (len == 0) {
+                continue;
+            }
+            if (scratch == null || scratch.length < len) {
+                scratch = new byte[len];
+            }
+            data.getBytes(start, scratch, 0, len);
+            if (Utf8Sanitizer.isWellFormed(scratch, 0, len) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Block ofSanitizedFlat(BaseVariableWidthVector base, BlockFactory blockFactory) {
+        int valueCount = base.getValueCount();
+        ArrowBuf offsets = base.getOffsetBuffer();
+        ArrowBuf data = base.getDataBuffer();
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(valueCount)) {
+            for (int i = 0; i < valueCount; i++) {
+                if (base.isNull(i)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = offsets.getInt((long) i * Integer.BYTES);
+                int end = offsets.getInt((long) (i + 1) * Integer.BYTES);
+                builder.appendBytesRef(Utf8Sanitizer.sanitize(copyRange(data, start, end)));
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Sanitizing rebuild of a multi-valued {@code VARCHAR} list. Mirrors {@link #ofList} exactly (the
+     * {@link ArrowListSupport} mapping: null/empty lists and all-null children collapse to a null
+     * position, mixed lists drop their null children), sanitizing each emitted value to well-formed UTF-8.
+     */
+    private static Block ofSanitizedList(ListVector listVector, BlockFactory blockFactory) {
+        int rowCount = listVector.getValueCount();
+        BaseVariableWidthVector child = (BaseVariableWidthVector) listVector.getDataVector();
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(rowCount)) {
+            for (int i = 0; i < rowCount; i++) {
+                if (listVector.isNull(i)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = listVector.getElementStartIndex(i);
+                int end = listVector.getElementEndIndex(i);
+                int nonNullCount = ArrowListSupport.countNonNull(child, start, end);
+                if (nonNullCount == 0) {
+                    builder.appendNull();
+                } else if (nonNullCount == 1) {
+                    for (int j = start; j < end; j++) {
+                        if (child.isNull(j) == false) {
+                            builder.appendBytesRef(Utf8Sanitizer.sanitize(new BytesRef(child.get(j))));
+                            break;
+                        }
+                    }
+                } else {
+                    builder.beginPositionEntry();
+                    for (int j = start; j < end; j++) {
+                        if (child.isNull(j) == false) {
+                            builder.appendBytesRef(Utf8Sanitizer.sanitize(new BytesRef(child.get(j))));
+                        }
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private static BytesRef copyRange(ArrowBuf data, int start, int end) {
+        int len = end - start;
+        byte[] bytes = new byte[len];
+        if (len > 0) {
+            data.getBytes(start, bytes, 0, len);
+        }
+        return new BytesRef(bytes, 0, len);
     }
 
     private static Block ofList(ListVector listVector, BlockFactory blockFactory) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/Utf8SanitizerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/Utf8SanitizerTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.charset.StandardCharsets;
+
+public class Utf8SanitizerTests extends ESTestCase {
+
+    private static final byte[] FFFD = { (byte) 0xEF, (byte) 0xBF, (byte) 0xBD };
+
+    public void testWellFormedInputsAreReturnedUnchanged() {
+        for (String s : new String[] { "", "ascii", "caf\u00e9", "\u20ac euro", "\ud83d\ude00 emoji", "mixed \u4e2d\u6587 text" }) {
+            BytesRef in = new BytesRef(s);
+            assertTrue(s, Utf8Sanitizer.isWellFormed(in.bytes, in.offset, in.length));
+            BytesRef out = Utf8Sanitizer.sanitize(in);
+            assertSame("well-formed input must not be copied", in, out);
+        }
+    }
+
+    public void testNullIsPassedThrough() {
+        assertNull(Utf8Sanitizer.sanitize(null));
+    }
+
+    public void testLoneContinuationByte() {
+        assertSanitized(new byte[] { (byte) 0x80 }, FFFD);
+        assertSanitized(new byte[] { 'a', (byte) 0xBF, 'b' }, concat(bytes('a'), FFFD, bytes('b')));
+    }
+
+    public void testHighLeadBytesF0xF8ToFF() {
+        // These are the bytes that crash Utf8AscTopNEncoder's 248-entry table.
+        for (int b = 0xF8; b <= 0xFF; b++) {
+            assertSanitized(new byte[] { (byte) b }, FFFD);
+        }
+    }
+
+    public void testTruncatedSequences() {
+        // 2-byte lead with no continuation.
+        assertSanitized(new byte[] { (byte) 0xC3 }, FFFD);
+        // 3-byte lead with only one valid continuation: maximal subpart is 2 bytes -> single U+FFFD.
+        assertSanitized(new byte[] { (byte) 0xE2, (byte) 0x82 }, FFFD);
+        // 4-byte lead truncated after two continuations -> single U+FFFD.
+        assertSanitized(new byte[] { (byte) 0xF0, (byte) 0x9F, (byte) 0x98 }, FFFD);
+    }
+
+    public void testOverlongEncodingsRejected() {
+        // Overlong '/' (0x2F) as C0 AF and as E0 80 AF.
+        assertSanitized(new byte[] { (byte) 0xC0, (byte) 0xAF }, concat(FFFD, FFFD));
+        assertSanitized(new byte[] { (byte) 0xE0, (byte) 0x80, (byte) 0xAF }, concat(FFFD, FFFD, FFFD));
+    }
+
+    public void testSurrogateRangeRejected() {
+        // U+D800 encoded as ED A0 80 is ill-formed in UTF-8.
+        assertSanitized(new byte[] { (byte) 0xED, (byte) 0xA0, (byte) 0x80 }, concat(FFFD, FFFD, FFFD));
+    }
+
+    public void testValidMultibyteAdjacentToInvalid() {
+        byte[] euro = "\u20ac".getBytes(StandardCharsets.UTF_8);
+        byte[] input = concat(bytes('x'), euro, new byte[] { (byte) 0xFF }, euro, bytes('y'));
+        byte[] expected = concat(bytes('x'), euro, FFFD, euro, bytes('y'));
+        assertSanitized(input, expected);
+    }
+
+    public void testSanitizedOutputIsWellFormed() {
+        for (int iter = 0; iter < 200; iter++) {
+            byte[] random = new byte[randomIntBetween(0, 64)];
+            random(random);
+            BytesRef out = Utf8Sanitizer.sanitize(new BytesRef(random, 0, random.length));
+            assertTrue("sanitized output must be valid UTF-8", Utf8Sanitizer.isWellFormed(out.bytes, out.offset, out.length));
+        }
+    }
+
+    public void testRespectsOffsetAndLength() {
+        byte[] backing = concat(new byte[] { (byte) 0xFF, (byte) 0xFF }, "ok".getBytes(StandardCharsets.UTF_8), new byte[] { (byte) 0xFF });
+        BytesRef slice = new BytesRef(backing, 2, 2);
+        BytesRef out = Utf8Sanitizer.sanitize(slice);
+        assertSame(slice, out);
+        assertEquals("ok", out.utf8ToString());
+    }
+
+    private void random(byte[] bytes) {
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) randomInt(255);
+        }
+    }
+
+    private void assertSanitized(byte[] input, byte[] expected) {
+        assertFalse("test input must be malformed", Utf8Sanitizer.isWellFormed(input, 0, input.length));
+        BytesRef out = Utf8Sanitizer.sanitize(new BytesRef(input, 0, input.length));
+        assertEquals(new BytesRef(expected), out);
+        assertTrue(Utf8Sanitizer.isWellFormed(out.bytes, out.offset, out.length));
+    }
+
+    private static byte[] bytes(char c) {
+        return new byte[] { (byte) c };
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int len = 0;
+        for (byte[] p : parts) {
+            len += p.length;
+        }
+        byte[] out = new byte[len];
+        int pos = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, pos, p.length);
+            pos += p.length;
+        }
+        return out;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/BytesRefArrowSanitizeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/BytesRefArrowSanitizeTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BitVectorHelper;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Tests for {@link BytesRefArrowBlock#ofSanitizedUtf8}, which repairs malformed UTF-8 in Arrow
+ * {@code VARCHAR} vectors while keeping the well-formed common case zero-copy.
+ */
+public class BytesRefArrowSanitizeTests extends ESTestCase {
+
+    private RootAllocator allocator;
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setup() {
+        allocator = new RootAllocator();
+        blockFactory = new BlockFactory(new NoopCircuitBreaker("test-noop"), BigArrays.NON_RECYCLING_INSTANCE);
+    }
+
+    @After
+    public void cleanup() {
+        allocator.close();
+    }
+
+    public void testWellFormedFlatStaysZeroCopy() {
+        try (VarCharVector arrowVec = new VarCharVector("test", allocator)) {
+            arrowVec.allocateNew();
+            arrowVec.set(0, "hello".getBytes(StandardCharsets.UTF_8));
+            arrowVec.set(1, "caf\u00e9".getBytes(StandardCharsets.UTF_8));
+            arrowVec.set(2, "\ud83d\ude00".getBytes(StandardCharsets.UTF_8));
+            arrowVec.setValueCount(3);
+
+            try (Block block = BytesRefArrowBlock.ofSanitizedUtf8(arrowVec, blockFactory)) {
+                assertTrue("well-formed VARCHAR must stay zero-copy", block instanceof BytesRefArrowBufBlock);
+                BytesRefBlock refs = (BytesRefBlock) block;
+                BytesRef scratch = new BytesRef();
+                assertEquals("hello", refs.getBytesRef(0, scratch).utf8ToString());
+                assertEquals("caf\u00e9", refs.getBytesRef(1, scratch).utf8ToString());
+                assertEquals("\ud83d\ude00", refs.getBytesRef(2, scratch).utf8ToString());
+            }
+        }
+    }
+
+    public void testMalformedFlatIsSanitized() {
+        try (VarCharVector arrowVec = new VarCharVector("test", allocator)) {
+            arrowVec.allocateNew();
+            arrowVec.set(0, new byte[] { (byte) 0xFF });               // lone invalid lead byte
+            arrowVec.setNull(1);
+            arrowVec.set(2, "ok".getBytes(StandardCharsets.UTF_8));
+            arrowVec.set(3, new byte[] { (byte) 0xC3, (byte) 0x28 });  // truncated 2-byte + '('
+            arrowVec.setValueCount(4);
+
+            try (Block block = BytesRefArrowBlock.ofSanitizedUtf8(arrowVec, blockFactory)) {
+                assertFalse("malformed VARCHAR must be rebuilt", block instanceof BytesRefArrowBufBlock);
+                BytesRefBlock refs = (BytesRefBlock) block;
+                BytesRef scratch = new BytesRef();
+                assertEquals(new BytesRef("\uFFFD"), refs.getBytesRef(refs.getFirstValueIndex(0), scratch));
+                assertTrue(refs.isNull(1));
+                assertEquals(new BytesRef("ok"), refs.getBytesRef(refs.getFirstValueIndex(2), scratch));
+                assertEquals(new BytesRef("\uFFFD("), refs.getBytesRef(refs.getFirstValueIndex(3), scratch));
+            }
+        }
+    }
+
+    public void testMalformedListIsSanitized() {
+        // Position 0: ["aa", <0xFF>], Position 1: ["ok"]; no null children (matches the zero-copy list contract).
+        try (ListVector listVector = ListVector.empty("test", allocator)) {
+            listVector.addOrGetVector(FieldType.nullable(Types.MinorType.VARCHAR.getType()));
+            listVector.allocateNew();
+            VarCharVector child = (VarCharVector) listVector.getDataVector();
+            child.allocateNew();
+            child.set(0, "aa".getBytes(StandardCharsets.UTF_8));
+            child.set(1, new byte[] { (byte) 0xFF });
+            child.set(2, "ok".getBytes(StandardCharsets.UTF_8));
+            child.setValueCount(3);
+
+            ArrowBuf offsets = listVector.getOffsetBuffer();
+            offsets.setInt(0, 0);
+            offsets.setInt(4, 2);
+            offsets.setInt(8, 3);
+
+            ArrowBuf validity = listVector.getValidityBuffer();
+            validity.setZero(0, validity.capacity());
+            BitVectorHelper.setBit(validity, 0);
+            BitVectorHelper.setBit(validity, 1);
+            listVector.setLastSet(1);
+            listVector.setValueCount(2);
+
+            try (Block block = BytesRefArrowBlock.ofSanitizedUtf8(listVector, blockFactory)) {
+                BytesRefBlock refs = (BytesRefBlock) block;
+                BytesRef scratch = new BytesRef();
+                assertEquals(2, refs.getValueCount(0));
+                int start = refs.getFirstValueIndex(0);
+                assertEquals(new BytesRef("aa"), refs.getBytesRef(start, scratch));
+                assertEquals(new BytesRef("\uFFFD"), refs.getBytesRef(start + 1, scratch));
+                assertEquals(1, refs.getValueCount(1));
+                assertEquals(new BytesRef("ok"), refs.getBytesRef(refs.getFirstValueIndex(1), scratch));
+            }
+        }
+    }
+
+    public void testMalformedListWithChildNullsFollowsArrowListSupport() {
+        // Position 0: ["aa", <null>, <0xFF>] -> null child dropped, malformed repaired -> ["aa", U+FFFD].
+        // Position 1: [<null>] -> all children null -> collapses to an ESQL null position (ofList semantics).
+        try (ListVector listVector = ListVector.empty("test", allocator)) {
+            listVector.addOrGetVector(FieldType.nullable(Types.MinorType.VARCHAR.getType()));
+            listVector.allocateNew();
+            VarCharVector child = (VarCharVector) listVector.getDataVector();
+            child.allocateNew();
+            child.set(0, "aa".getBytes(StandardCharsets.UTF_8));
+            child.setNull(1);
+            child.set(2, new byte[] { (byte) 0xFF });
+            child.setNull(3);
+            child.setValueCount(4);
+
+            ArrowBuf offsets = listVector.getOffsetBuffer();
+            offsets.setInt(0, 0);
+            offsets.setInt(4, 3);
+            offsets.setInt(8, 4);
+
+            ArrowBuf validity = listVector.getValidityBuffer();
+            validity.setZero(0, validity.capacity());
+            BitVectorHelper.setBit(validity, 0);
+            BitVectorHelper.setBit(validity, 1);
+            listVector.setLastSet(1);
+            listVector.setValueCount(2);
+
+            try (Block block = BytesRefArrowBlock.ofSanitizedUtf8(listVector, blockFactory)) {
+                BytesRefBlock refs = (BytesRefBlock) block;
+                BytesRef scratch = new BytesRef();
+                assertEquals(2, refs.getValueCount(0));
+                int start = refs.getFirstValueIndex(0);
+                assertEquals(new BytesRef("aa"), refs.getBytesRef(start, scratch));
+                assertEquals(new BytesRef("\uFFFD"), refs.getBytesRef(start + 1, scratch));
+                assertTrue("all-null child list must collapse to null", refs.isNull(1));
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetStringTopNSideChannelIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetStringTopNSideChannelIT.java
@@ -14,6 +14,7 @@ import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.elasticsearch.core.TimeValue;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.function.IntFunction;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -131,6 +133,67 @@ public class ExternalParquetStringTopNSideChannelIT extends AbstractExternalData
         } finally {
             Files.deleteIfExists(file);
         }
+    }
+
+    /**
+     * Regression for esql-planning#1010: sorting a {@code UTF8}-annotated Parquet column that actually
+     * holds malformed UTF-8 (e.g. Spark output) must not throw {@link ArrayIndexOutOfBoundsException}
+     * from the TopN Utf8 encoder. The reader sanitizes such bytes to {@code U+FFFD} on read, so the sort
+     * completes and every returned value is well-formed UTF-8.
+     */
+    public void testSortOverInvalidUtf8DoesNotCrash() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+        byte[][] names = {
+            { (byte) 0xF8, (byte) 0xFF },              // lead bytes that index past the 248-entry table
+            { (byte) 0xC3, (byte) 0x28 },              // truncated 2-byte sequence
+            "valid".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            { (byte) 0xED, (byte) 0xA0, (byte) 0x80 }, // surrogate half
+        };
+        Path file = writeParquetFileRawNames(names);
+        try {
+            String query = "EXTERNAL \"" + StoragePath.fileUri(file) + "\" | SORT name ASC | LIMIT 100 | KEEP name";
+            try (var response = run(syncEsqlQueryRequest(query), LONG_TIMEOUT)) {
+                // Reaching this point at all is the regression check: the malformed lead bytes previously
+                // threw ArrayIndexOutOfBoundsException from the TopN Utf8 encoder before any rows returned.
+                List<List<Object>> rows = getValuesList(response);
+                assertEquals(names.length, rows.size());
+                List<String> values = new ArrayList<>(rows.size());
+                for (List<Object> row : rows) {
+                    values.add(row.get(0) == null ? null : bytesRefToString(row.get(0)));
+                }
+                assertTrue("valid value must round-trip unchanged", values.contains("valid"));
+                // Every malformed input surfaces sanitized, carrying the replacement character.
+                long sanitized = values.stream().filter(v -> v != null && v.indexOf('\uFFFD') >= 0).count();
+                assertEquals(names.length - 1L, sanitized);
+            }
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    private Path writeParquetFileRawNames(byte[][] names) throws IOException {
+        Path tempFile = createTempDir().resolve("invalid_utf8_names.parquet");
+        MessageType schema = MessageTypeParser.parseMessageType(
+            "message test { optional binary name (UTF8); required binary payload (UTF8); }"
+        );
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(baos))
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (int i = 0; i < names.length; i++) {
+                Group group = factory.newGroup();
+                group.add("name", Binary.fromConstantByteArray(names[i]));
+                group.add("payload", "payload_" + i);
+                writer.write(group);
+            }
+        }
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
     }
 
     private QueryResult runTopN(Path file, String order, int limit) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/arrow/ArrowToEsql.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/arrow/ArrowToEsql.java
@@ -16,7 +16,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.arrow.ArrowToBlockConverter;
 import org.elasticsearch.compute.data.arrow.BooleanArrowBufBlock;
-import org.elasticsearch.compute.data.arrow.BytesRefArrowBufBlock;
+import org.elasticsearch.compute.data.arrow.BytesRefArrowBlock;
 import org.elasticsearch.compute.data.arrow.DoubleArrowBufBlock;
 import org.elasticsearch.compute.data.arrow.Float16ArrowBufBlock;
 import org.elasticsearch.compute.data.arrow.FloatArrowBufBlock;
@@ -168,7 +168,9 @@ public record ArrowToEsql(DataType dataType, ElementType elementType, ArrowToBlo
 
             case BIT -> new ArrowToEsql(DataType.BOOLEAN, ElementType.BOOLEAN, (v, b) -> BooleanArrowBufBlock.of((BitVector) v, b));
 
-            case VARCHAR -> new ArrowToEsql(DataType.KEYWORD, ElementType.BYTES_REF, BytesRefArrowBufBlock::of);
+            // VARCHAR is nominally UTF-8, but external producers can emit malformed bytes; sanitize to
+            // U+FFFD at conversion so downstream KEYWORD ops (e.g. the TopN Utf8 encoders) stay total.
+            case VARCHAR -> new ArrowToEsql(DataType.KEYWORD, ElementType.BYTES_REF, BytesRefArrowBlock::ofSanitizedUtf8);
             // TODO: add support for these
             case VIEWVARCHAR -> null;
             case LARGEVARCHAR -> null;


### PR DESCRIPTION
Raw, un-annotated Parquet BINARY/FIXED_LEN_BYTE_ARRAY now maps to
UNSUPPORTED instead of KEYWORD, and string-annotated bytes (Parquet
UTF8/enum/json/bson, ORC string family, Arrow VARCHAR) are repaired to
U+FFFD on read. ES|QL assumes every KEYWORD is well-formed UTF-8, so
arbitrary external bytes crashed the TopN Utf8 encoders on lead bytes
0xF8..0xFF. Fixing it at the reader boundary keeps downstream KEYWORD
operations total without touching the hot sort path.

Sanitization is confined to KEYWORD construction sites; the type-agnostic
dictionary decoder is left untouched so INT96/decimal/float16 fixed
binaries are not corrupted. UUID list elements are hex-formatted like the
scalar path rather than sanitized, so valid UUID bytes are never mangled.

The Arrow VARCHAR list rebuild mirrors ofList/ArrowListSupport semantics
(null/empty lists and all-null children collapse to null, null children
are dropped), sanitizing each emitted value.