### PR TITLE
ES|QL: external CSV/TSV — preserve whitespace, parse header with CSV rules, unify no-trim tokenizer

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
@@ -67,6 +67,7 @@ public class CsvDataSourcePlugin extends Plugin implements DataSourcePlugin {
         "multi_value_syntax",
         "header_row",
         "column_prefix",
+        "trim_spaces",
         "schema_sample_size"
     );
 

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -55,9 +55,11 @@ import java.util.Locale;
  *                           mirroring schema inference). Jackson only ever
  *                           trimmed unquoted values; with this off an unquoted padded value is preserved,
  *                           matching RFC 4180 and the byte-fidelity posture of {@link Mode#PLAIN}. Known
- *                           limitation: on the Jackson read path the FIRST column still loses its leading
- *                           whitespace (Jackson skips it at record start regardless of the feature); every
- *                           other column and all trailing whitespace is preserved.
+ *                           limitation: the Jackson read path — {@code mode: escaped}, or the direct-block
+ *                           fallback when it is disabled — still loses the FIRST column's leading whitespace
+ *                           (Jackson skips it at record start regardless of the feature); every other column
+ *                           and all trailing whitespace is preserved. The default PLAIN/QUOTED no-trim read
+ *                           uses the house grammar, which preserves it.
  */
 public record CsvFormatOptions(
     char delimiter,

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -55,11 +55,11 @@ import java.util.Locale;
  *                           mirroring schema inference). Jackson only ever
  *                           trimmed unquoted values; with this off an unquoted padded value is preserved,
  *                           matching RFC 4180 and the byte-fidelity posture of {@link Mode#PLAIN}. Known
- *                           limitation: the Jackson read path — {@code mode: escaped}, or the direct-block
- *                           fallback when it is disabled — still loses the FIRST column's leading whitespace
- *                           (Jackson skips it at record start regardless of the feature); every other column
- *                           and all trailing whitespace is preserved. The default PLAIN/QUOTED no-trim read
- *                           uses the house grammar, which preserves it.
+ *                           limitation: {@code mode: escaped} (the one dialect that stays on Jackson under
+ *                           no-trim) still loses the FIRST column's leading whitespace (Jackson skips it at
+ *                           record start regardless of the feature); every other column and all trailing
+ *                           whitespace is preserved. PLAIN/QUOTED no-trim reads — including when the
+ *                           direct-block path is disabled — use the house grammar, which preserves it.
  */
 public record CsvFormatOptions(
     char delimiter,

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -49,6 +49,15 @@ import java.util.Locale;
  *                           a raw newline is always a record boundary and a raw delimiter always a
  *                           field boundary, which is what allows the no-quote fast scan.
  * @param escaping           whether {@link #escapeChar} is consulted (see {@link #escapeChar}).
+ * @param trimSpaces         whether surrounding ASCII whitespace is trimmed from field values
+ *                           (default: {@code false}). Applies to string content only — typed
+ *                           (non-string) parses always tolerate padding (they trim before parsing,
+ *                           mirroring schema inference). Jackson only ever
+ *                           trimmed unquoted values; with this off an unquoted padded value is preserved,
+ *                           matching RFC 4180 and the byte-fidelity posture of {@link Mode#PLAIN}. Known
+ *                           limitation: on the Jackson read path the FIRST column still loses its leading
+ *                           whitespace (Jackson skips it at record start regardless of the feature); every
+ *                           other column and all trailing whitespace is preserved.
  */
 public record CsvFormatOptions(
     char delimiter,
@@ -63,7 +72,8 @@ public record CsvFormatOptions(
     boolean headerRow,
     String columnPrefix,
     boolean quoting,
-    boolean escaping
+    boolean escaping,
+    boolean trimSpaces
 ) {
 
     public enum MultiValueSyntax {
@@ -142,7 +152,8 @@ public record CsvFormatOptions(
         true,
         DEFAULT_COLUMN_PREFIX,
         true,
-        true
+        true,
+        false // trimSpaces (default; see the record javadoc)
     );
 
     /**
@@ -165,7 +176,8 @@ public record CsvFormatOptions(
         true,
         DEFAULT_COLUMN_PREFIX,
         false,
-        false
+        false,
+        false // trimSpaces (default; see the record javadoc)
     );
 
     /**
@@ -199,7 +211,8 @@ public record CsvFormatOptions(
             headerRow,
             columnPrefix,
             true,
-            true
+            true,
+            false // trimSpaces (default; see the record javadoc)
         );
     }
 

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -2202,7 +2202,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     if (escapeAware && c == esc) {
                         if (q + 1 < len) {
-                            value.append(decodeEscapeChar(record.charAt(q + 1)));
+                            value.append(decodeQuotedEscapeChar(record.charAt(q + 1)));
                             decodedLen++;
                             q += 2;
                         } else {
@@ -2285,7 +2285,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             char c = record.charAt(k);
             if (c == esc) {
                 if (k + 1 < end) {
-                    value.append(decodeEscapeChar(record.charAt(++k)));
+                    value.append(decodeQuotedEscapeChar(record.charAt(++k)));
                 }
                 // else: trailing lone escape, dropped
             } else {
@@ -2438,7 +2438,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
     /**
      * C-style escape decode: maps {@code \t}, {@code \n}, {@code \r}, {@code \0}, {@code \b},
      * {@code \f} to their control-character equivalents; any other {@code \c} decodes to {@code c}.
-     * Shared by {@link #decodeFieldValue} (Jackson path) and the direct-to-block walkers.
+     * This is the {@code mode: escaped} (quoting off) semantics, used by {@link #decodeFieldValue}.
+     * The QUOTED + escaping dialect uses {@link #decodeQuotedEscapeChar} instead — that dialect follows
+     * Jackson's CSV escape, which is a strictly smaller control set.
      */
     static char decodeEscapeChar(char next) {
         return switch (next) {
@@ -2449,6 +2451,25 @@ public class CsvFormatReader implements SegmentableFormatReader {
             case 'b' -> '\b';
             case 'f' -> '\f';
             // Any other \c is c — including \\ and \' — matching the C-style parse rule.
+            default -> next;
+        };
+    }
+
+    /**
+     * Escape decode for the QUOTED dialect with escaping on ({@code quote}/{@code escape} both live),
+     * matching Jackson's {@code CsvDecoder}: only {@code \t}, {@code \n}, {@code \r}, {@code \0} are
+     * control escapes; every other {@code \c} — including {@code \b} and {@code \f} — is the literal
+     * {@code c} (the escape merely protects the next character). This is a strict subset of the C-style
+     * {@link #decodeEscapeChar} set, which additionally maps {@code \b}/{@code \f} to control chars; that
+     * fuller set stays confined to {@code mode: escaped}, whose fallback is Jackson-with-C-style anyway.
+     */
+    static char decodeQuotedEscapeChar(char next) {
+        return switch (next) {
+            case 't' -> '\t';
+            case 'n' -> '\n';
+            case 'r' -> '\r';
+            case '0' -> '\0';
+            // Everything else — including \b, \f, \\ and \' — is the literal next character (Jackson's CSV rule).
             default -> next;
         };
     }
@@ -3869,7 +3890,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     if (escapeAware && c == esc) {
                         if (q + 1 < to) {
-                            cell.append(decodeEscapeChar(buf[q + 1]));
+                            cell.append(decodeQuotedEscapeChar(buf[q + 1]));
                             q += 2;
                         } else {
                             q++;
@@ -3885,7 +3906,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     char c = buf[j];
                     if (escapeAware && c == esc) {
                         if (j + 1 < to) {
-                            cell.append(decodeEscapeChar(buf[j + 1]));
+                            cell.append(decodeQuotedEscapeChar(buf[j + 1]));
                             j += 2;
                         } else {
                             j++;
@@ -4634,7 +4655,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         if (escapeAware && c == esc) {
                             if (q + 1 < len) {
                                 if (value != null) {
-                                    value.append(decodeEscapeChar(buf[q + 1]));
+                                    value.append(decodeQuotedEscapeChar(buf[q + 1]));
                                 }
                                 decodedLen++;
                                 q += 2;
@@ -4777,7 +4798,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 char c = buf[k];
                 if (c == esc) {
                     if (k + 1 < end) {
-                        value.append(decodeEscapeChar(buf[++k]));
+                        value.append(decodeQuotedEscapeChar(buf[++k]));
                     }
                     // else: trailing lone escape, dropped
                 } else {
@@ -4839,7 +4860,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 char decoded;
                 if (buf[k] == esc) {
                     if (k + 1 < end) {
-                        decoded = decodeEscapeChar(buf[++k]);
+                        decoded = decodeQuotedEscapeChar(buf[++k]);
                     } else {
                         continue; // trailing lone escape, dropped
                     }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -4326,7 +4326,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 try {
                     return splitAndConvertQuoted(buf, from, to);
                 } catch (MalformedRowException e) {
-                    onRowError("CSV parse error: " + e.getMessage(), e, EMPTY_ROW, true);
+                    onRowError("CSV parse error: " + CsvErrorMessages.summarize(e.getMessage()), e, EMPTY_ROW, true);
                     return false;
                 }
             }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -2003,6 +2003,18 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         continue;
                     }
                     inQuotes = false;
+                    // Trailing whitespace between the closing quote and the delimiter/EOL is not part of the value
+                    // (matches the direct quoted walker), so skip it; otherwise no-trim bracket mode keeps it
+                    // ("y"+ws -> value+ws) while the quoted grammar drops it. Non-whitespace after the closing
+                    // quote is still concatenated; bracket mode is lenient there by design.
+                    int j = i + 1;
+                    while (j < line.length() && line.charAt(j) <= ' ') {
+                        j++;
+                    }
+                    if (j == line.length() || line.charAt(j) == delim) {
+                        i = j;
+                        continue;
+                    }
                 } else if (c == esc && i + 1 < line.length() && line.charAt(i + 1) == delim) {
                     current.append(delim);
                     i += 2;
@@ -4946,6 +4958,17 @@ public class CsvFormatReader implements SegmentableFormatReader {
                             continue;
                         }
                         inQuotes = false;
+                        // Trailing whitespace between the closing quote and the delimiter/EOL is not part of
+                        // the value (matches the direct quoted walker and splitCommaDelimiterBracketAwareFields);
+                        // skip it so no-trim bracket mode agrees. Non-whitespace is still concatenated.
+                        int j = i + 1;
+                        while (j < line.length() && line.charAt(j) <= ' ') {
+                            j++;
+                        }
+                        if (j == line.length() || line.charAt(j) == delim) {
+                            i = j;
+                            continue;
+                        }
                     } else if (c == esc && i + 1 < line.length() && line.charAt(i + 1) == delim) {
                         if (isProjected) current.append(delim);
                         numericValid = false;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -1406,7 +1406,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         boolean useDirectBlockPlain = directEligible && options.quoting() == false;
         boolean useDirectBlockQuoted = directEligible && options.quoting();
         boolean useDirectBlock = useDirectBlockPlain || useDirectBlockQuoted;
-        // The quoted walk performs C-style escape decoding, so the record reader must carry escaped
+        // The quoted walk decodes escapes (Jackson's quoted-escape rule), so the record reader must carry escaped
         // terminators/quotes verbatim to match Jackson's record boundaries (see CsvLogicalRecordReader).
         // This is needed on every recordReader-backed data path for a QUOTED + escaping dialect — the
         // direct quoted walk, the _rowPosition per-record read, and the no-trim reroute onto the house
@@ -2168,7 +2168,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * QUOTED (RFC 4180, optional backslash escapes) split — the string-domain twin of
      * {@link CsvBatchIterator#splitAndConvertQuoted}. A field-leading quote (after optional outer
      * whitespace, never the delimiter itself even when it is a whitespace byte such as TAB) opens a quoted
-     * region where {@code ""} is a literal quote and, when escaping is on, {@code \}+char is C-style decoded;
+     * region where {@code ""} is a literal quote and, when escaping is on, {@code \}+char is decoded with Jackson's quoted-escape rule;
      * quoted content (including inner whitespace) is kept verbatim, an empty quoted field is {@code ""}
      * (downstream null), and only whitespace may follow a closing quote before the delimiter. Unquoted
      * fields are extracted by {@link #emitPlainSplitField} (no escape) or {@link #emitUnquotedEscapedSplitField}
@@ -4609,14 +4609,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
         /**
          * Direct-to-block field splitting and typed conversion for the quoted (RFC 4180) path,
          * including optional backslash escapes. Matches Jackson's {@code TRIM_SPACES} <em>whitespace and
-         * quote</em> grammar (field boundaries, outer-whitespace trimming, {@code ""} quote doubling) — but
-         * NOT its escape decoding: this walker C-style-decodes an escape sequence ({@code \t} → a TAB byte),
-         * whereas Jackson's escape is next-char-literal ({@code \t} → {@code t}). Under no-trim this walker
+         * quote</em> grammar (field boundaries, outer-whitespace trimming, {@code ""} quote doubling)
+         * <em>and</em> its escape decoding: {@link #decodeQuotedEscapeChar} reproduces Jackson's quoted-escape
+         * rule ({@code \t \n \r \0} control, every other {@code \c} literal). Under no-trim this walker
          * (and its string-domain twin {@link #splitRecordFields}) IS the grammar and Jackson is not used,
          * because Jackson's no-trim tokenization diverges (padded quotes mis-split, first-column leading
          * whitespace is eaten). A field-leading quote (after optional outer whitespace)
          * opens a quoted region where {@code ""} is a literal quote and, when escaping is on, {@code \}+char
-         * is C-style decoded; quoted content (including inner whitespace and embedded newlines) is preserved
+         * is decoded with Jackson's quoted-escape rule; quoted content (including inner whitespace and embedded newlines) is preserved
          * verbatim, while unquoted fields are trimmed only for typed columns (a keyword keeps its bytes
          * unless trim_spaces). Non-whitespace after a closing quote is a row error, and an empty quoted field
          * ({@code ""}) is null. Simple unquoted fields (no escape) take the same char-range fast path as
@@ -4781,18 +4781,19 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         /**
-         * Converts an unquoted field that contains the escape character: trims leading raw whitespace
-         * (matching Jackson's skip-leading-whitespace pass before the decode loop), applies C-style
-         * escape decoding into the reused buffer, then trims trailing whitespace from the <em>decoded</em>
-         * result (matching Jackson's {@code TRIM_SPACES} pass over the collected decoded chars). A
-         * trailing lone escape (no following char) is dropped, matching Jackson.
+         * Converts an unquoted field that contains the escape character: decodes {@code \}-escapes via
+         * {@link #decodeQuotedEscapeChar} (Jackson's quoted-escape semantics) into the reused buffer.
+         * Whitespace trimming is gated on {@code trim_spaces} only (leading raw, then decoded-trailing),
+         * mirroring the house peer {@link #emitUnquotedEscapedSplitField}; the typed trim is deferred to
+         * {@code tryConvertValue}. Under the no-trim default this method trims nothing and IS the house
+         * grammar (Jackson is not used). A trailing lone escape (no following char) is dropped.
          *
-         * <p>The trim order (raw-leading, decode, decoded-trailing) matches Jackson exactly: Jackson
-         * skips raw leading whitespace before entering its escape decode loop, then trims trailing
-         * whitespace from the collected (already-decoded) value. Trimming raw trailing whitespace before
-         * decoding (the naive order) would differ when the raw span ends with {@code \ }+whitespace,
-         * because Jackson decodes that pair to whitespace and then removes it, while a raw trim stops at
-         * {@code \} and leaves it as a lone escape (dropped), producing a different boundary value.
+         * <p>When trimming (i.e. {@code trim_spaces}), the order raw-leading, decode, decoded-trailing
+         * matches Jackson's: it skips raw leading whitespace before its escape-decode loop, then trims
+         * trailing whitespace from the collected (already-decoded) value. Trimming raw trailing whitespace
+         * before decoding would differ when the raw span ends with {@code \ }+whitespace, since the escape
+         * decodes that pair to whitespace which is then removed, whereas a raw trim stops at {@code \} and
+         * leaves a lone escape (dropped).
          */
         private boolean emitUnquotedEscapedField(char[] buf, int start, int end, int bufIdx, DataType dt) {
             // Only trim_spaces trims here (mirrors the house peer emitUnquotedEscapedSplitField); the typed
@@ -4843,9 +4844,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
         /**
          * Enforces the field-size cap for a non-projected unquoted field that contains escapes. Escapes
          * only shrink the value, so the raw span is an upper bound on the trimmed decoded length; the
-         * decode walk is only paid when the raw span already exceeds the cap. Mirrors
-         * {@link #emitUnquotedEscapedField}'s trim order (raw-leading trim, decode, decoded-trailing trim)
-         * so the counted length matches the value Jackson would have produced.
+         * decode walk is only paid when the raw span already exceeds the cap. The cap governs the
+         * tokenized value — trimmed only under {@code trim_spaces} (raw-leading, decode, decoded-trailing),
+         * matching {@link #emitUnquotedEscapedField} — so projection cannot change whether a row survives.
          *
          * @return {@code true} if within the cap, {@code false} if it was rejected (and the row dropped)
          */

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -4783,16 +4783,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
          * {@code \} and leaves it as a lone escape (dropped), producing a different boundary value.
          */
         private boolean emitUnquotedEscapedField(char[] buf, int start, int end, int bufIdx, DataType dt) {
-            // Typed columns always trim (they parse); string columns keep their bytes unless trim_spaces is set.
+            // Only trim_spaces trims here (mirrors the house peer emitUnquotedEscapedSplitField); the typed
+            // trim is deferred to tryConvertValue below, so a whitespace-bearing null_value survives to its
+            // raw-marker check instead of being stripped first.
             final boolean trimSpaces = options.trimSpaces();
-            final boolean trim = isStringType(dt) == false || trimSpaces;
-            // Trim raw leading whitespace (matches Jackson's skip-leading-ws before the decode loop). Remember
-            // how much we skipped: under no-trim Jackson counts it toward maxStringLength, so the cap must too.
-            int rawLeadingWs = 0;
-            if (trim) {
+            if (trimSpaces) {
                 while (start < end && buf[start] <= ' ') {
                     start++;
-                    rawLeadingWs++;
                 }
             }
             if (start == end) {
@@ -4815,7 +4812,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             // Trim trailing whitespace from the decoded value (matches Jackson's TRIM_SPACES: trim the
             // collected decoded chars, not the raw input) — gated the same way as the leading trim.
             int trimEnd = value.length();
-            if (trim) {
+            if (trimSpaces) {
                 while (trimEnd > 0 && value.charAt(trimEnd - 1) <= ' ') {
                     trimEnd--;
                 }
@@ -4824,12 +4821,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 stageNullValue(bufIdx);
                 return true;
             }
-            // The cap (Jackson's maxStringLength) governs the tokenized value: fully trimmed when trim_spaces
-            // is set, otherwise the raw token including the leading whitespace skipped above — matching the
-            // unprojected cap check so projection cannot change whether a row survives.
-            int capLen = trimSpaces ? trimEnd : value.length() + rawLeadingWs;
-            if (capLen > maxFieldChars) {
-                return rejectFieldTooLarge(capLen);
+            // Cap on the tokenized value (full decoded length under no-trim, trimmed under trim_spaces).
+            if (trimEnd > maxFieldChars) {
+                return rejectFieldTooLarge(trimEnd);
             }
             return emitConvertedStageField(trimEnd == value.length() ? value.toString() : value.substring(0, trimEnd), bufIdx, dt);
         }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -161,6 +161,10 @@ import java.util.regex.Pattern;
  *           a 0-based counter is appended (e.g. {@code col0, col1, col2, ...}). Ignored when
  *           {@code header_row} is {@code true}. An empty prefix yields purely numeric names
  *           ({@code 0, 1, 2, ...}) which must be backtick-quoted in ES|QL queries.</td></tr>
+ *   <tr><td>{@code trim_spaces}</td><td>{@code false}</td>
+ *       <td>When {@code true}, surrounding ASCII whitespace is trimmed from field values. Default
+ *           {@code false} keeps values verbatim (RFC 4180 — spaces are part of a field). Applies to
+ *           string content only; typed columns tolerate padding regardless.</td></tr>
  * </table>
  *
  * <h2>Mode, quote and escape — the override matrix</h2>
@@ -361,6 +365,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     static final String CONFIG_MULTI_VALUE_SYNTAX = "multi_value_syntax";
     static final String CONFIG_HEADER_ROW = "header_row";
     static final String CONFIG_COLUMN_PREFIX = "column_prefix";
+    static final String CONFIG_TRIM_SPACES = "trim_spaces";
     static final String CONFIG_SCHEMA_SAMPLE_SIZE = "schema_sample_size";
 
     /** Keys recognised by {@link #withConfigTrackingConsumedKeys(Map)}. */
@@ -377,6 +382,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         CONFIG_MULTI_VALUE_SYNTAX,
         CONFIG_HEADER_ROW,
         CONFIG_COLUMN_PREFIX,
+        CONFIG_TRIM_SPACES,
         CONFIG_SCHEMA_SAMPLE_SIZE
     );
 
@@ -497,9 +503,44 @@ public class CsvFormatReader implements SegmentableFormatReader {
         );
     }
 
+    /**
+     * Single source of truth for "may Jackson tokenize a record?". Jackson's CSV grammar coincides with
+     * the direct-to-block walkers (and the house {@link #splitRecordFields}) only when {@code trim_spaces}
+     * is on: with it off, (1) padding before a quote makes Jackson treat the field as unquoted — literal
+     * quotes and a column-count explosion for {@code 1, "a,b"} — and (2) {@code SKIP_EMPTY_LINES} eats the
+     * first column's leading whitespace on every row, independent of the quote char. Under trim both
+     * quirks are masked (the trim would have removed that whitespace anyway and quote detection is
+     * restored), so Jackson's tokenization is safe.
+     *
+     * <p>Escaped mode (quoting off, escaping on) is also kept on Jackson even under no-trim: it is the only
+     * dialect where {@link #decodeFieldValue} is non-identity, and the record-materialized paths apply that
+     * decode in {@code parseRecord} while the bulk consumer applies it again — routing escaped mode through
+     * the house splitter would either double-decode or diverge from inference. The direct walkers exclude
+     * escaped mode for the same reason (no house grammar to mirror), so this keeps the house path confined
+     * to exactly the QUOTED / PLAIN dialects the walkers serve, where {@code decodeFieldValue} is identity.
+     *
+     * <p>Consequence — the escaped-mode no-trim residual: because escaped mode stays on Jackson even under
+     * no-trim, it also KEEPS Jackson's {@code SKIP_EMPTY_LINES} first-column leading-whitespace eating (a
+     * padded {@code  x} at column 0 reads back as {@code x}; non-first columns keep their padding). This is a
+     * real no-trim gap for escaped mode that the QUOTED / PLAIN house grammar does not have, but it is uniform
+     * across every escaped arm (per-record, bulk, inference), so there is no cross-path misbind. Pinned by
+     * {@code CsvModeReadTests.testEscapedModeStillEatsColumnZeroLeadingWhitespaceUnderNoTrim}.
+     */
+    private boolean jacksonGrammarApplies() {
+        return options.trimSpaces() || options.decodesEscapes();
+    }
+
     private static CsvMapper createMapper(CsvFormatOptions opts) {
         CsvMapper mapper = new CsvMapper();
-        mapper.enable(CsvParser.Feature.TRIM_SPACES);
+        if (opts.trimSpaces()) {
+            // TRIM_SPACES is gated on so mode:plain (and any opt-out) keeps field bytes verbatim; typed
+            // columns tolerate padding independently (see tryConvertValue). This mapper is only consulted
+            // when jacksonGrammarApplies() (trim on, or escaped mode): under no-trim Jackson's grammar
+            // diverges from the walkers — it mis-splits padded quotes AND SKIP_EMPTY_LINES eats the first
+            // column's leading whitespace on every row — so the record paths tokenize with
+            // splitRecordFields instead and this mapper is not used for them.
+            mapper.enable(CsvParser.Feature.TRIM_SPACES);
+        }
         mapper.enable(CsvParser.Feature.SKIP_EMPTY_LINES);
         mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
         if (opts.maxFieldSize() > 0) {
@@ -594,6 +635,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         int maxFieldSize = parseInt(config.get(CONFIG_MAX_FIELD_SIZE), baseline.maxFieldSize());
         boolean headerRow = parseBooleanOption(CONFIG_HEADER_ROW, config.get(CONFIG_HEADER_ROW), baseline.headerRow());
         String columnPrefix = parseString(config.get(CONFIG_COLUMN_PREFIX), baseline.columnPrefix());
+        boolean trimSpaces = parseBooleanOption(CONFIG_TRIM_SPACES, config.get(CONFIG_TRIM_SPACES), baseline.trimSpaces());
 
         CsvFormatOptions merged = new CsvFormatOptions(
             delimiter,
@@ -608,7 +650,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             headerRow,
             columnPrefix,
             quoting,
-            escaping
+            escaping,
+            trimSpaces
         );
         return merged.equals(baseline) ? null : merged;
     }
@@ -886,6 +929,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private List<Attribute> inferSchemaFromSample(String headerLine, CsvLogicalRecordReader recordReader, String sourceLocation)
         throws IOException {
         String[] columnNames = splitFieldsForOptions(headerLine, options);
+        if (options.quoting()) {
+            // No type annotations on this path, so the fields are bare names — unwrap RFC 4180 quoting.
+            unquoteHeaderNames(columnNames, options.quoteChar());
+        }
         Iterator<List<?>> csvIterator = newCsvIterator(recordReader);
         CircuitBreaker breaker = blockFactory.breaker();
         SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker, effectivePolicy);
@@ -1025,10 +1072,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     /**
      * Per-record iterator used for schema reading, sampling, and bootstrap paths where each record is
-     * materialized into a {@link String} before Jackson parses it. Cost is bounded by
-     * {@link #schemaSampleSize} on inference paths; the bulk read loop swaps over to
-     * {@link #newJacksonBulkIterator} after schema resolution so the per-row hot path stays on
-     * Jackson's direct bulk char-buffer tokenization.
+     * materialized into a {@link String} before being tokenized ({@link CsvRecordIterator#parseRecord}
+     * tokenizes with Jackson when {@link #jacksonGrammarApplies()}, else with the house
+     * {@link #splitRecordFields}). Cost is bounded by {@link #schemaSampleSize} on inference paths. When
+     * Jackson's grammar applies the bulk read loop swaps over to {@link #newJacksonBulkIterator} after
+     * schema resolution so the per-row hot path stays on Jackson's direct bulk char-buffer tokenization;
+     * under no-trim (Jackson's grammar does not apply) the data path stays on this per-record iterator so
+     * every record is tokenized by the house grammar, matching the direct-to-block walkers.
      */
     private Iterator<List<?>> newCsvIterator(CsvLogicalRecordReader recordReader) throws IOException {
         return new CsvRecordIterator(recordReader, newCsvSchema());
@@ -1050,7 +1100,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * each logical record into a {@link StringBuilder} for a follow-up Jackson parse. The byte-level
      * {@code max_record_size} cap is enforced upstream by {@link CsvRecordCappingInputStream}, so this
      * path no longer needs the per-char accounting that {@link CsvLogicalRecordReader#readRecord} added.
-     * Used after schema resolution / sampling, where every subsequent record flows through this iterator.
+     * Used after schema resolution / sampling, where every subsequent record flows through this iterator —
+     * but only when {@link #jacksonGrammarApplies()} (trim on, or escaped mode). Under no-trim the data
+     * path routes to the per-record {@link #newCsvIterator} + house {@link #splitRecordFields} instead, so
+     * Jackson's diverging no-trim grammar (padded-quote mis-split, col-0 whitespace eating) is not used.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private Iterator<List<?>> newJacksonBulkIterator(Reader reader) throws IOException {
@@ -1355,12 +1408,26 @@ public class CsvFormatReader implements SegmentableFormatReader {
         boolean useDirectBlock = useDirectBlockPlain || useDirectBlockQuoted;
         // The quoted walk performs C-style escape decoding, so the record reader must carry escaped
         // terminators/quotes verbatim to match Jackson's record boundaries (see CsvLogicalRecordReader).
-        boolean recordEscapeAware = useDirectBlockQuoted && options.escaping();
-        // The recordReader-backed path (bracket mode or _rowPosition projection) and the direct-to-block
-        // path both enforce the per-record cap via CsvLogicalRecordReader.addBytes, so neither carries the
-        // byte-level cap wrap (wrapping the underlying stream would let the cap fire mid-fill, leaving the
-        // reader at an undefined offset).
-        boolean useRecordReaderPath = useBracketAware || rowPositionProjected;
+        // This is needed on every recordReader-backed data path for a QUOTED + escaping dialect — the
+        // direct quoted walk, the _rowPosition per-record read, and the no-trim reroute onto the house
+        // tokenizer — otherwise a `\`-escaped newline would terminate the record early and split one
+        // logical row in two. The Jackson bulk path (trim on / escaped mode) installs the escape char in
+        // its own schema instead, so it does not need the recordReader escape-aware. Bracket mode scans
+        // its own boundaries and is excluded.
+        boolean recordEscapeAware = options.quoting()
+            && options.escaping()
+            && useBracketAware == false
+            && (useDirectBlockQuoted || rowPositionProjected || jacksonGrammarApplies() == false);
+        // The recordReader-backed path (bracket mode, _rowPosition projection, or the no-trim reroute onto
+        // the house per-record tokenizer) and the direct-to-block path all enforce the per-record cap via
+        // CsvLogicalRecordReader.addBytes, so none carry the byte-level cap wrap (wrapping the underlying
+        // stream would let the cap fire mid-fill, leaving the reader at an undefined offset). The no-trim
+        // disjunct mirrors the routing below (rowPositionSlot >= 0 || jacksonGrammarApplies() == false):
+        // when Jackson's grammar does not apply and the read is not direct-eligible, the data path runs
+        // through newCsvIterator(recordReader), so it must skip the wrap exactly like the _rowPosition path.
+        boolean useRecordReaderPath = useBracketAware
+            || rowPositionProjected
+            || (useDirectBlock == false && jacksonGrammarApplies() == false);
         InputStream capped = (useRecordReaderPath || useDirectBlock)
             ? stream
             : new CsvRecordCappingInputStream(stream, context.maxRecordBytes());
@@ -1599,7 +1666,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (parts.length != 2) {
                 throw new ParsingException("Invalid CSV schema format: [{}]. Expected 'name:type'", column);
             }
-            String name = parts[0].trim();
+            String name = options.quoting() ? unquoteHeaderName(parts[0], options.quoteChar()) : parts[0].trim();
             String trimmedType = parts[1].trim();
             String typeName = trimmedType.toUpperCase(Locale.ROOT);
             DataType dataType = parseDataType(typeName);
@@ -1741,12 +1808,16 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Converts accumulated field content to a trimmed string, with a fast path that skips
-     * {@link String#trim()} when the first and last characters are already non-whitespace
-     * (the common case for clean CSV data).
+     * Converts accumulated field content to a string. When {@code trimSpaces} is set, surrounding
+     * whitespace is trimmed, with a fast path that skips {@link String#trim()} when the first and last
+     * characters are already non-whitespace (the common case for clean CSV data); when it is not set the
+     * content is returned verbatim (the default — RFC 4180 keeps surrounding spaces).
      */
-    static String emitField(StringBuilder current) {
+    static String emitField(StringBuilder current, boolean trimSpaces) {
         String s = current.toString();
+        if (trimSpaces == false) {
+            return s;
+        }
         int len = s.length();
         if (len == 0 || (s.charAt(0) > ' ' && s.charAt(len - 1) > ' ')) {
             return s;
@@ -1783,25 +1854,37 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Splits a <strong>header</strong> line into fields using the same comma/bracket/quote awareness as the data
-     * splitter, but <em>preserves the original substring</em> of each field — including any surrounding quote
-     * characters. Header fields like {@code "host:port"} need quotes intact so {@link #hasTypeAnnotations} can tell
-     * a quoted name from a {@code name:type} annotation.
+     * Splits a <strong>header</strong> line into fields. A quoting dialect (CSV) tokenizes the header by the
+     * same delimiter/quote/escape awareness as data cells — so a quoted name, a quoted field containing the
+     * delimiter, and RFC 4180 {@code ""} all round-trip the way they do for data — while <em>preserving the
+     * original substring</em> of each field, quotes included: header fields like {@code "host:port"} keep their
+     * quotes so {@link #hasTypeAnnotations} can tell a quoted name from a {@code name:type} annotation (the
+     * name is unquoted later, once that decision has been made). A non-quoting dialect ({@code mode: plain} /
+     * {@code escaped}) treats a quote as literal data, so the raw delimiter split is correct there.
      */
     private static String[] splitFieldsForOptions(String line, CsvFormatOptions options) {
-        if (options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS && options.delimiter() == ',') {
-            return splitHeaderCommaDelimiterBracketAware(line, options.quoteChar(), options.escapeChar());
+        // The header is the file's first line, so a UTF-8 BOM (Excel/Windows) lands on its first field.
+        line = stripLeadingBom(line);
+        if (options.quoting()) {
+            return splitHeaderQuoteAware(
+                line,
+                options.delimiter(),
+                options.quoteChar(),
+                options.escapeChar(),
+                options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS
+            );
         }
         return line.split(Pattern.quote(Character.toString(options.delimiter())));
     }
 
     /**
-     * Header-only variant of {@link #splitCommaDelimiterBracketAwareFields}: tracks the same state machine but
-     * emits the raw substring between commas instead of accumulating into a {@link StringBuilder} that strips
-     * quotes. Used by schema discovery / inference.
+     * Header-only variant of {@link #splitCommaDelimiterBracketAwareFields}: tracks the same quote/escape
+     * (and, when {@code bracketsMode}, bracket) state machine but emits the raw substring between delimiters
+     * instead of accumulating into a {@link StringBuilder} that strips quotes — the caller unquotes the
+     * resolved names after {@link #hasTypeAnnotations} has run. Used by schema discovery / inference for any
+     * delimiter (comma for CSV, tab for TSV).
      */
-    private static String[] splitHeaderCommaDelimiterBracketAware(String line, char quote, char esc) {
-        final char delim = ',';
+    private static String[] splitHeaderQuoteAware(String line, char delim, char quote, char esc, boolean bracketsMode) {
         List<String> entries = new ArrayList<>();
         int start = 0;
         boolean inQuotes = false;
@@ -1829,6 +1912,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
                 continue;
             }
+            // A delimiter outside quotes/brackets ends the field. Unlike the data splitter, an escaped
+            // delimiter OUTSIDE quotes (e.g. a\,b in an escaping dialect) is not un-escaped here — an exotic
+            // header shape whose full header/data parity belongs to the shared-tokenizer follow-up. Quoting
+            // ("a,b") is the RFC 4180 way to carry a delimiter in a header name and is handled above.
             if (c == delim) {
                 entries.add(line.substring(start, i).trim());
                 start = i + 1;
@@ -1839,7 +1926,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 inQuotes = true;
                 continue;
             }
-            if (c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i)) {
+            if (bracketsMode && c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i)) {
                 bracketDepth = 1;
                 continue;
             }
@@ -1848,13 +1935,54 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
         }
         entries.add(line.substring(start).trim());
-        return entries.toArray(String[]::new);
+        // Match String.split's default (limit 0), which the plain/escaped header path still uses: drop
+        // trailing empty fields so a trailing delimiter ("a,b,") yields the same column count everywhere,
+        // not a spurious empty-named last column.
+        int last = entries.size();
+        while (last > 0 && entries.get(last - 1).isEmpty()) {
+            last--;
+        }
+        return entries.subList(0, last).toArray(String[]::new);
+    }
+
+    /** Leading UTF-8 byte-order mark; decoded to this char by the {@link InputStreamReader} before it reaches us. */
+    private static final char BOM = '\uFEFF';
+
+    /**
+     * Strips a leading byte-order mark from the first line of a file. Excel/Windows CSV exports prepend a
+     * UTF-8 BOM ({@code EF BB BF}); without this the BOM would otherwise prefix the first column name.
+     */
+    private static String stripLeadingBom(String line) {
+        return line != null && line.isEmpty() == false && line.charAt(0) == BOM ? line.substring(1) : line;
+    }
+
+    /**
+     * Strips one layer of surrounding {@code quote} characters from a resolved header name and unescapes RFC
+     * 4180 doubled quotes ({@code ""} -> {@code "}), so an unquoted {@code id} and a quoted {@code "id"} both
+     * resolve to {@code id}. A name that is not fully quoted is returned trimmed and otherwise unchanged.
+     * Only meaningful for a quoting dialect; the caller does not invoke it for {@code plain}/{@code escaped},
+     * where a quote is literal name data.
+     */
+    private static String unquoteHeaderName(String name, char quote) {
+        String trimmed = name.trim();
+        if (trimmed.length() >= 2 && trimmed.charAt(0) == quote && trimmed.charAt(trimmed.length() - 1) == quote) {
+            String inner = trimmed.substring(1, trimmed.length() - 1);
+            return inner.replace(String.valueOf(quote) + quote, String.valueOf(quote));
+        }
+        return trimmed;
+    }
+
+    /** Applies {@link #unquoteHeaderName} to each name in place; called on the inference path when quoting. */
+    private static void unquoteHeaderNames(String[] names, char quote) {
+        for (int i = 0; i < names.length; i++) {
+            names[i] = unquoteHeaderName(names[i], quote);
+        }
     }
 
     /**
      * Bracket- and quote-aware comma split; must stay aligned with {@link CsvBatchIterator#splitLineBracketAware}.
      */
-    private static String[] splitCommaDelimiterBracketAwareFields(String line, char quote, char esc) {
+    private static String[] splitCommaDelimiterBracketAwareFields(String line, char quote, char esc, boolean trimSpaces) {
         final char delim = ',';
         List<String> entries = new ArrayList<>();
         StringBuilder current = new StringBuilder();
@@ -1897,6 +2025,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
                 i++;
             } else if (c == quote && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
+                // Drop any whitespace-only prefix accumulated before the opening quote so ` "y"` yields
+                // `y`, matching the direct quoted walker (splitAndConvertQuoted skips outer whitespace before
+                // quote detection). Behavior-neutral under trim_spaces (emitField would have trimmed it).
+                current.setLength(0);
                 inQuotes = true;
                 quoteOpenAt = i;
                 i++;
@@ -1911,7 +2043,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 if (i > 0 && line.charAt(i - 1) == esc) {
                     current.append(c);
                 } else {
-                    entries.add(emitField(current));
+                    entries.add(emitField(current, trimSpaces));
                     current = new StringBuilder();
                 }
                 i++;
@@ -1927,9 +2059,249 @@ public class CsvFormatReader implements SegmentableFormatReader {
             throw MalformedRowException.unclosedBracketCell(line, bracketOpenAt);
         }
         if (current.length() > 0) {
-            entries.add(emitField(current));
+            entries.add(emitField(current, trimSpaces));
         }
         return entries.toArray(String[]::new);
+    }
+
+    /**
+     * The detail portion of the over-max-field-size error, byte-for-byte the text Jackson's
+     * {@code StreamReadConstraints.maxStringLength} violation produces. Shared by the direct-block
+     * walker ({@link CsvBatchIterator#rejectFieldTooLarge}, which prefixes {@code "CSV parse error: "})
+     * and the house record tokenizer ({@link #splitRecordFields}, which throws it as a
+     * {@link MalformedRowException} that the batch loop re-prefixes identically), so both arms emit the
+     * same message. ASCII digits on purpose (locale-independent), unlike Jackson's {@code FORMAT}-locale
+     * number formatting.
+     */
+    static String fieldSizeExceededDetail(int valueLen, int maxFieldChars) {
+        return "String value length ("
+            + valueLen
+            + ") exceeds the maximum allowed ("
+            + maxFieldChars
+            + ", from `StreamReadConstraints.getMaxStringLength()`)";
+    }
+
+    /**
+     * House record tokenizer for the no-trim, non-escaped-mode dialects (QUOTED and PLAIN). Produces the
+     * same field values <em>and</em> field counts as the direct-to-block walkers
+     * ({@link CsvBatchIterator#splitAndConvertPlain} / {@link CsvBatchIterator#splitAndConvertQuoted}), so
+     * a record materialized through this splitter agrees byte-for-byte with a direct read of the same file.
+     * Used in place of Jackson whenever {@link #jacksonGrammarApplies()} is false — Jackson's tokenization
+     * only coincides with the walkers under {@code trim_spaces} (see that method), and it eats first-column
+     * leading whitespace on every row via {@code SKIP_EMPTY_LINES}, so under no-trim the walkers are the
+     * grammar and this splitter mirrors them for the record-materialized paths (per-record iterator,
+     * inference sampling, {@code _rowPosition} reads, bulk fallback).
+     *
+     * <p>Values are returned raw: an empty field is {@code ""} (not {@code null}) — downstream
+     * {@code tryConvertValue} maps empty / {@code null-marker} to null identically for both arms, so the
+     * split stays a pure tokenizer. Per field the same {@code maxFieldChars} cap the walkers enforce is
+     * applied, throwing a {@link MalformedRowException} whose message equals
+     * {@link #fieldSizeExceededDetail} so the error policy sees identical text on both arms.
+     *
+     * <p>Only reached when {@code decodeFieldValue} is the identity (QUOTED or PLAIN); the escaped mode
+     * (quoting off, escaping on), where {@code decodeFieldValue} is non-identity, keeps
+     * {@link #jacksonGrammarApplies()} true and never routes here.
+     */
+    static String[] splitRecordFields(String record, CsvFormatOptions options, int maxFieldChars) {
+        return options.quoting()
+            ? splitRecordFieldsQuoted(record, options, maxFieldChars)
+            : splitRecordFieldsPlain(record, options, maxFieldChars);
+    }
+
+    /**
+     * PLAIN (unquoted) split: walk on the delimiter, emitting one field per delimiter and one for the
+     * trailing segment (so a trailing delimiter yields an empty last field, exactly like
+     * {@link CsvBatchIterator#splitAndConvertPlain}'s {@code from..to} inclusive scan). A quote byte is
+     * literal data. No first-column whitespace is eaten (the col-0 fix for PLAIN dialects).
+     */
+    private static String[] splitRecordFieldsPlain(String record, CsvFormatOptions options, int maxFieldChars) {
+        final char delim = options.delimiter();
+        final boolean trimSpaces = options.trimSpaces();
+        final int len = record.length();
+        List<String> fields = new ArrayList<>();
+        int start = 0;
+        for (int i = 0; i <= len; i++) {
+            if (i == len || record.charAt(i) == delim) {
+                fields.add(emitPlainSplitField(record, start, i, trimSpaces, maxFieldChars));
+                start = i + 1;
+            }
+        }
+        return fields.toArray(String[]::new);
+    }
+
+    /**
+     * Extracts the value of a simple (unquoted, unescaped) field {@code record[start, end)}, mirroring
+     * {@link CsvBatchIterator#emitPlainField}'s whitespace and cap semantics: under {@code trim_spaces} the
+     * value is trimmed and the cap governs the trimmed length; otherwise the raw span is kept verbatim and
+     * the cap governs the raw length. Type-specific trimming (a typed column always parses trimmed) is left
+     * to the shared {@code tryConvertValue} downstream, so this stays type-agnostic.
+     */
+    private static String emitPlainSplitField(String record, int start, int end, boolean trimSpaces, int maxFieldChars) {
+        if (trimSpaces) {
+            while (start < end && record.charAt(start) <= ' ') {
+                start++;
+            }
+            while (end > start && record.charAt(end - 1) <= ' ') {
+                end--;
+            }
+        }
+        int fieldLen = end - start;
+        if (fieldLen > maxFieldChars) {
+            throw new MalformedRowException(fieldSizeExceededDetail(fieldLen, maxFieldChars));
+        }
+        return record.substring(start, end);
+    }
+
+    /**
+     * QUOTED (RFC 4180, optional backslash escapes) split — the string-domain twin of
+     * {@link CsvBatchIterator#splitAndConvertQuoted}. A field-leading quote (after optional outer
+     * whitespace, never the delimiter itself even when it is a whitespace byte such as TAB) opens a quoted
+     * region where {@code ""} is a literal quote and, when escaping is on, {@code \}+char is C-style decoded;
+     * quoted content (including inner whitespace) is kept verbatim, an empty quoted field is {@code ""}
+     * (downstream null), and only whitespace may follow a closing quote before the delimiter. Unquoted
+     * fields are extracted by {@link #emitPlainSplitField} (no escape) or {@link #emitUnquotedEscapedSplitField}
+     * (escape present). An unclosed quote throws {@link MalformedRowException#unclosedQuotedField}.
+     */
+    private static String[] splitRecordFieldsQuoted(String record, CsvFormatOptions options, int maxFieldChars) {
+        final char delim = options.delimiter();
+        final char quote = options.quoteChar();
+        final char esc = options.escapeChar();
+        final boolean escapeAware = options.escaping();
+        final boolean trimSpaces = options.trimSpaces();
+        final int len = record.length();
+        List<String> fields = new ArrayList<>();
+        int i = 0;
+        while (true) {
+            // Skip leading outer whitespace to decide quoted vs unquoted. The delimiter is never skipped
+            // even when it is itself a whitespace byte (a TAB in TSV), so an empty field before a quoted
+            // field is not mistaken for the quoted field. The unquoted branch re-scans from i (not p) so
+            // that leading whitespace stays part of an unquoted field.
+            int p = i;
+            while (p < len && record.charAt(p) <= ' ' && record.charAt(p) != delim) {
+                p++;
+            }
+            boolean lastField;
+            int next;
+            if (p < len && record.charAt(p) == quote) {
+                StringBuilder value = new StringBuilder();
+                int decodedLen = 0;
+                int q = p + 1;
+                boolean closed = false;
+                while (q < len) {
+                    char c = record.charAt(q);
+                    if (c == quote) {
+                        if (q + 1 < len && record.charAt(q + 1) == quote) {
+                            value.append(quote);
+                            decodedLen++;
+                            q += 2;
+                            continue;
+                        }
+                        closed = true;
+                        q++;
+                        break;
+                    }
+                    if (escapeAware && c == esc) {
+                        if (q + 1 < len) {
+                            value.append(decodeEscapeChar(record.charAt(q + 1)));
+                            decodedLen++;
+                            q += 2;
+                        } else {
+                            q++; // trailing lone escape: dropped
+                        }
+                        continue;
+                    }
+                    value.append(c);
+                    decodedLen++;
+                    q++;
+                }
+                if (closed == false) {
+                    throw MalformedRowException.unclosedQuotedField(record, p);
+                }
+                // Jackson checks maxStringLength on the aggregated value right after the closing quote,
+                // before inspecting trailing content, so the cap precedes the content-after-quote check.
+                if (decodedLen > maxFieldChars) {
+                    throw new MalformedRowException(fieldSizeExceededDetail(decodedLen, maxFieldChars));
+                }
+                int r = q;
+                while (r < len && record.charAt(r) <= ' ' && record.charAt(r) != delim) {
+                    r++;
+                }
+                if (r < len && record.charAt(r) != delim) {
+                    throw new MalformedRowException("CSV row has unexpected content after a closing quote");
+                }
+                fields.add(value.toString());
+                lastField = r >= len;
+                next = r + 1;
+            } else {
+                int j = i;
+                boolean hasEsc = false;
+                while (j < len) {
+                    char c = record.charAt(j);
+                    if (escapeAware && c == esc) {
+                        hasEsc = true;
+                        j += 2; // skip the escaped char (even if it is a delimiter)
+                        continue;
+                    }
+                    if (c == delim) {
+                        break;
+                    }
+                    j++;
+                }
+                int fieldEnd = Math.min(j, len);
+                fields.add(
+                    hasEsc
+                        ? emitUnquotedEscapedSplitField(record, i, fieldEnd, options, maxFieldChars)
+                        : emitPlainSplitField(record, i, fieldEnd, trimSpaces, maxFieldChars)
+                );
+                lastField = j >= len;
+                next = fieldEnd + 1;
+            }
+            if (lastField) {
+                break;
+            }
+            i = next;
+        }
+        return fields.toArray(String[]::new);
+    }
+
+    /**
+     * Extracts an unquoted field {@code record[start, end)} that contains the escape character, the
+     * string-domain twin of {@link CsvBatchIterator#emitUnquotedEscapedField}. Under {@code trim_spaces}
+     * the raw leading whitespace is stripped before the decode loop and trailing decoded whitespace after
+     * it (Jackson's TRIM_SPACES order), with the cap on the trimmed length. Under no-trim the whole span is
+     * decoded verbatim and the cap governs the full decoded length; type-specific trimming for a typed
+     * column is left to {@code tryConvertValue}. A trailing lone escape (no following char) is dropped.
+     */
+    private static String emitUnquotedEscapedSplitField(String record, int start, int end, CsvFormatOptions options, int maxFieldChars) {
+        final char esc = options.escapeChar();
+        final boolean trimSpaces = options.trimSpaces();
+        if (trimSpaces) {
+            while (start < end && record.charAt(start) <= ' ') {
+                start++;
+            }
+        }
+        StringBuilder value = new StringBuilder(end - start);
+        for (int k = start; k < end; k++) {
+            char c = record.charAt(k);
+            if (c == esc) {
+                if (k + 1 < end) {
+                    value.append(decodeEscapeChar(record.charAt(++k)));
+                }
+                // else: trailing lone escape, dropped
+            } else {
+                value.append(c);
+            }
+        }
+        int endLen = value.length();
+        if (trimSpaces) {
+            while (endLen > 0 && value.charAt(endLen - 1) <= ' ') {
+                endLen--;
+            }
+        }
+        if (endLen > maxFieldChars) {
+            throw new MalformedRowException(fieldSizeExceededDetail(endLen, maxFieldChars));
+        }
+        return endLen == value.length() ? value.toString() : value.substring(0, endLen);
     }
 
     private class CsvRecordIterator implements Iterator<List<?>> {
@@ -1982,6 +2354,33 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private List<String> parseRecord(String record) throws IOException {
+            if (jacksonGrammarApplies() == false) {
+                // No-trim, non-escaped-mode: the direct-block walkers are the grammar, so tokenize with
+                // their string-domain twin instead of Jackson (whose grammar diverges under no-trim — see
+                // jacksonGrammarApplies). Blank records are skipped here exactly as SKIP_EMPTY_LINES +
+                // the empty-row check below do on the Jackson path; comments are filtered by the callers on
+                // the first cell, so they are not dropped here. The decodeFieldValue seam runs unchanged —
+                // it is the identity for the QUOTED / PLAIN dialects this branch is gated to.
+                if (isBlankOrComment(record, null)) {
+                    return null;
+                }
+                int maxFieldChars = options.maxFieldSize() > 0 ? options.maxFieldSize() : Integer.MAX_VALUE;
+                String[] fields = splitRecordFields(record, options, maxFieldChars);
+                // A configured null marker maps to null here, mirroring what Jackson's withNullValue did at
+                // tokenization on the pre-B1 path and what the direct walkers' emitPlainField / tryConvertValue
+                // do (exact equality, gated on a non-empty marker, all fields incl. quoted — splitRecordFields
+                // strips quotes just as Jackson nulled a quoted "NA"). Without this the raw marker would reach
+                // CsvSchemaInferrer, which only knows empty / "null", and flip the inferred type. The default
+                // empty marker stays untouched: an empty cell already reads as null downstream.
+                boolean hasCustomNullValue = options.nullValue().isEmpty() == false;
+                String nullValueStr = options.nullValue();
+                List<String> row = new ArrayList<>(fields.length);
+                for (String field : fields) {
+                    String decoded = decodeFieldValue(field);
+                    row.add(hasCustomNullValue && nullValueStr.equals(decoded) ? null : decoded);
+                }
+                return row.isEmpty() ? null : row;
+            }
             try (CsvParser parser = sharedCsvMapper.getFactory().createParser(record)) {
                 parser.setSchema(csvSchema);
                 List<String> row = new ArrayList<>();
@@ -2513,6 +2912,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
         /**
          * Bulk Jackson iterator that also tracks per-record byte offsets via {@link ByteOffsetTrackingReader},
          * so canonical-stripe attribution works on the fast path without dropping onto the per-record reader.
+         * Live only when {@link #jacksonGrammarApplies()} (trim on, or escaped mode) and the encoding is
+         * UTF-8; under no-trim the read routes through the per-record recordReader path instead (which
+         * supplies byte-exact offsets for any encoding), so this tracked bulk path stays idle there.
          */
         @SuppressWarnings({ "rawtypes", "unchecked" })
         private Iterator<List<?>> newTrackedJacksonBulkIterator() throws IOException {
@@ -2680,13 +3082,22 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     // own bulk char buffer. The per-record byte cap is enforced upstream by the wrapping
                     // CsvRecordCappingInputStream, so we don't need CsvLogicalRecordReader's per-char loop here.
                     //
-                    // Exception: when _rowPosition is projected (rowPositionSlot >= 0, i.e. _id /
-                    // _file.record_ref is requested), route through the recordReader-backed iterator so each
-                    // record advances CsvLogicalRecordReader's byte accounting and the offset
-                    // (splitStartByte + bytesRead - lastRecordBytes) stays exact. The Jackson bulk path
-                    // bypasses recordReader and would pin every data row at the header boundary. read()
-                    // suppresses the byte-level cap wrap on this path to match (see useRecordReaderPath).
-                    if (rowPositionSlot >= 0) {
+                    // Two exceptions route through the recordReader-backed per-record iterator instead of the
+                    // Jackson bulk path. read() suppresses the byte-level cap wrap on both to match (see
+                    // useRecordReaderPath):
+                    // 1. _rowPosition projected (rowPositionSlot >= 0, i.e. _id / _file.record_ref): each
+                    // record must advance CsvLogicalRecordReader's byte accounting so the offset
+                    // (splitStartByte + bytesRead - lastRecordBytes) stays exact; the Jackson bulk path
+                    // bypasses recordReader and would pin every data row at the header boundary.
+                    // 2. Jackson's grammar does not apply (no-trim, non-escaped-mode — see
+                    // jacksonGrammarApplies): under no-trim Jackson mis-splits padded-quoted fields and
+                    // eats first-column leading whitespace, so the record path tokenizes with the house
+                    // splitRecordFields (parseRecord) to agree with the direct walkers. Stripe capture
+                    // still composes: recordReader supplies byte-exact per-record offsets (the
+                    // bulkByteTracker == null branch below), validated by the emit-time tripwire, so
+                    // capture is NOT disabled here even for non-UTF-8 — recordReader counts bytes per
+                    // options.encoding().
+                    if (rowPositionSlot >= 0 || jacksonGrammarApplies() == false) {
                         csvIterator = newCsvIterator(recordReader);
                     } else if (statsStripeSize > 0 && StandardCharsets.UTF_8.equals(options.encoding())) {
                         // Stripe capture on the bulk path: wrap the reader so each row's char offset maps to a
@@ -2938,11 +3349,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
          * Commas inside quotes or brackets are not delimiters. Escaped commas ({@code \,}) are skipped.
          */
         private String[] splitLineBracketAware(String line) {
-            return splitCommaDelimiterBracketAwareFields(line, options.quoteChar(), options.escapeChar());
+            return splitCommaDelimiterBracketAwareFields(line, options.quoteChar(), options.escapeChar(), options.trimSpaces());
         }
 
         private List<Attribute> inferSchemaFromBatchReader(String headerLine) throws IOException {
             String[] columnNames = splitFieldsForOptions(headerLine, options);
+            if (options.quoting()) {
+                // No type annotations on this path, so the fields are bare names — unwrap RFC 4180 quoting.
+                unquoteHeaderNames(columnNames, options.quoteChar());
+            }
             csvIterator = newCsvIterator(recordReader);
             SchemaSample sample = collectSampleRows(
                 csvIterator,
@@ -3061,7 +3476,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             int[] stringSlots = new int[columnCount];
             int stringColumns = 0;
             for (int i = 0; i < columnCount; i++) {
-                if (projectedTypes[i] == DataType.KEYWORD || projectedTypes[i] == DataType.TEXT) {
+                if (isStringType(projectedTypes[i])) {
                     stringSlots[stringColumns++] = i;
                 }
             }
@@ -3872,16 +4287,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
          * @return always {@code false}, so callers can {@code return rejectFieldTooLarge(len)} to drop the row
          */
         private boolean rejectFieldTooLarge(int valueLen) {
-            onRowError(
-                "CSV parse error: String value length ("
-                    + valueLen
-                    + ") exceeds the maximum allowed ("
-                    + maxFieldChars
-                    + ", from `StreamReadConstraints.getMaxStringLength()`)",
-                null,
-                EMPTY_ROW,
-                true
-            );
+            onRowError("CSV parse error: " + fieldSizeExceededDetail(valueLen, maxFieldChars), null, EMPTY_ROW, true);
             return false;
         }
 
@@ -3969,19 +4375,38 @@ public class CsvFormatReader implements SegmentableFormatReader {
          *         raised (SKIP_ROW / FAIL_FAST)
          */
         private boolean emitPlainField(char[] buf, int start, int end, int bufIdx, DataType dt) {
-            // Trim leading/trailing whitespace (chars <= ' '), matching Jackson TRIM_SPACES / emitField.
-            while (start < end && buf[start] <= ' ') {
-                start++;
-            }
-            while (end > start && buf[end - 1] <= ' ') {
-                end--;
+            // Whitespace mirrors the Jackson path: a typed column is always trimmed (it parses, like
+            // tryConvertValue); a string column keeps its bytes unless trim_spaces is set. The cap
+            // (Jackson's maxStringLength) governs the value AS TOKENIZED — trimmed only when trim_spaces is
+            // set, regardless of ES type — so a typed no-trim field caps the RAW token, then trims to parse.
+            // This keeps the cap decision identical to the Jackson arm and the unprojected cap check, so
+            // projection can never change whether a row survives. On the hot no-trim string path both
+            // branches skip the loops, so it never costs more than the old unconditional trim.
+            final boolean trimSpaces = options.trimSpaces();
+            if (trimSpaces) {
+                while (start < end && buf[start] <= ' ') {
+                    start++;
+                }
+                while (end > start && buf[end - 1] <= ' ') {
+                    end--;
+                }
+                if (end - start > maxFieldChars) {
+                    return rejectFieldTooLarge(end - start);
+                }
+            } else {
+                if (end - start > maxFieldChars) {
+                    return rejectFieldTooLarge(end - start);
+                }
+                if (isStringType(dt) == false) {
+                    while (start < end && buf[start] <= ' ') {
+                        start++;
+                    }
+                    while (end > start && buf[end - 1] <= ' ') {
+                        end--;
+                    }
+                }
             }
             int len = end - start;
-            // Jackson enforces maxStringLength on the trimmed value during tokenization, before any
-            // null/type interpretation, so the cap check precedes the null classification below.
-            if (len > maxFieldChars) {
-                return rejectFieldTooLarge(len);
-            }
             // Null classification mirrors tryConvertValue: empty, the literal "null" (any case), or the
             // configured null marker all become null.
             if (len == 0) {
@@ -4103,11 +4528,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (end - start <= maxFieldChars) {
                 return true;
             }
-            while (start < end && buf[start] <= ' ') {
-                start++;
-            }
-            while (end > start && buf[end - 1] <= ' ') {
-                end--;
+            // Only whitespace trimming can bring an over-cap field back under, and only when trim_spaces is
+            // set (otherwise the raw bytes are the stored value, so the raw length is what the cap governs).
+            if (options.trimSpaces()) {
+                while (start < end && buf[start] <= ' ') {
+                    start++;
+                }
+                while (end > start && buf[end - 1] <= ' ') {
+                    end--;
+                }
             }
             if (end - start > maxFieldChars) {
                 return rejectFieldTooLarge(end - start);
@@ -4139,12 +4568,18 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         /**
          * Direct-to-block field splitting and typed conversion for the quoted (RFC 4180) path,
-         * including optional backslash escapes. Matches Jackson's tokenization: a field-leading quote
-         * (after optional outer whitespace) opens a quoted region where {@code ""} is a literal quote
-         * and, when escaping is on, {@code \}+char is C-style decoded; quoted content (including inner
-         * whitespace and embedded newlines) is preserved verbatim, while unquoted fields are trimmed.
-         * Non-whitespace after a closing quote is a row error, and an empty quoted field ({@code ""})
-         * is null. Simple unquoted fields (no escape) take the same char-range fast path as
+         * including optional backslash escapes. Matches Jackson's {@code TRIM_SPACES} <em>whitespace and
+         * quote</em> grammar (field boundaries, outer-whitespace trimming, {@code ""} quote doubling) — but
+         * NOT its escape decoding: this walker C-style-decodes an escape sequence ({@code \t} → a TAB byte),
+         * whereas Jackson's escape is next-char-literal ({@code \t} → {@code t}). Under no-trim this walker
+         * (and its string-domain twin {@link #splitRecordFields}) IS the grammar and Jackson is not used,
+         * because Jackson's no-trim tokenization diverges (padded quotes mis-split, first-column leading
+         * whitespace is eaten). A field-leading quote (after optional outer whitespace)
+         * opens a quoted region where {@code ""} is a literal quote and, when escaping is on, {@code \}+char
+         * is C-style decoded; quoted content (including inner whitespace and embedded newlines) is preserved
+         * verbatim, while unquoted fields are trimmed only for typed columns (a keyword keeps its bytes
+         * unless trim_spaces). Non-whitespace after a closing quote is a row error, and an empty quoted field
+         * ({@code ""}) is null. Simple unquoted fields (no escape) take the same char-range fast path as
          * {@link #splitAndConvertPlain}; quoted or escaped fields are assembled into a reused buffer.
          *
          * @return {@code true} if the row was accepted, {@code false} if rejected by the error policy
@@ -4320,9 +4755,17 @@ public class CsvFormatReader implements SegmentableFormatReader {
          * {@code \} and leaves it as a lone escape (dropped), producing a different boundary value.
          */
         private boolean emitUnquotedEscapedField(char[] buf, int start, int end, int bufIdx, DataType dt) {
-            // Trim raw leading whitespace (matches Jackson's skip-leading-ws before the decode loop).
-            while (start < end && buf[start] <= ' ') {
-                start++;
+            // Typed columns always trim (they parse); string columns keep their bytes unless trim_spaces is set.
+            final boolean trimSpaces = options.trimSpaces();
+            final boolean trim = isStringType(dt) == false || trimSpaces;
+            // Trim raw leading whitespace (matches Jackson's skip-leading-ws before the decode loop). Remember
+            // how much we skipped: under no-trim Jackson counts it toward maxStringLength, so the cap must too.
+            int rawLeadingWs = 0;
+            if (trim) {
+                while (start < end && buf[start] <= ' ') {
+                    start++;
+                    rawLeadingWs++;
+                }
             }
             if (start == end) {
                 stageNullValue(bufIdx);
@@ -4342,17 +4785,23 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             // Trim trailing whitespace from the decoded value (matches Jackson's TRIM_SPACES: trim the
-            // collected decoded chars, not the raw input).
+            // collected decoded chars, not the raw input) — gated the same way as the leading trim.
             int trimEnd = value.length();
-            while (trimEnd > 0 && value.charAt(trimEnd - 1) <= ' ') {
-                trimEnd--;
+            if (trim) {
+                while (trimEnd > 0 && value.charAt(trimEnd - 1) <= ' ') {
+                    trimEnd--;
+                }
             }
             if (trimEnd == 0) {
                 stageNullValue(bufIdx);
                 return true;
             }
-            if (trimEnd > maxFieldChars) {
-                return rejectFieldTooLarge(trimEnd);
+            // The cap (Jackson's maxStringLength) governs the tokenized value: fully trimmed when trim_spaces
+            // is set, otherwise the raw token including the leading whitespace skipped above — matching the
+            // unprojected cap check so projection cannot change whether a row survives.
+            int capLen = trimSpaces ? trimEnd : value.length() + rawLeadingWs;
+            if (capLen > maxFieldChars) {
+                return rejectFieldTooLarge(capLen);
             }
             return emitConvertedStageField(trimEnd == value.length() ? value.toString() : value.substring(0, trimEnd), bufIdx, dt);
         }
@@ -4370,9 +4819,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (end - start <= maxFieldChars) {
                 return true;
             }
+            // Whitespace only counts against the cap when trim_spaces is off (the raw bytes are stored).
+            final boolean trim = options.trimSpaces();
             // Trim raw leading whitespace (matches Jackson's skip-leading-ws before the decode loop).
-            while (start < end && buf[start] <= ' ') {
-                start++;
+            if (trim) {
+                while (start < end && buf[start] <= ' ') {
+                    start++;
+                }
             }
             if (start == end) {
                 return true;
@@ -4400,7 +4853,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     trailingWs = 0;
                 }
             }
-            int trimmedLen = decodedLen - trailingWs;
+            int trimmedLen = decodedLen - (trim ? trailingWs : 0);
             if (trimmedLen > maxFieldChars) {
                 return rejectFieldTooLarge(trimmedLen);
             }
@@ -4492,6 +4945,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     i++;
                 } else if (c == quote && fieldHasNonWhitespace == false) {
+                    // Drop any whitespace-only prefix accumulated before the opening quote so ` "y"` yields
+                    // `y`, matching the direct quoted walker and staying aligned with
+                    // splitCommaDelimiterBracketAwareFields. Behavior-neutral under trim_spaces.
+                    if (isProjected) {
+                        current.setLength(0);
+                    }
                     trailingFieldHasContent = true;
                     inQuotes = true;
                     quoteOpenAt = i;
@@ -4635,12 +5094,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     return true;
                 }
             }
-            return emitConvertedStringField(emitField(current), bufIdx, dt, rawLine);
+            return emitConvertedStringField(emitField(current, options.trimSpaces()), bufIdx, dt, rawLine);
         }
 
         /**
-         * Converts a trimmed string field value and stores it in {@link #rowBuffer}, routing
-         * parse errors through the error policy.
+         * Converts a string field value (trimmed only when {@code trim_spaces} is set) and stores it in
+         * {@link #rowBuffer}, routing parse errors through the error policy.
          */
         private boolean emitConvertedStringField(String value, int bufIdx, DataType dt, String rawLine) {
             Object result = tryConvertValue(value, dt);
@@ -4661,6 +5120,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
             return true;
         }
 
+        /** The string data types, whose values are stored verbatim; every other type trims before parsing. */
+        private static boolean isStringType(DataType dataType) {
+            return dataType == DataType.KEYWORD || dataType == DataType.TEXT;
+        }
+
         private Object tryConvertValue(String value, DataType dataType) {
             if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
                 return null;
@@ -4668,8 +5132,25 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (hasCustomNullValue && value.equals(nullValueStr)) {
                 return null;
             }
-            if (bracketMultiValues && value.startsWith("[") && value.endsWith("]")) {
-                return tryConvertMultiValue(value, dataType);
+            if (bracketMultiValues) {
+                // Bracket syntax is structural: a padded " [1,2] " is the same multi-value cell, so the
+                // detection probe is whitespace-insensitive regardless of the trim_spaces setting.
+                String probe = value.trim();
+                if (probe.startsWith("[") && probe.endsWith("]")) {
+                    return tryConvertMultiValue(probe, dataType);
+                }
+            }
+            if (isStringType(dataType) == false) {
+                // Typed parses mirror CsvSchemaInferrer, which trims before type detection: a value the
+                // sampler classified as INTEGER (etc.) must convert as that type regardless of surrounding
+                // whitespace or quoting. A now-empty or "null" cell is null (as the sampler treats it —
+                // null/empty are compatible with every type); a padded custom null_value is null too, to
+                // match the top-of-method sentinel check. KEYWORD/TEXT keep their bytes verbatim — that
+                // fidelity is the trim_spaces axis, not this one.
+                value = value.trim();
+                if (value.isEmpty() || value.equalsIgnoreCase("null") || (hasCustomNullValue && value.equals(nullValueStr))) {
+                    return null;
+                }
             }
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);
@@ -4690,7 +5171,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Object tryConvertMultiValue(String value, DataType dataType) {
-            String content = value.substring(1, value.length() - 1).trim();
+            // Element extraction honors trim_spaces exactly like the scalar path (emitField): with trimming
+            // off, per-element whitespace in a string multi-value ([ a , b ] on a keyword column) is kept.
+            String inner = value.substring(1, value.length() - 1);
+            String content = options.trimSpaces() ? inner.trim() : inner;
             if (content.isEmpty()) {
                 return null;
             }
@@ -4713,6 +5197,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             StringBuilder current = new StringBuilder();
             char esc = options.escapeChar();
             char quote = options.quoteChar();
+            boolean trimSpaces = options.trimSpaces();
             boolean inQuotes = false;
             int i = 0;
             while (i < content.length()) {
@@ -4730,7 +5215,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     i++;
                 } else if (c == ',' && inQuotes == false) {
-                    result.add(current.toString().trim());
+                    result.add(trimSpaces ? current.toString().trim() : current.toString());
                     current = new StringBuilder();
                     i++;
                 } else if (c == esc && inQuotes == false && i + 1 < content.length() && content.charAt(i + 1) == ',') {
@@ -4741,7 +5226,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     i++;
                 }
             }
-            result.add(current.toString().trim());
+            result.add(trimSpaces ? current.toString().trim() : current.toString());
             return result;
         }
 
@@ -4755,6 +5240,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
             value = unquoteElement(value);
             if (value.isEmpty()) {
                 return null;
+            }
+            if (isStringType(dataType) == false) {
+                // Same typed-parse leniency as tryConvertValue: a quoted, padded numeric element (e.g.
+                // [" 5 ", 6]) converts by its inferred/declared type; padded null-sentinels become null.
+                value = value.trim();
+                if (value.isEmpty() || value.equalsIgnoreCase("null") || (hasCustomNullValue && value.equals(nullValueStr))) {
+                    return null;
+                }
             }
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -4326,7 +4326,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 try {
                     return splitAndConvertQuoted(buf, from, to);
                 } catch (MalformedRowException e) {
-                    onRowError(e.getMessage(), e, directRawLine(), true);
+                    onRowError("CSV parse error: " + e.getMessage(), e, EMPTY_ROW, true);
                     return false;
                 }
             }
@@ -4419,6 +4419,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     return rejectFieldTooLarge(end - start);
                 }
                 if (isStringType(dt) == false) {
+                    // Mirror tryConvertValue's raw-first null-marker check: a whitespace-bearing null_value
+                    // (e.g. " 0 ") must match the UNTRIMMED value, else a typed column trims it away and misses
+                    // it while the house arm (which compares the raw field) nulls it — a silent divergence.
+                    if (hasCustomNullValue && end - start == nullValueStr.length() && regionEquals(buf, start, nullValueStr)) {
+                        stageNullValue(bufIdx);
+                        return true;
+                    }
                     while (start < end && buf[start] <= ' ') {
                         start++;
                     }
@@ -4686,7 +4693,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         r++;
                     }
                     if (r < len && buf[r] != delim) {
-                        onRowError("CSV row has unexpected content after a closing quote", null, directRawLine(), true);
+                        onRowError("CSV parse error: CSV row has unexpected content after a closing quote", null, EMPTY_ROW, true);
                         return false;
                     }
                     if (projected) {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -22,10 +22,12 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalStatsCapture;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import org.junit.After;
@@ -122,8 +124,20 @@ public class CsvDirectBlockParityTests extends ESTestCase {
 
     /** The cap is measured on the trimmed value, so surrounding whitespace does not push a field over. */
     public void testMaxFieldSizeTrimmedWithinCap() throws IOException {
-        List<List<Object>> rows = read(false, Map.of("max_field_size", 5), "k:keyword\n  abc  \n");
+        List<List<Object>> rows = read(false, Map.of("max_field_size", 5, "trim_spaces", true), "k:keyword\n  abc  \n");
         assertEquals(List.of(row(br("abc"))), rows);
+    }
+
+    /**
+     * Under no-trim the cap governs the RAW token, so a padded typed value whose raw length (9) exceeds the
+     * cap (5) is dropped even though its trimmed value (3) would fit — and identically whether the padded
+     * column is projected or not, so projection cannot change whether the row survives.
+     */
+    public void testMaxFieldSizePaddedTypedNoTrimDroppedRegardlessOfProjection() throws IOException {
+        Map<String, Object> config = Map.of("max_field_size", 5);
+        String content = "a:integer,b:integer\n   123   ,7\n";
+        assertEquals(List.of(), read(false, config, skipRow(), null, content));
+        assertEquals(List.of(), read(false, config, skipRow(), List.of("b"), content));
     }
 
     /** A doubled quote decodes to a single character, so {@code "a""b"} (decoded {@code a"b}) is within a cap of 5. */
@@ -260,8 +274,20 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     }
 
     public void testKeywordWhitespaceTrimmed() throws IOException {
-        List<List<Object>> rows = read(false, Map.of(), "k:keyword\n  spaced  \n");
+        // Trimming a string column is opt-in now (default is no-trim, RFC 4180); with trim_spaces both the
+        // direct-block and Jackson paths trim to "spaced".
+        List<List<Object>> rows = read(false, Map.of("trim_spaces", true), "k:keyword\n  spaced  \n");
         assertEquals(List.of(row(br("spaced"))), rows);
+    }
+
+    public void testKeywordWhitespacePreservedByDefault() throws IOException {
+        // Default is no-trim: a string column keeps its surrounding whitespace, identically on both paths.
+        // Uses a second column so the value under test is not at column 0; column-0 leading-whitespace
+        // preservation is pinned separately by testColumnZeroLeadingWhitespaceCsv / ...TsvPlain, which now
+        // agree on both the direct and house arms under no-trim (QUOTED / PLAIN). (Escaped mode is the only
+        // dialect that still eats col-0 leading whitespace — it stays on Jackson; not exercised here.)
+        List<List<Object>> rows = read(false, Map.of(), "a:keyword,b:keyword\nx,  spaced  \n");
+        assertEquals(List.of(row(br("x"), br("  spaced  "))), rows);
     }
 
     public void testQuotedFieldWithDelimiterAndDoubledQuote() throws IOException {
@@ -295,6 +321,17 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     public void testCustomNullValue() throws IOException {
         List<List<Object>> rows = read(false, Map.of("null_value", "NULL"), "a:keyword,b:long\nNULL,NULL\nx,5\n");
         assertEquals(List.of(row(null, null), row(br("x"), 5L)), rows);
+    }
+
+    /**
+     * B1 inference parity: an untyped header forces inference, which under no-trim samples rows through the
+     * house record tokenizer. The configured {@code null_value} marker must map to null before the inferrer
+     * sees it (it only knows empty / {@code "null"}), so {@code score} infers INTEGER and the marker row reads
+     * back as null on both the direct-block and house arms.
+     */
+    public void testCustomNullValueInferredNumericUnderNoTrim() throws IOException {
+        List<List<Object>> rows = read(false, Map.of("null_value", "NA"), "id,score\n1,NA\n2,7\n");
+        assertEquals(List.of(row(1, null), row(2, 7)), rows);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -405,7 +442,7 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     }
 
     public void testTsvPlainKeywordWhitespaceTrimmed() throws IOException {
-        List<List<Object>> rows = read(true, Map.of(), "k:keyword\n  spaced  \n");
+        List<List<Object>> rows = read(true, Map.of("trim_spaces", true), "k:keyword\n  spaced  \n");
         assertEquals(List.of(row(br("spaced"))), rows);
     }
 
@@ -733,7 +770,7 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     }
 
     public void testTrailingLoneEscapeDropped() throws IOException {
-        List<List<Object>> rows = read(false, Map.of(), "k:keyword\nab\\\n");
+        List<List<Object>> rows = read(false, Map.of("trim_spaces", true), "k:keyword\nab\\\n");
         assertEquals(List.of(row(br("ab"))), rows);
     }
 
@@ -744,10 +781,10 @@ public class CsvDirectBlockParityTests extends ESTestCase {
      * The direct path must match that order.
      */
     public void testUnquotedEscapedTrailingSpaceTrimmedAfterDecode() throws IOException {
-        // Raw field: x\ (x + backslash + space). Jackson: skip-leading-ws, then decode \ → ' ',
-        // giving "x ", then trim trailing decoded ws → "x".
-        List<List<Object>> rows = read(false, Map.of(), "k:keyword\nx\\ \n");
-        assertEquals(List.of(row(br("x"))), rows);
+        // Raw field: x\ (x + backslash + space). With trim_spaces: skip-leading-ws, decode \ → ' ' giving
+        // "x ", then trim the trailing decoded ws → "x". Without trim_spaces the decoded "x " is kept.
+        assertEquals(List.of(row(br("x"))), read(false, Map.of("trim_spaces", true), "k:keyword\nx\\ \n"));
+        assertEquals(List.of(row(br("x "))), read(false, Map.of(), "k:keyword\nx\\ \n"));
     }
 
     /**
@@ -758,7 +795,7 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     public void testUnquotedEscapedLeadingAndTrailingWhitespaceTrimOrder() throws IOException {
         // Raw field: " x\ " (two spaces + x + backslash + space).
         // Jackson: skip-leading-raw-ws → "x\ ", decode → "x ", trim-trailing-decoded → "x".
-        List<List<Object>> rows = read(false, Map.of(), "k:keyword\n  x\\ \n");
+        List<List<Object>> rows = read(false, Map.of("trim_spaces", true), "k:keyword\n  x\\ \n");
         assertEquals(List.of(row(br("x"))), rows);
     }
 
@@ -770,6 +807,155 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     public void testTwoQuotedFieldsWithEmbeddedDelimiter() throws IOException {
         List<List<Object>> rows = read(false, Map.of(), "a:keyword,b:keyword\n\"p,q\",\"r\"\n");
         assertEquals(List.of(row(br("p,q"), br("r"))), rows);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // B1: padded-quoted fields and column-0 whitespace. Under no-trim the fallback arm is now the house
+    // per-record tokenizer, so each read() below is a direct-vs-house differential; under trim both arms
+    // agree with Jackson (the quirks are masked). Every case is asserted in both polarities.
+    // ---------------------------------------------------------------------------------------------
+
+    public void testPaddedQuoteBeforeQuotedField() throws IOException {
+        assertEquals(List.of(row(br("x"), br("y"))), read(false, Map.of(), "a:keyword,b:keyword\nx,  \"y\"\n"));
+        assertEquals(List.of(row(br("x"), br("y"))), read(false, Map.of("trim_spaces", true), "a:keyword,b:keyword\nx,  \"y\"\n"));
+    }
+
+    public void testPaddedQuoteBeforeQuotedFieldTsvQuotedMode() throws IOException {
+        assertEquals(List.of(row(br("x"), br("y"))), read(true, Map.of("mode", "quoted"), "a:keyword\tb:keyword\nx\t  \"y\"\n"));
+        assertEquals(
+            List.of(row(br("x"), br("y"))),
+            read(true, Map.of("mode", "quoted", "trim_spaces", true), "a:keyword\tb:keyword\nx\t  \"y\"\n")
+        );
+    }
+
+    public void testPaddedQuoteWithEmbeddedDelimiterKeepsThreeColumns() throws IOException {
+        String csv = "a:keyword,b:keyword,c:keyword\nx, \"a,b\",z\n";
+        assertEquals(List.of(row(br("x"), br("a,b"), br("z"))), read(false, Map.of(), csv));
+        assertEquals(List.of(row(br("x"), br("a,b"), br("z"))), read(false, Map.of("trim_spaces", true), csv));
+    }
+
+    public void testPaddedQuoteTypedHeadlineRepro() throws IOException {
+        String csv = "id:integer,name:keyword\n1, \"Alice, PhD\"\n";
+        assertEquals(List.of(row(1, br("Alice, PhD"))), read(false, Map.of(), csv));
+        assertEquals(List.of(row(1, br("Alice, PhD"))), read(false, Map.of("trim_spaces", true), csv));
+    }
+
+    public void testColumnZeroLeadingWhitespaceCsv() throws IOException {
+        assertEquals(List.of(row(br("  a"), br("b"))), read(false, Map.of(), "a:keyword,b:keyword\n  a,b\n"));
+        assertEquals(List.of(row(br("a"), br("b"))), read(false, Map.of("trim_spaces", true), "a:keyword,b:keyword\n  a,b\n"));
+    }
+
+    public void testColumnZeroPaddedBeforeQuoteCsv() throws IOException {
+        assertEquals(List.of(row(br("q"), br("b"))), read(false, Map.of(), "a:keyword,b:keyword\n  \"q\",b\n"));
+        assertEquals(List.of(row(br("q"), br("b"))), read(false, Map.of("trim_spaces", true), "a:keyword,b:keyword\n  \"q\",b\n"));
+    }
+
+    public void testColumnZeroLeadingWhitespaceTsvPlain() throws IOException {
+        assertEquals(List.of(row(br("  a"), br("b"))), read(true, Map.of(), "a:keyword\tb:keyword\n  a\tb\n"));
+        assertEquals(List.of(row(br("a"), br("b"))), read(true, Map.of("trim_spaces", true), "a:keyword\tb:keyword\n  a\tb\n"));
+    }
+
+    public void testTrailingWhitespaceAfterCloseQuoteBothPolarities() throws IOException {
+        assertEquals(List.of(row(br("x"), br("y"))), read(false, Map.of(), "a:keyword,b:keyword\n\"x\"  ,y\n"));
+        assertEquals(List.of(row(br("x"), br("y"))), read(false, Map.of("trim_spaces", true), "a:keyword,b:keyword\n\"x\"  ,y\n"));
+    }
+
+    public void testWhitespaceOnlyLineBothPolarities() throws IOException {
+        assertEquals(List.of(row(br("x")), row(br("y"))), read(false, Map.of(), "a:keyword\nx\n   \ny\n"));
+        assertEquals(List.of(row(br("x")), row(br("y"))), read(false, Map.of("trim_spaces", true), "a:keyword\nx\n   \ny\n"));
+    }
+
+    /**
+     * Prefetch replay: with a tiny {@code schema_sample_size}, the inferred-schema sample rows are read
+     * via the house per-record path and replayed, while later rows flow through a fresh iterator. Padded
+     * quotes inside AND beyond the sample window must tokenize identically (3 columns, {@code a,b} intact)
+     * on both arms.
+     */
+    public void testPrefetchReplayPaddedQuotedAcrossSampleBoundary() throws IOException {
+        String csv = "h1,h2,h3\nx, \"a,b\",z\np, \"c,d\",q\nr, \"e,f\",s\nt, \"g,h\",u\n";
+        List<List<Object>> rows = read(false, Map.of("schema_sample_size", 2), null, null, csv);
+        assertEquals(
+            List.of(
+                row(br("x"), br("a,b"), br("z")),
+                row(br("p"), br("c,d"), br("q")),
+                row(br("r"), br("e,f"), br("s")),
+                row(br("t"), br("g,h"), br("u"))
+            ),
+            rows
+        );
+    }
+
+    /**
+     * {@code _rowPosition} misbind pin: projecting the synthetic offset column (which forces the
+     * recordReader path on both arms) must not change the tokenized value of a padded-quoted data column
+     * versus a read that does not project it.
+     */
+    public void testRowPositionProjectionDoesNotChangeValues() throws IOException {
+        String csv = "id:integer,name:keyword\n1, \"Alice, PhD\"\n2, \"Bob, MD\"\n";
+        assertEquals(List.of(row(br("Alice, PhD")), row(br("Bob, MD"))), read(false, Map.of(), null, List.of("name"), csv));
+        List<List<Object>> withPos = read(false, Map.of(), null, List.of("_rowPosition", "name"), csv);
+        List<Object> names = new ArrayList<>();
+        for (List<Object> r : withPos) {
+            names.add(r.get(1));
+        }
+        assertEquals(List.of(br("Alice, PhD"), br("Bob, MD")), names);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Bracket-mode quote-prefix alignment (B-5): both bracket walkers must drop the outer whitespace
+    // before a quote so ` "y"` yields `y`, matching the direct quoted grammar.
+    // ---------------------------------------------------------------------------------------------
+
+    /** Fused bracket path (splitAndConvertProjected, walker 2) — the default (non-ALL) scope. */
+    public void testBracketModePaddedQuoteFusedPath() throws IOException {
+        List<List<Object>> rows = read(false, Map.of("multi_value_syntax", "brackets"), "a:keyword,b:keyword\nx,  \"y\"\n");
+        assertEquals(List.of(row(br("x"), br("y"))), rows);
+    }
+
+    /** Full-split bracket path (splitCommaDelimiterBracketAwareFields, walker 1) — reached via ALL scope. */
+    public void testBracketModePaddedQuoteAllScopeFullSplitPath() throws IOException {
+        List<List<Object>> rows = readAllScope(Map.of("multi_value_syntax", "brackets"), "a:keyword,b:keyword\nx,  \"y\"\n");
+        assertEquals(List.of(row(br("x"), br("y"))), rows);
+    }
+
+    /**
+     * Reads with an ALL stats scope bound to a throwaway sink, which routes bracket parsing through the
+     * full-split walker rather than the fused one. Only the direct-block arm is exercised (bracket mode is
+     * not direct-eligible, so both arms parse identically); the golden assertion pins the value.
+     */
+    private List<List<Object>> readAllScope(Map<String, Object> config, String content) throws IOException {
+        CsvFormatReader reader = (CsvFormatReader) baseReader(false).withConfig(config);
+        StorageObject object = new InMemoryStorageObject(content.getBytes(StandardCharsets.UTF_8));
+        FormatReadContext ctx = FormatReadContext.builder()
+            .batchSize(1024)
+            .recordAligned(true)
+            .firstSplit(true)
+            .lastSplit(true)
+            .splitStartByte(0)
+            .stats(0, 1024, true)
+            .statsColumnScope(StripeColumnScope.ALL)
+            .build();
+        List<List<Object>> rows = new ArrayList<>();
+        try (
+            var handle = ExternalStatsCapture.bind(ExternalStatsCapture.newSink());
+            CloseableIterator<Page> pages = reader.read(object, ctx)
+        ) {
+            while (pages.hasNext()) {
+                Page page = pages.next();
+                try {
+                    for (int p = 0; p < page.getPositionCount(); p++) {
+                        List<Object> r = new ArrayList<>(page.getBlockCount());
+                        for (int b = 0; b < page.getBlockCount(); b++) {
+                            r.add(valueAt(page.getBlock(b), p));
+                        }
+                        rows.add(r);
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        return rows;
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -725,6 +725,26 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row(br("a\tb"))), rows);
     }
 
+    /**
+     * The QUOTED + escaping dialect follows Jackson's CSV escape, whose control set is exactly
+     * {@code \t \n \r \0}; every other {@code \c} — including {@code \b} and {@code \f} — is the literal
+     * {@code c} (the escape only protects the next character). The C-style {@link CsvFormatReader#decodeEscapeChar}
+     * would map {@code \b}/{@code \f} to backspace/form-feed, which is the {@code mode: escaped} semantics and
+     * would diverge from Jackson under trim (its fallback arm). Pinned in both trim polarities so the direct
+     * walker, the house tokenizer, and Jackson all agree.
+     */
+    public void testQuotedEscapedBackslashBAndFAreLiteral() throws IOException {
+        assertEquals(List.of(row(br("abb"))), read(false, Map.of(), "k:keyword\n\"a\\bb\"\n"));
+        assertEquals(List.of(row(br("abb"))), read(false, Map.of("trim_spaces", true), "k:keyword\n\"a\\bb\"\n"));
+        assertEquals(List.of(row(br("afb"))), read(false, Map.of(), "k:keyword\n\"a\\fb\"\n"));
+        assertEquals(List.of(row(br("afb"))), read(false, Map.of("trim_spaces", true), "k:keyword\n\"a\\fb\"\n"));
+        // \t \n \r \0 stay control escapes (unchanged, and agreeing with Jackson).
+        assertEquals(List.of(row(br("a\tb"))), read(false, Map.of("trim_spaces", true), "k:keyword\n\"a\\tb\"\n"));
+        assertEquals(List.of(row(br("a\nb"))), read(false, Map.of("trim_spaces", true), "k:keyword\n\"a\\nb\"\n"));
+        // An unquoted escaped field in the same dialect follows the identical rule.
+        assertEquals(List.of(row(br("abb"))), read(false, Map.of(), "k:keyword\na\\bb\n"));
+    }
+
     public void testUnquotedEscapedCommaIsLiteral() throws IOException {
         List<List<Object>> rows = read(false, Map.of(), "k:keyword\na\\,b\n");
         assertEquals(List.of(row(br("a,b"))), rows);

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -265,6 +265,11 @@ public class CsvDirectBlockParityTests extends ESTestCase {
             List.of(row(br("y"))),
             read(false, Map.of("multi_value_syntax", "brackets"), null, List.of("b"), "a:keyword,b:keyword\nx,\"y\"  \n")
         );
+        // Trailing whitespace then a delimiter (not EOL) — the other disjunct of the skip.
+        assertEquals(
+            List.of(row(br("x"), br("y"), br("z"))),
+            read(false, Map.of("multi_value_syntax", "brackets"), "a:keyword,b:keyword,c:keyword\nx,\"y\" ,z\n")
+        );
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -122,6 +122,22 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row(br("ok")), row(br("fine"))), rows);
     }
 
+    /**
+     * Both arms report the identical wrapped message for junk after a closing quote — the direct-block arm
+     * previously emitted it without the {@code "CSV parse error: "} prefix that the fallback arm adds.
+     */
+    public void testContentAfterCloseQuoteErrorParity() throws IOException {
+        assertFailFastParity(
+            false,
+            Map.of(),
+            null,
+            "k:keyword\n\"x\"y\n",
+            "line -1:-1: CSV parse error at row [1]: CSV parse error: CSV row has unexpected content after a closing "
+                + "quote; row: <unparsed>; set error_mode to skip_row (or null_field) in WITH options to skip and warn "
+                + "instead of failing"
+        );
+    }
+
     /** The cap is measured on the trimmed value, so surrounding whitespace does not push a field over. */
     public void testMaxFieldSizeTrimmedWithinCap() throws IOException {
         List<List<Object>> rows = read(false, Map.of("max_field_size", 5, "trim_spaces", true), "k:keyword\n  abc  \n");
@@ -218,6 +234,19 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     public void testDecimalInLongColumnNullFieldYieldsNull() throws IOException {
         List<List<Object>> rows = read(false, nullField(), "a:long\n1.0\n");
         assertEquals(List.of(row((Object) null)), rows);
+    }
+
+    /**
+     * A whitespace-bearing {@code null_value} nulls a typed value that equals the RAW marker, identically on
+     * both arms — the direct arm previously trimmed the value before the marker check and missed it.
+     */
+    public void testPaddedNullMarkerOnTypedColumnParity() throws IOException {
+        // Padded marker " 0 ", value " 0 " (== raw marker) → null on both arms.
+        assertEquals(List.of(row((Object) null)), read(false, Map.of("null_value", " 0 "), "a:integer\n 0 \n"));
+        // Unpadded marker "0", padded value " 0 " → null via the trimmed re-check (both arms already agree).
+        assertEquals(List.of(row((Object) null)), read(false, Map.of("null_value", "0"), "a:integer\n 0 \n"));
+        // A padded value that is NOT the marker still parses.
+        assertEquals(List.of(row(5)), read(false, Map.of("null_value", " 0 "), "a:integer\n 5 \n"));
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -247,6 +247,10 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row((Object) null)), read(false, Map.of("null_value", "0"), "a:integer\n 0 \n"));
         // A padded value that is NOT the marker still parses.
         assertEquals(List.of(row(5)), read(false, Map.of("null_value", " 0 "), "a:integer\n 5 \n"));
+        // Escaped path: field "\ 5 " (escaped space + "5 ") decodes to " 5 " == the padded marker, and nulls
+        // on both arms — emitUnquotedEscapedField now defers the typed trim to tryConvertValue like its house
+        // peer, so the raw marker isn't stripped before the check.
+        assertEquals(List.of(row((Object) null)), read(false, Map.of("null_value", " 5 "), "a:integer\n\\ 5 \n"));
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -253,6 +253,20 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row((Object) null)), read(false, Map.of("null_value", " 5 "), "a:integer\n\\ 5 \n"));
     }
 
+    /** Bracket mode drops trailing whitespace after a closing quote under no-trim, matching the quoted grammar. */
+    public void testBracketTrailingWhitespaceAfterCloseQuoteDropped() throws IOException {
+        // Unprojected read → the full-split bracket walker.
+        assertEquals(
+            List.of(row(br("x"), br("y"))),
+            read(false, Map.of("multi_value_syntax", "brackets"), "a:keyword,b:keyword\nx,\"y\"  \n")
+        );
+        // Projected read → the fused bracket walker.
+        assertEquals(
+            List.of(row(br("y"))),
+            read(false, Map.of("multi_value_syntax", "brackets"), null, List.of("b"), "a:keyword,b:keyword\nx,\"y\"  \n")
+        );
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Double
     // ---------------------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderRecognizedKeysTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderRecognizedKeysTests.java
@@ -50,6 +50,7 @@ public class CsvFormatReaderRecognizedKeysTests extends ESTestCase {
         expected.add("null_value");
         expected.add("quote");
         expected.add("schema_sample_size");
+        expected.add("trim_spaces");
         assertEquals(expected, new TreeSet<>(CsvFormatReader.RECOGNIZED_KEYS));
     }
 
@@ -179,6 +180,7 @@ public class CsvFormatReaderRecognizedKeysTests extends ESTestCase {
             case "multi_value_syntax" -> "brackets";
             case "header_row" -> false;
             case "column_prefix" -> "f_";
+            case "trim_spaces" -> true;
             case "schema_sample_size" -> 10;
             default -> throw new AssertionError("update sampleValueFor() for new recognised key: " + key);
         };

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -115,6 +115,86 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    /**
+     * B1 inference fix: under the no-trim default a padded quote ({@code x, "a,b"}) is ONE quoted field,
+     * so headerless inference over this row synthesizes 3 columns. Jackson's no-trim tokenizer mis-splits
+     * it into 4 (padding before a quote makes the field unquoted, exploding the column count), which is the
+     * bug the house record tokenizer removes on every record-materialized path (here, schema sampling).
+     */
+    public void testHeaderlessInferenceKeepsPaddedQuotedColumnCount() throws IOException {
+        StorageObject object = createStorageObject("x, \"a,b\",z\n");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        assertEquals(3, reader.schema(object).size());
+    }
+
+    /**
+     * B1 inference fix: under no-trim the house record tokenizer feeds raw fields to {@link CsvSchemaInferrer},
+     * which classifies only empty / {@code "null"} as null. A configured {@code null_value} marker must be mapped
+     * to null before inference or the raw marker flips the column's inferred type (here {@code score} would become
+     * KEYWORD instead of INTEGER). Pre-B1 Jackson's {@code withNullValue} nulled the marker at tokenization.
+     */
+    public void testCustomNullValueInferenceUnderNoTrim() throws IOException {
+        StorageObject object = createStorageObject("id,score\n1,NA\n2,7\n");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("null_value", "NA"));
+        List<Attribute> schema = reader.schema(object);
+        assertEquals("score", schema.get(1).name());
+        assertEquals(DataType.INTEGER, schema.get(1).dataType());
+    }
+
+    // --- The header line is parsed with CSV rules (quoting, embedded delimiter, BOM) ---
+
+    /** Quoted header names (pandas/pyarrow/Excel default) resolve without the quote characters. */
+    public void testQuotedHeaderNamesUnquoted() throws IOException {
+        StorageObject object = createStorageObject("\"id\",\"a\",\"b\"\n1,-5,10\n");
+        List<Attribute> schema = new CsvFormatReader(blockFactory).schema(object);
+        assertEquals(List.of("id", "a", "b"), schema.stream().map(Attribute::name).toList());
+    }
+
+    /** A quoted header field containing the delimiter is ONE column, not silently mis-split. */
+    public void testQuotedHeaderEmbeddedDelimiter() throws IOException {
+        StorageObject object = createStorageObject("\"a,b\",\"c\"\n1,2\n");
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        assertEquals(List.of("a,b", "c"), reader.schema(object).stream().map(Attribute::name).toList());
+        try (CloseableIterator<Page> it = reader.read(object, null, 10)) {
+            Page page = it.next();
+            assertEquals(2, page.getBlockCount());
+            assertEquals(1, ((IntBlock) page.getBlock(0)).getInt(0));
+            assertEquals(2, ((IntBlock) page.getBlock(1)).getInt(0));
+        }
+    }
+
+    /** A trailing delimiter in the header adds no spurious empty-named column (matches String.split / the plain path). */
+    public void testQuotedHeaderTrailingDelimiterDropsEmptyColumn() throws IOException {
+        StorageObject object = createStorageObject("\"a\",b,\n1,2\n");
+        assertEquals(List.of("a", "b"), new CsvFormatReader(blockFactory).schema(object).stream().map(Attribute::name).toList());
+    }
+
+    /** RFC 4180 doubled-quote inside a quoted name unescapes to a single quote. */
+    public void testQuotedHeaderEscapedQuoteInName() throws IOException {
+        StorageObject object = createStorageObject("\"i\"\"d\",x\n1,2\n");
+        List<Attribute> schema = new CsvFormatReader(blockFactory).schema(object);
+        assertEquals("i\"d", schema.get(0).name());
+        assertEquals("x", schema.get(1).name());
+    }
+
+    /** A leading UTF-8 BOM (Excel/Windows) is stripped from the first column name. */
+    public void testLeadingBomStrippedFromHeader() throws IOException {
+        StorageObject object = createStorageObject("\uFEFFid,name\n1,alice\n");
+        List<Attribute> schema = new CsvFormatReader(blockFactory).schema(object);
+        assertEquals("id", schema.get(0).name());
+        assertEquals("name", schema.get(1).name());
+    }
+
+    /** The same quote-aware header rules apply for a tab delimiter (TSV with quoting on). */
+    public void testTabDelimitedQuotedHeaderNames() throws IOException {
+        StorageObject object = createStorageObject("\"i\td\"\t\"c\"\n1\t2\n");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("delimiter", "\t", "mode", "quoted")
+        );
+        // The quoted first name contains a tab; it must stay one column.
+        assertEquals(List.of("i\td", "c"), reader.schema(object).stream().map(Attribute::name).toList());
+    }
+
     public void testTypedSchemaTextAndTxtAliasesMapToKeyword() throws IOException {
         String csv = """
             a:text,b:txt
@@ -403,7 +483,9 @@ public class CsvFormatReaderTests extends ESTestCase {
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
-        assertEquals("\"host:port\"", schema.get(0).name());
+        // The quoted name is unwrapped (its internal colon is NOT a type annotation), so it resolves to
+        // host:port — not the literal "host:port" with quote characters the naive split used to produce.
+        assertEquals("host:port", schema.get(0).name());
         assertEquals(DataType.KEYWORD, schema.get(0).dataType());
         assertEquals("status", schema.get(1).name());
         assertEquals(DataType.INTEGER, schema.get(1).dataType());
@@ -1406,19 +1488,311 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     // --- Whitespace trimming ---
 
-    public void testWhitespaceTrimming() throws IOException {
+    public void testWhitespacePreservedByDefault() throws IOException {
         String csv = "id:long,name:keyword\n 1 , Alice \n 2 , Bob \n";
 
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
 
+        // Default is now no-trim (RFC 4180 — spaces are part of a field). Typed columns still tolerate
+        // padding (id → 1, 2); string columns keep their surrounding whitespace verbatim.
+        // (name is the second column; its leading space is preserved. Column 0 here is a typed LONG, so its
+        // padding is tolerated by the numeric parse regardless of whitespace; under no-trim the QUOTED / PLAIN
+        // house grammar now ALSO preserves a string column-0's leading whitespace — pinned by
+        // CsvDirectBlockParityTests.testColumnZeroLeadingWhitespaceCsv / ...TsvPlain on both the direct and
+        // house arms. Only escaped mode retains the col-0 leading-whitespace eating.)
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
             assertEquals(2, page.getPositionCount());
             assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef(" Alice "), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef(" Bob "), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    /** trim_spaces:true restores the legacy trim-everything behavior. */
+    public void testTrimSpacesTrueRestoresLegacyTrimming() throws IOException {
+        String csv = "id:long,name:keyword\n 1 , Alice \n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("trim_spaces", "true"));
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
             assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
         }
+    }
+
+    // --- Whitespace-as-value axis: typed-parse leniency. Characterization + fixes. ---
+
+    /**
+     * Characterization: Jackson's TRIM_SPACES trims UNQUOTED values only — a quoted keyword keeps its
+     * interior padding on the default (Jackson) path. This pins the premise the typed-parse fix relies on; if
+     * it ever fails on baseline, the whitespace model is wrong and the typed-guard reasoning must be redone.
+     */
+    public void testQuotedKeywordWhitespacePreservedJacksonPath() throws IOException {
+        String csv = "name:keyword\n\" a \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertEquals(new BytesRef(" a "), ((BytesRefBlock) page.getBlock(0)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    /** Characterization: an unquoted padded numeric already parses (via Jackson trim today, via the typed guard after). */
+    public void testUnquotedPaddedNumericParses() throws IOException {
+        String csv = "id:integer\n 5 \n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(5, ((IntBlock) page.getBlock(0)).getInt(0));
+        }
+    }
+
+    /**
+     * Headline repro: a quoted, numeric-looking value with interior whitespace (" 5 ") must NOT abort
+     * the whole file. The typed column parses it by trimming before the numeric parse (mirroring inference).
+     */
+    public void testQuotedPaddedIntegerDoesNotAbortRead() throws IOException {
+        String csv = "id:integer,name:keyword\n\" 5 \",a\n6,b\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            IntBlock ids = (IntBlock) page.getBlock(0);
+            assertEquals(5, ids.getInt(0));
+            assertEquals(6, ids.getInt(1));
+            BytesRefBlock names = (BytesRefBlock) page.getBlock(1);
+            assertEquals(new BytesRef("a"), names.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("b"), names.getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    /**
+     * As filed: with NO type annotation, inference (which trims before detection) resolves the column
+     * to INTEGER from quoted padded values, and conversion must agree end-to-end rather than abort.
+     */
+    public void testInferredPaddedQuotedNumericFullRead() throws IOException {
+        String csv = "id\n\" 5 \"\n\" 6 \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            IntBlock ids = (IntBlock) page.getBlock(0);
+            assertEquals(5, ids.getInt(0));
+            assertEquals(6, ids.getInt(1));
+        }
+    }
+
+    /** A clean and a quoted-padded numeric in the same column both parse to the same value. */
+    public void testMixedCleanAndPaddedNumerics() throws IOException {
+        String csv = "id:integer\n5\n\" 5 \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            IntBlock ids = (IntBlock) page.getBlock(0);
+            assertEquals(5, ids.getInt(0));
+            assertEquals(5, ids.getInt(1));
+        }
+    }
+
+    /**
+     * The padded-value tolerance is type-agnostic (one trim before the typed switch), so every non-string
+     * arm must tolerate a quoted, whitespace-padded value — not just the numeric ones. Pins evolvability:
+     * a future typed arm that forgets to route through the trim (or is mis-classified as string) fails here.
+     */
+    public void testPaddedQuotedValuesTolerateAcrossTypes() throws IOException {
+        String csv = "l:long,d:double,b:boolean,dt:datetime,ip:ip,v:version\n"
+            + "\" 9 \",\" 3.14 \",\" true \",\" 2021-01-01T00:00:00Z \",\" 127.0.0.1 \",\" 1.2.3 \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            for (int c = 0; c < page.getBlockCount(); c++) {
+                assertFalse("column " + c + " should tolerate the padded value, not null it", page.getBlock(c).isNull(0));
+            }
+            assertEquals(9L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(3.14, ((DoubleBlock) page.getBlock(1)).getDouble(0), 0.0);
+            assertTrue(((BooleanBlock) page.getBlock(2)).getBoolean(0));
+        }
+    }
+
+    /** A whitespace-only quoted cell on a typed column is null (as the sampler treats it), not a parse error. */
+    public void testWhitespaceOnlyQuotedTypedCellIsNull() throws IOException {
+        String csv = "id:integer\n\"   \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertTrue(page.getBlock(0).isNull(0));
+        }
+    }
+
+    /**
+     * A custom null_value that reaches a typed column with surrounding whitespace must still be recognised as
+     * null after trimming — not routed into a numeric parse that aborts (guards against the F2 regression).
+     * The keyword twin keeps the padded sentinel verbatim (fidelity is a separate axis).
+     */
+    public void testPaddedCustomNullOnTypedCellIsNull() throws IOException {
+        String csv = "id:integer,name:keyword\n\" NA \",\" NA \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("null_value", "NA"));
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertTrue("typed NA cell should be null", page.getBlock(0).isNull(0));
+            assertEquals(new BytesRef(" NA "), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    /** A quoted, padded element inside a bracket multi-value parses by type (parseElement sibling of the guard). */
+    public void testBracketQuotedPaddedElementParses() throws IOException {
+        String csv = "vals:integer\n[\" 5 \", 6]\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "brackets"));
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            IntBlock vals = (IntBlock) page.getBlock(0);
+            assertEquals(2, vals.getValueCount(0));
+            int idx = vals.getFirstValueIndex(0);
+            assertEquals(5, vals.getInt(idx));
+            assertEquals(6, vals.getInt(idx + 1));
+        }
+    }
+
+    /**
+     * Multi-value string elements keep their per-element whitespace under trim_spaces:false, matching the
+     * scalar keyword guarantee — element extraction gates its trim on trim_spaces like emitField does.
+     */
+    public void testMultiValueKeywordPreservesElementWhitespace() throws IOException {
+        String csv = "vals:keyword\n[ a , b ]\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("multi_value_syntax", "brackets", "trim_spaces", "false")
+        );
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            BytesRefBlock vals = (BytesRefBlock) page.getBlock(0);
+            assertEquals(2, vals.getValueCount(0));
+            int idx = vals.getFirstValueIndex(0);
+            assertEquals(new BytesRef(" a "), vals.getBytesRef(idx, new BytesRef()));
+            assertEquals(new BytesRef(" b "), vals.getBytesRef(idx + 1, new BytesRef()));
+        }
+    }
+
+    /** trim_spaces:true trims multi-value string elements (the legacy behavior, still available). */
+    public void testMultiValueKeywordTrimsElementsWhenTrimSpacesTrue() throws IOException {
+        String csv = "vals:keyword\n[ a , b ]\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("multi_value_syntax", "brackets", "trim_spaces", "true")
+        );
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            BytesRefBlock vals = (BytesRefBlock) page.getBlock(0);
+            int idx = vals.getFirstValueIndex(0);
+            assertEquals(new BytesRef("a"), vals.getBytesRef(idx, new BytesRef()));
+            assertEquals(new BytesRef("b"), vals.getBytesRef(idx + 1, new BytesRef()));
+        }
+    }
+
+    /** Under FAIL_FAST, a genuinely unparseable typed cell still aborts with a precise diagnostic (post-trim value shown). */
+    public void testGenuinelyBadPaddedTypedCellStillFailsFast() throws IOException {
+        String csv = "id:integer\n\" 5x \"\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue(e.getMessage().contains("Failed to parse CSV value"));
+        assertTrue("expected trimmed value in message, got: " + e.getMessage(), e.getMessage().contains("[5x]"));
+    }
+
+    /** Under a lenient (skip_row) policy the same bad cell drops its row instead of aborting the read. */
+    public void testGenuinelyBadPaddedTypedCellSkipsRowWhenLenient() throws IOException {
+        String csv = "id:integer\n\" 5x \"\n7\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(10, true);
+        try (
+            CloseableIterator<Page> iterator = reader.read(object, FormatReadContext.builder().batchSize(10).errorPolicy(lenient).build())
+        ) {
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertEquals(7, ((IntBlock) page.getBlock(0)).getInt(0));
+        }
+    }
+
+    // --- Whitespace-as-value axis: string fidelity via the trim_spaces option. ---
+    // These pin that the trim_spaces option flows to both the Jackson and the fused/bracket paths, in
+    // both polarities (independent of the no-trim default, which testWhitespacePreservedByDefault covers).
+
+    /** trim_spaces:false preserves an unquoted padded keyword on the default (Jackson) path. */
+    public void testTrimSpacesFalsePreservesUnquotedWhitespace() throws IOException {
+        String csv = "a:keyword,b:keyword\n x , y \n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.<String, Object>of("trim_spaces", "false")
+        );
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            // Trailing whitespace of every column, and leading whitespace of every column past the first,
+            // are preserved once trimming is off.
+            assertEquals(new BytesRef(" y "), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            // The default (direct-block) path preserves surrounding whitespace on every column, incl. the first.
+            assertEquals(new BytesRef(" x "), ((BytesRefBlock) page.getBlock(0)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    /** trim_spaces:false preserves an unquoted padded keyword on the fused/bracket path (the emitField half of the trimming fix). */
+    public void testTrimSpacesFalsePreservesUnquotedWhitespaceFusedPath() throws IOException {
+        String csv = "val:keyword\n a \n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("multi_value_syntax", "brackets", "trim_spaces", "false")
+        );
+        try (CloseableIterator<Page> iterator = reader.read(object, List.of("val"), 10)) {
+            Page page = iterator.next();
+            assertEquals(new BytesRef(" a "), ((BytesRefBlock) page.getBlock(0)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    /** trim_spaces:true trims an unquoted padded keyword — the explicit opt-in back into trimming. */
+    public void testTrimSpacesTrueTrimsUnquotedWhitespace() throws IOException {
+        String csv = "name:keyword\n a \n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("trim_spaces", "true"));
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            Page page = iterator.next();
+            assertEquals(new BytesRef("a"), ((BytesRefBlock) page.getBlock(0)).getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    /** emitField preserves whitespace verbatim when trimming is off. */
+    public void testEmitFieldNoTrimPreservesWhitespace() {
+        assertEquals("  hello  ", CsvFormatReader.emitField(new StringBuilder("  hello  "), false));
+        assertEquals("   ", CsvFormatReader.emitField(new StringBuilder("   "), false));
+        assertEquals(" ", CsvFormatReader.emitField(new StringBuilder(" "), false));
+        assertEquals("", CsvFormatReader.emitField(new StringBuilder(), false));
     }
 
     // --- All supported data types ---
@@ -5859,35 +6233,35 @@ public class CsvFormatReaderTests extends ESTestCase {
     // --- Phase 1A: emitField ---
 
     public void testEmitFieldCleanValue() {
-        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("hello")));
+        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("hello"), true));
     }
 
     public void testEmitFieldEmpty() {
-        assertEquals("", CsvFormatReader.emitField(new StringBuilder()));
+        assertEquals("", CsvFormatReader.emitField(new StringBuilder(), true));
     }
 
     public void testEmitFieldLeadingWhitespace() {
-        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("  hello")));
+        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("  hello"), true));
     }
 
     public void testEmitFieldTrailingWhitespace() {
-        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("hello  ")));
+        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("hello  "), true));
     }
 
     public void testEmitFieldBothWhitespace() {
-        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("  hello  ")));
+        assertEquals("hello", CsvFormatReader.emitField(new StringBuilder("  hello  "), true));
     }
 
     public void testEmitFieldWhitespaceOnly() {
-        assertEquals("", CsvFormatReader.emitField(new StringBuilder("   ")));
+        assertEquals("", CsvFormatReader.emitField(new StringBuilder("   "), true));
     }
 
     public void testEmitFieldSingleChar() {
-        assertEquals("x", CsvFormatReader.emitField(new StringBuilder("x")));
+        assertEquals("x", CsvFormatReader.emitField(new StringBuilder("x"), true));
     }
 
     public void testEmitFieldSingleWhitespace() {
-        assertEquals("", CsvFormatReader.emitField(new StringBuilder(" ")));
+        assertEquals("", CsvFormatReader.emitField(new StringBuilder(" "), true));
     }
 
     // --- Phase 2: Fused split+convert via bracket-aware path ---
@@ -6438,6 +6812,42 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
+     * Quoted + escaping dialect (both knobs on) with {@code trim_spaces=true}, so {@code jacksonGrammarApplies()}
+     * holds; projecting {@code _rowPosition} forces the recordReader-backed path, whose {@code recordEscapeAware}
+     * disjunct ({@code rowPositionProjected}) must build an escape-aware {@link CsvLogicalRecordReader}. An
+     * unquoted {@code \}-escaped newline is in-field content, so record 1 spans two physical lines and must NOT
+     * be split in two. Without the escape-aware record reader the boundary scan would end record 1 at the escaped
+     * newline, emitting a spurious extra row position. The two emitted offsets pin the single-record boundary:
+     * the header is 21 bytes and record 1 (bytes {@code 1,a\<nl>b<nl>}) is 7 bytes, so record 2 starts at 28.
+     */
+    public void testRowPositionNotSplitByEscapedNewlineInQuotedEscapingMode() throws IOException {
+        String csv = "id:long,name:keyword\n1,a\\\nb\n2,Bob\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("quote", "\"", "escape", "\\", "trim_spaces", true)
+        );
+        FormatReadContext ctx = FormatReadContext.builder()
+            .batchSize(64)
+            .errorPolicy(ErrorPolicy.STRICT)
+            .projectedColumns(List.of("_rowPosition"))
+            .firstSplit(true)
+            .lastSplit(true)
+            .build();
+        List<Long> offsets = new ArrayList<>();
+        try (CloseableIterator<Page> it = reader.read(object, ctx)) {
+            while (it.hasNext()) {
+                Page page = it.next();
+                LongBlock rowPos = (LongBlock) page.getBlock(0);
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    offsets.add(rowPos.getLong(i));
+                }
+                page.releaseBlocks();
+            }
+        }
+        assertEquals("escaped newline must not split record 1 into two rows", List.of(21L, 28L), offsets);
+    }
+
+    /**
      * Inferred-schema read (un-typed header forces {@code inferSchemaFromBatchReader}) must still
      * emit exact file-global {@code _rowPosition} offsets across the schema-sample boundary. The
      * sample rows are read via the recordReader-backed iterator and replayed with captured offsets;
@@ -6595,7 +7005,7 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * Regression for https://github.com/elastic/esql-planning/issues/894: the Jackson hot data path enforces
+     * Regression: the Jackson hot data path enforces
      * {@code max_record_size} via the upstream {@link CsvRecordCappingInputStream}. An oversized record
      * trips the cap during the {@link java.io.BufferedReader} bulk fill (potentially before any individual
      * row has been emitted), the {@link CsvRecordTooLargeException} propagates as an {@link IOException},
@@ -6645,10 +7055,14 @@ public class CsvFormatReaderTests extends ESTestCase {
         int maxRecordBytes = 32;
         String csv = "id:long,text:keyword\n1,ok\n100," + "x".repeat(maxRecordBytes) + "\n";
         StorageObject object = createStorageObject(csv);
-        // Pin the Jackson bulk path: the direct-to-block paths intentionally treat the per-record
-        // cap as recoverable (matching the bracket-aware path), so default CSV would otherwise
-        // recover under a lenient policy instead of aborting. See read() for the rationale.
-        CsvFormatReader reader = new CsvFormatReader(blockFactory).withDirectBlockEnabled(false);
+        // Pin the Jackson bulk path: the direct-to-block paths (and, under the no-trim default, the house
+        // per-record path on CsvLogicalRecordReader) intentionally treat the per-record cap as recoverable
+        // (matching the bracket-aware path), so default CSV would otherwise recover under a lenient policy
+        // instead of aborting. trim_spaces keeps Jackson's grammar applicable so the read stays on the bulk
+        // path (with its stream-fatal CsvRecordCappingInputStream); withDirectBlockEnabled(false) forces the
+        // bulk arm over the direct one. See read() for the rationale.
+        CsvFormatReader reader = ((CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("trim_spaces", true)))
+            .withDirectBlockEnabled(false);
 
         FormatReadContext context = FormatReadContext.builder()
             .batchSize(10)
@@ -6672,6 +7086,52 @@ public class CsvFormatReaderTests extends ESTestCase {
             rootCause instanceof CsvRecordTooLargeException
         );
         assertThat(rootCause.getMessage(), Matchers.containsString("max_record_size [" + maxRecordBytes + "]"));
+    }
+
+    /**
+     * No-trim sibling of {@link #testJacksonBulkPathAbortsOnCapTooLargeEvenUnderLenientPolicy}: with the
+     * direct-block kill-switch off ({@code withDirectBlockEnabled(false)}) AND the no-trim default,
+     * {@code jacksonGrammarApplies()} is false, so a non-direct read reroutes onto the house per-record path
+     * ({@code newCsvIterator} on {@link CsvLogicalRecordReader}) rather than the stream-fatal Jackson bulk
+     * path. That path enforces {@code max_record_size} via {@link CsvLogicalRecordReader#addBytes}, an exact
+     * RECOVERABLE per-record check, so under a lenient policy the oversized record is skipped and the
+     * surrounding rows read intact — the opposite of the trim=true bulk arm's destructive abort.
+     */
+    public void testNoTrimHousePathSkipsOversizedRecordUnderLenientPolicy() throws IOException {
+        int maxRecordBytes = 32;
+        String csv = "id:long,text:keyword\n" + "1,alpha\n" + "100," + "x".repeat(maxRecordBytes + 8) + "\n" + "2,beta\n" + "3,gamma\n";
+        StorageObject object = createStorageObject(csv);
+        // No trim_spaces (default no-trim) keeps Jackson's grammar inapplicable; the kill-switch forces the
+        // non-direct arm, which reroutes to the house per-record path (see read()'s useRecordReaderPath).
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withDirectBlockEnabled(false);
+
+        FormatReadContext context = FormatReadContext.builder()
+            .batchSize(10)
+            .errorPolicy(ErrorPolicy.LENIENT)
+            .maxRecordBytes(maxRecordBytes)
+            .build();
+
+        List<Long> ids = new ArrayList<>();
+        List<String> texts = new ArrayList<>();
+        try (CloseableIterator<Page> iterator = reader.read(object, context)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                try {
+                    LongBlock idBlock = (LongBlock) page.getBlock(0);
+                    BytesRefBlock textBlock = (BytesRefBlock) page.getBlock(1);
+                    BytesRef scratch = new BytesRef();
+                    for (int p = 0; p < page.getPositionCount(); p++) {
+                        ids.add(idBlock.getLong(idBlock.getFirstValueIndex(p)));
+                        texts.add(textBlock.getBytesRef(textBlock.getFirstValueIndex(p), scratch).utf8ToString());
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        // The oversized row is recoverably dropped; the rows before and after it survive in order.
+        assertEquals(List.of(1L, 2L, 3L), ids);
+        assertEquals(List.of("alpha", "beta", "gamma"), texts);
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvModeReadTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvModeReadTests.java
@@ -124,6 +124,25 @@ public class CsvModeReadTests extends ESTestCase {
         assertEquals("value", values.get(0).get(2));
     }
 
+    /**
+     * Documents the escaped-mode residual: {@code escaped} (quoting off, escaping on) keeps
+     * {@code jacksonGrammarApplies()} true even under no-trim (the house grammar mirrors only the QUOTED /
+     * PLAIN dialects, not the C-style decode), so escaped reads still tokenize with Jackson and inherit its
+     * {@code SKIP_EMPTY_LINES} first-column leading-whitespace eating. This is a real no-trim gap for escaped
+     * mode — but it is uniform across every escaped arm (per-record + bulk + inference all go through Jackson),
+     * so there is no cross-path misbind. Pinned so a future widening of the house grammar to escaped mode (which
+     * WOULD start preserving col-0 whitespace) is a deliberate, visible change rather than a silent drift.
+     */
+    public void testEscapedModeStillEatsColumnZeroLeadingWhitespaceUnderNoTrim() throws IOException {
+        String tsv = "a:keyword\tb:keyword\n  x\t  y\n";
+        List<List<String>> values = readAll(tsvReader(Map.of("mode", "escaped")), tsv);
+        assertEquals(1, values.size());
+        // Column 0's leading whitespace is eaten by Jackson's SKIP_EMPTY_LINES; a non-first column keeps its
+        // padding, so the residual is column-0-specific (not general trimming).
+        assertEquals("x", values.get(0).get(0));
+        assertEquals("  y", values.get(0).get(1));
+    }
+
     /** {@code escaped} is still a no-quote mode: a field-leading {@code "} is data, rows never glue. */
     public void testEscapedFieldLeadingQuoteIsData() throws IOException {
         String tsv = """

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvModeTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvModeTests.java
@@ -182,7 +182,8 @@ public class CsvModeTests extends ESTestCase {
             true,
             CsvFormatOptions.DEFAULT_COLUMN_PREFIX,
             mode.usesQuote(),
-            mode.usesEscape()
+            mode.usesEscape(),
+            false // trimSpaces: default no-trim
         );
     }
 

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordTokenizerTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvRecordTokenizerTests.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit + differential coverage for {@link CsvFormatReader#splitRecordFields}, the house record tokenizer
+ * that replaces Jackson on the no-trim, non-escaped-mode ({@code QUOTED} / {@code PLAIN}) record paths.
+ *
+ * <p>The no-trim cases pin the exact grammar the direct-to-block walkers implement (leading-whitespace
+ * preservation at column 0, outer-whitespace skip before a quote, padded-quoted column counts). The
+ * trim=true block is a Jackson-equivalence differential: it confirms the splitter agrees with Jackson's
+ * own tokenization under {@code TRIM_SPACES}, so widening {@link CsvFormatReader#jacksonGrammarApplies()}
+ * to route trim=true through the splitter would stay behavior-preserving.
+ */
+public class CsvRecordTokenizerTests extends ESTestCase {
+
+    private static final int NO_CAP = Integer.MAX_VALUE;
+
+    // ---------------------------------------------------------------------------------------------
+    // No-trim grammar (the production path): the B1 repros and the col-0 fix
+    // ---------------------------------------------------------------------------------------------
+
+    public void testQuotedPaddedBeforeQuoteSkipsWhitespace() {
+        assertTokens(csv(), "x,  \"y\"", "x", "y");
+    }
+
+    public void testQuotedPaddedQuoteWithEmbeddedDelimiterKeepsColumnCount() {
+        // The B1 headline: Jackson (no-trim) splits this into 4 fields; the house grammar keeps 3.
+        assertTokens(csv(), "x, \"a,b\",z", "x", "a,b", "z");
+    }
+
+    public void testQuotedPaddedQuoteTwoColumns() {
+        assertTokens(csv(), "1, \"Alice, PhD\"", "1", "Alice, PhD");
+    }
+
+    public void testCsvColumnZeroLeadingWhitespacePreserved() {
+        assertTokens(csv(), "  a,b", "  a", "b");
+    }
+
+    public void testCsvColumnZeroPaddedBeforeQuote() {
+        assertTokens(csv(), "  \"q\",b", "q", "b");
+    }
+
+    public void testPlainTsvColumnZeroLeadingWhitespacePreserved() {
+        assertTokens(tsv(), "  a\tb", "  a", "b");
+    }
+
+    public void testTrailingWhitespaceAfterCloseQuote() {
+        assertTokens(csv(), "x,\"y\"  ", "x", "y");
+    }
+
+    public void testEmptyQuotedFieldIsEmptyString() {
+        // The tokenizer emits "" for an empty quoted field; downstream tryConvertValue maps "" to null.
+        assertTokens(csv(), "\"\",x", "", "x");
+    }
+
+    public void testInnerWhitespacePreservedInQuotedField() {
+        assertTokens(csv(), "\"  x  \"", "  x  ");
+    }
+
+    public void testDoubledQuoteDecodes() {
+        assertTokens(csv(), "\"a\"\"b\"", "a\"b");
+    }
+
+    public void testUnquotedEscapedCommaIsLiteral() {
+        assertTokens(csv(), "a\\,b", "a,b");
+    }
+
+    public void testUnquotedFieldVerbatimUnderNoTrim() {
+        assertTokens(csv(), "x,  spaced  ", "x", "  spaced  ");
+    }
+
+    public void testTrailingDelimiterYieldsEmptyLastField() {
+        assertTokens(csv(), "a,b,", "a", "b", "");
+        assertTokens(tsv(), "a\tb\t", "a", "b", "");
+    }
+
+    public void testQuotedNewlinePreservedInsideField() {
+        assertTokens(csv(), "\"line1\nline2\",tail", "line1\nline2", "tail");
+    }
+
+    public void testQuoteInMiddleOfUnquotedIsLiteral() {
+        assertTokens(csv(), "ab\"cd\"", "ab\"cd\"");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // max_field_size cap: same message as the direct walker's rejectFieldTooLarge
+    // ---------------------------------------------------------------------------------------------
+
+    public void testPlainFieldOverCapThrowsWithJacksonMessage() {
+        MalformedRowException e = expectThrows(
+            MalformedRowException.class,
+            () -> CsvFormatReader.splitRecordFields("helloworld12", csv(), 10)
+        );
+        assertEquals(CsvFormatReader.fieldSizeExceededDetail(12, 10), e.getMessage());
+    }
+
+    public void testQuotedFieldOverCapCountsDecodedLength() {
+        MalformedRowException e = expectThrows(
+            MalformedRowException.class,
+            () -> CsvFormatReader.splitRecordFields("\"helloworld\"", csv(), 5)
+        );
+        assertEquals(CsvFormatReader.fieldSizeExceededDetail(10, 5), e.getMessage());
+    }
+
+    public void testDoubledQuoteWithinCap() {
+        // "a""b" decodes to a"b (length 3), within a cap of 5.
+        assertTokens(csv(), 5, "\"a\"\"b\"", "a\"b");
+    }
+
+    public void testNonFirstFieldOverCapStillThrows() {
+        MalformedRowException e = expectThrows(
+            MalformedRowException.class,
+            () -> CsvFormatReader.splitRecordFields("short,helloworld", csv(), 5)
+        );
+        assertEquals(CsvFormatReader.fieldSizeExceededDetail(10, 5), e.getMessage());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Unclosed quote
+    // ---------------------------------------------------------------------------------------------
+
+    public void testUnclosedQuoteThrows() {
+        expectThrows(MalformedRowException.class, () -> CsvFormatReader.splitRecordFields("\"unterminated,x", csv(), NO_CAP));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // trim=true: Jackson-equivalence differential (splitter vs the production Jackson mapper shape)
+    // ---------------------------------------------------------------------------------------------
+
+    public void testTrimTrueMatchesJacksonQuoted() throws IOException {
+        assertJacksonEquivalence(csvTrim(), quotedCorpus());
+    }
+
+    public void testTrimTrueMatchesJacksonPlain() throws IOException {
+        assertJacksonEquivalence(tsvTrim(), plainCorpus());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Harness
+    // ---------------------------------------------------------------------------------------------
+
+    private static void assertTokens(CsvFormatOptions options, String record, String... expected) {
+        assertTokens(options, NO_CAP, record, expected);
+    }
+
+    private static void assertTokens(CsvFormatOptions options, int maxFieldChars, String record, String... expected) {
+        assertEquals(
+            "tokenization of [" + record + "]",
+            Arrays.asList(expected),
+            Arrays.asList(CsvFormatReader.splitRecordFields(record, options, maxFieldChars))
+        );
+    }
+
+    /**
+     * Parses every record in {@code corpus} with both the house splitter (trim on) and a Jackson mapper
+     * built exactly as {@link CsvFormatReader#createMapper} / {@code newCsvSchema} do, and asserts the two
+     * agree field-for-field after normalizing Jackson's {@code null} (its {@code withNullValue} substitution)
+     * against the splitter's raw {@code ""}. Records Jackson skips entirely (blank under SKIP_EMPTY_LINES) are
+     * skipped here — blank-line handling lives outside the tokenizer, in the per-record read loop.
+     */
+    private static void assertJacksonEquivalence(CsvFormatOptions options, List<String> corpus) throws IOException {
+        CsvMapper mapper = jacksonMapper(options);
+        CsvSchema schema = jacksonSchema(options);
+        for (String record : corpus) {
+            List<String> jackson = jacksonTokens(mapper, schema, record);
+            if (jackson == null) {
+                continue; // Jackson skipped it (empty line); the splitter's blank handling is elsewhere.
+            }
+            String[] house = CsvFormatReader.splitRecordFields(record, options, NO_CAP);
+            assertEquals(
+                "column count for [" + record + "] (jackson=" + jackson + " house=" + Arrays.asList(house) + ")",
+                jackson.size(),
+                house.length
+            );
+            for (int i = 0; i < jackson.size(); i++) {
+                assertEquals(
+                    "field [" + i + "] of [" + record + "]",
+                    normalizeNull(jackson.get(i), options),
+                    normalizeNull(house[i], options)
+                );
+            }
+        }
+    }
+
+    /** Jackson's withNullValue substitutes null for a field equal to nullValue; fold both arms to one token. */
+    private static String normalizeNull(String value, CsvFormatOptions options) {
+        if (value == null || value.equals(options.nullValue())) {
+            return " NULL ";
+        }
+        return value;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static List<String> jacksonTokens(CsvMapper mapper, CsvSchema schema, String record) throws IOException {
+        try (MappingIterator<List> it = mapper.readerFor(List.class).with(schema).readValues(new StringReader(record))) {
+            if (it.hasNext() == false) {
+                return null;
+            }
+            List<?> row = it.next();
+            List<String> out = new ArrayList<>(row.size());
+            for (Object o : row) {
+                out.add(o == null ? null : o.toString());
+            }
+            return out;
+        }
+    }
+
+    private static CsvMapper jacksonMapper(CsvFormatOptions opts) {
+        CsvMapper mapper = new CsvMapper();
+        if (opts.trimSpaces()) {
+            mapper.enable(CsvParser.Feature.TRIM_SPACES);
+        }
+        mapper.enable(CsvParser.Feature.SKIP_EMPTY_LINES);
+        mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+        return mapper;
+    }
+
+    private static CsvSchema jacksonSchema(CsvFormatOptions opts) {
+        CsvSchema schema = CsvSchema.emptySchema().withColumnSeparator(opts.delimiter()).withNullValue(opts.nullValue());
+        if (opts.quoting() == false) {
+            return schema.withoutQuoteChar();
+        }
+        schema = schema.withQuoteChar(opts.quoteChar());
+        return opts.escaping() ? schema.withEscapeChar(opts.escapeChar()) : schema;
+    }
+
+    private static List<String> quotedCorpus() {
+        return List.of(
+            "a,b,c",
+            "x,  \"y\"",
+            "x, \"a,b\",z",
+            "1, \"Alice, PhD\"",
+            "\"has,comma\",\"he said \"\"hi\"\"\"",
+            "\"  x  \",tail",
+            "  \"q\",b",
+            "x,\"y\"  ,z",
+            "a,b,",
+            ",lead",
+            "one",
+            "\"quoted\"",
+            "n1,n2,n3,n4"
+        );
+    }
+
+    private static List<String> plainCorpus() {
+        return List.of("a\tb\tc", "  a\tb", "x\t  spaced  ", "a\tb\t", "\tlead", "one", "n1\tn2\tn3");
+    }
+
+    private static CsvFormatOptions csv() {
+        return CsvFormatOptions.DEFAULT;
+    }
+
+    private static CsvFormatOptions tsv() {
+        return CsvFormatOptions.TSV;
+    }
+
+    private static CsvFormatOptions csvTrim() {
+        return withTrim(CsvFormatOptions.DEFAULT, true);
+    }
+
+    private static CsvFormatOptions tsvTrim() {
+        return withTrim(CsvFormatOptions.TSV, true);
+    }
+
+    private static CsvFormatOptions withTrim(CsvFormatOptions o, boolean trim) {
+        return new CsvFormatOptions(
+            o.delimiter(),
+            o.quoteChar(),
+            o.escapeChar(),
+            o.commentPrefix(),
+            o.nullValue(),
+            o.encoding(),
+            o.datetimeFormatter(),
+            o.maxFieldSize(),
+            o.multiValueSyntax(),
+            o.headerRow(),
+            o.columnPrefix(),
+            o.quoting(),
+            o.escaping(),
+            trim
+        );
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvStripeStatsCaptureTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvStripeStatsCaptureTests.java
@@ -507,6 +507,40 @@ public class CsvStripeStatsCaptureTests extends ESTestCase {
         assertFalse("PROJECTED+COUNT(*) commits no column b", hasAnyColumnStat(projFrags, "b"));
     }
 
+    /**
+     * B1 stats regression: under the no-trim default an ALL-scope read routes through the house per-record
+     * tokenizer (Jackson's grammar does not apply), and stripe capture must still compose correctly over a
+     * padded-quoted file. A padded quote ({@code  "Alice, PhD"}) is ONE field, so the following integer
+     * column keeps its real values; the Jackson bug would mis-split it and corrupt {@code val}'s min/max.
+     * The captured min/max/count are stripe-layout invariant, so they equal the hand-computed truth
+     * regardless of the (deliberately small) stripe grid.
+     */
+    public void testAllScopeCaptureCorrectOnPaddedQuotedNoTrim() throws Exception {
+        byte[] full = "name:keyword,val:integer\n \"Alice, PhD\", 10\n \"Bob, MD\", 20\n \"Carol, PhD\", 30\n".getBytes(
+            StandardCharsets.UTF_8
+        );
+        long stripe = 20; // several stripes across the file, exercising per-stripe emit + reconcile fold
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD, Nullability.TRUE, null, false),
+            intCol("val")
+        );
+        Map<String, Object> meta = reconcileToMetadata(
+            captureScoped(full, 0, true, true, 1000, stripe, List.of("val"), StripeColumnScope.ALL),
+            schema
+        );
+        assertEquals(
+            "row count over the padded-quoted file",
+            3L,
+            ((Number) meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue()
+        );
+        assertEquals(
+            "val min (padding must not corrupt the integer column)",
+            10,
+            ((Number) SourceStatisticsSerializer.extractColumnMin(meta, "val")).intValue()
+        );
+        assertEquals("val max", 30, ((Number) SourceStatisticsSerializer.extractColumnMax(meta, "val")).intValue());
+    }
+
     // header "a,b\n" + rows "i,100+i\n"; both columns inferred INTEGER.
     private static byte[] twoColumnCsv(int count) {
         StringBuilder sb = new StringBuilder("a,b\n");
@@ -1105,7 +1139,15 @@ public class CsvStripeStatsCaptureTests extends ESTestCase {
         }
     }
 
-    /** Capture variant that also overrides the read encoding, to steer onto the plain Jackson bulk path. */
+    /**
+     * Capture variant that also overrides the read encoding, to steer onto the plain Jackson bulk path.
+     * {@code trim_spaces} is forced on so the read actually reaches that path: under the no-trim default,
+     * Jackson's grammar does not apply (padded-quoted mis-split, col-0 whitespace eating), so a
+     * non-direct read routes through the house per-record tokenizer on {@code CsvLogicalRecordReader}
+     * instead — which supplies byte-exact per-record offsets for any encoding and therefore captures
+     * stripes correctly rather than safe-missing. Trimming restores the Jackson bulk path this variant
+     * is meant to probe.
+     */
     private List<Map<String, Object>> captureScopedWithEncoding(
         byte[] bytes,
         long baseOffset,
@@ -1133,7 +1175,130 @@ public class CsvStripeStatsCaptureTests extends ESTestCase {
         try (
             var handle = ExternalStatsCapture.bind(sink);
             CloseableIterator<Page> it = new CsvFormatReader(blockFactory, "csv", List.of(".csv")).withConfig(
-                Map.of(CsvFormatReader.CONFIG_HEADER_ROW, headerRow, CsvFormatReader.CONFIG_ENCODING, encoding)
+                Map.of(
+                    CsvFormatReader.CONFIG_HEADER_ROW,
+                    headerRow,
+                    CsvFormatReader.CONFIG_ENCODING,
+                    encoding,
+                    CsvFormatReader.CONFIG_TRIM_SPACES,
+                    true
+                )
+            ).read(o, ctx)
+        ) {
+            while (it.hasNext()) {
+                it.next().releaseBlocks();
+            }
+        }
+        List<Map<String, Object>> raw = sink.get(o.path().toString());
+        return raw == null ? List.of() : raw;
+    }
+
+    /**
+     * B1 counterpart to {@link #testAllScopePlainJacksonBulkPathSafeMissesNoBogusStripes}: under the no-trim
+     * DEFAULT a non-UTF-8 read does NOT route onto the plain Jackson bulk path (Jackson's grammar does not
+     * apply — see {@code jacksonGrammarApplies}), so it flows through the house per-record tokenizer on
+     * {@link CsvLogicalRecordReader}, which supplies byte-exact per-record offsets for ANY encoding. Stripe
+     * capture must therefore SUCCEED here (not safe-miss), and differently-chunked scans of the same non-UTF-8
+     * file must fold to the exact row count. Exercised with a single-byte ISO-8859-1 file whose {@code é}
+     * (0xE9) is one byte in the read encoding but two in UTF-8, so char and byte cursors genuinely diverge.
+     */
+    /**
+     * B1 counterpart to {@link #testAllScopePlainJacksonBulkPathSafeMissesNoBogusStripes}: under the no-trim
+     * DEFAULT a non-UTF-8 read does NOT route onto the plain Jackson bulk path (Jackson's grammar does not
+     * apply — see {@code jacksonGrammarApplies}), so it flows through the house per-record tokenizer on
+     * {@link CsvLogicalRecordReader}, which supplies byte-exact per-record offsets for ANY encoding. Stripe
+     * capture must therefore SUCCEED here (not safe-miss), and differently-chunked scans of the same non-UTF-8
+     * file must fold to the exact row count. Exercised headerless (so a non-first split re-infers rather than
+     * eating a data row as a header) with single-byte encodings whose {@code é} (0xE9) is one byte in the read
+     * encoding but two in UTF-8, so char and byte cursors genuinely diverge — the case the byte tracker must
+     * get right. ALL scope, COUNT(*) projection: the fold checks the harvested per-stripe row counts.
+     */
+    public void testNonUtf8NoTrimHousePathCapturesStripesCorrectly() throws Exception {
+        for (String encoding : List.of("ISO-8859-1", "windows-1252")) {
+            byte[] full = latin1DataNoHeader(encoding, 10);
+            long stripe = 4; // many stripes across the file, so a collapsed/skewed offset would misattribute
+            int cut = latin1RecordBytes(encoding) * 4; // a record boundary partway through
+            List<Map<String, Object>> whole = captureScopedWithEncodingNoTrim(
+                full,
+                0,
+                true,
+                true,
+                1000,
+                stripe,
+                null,
+                StripeColumnScope.ALL,
+                encoding
+            );
+            assertFoldsTo(whole, 10, "encoding=" + encoding + " whole-file");
+            // Differently-chunked scan of the same file must fold to the SAME exact count.
+            List<Map<String, Object>> split = new ArrayList<>();
+            split.addAll(
+                captureScopedWithEncodingNoTrim(slice(full, 0, cut), 0, true, false, 1000, stripe, null, StripeColumnScope.ALL, encoding)
+            );
+            split.addAll(
+                captureScopedWithEncodingNoTrim(
+                    slice(full, cut, full.length),
+                    cut,
+                    false,
+                    true,
+                    1000,
+                    stripe,
+                    null,
+                    StripeColumnScope.ALL,
+                    encoding
+                )
+            );
+            assertFoldsTo(split, 10, "encoding=" + encoding + " two-chunk fold");
+        }
+    }
+
+    // Headerless single-column file: 'count' records, each a lone high-byte 'é' encoded in 'encoding'.
+    private static byte[] latin1DataNoHeader(String encoding, int count) {
+        java.nio.charset.Charset cs = java.nio.charset.Charset.forName(encoding);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            sb.append('é').append('\n');
+        }
+        return sb.toString().getBytes(cs);
+    }
+
+    // Bytes per data record ("é\n") in the given single-byte encoding: 'é' is one byte, '\n' one byte.
+    private static int latin1RecordBytes(String encoding) {
+        return "é\n".getBytes(java.nio.charset.Charset.forName(encoding)).length;
+    }
+
+    /**
+     * Encoding-overriding capture that leaves {@code trim_spaces} at its no-trim default (house per-record path)
+     * and reads headerless (synthetic column names) so a non-first split re-infers from its own rows rather than
+     * consuming a data row as a header. A {@code null} projection is a COUNT(*) read.
+     */
+    private List<Map<String, Object>> captureScopedWithEncodingNoTrim(
+        byte[] bytes,
+        long baseOffset,
+        boolean firstSplit,
+        boolean fileFinal,
+        int batchSize,
+        long stripeSize,
+        List<String> projectedColumns,
+        StripeColumnScope scope,
+        String encoding
+    ) throws Exception {
+        StorageObject o = memoryObject(bytes);
+        FormatReadContext ctx = FormatReadContext.builder()
+            .projectedColumns(projectedColumns)
+            .batchSize(batchSize)
+            .recordAligned(true)
+            .firstSplit(firstSplit)
+            .lastSplit(true)
+            .splitStartByte(baseOffset)
+            .stats(baseOffset, stripeSize, fileFinal)
+            .statsColumnScope(scope)
+            .build();
+        ConcurrentMap<String, List<Map<String, Object>>> sink = ExternalStatsCapture.newSink();
+        try (
+            var handle = ExternalStatsCapture.bind(sink);
+            CloseableIterator<Page> it = new CsvFormatReader(blockFactory, "csv", List.of(".csv")).withConfig(
+                Map.of(CsvFormatReader.CONFIG_HEADER_ROW, false, CsvFormatReader.CONFIG_ENCODING, encoding)
             ).read(o, ctx)
         ) {
             while (it.hasNext()) {

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourceValidatorTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3DataSourceValidatorTests.java
@@ -82,6 +82,7 @@ public class S3DataSourceValidatorTests extends AbstractDataSourceValidatorTests
         "multi_value_syntax",
         "header_row",
         "column_prefix",
+        "trim_spaces",
         "schema_sample_size"
     );
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -452,7 +452,7 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         String dataSourceName = ensureDataSourceForBackend();
         for (DatasetSource source : testCase.datasetSources) {
             String resource = transformTemplates(source.resource());
-            DatasetRegistry.ensureDataset(client(), source.name(), dataSourceName, resource, source.withJson());
+            DatasetRegistry.ensureDataset(client(), source.name(), dataSourceName, resource, withJsonForSource(source));
         }
         String query = testCase.query;
         logger.debug("Dataset-mode query for {} backend: {}", storageBackend, query);
@@ -561,11 +561,52 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         // EXTERNAL string literal so a resource containing a backslash or quote round-trips correctly.
         String literal = source.resource().replace("\\", "\\\\").replace("\"", "\\\"");
         StringBuilder external = new StringBuilder("EXTERNAL \"").append(literal).append("\"");
-        if (source.withJson() != null) {
-            external.append(" WITH ").append(source.withJson());
+        // Apply the same WITH JSON the FROM path uses (adds trim_spaces for the column-aligned csv/tsv
+        // fixtures) so the EXTERNAL-holdout path reads them identically.
+        String withJson = withJsonForSource(source);
+        if (withJson != null) {
+            external.append(" WITH ").append(withJson);
         }
         external.append(tail);
         return external.toString();
+    }
+
+    /**
+     * The {@code WITH}-clause JSON applied to a dataset source, both when registering the dataset
+     * ({@link #runDatasetMode()}) and when rebuilding an {@code EXTERNAL} query
+     * ({@link #rebuildExternalFromDatasets}).
+     * <p>
+     * The CSV/TSV test fixtures (employees.csv, books.csv, ...) are column-aligned with padding spaces for
+     * readability, so their expected spec values assume trimming. The reader default is now no-trim (RFC
+     * 4180 — spaces are part of a field), so read these aligned fixtures with {@code trim_spaces: true} to
+     * keep the expected values valid. Real-world no-trim fidelity is covered by CsvFormatReaderTests unit
+     * tests; a directive that sets {@code trim_spaces} explicitly is left untouched (so a spec can still
+     * exercise the no-trim default end to end).
+     */
+    private String withJsonForSource(DatasetSource source) {
+        // format is the base format or a codec-suffixed variant ("csv", "csv.gz", "tsv.zstd", ...). Other
+        // formats (parquet, ...) reject the trim_spaces key, so only the csv/tsv backends read the
+        // column-aligned fixtures with trimming; the shared injector adds the key.
+        boolean csvOrTsv = format.equals("csv") || format.startsWith("csv.") || format.equals("tsv") || format.startsWith("tsv.");
+        return csvOrTsv ? injectTrimSpaces(source.withJson()) : source.withJson();
+    }
+
+    /**
+     * Adds {@code "trim_spaces": true} to a dataset directive's {@code WITH} JSON, unless it already sets
+     * {@code trim_spaces} (matched as a key — the quoted name followed by a colon, so a value that merely
+     * equals {@code "trim_spaces"} still gets the injection). {@code withJson} is parser-guaranteed to be a
+     * brace-delimited object or {@code null}, so {@code lastIndexOf('}')} is always the structural closer.
+     */
+    static String injectTrimSpaces(String withJson) {
+        if (withJson != null && withJson.replaceAll("\\s", "").contains("\"trim_spaces\":")) {
+            return withJson;
+        }
+        if (withJson == null) {
+            return "{\"trim_spaces\": true}";
+        }
+        int close = withJson.lastIndexOf('}');
+        String head = withJson.substring(0, close).trim();
+        return head + (head.endsWith("{") ? "" : ", ") + "\"trim_spaces\": true}";
     }
 
     /**

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCaseTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCaseTests.java
@@ -55,4 +55,33 @@ public class AbstractExternalSourceSpecTestCaseTests extends ESTestCase {
         assertTrue("expected file:// URI, was: " + uri, uri.startsWith("file:"));
         assertTrue("expected glob to be preserved in URI, was: " + uri, uri.endsWith("/multifile/file?.csv"));
     }
+
+    public void testInjectTrimSpacesAddsToNullWith() {
+        assertEquals("{\"trim_spaces\": true}", AbstractExternalSourceSpecTestCase.injectTrimSpaces(null));
+    }
+
+    public void testInjectTrimSpacesAddsToEmptyObject() {
+        assertEquals("{\"trim_spaces\": true}", AbstractExternalSourceSpecTestCase.injectTrimSpaces("{}"));
+        assertEquals("{\"trim_spaces\": true}", AbstractExternalSourceSpecTestCase.injectTrimSpaces("{ }"));
+    }
+
+    public void testInjectTrimSpacesMergesIntoExistingOptions() {
+        assertEquals(
+            "{\"header_row\": false, \"trim_spaces\": true}",
+            AbstractExternalSourceSpecTestCase.injectTrimSpaces("{\"header_row\": false}")
+        );
+    }
+
+    public void testInjectTrimSpacesLeavesExplicitTrimSpacesUntouched() {
+        String withJson = "{\"trim_spaces\": false}";
+        assertEquals(withJson, AbstractExternalSourceSpecTestCase.injectTrimSpaces(withJson));
+    }
+
+    public void testInjectTrimSpacesDoesNotFalseMatchAValue() {
+        // "trim_spaces" appears only as a value here, so the injection must still fire.
+        assertEquals(
+            "{\"null_value\": \"trim_spaces\", \"trim_spaces\": true}",
+            AbstractExternalSourceSpecTestCase.injectTrimSpaces("{\"null_value\": \"trim_spaces\"}")
+        );
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKey.java
@@ -67,7 +67,9 @@ public record SchemaCacheKey(
         "max_field_size",
         "schema_sample_size",
         "skip_rows",
-        "trim_whitespace",
+        // trim_spaces changes stored string values and the null-ness of whitespace-only cells on the
+        // same bytes, so neither captured stats nor schemas may cross it.
+        "trim_spaces",
         "error_mode",
         "max_errors",
         "max_error_ratio",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -388,6 +388,15 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         assertTrue(escaped.formatConfig().contains("mode=escaped"));
     }
 
+    public void testSchemaCacheKeySeparatesTrimSpaces() {
+        // trim_spaces changes stored string values (and the null-ness of whitespace-only cells) on the
+        // same bytes, so two configs differing only in it must not share a cached schema/stats fingerprint.
+        SchemaCacheKey base = SchemaCacheKey.build("s3://b/f.csv", 1000L, ".csv", Map.of("format", "csv"));
+        SchemaCacheKey trimmed = SchemaCacheKey.build("s3://b/f.csv", 1000L, ".csv", Map.of("format", "csv", "trim_spaces", true));
+        assertNotEquals(base.formatConfig(), trimmed.formatConfig());
+        assertTrue(trimmed.formatConfig().contains("trim_spaces=true"));
+    }
+
     /**
      * Bare {@code multi_value_syntax: brackets} resolves the mode to quoted on a no-quote
      * baseline (and selects the bracket-aware record scanner everywhere), so two configs differing


### PR DESCRIPTION
## What this is about

Reading an external CSV/TSV dataset mishandled three things — field whitespace, the header line, and (once whitespace stopped being trimmed) which tokenizer serves each read. This PR fixes all three; they're the same reader.

**Whitespace / value handling:**
- A quoted, numeric-looking value with interior spaces (`" 5 "`) **aborted the whole file** — inference trims before picking a type, but value conversion parsed the raw ` 5 ` and threw.
- Every string value's surrounding whitespace was **silently trimmed** (Jackson `TRIM_SPACES`, on unconditionally; the direct-block path trimmed too). RFC 4180 is explicit: spaces are part of a field. ClickHouse / DuckDB / pandas preserve them; we didn't.

**Header parsing:** quoted names kept their quotes (`"id"` → `KEEP id` fails), a quoted embedded delimiter mis-split the schema, and a leading UTF-8 BOM prefixed the first column name.

**Tokenizer grammar under no-trim:** turning off Jackson's `TRIM_SPACES` also turns off its skip-whitespace-before-a-quote, and `SKIP_EMPTY_LINES` eats column-0 leading whitespace — so the Jackson-served paths (inference, `_rowPosition`/`METADATA _id` reads, cached-stats reads) mis-tokenized `1, "Alice, PhD"` and disagreed with the direct read of the same file. Silent wrong answers.

## What this PR does

- **Typed columns tolerate padding instead of aborting.** `tryConvertValue` trims before any typed, non-string parse (mirroring inference); string columns are untouched.
- **Whitespace is preserved by default.** A new `trim_spaces` dialect option (default `false`) gates trimming on **every** read path — the Jackson mapper, the fused/bracket splitter, and the direct-block path (typed columns still always trim; strings preserve unless `trim_spaces: true`). Plumbed like `header_row`. Perf-neutral — the trim loops are *skipped* on the no-trim default.
- **The header is tokenized with the same quote/delimiter/BOM awareness as the data.**
- **One grammar on both arms under no-trim.** Jackson's grammar coincides with the direct-block walkers only when `trim_spaces` is on, so a house string tokenizer (`splitRecordFields`) serves every record-materialized path — inference, `_rowPosition`, bulk fallback, stats — whenever trimming is off; Jackson tokenizes only under `trim_spaces` (or `mode:escaped`, its own dialect). A single `jacksonGrammarApplies()` predicate is the source of truth. Quoted-field backslash escapes decode with Jackson's semantics on every arm (`\t \n \r \0` control, everything else literal).

Along the way, three arm-consistency fixes fell out of building the two-grammar setup: a whitespace-bearing `null_value` on a typed column now nulls identically on both arms (the raw marker was being stripped before the check); structural parse-error messages are byte-identical across arms; and in bracket mode, trailing whitespace after a closing quote is dropped to match the quoted grammar.

## Does it work?

- New `CsvRecordTokenizerTests` (direct-vs-house grammar pins + a `trim_spaces:true` Jackson-equivalence differential), plus additions across `CsvFormatReaderTests`, `CsvDirectBlockParityTests`, `CsvStripeStatsCaptureTests`, `CsvModeReadTests`: the crash fix, the option on all paths, typed null/empty/custom-null edges (incl. a whitespace-bearing `null_value`, quoted and escaped), padded-quoted / embedded-delimiter / col-0 / BOM inputs both polarities, the `null_value` inference case, `_rowPosition` misbind, prefetch replay, stripe-stats parity, structural-error-message parity, and bracket trailing-whitespace.
- The `CsvDirectBlockParityTests` harness asserts direct-arm == fallback-arm on every test — under no-trim the fallback arm is the house tokenizer, so each test is a direct-vs-house differential.
- Full `esql-datasource-csv` module + precommit: green.

## What's out of scope

- Explicit `mode: escaped` (the one dialect that stays on Jackson under no-trim) still drops the first column's leading whitespace — a Jackson `SKIP_EMPTY_LINES` quirk, documented on `jacksonGrammarApplies` and pinned by a test. PLAIN/QUOTED no-trim reads — including when the direct-block path is disabled — use the house grammar, which preserves it.
- Collapsing the house tokenizer and the direct-block walker onto one shared grammar kernel is left to a GA follow-up — the two are pinned equivalent by the parity + differential tests, so the duplication is guarded, not a correctness risk.
- Two edge cases are tracked as follow-ups: a separators-only TSV row under `trim_spaces:true` (skipped as blank vs emitted as a null-row across arms), and a wrong row number in the abort message when a malformed row trips FAIL_FAST (cosmetic; the fix touches shared error-budget counting).
