### PR TITLE
[Inference API] Apply region policy headers to Elastic Inference Service authorization requests

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/RegionPolicyAuthorizationRefreshIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/RegionPolicyAuthorizationRefreshIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.http.MockRequest;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceSettings;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+
+import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMSettings.CCM_SUPPORTED_ENVIRONMENT;
+import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequest.X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER;
+import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequest.X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Verifies that putting or deleting a region policy immediately triggers a refresh of the EIS authorization
+ * (rather than waiting for the next periodic authorization poll), and that the refresh request carries the
+ * region/geo preference headers derived from the configured policy.
+ */
+public class RegionPolicyAuthorizationRefreshIT extends ESRestTestCase {
+
+    private static final String REGION_POLICY_PATH = "/_inference/_region_policy";
+    // See ElasticInferenceServiceAuthorizationRequest#AUTHORIZATION_PATH
+    private static final String AUTHORIZATION_PATH = "/api/v2/authorizations";
+    private static final String TEST_USERNAME = "x_pack_rest_user";
+    private static final String TEST_PASSWORD = "x-pack-test-password";
+
+    private static final MockElasticInferenceServiceAuthorizationServer mockEISServer =
+        new MockElasticInferenceServiceAuthorizationServer();
+
+    private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("xpack.security.enabled", "true")
+        .setting(ElasticInferenceServiceSettings.ELASTIC_INFERENCE_SERVICE_URL.getKey(), mockEISServer::getUrl)
+        .setting(ElasticInferenceServiceSettings.PERIODIC_AUTHORIZATION_ENABLED.getKey(), "false")
+        // Disables the periodic authorization poller entirely so the only authorization requests we observe
+        // are the ones triggered explicitly by putting/deleting the region policy below.
+        .setting(ElasticInferenceServiceSettings.AUTHORIZATION_ENABLED.getKey(), "false")
+        .setting(CCM_SUPPORTED_ENVIRONMENT.getKey(), "false")
+        .feature(FeatureFlag.INFERENCE_REGION_POLICY)
+        .plugin("inference-service-test")
+        .user(TEST_USERNAME, TEST_PASSWORD)
+        .build();
+
+    // The reason we're doing this is to make sure the mock server is initialized first so we can get the address before communicating
+    // it to the cluster as a setting.
+    // Note: @ClassRule is executed once for the entire test class
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(mockEISServer).around(cluster);
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        String token = basicAuthHeaderValue(TEST_USERNAME, new SecureString(TEST_PASSWORD.toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Before
+    public void clearRecordedRequests() {
+        mockEISServer.getWebServer().clearRequests();
+    }
+
+    public void testPutRegionPolicy_TriggersAuthorizationRefresh_WithAllowedRegionsHeader() throws IOException {
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+        putRegionPolicy("""
+            {
+              "region_policy": {
+                "allowed_regions": [ { "csp": "aws", "region": "us-east-1" } ]
+              }
+            }
+            """);
+
+        var authRequest = assertSingleAuthorizationRequest();
+        assertThat(authRequest.getHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER), is("aws:us-east-1"));
+        assertNull(authRequest.getHeader(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER));
+
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+        deleteRegionPolicy();
+    }
+
+    public void testPutRegionPolicy_TriggersAuthorizationRefresh_WithAllowedGeosHeader() throws IOException {
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+        putRegionPolicy("""
+            {
+              "region_policy": {
+                "allowed_geos": [ "us", "eu" ]
+              }
+            }
+            """);
+
+        var authRequest = assertSingleAuthorizationRequest();
+        assertThat(authRequest.getHeader(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER), is("us,eu"));
+        assertNull(authRequest.getHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER));
+
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+        deleteRegionPolicy();
+    }
+
+    public void testDeleteRegionPolicy_TriggersAuthorizationRefresh() throws IOException {
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+        putRegionPolicy("""
+            {
+              "region_policy": {
+                "allowed_geos": [ "us" ]
+              }
+            }
+            """);
+        mockEISServer.getWebServer().clearRequests();
+
+        mockEISServer.enqueueAuthorizeAllModelsResponse();
+        deleteRegionPolicy();
+
+        assertSingleAuthorizationRequest();
+    }
+
+    private static MockRequest assertSingleAuthorizationRequest() {
+        var requests = mockEISServer.getWebServer().requests();
+        assertThat(requests.size(), is(1));
+        var request = requests.get(0);
+        assertThat(request.getUri().getPath(), is(AUTHORIZATION_PATH));
+        assertThat(request.getMethod(), is("GET"));
+        return request;
+    }
+
+    private static void putRegionPolicy(String body) throws IOException {
+        var request = new Request("PUT", REGION_POLICY_PATH);
+        request.setJsonEntity(body);
+        assertOK(client().performRequest(request));
+    }
+
+    private static void deleteRegionPolicy() throws IOException {
+        assertOK(client().performRequest(new Request("DELETE", REGION_POLICY_PATH)));
+    }
+}

--- a/x-pack/plugin/inference/qa/inference-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceWithSecurityRestIT.java
+++ b/x-pack/plugin/inference/qa/inference-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceWithSecurityRestIT.java
@@ -43,6 +43,9 @@ public class InferenceWithSecurityRestIT extends ESClientYamlSuiteTestCase {
         .systemProperty("tests.seed", System.getProperty("tests.seed"))
         .setting("xpack.security.enabled", "true")
         .setting("xpack.license.self_generated.type", "trial")
+        // This might not be necessary because the authorization refresh will skip internally if the url
+        // is blank (which it should be because we don't set it for this cluster)
+        .setting("xpack.inference.region_policy.authorization.skip_refresh", "true")
         .rolesFile(Resource.fromClasspath("roles.yml"))
         .user(TEST_ADMIN_USERNAME, TEST_ADMIN_PASSWORD)    // admin user for setup and teardown
         .user(INFERENCE_USERNAME, INFERENCE_PASSWORD, "monitor_only_user", false)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -85,6 +85,7 @@ import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsActi
 import org.elasticsearch.xpack.core.inference.action.UnifiedCompletionAction;
 import org.elasticsearch.xpack.core.inference.action.UpdateInferenceModelAction;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.inference.action.RegionPolicySettings;
 import org.elasticsearch.xpack.inference.action.TransportDeleteCCMConfigurationAction;
 import org.elasticsearch.xpack.inference.action.TransportDeleteInferenceEndpointAction;
 import org.elasticsearch.xpack.inference.action.TransportDeleteRegionPolicyAction;
@@ -828,6 +829,7 @@ public class InferencePlugin extends Plugin
         settings.addAll(CCMCache.getSettingsDefinitions());
         settings.addAll(OAuth2TokenCache.getSettingsDefinitions());
         settings.addAll(OAuth2ClusterSettings.getSettingsDefinitions());
+        settings.addAll(RegionPolicySettings.getSettingsDefinitions());
         return Collections.unmodifiableSet(settings);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/RegionPolicySettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/RegionPolicySettings.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+
+public class RegionPolicySettings {
+    /**
+     * This setting is for testing only. It controls whether authorization refresh is performed.
+     */
+    public static final Setting<Boolean> SKIP_AUTHORIZATION_REFRESH = Setting.boolSetting(
+        "xpack.inference.region_policy.authorization.skip_refresh",
+        false,
+        Setting.Property.NodeScope
+    );
+
+    private final boolean skipAuthorizationRefresh;
+
+    public RegionPolicySettings(Settings settings) {
+        this.skipAuthorizationRefresh = SKIP_AUTHORIZATION_REFRESH.get(settings);
+    }
+
+    public boolean skipAuthorizationRefresh() {
+        return skipAuthorizationRefresh;
+    }
+
+    public static List<Setting<?>> getSettingsDefinitions() {
+        return List.of(SKIP_AUTHORIZATION_REFRESH);
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.inference.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -16,22 +17,33 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.inference.action.DeleteRegionPolicyAction;
+import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
 import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicyDoc;
 import org.elasticsearch.xpack.inference.InferenceIndex;
 
 public class TransportDeleteRegionPolicyAction extends HandledTransportAction<DeleteRegionPolicyAction.Request, AcknowledgedResponse> {
 
+    private static final Logger logger = LogManager.getLogger(TransportDeleteRegionPolicyAction.class);
     private final OriginSettingClient client;
+    private final RegionPolicySettings regionPolicySettings;
 
     @Inject
-    public TransportDeleteRegionPolicyAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+    public TransportDeleteRegionPolicyAction(
+        Settings settings,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client
+    ) {
         super(
             DeleteRegionPolicyAction.NAME,
             transportService,
@@ -40,6 +52,7 @@ public class TransportDeleteRegionPolicyAction extends HandledTransportAction<De
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.client = new OriginSettingClient(client, ClientHelper.INFERENCE_ORIGIN);
+        this.regionPolicySettings = new RegionPolicySettings(settings);
     }
 
     @Override
@@ -52,7 +65,7 @@ public class TransportDeleteRegionPolicyAction extends HandledTransportAction<De
                     if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
                         listener.onFailure(TransportGetRegionPolicyAction.noRegionPolicyConfiguredException());
                     } else {
-                        listener.onResponse(AcknowledgedResponse.TRUE);
+                        refreshAuthorizationEndpoints(listener);
                     }
                 }
 
@@ -65,5 +78,26 @@ public class TransportDeleteRegionPolicyAction extends HandledTransportAction<De
                     }
                 }
             });
+    }
+
+    private void refreshAuthorizationEndpoints(ActionListener<AcknowledgedResponse> listener) {
+        if (regionPolicySettings.skipAuthorizationRefresh()) {
+            logger.debug("Skipping refresh of authorized endpoints after deleting region policy due to test setting");
+            listener.onResponse(AcknowledgedResponse.TRUE);
+            return;
+        }
+
+        var authListener = ActionListener.<ActionResponse.Empty>wrap(
+            ignore -> listener.onResponse(AcknowledgedResponse.TRUE),
+            // If the refresh fails, we don't want to fail the delete region policy request, so we ignore the exception and log it
+            e -> {
+                logger.warn("""
+                    Failed to refresh authorized endpoints after deleting region policy. \
+                    The new region policy will not take effect until the next authorization poll.""", e);
+                listener.onResponse(AcknowledgedResponse.TRUE);
+            }
+        );
+
+        client.execute(RefreshAuthorizedEndpointsAction.INSTANCE, new RefreshAuthorizedEndpointsAction.Request(), authListener);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.inference.action;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -29,6 +30,8 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.inference.ToXContentParams;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.Task;
@@ -40,6 +43,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.inference.action.PutRegionPolicyAction;
+import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.RegionPolicyResponse;
 import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
 import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicyDoc;
@@ -53,10 +57,13 @@ import java.util.Optional;
 
 public class TransportPutRegionPolicyAction extends HandledTransportAction<PutRegionPolicyAction.Request, RegionPolicyResponse> {
 
+    private static final Logger logger = LogManager.getLogger(TransportPutRegionPolicyAction.class);
+
     private final OriginSettingClient client;
     private final Optional<SecurityContext> securityContext;
     private final ClusterService clusterService;
     private final FeatureService featureService;
+    private final RegionPolicySettings regionPolicySettings;
 
     @Inject
     public TransportPutRegionPolicyAction(
@@ -81,12 +88,33 @@ public class TransportPutRegionPolicyAction extends HandledTransportAction<PutRe
             : Optional.empty();
         this.clusterService = clusterService;
         this.featureService = featureService;
+        this.regionPolicySettings = new RegionPolicySettings(settings);
     }
 
     @Override
     protected void doExecute(Task task, PutRegionPolicyAction.Request request, ActionListener<RegionPolicyResponse> finalListener) {
         SubscribableListener.newForked(this::getRegionPolicyOrNullWhenMissing)
             .<RegionPolicyResponse>andThen((l, existingRegionPolicy) -> putRegionPolicy(existingRegionPolicy, request.regionPolicy(), l))
+            .<RegionPolicyResponse>andThen((policyListener, policy) -> {
+                if (regionPolicySettings.skipAuthorizationRefresh()) {
+                    logger.debug("Skipping authorization refresh after putting region policy due to test setting");
+                    policyListener.onResponse(policy);
+                    return;
+                }
+
+                var authListener = ActionListener.<ActionResponse.Empty>wrap(
+                    ignore -> policyListener.onResponse(policy),
+                    // If the refresh fails, we don't want to fail the put region policy request, so we ignore the exception and log it
+                    e -> {
+                        logger.warn("""
+                            Failed to refresh authorized endpoints after putting region policy. \
+                            The new region policy will not take effect until the next authorization poll.""", e);
+                        policyListener.onResponse(policy);
+                    }
+                );
+
+                client.execute(RefreshAuthorizedEndpointsAction.INSTANCE, new RefreshAuthorizedEndpointsAction.Request(), authListener);
+            })
             .addListener(finalListener);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.inference.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -24,12 +27,17 @@ import org.elasticsearch.inference.MinimalServiceSettings;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.metadata.EndpointMetadata;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.inference.action.GetRegionPolicyAction;
 import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
+import org.elasticsearch.xpack.core.inference.action.RegionPolicyResponse;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
 import org.elasticsearch.xpack.inference.InferenceFeatures;
+import org.elasticsearch.xpack.inference.InferencePlugin;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.features.InferenceFeatureService;
 import org.elasticsearch.xpack.inference.registry.InferenceEndpointRegistry;
@@ -99,9 +107,14 @@ public class TransportRefreshAuthorizedEndpointsAction extends HandledTransportA
     }
 
     private void sendRequest(ActionListener<ActionResponse.Empty> listener) {
-        SubscribableListener.<ElasticInferenceServiceAuthorizationModel>newForked(
-            authModelListener -> authorizationHandler.getAuthorization(authModelListener, sender)
-        )
+        SubscribableListener.newForked(this::getRegionPolicy)
+            .<ElasticInferenceServiceAuthorizationModel>andThen(
+                (authModelListener, inferencePreferences) -> authorizationHandler.getAuthorization(
+                    authModelListener,
+                    sender,
+                    inferencePreferences
+                )
+            )
             .<ElasticInferenceServiceAuthorizationModel>andThen(
                 (nextListener, authModel) -> deleteRemovedEndpoints(authModel, nextListener)
             )
@@ -109,6 +122,28 @@ public class TransportRefreshAuthorizedEndpointsAction extends HandledTransportA
                 (storeListener, inferenceIdsToPersist) -> storePreconfiguredModels(inferenceIdsToPersist, storeListener)
             )
             .addListener(listener);
+    }
+
+    // TODO replace this with the cache call
+    private void getRegionPolicy(ActionListener<InferencePreferences> listener) {
+        if (InferencePlugin.INFERENCE_REGION_POLICY_FEATURE_FLAG.isEnabled() == false) {
+            listener.onResponse(InferencePreferences.EMPTY);
+            return;
+        }
+
+        var policyListener = ActionListener.<RegionPolicyResponse>wrap(
+            response -> listener.onResponse(new InferencePreferences(response.regionPolicy().regionPolicy())),
+            e -> {
+                if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
+                    listener.onResponse(InferencePreferences.EMPTY);
+                    return;
+                }
+                logger.warn("Failed to fetch inference preferences", e);
+                listener.onFailure(new ElasticsearchStatusException("Failed to fetch inference preferences", RestStatus.BAD_REQUEST, e));
+            }
+        );
+
+        client.execute(GetRegionPolicyAction.INSTANCE, new GetRegionPolicyAction.Request(), policyListener);
     }
 
     private void deleteRemovedEndpoints(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/InferencePreferences.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/InferencePreferences.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
+
+public record InferencePreferences(@Nullable RegionPolicy regionPolicy) {
+
+    public static final InferencePreferences EMPTY = new InferencePreferences(null);
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceResponseHandler;
@@ -96,12 +97,26 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
     }
 
     /**
+     * Retrieve the authorization information from Elastic Inference Service and apply the inference preferences to the request headers.
+     * @param listener a listener to receive the response
+     * @param sender a {@link Sender} for making the request to the Elastic Inference Service
+     * @param inferencePreferences the inference preferences to apply to the request headers
+     */
+    public void getAuthorization(
+        ActionListener<ElasticInferenceServiceAuthorizationModel> listener,
+        Sender sender,
+        InferencePreferences inferencePreferences
+    ) {
+        getAuthorization(listener, sender, false, inferencePreferences);
+    }
+
+    /**
      * Retrieve the authorization information from Elastic Inference Service
      * @param listener a listener to receive the response
      * @param sender a {@link Sender} for making the request to the Elastic Inference Service
      */
     public void getAuthorization(ActionListener<ElasticInferenceServiceAuthorizationModel> listener, Sender sender) {
-        getAuthorization(listener, sender, false);
+        getAuthorization(listener, sender, false, null);
     }
 
     /**
@@ -113,13 +128,14 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
      * @param sender a {@link Sender} for making the request to the Elastic Inference Service
      */
     public void getAuthorizationIfPermittedEnvironment(ActionListener<ElasticInferenceServiceAuthorizationModel> listener, Sender sender) {
-        getAuthorization(listener, sender, true);
+        getAuthorization(listener, sender, true, null);
     }
 
     private void getAuthorization(
         ActionListener<ElasticInferenceServiceAuthorizationModel> listener,
         Sender sender,
-        boolean checkCcmState
+        boolean checkCcmState,
+        @Nullable InferencePreferences inferencePreferences
     ) {
         var countdownListener = ActionListener.runAfter(listener, requestCompleteLatch::countDown);
 
@@ -130,7 +146,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
                         logger.debug("CCM is not enabled, skipping authorization request to Elastic Inference Service");
                         countdownListener.onResponse(ElasticInferenceServiceAuthorizationModel.unauthorized());
                     } else {
-                        retrieveAuthorizationInformation(countdownListener, sender);
+                        retrieveAuthorizationInformation(countdownListener, sender, inferencePreferences);
                     }
                 }, e -> {
                     logger.atWarn().withThrowable(e).log("Failed to determine if CCM is enabled, returning unauthorized");
@@ -139,7 +155,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
 
                 ccmService.isEnabled(isCcmEnabledListener);
             } else {
-                retrieveAuthorizationInformation(countdownListener, sender);
+                retrieveAuthorizationInformation(countdownListener, sender, inferencePreferences);
             }
         } catch (Exception e) {
             logger.atWarn().withThrowable(e).log("Retrieving the authorization information encountered an exception");
@@ -147,7 +163,11 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
         }
     }
 
-    private void retrieveAuthorizationInformation(ActionListener<ElasticInferenceServiceAuthorizationModel> listener, Sender sender) {
+    private void retrieveAuthorizationInformation(
+        ActionListener<ElasticInferenceServiceAuthorizationModel> listener,
+        Sender sender,
+        @Nullable InferencePreferences inferencePreferences
+    ) {
         logger.debug("Retrieving authorization information from the Elastic Inference Service.");
 
         if (Strings.isNullOrEmpty(baseUrl)) {
@@ -167,7 +187,13 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
         SubscribableListener.newForked(authFactory::getAuthenticationApplier)
             .<InferenceServiceResults>andThen((authListener, authApplier) -> {
                 var requestMetadata = extractRequestMetadataFromThreadContext(threadPool.getThreadContext());
-                var request = new ElasticInferenceServiceAuthorizationRequest(baseUrl, getCurrentTraceInfo(), requestMetadata, authApplier);
+                var request = new ElasticInferenceServiceAuthorizationRequest(
+                    baseUrl,
+                    getCurrentTraceInfo(),
+                    requestMetadata,
+                    inferencePreferences,
+                    authApplier
+                );
                 sender.sendWithoutQueuing(logger, request, AUTH_RESPONSE_HANDLER, DEFAULT_AUTH_TIMEOUT, authListener);
             })
             .andThenApply(authResult -> {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequest.java
@@ -11,8 +11,10 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
@@ -25,17 +27,19 @@ import java.util.Objects;
 
 public class ElasticInferenceServiceAuthorizationRequest extends ElasticInferenceServiceRequest {
 
+    static final String AUTHORIZATION_PATH = "/api/v2/authorizations";
+
     private final URI uri;
     private final TraceContextHandler traceContextHandler;
-    static final String AUTHORIZATION_PATH = "/api/v2/authorizations";
 
     public ElasticInferenceServiceAuthorizationRequest(
         String url,
         TraceContext traceContext,
         ElasticInferenceServiceRequestMetadata requestMetadata,
+        @Nullable InferencePreferences inferencePreferences,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
-        super(requestMetadata, authApplier);
+        super(requestMetadata, inferencePreferences, authApplier);
         this.uri = createUri(Objects.requireNonNull(url));
         this.traceContextHandler = new TraceContextHandler(traceContext);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseEmbeddingsRequest.java
@@ -48,7 +48,7 @@ public class ElasticInferenceServiceDenseEmbeddingsRequest extends ElasticInfere
         InputType inputType,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
-        super(metadata, authApplier);
+        super(metadata, null, authApplier);
         this.inputs = inputs;
         this.model = Objects.requireNonNull(model);
         this.uri = model.uri();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequest.java
@@ -12,27 +12,36 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.telemetry.InferenceProductContext;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
 import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.inference.telemetry.InferenceProductContext.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_ES_VERSION;
 
 public abstract class ElasticInferenceServiceRequest implements OutboundRequest {
 
+    public static final String X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER = "X-Elastic-Inference-Allowed-Regions";
+    public static final String X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER = "X-Elastic-Inference-Allowed-Geos";
+
     private final ElasticInferenceServiceRequestMetadata metadata;
+    private final InferencePreferences preferences;
     protected final CCMAuthenticationApplierFactory.AuthApplier authApplier;
 
     public ElasticInferenceServiceRequest(
         ElasticInferenceServiceRequestMetadata metadata,
+        @Nullable InferencePreferences preferences,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
         this.metadata = Objects.requireNonNull(metadata);
+        this.preferences = preferences;
         this.authApplier = Objects.requireNonNull(authApplier);
     }
 
@@ -61,9 +70,28 @@ public abstract class ElasticInferenceServiceRequest implements OutboundRequest 
             request.addHeader(X_ELASTIC_ES_VERSION, esVersion);
         }
 
+        addRegionPolicyHeaders(request, preferences);
+
         request = authApplier.apply(request);
 
         listener.onResponse(new HttpRequest(request, getInferenceEntityId()));
+    }
+
+    private static void addRegionPolicyHeaders(HttpRequestBase request, @Nullable InferencePreferences preferences) {
+        if (preferences == null || preferences.regionPolicy() == null) {
+            return;
+        }
+
+        var regionPolicy = preferences.regionPolicy();
+        var allowedRegions = regionPolicy.allowedRegions();
+        var allowedGeos = regionPolicy.allowedGeos();
+
+        if (allowedRegions != null && allowedRegions.isEmpty() == false) {
+            var value = allowedRegions.stream().map(r -> r.csp() + ":" + r.region()).collect(Collectors.joining(","));
+            request.addHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER, value);
+        } else if (allowedGeos != null && allowedGeos.isEmpty() == false) {
+            request.addHeader(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER, String.join(",", allowedGeos));
+        }
     }
 
     protected abstract HttpRequestBase createHttpRequestBase();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRerankRequest.java
@@ -44,7 +44,7 @@ public class ElasticInferenceServiceRerankRequest extends ElasticInferenceServic
         ElasticInferenceServiceRequestMetadata metadata,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
-        super(metadata, authApplier);
+        super(metadata, null, authApplier);
         this.query = query;
         this.documents = documents;
         this.topN = topN;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
@@ -50,7 +50,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequest extends ElasticInfer
         InputType inputType,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
-        super(metadata, authApplier);
+        super(metadata, null, authApplier);
         this.truncator = truncator;
         this.truncationResult = truncationResult;
         this.model = Objects.requireNonNull(model);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceUnifiedChatCompletionRequest.java
@@ -42,7 +42,7 @@ public class ElasticInferenceServiceUnifiedChatCompletionRequest extends Elastic
         ElasticInferenceServiceRequestMetadata requestMetadata,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
-        super(requestMetadata, authApplier);
+        super(requestMetadata, null, authApplier);
         this.unifiedChatInput = Objects.requireNonNull(unifiedChatInput);
         this.model = Objects.requireNonNull(model);
         this.traceContextHandler = new TraceContextHandler(traceContext);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyActionTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.delete.TransportDeleteAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.DeleteRegionPolicyAction;
+import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicyDoc;
+import org.elasticsearch.xpack.inference.InferenceIndex;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportDeleteRegionPolicyActionTests extends ESTestCase {
+
+    private static final ShardId SHARD_ID = new ShardId(InferenceIndex.INDEX_NAME, "_na_", 0);
+
+    private Client mockClient;
+
+    @Before
+    public void init() {
+        mockClient = mock(Client.class);
+        var mockThreadPool = mock(ThreadPool.class);
+        when(mockThreadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(mockClient.threadPool()).thenReturn(mockThreadPool);
+    }
+
+    public void testDelete_TriggersAuthorizationRefresh_AndReturnsAcknowledged() {
+        givenDeleteRespondsWith(deletedResponse());
+        givenRefreshRespondsWith(ActionResponse.Empty.INSTANCE);
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        createAction(Settings.EMPTY).doExecute(null, new DeleteRegionPolicyAction.Request(), future);
+
+        assertThat(future.actionGet(TEST_REQUEST_TIMEOUT), is(AcknowledgedResponse.TRUE));
+        verify(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    public void testDelete_SwallowsRefreshFailure_AndStillReturnsAcknowledged() {
+        givenDeleteRespondsWith(deletedResponse());
+        givenRefreshFailsWith(new RuntimeException("refresh failed"));
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        createAction(Settings.EMPTY).doExecute(null, new DeleteRegionPolicyAction.Request(), future);
+
+        assertThat(future.actionGet(TEST_REQUEST_TIMEOUT), is(AcknowledgedResponse.TRUE));
+        verify(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    public void testDelete_WhenPolicyNotFound_FailsAndDoesNotRefresh() {
+        givenDeleteRespondsWith(notFoundResponse());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        createAction(Settings.EMPTY).doExecute(null, new DeleteRegionPolicyAction.Request(), future);
+
+        expectThrows(ResourceNotFoundException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        verify(mockClient, never()).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    public void testDelete_WhenIndexNotFound_FailsAndDoesNotRefresh() {
+        givenDeleteFailsWith(new IndexNotFoundException(InferenceIndex.INDEX_NAME));
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        createAction(Settings.EMPTY).doExecute(null, new DeleteRegionPolicyAction.Request(), future);
+
+        expectThrows(ResourceNotFoundException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        verify(mockClient, never()).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private static DeleteResponse deletedResponse() {
+        return new DeleteResponse(SHARD_ID, RegionPolicyDoc.DOCUMENT_ID, 1L, 1L, 2L, true);
+    }
+
+    private static DeleteResponse notFoundResponse() {
+        return new DeleteResponse(SHARD_ID, RegionPolicyDoc.DOCUMENT_ID, 1L, 1L, 1L, false);
+    }
+
+    private void givenDeleteRespondsWith(DeleteResponse response) {
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(TransportDeleteAction.TYPE), any(), any());
+    }
+
+    private void givenDeleteFailsWith(Exception exception) {
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(2);
+            listener.onFailure(exception);
+            return null;
+        }).when(mockClient).execute(eq(TransportDeleteAction.TYPE), any(), any());
+    }
+
+    private void givenRefreshRespondsWith(ActionResponse.Empty response) {
+        doAnswer(invocation -> {
+            ActionListener<ActionResponse.Empty> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private void givenRefreshFailsWith(Exception exception) {
+        doAnswer(invocation -> {
+            ActionListener<ActionResponse.Empty> listener = invocation.getArgument(2);
+            listener.onFailure(exception);
+            return null;
+        }).when(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private TransportDeleteRegionPolicyAction createAction(Settings settings) {
+        return new TransportDeleteRegionPolicyAction(settings, mock(TransportService.class), mock(ActionFilters.class), mockClient);
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyActionTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.index.TransportIndexAction;
+import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.inference.action.PutRegionPolicyAction;
+import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
+import org.elasticsearch.xpack.core.inference.action.RegionPolicyResponse;
+import org.elasticsearch.xpack.core.inference.regionpolicy.CspRegion;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicyDoc;
+import org.elasticsearch.xpack.inference.InferenceIndex;
+import org.junit.Before;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutRegionPolicyActionTests extends ESTestCase {
+
+    private static final String CSP = "aws";
+    private static final String REGION = "us-east-1";
+    private static final ShardId SHARD_ID = new ShardId(InferenceIndex.INDEX_NAME, "_na_", 0);
+    private static final Settings SECURITY_DISABLED_SETTINGS = Settings.builder()
+        .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+        .build();
+
+    private Client mockClient;
+    private ClusterService mockClusterService;
+    private FeatureService mockFeatureService;
+
+    @Before
+    public void init() {
+        mockClient = mock(Client.class);
+        var mockThreadPool = mock(ThreadPool.class);
+        when(mockThreadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(mockClient.threadPool()).thenReturn(mockThreadPool);
+        mockClusterService = mock(ClusterService.class);
+        when(mockClusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
+        mockFeatureService = mock(FeatureService.class);
+
+        // No region policy exists yet, so the put is treated as a create.
+        givenSearchFailsWith(new IndexNotFoundException(InferenceIndex.INDEX_NAME));
+        givenIndexRespondsWith(createdResponse());
+    }
+
+    public void testPut_TriggersAuthorizationRefresh_AndReturnsPolicy() {
+        givenRefreshRespondsWith(ActionResponse.Empty.INSTANCE);
+
+        var future = new TestPlainActionFuture<RegionPolicyResponse>();
+        createAction().doExecute(null, new PutRegionPolicyAction.Request(newRegionPolicy()), future);
+
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+        assertThat(response.regionPolicy().regionPolicy(), is(newRegionPolicy()));
+        verify(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    public void testPut_SwallowsRefreshFailure_AndStillReturnsPolicy() {
+        givenRefreshFailsWith(new RuntimeException("refresh failed"));
+
+        var future = new TestPlainActionFuture<RegionPolicyResponse>();
+        createAction().doExecute(null, new PutRegionPolicyAction.Request(newRegionPolicy()), future);
+
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+        assertThat(response.regionPolicy().regionPolicy(), is(newRegionPolicy()));
+        verify(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private static RegionPolicy newRegionPolicy() {
+        return new RegionPolicy(null, List.of(new CspRegion(CSP, REGION)), null);
+    }
+
+    private static IndexResponse createdResponse() {
+        return new IndexResponse(SHARD_ID, RegionPolicyDoc.DOCUMENT_ID, 1L, 1L, 1L, true);
+    }
+
+    private void givenSearchFailsWith(Exception exception) {
+        doAnswer(invocation -> {
+            ActionListener<?> listener = invocation.getArgument(2);
+            listener.onFailure(exception);
+            return null;
+        }).when(mockClient).execute(eq(TransportSearchAction.TYPE), any(), any());
+    }
+
+    private void givenIndexRespondsWith(IndexResponse response) {
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(TransportIndexAction.TYPE), any(), any());
+    }
+
+    private void givenRefreshRespondsWith(ActionResponse.Empty response) {
+        doAnswer(invocation -> {
+            ActionListener<ActionResponse.Empty> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private void givenRefreshFailsWith(Exception exception) {
+        doAnswer(invocation -> {
+            ActionListener<ActionResponse.Empty> listener = invocation.getArgument(2);
+            listener.onFailure(exception);
+            return null;
+        }).when(mockClient).execute(eq(RefreshAuthorizedEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private TransportPutRegionPolicyAction createAction() {
+        return new TransportPutRegionPolicyAction(
+            SECURITY_DISABLED_SETTINGS,
+            mock(TransportService.class),
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            mockClient,
+            mockClusterService,
+            mockFeatureService
+        );
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.inference.action;
 
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -24,11 +26,17 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.GetRegionPolicyAction;
 import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
+import org.elasticsearch.xpack.core.inference.action.RegionPolicyResponse;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
+import org.elasticsearch.xpack.core.inference.regionpolicy.CspRegion;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicyDoc;
 import org.elasticsearch.xpack.core.inference.results.ModelStoreResponse;
 import org.elasticsearch.xpack.inference.InferenceFeatures;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.features.InferenceFeatureService;
 import org.elasticsearch.xpack.inference.registry.ClearInferenceEndpointCacheAction;
@@ -43,6 +51,7 @@ import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.Elast
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +75,8 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
     private static final String URL = "eis-url";
     private static final String STORED_INFERENCE_ID = "stored-inference-id";
     private static final String FAILED_INFERENCE_ID = "failed-inference-id";
+    private static final String REGION_POLICY_CSP = "aws";
+    private static final String REGION_POLICY_REGION = "us-east-1";
 
     private InferenceFeatureService inferenceFeatureServiceMock;
     private ModelRegistry mockRegistry;
@@ -82,6 +93,9 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         var mockThreadPool = mock(ThreadPool.class);
         when(mockThreadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(mockClient.threadPool()).thenReturn(mockThreadPool);
+        // Default: no region policy is configured, so getRegionPolicy() should resolve to InferencePreferences.EMPTY.
+        // Individual tests override this via givenRegionPolicyReturns/givenRegionPolicyFails.
+        givenRegionPolicyNotFound();
     }
 
     public void testDoesNotSendAuthorizationRequest_WhenModelRegistryIsNotReady() {
@@ -92,7 +106,7 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), future);
 
         assertThat(future.actionGet(), is(ActionResponse.Empty.INSTANCE));
-        verify(mockAuthHandler, never()).getAuthorization(any(), any());
+        verify(mockAuthHandler, never()).getAuthorization(any(), any(), any());
     }
 
     public void testDoesNotSendAuthorizationRequest_WhenClusterDoesNotIncludeMetadata_MappingUpdate() {
@@ -104,7 +118,7 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), future);
 
         assertThat(future.actionGet(), is(ActionResponse.Empty.INSTANCE));
-        verify(mockAuthHandler, never()).getAuthorization(any(), any());
+        verify(mockAuthHandler, never()).getAuthorization(any(), any(), any());
     }
 
     public void testSendsAuthorizationRequest_WhenModelRegistryIsReady() {
@@ -314,6 +328,48 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         verify(mockRegistry, never()).deleteModels(any(), any());
     }
 
+    public void testGetRegionPolicy_ForwardsPolicyPreferences_ToAuthorization() {
+        when(mockRegistry.isReady()).thenReturn(true);
+
+        var regionPolicy = new RegionPolicy(null, List.of(new CspRegion(REGION_POLICY_CSP, REGION_POLICY_REGION)), null);
+        givenRegionPolicyReturns(regionPolicy);
+        givenAuthHandlerReturnsEndpointsForUrl(URL, List.of());
+
+        var action = createAction();
+        action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), new TestPlainActionFuture<>());
+
+        var preferencesCaptor = ArgumentCaptor.forClass(InferencePreferences.class);
+        verify(mockAuthHandler).getAuthorization(any(), any(), preferencesCaptor.capture());
+        assertThat(preferencesCaptor.getValue().regionPolicy(), is(regionPolicy));
+    }
+
+    public void testGetRegionPolicy_ForwardsEmptyPreferences_WhenPolicyNotFound() {
+        when(mockRegistry.isReady()).thenReturn(true);
+
+        // init() already stubs the region policy lookup to fail with a ResourceNotFoundException.
+        givenAuthHandlerReturnsEndpointsForUrl(URL, List.of());
+
+        var action = createAction();
+        action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), new TestPlainActionFuture<>());
+
+        var preferencesCaptor = ArgumentCaptor.forClass(InferencePreferences.class);
+        verify(mockAuthHandler).getAuthorization(any(), any(), preferencesCaptor.capture());
+        assertThat(preferencesCaptor.getValue(), is(InferencePreferences.EMPTY));
+    }
+
+    public void testGetRegionPolicy_FailsAction_WhenPolicyFetchFails() {
+        when(mockRegistry.isReady()).thenReturn(true);
+        givenRegionPolicyFails(new RuntimeException("boom"));
+
+        var action = createAction();
+        var future = new TestPlainActionFuture<ActionResponse.Empty>();
+        action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), future);
+
+        var exception = expectThrows(ElasticsearchStatusException.class, future::actionGet);
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        verify(mockAuthHandler, never()).getAuthorization(any(), any(), any());
+    }
+
     private TransportRefreshAuthorizedEndpointsAction createAction() {
         return new TransportRefreshAuthorizedEndpointsAction(
             mock(TransportService.class),
@@ -356,7 +412,7 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
                 )
             );
             return Void.TYPE;
-        }).when(mockAuthHandler).getAuthorization(any(), any());
+        }).when(mockAuthHandler).getAuthorization(any(), any(), any());
     }
 
     private void givenStoreActionRespondsWith(ModelStoreResponse... results) {
@@ -365,6 +421,30 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
             listener.onResponse(new StoreInferenceEndpointsAction.Response(List.of(results)));
             return null;
         }).when(mockClient).execute(eq(StoreInferenceEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private void givenRegionPolicyNotFound() {
+        doAnswer(invocation -> {
+            ActionListener<RegionPolicyResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new ResourceNotFoundException("no region policy configured"));
+            return null;
+        }).when(mockClient).execute(eq(GetRegionPolicyAction.INSTANCE), any(), any());
+    }
+
+    private void givenRegionPolicyReturns(RegionPolicy regionPolicy) {
+        doAnswer(invocation -> {
+            ActionListener<RegionPolicyResponse> listener = invocation.getArgument(2);
+            listener.onResponse(new RegionPolicyResponse(new RegionPolicyDoc(regionPolicy, Instant.EPOCH, null, null, null)));
+            return null;
+        }).when(mockClient).execute(eq(GetRegionPolicyAction.INSTANCE), any(), any());
+    }
+
+    private void givenRegionPolicyFails(Exception exception) {
+        doAnswer(invocation -> {
+            ActionListener<RegionPolicyResponse> listener = invocation.getArgument(2);
+            listener.onFailure(exception);
+            return null;
+        }).when(mockClient).execute(eq(GetRegionPolicyAction.INSTANCE), any(), any());
     }
 
     private void sendAuthRequestAndVerifyStoreActionCalledForSparseEndpoints(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -379,6 +379,7 @@ public class HttpRequestSenderTests extends ESTestCase {
                 getUrl(webServer),
                 new TraceContext("", ""),
                 randomElasticInferenceServiceRequestMetadata(),
+                null,
                 CCMAuthenticationApplierFactory.NOOP_APPLIER
             );
             var responseHandler = new ElasticInferenceServiceResponseHandler(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
@@ -22,7 +22,10 @@ import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xpack.core.inference.regionpolicy.CspRegion;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -47,6 +50,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.ap
 import static org.elasticsearch.xpack.inference.services.SenderServiceTests.createMockSender;
 import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactoryTests.createApplierFactory;
 import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactoryTests.createNoopApplierFactory;
+import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequest.X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER;
 import static org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceAuthorizationResponseEntityTests.ELSER_V2_ENDPOINT_ID;
 import static org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceAuthorizationResponseEntityTests.getEisAuthorizationResponseWithMultipleEndpoints;
 import static org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceAuthorizationResponseEntityTests.getEisElserAuthorizationResponse;
@@ -64,6 +68,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ElasticInferenceServiceAuthorizationRequestHandlerTests extends ESTestCase {
+    private static final String REGION_POLICY_CSP = "aws";
+    private static final String REGION_POLICY_REGION = "us-east-1";
+
     private final MockWebServer webServer = new MockWebServer();
     private ThreadPool threadPool;
 
@@ -493,6 +500,42 @@ public class ElasticInferenceServiceAuthorizationRequestHandlerTests extends EST
     private static void assertAuthHeader(List<MockRequest> requests, String secret) {
         assertThat(requests.size(), is(1));
         assertThat(requests.get(0).getHeader(HttpHeaders.AUTHORIZATION), is(apiKey(secret)));
+    }
+
+    public void testGetAuthorization_ForwardsRegionPolicyHeaders() throws IOException {
+        var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
+        var eisGatewayUrl = getUrl(webServer);
+        var logger = mock(Logger.class);
+        var authHandler = new ElasticInferenceServiceAuthorizationRequestHandler(
+            eisGatewayUrl,
+            threadPool,
+            logger,
+            createNoopApplierFactory(),
+            createMockCcmFeature(false),
+            createMockCcmService(false)
+        );
+
+        var elserResponseBody = getEisElserAuthorizationResponse(eisGatewayUrl).responseJson();
+        var regionPolicy = new RegionPolicy(null, List.of(new CspRegion(REGION_POLICY_CSP, REGION_POLICY_REGION)), null);
+        var preferences = new InferencePreferences(regionPolicy);
+
+        try (var sender = senderFactory.createSender()) {
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(elserResponseBody));
+
+            PlainActionFuture<ElasticInferenceServiceAuthorizationModel> listener = new PlainActionFuture<>();
+            authHandler.getAuthorization(listener, sender, preferences);
+
+            var authResponse = listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT);
+            assertTrue(authResponse.isAuthorized());
+
+            authHandler.waitForAuthRequestCompletion(ESTestCase.TEST_REQUEST_TIMEOUT);
+
+            assertThat(webServer.requests().size(), is(1));
+            assertThat(
+                webServer.requests().get(0).getHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER),
+                is(REGION_POLICY_CSP + ":" + REGION_POLICY_REGION)
+            );
+        }
     }
 
     public void testGetAuthorization_OnResponseCalledOnce() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequestTests.java
@@ -10,19 +10,28 @@ package org.elasticsearch.xpack.inference.services.elastic.request;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.inference.regionpolicy.CspRegion;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
+import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 import org.elasticsearch.xpack.inference.telemetry.TraceContext;
 import org.junit.Before;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceAuthorizationRequest.AUTHORIZATION_PATH;
+import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequest.X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER;
 import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequestTests.randomElasticInferenceServiceRequestMetadata;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class ElasticInferenceServiceAuthorizationRequestTests extends ESTestCase {
+
+    private static final String CSP = "aws";
+    private static final String REGION = "us-east-1";
 
     private TraceContext traceContext;
 
@@ -40,6 +49,7 @@ public class ElasticInferenceServiceAuthorizationRequestTests extends ESTestCase
                 invalidUrl,
                 traceContext,
                 randomElasticInferenceServiceRequestMetadata(),
+                null,
                 CCMAuthenticationApplierFactory.NOOP_APPLIER
             )
         );
@@ -49,14 +59,36 @@ public class ElasticInferenceServiceAuthorizationRequestTests extends ESTestCase
     }
 
     public void testCreateUri_CreatesUri() throws URISyntaxException {
-        String url = "https://inference.us-east-1.aws.svc.elastic.cloud";
+        String url = "https://inference.cloud";
 
         var request = new ElasticInferenceServiceAuthorizationRequest(
             url,
             traceContext,
             randomElasticInferenceServiceRequestMetadata(),
+            null,
             CCMAuthenticationApplierFactory.NOOP_APPLIER
         );
         assertThat(request.getURI(), is(new URI(url + AUTHORIZATION_PATH)));
+    }
+
+    public void testCreateHttpRequest_ForwardsRegionPolicyHeaders_WhenPreferencesProvided() {
+        String url = "https://inference.cloud";
+        var preferences = new InferencePreferences(new RegionPolicy(null, List.of(new CspRegion(CSP, REGION)), null));
+
+        var request = new ElasticInferenceServiceAuthorizationRequest(
+            url,
+            traceContext,
+            randomElasticInferenceServiceRequestMetadata(),
+            preferences,
+            CCMAuthenticationApplierFactory.NOOP_APPLIER
+        );
+
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, is(1));
+        assertThat(
+            httpRequest.httpRequestBase().getFirstHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).getValue(),
+            is(CSP + ":" + REGION)
+        );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
@@ -11,24 +11,38 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.telemetry.InferenceProductContext;
 import org.elasticsearch.inference.telemetry.InferenceProductContextTests;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.inference.regionpolicy.CspRegion;
+import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicy;
+import org.elasticsearch.xpack.inference.common.InferencePreferences;
 import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.elasticsearch.inference.telemetry.InferenceProductContext.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_ES_VERSION;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
+import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequest.X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER;
+import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequest.X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class ElasticInferenceServiceRequestTests extends ESTestCase {
+
+    private static final String CSP_AWS = "aws";
+    private static final String REGION_US_EAST_1 = "us-east-1";
+    private static final String CSP_GCP = "gcp";
+    private static final String REGION_EUROPE_WEST_1 = "europe-west1";
+    private static final String GEO_US = "us";
+    private static final String GEO_EU = "eu";
 
     public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithAuthorizationHeader() {
         var secret = "secret";
@@ -82,6 +96,90 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
         assertThat(productUseCaseHeader.getValue(), equalTo(esVersion));
     }
 
+    public void testCreateHttpRequest_AddsAllowedRegionsHeader() {
+        var regionPolicy = new RegionPolicy(
+            null,
+            List.of(new CspRegion(CSP_AWS, REGION_US_EAST_1), new CspRegion(CSP_GCP, REGION_EUROPE_WEST_1)),
+            null
+        );
+        var request = getDummyElasticInferenceServiceRequest(
+            randomElasticInferenceServiceRequestMetadata(),
+            new InferencePreferences(regionPolicy)
+        );
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, equalTo(1));
+        assertThat(
+            httpRequest.httpRequestBase().getFirstHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).getValue(),
+            equalTo(CSP_AWS + ":" + REGION_US_EAST_1 + "," + CSP_GCP + ":" + REGION_EUROPE_WEST_1)
+        );
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).length, equalTo(0));
+    }
+
+    public void testCreateHttpRequest_AddsAllowedGeosHeader() {
+        var regionPolicy = new RegionPolicy(List.of(GEO_US, GEO_EU), null, null);
+        var request = getDummyElasticInferenceServiceRequest(
+            randomElasticInferenceServiceRequestMetadata(),
+            new InferencePreferences(regionPolicy)
+        );
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).length, equalTo(1));
+        assertThat(
+            httpRequest.httpRequestBase().getFirstHeader(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).getValue(),
+            equalTo(GEO_US + "," + GEO_EU)
+        );
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, equalTo(0));
+    }
+
+    public void testCreateHttpRequest_PrefersAllowedRegions_OverAllowedGeos() {
+        var regionPolicy = new RegionPolicy(List.of(GEO_US), List.of(new CspRegion(CSP_AWS, REGION_US_EAST_1)), null);
+        var request = getDummyElasticInferenceServiceRequest(
+            randomElasticInferenceServiceRequestMetadata(),
+            new InferencePreferences(regionPolicy)
+        );
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, equalTo(1));
+        assertThat(
+            httpRequest.httpRequestBase().getFirstHeader(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).getValue(),
+            equalTo(CSP_AWS + ":" + REGION_US_EAST_1)
+        );
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).length, equalTo(0));
+    }
+
+    public void testCreateHttpRequest_AddsNoRegionHeaders_WhenPreferencesNull() {
+        var request = getDummyElasticInferenceServiceRequest(
+            randomElasticInferenceServiceRequestMetadata(),
+            null,
+            CCMAuthenticationApplierFactory.NOOP_APPLIER
+        );
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, equalTo(0));
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).length, equalTo(0));
+    }
+
+    public void testCreateHttpRequest_AddsNoRegionHeaders_WhenRegionPolicyNull() {
+        var request = getDummyElasticInferenceServiceRequest(randomElasticInferenceServiceRequestMetadata(), InferencePreferences.EMPTY);
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, equalTo(0));
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).length, equalTo(0));
+    }
+
+    public void testCreateHttpRequest_AddsNoRegionHeaders_WhenListsEmpty() {
+        var regionPolicy = new RegionPolicy(List.of(), List.of(), null);
+        var request = getDummyElasticInferenceServiceRequest(
+            randomElasticInferenceServiceRequestMetadata(),
+            new InferencePreferences(regionPolicy)
+        );
+        var httpRequest = RequestTests.getHttpRequestSync(request);
+
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_REGIONS_HEADER).length, equalTo(0));
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_INFERENCE_ALLOWED_GEOS_HEADER).length, equalTo(0));
+    }
+
     private static ElasticInferenceServiceRequest getDummyElasticInferenceServiceRequest(
         ElasticInferenceServiceRequestMetadata requestMetadata
     ) {
@@ -92,7 +190,22 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
         ElasticInferenceServiceRequestMetadata requestMetadata,
         CCMAuthenticationApplierFactory.AuthApplier authApplier
     ) {
-        return new ElasticInferenceServiceRequest(requestMetadata, authApplier) {
+        return getDummyElasticInferenceServiceRequest(requestMetadata, null, authApplier);
+    }
+
+    private static ElasticInferenceServiceRequest getDummyElasticInferenceServiceRequest(
+        ElasticInferenceServiceRequestMetadata requestMetadata,
+        @Nullable InferencePreferences preferences
+    ) {
+        return getDummyElasticInferenceServiceRequest(requestMetadata, preferences, CCMAuthenticationApplierFactory.NOOP_APPLIER);
+    }
+
+    private static ElasticInferenceServiceRequest getDummyElasticInferenceServiceRequest(
+        ElasticInferenceServiceRequestMetadata requestMetadata,
+        @Nullable InferencePreferences preferences,
+        CCMAuthenticationApplierFactory.AuthApplier authApplier
+    ) {
+        return new ElasticInferenceServiceRequest(requestMetadata, preferences, authApplier) {
             @Override
             protected HttpRequestBase createHttpRequestBase() {
                 return new HttpGet("http://localhost:8080");

--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -35,6 +35,9 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
         .setting("xpack.security.enabled", "false")
         .setting("xpack.security.http.ssl.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        // This might not be necessary because the authorization refresh will skip internally if the url
+        // is blank (which it should be because we don't set it for this cluster)
+        .setting("xpack.inference.region_policy.authorization.skip_refresh", "true")
         .plugin("inference-service-test")
         .feature(FeatureFlag.INFERENCE_REGION_POLICY)
         .distribution(DistributionType.DEFAULT)


### PR DESCRIPTION
Wires the configured region policy into the Elastic Inference Service (EIS)
authorization request so EIS returns only endpoints permitted by the policy.

- `ElasticInferenceServiceRequest` adds `X-Elastic-Inference-Allowed-Regions` /
  `X-Elastic-Inference-Allowed-Geos` headers derived from the region policy,
  carried via the new `InferencePreferences` record.
- `TransportRefreshAuthorizedEndpointsAction` fetches the current region policy
  (behind the region-policy feature flag) and passes it to the auth handler.
- Putting or deleting a region policy now triggers an authorization refresh so
  the change takes effect immediately; refresh failures are logged and **do not
  fail the request**.
- Adds a test-only setting
  `xpack.inference.region_policy.authorization.skip_refresh` to disable the
  refresh in tests.