### PR TITLE
Skip semantic_field source yaml tests in release

### DIFF
--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -578,6 +578,8 @@ tasks.named('yamlRestTest') {
       'inference/140_semantic_field_query_vector_builder/*',
       'inference/150_semantic_field_inference/*',
       'inference/160_semantic_field_highlighter/*',
+      'inference/172_semantic_field_doc_values_source/*',
+      'inference/173_semantic_field_columnar_source/*',
       'inference/181_semantic_text_columnar_source/*'
     ]
     systemProperty 'tests.rest.blacklist', snapshotOnlyTests.join(',')


### PR DESCRIPTION
#152470 added two yaml suites `inference/172_semantic_field_doc_values_source`                                                
  and 
`inference/173_semantic_field_columnar_source` that require the cluster                                                 feature `semantic_field.semantic_field_mapper`, but didn't add them to the release-build blacklist        

This adds both suites to the existing `snapshotOnlyTests` blacklist

Closes #152828                                                                                                                 
