### PR TITLE
boost the priority for xpack license update task

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
@@ -232,7 +232,8 @@ public class ClusterStateLicenseService extends AbstractLifecycleComponent
                 }
             }
 
-            submitUnbatchedTask("register license [" + newLicense.uid() + "]", new AckedClusterStateUpdateTask(request, listener) {
+            submitUnbatchedTask("register license [" + newLicense.uid() + "]",
+                new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) {
                 @Override
                 protected PutLicenseResponse newResponse(boolean acknowledged) {
                     return new PutLicenseResponse(acknowledged, LicensesStatus.VALID);


### PR DESCRIPTION
## Title

`Boost priority of xpack license registration cluster state update task`

---

## Description

### Problem

When a new license is registered via the `PUT /_license` API, the cluster state update task is submitted with the default priority (`NORMAL`). Under high cluster load — for example, when many other `NORMAL`-priority tasks (such as shard allocation, index creation, etc.) are queued — the license update task may be delayed significantly.

This delay can cause a window where the cluster is operating with an outdated or expired license state, potentially affecting feature availability that depends on license checks.

### Root Cause

In `ClusterStateLicenseService.java`, the `submitUnbatchedTask` call for license registration uses `AckedClusterStateUpdateTask` without explicitly specifying a priority, which defaults to `Priority.NORMAL`:

```java
// Before
submitUnbatchedTask("register license [" + newLicense.uid() + "]",
    new AckedClusterStateUpdateTask(request, listener) { ... });
```

License registration is a critical administrative operation that should not be blocked behind routine cluster maintenance tasks.

### Fix

Explicitly set `Priority.IMMEDIATE` for the license registration cluster state update task, ensuring it is processed ahead of `NORMAL`-priority tasks:

```java
// After
submitUnbatchedTask("register license [" + newLicense.uid() + "]",
    new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) { ... });
```

`Priority.IMMEDIATE` is already used for other time-sensitive cluster state operations (e.g., shard started, node join). License registration is equally critical since it directly affects cluster feature availability.

### Impact

- No behavioral change under normal (low-load) conditions.
- Under high cluster load, license updates are now processed promptly without being queued behind routine tasks.
- No risk of regression: `AckedClusterStateUpdateTask` already supports a `Priority` constructor parameter.