### PR TITLE
[ESQL] Reconcile temporal stat units in cross-file merge

### DIFF
--- a/docs/changelog/152859.yaml
+++ b/docs/changelog/152859.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152859
+summary: Reconcile temporal stat units in cross-file merge
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
@@ -11,12 +11,14 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitStats;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -136,14 +138,16 @@ public class CoalescedSplit implements ExternalSplit {
             return children.getFirst().splitStats();
         }
         List<SplitStats> childStats = new ArrayList<>(children.size());
+        List<Map<String, DataType>> childTypes = new ArrayList<>(children.size());
         for (ExternalSplit child : children) {
             SplitStats cs = child.splitStats();
             if (cs == null) {
                 return null;
             }
             childStats.add(cs);
+            childTypes.add(MergedSplitStats.readSchemaTypes(child));
         }
-        return new MergedSplitStats(childStats);
+        return new MergedSplitStats(childStats, childTypes);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStats.java
@@ -8,8 +8,15 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Lazily merges statistics from a list of child {@link org.elasticsearch.xpack.esql.datasources.spi.SplitStats} instances.
@@ -23,17 +30,58 @@ import java.util.List;
 public final class MergedSplitStats implements org.elasticsearch.xpack.esql.datasources.spi.SplitStats {
 
     private final List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children;
+    /**
+     * Per-child column name to ESQL {@link DataType}, parallel to {@link #children}. Entries (and the whole
+     * list) may be {@code null} when a child carries no per-file schema (older nodes, self-inferring sources).
+     * Used only to reconcile temporal resolution during {@link #columnMin}/{@link #columnMax}: {@code DATETIME}
+     * stats are epoch-millis and {@code DATE_NANOS} stats are epoch-nanos, but both are {@code Long} at the Java
+     * level, so a value-only merge would compare them unit-blind. See {@link #mergeExtremum}.
+     */
+    @Nullable
+    private final List<Map<String, DataType>> childColumnTypes;
 
     public MergedSplitStats(List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children) {
+        this(children, null);
+    }
+
+    public MergedSplitStats(
+        List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children,
+        @Nullable List<Map<String, DataType>> childColumnTypes
+    ) {
         if (children == null || children.isEmpty()) {
             throw new IllegalArgumentException("children cannot be null or empty");
         }
+        if (childColumnTypes != null && childColumnTypes.size() != children.size()) {
+            throw new IllegalArgumentException("childColumnTypes must be parallel to children");
+        }
         this.children = List.copyOf(children);
+        // Entries may be null, so this defensive copy cannot use List.copyOf (which rejects null elements).
+        this.childColumnTypes = childColumnTypes == null ? null : Collections.unmodifiableList(new ArrayList<>(childColumnTypes));
     }
 
     /** Returns the list of child stats that this instance merges. */
     public List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children() {
         return children;
+    }
+
+    /**
+     * Extracts a column-name to ESQL {@link DataType} map from a split's per-file {@code readSchema}, or
+     * {@code null} when the split carries no schema pin ({@link FileSplit#readSchema()} is {@code null}, e.g.
+     * older nodes or self-inferring sources). Used to reconcile temporal resolution (epoch-millis
+     * {@code DATETIME} vs epoch-nanos {@code DATE_NANOS}) across files before merging min/max stats. Under
+     * UNION_BY_NAME the per-file schema names match the unified stat keys, so no mapping translation is needed.
+     */
+    @Nullable
+    static Map<String, DataType> readSchemaTypes(ExternalSplit split) {
+        List<Attribute> schema = split instanceof FileSplit fileSplit ? fileSplit.readSchema() : null;
+        if (schema == null || schema.isEmpty()) {
+            return null;
+        }
+        Map<String, DataType> types = new HashMap<>(schema.size());
+        for (Attribute attr : schema) {
+            types.put(attr.name(), attr.dataType());
+        }
+        return types;
     }
 
     @Override
@@ -118,27 +166,7 @@ public final class MergedSplitStats implements org.elasticsearch.xpack.esql.data
     @Override
     @Nullable
     public Object columnMin(String name) {
-        Object result = null;
-        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
-            long nc = child.columnNullCount(name);
-            if (nc < 0) {
-                return null;
-            }
-            if (nc == child.rowCount()) {
-                continue;
-            }
-            Object childMin = child.columnMin(name);
-            if (childMin == null) {
-                // Present, not all-null, but reader produced no min — inconsistent; poison defensively.
-                return null;
-            }
-            result = SplitStats.mergedMin(result, childMin);
-            if (result == null) {
-                // Incompatible types — clear the stat
-                return null;
-            }
-        }
-        return result;
+        return mergeExtremum(name, true);
     }
 
     /**
@@ -150,8 +178,28 @@ public final class MergedSplitStats implements org.elasticsearch.xpack.esql.data
     @Override
     @Nullable
     public Object columnMax(String name) {
+        return mergeExtremum(name, false);
+    }
+
+    /**
+     * Shared min/max merge across children, unit-aware for temporal columns. Follows the SPI's implicit-nulls
+     * contract (children whose null count equals their row count contribute no candidate; an unknown null count
+     * poisons; a present-but-valueless child poisons).
+     * <p>
+     * When {@link #childColumnTypes} shows the column mixes temporal resolutions across files (a
+     * {@code DATETIME}/epoch-millis file and a {@code DATE_NANOS}/epoch-nanos file for the same column, which
+     * {@code SchemaReconciliation} widens to {@code DATE_NANOS}), each contributing value is rescaled to the
+     * finer unit (epoch-nanos) before comparison, so the returned extremum is in the reconciled unit. A
+     * contributing child whose type is unknown while others are temporal, or a millis value that overflows the
+     * nanosecond range, poisons the stat (returns {@code null}) so the aggregate falls back to a scan.
+     */
+    @Nullable
+    private Object mergeExtremum(String name, boolean wantMin) {
+        DataType targetUnit = temporalTarget(name);
+        boolean temporal = targetUnit != null;
         Object result = null;
-        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+        for (int i = 0; i < children.size(); i++) {
+            org.elasticsearch.xpack.esql.datasources.spi.SplitStats child = children.get(i);
             long nc = child.columnNullCount(name);
             if (nc < 0) {
                 return null;
@@ -159,16 +207,80 @@ public final class MergedSplitStats implements org.elasticsearch.xpack.esql.data
             if (nc == child.rowCount()) {
                 continue;
             }
-            Object childMax = child.columnMax(name);
-            if (childMax == null) {
+            Object value = wantMin ? child.columnMin(name) : child.columnMax(name);
+            if (value == null) {
+                // Present, not all-null, but reader produced no extremum — inconsistent; poison defensively.
                 return null;
             }
-            result = SplitStats.mergedMax(result, childMax);
+            if (temporal) {
+                DataType childType = columnType(i, name);
+                if (childType != DataType.DATETIME && childType != DataType.DATE_NANOS) {
+                    // Column is temporal in at least one file but this contributing child's unit is unknown;
+                    // we cannot safely rescale it, so poison rather than compare unit-blind.
+                    return null;
+                }
+                value = rescaleTemporal(value, childType, targetUnit);
+                if (value == null) {
+                    return null;
+                }
+            }
+            result = wantMin ? SplitStats.mergedMin(result, value) : SplitStats.mergedMax(result, value);
             if (result == null) {
+                // Incompatible types — clear the stat.
                 return null;
             }
         }
         return result;
+    }
+
+    /**
+     * Returns the finest temporal resolution ({@code DATE_NANOS} &gt; {@code DATETIME}) declared for the column
+     * across children that carry per-file types, or {@code null} when the column is non-temporal or no type
+     * information is available (in which case the merge stays value-only, preserving prior behavior).
+     */
+    @Nullable
+    private DataType temporalTarget(String name) {
+        if (childColumnTypes == null) {
+            return null;
+        }
+        DataType target = null;
+        for (int i = 0; i < children.size(); i++) {
+            DataType t = columnType(i, name);
+            if (t == DataType.DATE_NANOS) {
+                return DataType.DATE_NANOS;
+            }
+            if (t == DataType.DATETIME) {
+                target = DataType.DATETIME;
+            }
+        }
+        return target;
+    }
+
+    @Nullable
+    private DataType columnType(int childIndex, String name) {
+        if (childColumnTypes == null) {
+            return null;
+        }
+        Map<String, DataType> types = childColumnTypes.get(childIndex);
+        return types == null ? null : types.get(name);
+    }
+
+    /**
+     * Rescales a temporal stat value from its source unit to {@code targetUnit}. Only a {@code DATETIME}
+     * (epoch-millis) value widened to a {@code DATE_NANOS} (epoch-nanos) target needs scaling (×1_000_000);
+     * all other combinations pass through. Returns {@code null} if the millis value has no nanosecond
+     * representation (outside ~1677-2262), signalling the caller to poison the stat.
+     */
+    @Nullable
+    private static Object rescaleTemporal(Object value, DataType fromUnit, DataType targetUnit) {
+        if (fromUnit == DataType.DATETIME && targetUnit == DataType.DATE_NANOS) {
+            try {
+                return Math.multiplyExact(((Number) value).longValue(), 1_000_000L);
+            } catch (ArithmeticException overflow) {
+                return null;
+            }
+        }
+        return value;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 
 import java.io.IOException;
@@ -605,14 +606,16 @@ public final class SplitStats implements org.elasticsearch.xpack.esql.datasource
             return of(sourceMetadata);
         }
         List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> perSplitStats = new ArrayList<>(splits.size());
+        List<Map<String, DataType>> perSplitTypes = new ArrayList<>(splits.size());
         for (ExternalSplit split : splits) {
             org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats = split.splitStats();
             if (stats == null) {
                 return null;
             }
             perSplitStats.add(stats);
+            perSplitTypes.add(MergedSplitStats.readSchemaTypes(split));
         }
-        return new MergedSplitStats(perSplitStats);
+        return new MergedSplitStats(perSplitStats, perSplitTypes);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
@@ -8,8 +8,11 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class MergedSplitStatsTests extends ESTestCase {
 
@@ -189,6 +192,63 @@ public class MergedSplitStatsTests extends ESTestCase {
         assertEquals(-1, merged.columnSizeBytes("age"));
     }
 
+    // -- temporal-unit reconciliation (millis DATETIME vs nanos DATE_NANOS) --
+
+    public void testColumnMinMaxMixedTemporalUnitsRescaleToNanos() {
+        // File A: ts is DATETIME (epoch-millis), min=2 max=5 -> 2_000_000 / 5_000_000 ns.
+        // File B: ts is DATE_NANOS (epoch-nanos), min=1 max=9_999_999 ns.
+        SplitStats a = temporalColumn("ts", 2L, 5L);
+        SplitStats b = temporalColumn("ts", 1L, 9_999_999L);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b), types(DataType.DATETIME, DataType.DATE_NANOS));
+        assertEquals("min widened to epoch-nanos", 1L, ((Number) merged.columnMin("ts")).longValue());
+        assertEquals("max widened to epoch-nanos", 9_999_999L, ((Number) merged.columnMax("ts")).longValue());
+    }
+
+    public void testColumnMinMaxUniformDatetimeStaysMillis() {
+        // Both files DATETIME: no rescale, result stays epoch-millis (reconciled type is DATETIME).
+        SplitStats a = temporalColumn("ts", 2L, 5L);
+        SplitStats b = temporalColumn("ts", 1L, 9L);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b), types(DataType.DATETIME, DataType.DATETIME));
+        assertEquals(1L, ((Number) merged.columnMin("ts")).longValue());
+        assertEquals(9L, ((Number) merged.columnMax("ts")).longValue());
+    }
+
+    public void testColumnMinMaxUniformDateNanosUnchanged() {
+        SplitStats a = temporalColumn("ts", 2000L, 5000L);
+        SplitStats b = temporalColumn("ts", 1000L, 9000L);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b), types(DataType.DATE_NANOS, DataType.DATE_NANOS));
+        assertEquals(1000L, ((Number) merged.columnMin("ts")).longValue());
+        assertEquals(9000L, ((Number) merged.columnMax("ts")).longValue());
+    }
+
+    public void testColumnMinMaxTemporalWithUnknownTypeIsPoisoned() {
+        // Column is temporal in file A but file B carries no per-file type; we cannot safely rescale -> poison.
+        SplitStats a = temporalColumn("ts", 2L, 5L);
+        SplitStats b = temporalColumn("ts", 1L, 9L);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b), types(DataType.DATE_NANOS, null));
+        assertNull(merged.columnMin("ts"));
+        assertNull(merged.columnMax("ts"));
+    }
+
+    public void testColumnMinMaxMillisOverflowingNanosIsPoisoned() {
+        // File A DATETIME value has no nanosecond representation (millis * 1e6 overflows a long) -> poison.
+        SplitStats a = temporalColumn("ts", 10_000_000_000_000L, 20_000_000_000_000L);
+        SplitStats b = temporalColumn("ts", 1L, 9L);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b), types(DataType.DATETIME, DataType.DATE_NANOS));
+        assertNull(merged.columnMin("ts"));
+        assertNull(merged.columnMax("ts"));
+    }
+
+    public void testColumnMinMaxMixedUnitsWithoutTypesMergesUnitBlind() {
+        // No per-file types (old-node / self-infer path): behavior is unchanged value-only merge. Documents that
+        // the reconciliation only kicks in when per-file types are available.
+        SplitStats a = temporalColumn("ts", 2L, 5L);
+        SplitStats b = temporalColumn("ts", 1L, 9L);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(1L, ((Number) merged.columnMin("ts")).longValue());
+        assertEquals(9L, ((Number) merged.columnMax("ts")).longValue());
+    }
+
     // -- children() --
 
     public void testChildrenReturnsAllChildren() {
@@ -250,5 +310,19 @@ public class MergedSplitStatsTests extends ESTestCase {
         SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
         b.addColumn(name, -1L, null, null, -1L);
         return b.build();
+    }
+
+    private static SplitStats temporalColumn(String name, long minEpoch, long maxEpoch) {
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn(name, 0L, minEpoch, maxEpoch, 400);
+        return b.build();
+    }
+
+    private static List<Map<String, DataType>> types(DataType... perChild) {
+        List<Map<String, DataType>> result = new ArrayList<>(perChild.length);
+        for (DataType type : perChild) {
+            result.add(type == null ? null : Map.of("ts", type));
+        }
+        return result;
     }
 }


### PR DESCRIPTION
MergedSplitStats merged min/max stats across files by comparing raw
Longs. DATETIME (epoch-millis) and DATE_NANOS (epoch-nanos) are both
Long, so a column exposed with different temporal resolutions across
files (which schema reconciliation widens to DATE_NANOS) merged the
millis value unit-blind and reinterpreted it as nanos, yielding a
wrong MIN/MAX.

Thread each split per-file column type (already carried on the file
split read schema) into the cross-file merge. When a temporal column
mixes resolutions, rescale every contributing value to the finer unit
(epoch-nanos) before comparing, so the merged extremum is in the
reconciled unit. Poison the stat when a contributing unit is unknown
or a millis value has no nanosecond representation, forcing a scan.
Within-file merges and uniform-unit datasets are unchanged.