### PR TITLE
[ESQL] Preserve Parquet micros/nanos timestamp precision

### DIFF
--- a/docs/changelog/152855.yaml
+++ b/docs/changelog/152855.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152855
+summary: Preserve Parquet micros/nanos timestamp precision
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -170,6 +170,7 @@ final class PageColumnReader implements Releasable {
             case DOUBLE -> readDoubleBatch(maxRows, blockFactory);
             case KEYWORD, TEXT -> readBytesBatch(maxRows, blockFactory);
             case DATETIME -> readDatetimeBatch(maxRows, blockFactory);
+            case DATE_NANOS -> readDateNanosBatch(maxRows, blockFactory);
             default -> {
                 skipRows(maxRows);
                 yield blockFactory.newConstantNullBlock(maxRows);
@@ -1486,6 +1487,129 @@ final class PageColumnReader implements Releasable {
                 }
             }
         }
+    }
+
+    /**
+     * Optimized-path counterpart of {@link ParquetFormatReader}'s {@code readDateNanosColumn}: decodes an INT64
+     * {@code TIMESTAMP(MICROS|NANOS)} column into a {@code DATE_NANOS} block of epoch-nanoseconds. {@code NANOS}
+     * passes through; {@code MICROS} is scaled ×1_000. {@code MICROS} values whose scaled instant falls outside the
+     * representable {@code date_nanos} range (~1677-2262) are emitted as null (with one deduplicated warning) rather
+     * than silently wrapping. The common in-range case keeps the existing no-null fast vector path; a null mask is
+     * only materialised when a value actually overflows.
+     */
+    private Block readDateNanosBatch(int maxRows, BlockFactory blockFactory) {
+        boolean micros = ParquetColumnDecoding.isMicrosTimestamp(info.logicalType());
+        long[] values = UninitializedArrays.newLongArray(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readLongsDispatch(values, produced, fromPage);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            WordMask overflow = scaleDateNanosDense(values, produced, micros);
+            if (overflow == null) {
+                Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+                if (constant != null) return constant;
+                if (needsShrinking(produced, maxRows)) values = Arrays.copyOf(values, produced);
+                return blockFactory.newLongArrayVector(values, produced).asBlock();
+            }
+            ParquetColumnDecoding.warnTimestampOutOfRange(info);
+            Block allNull = ConstantBlockDetection.tryAllNull(overflow.toBitSet(), produced, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+            if (needsShrinking(produced, maxRows)) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayBlock(values, produced, null, overflow.toBitSet(), Block.MvOrdering.UNORDERED);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readLongsDispatch(values, produced, nonNull);
+                } else {
+                    long[] packed = UninitializedArrays.newLongArray(nonNull);
+                    readLongsDispatch(packed, 0, nonNull);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        boolean anyOverflow = scaleDateNanosMasked(values, produced, micros, nulls);
+        if (anyOverflow) {
+            ParquetColumnDecoding.warnTimestampOutOfRange(info);
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            if (needsShrinking(produced, maxRows)) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        if (needsShrinking(produced, maxRows)) values = Arrays.copyOf(values, produced);
+        return blockFactory.newLongArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
+    }
+
+    /**
+     * Scales a dense (no definition-level nulls) {@code MICROS} timestamp array to epoch-nanoseconds in place. A
+     * {@code NANOS} column is already in its final unit and is left untouched. Returns a mask of positions that
+     * overflowed the representable {@code date_nanos} range (for the caller to null out), or {@code null} when
+     * nothing overflowed (the common case, which keeps the no-null fast path).
+     */
+    private WordMask scaleDateNanosDense(long[] values, int count, boolean micros) {
+        if (micros == false) {
+            return null;
+        }
+        WordMask overflow = null;
+        for (int i = 0; i < count; i++) {
+            long raw = values[i];
+            if (ParquetColumnDecoding.microsOverflowsNanos(raw)) {
+                if (overflow == null) {
+                    overflow = buffers.nullsMask(count);
+                }
+                overflow.set(i);
+            } else {
+                values[i] = raw * ParquetColumnDecoding.NANOS_PER_MICRO;
+            }
+        }
+        return overflow;
+    }
+
+    /**
+     * Scales the non-null {@code MICROS} timestamp positions to epoch-nanoseconds in place, extending {@code nulls}
+     * with any positions that overflow the representable {@code date_nanos} range. A {@code NANOS} column needs no
+     * scaling. Returns whether any overflow occurred.
+     */
+    private static boolean scaleDateNanosMasked(long[] values, int count, boolean micros, WordMask nulls) {
+        if (micros == false) {
+            return false;
+        }
+        boolean anyOverflow = false;
+        for (int i = 0; i < count; i++) {
+            if (nulls.get(i)) {
+                continue;
+            }
+            long raw = values[i];
+            if (ParquetColumnDecoding.microsOverflowsNanos(raw)) {
+                nulls.set(i);
+                anyOverflow = true;
+            } else {
+                values[i] = raw * ParquetColumnDecoding.NANOS_PER_MICRO;
+            }
+        }
+        return anyOverflow;
     }
 
     private Block readInt96Batch(int maxRows, BlockFactory blockFactory) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.io.api.GroupConverter;
@@ -16,8 +17,10 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 
@@ -57,6 +60,65 @@ final class ParquetColumnDecoding {
         return raw;
     }
 
+    // ---- date_nanos (epoch-nanoseconds) helpers ----
+
+    static final long NANOS_PER_MICRO = 1_000L;
+
+    /**
+     * Largest / smallest epoch-microsecond value that can be scaled to epoch-nanoseconds without
+     * overflowing a {@code long}. These bounds coincide with the representable {@code date_nanos}
+     * instant range (~1677-09-21 .. 2262-04-11): {@code Long.MAX_VALUE} nanoseconds is ~year 2262,
+     * so a microsecond value beyond {@code Long.MAX_VALUE / 1_000} has no nanosecond representation.
+     */
+    static final long MAX_MICROS_AS_NANOS = Long.MAX_VALUE / NANOS_PER_MICRO;
+    static final long MIN_MICROS_AS_NANOS = Long.MIN_VALUE / NANOS_PER_MICRO;
+
+    /** Whether {@code logicalType} is a {@code TIMESTAMP(MICROS)} annotation (the only unit whose nanos scaling can overflow). */
+    static boolean isMicrosTimestamp(LogicalTypeAnnotation logicalType) {
+        return logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts
+            && ts.getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS;
+    }
+
+    /** Whether scaling a {@code TIMESTAMP(MICROS)} value to epoch-nanoseconds would overflow a {@code long}. */
+    static boolean microsOverflowsNanos(long micros) {
+        return micros > MAX_MICROS_AS_NANOS || micros < MIN_MICROS_AS_NANOS;
+    }
+
+    /**
+     * Converts a Parquet INT64 timestamp value to epoch-nanoseconds for a {@code DATE_NANOS} column:
+     * {@code MICROS} is scaled by 1_000, {@code NANOS} passes through. {@code MILLIS} is included for
+     * completeness (×1_000_000) although the type mapper only routes {@code MICROS}/{@code NANOS}
+     * timestamps to {@code DATE_NANOS}. Callers must guard {@code MICROS} inputs against overflow via
+     * {@link #microsOverflowsNanos(long)}; this method does not check.
+     */
+    static long convertTimestampToNanos(long raw, LogicalTypeAnnotation logicalType) {
+        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return switch (ts.getUnit()) {
+                case MILLIS -> raw * 1_000_000L;
+                case MICROS -> raw * NANOS_PER_MICRO;
+                case NANOS -> raw;
+            };
+        }
+        return raw;
+    }
+
+    /**
+     * Emits a response {@code Warning} header noting that a Parquet timestamp column carried instants
+     * outside the representable {@code date_nanos} range and those values were returned as null. The
+     * message is column-scoped and constant, so the response-header machinery deduplicates it to a
+     * single entry per affected column regardless of how many values or batches triggered it.
+     */
+    static void warnTimestampOutOfRange(ColumnInfo info) {
+        ColumnDescriptor descriptor = info.descriptor();
+        String column = descriptor == null ? "<unknown>" : String.join(".", descriptor.getPath());
+        HeaderWarning.addWarning(
+            "Parquet timestamp column ["
+                + column
+                + "] contains values outside the representable date_nanos range (~1677-09-21 to 2262-04-11); "
+                + "such values are returned as null"
+        );
+    }
+
     /** Converts a date32 value (days since epoch) to epoch milliseconds. */
     static long dateDaysToMillis(long days) {
         return days * MILLIS_PER_DAY;
@@ -82,22 +144,32 @@ final class ParquetColumnDecoding {
      * Decodes a Parquet footer stat value into the same representation the scan path produces, so
      * pushed-down MIN/MAX match a scan:
      * <ul>
-     *   <li>date32 -&gt; epoch-millis</li>
-     *   <li>timestamp -&gt; epoch-millis (unit-scaled)</li>
+     *   <li>date32 -&gt; epoch-millis (DATETIME)</li>
+     *   <li>timestamp[millis] -&gt; epoch-millis (DATETIME)</li>
+     *   <li>timestamp[micros|nanos] -&gt; epoch-nanos (DATE_NANOS), matching the scan path</li>
      *   <li>time -&gt; raw milliseconds for TIME_MILLIS (physical INT32), nanoseconds otherwise</li>
      * </ul>
      * Returns {@code null} when the type is not one of the above (caller falls through to other
      * normalization). INT96 is deliberately excluded: its footer min/max are compared by parquet-mr
      * as unsigned little-endian bytes (nanos-of-day in the low bytes), so they are not chronological
-     * and cannot be trusted for MIN/MAX pushdown — returning {@code null} forces a scan instead.
+     * and cannot be trusted for MIN/MAX pushdown — returning {@code null} forces a scan instead. A
+     * {@code timestamp[micros]} stat whose scaled value would overflow the {@code date_nanos} range
+     * also returns {@code null} (forcing a scan) rather than publishing a wrapped-around bound.
      */
     static Long decodeTemporalStat(Object value, PrimitiveType type) {
         LogicalTypeAnnotation logical = type.getLogicalTypeAnnotation();
         if (logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
             return dateDaysToMillis(((Number) value).longValue());
         }
-        if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
-            return convertTimestampToMillis(((Number) value).longValue(), logical);
+        if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            long raw = ((Number) value).longValue();
+            return switch (ts.getUnit()) {
+                // MILLIS stays DATETIME (epoch-millis); MICROS/NANOS become DATE_NANOS (epoch-nanos) so the
+                // published bound matches what the DATE_NANOS scan produces.
+                case MILLIS -> raw;
+                case NANOS -> raw;
+                case MICROS -> microsOverflowsNanos(raw) ? null : raw * NANOS_PER_MICRO;
+            };
         }
         if (logical instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation time) {
             long raw = ((Number) value).longValue();
@@ -107,6 +179,23 @@ final class ParquetColumnDecoding {
             return type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32 ? raw : raw * timeNanoMultiplier(time);
         }
         return null;
+    }
+
+    /**
+     * Whether the column carries a temporal logical-type annotation (date32, timestamp, or time) that
+     * {@link #decodeTemporalStat} scales into the scan's output unit. When this is {@code true} but
+     * {@code decodeTemporalStat} returns {@code null}, the footer statistic is temporal yet unusable
+     * (a {@code timestamp[us]} value outside the representable {@code date_nanos} range, which the scan
+     * nulls out) and the caller must drop the column's min/max <em>and</em> null count rather than
+     * publishing a raw physical value. INT96 timestamps are deliberately excluded here: they have no
+     * logical annotation and their footer min/max are not chronological, so they fall through to the
+     * caller's generic fallback (unchanged behavior).
+     */
+    static boolean hasTemporalStatEncoding(PrimitiveType type) {
+        LogicalTypeAnnotation logical = type.getLogicalTypeAnnotation();
+        return logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation
+            || logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation
+            || logical instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
     }
 
     /**
@@ -224,6 +313,7 @@ final class ParquetColumnDecoding {
             case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows, blockFactory);
             case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows, blockFactory);
             case DATETIME -> readListDatetimeColumn(cr, info, rows, blockFactory);
+            case DATE_NANOS -> readListDateNanosColumn(cr, info, rows, blockFactory);
             default -> {
                 skipListValues(cr, rows);
                 yield blockFactory.newConstantNullBlock(rows);
@@ -361,6 +451,84 @@ final class ParquetColumnDecoding {
             }
             return builder.build();
         }
+    }
+
+    /**
+     * Reads a LIST of {@code DATE_NANOS} timestamps (Parquet INT64 {@code TIMESTAMP(MICROS|NANOS)}) into a
+     * {@code LongBlock} of epoch-nanoseconds. {@code MICROS} elements whose scaled value would overflow the
+     * representable {@code date_nanos} range are dropped from their list (mirroring how the generic list reader
+     * already skips null elements); a list whose elements <em>all</em> overflow becomes a null position. A single
+     * deduplicated warning header is emitted when any element was dropped. This uses a lazy {@code beginPositionEntry}
+     * so an all-overflow defined list never triggers the empty-position assertion in {@link Block.Builder}.
+     */
+    private static Block readListDateNanosColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        int maxDef = info.maxDefLevel();
+        LogicalTypeAnnotation logical = info.logicalType();
+        boolean micros = isMicrosTimestamp(logical);
+        boolean[] anyOverflow = { false };
+        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(rows)) {
+            for (int row = 0; row < rows; row++) {
+                readDateNanosListRow(cr, maxDef, micros, logical, builder, anyOverflow);
+            }
+            if (anyOverflow[0]) {
+                warnTimestampOutOfRange(info);
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Reads a single {@code DATE_NANOS} list row, mirroring {@link #readListRow} but scaling each element to
+     * epoch-nanoseconds and dropping {@code MICROS} elements that overflow the representable range. The position
+     * entry is opened lazily on the first retained element, so a list with no retained elements is emitted as null.
+     */
+    private static void readDateNanosListRow(
+        ColumnReader cr,
+        int maxDef,
+        boolean micros,
+        LogicalTypeAnnotation logical,
+        LongBlock.Builder builder,
+        boolean[] anyOverflow
+    ) {
+        boolean open = cr.getCurrentDefinitionLevel() >= maxDef && appendDateNanosElement(cr, logical, micros, builder, false, anyOverflow);
+        cr.consume();
+        while (cr.getCurrentRepetitionLevel() > 0) {
+            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                open = appendDateNanosElement(cr, logical, micros, builder, open, anyOverflow);
+            }
+            cr.consume();
+        }
+        if (open) {
+            builder.endPositionEntry();
+        } else {
+            builder.appendNull();
+        }
+    }
+
+    /**
+     * Appends the current column value as an epoch-nanosecond element, opening the position entry lazily.
+     * Returns whether the entry is open afterwards. An out-of-range {@code MICROS} value is skipped (not appended)
+     * and flips {@code anyOverflow}.
+     */
+    private static boolean appendDateNanosElement(
+        ColumnReader cr,
+        LogicalTypeAnnotation logical,
+        boolean micros,
+        LongBlock.Builder builder,
+        boolean open,
+        boolean[] anyOverflow
+    ) {
+        long raw = cr.getLong();
+        if (micros && microsOverflowsNanos(raw)) {
+            anyOverflow[0] = true;
+            return open;
+        }
+        if (open == false) {
+            builder.beginPositionEntry();
+            open = true;
+        }
+        builder.appendLong(convertTimestampToNanos(raw, logical));
+        return open;
     }
 
     // ---- NoOp converters for ColumnReadStoreImpl ----

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -81,7 +81,8 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         || dt == DataType.DOUBLE
         || dt == DataType.KEYWORD
         || dt == DataType.BOOLEAN
-        || dt == DataType.DATETIME;
+        || dt == DataType.DATETIME
+        || dt == DataType.DATE_NANOS;
 
     @Override
     public PushdownResult pushFilters(List<Expression> filters) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -929,6 +929,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         // a reliable total. We must report the null count as unknown for these rather than treating
         // a missing value as zero, otherwise COUNT(col) would be answered as the row count downstream.
         Set<String> unknownNullCounts = new HashSet<>();
+        // Columns whose footer statistics are temporal but not representable in the scan's output unit
+        // (a timestamp[us] value outside the date_nanos range, which the scan nulls out). For these the
+        // physical min/max and null_count disagree with what a scan produces, so min/max are dropped and
+        // the null count is treated as unknown — MIN/MAX/COUNT then fall back to a scan for that column.
+        Set<String> poisonedTemporalStats = new HashSet<>();
 
         for (BlockMetaData rowGroup : rowGroups) {
             totalRows += rowGroup.getRowCount();
@@ -953,18 +958,24 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 }
                 if (stats.hasNonNullValue()) {
                     PrimitiveType pt = col.getPrimitiveType();
-                    mins.merge(colName, new Comparable[] { (Comparable) normalizeStatValue(stats.genericGetMin(), pt) }, (a, b) -> {
-                        @SuppressWarnings("unchecked")
-                        int cmp = a[0].compareTo(b[0]);
-                        if (cmp > 0) a[0] = b[0];
-                        return a;
-                    });
-                    maxs.merge(colName, new Comparable[] { (Comparable) normalizeStatValue(stats.genericGetMax(), pt) }, (a, b) -> {
-                        @SuppressWarnings("unchecked")
-                        int cmp = a[0].compareTo(b[0]);
-                        if (cmp < 0) a[0] = b[0];
-                        return a;
-                    });
+                    Object minVal = normalizeStatValue(stats.genericGetMin(), pt);
+                    Object maxVal = normalizeStatValue(stats.genericGetMax(), pt);
+                    if (minVal == null || maxVal == null) {
+                        poisonedTemporalStats.add(colName);
+                    } else {
+                        mins.merge(colName, new Comparable[] { (Comparable) minVal }, (a, b) -> {
+                            @SuppressWarnings("unchecked")
+                            int cmp = a[0].compareTo(b[0]);
+                            if (cmp > 0) a[0] = b[0];
+                            return a;
+                        });
+                        maxs.merge(colName, new Comparable[] { (Comparable) maxVal }, (a, b) -> {
+                            @SuppressWarnings("unchecked")
+                            int cmp = a[0].compareTo(b[0]);
+                            if (cmp < 0) a[0] = b[0];
+                            return a;
+                        });
+                    }
                 }
             }
         }
@@ -988,15 +999,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             Comparable[] mx = maxs.get(name);
             long[] cs = colSizes.get(name);
             if (nc != null || mn != null || mx != null || cs != null) {
+                // A poisoned temporal column has an out-of-range timestamp[us] stat: the scan nulls those
+                // values out, so both the physical min/max and the physical null count are unusable.
+                final boolean poisoned = poisonedTemporalStats.contains(name);
                 // The null count is only known when every covering row group recorded it. A missing
                 // statistic in any row group ({@code unknownNullCounts}) leaves the total unknown, so
                 // report {@link OptionalLong#empty()} and let COUNT(col) fall back to a scan rather
                 // than counting the missing nulls as zero (which would return the row count).
-                final OptionalLong nullCount = nc != null && unknownNullCounts.contains(name) == false
+                final OptionalLong nullCount = nc != null && unknownNullCounts.contains(name) == false && poisoned == false
                     ? OptionalLong.of(nc[0])
                     : OptionalLong.empty();
-                final Object minVal = mn != null ? mn[0] : null;
-                final Object maxVal = mx != null ? mx[0] : null;
+                final Object minVal = mn != null && poisoned == false ? mn[0] : null;
+                final Object maxVal = mx != null && poisoned == false ? mx[0] : null;
                 final long colSize = cs != null ? cs[0] : -1;
                 columnStats.put(name, new SourceStatistics.ColumnStatistics() {
                     @Override
@@ -1203,22 +1217,39 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             }
             if (colStats.hasNonNullValue()) {
                 PrimitiveType pt = col.getPrimitiveType();
-                stats.put(SourceStatisticsSerializer.columnMinKey(colName), normalizeStatValue(colStats.genericGetMin(), pt));
-                stats.put(SourceStatisticsSerializer.columnMaxKey(colName), normalizeStatValue(colStats.genericGetMax(), pt));
+                Object minVal = normalizeStatValue(colStats.genericGetMin(), pt);
+                Object maxVal = normalizeStatValue(colStats.genericGetMax(), pt);
+                if (minVal == null || maxVal == null) {
+                    // Out-of-range timestamp[us] stat: the scan nulls those values out, so the physical
+                    // min/max and null count disagree with the scan. Drop min/max and the (already-published)
+                    // null count so MIN/MAX/COUNT fall back to a scan for this column. Map values may not be
+                    // null anyway (Map.copyOf below rejects nulls).
+                    stats.remove(SourceStatisticsSerializer.columnNullCountKey(colName));
+                } else {
+                    stats.put(SourceStatisticsSerializer.columnMinKey(colName), minVal);
+                    stats.put(SourceStatisticsSerializer.columnMaxKey(colName), maxVal);
+                }
             }
         }
         return Map.copyOf(stats);
     }
 
     /**
-     * Normalizes Parquet-specific stat values to types that Elasticsearch can serialize.
-     * Temporal types (date32, timestamp, INT96) are decoded to epoch-millis.
-     * Parquet {@link Binary} (used for BYTE_ARRAY / string columns) is converted to String.
+     * Normalizes Parquet-specific stat values to types that Elasticsearch can serialize, in the same unit
+     * the scan path emits: date32 and {@code timestamp[ms]} to epoch-millis (DATETIME), {@code timestamp[us|ns]}
+     * to epoch-nanos (DATE_NANOS), and TIME to its scan unit. Parquet {@link Binary} (BYTE_ARRAY / string) is
+     * converted to String.
+     * <p>
+     * Returns {@code null} for a scaled-temporal column (see {@link ParquetColumnDecoding#hasTemporalStatEncoding})
+     * whose statistic is not representable in the scan's output unit — i.e. a {@code timestamp[us]} value beyond
+     * the {@code date_nanos} range, which the scan nulls out. Callers must treat {@code null} as "poison this
+     * column's min/max and null count" so MIN/MAX/COUNT fall back to a scan rather than trusting a physical value
+     * that disagrees with what the scan produces. A raw physical value is only returned for non-temporal columns
+     * (and INT96, whose non-chronological footer stats keep their pre-existing fallback).
      */
     private static Object normalizeStatValue(Object value, PrimitiveType primitiveType) {
-        Long temporal = ParquetColumnDecoding.decodeTemporalStat(value, primitiveType);
-        if (temporal != null) {
-            return temporal;
+        if (ParquetColumnDecoding.hasTemporalStatEncoding(primitiveType)) {
+            return ParquetColumnDecoding.decodeTemporalStat(value, primitiveType);
         }
         if (value instanceof Binary binary) {
             return binary.toStringUsingUTF8();
@@ -2121,8 +2152,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     if (intLogical.isSigned() == false && intLogical.getBitWidth() == 64) {
                         yield DataType.UNSIGNED_LONG;
                     }
-                } else if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation) {
-                    yield DataType.DATETIME;
+                } else if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+                    // Map by unit so sub-millisecond precision is preserved: MILLIS fits DATETIME (epoch-millis),
+                    // while MICROS/NANOS require DATE_NANOS (epoch-nanos). See ParquetColumnDecoding#convertTimestampToNanos.
+                    yield switch (ts.getUnit()) {
+                        case MILLIS -> DataType.DATETIME;
+                        case MICROS, NANOS -> DataType.DATE_NANOS;
+                    };
                 } else if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
                     yield DataType.DOUBLE;
                 }
@@ -2576,6 +2612,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     yield readBytesRefColumn(cr, info, rowsToRead, scaledHint);
                 }
                 case DATETIME -> readDatetimeColumn(cr, info, rowsToRead);
+                case DATE_NANOS -> readDateNanosColumn(cr, info, rowsToRead);
                 default -> {
                     ParquetColumnDecoding.skipValues(cr, rowsToRead);
                     yield blockFactory.newConstantNullBlock(rowsToRead);
@@ -2770,6 +2807,44 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     values[i] = ParquetColumnDecoding.convertTimestampToMillis(cr.getLong(), info.logicalType());
                 }
                 cr.consume();
+            }
+            return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull, false);
+        }
+
+        /**
+         * Reads an INT64 {@code TIMESTAMP(MICROS|NANOS)} column into a {@code DATE_NANOS} block of epoch-nanoseconds.
+         * {@code NANOS} passes through; {@code MICROS} is scaled ×1_000. A {@code MICROS} value whose scaled instant
+         * would fall outside the representable {@code date_nanos} range (~1677-2262) has no nanosecond representation,
+         * so it is emitted as null (with a single deduplicated response warning) rather than silently wrapping around.
+         */
+        private Block readDateNanosColumn(ColumnReader cr, ColumnInfo info, int rows) {
+            LogicalTypeAnnotation logical = info.logicalType();
+            boolean micros = ParquetColumnDecoding.isMicrosTimestamp(logical);
+            long[] values = UninitializedArrays.newLongArray(rows);
+            BitSet isNull = info.maxDefLevel() > 0 ? new BitSet(rows) : null;
+            boolean noNulls = true;
+            boolean anyOverflow = false;
+            for (int i = 0; i < rows; i++) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
+                    isNull.set(i);
+                    noNulls = false;
+                } else {
+                    long raw = cr.getLong();
+                    if (micros && ParquetColumnDecoding.microsOverflowsNanos(raw)) {
+                        if (isNull == null) {
+                            isNull = new BitSet(rows);
+                        }
+                        isNull.set(i);
+                        noNulls = false;
+                        anyOverflow = true;
+                    } else {
+                        values[i] = ParquetColumnDecoding.convertTimestampToNanos(raw, logical);
+                    }
+                }
+                cr.consume();
+            }
+            if (anyOverflow) {
+                ParquetColumnDecoding.warnTimestampOutOfRange(info);
             }
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull, false);
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -426,6 +426,7 @@ final class ParquetPushedExpressions {
                 };
             }
             case DATETIME -> buildDatetimePredicate(columnName, value, op, schema);
+            case DATE_NANOS -> buildDateNanosPredicate(columnName, value, op, schema);
             default -> null;
         };
     }
@@ -618,6 +619,47 @@ final class ParquetPushedExpressions {
         return millis;
     }
 
+    /**
+     * Builds a predicate for an ESQL {@code DATE_NANOS} column. These columns come only from INT64
+     * {@code TIMESTAMP(MICROS|NANOS)} (see {@link ParquetFormatReader}'s type mapper), and the query literal is
+     * epoch-nanoseconds. For a physical {@code NANOS} column the bound is pushed exactly. For a physical
+     * {@code MICROS} column the nanosecond bound is converted to a microsecond bound rounded outward
+     * ({@link #nanosBoundToMicros}) so the pushed predicate is never stricter than the true nanosecond predicate —
+     * safe because temporal pushdown is always RECHECK (see {@link ParquetFilterPushdownSupport#isFullyEvaluable}),
+     * so {@code FilterExec} re-applies the exact semantics regardless.
+     */
+    private static FilterPredicate buildDateNanosPredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
+            return null;
+        }
+        if (value == null) {
+            return orderedPredicate(FilterApi.longColumn(columnName), null, op);
+        }
+        long nanos = ((Number) value).longValue();
+        if (ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation()) == false) {
+            // Physical NANOS: literal and stored unit match, so the bound is exact.
+            return orderedPredicate(FilterApi.longColumn(columnName), nanos, op);
+        }
+        Long micros = nanosBoundToMicros(nanos, op);
+        return micros == null ? null : orderedPredicate(FilterApi.longColumn(columnName), micros, op);
+    }
+
+    /**
+     * Converts an epoch-nanosecond bound to the epoch-microsecond bound to push against a physical {@code MICROS}
+     * column, rounding each comparison outward so the pushed predicate never excludes a matching row (a stored
+     * micro {@code m} represents the instant {@code m × 1_000} ns). Equality/inequality are only representable when
+     * the bound is an exact multiple of 1_000 ns; otherwise {@code null} is returned and no predicate is pushed
+     * (the scan plus {@code FilterExec} recheck still yields the correct result, only without pruning).
+     */
+    private static Long nanosBoundToMicros(long nanos, PredicateOp op) {
+        return switch (op) {
+            case GT, LTE -> Math.floorDiv(nanos, ParquetColumnDecoding.NANOS_PER_MICRO);
+            case GTE, LT -> Math.ceilDiv(nanos, ParquetColumnDecoding.NANOS_PER_MICRO);
+            case EQ, NOT_EQ -> nanos % ParquetColumnDecoding.NANOS_PER_MICRO == 0 ? nanos / ParquetColumnDecoding.NANOS_PER_MICRO : null;
+        };
+    }
+
     private static <T extends Comparable<T>, C extends Operators.Column<T> & Operators.SupportsLtGt> FilterPredicate orderedPredicate(
         C col,
         T value,
@@ -656,6 +698,7 @@ final class ParquetPushedExpressions {
             case KEYWORD -> inPredicate(FilterApi.binaryColumn(columnName), rawValues, ParquetPushedExpressions::toBinary);
             case BOOLEAN -> inPredicate(FilterApi.booleanColumn(columnName), rawValues, v -> (Boolean) v);
             case DATETIME -> translateDatetimeIn(columnName, rawValues, schema);
+            case DATE_NANOS -> translateDateNanosIn(columnName, rawValues, schema);
             default -> null;
         };
     }
@@ -717,6 +760,31 @@ final class ParquetPushedExpressions {
         } catch (ArithmeticException e) {
             return null;
         }
+    }
+
+    /**
+     * {@code IN} counterpart to {@link #buildDateNanosPredicate}. The query literals are epoch-nanoseconds. For a
+     * physical {@code NANOS} column each value is pushed exactly. For a physical {@code MICROS} column, an element
+     * can only equal a stored value when it is an exact multiple of 1_000 ns; non-multiples are dropped (they can
+     * never match, so omitting them keeps the pushed set a correct subset). If every element is dropped, no
+     * predicate is pushed and the scan + recheck yields the (empty) result.
+     */
+    private static FilterPredicate translateDateNanosIn(String columnName, List<Object> rawValues, MessageType schema) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
+            return null;
+        }
+        if (ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation()) == false) {
+            return inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
+        }
+        List<Object> micros = new ArrayList<>();
+        for (Object v : rawValues) {
+            long nanos = ((Number) v).longValue();
+            if (nanos % ParquetColumnDecoding.NANOS_PER_MICRO == 0) {
+                micros.add(nanos / ParquetColumnDecoding.NANOS_PER_MICRO);
+            }
+        }
+        return micros.isEmpty() ? null : inPredicate(FilterApi.longColumn(columnName), micros, v -> (Long) v);
     }
 
     private static <T extends Comparable<T>, C extends Operators.Column<T> & Operators.SupportsEqNotEq> FilterPredicate inPredicate(

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1443,7 +1443,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
     // --- TIMESTAMP MICROS/NANOS tests ---
 
     public void testReadTimestampMicrosColumn() throws Exception {
-        // TIMESTAMP(MICROS, adjustedToUTC=true)
+        // TIMESTAMP(MICROS, adjustedToUTC=true) maps to DATE_NANOS and preserves sub-millisecond precision.
         MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT64)
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
@@ -1451,7 +1451,9 @@ public class ParquetFormatReaderTests extends ESTestCase {
             .named("test_schema");
 
         long epochMillis = 946728000000L; // 2000-01-01T12:00:00Z
-        long epochMicros = epochMillis * 1000;
+        // .123456 fractional seconds: the .456 microseconds must survive (were truncated before the fix).
+        long epochMicros = epochMillis * 1000 + 456;
+        long expectedNanos = epochMicros * 1000;
 
         byte[] parquetData = createParquetFile(schema, factory -> {
             Group g1 = factory.newGroup();
@@ -1463,18 +1465,18 @@ public class ParquetFormatReaderTests extends ESTestCase {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
         SourceMetadata metadata = reader.metadata(storageObject);
-        assertEquals(DataType.DATETIME, metadata.schema().get(0).dataType());
+        assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
             LongBlock block = (LongBlock) page.getBlock(0);
-            assertEquals(epochMillis, block.getLong(0));
+            assertEquals("timestamp[us] must decode to epoch-nanos with full precision", expectedNanos, block.getLong(0));
         }
     }
 
     public void testReadTimestampNanosColumn() throws Exception {
-        // TIMESTAMP(NANOS, adjustedToUTC=true)
+        // TIMESTAMP(NANOS, adjustedToUTC=true) maps to DATE_NANOS and passes the epoch-nanos value through unchanged.
         MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT64)
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
@@ -1482,7 +1484,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             .named("test_schema");
 
         long epochMillis = 946728000000L; // 2000-01-01T12:00:00Z
-        long epochNanos = epochMillis * 1_000_000;
+        // .123456789 fractional seconds: all nine digits must survive (were truncated before the fix).
+        long epochNanos = epochMillis * 1_000_000 + 456_789;
 
         byte[] parquetData = createParquetFile(schema, factory -> {
             Group g1 = factory.newGroup();
@@ -1493,11 +1496,14 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
+
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
             LongBlock block = (LongBlock) page.getBlock(0);
-            assertEquals(epochMillis, block.getLong(0));
+            assertEquals("timestamp[ns] must decode to epoch-nanos with full precision", epochNanos, block.getLong(0));
         }
     }
 
@@ -1520,11 +1526,102 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals("timestamp[ms] must remain DATETIME", DataType.DATETIME, metadata.schema().get(0).dataType());
+
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
             LongBlock block = (LongBlock) page.getBlock(0);
             assertEquals(epochMillis, block.getLong(0));
+        }
+    }
+
+    /**
+     * A single Parquet file mixing timestamp[ms]/[us]/[ns] columns with distinct sub-millisecond fractions:
+     * the millis column stays DATETIME (epoch-millis) while the micros/nanos columns resolve to DATE_NANOS and
+     * round-trip their full fractional precision (the core of elastic/esql-planning#1027).
+     */
+    public void testReadMixedTimestampUnitsPreservesPrecision() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts_ms")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts_us")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
+            .named("ts_ns")
+            .named("test_schema");
+
+        long baseMillis = 1_767_225_600_123L; // 2026-01-01T00:00:00.123Z
+        long micros = baseMillis * 1_000 + 456;         // ...00.123456
+        long nanos = baseMillis * 1_000_000 + 456_789;  // ...00.123456789
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("ts_ms", baseMillis);
+            g.add("ts_us", micros);
+            g.add("ts_ns", nanos);
+            return List.of(g);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DATETIME, metadata.schema().get(0).dataType());
+        assertEquals(DataType.DATE_NANOS, metadata.schema().get(1).dataType());
+        assertEquals(DataType.DATE_NANOS, metadata.schema().get(2).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(baseMillis, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(micros * 1_000, ((LongBlock) page.getBlock(1)).getLong(0));
+            assertEquals(nanos, ((LongBlock) page.getBlock(2)).getLong(0));
+        }
+    }
+
+    /**
+     * A timestamp[us] value beyond the representable date_nanos range (~year 2262) has no nanosecond
+     * representation, so it is returned as null rather than silently wrapping around. A defined in-range
+     * value in the same column is unaffected.
+     */
+    public void testReadTimestampMicrosOutOfRangeReturnsNull() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test_schema");
+
+        long inRangeMicros = 946728000000L * 1_000; // 2000-01-01T12:00:00Z
+        // Year ~2600 in micros: in range for micros/millis, but micros*1000 overflows the date_nanos (long-nanos) range.
+        long outOfRangeMicros = 20_000_000_000_000_000L;
+        assertTrue("precondition: value must overflow nanos scaling", ParquetColumnDecoding.microsOverflowsNanos(outOfRangeMicros));
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("ts", inRangeMicros);
+            Group g2 = factory.newGroup();
+            g2.add("ts", outOfRangeMicros);
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            LongBlock block = (LongBlock) page.getBlock(0);
+            assertFalse("in-range value must be present", block.isNull(0));
+            assertEquals(inRangeMicros * 1_000, block.getLong(0));
+            assertTrue("out-of-range value must be null", block.isNull(1));
         }
     }
 
@@ -2091,6 +2188,75 @@ public class ParquetFormatReaderTests extends ESTestCase {
             // ESQL multivalue blocks have no distinct empty-list representation). This is pre-existing list behavior,
             // independent of the unsigned encoding, asserted here to document it for the unsigned_long path.
             assertTrue(block.isNull(3));
+        }
+    }
+
+    public void testReadListOfDateNanosColumn() throws Exception {
+        assertReadListOfDateNanosColumn(new ParquetFormatReader(blockFactory, false)); // baseline reader
+    }
+
+    public void testReadListOfDateNanosColumnOptimizedReader() throws Exception {
+        assertReadListOfDateNanosColumn(new ParquetFormatReader(blockFactory, true)); // optimized reader
+    }
+
+    /**
+     * A LIST of timestamp[us] resolves to a DATE_NANOS multivalue column: each element is scaled to epoch-nanos with
+     * full precision, null lists stay null, and null elements within a list are dropped (multivalue blocks have no
+     * per-element null slot). Both reader paths route list columns through the same shared decoder.
+     */
+    private void assertReadListOfDateNanosColumn(ParquetFormatReader reader) throws Exception {
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("values");
+        MessageType schema = new MessageType("test_schema", listType);
+
+        long micros1 = 946728000000L * 1_000 + 111; // sub-millisecond fraction .000111 ms
+        long micros2 = 946728000000L * 1_000 + 222;
+        long micros3 = 946728000000L * 1_000 + 333;
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            // Row 0: [micros1, micros2]
+            Group g1 = factory.newGroup();
+            Group list1 = g1.addGroup("values");
+            list1.addGroup("list").append("element", micros1);
+            list1.addGroup("list").append("element", micros2);
+
+            // Row 1: null list
+            Group g2 = factory.newGroup();
+
+            // Row 2: [micros3, null element]
+            Group g3 = factory.newGroup();
+            Group list3 = g3.addGroup("values");
+            list3.addGroup("list").append("element", micros3);
+            list3.addGroup("list"); // element absent -> null within the list
+
+            return List.of(g1, g2, g3);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
+
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+
+            LongBlock block = (LongBlock) page.getBlock(0);
+            // Row 0: [micros1, micros2] scaled to nanos with full precision
+            assertFalse(block.isNull(0));
+            assertEquals(2, block.getValueCount(0));
+            int start0 = block.getFirstValueIndex(0);
+            assertEquals(micros1 * 1_000, block.getLong(start0));
+            assertEquals(micros2 * 1_000, block.getLong(start0 + 1));
+
+            // Row 1: null list
+            assertTrue(block.isNull(1));
+
+            // Row 2: [micros3]; the null element is dropped
+            assertFalse(block.isNull(2));
+            assertEquals(1, block.getValueCount(2));
+            assertEquals(micros3 * 1_000, block.getLong(block.getFirstValueIndex(2)));
         }
     }
 
@@ -4608,6 +4774,9 @@ public class ParquetFormatReaderTests extends ESTestCase {
         int days2020 = (int) (millis2020 / ParquetColumnDecoding.MILLIS_PER_DAY);
         long micros2000 = millis2000 * 1_000;
         long micros2020 = millis2020 * 1_000;
+        // timestamp[us] resolves to DATE_NANOS, so its published stats are epoch-nanos (matching the scan).
+        long nanos2000 = millis2000 * 1_000_000;
+        long nanos2020 = millis2020 * 1_000_000;
 
         MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT32)
@@ -4646,8 +4815,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals("date32 max must be epoch-millis", Optional.of(millis2020), d32Stats.maxValue());
 
         var tusStats = colStats.get("tus");
-        assertEquals("timestamp[us] min must be epoch-millis", Optional.of(millis2000), tusStats.minValue());
-        assertEquals("timestamp[us] max must be epoch-millis", Optional.of(millis2020), tusStats.maxValue());
+        assertEquals("timestamp[us] min must be epoch-nanos (DATE_NANOS)", Optional.of(nanos2000), tusStats.minValue());
+        assertEquals("timestamp[us] max must be epoch-nanos (DATE_NANOS)", Optional.of(nanos2020), tusStats.maxValue());
 
         var tmsStats = colStats.get("tms");
         assertEquals("timestamp[ms] min must be epoch-millis (no double-divide)", Optional.of(millis2000), tmsStats.minValue());
@@ -4658,19 +4827,22 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertFalse("expected at least one split range", ranges.isEmpty());
 
         // buildRowGroupStats is wired separately from extractStatistics, so assert every temporal
-        // column here too (date32, timestamp[us], timestamp[ms]) rather than date32 alone.
+        // column here too. date32 and timestamp[ms] publish epoch-millis; timestamp[us] is DATE_NANOS
+        // and publishes epoch-nanos.
         for (RangeAwareFormatReader.SplitRange range : ranges) {
             Map<String, Object> stats = range.statistics();
             for (String col : List.of("d32", "tus", "tms")) {
+                long lo = col.equals("tus") ? nanos2000 : millis2000;
+                long hi = col.equals("tus") ? nanos2020 : millis2020;
                 Object min = stats.get("_stats.columns." + col + ".min");
                 Object max = stats.get("_stats.columns." + col + ".max");
                 if (min != null) {
-                    long minMs = ((Number) min).longValue();
-                    assertTrue(col + " split min must be epoch-millis", minMs == millis2000 || minMs == millis2020);
+                    long minVal = ((Number) min).longValue();
+                    assertTrue(col + " split min must match scan-path decode", minVal == lo || minVal == hi);
                 }
                 if (max != null) {
-                    long maxMs = ((Number) max).longValue();
-                    assertTrue(col + " split max must be epoch-millis", maxMs == millis2000 || maxMs == millis2020);
+                    long maxVal = ((Number) max).longValue();
+                    assertTrue(col + " split max must match scan-path decode", maxVal == lo || maxVal == hi);
                 }
             }
         }
@@ -4721,10 +4893,13 @@ public class ParquetFormatReaderTests extends ESTestCase {
         PrimitiveType date32 = Types.required(PrimitiveType.PrimitiveTypeName.INT32).as(LogicalTypeAnnotation.dateType()).named("d");
         assertEquals(Long.valueOf(millis), ParquetColumnDecoding.decodeTemporalStat((int) days, date32));
 
+        // timestamp[us]/[ns] resolve to DATE_NANOS, so their stats decode to epoch-nanos (matching the scan).
         PrimitiveType tsMicros = Types.required(PrimitiveType.PrimitiveTypeName.INT64)
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
             .named("us");
-        assertEquals(Long.valueOf(millis), ParquetColumnDecoding.decodeTemporalStat(millis * 1_000, tsMicros));
+        assertEquals(Long.valueOf(millis * 1_000_000), ParquetColumnDecoding.decodeTemporalStat(millis * 1_000, tsMicros));
+        // A timestamp[us] stat beyond the date_nanos range returns null so the caller falls back to a scan.
+        assertNull(ParquetColumnDecoding.decodeTemporalStat(20_000_000_000_000_000L, tsMicros));
 
         PrimitiveType tsMillis = Types.required(PrimitiveType.PrimitiveTypeName.INT64)
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
@@ -4734,7 +4909,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         PrimitiveType tsNanos = Types.required(PrimitiveType.PrimitiveTypeName.INT64)
             .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
             .named("ns");
-        assertEquals(Long.valueOf(millis), ParquetColumnDecoding.decodeTemporalStat(millis * 1_000_000, tsNanos));
+        assertEquals(Long.valueOf(millis * 1_000_000), ParquetColumnDecoding.decodeTemporalStat(millis * 1_000_000, tsNanos));
 
         // TIME must mirror the scan path: TIME_MILLIS (physical INT32) stays raw ms; TIME_MICROS
         // scales x1_000 to nanos; TIME_NANOS is as-is.
@@ -4768,6 +4943,84 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertNull(ParquetColumnDecoding.decodeTemporalStat(5, plainInt));
         PrimitiveType plainLong = Types.required(PrimitiveType.PrimitiveTypeName.INT64).named("l");
         assertNull(ParquetColumnDecoding.decodeTemporalStat(5L, plainLong));
+    }
+
+    /**
+     * A timestamp[us] column that mixes an in-range value with one beyond the date_nanos range: the scan
+     * nulls the out-of-range value out, so the physical footer statistics no longer describe the scan.
+     * Both min/max and the null count must be poisoned (omitted / unknown) so MIN/MAX/COUNT fall back to a
+     * scan instead of trusting a raw micros extremum or an under-counted null count. Covered on both the
+     * {@code extractStatistics} (metadata) and {@code buildRowGroupStats} (split ranges) paths.
+     */
+    public void testOutOfRangeTimestampMicrosPoisonsStats() throws Exception {
+        long millis2000 = Instant.parse("2000-01-01T00:00:00Z").toEpochMilli();
+        long micros2000 = millis2000 * 1_000;
+        // micros * 1000 overflows Long, i.e. beyond the representable date_nanos range; the scan nulls it.
+        long microsOverflow = 20_000_000_000_000_000L;
+
+        MessageType schema = Types.buildMessage()
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("tus")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g1 = factory.newGroup();
+            g1.add("tus", micros2000);
+            Group g2 = factory.newGroup();
+            g2.add("tus", microsOverflow);
+            return List.of(g1, g2);
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        // --- extractStatistics path (metadata): min/max omitted, null count unknown ---
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertTrue("expected source statistics", metadata.statistics().isPresent());
+        var tusStats = metadata.statistics().get().columnStatistics().get().get("tus");
+        assertNotNull("column statistics entry must still exist (size is published)", tusStats);
+        assertEquals("out-of-range timestamp[us] min must be omitted", Optional.empty(), tusStats.minValue());
+        assertEquals("out-of-range timestamp[us] max must be omitted", Optional.empty(), tusStats.maxValue());
+        assertEquals("out-of-range timestamp[us] null count must be unknown", OptionalLong.empty(), tusStats.nullCount());
+
+        // --- buildRowGroupStats path (discoverSplitRanges): min/max + null_count keys dropped ---
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertFalse("expected at least one split range", ranges.isEmpty());
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            Map<String, Object> stats = range.statistics();
+            if (stats.containsKey("_stats.columns.tus.min") || stats.containsKey("_stats.columns.tus.max")) {
+                // The row group that only holds the in-range value may still publish a usable min/max; the
+                // one covering the overflow value must publish neither, and never a raw micros extremum.
+                Object min = stats.get("_stats.columns.tus.min");
+                Object max = stats.get("_stats.columns.tus.max");
+                if (min != null) {
+                    assertNotEquals("must never publish raw micros as min", microsOverflow, ((Number) min).longValue());
+                }
+                if (max != null) {
+                    assertNotEquals("must never publish raw micros as max", microsOverflow, ((Number) max).longValue());
+                }
+            }
+        }
+
+        // --- scan parity: the overflow row is nulled, so the scan sees one null the footer never counted ---
+        int nullsSeen = 0;
+        int rows = 0;
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 100)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                LongBlock block = (LongBlock) page.getBlock(0);
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    rows++;
+                    if (block.isNull(i)) {
+                        nullsSeen++;
+                    }
+                }
+                page.releaseBlocks();
+            }
+        }
+        assertEquals("both rows scanned", 2, rows);
+        assertEquals("the out-of-range value must be nulled on scan", 1, nullsSeen);
     }
 
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -123,6 +123,97 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         assertThat(fp.toString(), containsString(String.valueOf(millis * 1_000_000)));
     }
 
+    // --- DATE_NANOS pushdown (production path for timestamp[us]/[ns]) ---
+
+    public void testToFilterPredicateDateNanosOnNanosColumnIsExact() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
+            .named("ts")
+            .named("test");
+
+        long nanos = 1_700_000_000_123_456_789L;
+        Expression expr = eq("ts", DataType.DATE_NANOS, nanos);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(nanos)));
+    }
+
+    public void testToFilterPredicateDateNanosOnMicrosColumnScalesToMicros() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test");
+
+        long nanos = 1_700_000_000_123_456_000L; // exact multiple of 1_000 ns
+        long expectedMicros = nanos / 1_000;
+        Expression expr = eq("ts", DataType.DATE_NANOS, nanos);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(expectedMicros)));
+    }
+
+    public void testToFilterPredicateDateNanosMicrosGreaterThanRoundsOutward() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test");
+
+        long nanos = 1_700_000_000_123_456_789L; // not a multiple of 1_000 ns
+        // GT widens downward (floorDiv) so no matching micro is excluded (pushdown is RECHECK).
+        long expectedMicros = Math.floorDiv(nanos, 1_000L);
+        Expression expr = new GreaterThan(Source.EMPTY, attr("ts", DataType.DATE_NANOS), lit(nanos, DataType.DATE_NANOS), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(expectedMicros)));
+    }
+
+    public void testToFilterPredicateDateNanosMicrosEqNonDivisibleSkipsPushdown() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test");
+
+        long nanos = 1_700_000_000_123_456_789L; // not a multiple of 1_000 ns: no micro equals it exactly
+        Expression expr = eq("ts", DataType.DATE_NANOS, nanos);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        // No predicate is pushed; the scan + FilterExec recheck still yields the correct (empty) result.
+        assertNull(pushed.toFilterPredicate(schema));
+    }
+
+    public void testToFilterPredicateInListOnDateNanosMicros() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test");
+
+        long nanos1 = 1_000_000L; // 1_000 micros
+        long nanos2 = 2_000_000L; // 2_000 micros
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("ts", DataType.DATE_NANOS),
+            List.of(lit(nanos1, DataType.DATE_NANOS), lit(nanos2, DataType.DATE_NANOS))
+        );
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(inExpr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull(fp);
+        String repr = fp.toString();
+        assertThat(repr, containsString(String.valueOf(nanos1 / 1_000)));
+        assertThat(repr, containsString(String.valueOf(nanos2 / 1_000)));
+    }
+
     // --- DATE (INT32) ---
 
     public void testToFilterPredicateDateInt32() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
@@ -308,9 +308,17 @@ public final class SplitStats implements org.elasticsearch.xpack.esql.datasource
      * (Integer+Long→Long, Integer+Double→Double), plus Parquet FLOAT vs DOUBLE which both
      * map to ESQL {@code DOUBLE} at the schema level but retain distinct Java stat types.
      * Long+Double and Long+Float are intentionally incompatible (lossy above 2^53).
-     * DATETIME/DATE_NANOS is not handled — both are {@code Long} at the Java level so
-     * the same-class fast path covers them; if different epoch resolutions ever surface
-     * as different Java types in stats, they will fall through to the incompatible path.
+     * <p>
+     * Known limitation: DATETIME (epoch-millis) and DATE_NANOS (epoch-nanos) stats are both {@code Long}
+     * at the Java level, so the same-class fast path merges them numerically without unit awareness. This
+     * is only reachable across schema-inconsistent files that expose the <em>same</em> column with different
+     * temporal resolutions (e.g. a Parquet {@code timestamp[ms]} file and a {@code timestamp[us]} file, or a
+     * DATE_NANOS Arrow file), which {@link SchemaReconciliation} widens to DATE_NANOS while the per-split
+     * stats retain their original units. Reconciling stat units requires threading the reconciled column type
+     * into this value-only merge; a follow-up (elastic/elasticsearch#152859) does exactly that in
+     * {@link MergedSplitStats}, rescaling temporal values to a common unit (or poisoning on unknown/overflow)
+     * before this compare. Until it lands such a mixed-unit merge can produce a wrong extremum; uniform-schema
+     * datasets (the overwhelmingly common case) are correct regardless, because every split reports the same unit.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Nullable


### PR DESCRIPTION
Parquet TIMESTAMP(MICROS|NANOS) columns were mapped to DATETIME and
silently truncated to milliseconds. Map them to DATE_NANOS so the full
sub-millisecond precision is preserved (MILLIS stays DATETIME).

MICROS values are scaled x1000 to epoch-nanos; NANOS pass through.
Values outside the representable date_nanos range (~1677-2262) have no
nanosecond representation and are returned as null with a single
deduplicated response warning, on the baseline, optimized and list
decode paths.

Filter pushdown handles DATE_NANOS predicates, conservatively widening
nanosecond bounds to microsecond bounds for physical MICROS columns and
relying on the post-scan recheck for exactness.

Footer statistics decode to the same unit the scan emits (epoch-nanos
for MICROS/NANOS). An out-of-range MICROS stat is unusable because the
scan nulls the value out, so both min/max and the null count are
dropped for that column, forcing MIN/MAX/COUNT to fall back to a scan.

Relates to elastic/esql-planning#1027