### PR TITLE
Bump timeout in KeyRotationIT::stopKeyRotationCoordinators

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -865,6 +865,3 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
   method: testMixedOperationsDuringSplitWithDisruption
   issue: https://github.com/elastic/elasticsearch/issues/151090
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationContinuesAfterMasterFailover
-  issue: https://github.com/elastic/elasticsearch/issues/152676

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -70,7 +70,10 @@ public class KeyRotationIT extends SecurityIntegTestCase {
      * but cannot atomically abort a tick that is already executing on the generic thread pool. The
      * {@code assertBusy} wait ensures any task that slipped into the master-service queue after
      * {@code close()} has been executed and its cluster-state publication committed before we hand
-     * off to the framework — whose own {@code safeGet} has only a 10-second budget.
+     * off to the framework's own consistency check. Publishing a retire/re-encrypt task can take
+     * several seconds on loaded CI (especially right after the master failover exercised by
+     * {@code testRotationContinuesAfterMasterFailover}), so this waits generously rather than racing
+     * a tight budget — every second spent draining here is a second the framework's check won't need.
      */
     @After
     public void stopKeyRotationCoordinators() throws Exception {
@@ -90,7 +93,7 @@ public class KeyRotationIT extends SecurityIntegTestCase {
                     .toList(),
                 empty()
             ),
-            5,
+            30,
             TimeUnit.SECONDS
         );
     }


### PR DESCRIPTION
The `@After stopKeyRotationCoordinators` teardown in `KeyRotationIT` used a 5 second assertBusy to wait for pending PEK cluster tasks to drain before the framework's own consistency check. Under CI load, publishing a retire-project-encryption-keys task (especially right after the master failover in `testRotationContinuesAfterMasterFailover`) can legitimately take a few seconds, and 5 seconds was too tight. This is not a hang, cluster state publication is bounded by cluster.publish.timeout (default 30s).

I also looked into why publishing was slow: ProjectEncryptionKeyMetadata.wrappedKeyCache never survives across cluster state versions since a fresh immutable instance is built on every PEK task, so every metadata change re-runs the 210000 iteration PBKDF2 wrap for every live key on every node. In production this is harmless since rotation defaults to every 30 days, so I decided not to add caching complexity for a problem that only shows up because the test compresses rotation/check intervals down to seconds.

Fix: bumped the teardown `assertBusy` timeout from 5s to 30s in `KeyRotationIT`, matching the real publish timeout ceiling. No production code changes.

Resolves: https://github.com/elastic/elasticsearch/issues/152676