### PR TITLE
Add AllocateReshardSplitTargetPrimaryCommand

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReshardSplitTargetPrimaryCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReshardSplitTargetPrimaryCommand.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation.command;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.RerouteExplanation;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
+
+import java.util.Optional;
+
+public class AllocateReshardSplitTargetPrimaryCommand extends BasePrimaryAllocationCommand {
+    protected AllocateReshardSplitTargetPrimaryCommand(String index, int shardId, String node, boolean acceptDataLoss, ProjectId projectId) {
+        super(index, shardId, node, acceptDataLoss, projectId);
+    }
+
+    @Override
+    public String name() {
+        return "allocate_reshard_split_primary";
+    }
+
+    @Override
+    public RerouteExplanation execute(RoutingAllocation allocation, boolean explain) {
+        ShardRouting shardRouting;
+        try {
+            shardRouting = allocation.globalRoutingTable().routingTable(projectId).shardRoutingTable(index, shardId).primaryShard();
+        } catch (IndexNotFoundException | ShardNotFoundException e) {
+            return explainOrThrowRejectedCommand(explain, allocation, e);
+        }
+
+        if (shardRouting.unassigned() == false || shardRouting.recoverySource().getType() != RecoverySource.Type.EMPTY_STORE) {
+            return explainOrThrowRejectedCommand(explain, allocation, "Requested shard is not in unassigned state");
+        }
+
+        Optional<IndexMetadata> maybeIndexMetadata = allocation.metadata().findIndex(shardRouting.index());
+        if (maybeIndexMetadata.isEmpty()) {
+            return explainOrThrowRejectedCommand(explain, allocation, "Requested index does not exist");
+        }
+        IndexMetadata indexMetadata = maybeIndexMetadata.get();
+
+        if (indexMetadata.getReshardingMetadata() == null || indexMetadata.getReshardingMetadata().isSplit() == false) {
+            return explainOrThrowRejectedCommand(explain, allocation, "Requested index is not being split");
+        }
+
+        if (indexMetadata.getReshardingMetadata().getSplit().isTargetShard(shardId) == false) {
+            return explainOrThrowRejectedCommand(explain, allocation, "Requested shard is not a split target shard");
+        }
+
+        for (RoutingNodes.UnassignedShards.UnassignedIterator it = allocation.routingNodes().unassigned().iterator(); it.hasNext();) {
+            ShardRouting unassigned = it.next();
+            if (unassigned.equalsIgnoringMetadata(shardRouting) == false) {
+                continue;
+            }
+
+            var unassignedInfo = new UnassignedInfo(
+                UnassignedInfo.Reason.RESHARD_ADDED,
+                "force allocation of resharding split target shard"
+            );
+
+            var recoverySource = new RecoverySource.ReshardSplitRecoverySource(
+                new ShardId(shardRouting.index(), indexMetadata.getReshardingMetadata().getSplit().sourceShard(shardId))
+            );
+
+            it.updateUnassigned(unassignedInfo, recoverySource, allocation.changes());
+            break;
+        }
+
+        return new RerouteExplanation(this, allocation.decision(Decision.YES, name() + " (allocation command)", "ignore deciders"));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReshardSplitTargetPrimaryCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReshardSplitTargetPrimaryCommand.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.cluster.routing.allocation.command;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNodes;
@@ -18,26 +19,65 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RerouteExplanation;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
 
+import java.io.IOException;
 import java.util.Optional;
 
 public class AllocateReshardSplitTargetPrimaryCommand extends BasePrimaryAllocationCommand {
-    protected AllocateReshardSplitTargetPrimaryCommand(
-        String index,
-        int shardId,
-        String node,
-        boolean acceptDataLoss,
-        ProjectId projectId
-    ) {
+    public static final String NAME = "allocate_reshard_split_target_primary";
+    public static final ParseField COMMAND_NAME_FIELD = new ParseField(NAME);
+
+    private static final ObjectParser<AllocateReshardSplitTargetPrimaryCommand.Builder, ProjectId> PARSER = BasePrimaryAllocationCommand
+        .createAllocatePrimaryParser(NAME);
+
+    public AllocateReshardSplitTargetPrimaryCommand(String index, int shardId, String node, boolean acceptDataLoss, ProjectId projectId) {
         super(index, shardId, node, acceptDataLoss, projectId);
+    }
+
+    @FixForMultiProject(description = "Should be removed since a ProjectId must always be available")
+    @Deprecated(forRemoval = true)
+    public AllocateReshardSplitTargetPrimaryCommand(String index, int shardId, String node, boolean acceptDataLoss) {
+        this(index, shardId, node, acceptDataLoss, Metadata.DEFAULT_PROJECT_ID);
+    }
+
+    public AllocateReshardSplitTargetPrimaryCommand(StreamInput in) throws IOException {
+        super(in);
     }
 
     @Override
     public String name() {
-        return "allocate_reshard_split_primary";
+        return NAME;
+    }
+
+    @FixForMultiProject(description = "projectId should not be null once multi-project is fully in place")
+    public static AllocateReshardSplitTargetPrimaryCommand fromXContent(XContentParser parser, Object projectId) throws IOException {
+        assert projectId == null || projectId instanceof ProjectId : projectId;
+        return new AllocateReshardSplitTargetPrimaryCommand.Builder((ProjectId) projectId).parse(parser).build();
+    }
+
+    public static class Builder extends BasePrimaryAllocationCommand.Builder<AllocateReshardSplitTargetPrimaryCommand> {
+
+        Builder(ProjectId projectId) {
+            super(projectId);
+        }
+
+        private AllocateReshardSplitTargetPrimaryCommand.Builder parse(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, this, null);
+        }
+
+        @Override
+        public AllocateReshardSplitTargetPrimaryCommand build() {
+            validate();
+            return new AllocateReshardSplitTargetPrimaryCommand(index, shard, node, acceptDataLoss, projectId);
+        }
     }
 
     @Override
@@ -50,7 +90,7 @@ public class AllocateReshardSplitTargetPrimaryCommand extends BasePrimaryAllocat
         }
 
         if (shardRouting.unassigned() == false || shardRouting.recoverySource().getType() != RecoverySource.Type.EMPTY_STORE) {
-            return explainOrThrowRejectedCommand(explain, allocation, "Requested shard is not in unassigned state");
+            return explainOrThrowRejectedCommand(explain, allocation, "Requested shard is not in unassigned state " + shardRouting);
         }
 
         Optional<IndexMetadata> maybeIndexMetadata = allocation.metadata().findIndex(shardRouting.index());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReshardSplitTargetPrimaryCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReshardSplitTargetPrimaryCommand.java
@@ -25,7 +25,13 @@ import org.elasticsearch.index.shard.ShardNotFoundException;
 import java.util.Optional;
 
 public class AllocateReshardSplitTargetPrimaryCommand extends BasePrimaryAllocationCommand {
-    protected AllocateReshardSplitTargetPrimaryCommand(String index, int shardId, String node, boolean acceptDataLoss, ProjectId projectId) {
+    protected AllocateReshardSplitTargetPrimaryCommand(
+        String index,
+        int shardId,
+        String node,
+        boolean acceptDataLoss,
+        ProjectId projectId
+    ) {
         super(index, shardId, node, acceptDataLoss, projectId);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkModule.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkModule.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.network;
 import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateReshardSplitTargetPrimaryCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateStalePrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
@@ -103,6 +104,11 @@ public final class NetworkModule {
             AllocateStalePrimaryAllocationCommand::new,
             AllocateStalePrimaryAllocationCommand::fromXContent,
             AllocateStalePrimaryAllocationCommand.COMMAND_NAME_FIELD
+        );
+        registerAllocationCommand(
+            AllocateReshardSplitTargetPrimaryCommand::new,
+            AllocateReshardSplitTargetPrimaryCommand::fromXContent,
+            AllocateReshardSplitTargetPrimaryCommand.COMMAND_NAME_FIELD
         );
         namedWriteables.add(new NamedWriteableRegistry.Entry(Task.Status.class, ReplicationTask.Status.NAME, ReplicationTask.Status::new));
         namedWriteables.add(new NamedWriteableRegistry.Entry(Task.Status.class, RawTaskStatus.NAME, RawTaskStatus::new));

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -68,10 +68,13 @@ import org.elasticsearch.cluster.metadata.IndexReshardingState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.IndexRouting;
+import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.IndexBalanceConstraintSettings;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateReshardSplitTargetPrimaryCommand;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
@@ -4549,6 +4552,44 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         if (failure.get() != null) {
             throw failure.get();
         }
+    }
+
+    public void testRecoveryFromTargetShardEmptyPrimaryAllocation() {
+        String indexNode = startMasterAndIndexNode();
+        ensureStableCluster(1);
+
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createIndex(indexName, indexSettings(1, 0).build());
+        ensureGreen(indexName);
+        checkNumberOfShardsSetting(indexNode, indexName, 1);
+
+        updateClusterSettings(Settings.builder().put("cluster.routing.allocation.enable", "none"));
+
+        client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet(SAFE_AWAIT_TIMEOUT);
+
+        awaitClusterState(state -> {
+            if (state.projectState().metadata().index(indexName).getReshardingMetadata() == null) {
+                return false;
+            }
+            ShardRouting targetShardRouting = state.routingTable().index(indexName).shard(1).primaryShard();
+            return targetShardRouting.unassigned()
+                && targetShardRouting.recoverySource() instanceof RecoverySource.ReshardSplitRecoverySource;
+        });
+
+        ClusterRerouteUtils.reroute(client(), new AllocateEmptyPrimaryAllocationCommand(indexName, 1, indexNode, true));
+
+        updateClusterSettings(Settings.builder().putNull("cluster.routing.allocation.enable"));
+
+        // Wait until the allocation tries to allocate the shard and fails (replicate the real world scenario).
+        awaitClusterState(state -> {
+            ShardRouting targetShardRouting = state.routingTable().index(indexName).shard(1).primaryShard();
+            return targetShardRouting.unassigned() && targetShardRouting.unassignedInfo().failedAllocations() == 5;
+        });
+
+        ClusterRerouteUtils.reroute(client(), new AllocateReshardSplitTargetPrimaryCommand(indexName, 1, indexNode, true));
+
+        // Target shard successfully performs recovery with correct recovery source and resharding eventually completes.
+        waitForReshardCompletion(indexName);
     }
 
     @Override


### PR DESCRIPTION
This PR adds a _temporary_ allocation command that can be used to fix routing of resharding split target shards that use `EMPTY_STORE` recovery after a master failover.