### PR TITLE
ES|QL: implement watchdog timeout for GROK

### DIFF
--- a/docs/changelog/152851.yaml
+++ b/docs/changelog/152851.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152851
+summary: Implement watchdog timeout for GROK
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Verifies that {@link EsqlPlugin#GROK_WATCHDOG_MAX_EXECUTION_TIME} is honored at execution time.
+ * The setting is {@code NodeScope} only: every node reads its own local value when it builds the
+ * GROK matcher used against real data (see {@code LocalExecutionPlanner#planGrok}), so there is no
+ * need to carry the value in the ES|QL wire format.
+ */
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class GrokWatchdogIT extends AbstractEsqlIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey(), TimeValue.timeValueMillis(1))
+            .build();
+    }
+
+    public void testCatastrophicBacktrackingPatternIsInterrupted() {
+        prepareIndex("test").setId("1").setSource("message", "a".repeat(30) + "X").get();
+        refresh("test");
+
+        Exception e = expectThrows(Exception.class, () -> run("FROM test | GROK message \"(?<a>a+)+b\" | KEEP a"));
+        assertThat(ExceptionsHelper.stackTrace(e), containsString("interrupted"));
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
@@ -12,29 +12,32 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.junit.After;
 
 import static org.hamcrest.Matchers.containsString;
 
 /**
  * Verifies that {@link EsqlPlugin#GROK_WATCHDOG_MAX_EXECUTION_TIME} is honored at execution time.
- * The setting is {@code NodeScope} only: every node reads its own local value when it builds the
- * GROK matcher used against real data (see {@code LocalExecutionPlanner#planGrok}), so there is no
- * need to carry the value in the ES|QL wire format.
+ * The setting is {@code NodeScope} (every node reads its own value when it builds the GROK matcher
+ * used against real data, see {@code LocalExecutionPlanner#planGrok} — no need to carry it in the
+ * ES|QL wire format) and {@code Dynamic} (it can be changed via the cluster settings API without a
+ * node restart, since {@code ComputeService} re-resolves it from the live {@code ClusterSettings}
+ * for every query).
  */
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
 public class GrokWatchdogIT extends AbstractEsqlIntegTestCase {
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .put(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey(), TimeValue.timeValueMillis(1))
-            .build();
+    @After
+    public void resetWatchdogSetting() {
+        updateClusterSettings(Settings.builder().putNull(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey()));
     }
 
-    public void testCatastrophicBacktrackingPatternIsInterrupted() {
+    public void testCatastrophicBacktrackingPatternIsInterruptedAfterLiveSettingUpdate() {
         prepareIndex("test").setId("1").setSource("message", "a".repeat(30) + "X").get();
         refresh("test");
+
+        // No restart: the setting is dynamic, so this update must take effect on the very next query.
+        updateClusterSettings(Settings.builder().put(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey(), TimeValue.timeValueMillis(1)));
 
         Exception e = expectThrows(Exception.class, () -> run("FROM test | GROK message \"(?<a>a+)+b\" | KEEP a"));
         assertThat(ExceptionsHelper.stackTrace(e), containsString("interrupted"));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.grok.GrokBuiltinPatterns;
 import org.elasticsearch.grok.GrokCaptureConfig;
 import org.elasticsearch.grok.GrokCaptureType;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
@@ -95,9 +96,19 @@ public class Grok extends RegexExtract implements TelemetryAware, SortPreserving
     }
 
     public static Parser pattern(Source source, String pattern) {
+        return pattern(source, pattern, MatcherWatchdog.noop());
+    }
+
+    /**
+     * Builds a parser using the given watchdog to interrupt expensive matches. Used by the local execution
+     * planner to bind the node-local {@code esql.grok.watchdog.max_execution_time} setting to the matcher
+     * that will actually run against real data; parsing/deserialization use the no-op watchdog above since
+     * they never execute the pattern against untrusted input.
+     */
+    public static Parser pattern(Source source, String pattern, MatcherWatchdog matcherWatchdog) {
         try {
             var builtinPatterns = GrokBuiltinPatterns.get(true);
-            org.elasticsearch.grok.Grok grok = new org.elasticsearch.grok.Grok(builtinPatterns, pattern, logger::warn);
+            org.elasticsearch.grok.Grok grok = new org.elasticsearch.grok.Grok(builtinPatterns, pattern, matcherWatchdog, logger::warn);
             return new Parser(pattern, grok);
         } catch (IllegalArgumentException e) {
             throw new ParsingException(source, "Invalid pattern [{}] for grok: {}", pattern, e.getMessage());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -278,7 +278,8 @@ public class LocalExecutionPlanner {
         AbstractPhysicalOperationProviders physicalOperationProviders,
         OperatorFactoryRegistry operatorFactoryRegistry,
         @Nullable Executor parallelWorkerExecutor,
-        int esqlWorkerPoolSize
+        int esqlWorkerPoolSize,
+        MatcherWatchdog grokMatcherWatchdog
     ) {
 
         this.sessionId = sessionId;
@@ -300,9 +301,10 @@ public class LocalExecutionPlanner {
         this.operatorFactoryRegistry = operatorFactoryRegistry;
         this.parallelWorkerExecutor = parallelWorkerExecutor;
         this.esqlWorkerPoolSize = esqlWorkerPoolSize;
-        // MatcherWatchdog.Default is a stateless, immutable wrapper around this node's max execution
-        // time, so one instance is shared by every GROK matcher this planner builds.
-        this.grokMatcherWatchdog = MatcherWatchdog.newInstance(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.get(settings).millis());
+        // Resolved once by the caller from the live ClusterSettings (the setting is dynamic), then shared
+        // by every GROK matcher this planner builds — MatcherWatchdog.Default is a stateless, immutable
+        // wrapper around a single timeout value.
+        this.grokMatcherWatchdog = grokMatcherWatchdog;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -83,6 +83,7 @@ import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -148,6 +149,7 @@ import org.elasticsearch.xpack.esql.inference.completion.CompletionOperator;
 import org.elasticsearch.xpack.esql.inference.rerank.RerankOperator;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.ProjectAwayColumns;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.HighlightOptions;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -255,6 +257,7 @@ public class LocalExecutionPlanner {
     @Nullable
     private final Executor parallelWorkerExecutor;
     private final int esqlWorkerPoolSize;
+    private final MatcherWatchdog grokMatcherWatchdog;
 
     public LocalExecutionPlanner(
         String sessionId,
@@ -297,6 +300,9 @@ public class LocalExecutionPlanner {
         this.operatorFactoryRegistry = operatorFactoryRegistry;
         this.parallelWorkerExecutor = parallelWorkerExecutor;
         this.esqlWorkerPoolSize = esqlWorkerPoolSize;
+        // MatcherWatchdog.Default is a stateless, immutable wrapper around this node's max execution
+        // time, so one instance is shared by every GROK matcher this planner builds.
+        this.grokMatcherWatchdog = MatcherWatchdog.newInstance(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.get(settings).millis());
     }
 
     /**
@@ -1205,11 +1211,14 @@ public class LocalExecutionPlanner {
         }
 
         Layout layout = layoutBuilder.build();
+        // Rebind the matcher to this node's own grok.watchdog.max_execution_time setting instead of the
+        // no-op watchdog it was parsed/deserialized with, since the pattern is about to run against real data.
+        org.elasticsearch.grok.Grok watchdogGrok = Grok.pattern(grok.source(), grok.pattern().pattern(), grokMatcherWatchdog).grok();
         source = source.with(
             new ColumnExtractOperator.Factory(
                 types,
                 EvalMapper.toEvaluator(context.foldCtx(), grok.inputExpression(), layout, context.analysisRegistry()),
-                new GrokEvaluatorExtracter.Factory(grok.pattern().grok(), grok.pattern().pattern(), fieldToPos, fieldToType)
+                new GrokEvaluatorExtracter.Factory(watchdogGrok, grok.pattern().pattern(), fieldToPos, fieldToType)
             ),
             layout
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -36,6 +36,7 @@ import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.IndicesService;
@@ -110,6 +111,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -117,6 +119,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.action.EsqlExecutionInfo.IncludeExecutionMetadata.ALWAYS;
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME;
 
 /**
  * Once query is parsed and validated it is scheduled for execution by {@code org.elasticsearch.xpack.esql.plugin.ComputeService#execute}
@@ -188,6 +191,9 @@ public class ComputeService {
     private final OperatorFactoryRegistry operatorFactoryRegistry;
     private final FormatReaderRegistry formatReaderRegistry;
     private final Executor searchExecutor;
+    // Single shared instance, refreshed in place whenever the dynamic setting changes, rather than
+    // re-resolving it from ClusterSettings for every query.
+    private final AtomicReference<MatcherWatchdog> grokMatcherWatchdog = new AtomicReference<>();
 
     @SuppressWarnings("this-escape")
     public ComputeService(
@@ -214,6 +220,11 @@ public class ComputeService {
         this.ipLocationService = transportActionServices.ipLocationService();
         this.clusterService = transportActionServices.clusterService();
         this.projectResolver = transportActionServices.projectResolver();
+        this.clusterService.getClusterSettings()
+            .initializeAndWatch(
+                GROK_WATCHDOG_MAX_EXECUTION_TIME,
+                timeValue -> grokMatcherWatchdog.set(MatcherWatchdog.newInstance(timeValue.millis()))
+            );
         this.dataNodeComputeHandler = new DataNodeComputeHandler(
             this,
             clusterService,
@@ -1242,7 +1253,8 @@ public class ComputeService {
                 physicalOperationProviders,
                 operatorFactoryRegistry,
                 parallelWorkerExecutor,
-                esqlWorkerPoolSize
+                esqlWorkerPoolSize,
+                grokMatcherWatchdog.get()
             );
 
             LOGGER.debug("Received physical plan for {}:\n{}", context.description(), plan);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -268,15 +268,17 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
     /**
      * Maximum time (in milliseconds) that a GROK matcher is allowed to run before being interrupted.
      * Limits how long a GROK matcher can run to protect against expensive regex patterns. Read directly
-     * from the local node's settings wherever the matcher is built for execution (see
-     * {@code LocalExecutionPlanner#planGrok}) rather than being carried in the ES|QL {@code Configuration}
-     * wire format, since every node already has its own copy of this node-scoped setting.
+     * from each node's own {@link org.elasticsearch.common.settings.ClusterSettings} wherever the matcher
+     * is built for execution (see {@code LocalExecutionPlanner#planGrok}) rather than being carried in the
+     * ES|QL {@code Configuration} wire format, since every node can resolve this node-scoped setting on
+     * its own — including live updates, since it is also dynamic.
      */
     public static final Setting<TimeValue> GROK_WATCHDOG_MAX_EXECUTION_TIME = Setting.timeSetting(
         "esql.grok.watchdog.max_execution_time",
         TimeValue.timeValueMillis(1000),
         TimeValue.timeValueMillis(0),
-        Setting.Property.NodeScope
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
     );
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -266,6 +266,20 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
     );
 
     /**
+     * Maximum time (in milliseconds) that a GROK matcher is allowed to run before being interrupted.
+     * Limits how long a GROK matcher can run to protect against expensive regex patterns. Read directly
+     * from the local node's settings wherever the matcher is built for execution (see
+     * {@code LocalExecutionPlanner#planGrok}) rather than being carried in the ES|QL {@code Configuration}
+     * wire format, since every node already has its own copy of this node-scoped setting.
+     */
+    public static final Setting<TimeValue> GROK_WATCHDOG_MAX_EXECUTION_TIME = Setting.timeSetting(
+        "esql.grok.watchdog.max_execution_time",
+        TimeValue.timeValueMillis(1000),
+        TimeValue.timeValueMillis(0),
+        Setting.Property.NodeScope
+    );
+
+    /**
      * Tuning parameter for deciding when to use the "merge" stored field loader.
      * Think of it as "how similar to a sequential block of documents do I have to
      * be before I'll use the merge reader?" So a value of {@code 1} means I have to
@@ -544,7 +558,8 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
                 ViewService.MAX_VIEW_LENGTH_SETTING,
                 ViewResolver.MAX_VIEW_DEPTH_SETTING,
                 DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING,
-                DatasetService.MAX_DATASETS_COUNT_SETTING
+                DatasetService.MAX_DATASETS_COUNT_SETTING,
+                GROK_WATCHDOG_MAX_EXECUTION_TIME
             )
         );
         settings.addAll(PlannerSettings.settings());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.ShapeType;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -9849,7 +9850,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             ),
             null,  // OperatorFactoryRegistry - not needed for these tests
             null,  // parallelWorkerExecutor - not needed for these tests
-            0      // esqlWorkerPoolSize - not needed for these tests
+            0,     // esqlWorkerPoolSize - not needed for these tests
+            MatcherWatchdog.noop()
         );
 
         return planner.plan("test", FoldContext.small(), plannerSettings, plan, EmptyIndexedByShardId.instance());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokTests.java
@@ -7,10 +7,26 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.anonymizer.AnonymizationContext;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class GrokTests extends ESTestCase {
+
+    public void testWatchdogInterruptsBacktracking() {
+        // With timeout 0 the watchdog fires immediately after the first check.
+        Grok.Parser parser = Grok.pattern(Source.EMPTY, "(?<a>a+)+b", MatcherWatchdog.newInstance(0));
+        RuntimeException ex = expectThrows(RuntimeException.class, () -> parser.grok().match("aaaaaaaaX"));
+        assertThat(ex.getMessage(), containsString("interrupted"));
+    }
+
+    public void testNoopWatchdogDoesNotInterruptSimplePattern() {
+        Grok.Parser parser = Grok.pattern(Source.EMPTY, "%{IP:client_ip}", MatcherWatchdog.noop());
+        assertNotNull(parser.grok().captures("192.168.1.1"));
+    }
 
     public void testRewriteGrokPatternKeepsLibraryIdentifierTokenizesCaptureName() {
         var ctx = AnonymizationContext.forSubmission(randomUUID());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.mapper.BlockSourceReader;
@@ -833,7 +834,8 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             esPhysicalOperationProviders(shardContexts),
             operatorFactoryRegistry,
             null, // parallelWorkerExecutor - not needed for these tests
-            0     // esqlWorkerPoolSize - not needed for these tests
+            0,    // esqlWorkerPoolSize - not needed for these tests
+            MatcherWatchdog.noop()
         );
     }
 


### PR DESCRIPTION
After revert of https://github.com/elastic/elasticsearch/pull/152170, and following off-line discussions, let's re-introduce the watchdog without changes to the transport protocol. This will make backports easier
