### PR TITLE
[ESQL] Fix Parquet TopN early-termination race and error detail

### DIFF
--- a/docs/changelog/152838.yaml
+++ b/docs/changelog/152838.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152838
+summary: Fix Parquet TopN early-termination race and error detail
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -596,9 +596,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.cluster.FloatHierarchicalKMeansTests
   method: testHKmeans
   issue: https://github.com/elastic/elasticsearch/issues/152027
-- class: org.elasticsearch.xpack.esql.action.ExternalParquetStringTopNSideChannelIT
-  method: testNullsFirstEarlyTermination
-  issue: https://github.com/elastic/elasticsearch/issues/152038
 - class: org.elasticsearch.cluster.metadata.MetadataCreateIndexServiceIT
   method: testCreateIndexBatching
   issue: https://github.com/elastic/elasticsearch/issues/152041

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -828,11 +828,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (exhausted) {
             return false;
         }
-        if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
-            exhausted = true;
-            cancelPendingPrefetch();
-            return false;
-        }
         if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
             exhausted = true;
             return false;
@@ -845,8 +840,22 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 rowsRemainingInGroup = 0;
             }
         }
+        // Serve rows already materialized for the current row group before consulting the
+        // early-termination side channel. dynamicThreshold.noFurtherCandidates() is a volatile flag
+        // that a concurrent TopN worker can flip at any moment (e.g. once a NULLS FIRST top-K
+        // saturates with nulls). Checking it first would let a flip land between a caller's hasNext()
+        // and its next() and turn an already-available batch into a NoSuchElementException — the race
+        // behind the intermittent "Unexpected failure reading external source" surfaced from next().
+        // Early termination still takes effect below, where it stops us from advancing to (and
+        // prefetching) any further row groups; the only extra work is draining the already-decoded,
+        // in-memory current group, which the TopN simply discards.
         if (rowsRemainingInGroup > 0) {
             return true;
+        }
+        if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
+            exhausted = true;
+            cancelPendingPrefetch();
+            return false;
         }
         try {
             return advanceRowGroup();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
@@ -128,6 +129,32 @@ public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
         );
 
         assertThat(rows.size(), equalTo(0));
+    }
+
+    public void testBufferedRowsSurviveNoFurtherCandidatesFlipBetweenHasNextAndNext() throws Exception {
+        // Deterministic reproduction of the intermittent NoSuchElementException from next(): a single row
+        // group of materialized rows, and a bound that prunes nothing so the first hasNext() decodes the
+        // group and leaves rowsRemainingInGroup > 0. We then flip the early-termination flag (as a
+        // concurrent TopN worker would) between hasNext() and next(). next() must still drain the
+        // already-decoded batch; before the fix hasNext() consulted the flag first and turned the
+        // available batch into a NoSuchElementException.
+        byte[] data = writeLongParquet(REQUIRED_LONG_SCHEMA, 64L * 1024 * 1024, 1024, 500, i -> (long) i);
+        SharedNumericThreshold channel = new SharedNumericThreshold.Supplier(true, false).get();
+        channel.offer(10_000L); // bound above every value, so no row group is skipped
+        DynamicThreshold threshold = new DynamicThreshold("id", ElementType.LONG, true, false, channel);
+        try (
+            threshold;
+            CloseableIterator<Page> iterator = reader(threshold).read(storageObject(data), FormatReadContext.of(List.of("id"), 128))
+        ) {
+            assertTrue("first hasNext() must materialize the row group", iterator.hasNext());
+            channel.markNoFurtherCandidates();
+            Page page = iterator.next();
+            try {
+                assertThat(page.getPositionCount(), greaterThan(0));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
     }
 
     public void testNullsLastCanSkipNullAndDominatedRowGroups() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFailures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFailures.java
@@ -99,9 +99,11 @@ public final class ExternalFailures {
             return iae;
         }
         if (t instanceof IOException || t instanceof UncheckedIOException || isMalformedDataException(t)) {
-            return new ExternalClientException(t, "Failed to read external source: {}", t.getMessage());
+            return new ExternalClientException(t, "Failed to read external source: {}", detail(t));
         }
-        return new ExternalServerException(t, "Unexpected failure reading external source: {}", t.getMessage());
+        // Use detail() rather than the raw getMessage() so a null-message fault (e.g. a bare NPE) surfaces
+        // its class name instead of a useless "null", while the original cause stays chained for the stack.
+        return new ExternalServerException(t, "Unexpected failure reading external source: {}", detail(t));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFailuresTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFailuresTests.java
@@ -119,6 +119,21 @@ public class ExternalFailuresTests extends ESTestCase {
         }
     }
 
+    public void testClassifyFallsBackToClassNameWhenMessageIsNull() {
+        // The actual bug this hunk fixes: classify() must use detail() so a null-message fault surfaces its
+        // class name instead of a useless "null" in the user-facing message. Covers both the server (bare
+        // NPE) and client (bare IOException) branches.
+        RuntimeException server = ExternalFailures.classify(new NullPointerException());
+        assertThat(server, org.hamcrest.Matchers.instanceOf(ExternalServerException.class));
+        assertThat(server.getMessage(), org.hamcrest.Matchers.containsString("NullPointerException"));
+        assertThat(server.getMessage(), org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("null")));
+
+        RuntimeException client = ExternalFailures.classify(new IOException());
+        assertThat(client, org.hamcrest.Matchers.instanceOf(ExternalClientException.class));
+        assertThat(client.getMessage(), org.hamcrest.Matchers.containsString("IOException"));
+        assertThat(client.getMessage(), org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("null")));
+    }
+
     public void testSurfaceRethrowsErrorUnchanged() {
         AssertionError error = new AssertionError("boom");
         AssertionError thrown = expectThrows(AssertionError.class, () -> ExternalFailures.surface(error, "ctx"));


### PR DESCRIPTION
`OptimizedParquetColumnIterator.hasNext` consulted the volatile TopN `noFurtherCandidates` side channel before serving already-materialized rows. A concurrent flip between a caller's `hasNext` and its `next` turned an available batch into a `NoSuchElementException`, surfaced as an opaque failure. Reorder `hasNext` to serve buffered rows first; early termination still stops advancing to and prefetching new row groups. Also make `ExternalFailures.classify` use `detail()` so a null-message cause shows its class name. Unmutes `testNullsFirstEarlyTermination`.