### PR TITLE
ESQL:DS: Further EXTERNAL to FROM migration

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalMaxRecordSizeTruncationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalMaxRecordSizeTruncationIT.java
@@ -14,13 +14,10 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.gzip.GzipDataSourcePlugin;
-import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
-import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.junit.Before;
@@ -31,9 +28,9 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +40,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPOutputStream;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -61,7 +57,7 @@ import static org.hamcrest.Matchers.greaterThan;
  * {@code Warning} headers (mirroring {@code ExternalCsvHivePartitionedIT} and {@code WarningsIT}).
  * Follow-up to the record-boundary livelock fix (capped grow loop). See elastic/esql-planning#835.
  */
-public class ExternalMaxRecordSizeTruncationIT extends AbstractEsqlIntegTestCase {
+public class ExternalMaxRecordSizeTruncationIT extends AbstractExternalDataSourceIT {
 
     private static final int LEADING_ROWS = 5;
     /** {@code max_record_size} pragma value; {@code 1mb} == {@link #MAX_RECORD_SIZE_BYTES} bytes. */
@@ -74,36 +70,9 @@ public class ExternalMaxRecordSizeTruncationIT extends AbstractEsqlIntegTestCase
      */
     private static final int GIANT_RECORD_BYTES = 4 * 1024 * 1024;
 
-    /**
-     * {@link EsqlPluginWithEnterpriseOrTrialLicense} suppresses {@link ExtensiblePlugin#loadExtensions} to keep the
-     * IT base lean (extensions can pull in heavy deps); we need extensions ON so the datasource plugins added in
-     * {@link #nodePlugins()} can register their format readers / storage providers via SPI. This subclass restores the
-     * default behavior — call {@code super} explicitly.
-     */
-    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
-        @Override
-        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
-            super.loadExtensions(loader);
-        }
-    }
-
     @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
-        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
-        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
-        plugins.add(HttpDataSourcePlugin.class);
-        plugins.add(CsvDataSourcePlugin.class);
-        plugins.add(GzipDataSourcePlugin.class);
-        return plugins;
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .putList(ExternalSourceSettings.LOCAL_ALLOWED_PATHS.getKey(), createTempDir().getParent().toString())
-            .build();
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class, GzipDataSourcePlugin.class);
     }
 
     /**
@@ -120,7 +89,6 @@ public class ExternalMaxRecordSizeTruncationIT extends AbstractEsqlIntegTestCase
             (long) GIANT_RECORD_BYTES,
             greaterThan(2 * MAX_RECORD_SIZE_BYTES)
         );
-        assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
     }
 
     /**
@@ -128,11 +96,11 @@ public class ExternalMaxRecordSizeTruncationIT extends AbstractEsqlIntegTestCase
      * a diagnosable error, as before this change.
      */
     public void testStrictPolicyHardFailsOnOversizedRecord() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         assumeTrue("max_record_size / parsing_parallelism pragmas are snapshot-only", Build.current().isSnapshot());
         Path file = writeGzipWithOversizedRecord();
         try {
-            String query = "EXTERNAL \"" + StoragePath.fileUri(file) + "\" WITH {\"header_row\": false} | STATS c = COUNT(*)";
+            String dataset = registerDataset("strict_oversized", StoragePath.fileUri(file), Map.of("header_row", false));
+            String query = "FROM " + dataset + " | STATS c = COUNT(*)";
             // Pin allow_partial_results=false (cluster default is true) so the hard failure is thrown
             // rather than swallowed into a partial response.
             EsqlQueryRequest request = syncEsqlQueryRequest(query).pragmas(pragmas(4, MAX_RECORD_SIZE)).allowPartialResults(false);
@@ -156,13 +124,15 @@ public class ExternalMaxRecordSizeTruncationIT extends AbstractEsqlIntegTestCase
      * driver ran the external read (coordinator or data node) through {@code DriverCompletionInfo}.
      */
     public void testSkipRowPolicyReturnsPartialResultsAndWarnsClient() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         assumeTrue("max_record_size / parsing_parallelism pragmas are snapshot-only", Build.current().isSnapshot());
         Path file = writeGzipWithOversizedRecord();
         try {
-            String query = "EXTERNAL \""
-                + StoragePath.fileUri(file)
-                + "\" WITH {\"header_row\": false, \"error_mode\": \"skip_row\"} | STATS c = COUNT(*)";
+            String dataset = registerDataset(
+                "skip_row_oversized",
+                StoragePath.fileUri(file),
+                Map.of("header_row", false, "error_mode", "skip_row")
+            );
+            String query = "FROM " + dataset + " | STATS c = COUNT(*)";
             EsqlQueryRequest request = syncEsqlQueryRequest(query).pragmas(pragmas(4, MAX_RECORD_SIZE));
 
             DiscoveryNode coordinator = randomFrom(clusterService().state().nodes().stream().toList());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetTemporalAggregatePushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetTemporalAggregatePushdownIT.java
@@ -14,32 +14,26 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.OutputFile;
-import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
-import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
-import org.junit.Before;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -47,29 +41,12 @@ import static org.hamcrest.Matchers.equalTo;
  * Verifies that ungrouped MIN/MAX over temporal columns in Parquet files return
  * epoch-millis values that match the scan-path decode, not raw physical units
  * (days, microseconds). Covers date32, timestamp[us], and timestamp[ms].
- * <p>
- * The {@code EsqlEnterpriseWithDatasourceExtensions}/{@code nodePlugins()}/{@code createOutputFile}
- * boilerplate mirrors the other {@code ExternalParquet*IT} suites (e.g. {@link ExternalParquetCountPushdownIT});
- * there is no shared base for these {@code EXTERNAL "file://..."} tests, so the pattern is duplicated for
- * consistency rather than extracted here.
  */
-public class ExternalParquetTemporalAggregatePushdownIT extends AbstractEsqlIntegTestCase {
-
-    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
-        @Override
-        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
-            super.loadExtensions(loader);
-        }
-    }
+public class ExternalParquetTemporalAggregatePushdownIT extends AbstractExternalDataSourceIT {
 
     @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
-        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
-        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
-        plugins.add(HttpDataSourcePlugin.class);
-        plugins.add(ParquetDataSourcePlugin.class);
-        return plugins;
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
     }
 
     @Override
@@ -77,22 +54,7 @@ public class ExternalParquetTemporalAggregatePushdownIT extends AbstractEsqlInte
         return new QueryPragmas(Settings.builder().put("parsing_parallelism", 1).build());
     }
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .putList(ExternalSourceSettings.LOCAL_ALLOWED_PATHS.getKey(), createTempDir().getParent().toString())
-            .build();
-    }
-
-    @Before
-    public void requireLocalFilesEnabled() {
-        assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
-    }
-
     public void testMinMaxTemporalColumns() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
-
         long millis2000 = Instant.parse("2000-01-01T00:00:00Z").toEpochMilli();
         long millis2020 = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
         int days2000 = (int) (millis2000 / 86_400_000L);
@@ -103,14 +65,15 @@ public class ExternalParquetTemporalAggregatePushdownIT extends AbstractEsqlInte
         Path parquetFile = writeTemporalParquetFile(days2000, days2020, micros2000, micros2020, millis2000, millis2020);
         try {
             String fileUri = StoragePath.fileUri(parquetFile);
+            String dataset = registerDataset("temporal_pushdown", fileUri, Map.of());
 
             // STATS MIN/MAX is served from the Parquet footer stats via PushStatsToExternalSource.
             // This is the path that returned raw days/micros before the decode fix; profile=true +
             // the no-Async assertion below ensure the values come from pushdown, not a scan fallback
             // (the scan path was always correct, so without this a regression could hide).
-            String statsQuery = "EXTERNAL \""
-                + fileUri
-                + "\" | STATS lo_d32=MIN(d32), hi_d32=MAX(d32), lo_tus=MIN(tus), hi_tus=MAX(tus), lo_tms=MIN(tms), hi_tms=MAX(tms)";
+            String statsQuery = "FROM "
+                + dataset
+                + " | STATS lo_d32=MIN(d32), hi_d32=MAX(d32), lo_tus=MIN(tus), hi_tus=MAX(tus), lo_tms=MIN(tms), hi_tms=MAX(tms)";
 
             try (var response = run(syncEsqlQueryRequest(statsQuery).profile(true))) {
                 List<List<Object>> rows = getValuesList(response);
@@ -196,48 +159,5 @@ public class ExternalParquetTemporalAggregatePushdownIT extends AbstractEsqlInte
             return Instant.parse(s).toEpochMilli();
         }
         return ((Number) value).longValue();
-    }
-
-    private static OutputFile createOutputFile(ByteArrayOutputStream baos) {
-        return new OutputFile() {
-            @Override
-            public PositionOutputStream create(long blockSizeHint) {
-                return new PositionOutputStream() {
-                    private long position = 0;
-
-                    @Override
-                    public long getPos() {
-                        return position;
-                    }
-
-                    @Override
-                    public void write(int b) throws IOException {
-                        baos.write(b);
-                        position++;
-                    }
-
-                    @Override
-                    public void write(byte[] b, int off, int len) throws IOException {
-                        baos.write(b, off, len);
-                        position += len;
-                    }
-                };
-            }
-
-            @Override
-            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
-                return create(blockSizeHint);
-            }
-
-            @Override
-            public boolean supportsBlockSize() {
-                return false;
-            }
-
-            @Override
-            public long defaultBlockSize() {
-                return 0;
-            }
-        };
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceProfileIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceProfileIT.java
@@ -271,20 +271,27 @@ public class ExternalSourceProfileIT extends AbstractExternalDataSourceIT {
         long totalRows = (long) files * rowsPerFile;
 
         // FFW + LIMIT: defer path. Only the anchor footer is needed at planning time, but the page must be correct.
-        try (var response = run(syncEsqlQueryRequest(externalQuery(glob, "first_file_wins", "| LIMIT 10")), TIMEOUT)) {
+        try (var response = run(syncEsqlQueryRequest(datasetQuery(glob, "first_file_wins", "| LIMIT 10")), TIMEOUT)) {
             assertThat(getValuesList(response), hasSize(10));
         }
 
         // FFW + ungrouped COUNT(*): eager path — the global row count must span every file.
-        assertSingleLong(externalQuery(glob, "first_file_wins", "| STATS c = COUNT(*)"), totalRows);
+        assertSingleLong(datasetQuery(glob, "first_file_wins", "| STATS c = COUNT(*)"), totalRows);
 
         // UNION_BY_NAME / STRICT still read every file for schema reconciliation; the count stays correct.
-        assertSingleLong(externalQuery(glob, "union_by_name", "| STATS c = COUNT(*)"), totalRows);
-        assertSingleLong(externalQuery(glob, "strict", "| STATS c = COUNT(*)"), totalRows);
+        assertSingleLong(datasetQuery(glob, "union_by_name", "| STATS c = COUNT(*)"), totalRows);
+        assertSingleLong(datasetQuery(glob, "strict", "| STATS c = COUNT(*)"), totalRows);
     }
 
-    private static String externalQuery(String glob, String schemaResolution, String tail) {
-        return "EXTERNAL \"" + glob + "\" WITH {\"schema_resolution\": \"" + schemaResolution + "\"} " + tail;
+    /**
+     * Registers (or reuses) a dataset over {@code glob} with the given {@code schema_resolution} dataset
+     * setting — the {@code FROM <dataset>} equivalent of the legacy {@code EXTERNAL ... WITH
+     * {"schema_resolution": ...}} clause — and returns a {@code FROM <dataset> <tail>} query. Each
+     * resolution mode gets its own dataset name so the three modes can coexist against the same glob.
+     */
+    private String datasetQuery(String glob, String schemaResolution, String tail) {
+        String dataset = registerDataset("profile_ffw_" + schemaResolution, glob, Map.of("schema_resolution", schemaResolution));
+        return "FROM " + dataset + " " + tail;
     }
 
     private void assertSingleLong(String query, long expected) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalUncompressedSeamCountIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalUncompressedSeamCountIT.java
@@ -9,27 +9,22 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
-import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
-import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
-import org.junit.Before;
 
 import java.io.BufferedWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -53,38 +48,11 @@ import static org.hamcrest.Matchers.equalTo;
  * Column {@code col0} is globally unique per row (0..total-1), so {@code COUNT/MIN/MAX} together prove
  * every record was seen exactly once across every seam.
  */
-public class ExternalUncompressedSeamCountIT extends AbstractEsqlIntegTestCase {
-
-    /** Re-enables datasource extension loading that {@link EsqlPluginWithEnterpriseOrTrialLicense} suppresses. */
-    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
-        @Override
-        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
-            super.loadExtensions(loader);
-        }
-    }
+public class ExternalUncompressedSeamCountIT extends AbstractExternalDataSourceIT {
 
     @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
-        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
-        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
-        plugins.add(HttpDataSourcePlugin.class);
-        plugins.add(CsvDataSourcePlugin.class);
-        plugins.add(NdJsonDataSourcePlugin.class);
-        return plugins;
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .putList(ExternalSourceSettings.LOCAL_ALLOWED_PATHS.getKey(), createTempDir().getParent().toString())
-            .build();
-    }
-
-    @Before
-    public void requireLocalFilesEnabled() {
-        assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class, NdJsonDataSourcePlugin.class);
     }
 
     @Override
@@ -99,55 +67,53 @@ public class ExternalUncompressedSeamCountIT extends AbstractEsqlIntegTestCase {
      * the seam off-by-one — a record whose first byte is exactly a macro-split offset.
      */
     public void testCsvHeaderlessMultiMacroSplitRecordOnSeam() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         Path dir = createTempDir();
         // Fixed 32-byte rows: "col0,<padded-b>\n". target_split_size 1mb is an exact multiple of 32,
         // so every stride boundary lands on a record start. CSV's minimum segment is 1 MiB, so a 1 MiB
         // stride yields macro-splits at the segmenting floor (one read each) and isolates the macro seam.
         long rows = writeFixedWidthCsv(dir.resolve("part-0.csv"), 0, 4 * 1024 * 1024, true);
-        assertExactCount(globUri(dir, "*.csv"), "\"header_row\":false,\"error_mode\":\"null_field\",\"target_split_size\":\"1mb\"", rows);
+        assertExactCount("seam_record_on_seam", globUri(dir, "*.csv"), headerlessOptions("1mb"), rows);
     }
 
     /** Headerless multi-file glob, several macro-splits per file, trailing newline present. */
     public void testCsvHeaderlessMultiFileMultiMacroSplit() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         Path dir = createTempDir();
         long total = 0;
         for (int f = 0; f < 3; f++) {
             total += writeVarWidthCsv(dir.resolve("part-" + f + ".csv"), total, 5 * 1024 * 1024, true);
         }
-        assertExactCount(globUri(dir, "*.csv"), "\"header_row\":false,\"error_mode\":\"null_field\",\"target_split_size\":\"1mb\"", total);
+        assertExactCount("seam_multi_file_multi_macro_split", globUri(dir, "*.csv"), headerlessOptions("1mb"), total);
     }
 
     /** The file's final record carries NO trailing newline, across multiple macro-splits. */
     public void testCsvHeaderlessMultiMacroSplitNoTrailingNewline() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         Path dir = createTempDir();
         long rows = writeVarWidthCsv(dir.resolve("part-0.csv"), 0, 5 * 1024 * 1024, false);
-        assertExactCount(globUri(dir, "*.csv"), "\"header_row\":false,\"error_mode\":\"null_field\",\"target_split_size\":\"1mb\"", rows);
+        assertExactCount("seam_no_trailing_newline", globUri(dir, "*.csv"), headerlessOptions("1mb"), rows);
     }
 
     /** Headerless, single macro-split per file (large target_split_size) but intra-file segmented. */
     public void testCsvHeaderlessIntraFileSegmented() throws Exception {
-        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
         Path dir = createTempDir();
         long total = 0;
         for (int f = 0; f < 3; f++) {
             total += writeVarWidthCsv(dir.resolve("part-" + f + ".csv"), total, 3_500_000, true);
         }
-        assertExactCount(
-            globUri(dir, "*.csv"),
-            "\"header_row\":false,\"error_mode\":\"null_field\",\"target_split_size\":\"256mb\"",
-            total
-        );
+        assertExactCount("seam_intra_file_segmented", globUri(dir, "*.csv"), headerlessOptions("256mb"), total);
     }
 
-    private void assertExactCount(String globUri, String withOptions, long total) throws Exception {
-        String query = "EXTERNAL \""
-            + globUri
-            + "\" WITH {"
-            + withOptions
-            + "} | RENAME col0 AS a | STATS c = COUNT(*), mn = MIN(a), mx = MAX(a)";
+    /** The {@code header_row}/{@code error_mode} pair every test in this suite shares; only {@code target_split_size} varies. */
+    private static Map<String, Object> headerlessOptions(String targetSplitSize) {
+        return Map.of("header_row", false, "error_mode", "null_field", "target_split_size", targetSplitSize);
+    }
+
+    /**
+     * Registers {@code globUri} as a dataset with the given settings — the {@code FROM <dataset>} equivalent
+     * of the legacy {@code EXTERNAL ... WITH {...}} clause — and asserts the exact row count/bounds.
+     */
+    private void assertExactCount(String datasetName, String globUri, Map<String, Object> settings, long total) throws Exception {
+        String dataset = registerDataset(datasetName, globUri, settings);
+        String query = "FROM " + dataset + " | RENAME col0 AS a | STATS c = COUNT(*), mn = MIN(a), mx = MAX(a)";
 
         var request = syncEsqlQueryRequest(query);
         try (var response = run(request, TimeValue.timeValueMinutes(5))) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLogicalPlanOptimizerTests.java
@@ -8,12 +8,23 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.metadata.DataSourceReference;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.TestAnalyzer;
 import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
+import org.elasticsearch.xpack.esql.datasources.DatasetRewriter;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSource;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValues;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
@@ -201,6 +212,31 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
 
     protected LogicalPlan plan(String query, LogicalPlanOptimizer optimizer) {
         return optimizer.optimize(defaultAnalyzer().query(query));
+    }
+
+    /**
+     * Plans a {@code query} that references an external dataset via {@code FROM <datasetName>}, mirroring the
+     * production path: an in-memory {@link ProjectMetadata} registers {@code datasetName} against {@code resource}
+     * so {@link DatasetRewriter} rewrites the {@code FROM} target into an (unresolved) external relation, then the
+     * analyzer resolves it using the given pre-resolved {@code schema} (see {@code GoldenTestCase#datasetMetadata}
+     * for the golden-test equivalent of this same pattern).
+     */
+    protected LogicalPlan datasetPlan(String query, String datasetName, String resource, List<Attribute> schema) {
+        assumeTrue("requires FROM <dataset> capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
+        String dataSourceName = datasetName + "_ds";
+        ProjectMetadata datasetMetadata = ProjectMetadata.builder(ProjectId.DEFAULT)
+            .putCustom(
+                DataSourceMetadata.TYPE,
+                new DataSourceMetadata(Map.of(dataSourceName, new DataSource(dataSourceName, "test", null, Map.of())))
+            )
+            .datasets(Map.of(datasetName, new Dataset(datasetName, new DataSourceReference(dataSourceName), resource, null, Map.of())))
+            .build();
+        LogicalPlan rewritten = DatasetRewriter.rewriteUnsecured(
+            TEST_PARSER.parseQuery(query),
+            datasetMetadata,
+            TestIndexNameExpressionResolver.newInstance()
+        );
+        return optimize(analyzer().externalSourceResolution(resource, schema, FileList.UNRESOLVED).buildAnalyzer().analyze(rewritten));
     }
 
     protected LogicalPlan planAirports(String query) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PruneRedundantAggregateGroupingsGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PruneRedundantAggregateGroupingsGoldenTests.java
@@ -8,11 +8,17 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.metadata.DataSourceReference;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSource;
+import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantAggregateGroupings;
 
@@ -28,6 +34,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
  */
 public class PruneRedundantAggregateGroupingsGoldenTests extends GoldenTestCase {
     private static final EnumSet<Stage> STAGES = EnumSet.of(Stage.LOGICAL_OPTIMIZATION);
+    private static final String DATASET_NAME = "ext_ds";
     private static final String DATA_RESOURCE = "s3://bucket/data.parquet";
 
     /**
@@ -35,17 +42,28 @@ public class PruneRedundantAggregateGroupingsGoldenTests extends GoldenTestCase 
      * rebuilt above the aggregate reading the rename alias, so the plan stays consistent.
      */
     public void testRenamedDerivedExternalGrouping() {
-        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
+        assumeTrue("requires FROM <dataset> capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
         String query = """
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | RENAME ClientIP AS cip
             | EVAL c = cip - 1
             | STATS count = COUNT(*) BY cip, c
             """;
         builder(query).stages(STAGES)
             .transportVersion(TransportVersion.current())
+            .datasetMetadata(datasetMetadata())
             .externalSourceResolution(externalSourceResolution())
             .run();
+    }
+
+    /** Registers {@code ext_ds} as an external dataset so {@code FROM ext_ds} becomes an external relation. */
+    private static ProjectMetadata datasetMetadata() {
+        DataSource dataSource = new DataSource("ext_ds_ds", "test", null, Map.of());
+        Dataset dataset = new Dataset(DATASET_NAME, new DataSourceReference("ext_ds_ds"), DATA_RESOURCE, null, Map.of());
+        return ProjectMetadata.builder(ProjectId.DEFAULT)
+            .putCustom(DataSourceMetadata.TYPE, new DataSourceMetadata(Map.of("ext_ds_ds", dataSource)))
+            .datasets(Map.of(DATASET_NAME, dataset))
+            .build();
     }
 
     private static ExternalSourceResolution externalSourceResolution() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantAggregateGroupingsTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
-import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
@@ -24,7 +23,6 @@ import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 
 import java.util.List;
 
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
@@ -33,7 +31,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOptimizerTests {
-    private static final String S3_PATH = "s3://bucket/data.parquet";
+    private static final String DATASET_NAME = "ext_ds";
+    private static final String S3_RESOURCE = "s3://bucket/data.parquet";
 
     public void testPrunesEvalConstantGrouping() {
         var plan = plan("""
@@ -120,7 +119,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
 
     public void testPrunesDerivedExternalGroupings() {
         var plan = externalPlan("""
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | EVAL ip_m1 = ClientIP - 1, ip_m2 = ClientIP - 2, ip_m3 = ClientIP - 3
             | STATS c = COUNT(*) BY ClientIP, ip_m1, ip_m2, ip_m3
             """);
@@ -143,7 +142,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
 
     public void testPrunesRecursiveDerivedExternalGrouping() {
         var plan = externalPlan("""
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | EVAL ip_m1 = ClientIP - 1, ip_m2 = ip_m1 - 1
             | STATS c = COUNT(*) BY ClientIP, ip_m2
             """);
@@ -166,7 +165,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
 
     public void testPartialDerivedExternalPruningKeepsNeededPreAggregateEval() {
         var plan = externalPlan("""
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | EVAL ip_m1 = ClientIP - 1, other_m1 = OtherIP - 1
             | STATS c = COUNT(*) BY ClientIP, ip_m1, other_m1
             """);
@@ -197,7 +196,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
      */
     public void testPrunesRenamedDerivedExternalGrouping() {
         var plan = externalPlan("""
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | RENAME ClientIP AS cip
             | EVAL c = cip - 1
             | STATS count = COUNT(*) BY cip, c
@@ -259,7 +258,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
 
     public void testDoesNotPruneIndependentExternalExpression() {
         var plan = externalPlan("""
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | EVAL other_m1 = OtherIP - 1
             | STATS c = COUNT(*) BY ClientIP, other_m1
             """);
@@ -270,7 +269,7 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
 
     public void testDoesNotPruneNonWhitelistedExternalExpression() {
         var plan = externalPlan("""
-            EXTERNAL "s3://bucket/data.parquet"
+            FROM ext_ds
             | EVAL ip_mul = ClientIP * 2
             | STATS c = COUNT(*) BY ClientIP, ip_mul
             """);
@@ -280,13 +279,12 @@ public class PruneRedundantAggregateGroupingsTests extends AbstractLogicalPlanOp
     }
 
     private LogicalPlan externalPlan(String query) {
-        assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
         List<Attribute> schema = List.of(
             referenceAttribute("ClientIP", INTEGER),
             referenceAttribute("OtherIP", INTEGER),
             referenceAttribute("URL", KEYWORD)
         );
-        return optimize(analyzer().externalSourceResolution(S3_PATH, schema, FileList.UNRESOLVED).query(query));
+        return datasetPlan(query, DATASET_NAME, S3_RESOURCE, schema);
     }
 
     private static Project rewrittenProject(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PruneRedundantAggregateGroupingsGoldenTests/testRenamedDerivedExternalGrouping/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PruneRedundantAggregateGroupingsGoldenTests/testRenamedDerivedExternalGrouping/query.esql
@@ -1,4 +1,4 @@
-EXTERNAL "s3://bucket/data.parquet"
+FROM ext_ds
 | RENAME ClientIP AS cip
 | EVAL c = cip - 1
 | STATS count = COUNT(*) BY cip, c


### PR DESCRIPTION
This migrates all the rest of the tests that can currently be migrated from `EXTERNAL .. WITH` to `FROM <dataset>`.
