### PR TITLE
Unmute testEachInstallOrRotationAddsExactlyOneNewKey

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -826,9 +826,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/152734
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testEachInstallOrRotationAddsExactlyOneNewKey
-  issue: https://github.com/elastic/elasticsearch/issues/152776
 - class: org.elasticsearch.transport.RemoteClusterClientTests
   method: testGetConnectionFailureCompletesOnResponseExecutor
   issue: https://github.com/elastic/elasticsearch/issues/152779


### PR DESCRIPTION
This was fixed in https://github.com/elastic/elasticsearch/pull/152630 so unmuting this test. 

Resolves: https://github.com/elastic/elasticsearch/issues/152776