### PR TITLE
[ESQL] Normalize local StorageObject path for stats reconcile

### DIFF
--- a/docs/changelog/152837.yaml
+++ b/docs/changelog/152837.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152837
+summary: Normalize local `StorageObject` path for stats reconcile
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -440,24 +440,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonFormatSpecIT
   method: test {csv-spec:external-basic.inlineStatsMaxSalary [AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150791
-- class: org.elasticsearch.xpack.esql.qa.csv.ExternalCsvMultiNodePushdownIT
-  method: testCountStarColdThenWarmShortCircuitsAcrossNodes
-  issue: https://github.com/elastic/elasticsearch/issues/150594
-- class: org.elasticsearch.xpack.esql.action.ExternalCsvMultiScanPushdownIT
-  method: testMultiScanColdDoesNotDoubleCountWarmCountStar
-  issue: https://github.com/elastic/elasticsearch/issues/150836
-- class: org.elasticsearch.xpack.esql.action.ExternalNdJsonAggregatePushdownIT
-  method: testCountStarColdThenWarmShortCircuits
-  issue: https://github.com/elastic/elasticsearch/issues/150614
-- class: org.elasticsearch.xpack.esql.action.ExternalNdJsonAggregatePushdownIT
-  method: testMinMaxColdThenWarmShortCircuits
-  issue: https://github.com/elastic/elasticsearch/issues/150616
-- class: org.elasticsearch.xpack.esql.action.ExternalNdJsonAggregatePushdownIT
-  method: testCountColumnColdThenWarmShortCircuits
-  issue: https://github.com/elastic/elasticsearch/issues/150615
-- class: org.elasticsearch.xpack.esql.action.ExternalNdJsonMultiScanPushdownIT
-  method: testMultiScanColdDoesNotDoubleCountWarmCountStar
-  issue: https://github.com/elastic/elasticsearch/issues/150837
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonFormatSpecIT
   method: test {csv-spec:external-basic.forkTwoBranches [AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150844
@@ -632,9 +614,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.datafeed.CredentialTransitionsTests
   method: testValidateSearchBeforeMintWhenProbeReturnsNoMatchingProjectForQualifiedIndexShouldFail
   issue: https://github.com/elastic/elasticsearch/issues/152131
-- class: org.elasticsearch.xpack.esql.action.ExternalSourceProfileIT
-  method: testCsvCountStarScansColdThenSkipsWarm
-  issue: https://github.com/elastic/elasticsearch/issues/152132
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:stats_sparkline.sparklineWithWeightedAvg}
   issue: https://github.com/elastic/elasticsearch/issues/152159

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObject.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObject.java
@@ -44,7 +44,15 @@ public final class LocalStorageObject extends AbstractMeteredStorageObject {
             throw new IllegalArgumentException("filePath cannot be null");
         }
         this.filePath = filePath;
-        this.storagePath = StoragePath.of("file://" + filePath.toAbsolutePath());
+        // Use the shared canonical factory (not "file://" + toAbsolutePath) so the location is
+        // normalized identically to every other producer of a local StoragePath (the directory
+        // listing's toStoragePath, the query's location). On Windows toAbsolutePath() keeps
+        // backslashes and yields a two-slash "file://C:\dir\file" form, whereas the factory
+        // normalizes to "file:///C:/dir/file"; the mismatch made object.path() (the stats-capture
+        // key) differ from the planning-side SchemaCacheKey canonicalPath, so
+        // ExternalSourceCacheService.reconcileSourceStats silently dropped every captured
+        // contribution and warm queries re-scanned. On POSIX both forms already coincide.
+        this.storagePath = StoragePath.ofLocalPath(filePath);
     }
 
     public LocalStorageObject(Path filePath, long length) {

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProvider.java
@@ -141,7 +141,7 @@ public final class LocalStorageProvider implements StorageProvider {
     }
 
     private static StoragePath toStoragePath(Path filePath) {
-        return StoragePath.of(StoragePath.fileUri(filePath));
+        return StoragePath.ofLocalPath(filePath);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObjectTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.http.local;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,5 +72,27 @@ public class LocalStorageObjectTests extends ESTestCase {
         LocalStorageObject obj = new LocalStorageObject(file);
         // -1 is the READ_TO_END sentinel; any other negative length is still rejected.
         expectThrows(IllegalArgumentException.class, () -> obj.newStream(0, -2));
+    }
+
+    /**
+     * The location exposed by {@link LocalStorageObject#path()} is the key under which data nodes record
+     * captured source statistics, and it must match the canonical {@code file://} form the coordinator
+     * derives for the schema-cache key ({@link StoragePath#fileUri}). If they diverge — as they did on
+     * Windows, where {@code toAbsolutePath()} keeps backslashes — the coordinator drops every captured
+     * contribution and cold→warm pushdown never short-circuits.
+     * <p>
+     * We assert the object goes through the shared {@link StoragePath#ofLocalPath} factory, and also
+     * pin the canonical shape directly (no backslashes, three-slash {@code file:///} prefix). The shape
+     * checks are trivially true on POSIX but encode the Windows contract: reverting the constructor to
+     * {@code "file://" + toAbsolutePath()} would reintroduce backslashes / a two-slash prefix and fail
+     * here on Windows. Full cross-platform coverage still relies on the {@code test-windows} CI lane.
+     */
+    public void testPathUsesCanonicalFileUri() throws IOException {
+        Path file = createTempFile();
+        LocalStorageObject obj = new LocalStorageObject(file);
+        assertEquals(StoragePath.ofLocalPath(file), obj.path());
+        String location = obj.path().toString();
+        assertFalse("canonical location must not contain backslashes: " + location, location.contains("\\"));
+        assertTrue("canonical location must use the three-slash file:/// form: " + location, location.startsWith("file:///"));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePath.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePath.java
@@ -64,6 +64,16 @@ public final class StoragePath {
         return "file://" + absPath;
     }
 
+    /**
+     * Builds a canonical {@code file://} {@link StoragePath} from a local filesystem {@link Path}. All
+     * local producers (directory listings, the query's location, per-object stats keys) must funnel
+     * through this so their normalized locations cannot diverge; divergence between two such producers
+     * is exactly what broke stats reconciliation on Windows.
+     */
+    public static StoragePath ofLocalPath(Path path) {
+        return of(fileUri(path));
+    }
+
     public static StoragePath of(String location) {
         if (location == null) {
             throw new IllegalArgumentException("location cannot be null");


### PR DESCRIPTION
`LocalStorageObject` built its `StoragePath` via `"file://" + toAbsolutePath()`, keeping backslashes on Windows (`file://C:\dir\file`), while every other producer uses `StoragePath.fileUri` (`file:///C:/dir/file`). So the stats-capture key (`object.path()`) never matched the planning-side `SchemaCacheKey` canonical path on Windows, and `reconcileSourceStats` silently dropped every contribution — warm queries re-scanned instead of short-circuiting. Use `fileUri` in the constructor (no-op on POSIX), add a cross-platform regression test. Unmutes the pushdown cold-then-warm suite.