### PR TITLE
Set min recovery bytes limit as 1MB.

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AdjustableSemaphore;
+import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -53,6 +54,7 @@ public class RecoverySettings {
 
     private static final Logger logger = LogManager.getLogger(RecoverySettings.class);
 
+    private static final long ONE_MB_IN_BYTES = 1024 * 1024L;
     /**
      * Undocumented setting, used to override the total physical available memory in tests
      **/
@@ -506,8 +508,11 @@ public class RecoverySettings {
     }
 
     private void computeMaxBytesPerSec(Settings settings) {
-        // limit as computed before 8.1.0
-        final long defaultBytesPerSec = Math.max(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.get(settings).getBytes(), 0L);
+        // limit as computed before 8.1.0, default should never lower than 1MB
+        final long defaultBytesPerSec = Math.max(
+            INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.get(settings).getBytes(),
+            Assertions.ENABLED ? 0L : ONE_MB_IN_BYTES
+        );
 
         // available network bandwidth
         final long networkBandwidthBytesPerSec = Math.max(availableNetworkBandwidth.getBytes(), 0L);


### PR DESCRIPTION
## PR Title

`Set a minimum floor of 1MB for recovery max bytes per second`

---

## Description

### Problem

When `indices.recovery.max_bytes_per_sec` is set to a very small value (or the computed `defaultBytesPerSec` evaluates to near zero due to bandwidth-based auto-throttling), the recovery throughput can be throttled down to an extremely low rate — potentially just a few bytes per second. This causes shard recoveries to stall indefinitely or take an unreasonably long time to complete, even when the cluster has sufficient resources.

### Root Cause

In `RecoverySettings.computeMaxBytesPerSec()`, the `defaultBytesPerSec` is computed as:

```java
// Before
final long defaultBytesPerSec = Math.max(
    INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.get(settings).getBytes(),
    0L
);
```

The lower bound is `0L`, which means there is no meaningful floor on the recovery rate. When the setting is configured to a very small value or the bandwidth detection returns a near-zero result, recovery can be throttled to an impractically low speed.

### Fix

Introduce a constant `ONE_MB_IN_BYTES` (1 MiB = 1024 × 1024 bytes) and use it as the minimum floor for `defaultBytesPerSec` in non-assertion (production) mode:

```java
private static final long ONE_MB_IN_BYTES = 1024 * 1024L;

// After
final long defaultBytesPerSec = Math.max(
    INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.get(settings).getBytes(),
    Assertions.ENABLED ? 0L : ONE_MB_IN_BYTES
);
```

- **Production mode** (`Assertions.ENABLED == false`): the recovery rate is always at least 1 MB/s, preventing indefinitely stalled recoveries.
- **Test mode** (`Assertions.ENABLED == true`): the floor remains `0L` to preserve existing test behavior that may intentionally set the rate to zero.

### Impact

- Prevents shard recovery from stalling when the configured or computed rate is near zero.
- No impact on clusters where `indices.recovery.max_bytes_per_sec` is set to a reasonable value (the `Math.max` only kicks in when the configured value is below 1 MB/s).
- Test behavior is unchanged (the `0L` floor is preserved when assertions are enabled).