### PR TITLE
[Gradle] Set tmp dir for build integ tests explicitly

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -396,9 +396,7 @@ tasks.register("integTest", Test) {
   // ElasticsearchTestBasePlugin cannot apply itself, so java.io.tmpdir must be set manually here.
   // Without it, JUnit/Spock create temp dirs under /tmp (root fs) instead of the build dir (/dev/shm in CI).
   // JvmArgumentProvider keeps the absolute path out of task inputs so it doesn't break cache relocatability.
-  def tempDir = layout.buildDirectory.dir("testrun/integTest/temp")
-  doFirst { tempDir.get().asFile.mkdirs() }
-  jvmArgumentProviders.add { ["-Djava.io.tmpdir=${tempDir.get().asFile}"] as List<String> }
+  jvmArgumentProviders.add { ["-Djava.io.tmpdir=${getTemporaryDir().get().asFile}"] as List<String> }
 }
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -9,6 +9,7 @@
 
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo
+import org.gradle.process.CommandLineArgumentProvider
 
 plugins {
   id 'java-gradle-plugin'
@@ -395,8 +396,10 @@ tasks.register("integTest", Test) {
   useJUnitPlatform()
   // ElasticsearchTestBasePlugin cannot apply itself, so java.io.tmpdir must be set manually here.
   // Without it, JUnit/Spock create temp dirs under /tmp (root fs) instead of the build dir (/dev/shm in CI).
-  // JvmArgumentProvider keeps the absolute path out of task inputs so it doesn't break cache relocatability.
-  jvmArgumentProviders.add { ["-Djava.io.tmpdir=${getTemporaryDir().get().asFile}"] as List<String> }
+  // The nested Gradle TestKit runners require an absolute path, so a relative value is not an option here.
+  // A CommandLineArgumentProvider keeps that absolute path out of the task inputs so it stays cache relocatable.
+  def tempDir = temporaryDir
+  jvmArgumentProviders.add({ ["-Djava.io.tmpdir=${tempDir}"] as List<String> } as CommandLineArgumentProvider)
 }
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -393,6 +393,12 @@ tasks.register("integTest", Test) {
   testClassesDirs = sourceSets.integTest.output.classesDirs
   classpath = sourceSets.integTest.runtimeClasspath
   useJUnitPlatform()
+  // ElasticsearchTestBasePlugin cannot apply itself, so java.io.tmpdir must be set manually here.
+  // Without it, JUnit/Spock create temp dirs under /tmp (root fs) instead of the build dir (/dev/shm in CI).
+  // JvmArgumentProvider keeps the absolute path out of task inputs so it doesn't break cache relocatability.
+  def tempDir = layout.buildDirectory.dir("testrun/integTest/temp")
+  doFirst { tempDir.get().asFile.mkdirs() }
+  jvmArgumentProviders.add { ["-Djava.io.tmpdir=${tempDir.get().asFile}"] as List<String> }
 }
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -185,6 +185,7 @@ tasks.named('test').configure {
 tasks.register("integTest", Test) {
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
+    jvmArgumentProviders.add { ["-Djava.io.tmpdir=${getTemporaryDir().get().asFile}"] as List<String> }
     useJUnitPlatform()
 }
 

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -185,7 +185,10 @@ tasks.named('test').configure {
 tasks.register("integTest", Test) {
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
-    jvmArgumentProviders.add { ["-Djava.io.tmpdir=${getTemporaryDir().get().asFile}"] as List<String> }
+    // The nested Gradle TestKit runners require an absolute path, so a relative value is not an option here.
+    // A CommandLineArgumentProvider keeps that absolute path out of the task inputs so it stays cache relocatable.
+    def tempDir = temporaryDir
+    jvmArgumentProviders.add({ ["-Djava.io.tmpdir=${tempDir}"] as List<String> } as CommandLineArgumentProvider)
     useJUnitPlatform()
 }
 


### PR DESCRIPTION
Setting explicitly the tmp dir for our build interg tests allows us to run them always on quicker partitions on ci and keep output in the build dirs similar to regular production code testing

Fixes #151851