### PR TITLE
[ESQL] Fix ExternalSourceExec BWC serialization test types

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -113,9 +113,6 @@ tests:
 - class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
   method: testHAProxyModeConnectionWorks
   issue: https://github.com/elastic/elasticsearch/issues/139171
-- class: org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExecSerializationTests
-  method: testEncryptedDatasourceSecretStrippedForOlderTransportVersion
-  issue: https://github.com/elastic/elasticsearch/issues/152657
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:PROMQL}
   issue: https://github.com/elastic/elasticsearch/issues/146923

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/FieldAttributeTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/FieldAttributeTestUtils.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
@@ -36,17 +37,34 @@ public class FieldAttributeTestUtils {
      * @param onlyRepresentable if true, only generates attributes with representable data types
      */
     public static FieldAttribute createFieldAttribute(int maxDepth, boolean onlyRepresentable) {
+        return createFieldAttribute(maxDepth, onlyRepresentable, null);
+    }
+
+    /**
+     * Creates a random {@link FieldAttribute} whose field (including nested properties) is serializable on the
+     * given transport version.
+     *
+     * @param maxDepth          maximum depth for nested EsField properties
+     * @param onlyRepresentable if true, only generates attributes with representable data types
+     * @param supportedOn       if non-null, only generates field types supported on this transport version
+     */
+    public static FieldAttribute createFieldAttribute(int maxDepth, boolean onlyRepresentable, TransportVersion supportedOn) {
         Source source = Source.EMPTY;
         String parentName = maxDepth == 0 || randomBoolean() ? null : randomAlphaOfLength(3);
         String qualifier = randomBoolean() ? null : randomAlphaOfLength(3);
         String name = randomAlphaOfLength(5);
-        EsField field = onlyRepresentable ? randomRepresentableEsField(maxDepth) : randomSerializableEsField(maxDepth);
+        EsField field = onlyRepresentable
+            ? randomRepresentableEsField(maxDepth, supportedOn)
+            : randomSerializableEsField(maxDepth, supportedOn);
         Nullability nullability = randomFrom(Nullability.values());
         boolean synthetic = randomBoolean();
         return new FieldAttribute(source, parentName, qualifier, name, field, nullability, new NameId(), synthetic);
     }
 
-    private static EsField randomRepresentableEsField(int maxDepth) {
-        return randomValueOtherThanMany(f -> false == DataType.isRepresentable(f.getDataType()), () -> randomSerializableEsField(maxDepth));
+    private static EsField randomRepresentableEsField(int maxDepth, TransportVersion supportedOn) {
+        return randomValueOtherThanMany(
+            f -> false == DataType.isRepresentable(f.getDataType()),
+            () -> randomSerializableEsField(maxDepth, supportedOn)
+        );
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/ReferenceAttributeTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/ReferenceAttributeTestUtils.java
@@ -7,13 +7,13 @@
 
 package org.elasticsearch.xpack.esql.expression.function;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.type.RandomDataTypeUtils;
 
 import java.util.function.Supplier;
 
@@ -50,13 +50,7 @@ public class ReferenceAttributeTestUtils {
         Source source = Source.EMPTY;
         String qualifier = randomBoolean() ? null : randomAlphaOfLength(3);
         String name = randomAlphaOfLength(5);
-        boolean isSnapshot = Build.current().isSnapshot();
-        Supplier<DataType> randomType = () -> randomValueOtherThanMany(
-            t -> false == t.supportedVersion().supportedLocally()
-                || DataType.UNDER_CONSTRUCTION.contains(t)
-                || (supportedOn != null && false == t.supportedVersion().supportedOn(supportedOn, isSnapshot)),
-            () -> randomFrom(DataType.types())
-        );
+        Supplier<DataType> randomType = () -> RandomDataTypeUtils.randomSerializableDataType(supportedOn);
         DataType type = onlyRepresentable
             ? randomValueOtherThanMany(t -> false == DataType.isRepresentable(t), randomType)
             : randomType.get();

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/plan/AbstractNodeSerializationTests.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/plan/AbstractNodeSerializationTests.java
@@ -49,7 +49,16 @@ public abstract class AbstractNodeSerializationTests<T extends Node<? super T>> 
     }
 
     public static List<Attribute> randomFieldAttributes(int min, int max, boolean onlyRepresentable) {
-        return randomList(min, max, () -> createFieldAttribute(0, onlyRepresentable));
+        return randomFieldAttributes(min, max, onlyRepresentable, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomFieldAttributes(int, int, boolean)} that only produces attributes whose
+     * data types serialize on {@code supportedOn}. Use this when the generated attributes will be round-tripped through
+     * an older transport version, so that release builds don't blow up on types gated behind a later version.
+     */
+    public static List<Attribute> randomFieldAttributes(int min, int max, boolean onlyRepresentable, TransportVersion supportedOn) {
+        return randomList(min, max, () -> createFieldAttribute(0, onlyRepresentable, supportedOn));
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/type/EsFieldTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/type/EsFieldTestUtils.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.type;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DateEsField;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.KeywordEsField;
@@ -22,7 +24,6 @@ import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomList;
-import static org.elasticsearch.test.ESTestCase.randomValueOtherThanMany;
 
 /**
  * Utility class providing factory and random-instance methods for EsField subtype testing.
@@ -37,12 +38,21 @@ public class EsFieldTestUtils {
      * Returns a random instance of any concrete serializable {@link EsField} subtype up to the given depth.
      */
     public static EsField randomSerializableEsField(int maxDepth) {
+        return randomSerializableEsField(maxDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomSerializableEsField(int)} that only generates fields whose
+     * data types (including nested properties) are serializable on {@code supportedOn}. Pass {@code null}
+     * to keep the unrestricted behavior.
+     */
+    public static EsField randomSerializableEsField(int maxDepth, TransportVersion supportedOn) {
         return switch (between(0, 4)) {
-            case 0 -> randomEsField(maxDepth);
-            case 1 -> randomDateEsField(maxDepth);
-            case 2 -> randomKeywordEsField(maxDepth);
-            case 3 -> randomTextEsField(maxDepth);
-            case 4 -> randomUnsupportedEsField(maxDepth);
+            case 0 -> randomEsField(maxDepth, supportedOn);
+            case 1 -> randomDateEsField(maxDepth, supportedOn);
+            case 2 -> randomKeywordEsField(maxDepth, supportedOn);
+            case 3 -> randomTextEsField(maxDepth, supportedOn);
+            case 4 -> randomUnsupportedEsField(maxDepth, supportedOn);
             default -> throw new IllegalArgumentException();
         };
     }
@@ -51,12 +61,19 @@ public class EsFieldTestUtils {
      * Returns a random {@link EsField} instance with properties nested up to {@code maxPropertiesDepth}.
      */
     public static EsField randomEsField(int maxPropertiesDepth) {
+        return randomEsField(maxPropertiesDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomEsField(int)}. The generated data type is restricted to
+     * types that serialize on {@code supportedOn} (mirroring the gate in {@code DataType#writeTo}), or
+     * unconstrained when {@code null}; under-construction types are always excluded. See
+     * {@link RandomDataTypeUtils}.
+     */
+    public static EsField randomEsField(int maxPropertiesDepth, TransportVersion supportedOn) {
         String name = randomAlphaOfLength(4);
-        org.elasticsearch.xpack.esql.core.type.DataType esDataType = randomValueOtherThanMany(
-            t -> false == t.supportedVersion().supportedLocally(),
-            () -> randomFrom(org.elasticsearch.xpack.esql.core.type.DataType.types())
-        );
-        Map<String, EsField> properties = randomProperties(maxPropertiesDepth);
+        DataType esDataType = RandomDataTypeUtils.randomSerializableDataType(supportedOn);
+        Map<String, EsField> properties = randomProperties(maxPropertiesDepth, supportedOn);
         boolean aggregatable = randomBoolean();
         boolean isAlias = randomBoolean();
         EsField.TimeSeriesFieldType tsType = randomFrom(EsField.TimeSeriesFieldType.values());
@@ -67,9 +84,17 @@ public class EsFieldTestUtils {
      * Returns a random {@link DateEsField} instance with properties nested up to {@code maxPropertiesDepth}.
      */
     public static DateEsField randomDateEsField(int maxPropertiesDepth) {
+        return randomDateEsField(maxPropertiesDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomDateEsField(int)} that restricts nested property types to those
+     * serializable on {@code supportedOn}.
+     */
+    public static DateEsField randomDateEsField(int maxPropertiesDepth, TransportVersion supportedOn) {
         return DateEsField.dateEsField(
             randomAlphaOfLength(5),
-            randomProperties(maxPropertiesDepth),
+            randomProperties(maxPropertiesDepth, supportedOn),
             randomBoolean(),
             randomFrom(EsField.TimeSeriesFieldType.values())
         );
@@ -79,8 +104,16 @@ public class EsFieldTestUtils {
      * Returns a random {@link KeywordEsField} instance with properties nested up to {@code maxPropertiesDepth}.
      */
     public static KeywordEsField randomKeywordEsField(int maxPropertiesDepth) {
+        return randomKeywordEsField(maxPropertiesDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomKeywordEsField(int)} that restricts nested property types to those
+     * serializable on {@code supportedOn}.
+     */
+    public static KeywordEsField randomKeywordEsField(int maxPropertiesDepth, TransportVersion supportedOn) {
         String name = randomAlphaOfLength(4);
-        Map<String, EsField> properties = randomProperties(maxPropertiesDepth);
+        Map<String, EsField> properties = randomProperties(maxPropertiesDepth, supportedOn);
         boolean hasDocValues = randomBoolean();
         int precision = org.elasticsearch.test.ESTestCase.randomInt();
         boolean normalized = randomBoolean();
@@ -93,8 +126,16 @@ public class EsFieldTestUtils {
      * Returns a random {@link TextEsField} instance with properties nested up to {@code maxPropertiesDepth}.
      */
     public static TextEsField randomTextEsField(int maxPropertiesDepth) {
+        return randomTextEsField(maxPropertiesDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomTextEsField(int)} that restricts nested property types to those
+     * serializable on {@code supportedOn}.
+     */
+    public static TextEsField randomTextEsField(int maxPropertiesDepth, TransportVersion supportedOn) {
         String name = randomAlphaOfLength(4);
-        Map<String, EsField> properties = randomProperties(maxPropertiesDepth);
+        Map<String, EsField> properties = randomProperties(maxPropertiesDepth, supportedOn);
         boolean hasDocValues = randomBoolean();
         boolean isAlias = randomBoolean();
         EsField.TimeSeriesFieldType tsType = randomFrom(EsField.TimeSeriesFieldType.values());
@@ -105,10 +146,18 @@ public class EsFieldTestUtils {
      * Returns a random {@link UnsupportedEsField} instance with properties nested up to {@code maxPropertiesDepth}.
      */
     public static UnsupportedEsField randomUnsupportedEsField(int maxPropertiesDepth) {
+        return randomUnsupportedEsField(maxPropertiesDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomUnsupportedEsField(int)} that restricts nested property types to those
+     * serializable on {@code supportedOn}.
+     */
+    public static UnsupportedEsField randomUnsupportedEsField(int maxPropertiesDepth, TransportVersion supportedOn) {
         String name = randomAlphaOfLength(4);
         List<String> originalTypes = randomOriginalTypes();
         String inherited = randomBoolean() ? null : randomAlphaOfLength(5);
-        Map<String, EsField> properties = randomProperties(maxPropertiesDepth);
+        Map<String, EsField> properties = randomProperties(maxPropertiesDepth, supportedOn);
         return new UnsupportedEsField(name, originalTypes, inherited, properties);
     }
 
@@ -125,6 +174,17 @@ public class EsFieldTestUtils {
      * @param maxDepth the maximum number of levels of properties to make
      */
     public static Map<String, EsField> randomProperties(int maxDepth) {
+        return randomProperties(maxDepth, null);
+    }
+
+    /**
+     * Version-aware variant of {@link #randomProperties(int)} that restricts generated property types to those
+     * serializable on {@code supportedOn}.
+     *
+     * @param maxDepth the maximum number of levels of properties to make
+     * @param supportedOn if non-null, only generates property types supported on this transport version
+     */
+    public static Map<String, EsField> randomProperties(int maxDepth, TransportVersion supportedOn) {
         if (maxDepth < 0) {
             throw new IllegalArgumentException("depth must be >= 0");
         }
@@ -134,7 +194,7 @@ public class EsFieldTestUtils {
         int targetSize = between(1, 5);
         Map<String, EsField> properties = new TreeMap<>();
         while (properties.size() < targetSize) {
-            properties.put(randomAlphaOfLength(properties.size() + 1), randomSerializableEsField(maxDepth - 1));
+            properties.put(randomAlphaOfLength(properties.size() + 1), randomSerializableEsField(maxDepth - 1, supportedOn));
         }
         return properties;
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/type/RandomDataTypeUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/type/RandomDataTypeUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.type;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomValueOtherThanMany;
+
+/**
+ * Shared randomization predicate for {@link DataType}, so the several test fixtures that pick a random
+ * serializable type ({@link EsFieldTestUtils}, {@code ReferenceAttributeTestUtils}) filter it the same
+ * way and cannot drift apart. A type is usable when it is supported on the current node, is not
+ * under construction, and — when a target version is given — serializes on that version (the same gate
+ * {@code DataType#writeTo} enforces).
+ */
+public final class RandomDataTypeUtils {
+
+    private RandomDataTypeUtils() {}
+
+    /**
+     * Whether a random generator may emit {@code type}. {@code supportedOn} is the transport version the
+     * generated value will be serialized to (or {@code null} for no version constraint).
+     */
+    public static boolean isSerializable(DataType type, TransportVersion supportedOn, boolean currentBuildIsSnapshot) {
+        if (type.supportedVersion().supportedLocally() == false) {
+            return false;
+        }
+        if (DataType.UNDER_CONSTRUCTION.contains(type)) {
+            return false;
+        }
+        return supportedOn == null || type.supportedVersion().supportedOn(supportedOn, currentBuildIsSnapshot);
+    }
+
+    /** Picks a random {@link DataType} serializable on {@code supportedOn} (or unconstrained when {@code null}). */
+    public static DataType randomSerializableDataType(TransportVersion supportedOn) {
+        boolean isSnapshot = Build.current().isSnapshot();
+        return randomValueOtherThanMany(t -> isSerializable(t, supportedOn, isSnapshot) == false, () -> randomFrom(DataType.types()));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
@@ -168,11 +168,20 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
     }
 
     private static ExternalSourceExec externalSourceExecWithConfig(Map<String, Object> config) {
+        return externalSourceExecWithConfig(config, null);
+    }
+
+    /**
+     * Build an {@link ExternalSourceExec} whose attributes only use data types serializable on {@code supportedOn}.
+     * Passing the target (older) transport version keeps release builds from generating types gated behind a later
+     * version (e.g. FLATTENED), which would otherwise fail {@code DataType#writeTo} before the config assertions run.
+     */
+    private static ExternalSourceExec externalSourceExecWithConfig(Map<String, Object> config, TransportVersion supportedOn) {
         return new ExternalSourceExec(
             randomSource(),
             "teststore:///data.csv",
             "csv",
-            randomFieldAttributes(1, 3, false),
+            randomFieldAttributes(1, 3, false, supportedOn),
             config,
             Map.of(),
             null,
@@ -217,7 +226,7 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
         config.put(ExternalSourceResolver.DATASOURCE_CONFIG_KEY, datasource);
 
         TransportVersion beforeCarrier = TransportVersionUtils.getPreviousVersion(TransportVersion.fromName("data_source_encrypted_data"));
-        ExternalSourceExec roundTripped = copyInstance(externalSourceExecWithConfig(config), beforeCarrier);
+        ExternalSourceExec roundTripped = copyInstance(externalSourceExecWithConfig(config, beforeCarrier), beforeCarrier);
 
         assertThat(roundTripped.config().containsKey(ExternalSourceResolver.DATASOURCE_CONFIG_KEY), equalTo(false));
         assertThat(roundTripped.config().get("format"), equalTo("csv"));


### PR DESCRIPTION
`testEncryptedDatasourceSecretStrippedForOlderTransportVersion` built random field attributes filtered only by `supportedLocally`, so on release builds `FLATTENED` could be generated and then fail `DataType#writeTo` when copied to a pre-carrier transport version, before the config assertions ran. Add version-aware random field attribute overloads that filter types by `supportedOn` (mirroring `DataType#writeTo` and `ReferenceAttributeTestUtils`) and build the attributes with the target version. Unmutes the test.