### PR TITLE
Fix highlight format issue.

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomPassageFormatter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomPassageFormatter.java
@@ -12,6 +12,8 @@ package org.elasticsearch.lucene.search.uhighlight;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.uhighlight.Passage;
 import org.apache.lucene.search.uhighlight.PassageFormatter;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightUtils;
 
 /**
@@ -25,6 +27,7 @@ public class CustomPassageFormatter extends PassageFormatter {
     private final String postTag;
     private final Encoder encoder;
     private final int numberOfFragments;
+    private static final Logger logger = LogManager.getLogger(CustomPassageFormatter.class);
 
     public CustomPassageFormatter(String preTag, String postTag, Encoder encoder, int numberOfFragments) {
         this.preTag = preTag;
@@ -66,7 +69,11 @@ public class CustomPassageFormatter extends PassageFormatter {
             // Replace the null separator (used to join multi-value fields) with a space,
             // and remove the paragraph separator if present at the end of the snippet.
             String snippetText = sb.toString().replace(HighlightUtils.NULL_SEPARATOR, ' ');
-            if (snippetText.charAt(snippetText.length() - 1) == HighlightUtils.PARAGRAPH_SEPARATOR) {
+            if (sb.isEmpty()) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Got empty highlight format for passage [{}], pre tag [{}], post tag [{}]", passage, preTag, postTag);
+                }
+            } else if (snippetText.charAt(snippetText.length() - 1) == HighlightUtils.PARAGRAPH_SEPARATOR) {
                 snippetText = snippetText.substring(0, snippetText.length() - 1);
             }
             if (numberOfFragments > 0) {


### PR DESCRIPTION
## PR Title

`Fix potential StringIndexOutOfBoundsException in CustomPassageFormatter when passage produces empty snippet`

---

## Description

### Problem

In `CustomPassageFormatter.format()`, after building the snippet text from a passage, the code directly accesses `snippetText.charAt(snippetText.length() - 1)` to check for a trailing paragraph separator:

```java
String snippetText = sb.toString().replace(HighlightUtils.NULL_SEPARATOR, ' ');
if (snippetText.charAt(snippetText.length() - 1) == HighlightUtils.PARAGRAPH_SEPARATOR) {
    snippetText = snippetText.substring(0, snippetText.length() - 1);
}
```

If the `StringBuilder` is empty (e.g., a passage with zero-length content or all content filtered out), `snippetText` will be an empty string, and calling `charAt(-1)` throws a `StringIndexOutOfBoundsException`.

### Root Cause

There is no guard against an empty `StringBuilder` before accessing the last character of the resulting string. An empty passage (where `startOffset == endOffset` or all match ranges are degenerate) can produce an empty `sb`, leading to an empty `snippetText` after the `replace()` call.

### Fix

Add an explicit `sb.isEmpty()` check before accessing `snippetText.charAt(snippetText.length() - 1)`. When the snippet is empty, log a debug message to aid future diagnosis, and skip the paragraph separator trimming:

```java
String snippetText = sb.toString().replace(HighlightUtils.NULL_SEPARATOR, ' ');
if (sb.isEmpty()) {
    if (logger.isDebugEnabled()) {
        logger.debug("Got empty highlight format for passage [{}], pre tag [{}], post tag [{}]",
            passage, preTag, postTag);
    }
} else if (snippetText.charAt(snippetText.length() - 1) == HighlightUtils.PARAGRAPH_SEPARATOR) {
    snippetText = snippetText.substring(0, snippetText.length() - 1);
}
```

### Impact

- Prevents a `StringIndexOutOfBoundsException` crash when a passage produces an empty formatted snippet.
- The debug log helps operators diagnose why certain passages yield no highlight output without impacting production performance (guarded by `isDebugEnabled()`).
- No behavioral change for non-empty passages.