### PR TITLE
Always report script queries as maximum cost

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -187,7 +188,7 @@ public class ScriptQueryBuilder extends LeafQueryBuilder<ScriptQueryBuilder> {
 
                 @Override
                 public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-                    DocIdSetIterator approximation = DocIdSetIterator.all(context.reader().maxDoc());
+                    DocIdSetIterator approximation = new ExpensiveMatchAllIterator(context.reader().maxDoc());
                     final FilterScript leafScript = filterScript.newInstance(new DocValuesDocReader(lookup, context));
                     leafScript._setCancellationCheck(cancellationCheck);
                     TwoPhaseIterator twoPhase = new TwoPhaseIterator(approximation) {
@@ -216,6 +217,26 @@ public class ScriptQueryBuilder extends LeafQueryBuilder<ScriptQueryBuilder> {
                     return false;
                 }
             };
+        }
+
+        /**
+         * A match-all approximation whose {@link #cost()} is deliberately reported as higher than any
+         * real iterator could report, including a worst-case {@link DocIdSetIterator#NO_MORE_DOCS}
+         * estimate from another clause. Running the script in {@code matches()} is the most expensive
+         * part of evaluating this query, so a conjunction with any other clause should always confirm
+         * that clause's approximation first rather than treating this one as cheap to lead with just
+         * because it happens to match every document.
+         */
+        private static final class ExpensiveMatchAllIterator extends FilterDocIdSetIterator {
+
+            ExpensiveMatchAllIterator(int maxDoc) {
+                super(DocIdSetIterator.all(maxDoc));
+            }
+
+            @Override
+            public long cost() {
+                return (long) DocIdSetIterator.NO_MORE_DOCS + 100;
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -12,9 +12,11 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ParsingException;
@@ -32,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -186,5 +189,36 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
             }""";
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
         assertThat(e.getMessage(), containsString("[script] query does not support token [VALUE_NULL]"));
+    }
+
+    public void testReportedCost() throws IOException {
+        SearchLookup lookup = new SearchLookup(null, null, (ctx, doc) -> null);
+        FilterScript.LeafFactory leafFactory = docReader -> new FilterScript(Map.of(), null, docReader) {
+            @Override
+            public boolean execute() {
+                return false;
+            }
+        };
+        ScriptQueryBuilder.ScriptQuery query = new ScriptQueryBuilder.ScriptQuery(new Script("test"), leafFactory, lookup);
+
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+                w.addDocument(new Document());
+                w.commit();
+            }
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                ContextIndexSearcher contextSearcher = new ContextIndexSearcher(
+                    reader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true
+                );
+                Scorer scorer = query.createWeight(contextSearcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f)
+                    .scorerSupplier(reader.leaves().getFirst())
+                    .get(DocIdSetIterator.NO_MORE_DOCS);
+                assertThat(scorer.iterator().cost(), greaterThan((long) DocIdSetIterator.NO_MORE_DOCS));
+            }
+        }
     }
 }


### PR DESCRIPTION
Script queries currently report their cost() as maxDoc(), which means they can be selected to lead iteration if in a conjunction with other iterators that don't have good cost heuristics. Script queries should *never* lead iteration. This changes the cost of a script query to report as Integer.MAX_VALUE + 100, meaning that it will always report as more expensive than anything other than another script query.