### PR TITLE
ES|QL: parse the external CSV/TSV header with CSV rules (quotes, embedded delimiter, BOM)

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -827,6 +827,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private List<Attribute> inferSchemaFromSample(String headerLine, CsvLogicalRecordReader recordReader, String sourceLocation)
         throws IOException {
         String[] columnNames = splitFieldsForOptions(headerLine, options);
+        if (options.quoting()) {
+            // No type annotations on this path, so the fields are bare names — unwrap RFC 4180 quoting.
+            unquoteHeaderNames(columnNames, options.quoteChar());
+        }
         Iterator<List<?>> csvIterator = newCsvIterator(recordReader);
         CircuitBreaker breaker = blockFactory.breaker();
         SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker, effectivePolicy);
@@ -1471,7 +1475,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (parts.length != 2) {
                 throw new ParsingException("Invalid CSV schema format: [{}]. Expected 'name:type'", column);
             }
-            String name = parts[0].trim();
+            String name = options.quoting() ? unquoteHeaderName(parts[0], options.quoteChar()) : parts[0].trim();
             String trimmedType = parts[1].trim();
             String typeName = trimmedType.toUpperCase(Locale.ROOT);
             DataType dataType = parseDataType(typeName);
@@ -1607,25 +1611,37 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Splits a <strong>header</strong> line into fields using the same comma/bracket/quote awareness as the data
-     * splitter, but <em>preserves the original substring</em> of each field — including any surrounding quote
-     * characters. Header fields like {@code "host:port"} need quotes intact so {@link #hasTypeAnnotations} can tell
-     * a quoted name from a {@code name:type} annotation.
+     * Splits a <strong>header</strong> line into fields. A quoting dialect (CSV) tokenizes the header by the
+     * same delimiter/quote/escape awareness as data cells — so a quoted name, a quoted field containing the
+     * delimiter, and RFC 4180 {@code ""} all round-trip the way they do for data — while <em>preserving the
+     * original substring</em> of each field, quotes included: header fields like {@code "host:port"} keep their
+     * quotes so {@link #hasTypeAnnotations} can tell a quoted name from a {@code name:type} annotation (the
+     * name is unquoted later, once that decision has been made). A non-quoting dialect ({@code mode: plain} /
+     * {@code escaped}) treats a quote as literal data, so the raw delimiter split is correct there.
      */
     private static String[] splitFieldsForOptions(String line, CsvFormatOptions options) {
-        if (options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS && options.delimiter() == ',') {
-            return splitHeaderCommaDelimiterBracketAware(line, options.quoteChar(), options.escapeChar());
+        // The header is the file's first line, so a UTF-8 BOM (Excel/Windows) lands on its first field.
+        line = stripLeadingBom(line);
+        if (options.quoting()) {
+            return splitHeaderQuoteAware(
+                line,
+                options.delimiter(),
+                options.quoteChar(),
+                options.escapeChar(),
+                options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS
+            );
         }
         return line.split(Pattern.quote(Character.toString(options.delimiter())));
     }
 
     /**
-     * Header-only variant of {@link #splitCommaDelimiterBracketAwareFields}: tracks the same state machine but
-     * emits the raw substring between commas instead of accumulating into a {@link StringBuilder} that strips
-     * quotes. Used by schema discovery / inference.
+     * Header-only variant of {@link #splitCommaDelimiterBracketAwareFields}: tracks the same quote/escape
+     * (and, when {@code bracketsMode}, bracket) state machine but emits the raw substring between delimiters
+     * instead of accumulating into a {@link StringBuilder} that strips quotes — the caller unquotes the
+     * resolved names after {@link #hasTypeAnnotations} has run. Used by schema discovery / inference for any
+     * delimiter (comma for CSV, tab for TSV).
      */
-    private static String[] splitHeaderCommaDelimiterBracketAware(String line, char quote, char esc) {
-        final char delim = ',';
+    private static String[] splitHeaderQuoteAware(String line, char delim, char quote, char esc, boolean bracketsMode) {
         List<String> entries = new ArrayList<>();
         int start = 0;
         boolean inQuotes = false;
@@ -1663,7 +1679,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 inQuotes = true;
                 continue;
             }
-            if (c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i)) {
+            if (bracketsMode && c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i)) {
                 bracketDepth = 1;
                 continue;
             }
@@ -1673,6 +1689,40 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
         entries.add(line.substring(start).trim());
         return entries.toArray(String[]::new);
+    }
+
+    /** Leading UTF-8 byte-order mark; decoded to this char by the {@link InputStreamReader} before it reaches us. */
+    private static final char BOM = '﻿';
+
+    /**
+     * Strips a leading byte-order mark from the first line of a file. Excel/Windows CSV exports prepend a
+     * UTF-8 BOM ({@code EF BB BF}); without this the first column would be named e.g. {@code ﻿id}.
+     */
+    private static String stripLeadingBom(String line) {
+        return line != null && line.isEmpty() == false && line.charAt(0) == BOM ? line.substring(1) : line;
+    }
+
+    /**
+     * Strips one layer of surrounding {@code quote} characters from a resolved header name and unescapes RFC
+     * 4180 doubled quotes ({@code ""} -> {@code "}), so an unquoted {@code id} and a quoted {@code "id"} both
+     * resolve to {@code id}. A name that is not fully quoted is returned trimmed and otherwise unchanged.
+     * Only meaningful for a quoting dialect; the caller does not invoke it for {@code plain}/{@code escaped},
+     * where a quote is literal name data.
+     */
+    private static String unquoteHeaderName(String name, char quote) {
+        String trimmed = name.trim();
+        if (trimmed.length() >= 2 && trimmed.charAt(0) == quote && trimmed.charAt(trimmed.length() - 1) == quote) {
+            String inner = trimmed.substring(1, trimmed.length() - 1);
+            return inner.replace(String.valueOf(quote) + quote, String.valueOf(quote));
+        }
+        return trimmed;
+    }
+
+    /** Applies {@link #unquoteHeaderName} to each name in place; called on the inference path when quoting. */
+    private static void unquoteHeaderNames(String[] names, char quote) {
+        for (int i = 0; i < names.length; i++) {
+            names[i] = unquoteHeaderName(names[i], quote);
+        }
     }
 
     /**
@@ -2353,6 +2403,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private List<Attribute> inferSchemaFromBatchReader(String headerLine) throws IOException {
             String[] columnNames = splitFieldsForOptions(headerLine, options);
+            if (options.quoting()) {
+                // No type annotations on this path, so the fields are bare names — unwrap RFC 4180 quoting.
+                unquoteHeaderNames(columnNames, options.quoteChar());
+            }
             csvIterator = newCsvIterator(recordReader);
             SchemaSample sample = collectSampleRows(
                 csvIterator,

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -115,7 +115,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
-    // --- #1051: the header line is parsed with CSV rules (quoting, embedded delimiter, BOM) ---
+    // --- The header line is parsed with CSV rules (quoting, embedded delimiter, BOM) ---
 
     /** Quoted header names (pandas/pyarrow/Excel default) resolve without the quote characters. */
     public void testQuotedHeaderNamesUnquoted() throws IOException {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -115,6 +115,54 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    // --- #1051: the header line is parsed with CSV rules (quoting, embedded delimiter, BOM) ---
+
+    /** Quoted header names (pandas/pyarrow/Excel default) resolve without the quote characters. */
+    public void testQuotedHeaderNamesUnquoted() throws IOException {
+        StorageObject object = createStorageObject("\"id\",\"a\",\"b\"\n1,-5,10\n");
+        List<Attribute> schema = new CsvFormatReader(blockFactory).schema(object);
+        assertEquals(List.of("id", "a", "b"), schema.stream().map(Attribute::name).toList());
+    }
+
+    /** A quoted header field containing the delimiter is ONE column, not silently mis-split. */
+    public void testQuotedHeaderEmbeddedDelimiter() throws IOException {
+        StorageObject object = createStorageObject("\"a,b\",\"c\"\n1,2\n");
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        assertEquals(List.of("a,b", "c"), reader.schema(object).stream().map(Attribute::name).toList());
+        try (CloseableIterator<Page> it = reader.read(object, null, 10)) {
+            Page page = it.next();
+            assertEquals(2, page.getBlockCount());
+            assertEquals(1, ((IntBlock) page.getBlock(0)).getInt(0));
+            assertEquals(2, ((IntBlock) page.getBlock(1)).getInt(0));
+        }
+    }
+
+    /** RFC 4180 doubled-quote inside a quoted name unescapes to a single quote. */
+    public void testQuotedHeaderEscapedQuoteInName() throws IOException {
+        StorageObject object = createStorageObject("\"i\"\"d\",x\n1,2\n");
+        List<Attribute> schema = new CsvFormatReader(blockFactory).schema(object);
+        assertEquals("i\"d", schema.get(0).name());
+        assertEquals("x", schema.get(1).name());
+    }
+
+    /** A leading UTF-8 BOM (Excel/Windows) is stripped from the first column name. */
+    public void testLeadingBomStrippedFromHeader() throws IOException {
+        StorageObject object = createStorageObject("﻿id,name\n1,alice\n");
+        List<Attribute> schema = new CsvFormatReader(blockFactory).schema(object);
+        assertEquals("id", schema.get(0).name());
+        assertEquals("name", schema.get(1).name());
+    }
+
+    /** The same quote-aware header rules apply for a tab delimiter (TSV with quoting on). */
+    public void testTabDelimitedQuotedHeaderNames() throws IOException {
+        StorageObject object = createStorageObject("\"i\td\"\t\"c\"\n1\t2\n");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("delimiter", "\t", "mode", "quoted")
+        );
+        // The quoted first name contains a tab; it must stay one column.
+        assertEquals(List.of("i\td", "c"), reader.schema(object).stream().map(Attribute::name).toList());
+    }
+
     public void testTypedSchemaTextAndTxtAliasesMapToKeyword() throws IOException {
         String csv = """
             a:text,b:txt
@@ -403,7 +451,9 @@ public class CsvFormatReaderTests extends ESTestCase {
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(2, schema.size());
-        assertEquals("\"host:port\"", schema.get(0).name());
+        // The quoted name is unwrapped (its internal colon is NOT a type annotation), so it resolves to
+        // host:port — not the literal "host:port" with quote characters the naive split used to produce.
+        assertEquals("host:port", schema.get(0).name());
         assertEquals(DataType.KEYWORD, schema.get(0).dataType());
         assertEquals("status", schema.get(1).name());
         assertEquals(DataType.INTEGER, schema.get(1).dataType());


### PR DESCRIPTION
## What this is about

Reading an external CSV/TSV dataset parsed the **header** line by different rules than the data cells, so real-world CSVs came back with mangled column names. Data rows honor RFC 4180 quoting; the header didn't. Three symptoms, one root:

- **Quoted header names kept their quotes.** `"id","a","b"` (pandas/pyarrow/Excel default) → columns literally named `"id"`, `"a"`, `"b"`, so `KEEP id` fails `Unknown column`. The NYC TLC `taxi_zone_lookup.csv` — a standard published dataset with a quoted header — can't be referenced by column name.
- **A quoted field containing the delimiter mis-split the schema, silently.** `"a,b","c"` → three columns `["a`, `b"`, `"c"]` instead of two, and the data then maps under the wrong columns with no error.
- **A leading UTF-8 BOM was not stripped.** An Excel/Windows file beginning `EF BB BF` → the first column is named `﻿id` instead of `id`.

## What this PR does

- Tokenizes the header with the **same** delimiter/quote/escape awareness as data cells whenever the dialect quotes (the header splitter is generalized to any delimiter and engaged on `quoting`), so a quoted name, a quoted embedded delimiter, and RFC 4180 `""` all round-trip.
- Unquotes the resolved column names **after** the name-vs-type decision has been made, so a quoted `"host:port"` is one name (its colon is not a type annotation), not `"host:port"` with quote characters.
- Strips a leading BOM from the header line.
- `plain`/`escaped` dialects keep the raw delimiter split, where a quote is literal name data.

## Does it work?

New `CsvFormatReaderTests` cover quoted names, a quoted embedded delimiter (both the resolved column count *and* that the data maps to the right columns), an RFC 4180 doubled-quote in a name (`"i""d"` → `i"d`), a leading BOM, and a tab-delimited quoted header. An existing test that asserted the *buggy* behavior (a name kept as literal `"host:port"`) is corrected to the unquoted `host:port`. Full module test + qa `CsvFormatSpecIT` green.

## What's out of scope

A headerless file whose first data cell carries a BOM (the header path is where the BOM lands in the common case). Deferred; noted for follow-up.
