### PR TITLE
[ESQL] Preserve secrets on data source PUT

### DIFF
--- a/docs/changelog/152854.yaml
+++ b/docs/changelog/152854.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152854
+summary: Preserve secrets on data source PUT
+type: enhancement

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureConfiguration.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureConfiguration.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition;
 import org.elasticsearch.xpack.esql.datasources.spi.FileDataSourceConfiguration;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition.plaintext;
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition.secret;
@@ -60,6 +61,10 @@ public class AzureConfiguration extends FileDataSourceConfiguration {
         super(raw, FIELDS);
     }
 
+    private AzureConfiguration(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        super(raw, FIELDS, preexistingSecretKeys);
+    }
+
     @Override
     protected void validateCredentials(ValidationException errors) {
         if (hasKeylessAuth()) {
@@ -74,6 +79,10 @@ public class AzureConfiguration extends FileDataSourceConfiguration {
 
     public static AzureConfiguration fromMap(Map<String, Object> raw) {
         return raw == null || raw.isEmpty() ? null : new AzureConfiguration(raw);
+    }
+
+    public static AzureConfiguration fromMap(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        return raw == null || raw.isEmpty() ? null : new AzureConfiguration(raw, preexistingSecretKeys);
     }
 
     /**
@@ -177,8 +186,10 @@ public class AzureConfiguration extends FileDataSourceConfiguration {
         // Every form the STATIC_CREDENTIALS provider arm can actually build: a full connection_string, account+key,
         // or account+sas_token. sas_token alone (no account) is NOT a complete credential — requiring account here
         // means validate() rejects it up front instead of letting it resolve to static and fail at query time.
-        return Strings.hasText(connectionString())
-            || (Strings.hasText(account()) && Strings.hasText(key()))
-            || (Strings.hasText(account()) && Strings.hasText(sasToken()));
+        // key/sas_token/connection_string are secrets, so hasStoredSecret() also accepts a carried-forward
+        // update; account is plaintext and must be present each time.
+        return hasStoredSecret(CONNECTION_STRING.name())
+            || (Strings.hasText(account()) && hasStoredSecret(KEY.name()))
+            || (Strings.hasText(account()) && hasStoredSecret(SAS_TOKEN.name()));
     }
 }

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfiguration.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsConfiguration.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.esql.datasource.gcs;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition;
 import org.elasticsearch.xpack.esql.datasources.spi.FileDataSourceConfiguration;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition.plaintext;
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition.secret;
@@ -64,6 +64,10 @@ public class GcsConfiguration extends FileDataSourceConfiguration {
         super(raw, FIELDS);
     }
 
+    private GcsConfiguration(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        super(raw, FIELDS, preexistingSecretKeys);
+    }
+
     @Override
     protected void validateCredentials(ValidationException errors) {
         // service_account_impersonation_url is optional: direct workload-identity federation maps the
@@ -77,6 +81,10 @@ public class GcsConfiguration extends FileDataSourceConfiguration {
 
     public static GcsConfiguration fromMap(Map<String, Object> raw) {
         return raw == null || raw.isEmpty() ? null : new GcsConfiguration(raw);
+    }
+
+    public static GcsConfiguration fromMap(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        return raw == null || raw.isEmpty() ? null : new GcsConfiguration(raw, preexistingSecretKeys);
     }
 
     /**
@@ -183,7 +191,7 @@ public class GcsConfiguration extends FileDataSourceConfiguration {
 
     @Override
     public boolean hasCredentials() {
-        return Strings.hasText(serviceAccountCredentials()) || Strings.hasText(accessToken());
+        return hasStoredSecret(CREDENTIALS.name()) || hasStoredSecret(ACCESS_TOKEN.name());
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/NoAuthDataSourceConfiguration.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/NoAuthDataSourceConfiguration.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfiguration;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Minimal {@link DataSourceConfiguration} for unauthenticated sources (HTTP/HTTPS and local files).
@@ -69,5 +70,10 @@ public final class NoAuthDataSourceConfiguration extends DataSourceConfiguration
     /** Returns {@code null} for empty input so callers treat a settings-less datasource as "no configuration". */
     public static NoAuthDataSourceConfiguration fromMap(Map<String, Object> raw) {
         return raw == null || raw.isEmpty() ? null : new NoAuthDataSourceConfiguration(raw);
+    }
+
+    /** No secret fields exist here, so there is nothing to carry forward on an update; delegates unchanged. */
+    public static NoAuthDataSourceConfiguration fromMap(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        return fromMap(raw);
     }
 }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3Configuration.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3Configuration.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.esql.datasource.s3;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition;
 import org.elasticsearch.xpack.esql.datasources.spi.FileDataSourceConfiguration;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition.plaintext;
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceConfigDefinition.secret;
@@ -64,6 +64,10 @@ public class S3Configuration extends FileDataSourceConfiguration {
         super(raw, FIELDS);
     }
 
+    private S3Configuration(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        super(raw, FIELDS, preexistingSecretKeys);
+    }
+
     @Override
     protected void validateCredentials(ValidationException errors) {
         // role_session_name, sts_endpoint, and jwt_audience are optional; role_arn is the minimum
@@ -77,6 +81,10 @@ public class S3Configuration extends FileDataSourceConfiguration {
 
     public static S3Configuration fromMap(Map<String, Object> raw) {
         return raw == null || raw.isEmpty() ? null : new S3Configuration(raw);
+    }
+
+    public static S3Configuration fromMap(Map<String, Object> raw, Set<String> preexistingSecretKeys) {
+        return raw == null || raw.isEmpty() ? null : new S3Configuration(raw, preexistingSecretKeys);
     }
 
     /**
@@ -205,7 +213,7 @@ public class S3Configuration extends FileDataSourceConfiguration {
 
     @Override
     public boolean hasCredentials() {
-        return Strings.hasText(accessKey()) && Strings.hasText(secretKey());
+        return hasStoredSecret(ACCESS_KEY.name()) && hasStoredSecret(SECRET_KEY.name());
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3ConfigurationTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3ConfigurationTests.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 public class S3ConfigurationTests extends ESTestCase {
 
@@ -131,6 +132,16 @@ public class S3ConfigurationTests extends ESTestCase {
             () -> S3Configuration.fromFields("ak", "sk", null, null, "anonymous")
         );
         assertThat(e.getMessage(), containsString("auth=anonymous cannot be combined with explicit credentials"));
+    }
+
+    public void testAuthAnonymousConflictsWithCarriedForwardSecretHasDistinctMessage() {
+        // No secret in this request at all — only carried forward from an existing stored data source. The
+        // message must say so, not claim the request itself supplied credentials.
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("auth", "anonymous");
+        ValidationException e = expectThrows(ValidationException.class, () -> S3Configuration.fromMap(raw, Set.of("access_key")));
+        assertThat(e.getMessage(), containsString("credentials carried over from the stored data source"));
+        assertThat(e.getMessage(), not(containsString("explicit credentials")));
     }
 
     public void testAuthAnonymousAllowsEndpointAndRegion() {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/AbstractDataSourceValidatorTests.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/AbstractDataSourceValidatorTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceSetting;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -191,6 +192,28 @@ public abstract class AbstractDataSourceValidatorTests extends ESTestCase {
         for (String key : first.keySet()) {
             assertEquals("secret flag differs for [" + key + "] between runs", first.get(key).secret(), second.get(key).secret());
             assertEquals("rawValue differs for [" + key + "] between runs", first.get(key).rawValue(), second.get(key).rawValue());
+        }
+    }
+
+    /**
+     * A request that omits every secret field fails without existing-secret context, but succeeds and does
+     * not re-emit the omitted secrets when the caller passes those field names as {@code existingSecretKeys},
+     * as {@code DataSourceService} does on a PUT-as-update. Skips validators with no secret fields.
+     */
+    public void testMergeAwareValidateDatasourceOmitsExistingSecrets() {
+        Set<String> secretKeys = expectedSecretFieldNames();
+        assumeFalse("validator has no secret fields", secretKeys.isEmpty());
+        Map<String, Object> withoutSecrets = new HashMap<>(sampleConfigWithAllSecrets());
+        secretKeys.forEach(withoutSecrets::remove);
+
+        expectThrows(ValidationException.class, () -> validator().validateDatasource(withoutSecrets));
+
+        Map<String, DataSourceSetting> merged = validator().validateDatasource(withoutSecrets, secretKeys);
+        for (String key : secretKeys) {
+            assertFalse(
+                "merge-aware validateDatasource should not re-emit an omitted, carried-forward secret [" + key + "]",
+                merged.containsKey(key)
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Dataset;
 import org.elasticsearch.cluster.metadata.View;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -191,22 +193,7 @@ public class DataSourceCrudIT extends ESIntegTestCase {
         DataSourceSetting secretAfter = after.settings().get("secret_access_key");
         assertNotNull("secret omitted from an update must be carried forward, not wiped", secretAfter);
         assertTrue("carried-forward secret must remain encrypted", secretAfter.isEncrypted());
-
-        DataSourceCredentials credentials = new DataSourceCredentials(new EncryptionService() {
-            @Override
-            public EncryptedData encrypt(byte[] bytes) {
-                return new EncryptedData(TestEncryptionServicePlugin.TEST_KEY_ID, bytes);
-            }
-
-            @Override
-            public byte[] decrypt(EncryptedData encryptedData) {
-                return encryptedData.payload();
-            }
-        });
-        Map<String, Object> connectorInput = new HashMap<>();
-        connectorInput.put("secret_access_key", secretAfter.rawValue());
-        Map<String, Object> decrypted = credentials.decryptInPlace(connectorInput);
-        assertThat("carried-forward secret must decrypt to the original value", decrypted.get("secret_access_key"), equalTo("AKIAXYZ"));
+        assertThat("carried-forward secret must decrypt to the original value", decryptSecret(secretAfter), equalTo("AKIAXYZ"));
 
         assertAcked(client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest(dsName)));
     }
@@ -241,6 +228,105 @@ public class DataSourceCrudIT extends ESIntegTestCase {
         );
 
         assertAcked(client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest(dsName)));
+    }
+
+    /**
+     * Regression: an explicitly-supplied secret value must stand on its own and satisfy completeness on its
+     * own merits, not inherit "still there" credit from the stored value it's replacing just because some
+     * other required secret is genuinely omitted on the same request. Uses
+     * {@link RequiredSecretTestValidator}, which requires {@code secret_access_key} either in the request or
+     * carried forward, closely mirroring a real CSP's {@code hasCredentials()}.
+     */
+    public void testPutWithBlankSecretDoesNotInheritCarryForwardCredit() throws Exception {
+        final String dsName = "blank_secret_ds";
+        assertAcked(
+            client().execute(
+                PutDataSourceAction.INSTANCE,
+                requiredSecretDataSourceRequest(dsName, Map.of("region", "us-east-1", "secret_access_key", "AKIAXYZ"))
+            )
+        );
+
+        // An empty value must fail validation on its own, not pass by inheriting the credit the omitted case
+        // would get.
+        ExecutionException err = expectThrows(
+            ExecutionException.class,
+            () -> client().execute(
+                PutDataSourceAction.INSTANCE,
+                requiredSecretDataSourceRequest(dsName, Map.of("region", "us-west-2", "secret_access_key", ""))
+            ).get()
+        );
+        assertThat(err.getCause(), instanceOf(ValidationException.class));
+
+        // The rejected PUT must not have touched the real secret.
+        DataSource after = client().execute(GetDataSourceAction.INSTANCE, getDataSourceRequest(dsName))
+            .get()
+            .getDataSources()
+            .iterator()
+            .next();
+        assertThat(after.settings().get("region").nonSecretValue(), equalTo("us-east-1"));
+        assertThat(decryptSecret(after.settings().get("secret_access_key")), equalTo("AKIAXYZ"));
+
+        assertAcked(client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest(dsName)));
+    }
+
+    /**
+     * Regression: {@code DataSourceService.putDataSource} must re-validate against the authoritative state it
+     * reads inside the cluster-state-update task, not just the pre-encryption snapshot taken before submitting
+     * it. Races two PUTs behind a blocked master task queue (mirrors {@link #testDispatchVsTaskExecuteRace}):
+     * both are coordinator-pre-validated against the same state (secret still present), but the one that
+     * clears the secret is submitted first, so by the time the second PUT's task actually runs, the secret it
+     * was relying on to carry forward is gone. That PUT must fail, not silently persist an incomplete data
+     * source.
+     */
+    public void testPutRevalidatesCarriedForwardSecretAgainstAuthoritativeState() throws Exception {
+        final String dsName = "race_required_secret";
+        assertAcked(
+            client().execute(
+                PutDataSourceAction.INSTANCE,
+                requiredSecretDataSourceRequest(dsName, Map.of("region", "us-east-1", "secret_access_key", "AKIAXYZ"))
+            )
+        );
+
+        ClusterService masterCs = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        masterCs.submitUnbatchedStateUpdateTask("test-block", new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                safeAwait(barrier);
+                safeAwait(barrier);
+                return currentState;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError("blocking task failed", e);
+            }
+        });
+        safeAwait(barrier); // master is now blocked inside the no-op task
+
+        // Both requests are coordinator-pre-validated against the same pre-block state, where the data source
+        // (and its secret) still exists, so the PUT's pre-check passes. Submission order controls processing
+        // order once the barrier releases: the delete runs first, so by the time the PUT's task actually runs,
+        // the entry it was relying on to carry the secret forward from is already gone.
+        ActionFuture<AcknowledgedResponse> deleteFuture = client().execute(
+            DeleteDataSourceAction.INSTANCE,
+            deleteDataSourceRequest(dsName)
+        );
+        ActionFuture<AcknowledgedResponse> omitFuture = client().execute(
+            PutDataSourceAction.INSTANCE,
+            requiredSecretDataSourceRequest(dsName, Map.of("region", "us-west-2"))
+        );
+
+        safeAwait(barrier); // release; master processes the delete, then the PUT
+
+        assertAcked(deleteFuture.get(30, TimeUnit.SECONDS));
+
+        ExecutionException err = expectThrows(ExecutionException.class, () -> omitFuture.get(30, TimeUnit.SECONDS));
+        assertThat(err.getCause(), instanceOf(ValidationException.class));
+        assertThat(err.getCause().getMessage(), containsString("secret_access_key is required"));
+
+        // The PUT must not have silently created an incomplete data source in place of the deleted one.
+        expectDataSourceMissing(dsName);
     }
 
     public void testGatewayPersistence() throws Exception {
@@ -735,6 +821,28 @@ public class DataSourceCrudIT extends ESIntegTestCase {
         return new PutDataSourceAction.Request(TEST_TIMEOUT, TEST_TIMEOUT, name, "test", null, new HashMap<>(settings));
     }
 
+    private static PutDataSourceAction.Request requiredSecretDataSourceRequest(String name, Map<String, Object> settings) {
+        return new PutDataSourceAction.Request(TEST_TIMEOUT, TEST_TIMEOUT, name, "test_requires_secret", null, new HashMap<>(settings));
+    }
+
+    /** Decrypts a secret setting's carrier using the test encryption key from {@link TestEncryptionServicePlugin}. */
+    private static Object decryptSecret(DataSourceSetting secret) {
+        DataSourceCredentials credentials = new DataSourceCredentials(new EncryptionService() {
+            @Override
+            public EncryptedData encrypt(byte[] bytes) {
+                return new EncryptedData(TestEncryptionServicePlugin.TEST_KEY_ID, bytes);
+            }
+
+            @Override
+            public byte[] decrypt(EncryptedData encryptedData) {
+                return encryptedData.payload();
+            }
+        });
+        Map<String, Object> input = new HashMap<>();
+        input.put("secret", secret.rawValue());
+        return credentials.decryptInPlace(input).get("secret");
+    }
+
     private static PutDatasetAction.Request putDatasetRequest(
         String name,
         String dataSource,
@@ -824,7 +932,7 @@ public class DataSourceCrudIT extends ESIntegTestCase {
     public static class TestDataSourcePlugin extends Plugin implements DataSourcePlugin {
         @Override
         public Map<String, DataSourceValidator> datasourceValidators(Settings settings) {
-            return Map.of("test", new TestValidator());
+            return Map.of("test", new TestValidator(), "test_requires_secret", new RequiredSecretTestValidator());
         }
     }
 
@@ -863,6 +971,54 @@ public class DataSourceCrudIT extends ESIntegTestCase {
                 ve.addValidationError("test validator rejected dataset: " + REJECT_SENTINEL + " sentinel present");
                 throw ve;
             }
+            return new HashMap<>(datasetSettings);
+        }
+    }
+
+    /**
+     * Requires {@code secret_access_key} (present in the request or carried forward), mirroring a real CSP's
+     * {@code hasCredentials()} closely enough to exercise {@code DataSourceService}'s carry-forward and
+     * re-validation behavior in tests, without needing a real S3/GCS/Azure setup. Kept separate from
+     * {@link TestValidator} so it doesn't impose this requirement on the many other tests in this file that
+     * never supply a secret at all.
+     */
+    static class RequiredSecretTestValidator implements DataSourceValidator {
+        static final String REQUIRED_SECRET = "secret_access_key";
+
+        @Override
+        public String type() {
+            return "test_requires_secret";
+        }
+
+        @Override
+        public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings) {
+            return validateDatasource(datasourceSettings, Set.of());
+        }
+
+        @Override
+        public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings, Set<String> existingSecretKeys) {
+            Object provided = datasourceSettings.get(REQUIRED_SECRET);
+            boolean hasRequiredSecret = Strings.hasText(provided == null ? null : provided.toString())
+                || existingSecretKeys.contains(REQUIRED_SECRET);
+            if (hasRequiredSecret == false) {
+                ValidationException ve = new ValidationException();
+                ve.addValidationError("test validator rejected: " + REQUIRED_SECRET + " is required");
+                throw ve;
+            }
+            Map<String, DataSourceSetting> out = new HashMap<>();
+            for (Map.Entry<String, Object> e : datasourceSettings.entrySet()) {
+                boolean secret = e.getKey().startsWith("secret_");
+                out.put(e.getKey(), new DataSourceSetting(e.getValue(), secret));
+            }
+            return out;
+        }
+
+        @Override
+        public Map<String, Object> validateDataset(
+            Map<String, DataSourceSetting> datasourceSettings,
+            String resource,
+            Map<String, Object> datasetSettings
+        ) {
             return new HashMap<>(datasetSettings);
         }
     }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
@@ -166,6 +166,83 @@ public class DataSourceCrudIT extends ESIntegTestCase {
         assertAcked(client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest(dsName)));
     }
 
+    /**
+     * Regression: a PUT that omits an already-stored secret (as Kibana's edit-and-save flow does, since the
+     * corresponding GET masks it) must carry the secret forward rather than wiping it.
+     */
+    public void testPutOmittingSecretPreservesExistingSecret() throws Exception {
+        final String dsName = "omit_secret_ds";
+        assertAcked(
+            client().execute(
+                PutDataSourceAction.INSTANCE,
+                putDataSourceRequest(dsName, Map.of("region", "us-east-1", "secret_access_key", "AKIAXYZ"))
+            )
+        );
+
+        // Update omitting the secret entirely; only region changes.
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest(dsName, Map.of("region", "us-west-2"))));
+
+        DataSource after = client().execute(GetDataSourceAction.INSTANCE, getDataSourceRequest(dsName))
+            .get()
+            .getDataSources()
+            .iterator()
+            .next();
+        assertThat(after.settings().get("region").nonSecretValue(), equalTo("us-west-2"));
+        DataSourceSetting secretAfter = after.settings().get("secret_access_key");
+        assertNotNull("secret omitted from an update must be carried forward, not wiped", secretAfter);
+        assertTrue("carried-forward secret must remain encrypted", secretAfter.isEncrypted());
+
+        DataSourceCredentials credentials = new DataSourceCredentials(new EncryptionService() {
+            @Override
+            public EncryptedData encrypt(byte[] bytes) {
+                return new EncryptedData(TestEncryptionServicePlugin.TEST_KEY_ID, bytes);
+            }
+
+            @Override
+            public byte[] decrypt(EncryptedData encryptedData) {
+                return encryptedData.payload();
+            }
+        });
+        Map<String, Object> connectorInput = new HashMap<>();
+        connectorInput.put("secret_access_key", secretAfter.rawValue());
+        Map<String, Object> decrypted = credentials.decryptInPlace(connectorInput);
+        assertThat("carried-forward secret must decrypt to the original value", decrypted.get("secret_access_key"), equalTo("AKIAXYZ"));
+
+        assertAcked(client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest(dsName)));
+    }
+
+    /**
+     * Counterpart to {@link #testPutOmittingSecretPreservesExistingSecret}: an explicit JSON {@code null}
+     * clears a secret, rather than carrying the old value forward.
+     */
+    public void testPutExplicitNullClearsSecret() throws Exception {
+        final String dsName = "null_clear_ds";
+        assertAcked(
+            client().execute(
+                PutDataSourceAction.INSTANCE,
+                putDataSourceRequest(dsName, Map.of("region", "us-east-1", "secret_access_key", "AKIAXYZ"))
+            )
+        );
+
+        Map<String, Object> clearing = new HashMap<>();
+        clearing.put("region", "us-east-1");
+        clearing.put("secret_access_key", null);
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest(dsName, clearing)));
+
+        DataSource after = client().execute(GetDataSourceAction.INSTANCE, getDataSourceRequest(dsName))
+            .get()
+            .getDataSources()
+            .iterator()
+            .next();
+        DataSourceSetting secretAfter = after.settings().get("secret_access_key");
+        assertTrue(
+            "an explicit null must clear the secret rather than carry it forward",
+            secretAfter == null || secretAfter.rawValue() == null
+        );
+
+        assertAcked(client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest(dsName)));
+    }
+
     public void testGatewayPersistence() throws Exception {
         final String dsName = "persists_across_restart";
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest(dsName, Map.of("region", "us-west-2"))));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -42,10 +43,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /** Orchestrates create / replace / delete of data sources in cluster state. */
 public class DataSourceService {
@@ -88,35 +91,58 @@ public class DataSourceService {
         return DataSourceMetadata.get(projectMetadata);
     }
 
-    /** Validate the put-data-source request and build the domain {@link DataSource}. Runs coordinator-side. */
-    public DataSource validatePutDataSource(PutDataSourceAction.Request request) {
+    /**
+     * Validate the put-data-source request and build the domain {@link DataSource}. Runs coordinator-side
+     * against local (possibly stale) cluster state, and again master-side (from {@link #putDataSource}) against
+     * authoritative state. {@code project} supplies the existing entry, if any, so a request that omits an
+     * already-stored secret still satisfies credential-completeness checks instead of being rejected as
+     * incomplete.
+     */
+    public DataSource validatePutDataSource(ProjectMetadata project, PutDataSourceAction.Request request) {
         DataSourceValidator validator = validatorsByType.get(request.type());
         if (validator == null) {
             throw new IllegalArgumentException("unknown data source type [" + request.type() + "]");
         }
-        final Map<String, DataSourceSetting> validated = validator.validateDatasource(request.rawSettings());
+        final DataSource current = getMetadata(project).get(request.name());
+        Set<String> existingSecretKeys = new HashSet<>();
+        if (current != null && current.type().equals(request.type())) {
+            for (var entry : current.settings()) {
+                if (isUntouchedSecret(entry.getValue(), entry.getKey(), request.rawSettings())) {
+                    existingSecretKeys.add(entry.getKey());
+                }
+            }
+        }
+        final Map<String, DataSourceSetting> validated = validator.validateDatasource(request.rawSettings(), existingSecretKeys);
         return new DataSource(request.name(), request.type(), request.description(), validated);
     }
 
-    /** Create or replace a data source. Secrets are encrypted master-side ({@link #applyEncryption}). */
+    /**
+     * Create or replace a data source. A newly-supplied secret is encrypted master-side
+     * ({@link #applyEncryption}) off the CAS task thread, since that's expensive and would otherwise block
+     * the master on every concurrent PUT. A secret omitted from the request is instead carried forward from
+     * the current entry inside the CAS task (via {@link #mergeCarriedForwardSecrets}), where {@code current}
+     * is read fresh against authoritative state and carrying the secret forward needs no encryption. Every
+     * other field is a full replace, matching the pre-existing PUT semantics.
+     */
     public void putDataSource(ProjectId projectId, PutDataSourceAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        // Encrypt off the CAS task thread: it's expensive and would block the master on every concurrent PUT.
-        final DataSource validated = validatePutDataSource(request);
-        final DataSourceSettings stored = applyEncryption(validated.name(), validated.settings());
-        final DataSource encrypted = new DataSource(validated.name(), validated.type(), validated.description(), stored);
-        logger.debug("submitting put data source [{}] of type [{}]", encrypted.name(), encrypted.type());
+        final ProjectMetadata projectSnapshot = clusterService.state().metadata().getProject(projectId);
+        final DataSource validated = validatePutDataSource(projectSnapshot, request);
+        final DataSourceSettings encryptedNew = applyEncryption(validated.name(), validated.settings());
+        logger.debug("submitting put data source [{}] of type [{}]", validated.name(), validated.type());
         final AckedClusterStateUpdateTask task = new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 final ProjectMetadata project = currentState.metadata().getProject(projectId);
                 final DataSourceMetadata metadata = getMetadata(project);
-                final DataSource current = metadata.get(encrypted.name());
+                final DataSource current = metadata.get(validated.name());
                 if (current == null && metadata.dataSources().size() >= maxDataSourcesCount) {
-                    logger.warn("rejected put for data source [{}]: maximum count [{}] reached", encrypted.name(), maxDataSourcesCount);
+                    logger.warn("rejected put for data source [{}]: maximum count [{}] reached", validated.name(), maxDataSourcesCount);
                     throw new IllegalArgumentException(
                         "cannot add data source, the maximum number of data sources is reached: " + maxDataSourcesCount
                     );
                 }
+                final DataSourceSettings merged = mergeCarriedForwardSecrets(current, validated.type(), encryptedNew, request);
+                final DataSource encrypted = new DataSource(validated.name(), validated.type(), validated.description(), merged);
                 final Map<String, DataSource> updated = new HashMap<>(metadata.dataSources());
                 updated.put(encrypted.name(), encrypted);
                 return ClusterState.builder(currentState)
@@ -127,6 +153,44 @@ public class DataSourceService {
             }
         };
         taskQueue.submitTask("update-esql-data-source-metadata-[" + request.name() + "]", task, task.timeout());
+    }
+
+    /**
+     * True iff {@code setting} is a secret that the request leaves untouched, so it should carry forward from
+     * the existing entry rather than being wiped. A request that explicitly sets the field to JSON {@code null}
+     * clears it instead; a request that supplies a non-null value overrides it via its own validated settings.
+     */
+    private static boolean isUntouchedSecret(DataSourceSetting setting, String key, Map<String, Object> rawSettings) {
+        if (setting.secret() == false) {
+            return false;
+        }
+        return rawSettings.containsKey(key) == false || rawSettings.get(key) != null;
+    }
+
+    /**
+     * Adds every untouched secret from {@code current} (same type, not already present in {@code encryptedNew})
+     * to the settings being stored, so it survives a PUT that only touches other fields.
+     */
+    private static DataSourceSettings mergeCarriedForwardSecrets(
+        @Nullable DataSource current,
+        String requestType,
+        DataSourceSettings encryptedNew,
+        PutDataSourceAction.Request request
+    ) {
+        if (current == null || current.type().equals(requestType) == false) {
+            return encryptedNew;
+        }
+        Map<String, DataSourceSetting> merged = new HashMap<>(encryptedNew.asMap());
+        for (var entry : current.settings()) {
+            String key = entry.getKey();
+            if (merged.containsKey(key)) {
+                continue;
+            }
+            if (isUntouchedSecret(entry.getValue(), key, request.rawSettings())) {
+                merged.put(key, entry.getValue());
+            }
+        }
+        return new DataSourceSettings(merged);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
@@ -92,11 +92,7 @@ public class DataSourceService {
     }
 
     /**
-     * Validate the put-data-source request and build the domain {@link DataSource}. Runs coordinator-side
-     * against local (possibly stale) cluster state, and again master-side (from {@link #putDataSource}) against
-     * authoritative state. {@code project} supplies the existing entry, if any, so a request that omits an
-     * already-stored secret still satisfies credential-completeness checks instead of being rejected as
-     * incomplete.
+     * Validate the put-data-source request and build the domain {@link DataSource}.
      */
     public DataSource validatePutDataSource(ProjectMetadata project, PutDataSourceAction.Request request) {
         DataSourceValidator validator = validatorsByType.get(request.type());
@@ -121,8 +117,10 @@ public class DataSourceService {
      * ({@link #applyEncryption}) off the CAS task thread, since that's expensive and would otherwise block
      * the master on every concurrent PUT. A secret omitted from the request is instead carried forward from
      * the current entry inside the CAS task (via {@link #mergeCarriedForwardSecrets}), where {@code current}
-     * is read fresh against authoritative state and carrying the secret forward needs no encryption. Every
-     * other field is a full replace, matching the pre-existing PUT semantics.
+     * is read fresh against authoritative state and carrying the secret forward needs no encryption. The task
+     * also re-validates against that same fresh state, so a concurrent change to a secret this request relies
+     * on carrying forward fails the PUT instead of silently persisting an incomplete data source. Every other
+     * field is a full replace, matching the pre-existing PUT semantics.
      */
     public void putDataSource(ProjectId projectId, PutDataSourceAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         final ProjectMetadata projectSnapshot = clusterService.state().metadata().getProject(projectId);
@@ -141,6 +139,11 @@ public class DataSourceService {
                         "cannot add data source, the maximum number of data sources is reached: " + maxDataSourcesCount
                     );
                 }
+                // Re-validate here, against the state just read, not the pre-encryption snapshot above: a
+                // concurrent operation could have cleared or removed a secret this request relies on carrying
+                // forward between that snapshot and this task running. Cheap (no I/O); throwing here fails the
+                // whole PUT instead of silently persisting a data source with incomplete credentials.
+                validatePutDataSource(project, request);
                 final DataSourceSettings merged = mergeCarriedForwardSecrets(current, validated.type(), encryptedNew, request);
                 final DataSource encrypted = new DataSource(validated.name(), validated.type(), validated.description(), merged);
                 final Map<String, DataSource> updated = new HashMap<>(metadata.dataSources());
@@ -156,15 +159,11 @@ public class DataSourceService {
     }
 
     /**
-     * True iff {@code setting} is a secret that the request leaves untouched, so it should carry forward from
-     * the existing entry rather than being wiped. A request that explicitly sets the field to JSON {@code null}
-     * clears it instead; a request that supplies a non-null value overrides it via its own validated settings.
+     * True iff {@code setting} is a secret the request leaves untouched, so it should carry forward from the
+     * existing entry rather than being wiped.
      */
-    private static boolean isUntouchedSecret(DataSourceSetting setting, String key, Map<String, Object> rawSettings) {
-        if (setting.secret() == false) {
-            return false;
-        }
-        return rawSettings.containsKey(key) == false || rawSettings.get(key) != null;
+    static boolean isUntouchedSecret(DataSourceSetting setting, String key, Map<String, Object> rawSettings) {
+        return setting.secret() && setting.rawValue() != null && rawSettings.containsKey(key) == false;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/TransportPutDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/TransportPutDataSourceAction.java
@@ -23,6 +23,8 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportPutDataSourceAction extends AcknowledgedTransportMasterNodeProjectAction<PutDataSourceAction.Request> {
     private final DataSourceService dataSourceService;
+    private final ClusterService clusterService;
+    private final ProjectResolver projectResolver;
 
     @Inject
     public TransportPutDataSourceAction(
@@ -44,13 +46,18 @@ public class TransportPutDataSourceAction extends AcknowledgedTransportMasterNod
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.dataSourceService = dataSourceService;
+        this.clusterService = clusterService;
+        this.projectResolver = projectResolver;
     }
 
     @Override
     protected void doExecute(Task task, PutDataSourceAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        // Coord-side pre-check: fail fast on unknown type / validation error before the master round-trip.
+        // Coord-side pre-check against local (possibly stale) cluster state; the task body re-validates
+        // against master's authoritative state. Resolving the project here lets a PUT that omits an
+        // already-stored secret pass this pre-check too.
         try {
-            dataSourceService.validatePutDataSource(request);
+            var project = clusterService.state().metadata().getProject(projectResolver.getProjectId());
+            dataSourceService.validatePutDataSource(project, request);
         } catch (Exception e) {
             listener.onFailure(e);
             return;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourceConfiguration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourceConfiguration.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -48,6 +49,7 @@ public abstract class DataSourceConfiguration {
 
     private final Map<String, DataSourceConfigDefinition> fieldDefs;
     private final Map<String, Object> values;
+    private final Set<String> preexistingSecretKeys;
 
     /**
      * Parses, normalizes, and validates raw settings from a REST request or CRUD layer.
@@ -65,9 +67,26 @@ public abstract class DataSourceConfiguration {
      * @param fieldDefs the field definitions
      * @throws ValidationException if any validation errors are found
      */
-    @SuppressWarnings("this-escape")
     protected DataSourceConfiguration(Map<String, Object> raw, Map<String, DataSourceConfigDefinition> fieldDefs) {
+        this(raw, fieldDefs, Set.of());
+    }
+
+    /**
+     * Like {@link #DataSourceConfiguration(Map, Map)}, but for a PUT-as-update: a secret field omitted from
+     * {@code raw} is still treated as present (see {@link #hasStoredSecret}) if its name is in
+     * {@code preexistingSecretKeys}, so credential-completeness checks pass when the caller intends to keep
+     * the existing value. The caller excludes any key the request explicitly clears (JSON {@code null}).
+     *
+     * @param preexistingSecretKeys secret field names already stored, empty for a create
+     */
+    @SuppressWarnings("this-escape")
+    protected DataSourceConfiguration(
+        Map<String, Object> raw,
+        Map<String, DataSourceConfigDefinition> fieldDefs,
+        Set<String> preexistingSecretKeys
+    ) {
         this.fieldDefs = fieldDefs;
+        this.preexistingSecretKeys = Set.copyOf(preexistingSecretKeys);
         ValidationException errors = new ValidationException();
         DataSourceValidationUtils.rejectUnknownFields(raw, fieldDefs.keySet(), errors);
         Map<String, Object> parsed = new HashMap<>();
@@ -99,7 +118,7 @@ public abstract class DataSourceConfiguration {
     /** Cross-field validation. Accumulate errors into the provided exception. */
     protected abstract void validate(ValidationException errors);
 
-    /** Returns true if any field marked as secret has a value set. Null values are already excluded. */
+    /** True if any field marked secret has a value set, or a preexisting one carries forward (see {@link #hasStoredSecret}). */
     protected boolean hasAnySecretValue() {
         for (var entry : values.entrySet()) {
             DataSourceConfigDefinition def = fieldDefs.get(entry.getKey());
@@ -108,7 +127,17 @@ public abstract class DataSourceConfiguration {
                 return true;
             }
         }
-        return false;
+        return preexistingSecretKeys.isEmpty() == false;
+    }
+
+    /**
+     * True if the named secret field has a value set in this request, or carries forward from a preexisting
+     * stored value on a PUT-as-update. Use this, not {@code Strings.hasText(get(key))}, in
+     * {@code hasCredentials()}/credential-completeness checks so an update that omits an already-stored
+     * secret still satisfies them.
+     */
+    protected boolean hasStoredSecret(String key) {
+        return Strings.hasText(get(key)) || preexistingSecretKeys.contains(key);
     }
 
     /** Returns true if any field marked as keyless auth has a value set. Null values are already excluded. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourceConfiguration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourceConfiguration.java
@@ -120,6 +120,16 @@ public abstract class DataSourceConfiguration {
 
     /** True if any field marked secret has a value set, or a preexisting one carries forward (see {@link #hasStoredSecret}). */
     protected boolean hasAnySecretValue() {
+        return hasAnyExplicitSecretValue() || preexistingSecretKeys.isEmpty() == false;
+    }
+
+    /**
+     * True if any field marked secret has a value set in this request specifically, excluding any preexisting
+     * secret carried forward from a stored value. Use this to distinguish "this request supplied credentials"
+     * from "credentials came from the existing entry" in a conflict message — e.g. rejecting {@code
+     * auth=anonymous} because a stored secret wasn't cleared shouldn't say the request supplied one.
+     */
+    protected boolean hasAnyExplicitSecretValue() {
         for (var entry : values.entrySet()) {
             DataSourceConfigDefinition def = fieldDefs.get(entry.getKey());
             assert def != null : "values map should only contain known fields, got [" + entry.getKey() + "]";
@@ -127,7 +137,7 @@ public abstract class DataSourceConfiguration {
                 return true;
             }
         }
-        return preexistingSecretKeys.isEmpty() == false;
+        return false;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourceValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DataSourceValidator.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceSetting;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Validates data source + dataset settings at CRUD time. No blocking I/O. {@link #validateDataset}
@@ -26,6 +27,17 @@ public interface DataSourceValidator {
      * travels into cluster state. Throws {@link ValidationException} if invalid.
      */
     Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings);
+
+    /**
+     * Merge-aware variant used when a PUT replaces an existing data source: {@code existingSecretKeys}
+     * names secret fields already stored for it, so a request that omits one still satisfies
+     * credential-completeness checks. The returned map, like {@link #validateDatasource(Map)}, contains only
+     * the fields present in {@code datasourceSettings}; carrying the omitted secret's stored value forward is
+     * the caller's job. The default ignores {@code existingSecretKeys} and delegates to the single-arg overload.
+     */
+    default Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings, Set<String> existingSecretKeys) {
+        return validateDatasource(datasourceSettings);
+    }
 
     /**
      * Validates dataset settings. Returns plain values — datasets carry no secrets. Parent passed for

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceConfiguration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceConfiguration.java
@@ -107,6 +107,16 @@ public abstract class FileDataSourceConfiguration extends DataSourceConfiguratio
         super(raw, fieldDefs);
     }
 
+    /** Like {@link #FileDataSourceConfiguration(Map, Map)}, but for a PUT-as-update; see
+     *  {@link DataSourceConfiguration#DataSourceConfiguration(Map, Map, Set)}. */
+    protected FileDataSourceConfiguration(
+        Map<String, Object> raw,
+        Map<String, DataSourceConfigDefinition> fieldDefs,
+        Set<String> preexistingSecretKeys
+    ) {
+        super(raw, fieldDefs, preexistingSecretKeys);
+    }
+
     @Override
     protected void normalize(Map<String, Object> parsed) {
         Object value = parsed.get(AUTH.name());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceConfiguration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceConfiguration.java
@@ -188,7 +188,7 @@ public abstract class FileDataSourceConfiguration extends DataSourceConfiguratio
             // The per-mode branches above already forbid secret+federated for every explicit mode; auto is the only
             // path where the two can arrive together, so the conflict check is scoped here.
             if (secrets && federatedAuth) {
-                errors.addValidationError(credentialSource() + " cannot be combined with keyless authentication settings");
+                errors.addValidationError(credentialSource() + " cannot be combined with federated authentication settings");
             }
         }
         validateCredentials(errors);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceConfiguration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceConfiguration.java
@@ -142,7 +142,7 @@ public abstract class FileDataSourceConfiguration extends DataSourceConfiguratio
         if (isAnonymous()) {
             if (secrets) {
                 errors.addValidationError(
-                    "auth=anonymous cannot be combined with explicit credentials; anonymous access uses no credentials"
+                    "auth=anonymous cannot be combined with " + credentialSource() + "; anonymous access uses no credentials"
                 );
             }
             if (keyless) {
@@ -153,7 +153,7 @@ public abstract class FileDataSourceConfiguration extends DataSourceConfiguratio
         }
         if (isManagedIdentity()) {
             if (secrets) {
-                errors.addValidationError("auth=managed_identity cannot be combined with explicit credentials");
+                errors.addValidationError("auth=managed_identity cannot be combined with " + credentialSource());
             }
             if (keyless) {
                 errors.addValidationError("auth=managed_identity cannot be combined with keyless authentication settings");
@@ -175,7 +175,7 @@ public abstract class FileDataSourceConfiguration extends DataSourceConfiguratio
                 errors.addValidationError("auth=federated_identity requires keyless authentication settings");
             }
             if (secrets) {
-                errors.addValidationError("auth=federated_identity cannot be combined with explicit credentials");
+                errors.addValidationError("auth=federated_identity cannot be combined with " + credentialSource());
             }
         }
         // auto (or omitted) resolves the mode from the fields present; reject a config that resolves to nothing here
@@ -188,10 +188,23 @@ public abstract class FileDataSourceConfiguration extends DataSourceConfiguratio
             // The per-mode branches above already forbid secret+keyless for every explicit mode; auto is the only
             // path where the two can arrive together, so the conflict check is scoped here.
             if (secrets && keyless) {
-                errors.addValidationError("explicit credentials cannot be combined with keyless authentication settings");
+                errors.addValidationError(credentialSource() + " cannot be combined with keyless authentication settings");
             }
         }
         validateCredentials(errors);
+    }
+
+    /**
+     * Names the source of the credentials that {@link #hasAnySecretValue()} found, for a conflict message: this
+     * request ("explicit credentials") or, on a PUT-as-update where the request itself supplies none, the
+     * existing stored data source. A message built from the latter also points at how to actually clear them,
+     * since simply omitting the secret field again would just carry it forward again.
+     */
+    private String credentialSource() {
+        if (hasAnyExplicitSecretValue()) {
+            return "explicit credentials";
+        }
+        return "credentials carried over from the stored data source (send the secret field(s) as null to clear them)";
     }
 
     /** Subclass hook for datasource-specific credential validation. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileDataSourceValidator.java
@@ -22,8 +22,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidationUtils.rejectUnknownFields;
 import static org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidationUtils.validateEnum;
@@ -101,7 +101,7 @@ public class FileDataSourceValidator implements DataSourceValidator {
     }
 
     private final String type;
-    private final Function<Map<String, Object>, DataSourceConfiguration> configFactory;
+    private final BiFunction<Map<String, Object>, Set<String>, DataSourceConfiguration> configFactory;
     private final Set<String> supportedSchemes;
     @Nullable
     private final FormatConfigKeyResolver formatConfigKeyResolver;
@@ -110,7 +110,7 @@ public class FileDataSourceValidator implements DataSourceValidator {
 
     public FileDataSourceValidator(
         String type,
-        Function<Map<String, Object>, DataSourceConfiguration> configFactory,
+        BiFunction<Map<String, Object>, Set<String>, DataSourceConfiguration> configFactory,
         Set<String> supportedSchemes
     ) {
         this(type, configFactory, supportedSchemes, null, Set.of(), () -> false);
@@ -118,7 +118,7 @@ public class FileDataSourceValidator implements DataSourceValidator {
 
     private FileDataSourceValidator(
         String type,
-        Function<Map<String, Object>, DataSourceConfiguration> configFactory,
+        BiFunction<Map<String, Object>, Set<String>, DataSourceConfiguration> configFactory,
         Set<String> supportedSchemes,
         @Nullable FormatConfigKeyResolver formatConfigKeyResolver,
         Set<String> compressionExtensions,
@@ -164,10 +164,15 @@ public class FileDataSourceValidator implements DataSourceValidator {
 
     @Override
     public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings) {
+        return validateDatasource(datasourceSettings, Set.of());
+    }
+
+    @Override
+    public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings, Set<String> existingSecretKeys) {
         if (datasourceSettings == null || datasourceSettings.isEmpty()) {
             return Map.of();
         }
-        DataSourceConfiguration config = configFactory.apply(datasourceSettings);
+        DataSourceConfiguration config = configFactory.apply(datasourceSettings, existingSecretKeys);
         if (config instanceof FileDataSourceConfiguration fc && fc.isManagedIdentity() && managedIdentityEnabled.getAsBoolean() == false) {
             throw new ValidationException().addValidationError(FileDataSourceConfiguration.MANAGED_IDENTITY_DISABLED_MESSAGE);
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceServiceCarryForwardTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceServiceCarryForwardTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.datasource;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceSetting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DataSourceService#isUntouchedSecret}, the predicate deciding whether a stored secret
+ * should carry forward into a PUT-as-update. Two regressions found in review: a request that explicitly
+ * supplies a value (even an empty one) for a secret must stand on its own rather than inheriting "still
+ * there" credit from the value it's replacing; and a secret already wiped (e.g. by a destructive encryption
+ * reset, stored with a {@code null} value) must never count as carried forward.
+ */
+public class DataSourceServiceCarryForwardTests extends ESTestCase {
+
+    public void testAbsentSecretIsUntouched() {
+        DataSourceSetting stored = new DataSourceSetting("s3cr3t", true);
+        assertTrue(DataSourceService.isUntouchedSecret(stored, "secret_key", Map.of()));
+    }
+
+    public void testExplicitNonNullValueIsNotUntouched() {
+        // A supplied value (even an empty string) must stand on its own, not inherit carry-forward credit
+        // from the stored value it's replacing.
+        DataSourceSetting stored = new DataSourceSetting("s3cr3t", true);
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("secret_key", "");
+        assertFalse(DataSourceService.isUntouchedSecret(stored, "secret_key", raw));
+    }
+
+    public void testExplicitNullValueIsNotUntouched() {
+        DataSourceSetting stored = new DataSourceSetting("s3cr3t", true);
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("secret_key", null);
+        assertFalse(DataSourceService.isUntouchedSecret(stored, "secret_key", raw));
+    }
+
+    public void testWipedSecretIsNeverUntouched() {
+        // A secret already wiped (present but null-valued, e.g. after a destructive encryption reset meant
+        // to force re-entry of credentials) has nothing to carry forward, regardless of the request.
+        DataSourceSetting wiped = new DataSourceSetting(null, true);
+        assertFalse(DataSourceService.isUntouchedSecret(wiped, "secret_key", Map.of()));
+    }
+
+    public void testNonSecretFieldIsNeverUntouched() {
+        DataSourceSetting nonSecret = new DataSourceSetting("us-east-1", false);
+        assertFalse(DataSourceService.isUntouchedSecret(nonSecret, "region", Map.of()));
+    }
+}


### PR DESCRIPTION
`PUT /_query/data_source/{name}` did a full-replace with no merge.  GET masks secrets as `::es_redacted::`, so a client echoing that value back on save (Kibana's edit-and-save flow does) got it encrypted and stored as the literal secret, wiping the real credential.

`PUT` now gives secret fields update semantics: omitting one keeps the stored value, an explicit JSON null clears it, a supplied value replaces it. Non-secret fields keep full-replace behavior. The `::es_redacted::` string is not detected or special-cased, since it could in principle be a legitimate secret.

## Changes
- `DataSourceConfiguration` gains a preexistingSecretKeys-aware constructor and a `hasStoredSecret(key)` helper; each CSP's `hasCredentials()` (`S3Configuration`, `GcsConfiguration`, `AzureConfiguration`) uses it instead of `Strings.hasText()`, so an update omitting an already-set credential still resolves. No secret value is fabricated or decrypted.
- `DataSourceService.validatePutDataSource` computes which secret keys are being carried forward and passes that into validation. `putDataSource` merges those values back in inside the cluster-state-update task, against freshly read authoritative state, so concurrent updates can't resurrect a stale secret.
- `TransportPutDataSourceAction`'s coordinator pre-check resolves the existing entry from local cluster state first, so it doesn't reject a legitimate omit-secret update before the master round-trip.