### PR TITLE
Fix schema reconciliation in non-flat col names

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
@@ -398,12 +398,30 @@ public final class SchemaReconciliation {
      * {@code NdJsonPageDecoder#hasDottedPrefixConflict}), so only those unrelated dotted columns
      * are excluded from the family; see {@link #resolveFamily} for why exempting the file's leaf
      * contribution too would silently reopen the conflict.
+     * <p>
+     * Only files whose {@link SourceMetadata#sourceType()} is {@link #supportsShapeConflictResolution
+     * shape-conflict-capable} ever enter this family vote — see that method for why. A file from
+     * any other format that happens to carry a name matching {@code root} or {@code root.*} is
+     * therefore never touched here, however it looks lexically: e.g. a CSV file with a literal
+     * {@code user.tag} header alongside another (CSV or NDJSON) file's scalar {@code user} column
+     * is not a shape conflict — both are ordinary, independent columns and both survive in the
+     * unified schema, one NULL-filled in whichever file lacks it, exactly like any other pair of
+     * unrelated column names would.
      */
     private static Map<StoragePath, List<Attribute>> resolveShapeConflicts(
         LinkedHashMap<String, MergeEntry> unified,
         Map<StoragePath, SourceMetadata> fileMetadata
     ) {
-        List<String> familyRoots = findFamilyRoots(unified.keySet());
+        Set<String> namesFromCapableFiles = new LinkedHashSet<>();
+        for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            if (supportsShapeConflictResolution(entry.getValue().sourceType()) == false) {
+                continue;
+            }
+            for (Attribute attr : entry.getValue().schema()) {
+                namesFromCapableFiles.add(attr.name());
+            }
+        }
+        List<String> familyRoots = findFamilyRoots(namesFromCapableFiles);
         if (familyRoots.isEmpty()) {
             return Map.of();
         }
@@ -433,6 +451,38 @@ public final class SchemaReconciliation {
         }
         emitShapeConflictWarnings(conflicts);
         return overrides;
+    }
+
+    /**
+     * Whether {@code sourceType} may participate in {@link #resolveShapeConflicts}: its reader
+     * must both (a) genuinely flatten nested objects into dotted attribute names, so a
+     * {@code root}/{@code root.*} pair can actually mean "scalar in one file, object in another"
+     * rather than two unrelated literal names, and (b) have a per-file, read-time mechanism that
+     * routes a pinned-shape mismatch through {@link org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy}
+     * once this pass overrides a losing file's {@code readSchema} — see {@link #resolveShapeConflicts}'s
+     * javadoc for how that override is used downstream.
+     * <p>
+     * Today only NDJSON satisfies both: {@code NdJsonSchemaInferrer} flattens
+     * {@code {"user": {"id": ...}}} into {@code user.id}, and {@code NdJsonPageDecoder}'s
+     * {@code shapeConflict} handling (elastic/esql-planning#1028) is exactly the read-time fallback
+     * (a) needs. Every other format fails at least one requirement, and enabling it there would
+     * silently drop <em>valid</em> UBN columns instead of resolving a real conflict:
+     * <ul>
+     *   <li>CSV/TSV headers are always literal — a {@code "."} never means nesting, so
+     *       {@code user} and {@code user.tag} in two CSV files are simply two unrelated columns,
+     *       not a shape conflict.</li>
+     *   <li>Iceberg never flattens structs (they're skipped as {@code UNSUPPORTED}), so any dotted
+     *       name it does surface is, like CSV, always a literal top-level column name.</li>
+     *   <li>Parquet and ORC <em>do</em> flatten nested structs into dotted names (satisfying (a)),
+     *       but neither reader has an equivalent of NDJSON's {@code shapeConflict} fallback for a
+     *       column pinned to a shape that disagrees with the file's actual footer-declared type
+     *       (failing (b)) — so overriding a losing Parquet/ORC file's {@code readSchema} here would
+     *       misfire (e.g. a read-time type error) instead of gracefully degrading through
+     *       {@code ErrorPolicy}.</li>
+     * </ul>
+     */
+    private static boolean supportsShapeConflictResolution(String sourceType) {
+        return "ndjson".equals(sourceType);
     }
 
     private static int dotDepth(String name) {
@@ -485,6 +535,11 @@ public final class SchemaReconciliation {
      * version of this method did) let such a file's scalar {@code root} silently keep coexisting
      * with a winning nested shape from another file, reopening the exact ambiguity this method
      * exists to close.
+     * <p>
+     * A file whose format is not {@link #supportsShapeConflictResolution shape-conflict-capable}
+     * (e.g. CSV, Iceberg, Parquet, ORC) is skipped outright, regardless of whether it happens to
+     * carry {@code root} or a {@code root.*} name — see {@link #resolveShapeConflicts} for why
+     * such names there are always literal/independent, never a genuine shape conflict.
      */
     @Nullable
     private static FamilyConflict resolveFamily(
@@ -507,6 +562,9 @@ public final class SchemaReconciliation {
         LinkedHashMap<StoragePath, List<String>> losingFileNames = new LinkedHashMap<>();
 
         for (Map.Entry<StoragePath, SourceMetadata> entry : fileMetadata.entrySet()) {
+            if (supportsShapeConflictResolution(entry.getValue().sourceType()) == false) {
+                continue;
+            }
             boolean hasLeaf = false;
             List<String> dottedNames = new ArrayList<>();
             for (Attribute attr : entry.getValue().schema()) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -373,7 +373,7 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         StoragePath a = path("s3://b/a.ndjson");
         StoragePath b = path("s3://b/b.ndjson");
-        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile, "ndjson"), b, meta(objectFile, "ndjson"));
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
 
         assertThat(
@@ -395,7 +395,7 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         StoragePath a = path("s3://b/a.ndjson");
         StoragePath b = path("s3://b/b.ndjson");
-        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(objectFile), b, meta(scalarFile));
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(objectFile, "ndjson"), b, meta(scalarFile, "ndjson"));
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
 
         assertThat(
@@ -423,7 +423,7 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         StoragePath a = path("s3://b/a.ndjson");
         StoragePath b = path("s3://b/b.ndjson");
-        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile, "ndjson"), b, meta(objectFile, "ndjson"));
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
 
         List<Attribute> losingReadSchema = result.perFileInfo().get(b).fileSchema().attributes();
@@ -446,7 +446,7 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         StoragePath a = path("s3://b/a.ndjson");
         StoragePath b = path("s3://b/b.ndjson");
-        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile), b, meta(objectFile));
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile, "ndjson"), b, meta(objectFile, "ndjson"));
         SchemaReconciliation.reconcileUnionByName(metadata);
 
         List<String> warnings = drainWarningMessages();
@@ -467,9 +467,9 @@ public class SchemaReconciliationTests extends ESTestCase {
         StoragePath b = path("s3://b/b.ndjson");
         StoragePath c = path("s3://b/c.ndjson");
         Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
-        metadata.put(a, meta(objectFile1));
-        metadata.put(b, meta(scalarFile));
-        metadata.put(c, meta(objectFile2));
+        metadata.put(a, meta(objectFile1, "ndjson"));
+        metadata.put(b, meta(scalarFile, "ndjson"));
+        metadata.put(c, meta(objectFile2, "ndjson"));
 
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
 
@@ -511,9 +511,9 @@ public class SchemaReconciliationTests extends ESTestCase {
         StoragePath objectPath = path("s3://b/b.ndjson");
         StoragePath bothPath = path("s3://b/c.ndjson");
         Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
-        metadata.put(scalarPath, meta(scalarFile));
-        metadata.put(objectPath, meta(objectFile));
-        metadata.put(bothPath, meta(bothShapesFile));
+        metadata.put(scalarPath, meta(scalarFile, "ndjson"));
+        metadata.put(objectPath, meta(objectFile, "ndjson"));
+        metadata.put(bothPath, meta(bothShapesFile, "ndjson"));
 
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
 
@@ -554,9 +554,9 @@ public class SchemaReconciliationTests extends ESTestCase {
         StoragePath scalarPath = path("s3://b/b.ndjson");
         StoragePath bothPath = path("s3://b/c.ndjson");
         Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
-        metadata.put(objectPath, meta(objectFile));
-        metadata.put(scalarPath, meta(scalarFile));
-        metadata.put(bothPath, meta(bothShapesFile));
+        metadata.put(objectPath, meta(objectFile, "ndjson"));
+        metadata.put(scalarPath, meta(scalarFile, "ndjson"));
+        metadata.put(bothPath, meta(bothShapesFile, "ndjson"));
 
         SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
 
@@ -604,6 +604,95 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(a, metadata));
         assertThat(e.getMessage(), containsString("Schema mismatch"));
+    }
+
+    /**
+     * Regression for the review feedback on #152775: {@link SchemaReconciliation#resolveFamily}
+     * only has flattened column names to work with, so a {@code root}/{@code root.*} pair can be a
+     * genuine cross-file scalar/object conflict (NDJSON) or two entirely unrelated, independent
+     * columns that merely share a naming prefix — e.g. a CSV file whose header is literally
+     * {@code user.tag} next to another CSV file's ordinary {@code user} column. CSV headers are
+     * never nested, so these must both survive in the unified schema, NULL-filled in whichever
+     * file lacks them, exactly like any other unrelated pair of column names — not be treated as a
+     * shape conflict that silently drops one of them.
+     */
+    public void testUnionByNameScalarAndDottedLiteralCoexistForNonNdjsonFormat() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> literalDottedFile = List.of(attr("event", DataType.INTEGER), attr("user.tag", DataType.KEYWORD));
+
+        StoragePath a = path("s3://b/a.csv");
+        StoragePath b = path("s3://b/b.csv");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile, "csv"), b, meta(literalDottedFile, "csv"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(
+            "both the literal [user] and [user.tag] columns must survive independently, not collapse to one shape",
+            userFamily(result),
+            equalTo(List.of("user", "user.tag"))
+        );
+        List<Attribute> unifiedAttributes = result.unifiedSchema().attributes();
+        assertThat(
+            unifiedAttributes.stream().filter(at -> at.name().equals("user")).findFirst().orElseThrow().nullable(),
+            equalTo(Nullability.TRUE)
+        );
+        assertThat(
+            unifiedAttributes.stream().filter(at -> at.name().equals("user.tag")).findFirst().orElseThrow().nullable(),
+            equalTo(Nullability.TRUE)
+        );
+        assertThat(result.perFileInfo().get(a).fileSchema().attributes(), equalTo(scalarFile));
+        assertThat(result.perFileInfo().get(b).fileSchema().attributes(), equalTo(literalDottedFile));
+        assertNoResponseWarnings();
+    }
+
+    /**
+     * Same regression as {@link #testUnionByNameScalarAndDottedLiteralCoexistForNonNdjsonFormat}
+     * but for Parquet: unlike CSV, Parquet's reader genuinely flattens nested structs into dotted
+     * names, but it has no equivalent of NDJSON's {@code shapeConflict} read-time fallback for a
+     * column pinned to a shape that disagrees with the file's own footer-declared type — so this
+     * pass must not touch Parquet files either. See {@code supportsShapeConflictResolution}.
+     */
+    public void testUnionByNameScalarVsObjectConflictIgnoredForParquetFormat() {
+        List<Attribute> scalarFile = List.of(attr("event", DataType.INTEGER), attr("user", DataType.KEYWORD));
+        List<Attribute> objectFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+
+        StoragePath a = path("s3://b/a.parquet");
+        StoragePath b = path("s3://b/b.parquet");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(scalarFile, "parquet"), b, meta(objectFile, "parquet"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(userFamily(result), equalTo(List.of("user", "user.id", "user.tier")));
+        assertThat(result.perFileInfo().get(a).fileSchema().attributes(), equalTo(scalarFile));
+        assertThat(result.perFileInfo().get(b).fileSchema().attributes(), equalTo(objectFile));
+        assertNoResponseWarnings();
+    }
+
+    /**
+     * A single NDJSON file's nested {@code user.*} shape must not be treated as conflicting with a
+     * literal {@code user.tag} column from an unrelated CSV file in the same query — only files
+     * whose format actually supports shape-conflict resolution ever enter the family vote, and one
+     * ndjson contributor alone (agreeing with itself) is not a conflict.
+     */
+    public void testUnionByNameMixedFormatsOnlyNdjsonParticipatesInFamily() {
+        List<Attribute> ndjsonFile = List.of(
+            attr("event", DataType.INTEGER),
+            attr("user.id", DataType.KEYWORD),
+            attr("user.tier", DataType.KEYWORD)
+        );
+        List<Attribute> csvFile = List.of(attr("event", DataType.INTEGER), attr("user.tag", DataType.KEYWORD));
+
+        StoragePath a = path("s3://b/a.ndjson");
+        StoragePath b = path("s3://b/b.csv");
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(a, meta(ndjsonFile, "ndjson"), b, meta(csvFile, "csv"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(userFamily(result), equalTo(List.of("user.id", "user.tier", "user.tag")));
+        assertThat(result.perFileInfo().get(a).fileSchema().attributes(), equalTo(ndjsonFile));
+        assertThat(result.perFileInfo().get(b).fileSchema().attributes(), equalTo(csvFile));
+        assertNoResponseWarnings();
     }
 
     /** The {@code [user]}-family column names present in the unified schema, in schema order. */
@@ -1013,7 +1102,12 @@ public class SchemaReconciliationTests extends ESTestCase {
     }
 
     private static SourceMetadata meta(List<Attribute> schema) {
-        return new SimpleMetadata(schema);
+        return new SimpleMetadata(schema, "parquet");
+    }
+
+    /** Like {@link #meta(List)} but with an explicit {@code sourceType}, e.g. {@code "ndjson"}. */
+    private static SourceMetadata meta(List<Attribute> schema, String sourceType) {
+        return new SimpleMetadata(schema, sourceType);
     }
 
     private static Map<StoragePath, SourceMetadata> orderedMap(StoragePath k1, SourceMetadata v1, StoragePath k2, SourceMetadata v2) {
@@ -1025,9 +1119,11 @@ public class SchemaReconciliationTests extends ESTestCase {
 
     private static class SimpleMetadata implements SourceMetadata {
         private final List<Attribute> schema;
+        private final String sourceType;
 
-        SimpleMetadata(List<Attribute> schema) {
+        SimpleMetadata(List<Attribute> schema, String sourceType) {
             this.schema = schema;
+            this.sourceType = sourceType;
         }
 
         @Override
@@ -1037,7 +1133,7 @@ public class SchemaReconciliationTests extends ESTestCase {
 
         @Override
         public String sourceType() {
-            return "parquet";
+            return sourceType;
         }
 
         @Override


### PR DESCRIPTION
This addresses an issue with `resolveFamily` in
`SchemaReconciliation.java` only detecting cross-file `root`/`root.*` name pairs and treating them as scalar/object shape conflicts purely by string matching, while reconciliation only seeings flattened attribute names, so not being able to tell a genuinely nested field `({"user": {"tag": ...}})` from a literal dotted key.

Related: https://github.com/elastic/elasticsearch/pull/152775#pullrequestreview-4625015171