### PR TITLE
[9.4] [CI] Increase logging for SearchWithRandomIOExceptionsIT testRandomDirectoryIOExceptions

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSDirectoryFactory;
 import org.elasticsearch.test.store.MockFSIndexStore;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -42,6 +43,10 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
         return Arrays.asList(MockFSIndexStore.TestPlugin.class);
     }
 
+    @TestLogging(
+        value = "org.elasticsearch.index.seqno.ReplicationTracker:TRACE,org.elasticsearch.indices.recovery.RecoverySourceHandler:TRACE",
+        reason = "debugging potential retention lease race from https://github.com/elastic/elasticsearch/issues/152037"
+    )
     public void testRandomDirectoryIOExceptions() throws IOException, InterruptedException, ExecutionException {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()


### PR DESCRIPTION
Increase logging for SearchWithRandomIOExceptionsIT testRandomDirectoryIOExceptions (https://github.com/elastic/elasticsearch/pull/152510)

The test fails with "no retention lease for tracked shard" in org.elasticsearch.index.seqno.ReplicationTracker#initiateTracking.
I hope the increased logging would make the potential race clearer to understand.

Backport https://github.com/elastic/elasticsearch/pull/152510