### PR TITLE
Fix semantic_text testSupportsParsingObject inference ID mismatch

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -844,12 +844,6 @@ tests:
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testConsecutiveRotations
   issue: https://github.com/elastic/elasticsearch/issues/152472
-- class: org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests
-  method: testSupportsParsingObject {p0=true p1=BASIC}
-  issue: https://github.com/elastic/elasticsearch/issues/152790
-- class: org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests
-  method: testSupportsParsingObject {p0=true p1=ENTERPRISE}
-  issue: https://github.com/elastic/elasticsearch/issues/152791
 - class: org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.DivTests
   method: testCrankyEvaluateBlockWithoutNulls {TestCase=<double>, <dense_vector>}
   issue: https://github.com/elastic/elasticsearch/issues/152794

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -406,12 +406,14 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
     protected Object getSampleObjectForDocument() {
         // Only consulted by testSupportsParsingObject, and only for the legacy format (supportsParsingObject() is true only then). A
         // legacy value is the {text, inference} object; a minimal one with the resolved inference id and no inference results parses.
-        // The minimalMapping (no explicit inference_id) resolves to DEFAULT_FALLBACK_ELSER_INFERENCE_ID on the legacy index versions.
+        final String expectedInferenceId = testIndexVersion.onOrAfter(IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_JINA_V5)
+            ? DEFAULT_EIS_JINA_V5_INFERENCE_ID
+            : DEFAULT_FALLBACK_ELSER_INFERENCE_ID;
         return Map.of(
             SemanticTextField.TEXT_FIELD,
             randomAlphaOfLength(10),
             SemanticTextField.INFERENCE_FIELD,
-            Map.of(SemanticTextField.INFERENCE_ID_FIELD, DEFAULT_FALLBACK_ELSER_INFERENCE_ID, SemanticTextField.CHUNKS_FIELD, List.of())
+            Map.of(SemanticTextField.INFERENCE_ID_FIELD, expectedInferenceId, SemanticTextField.CHUNKS_FIELD, List.of())
         );
     }
 


### PR DESCRIPTION
#152470 enabled the object-parsing branch of `testSupportsParsingObject` for the
legacy `semantic_text` format and added a `getSampleObjectForDocument()` override
that hardcodes `DEFAULT_FALLBACK_ELSER_INFERENCE_ID` as the document's inference id.

However, the legacy-compatible index version range on 9.x
(`UPGRADE_TO_LUCENE_10_0_0` … before `SEMANTIC_TEXT_LEGACY_FORMAT_FORBIDDEN`)
overlaps `SEMANTIC_TEXT_DEFAULTS_TO_JINA_V5`. When the randomly chosen test index
version lands in that window, the minimal mapping (no explicit `inference_id`)
resolves its default inference id to the Jina V5 EIS endpoint registered in the
test's `@Before` setup, so the hardcoded ELSER id in the sample document mismatches
and parsing throws `DocumentParsingException` (~1.8% fail rate).

This fixes `getSampleObjectForDocument()` to mirror the mapper's default inference
id resolution based on the test index version, and unmutes the test.

Verified by reproducing with the CI seed `8277FF8CF6E0B05E` (fails before, passes
after) and 50 iterations across all test parameters with random seeds.

Closes #152790
Closes #152791
