### PR TITLE
[9.4] Fix errors/warnings with spatial functions that parse invalid BBOX

### DIFF
--- a/docs/changelog/152877.yaml
+++ b/docs/changelog/152877.yaml
@@ -1,0 +1,6 @@
+area: "ES|QL"
+issues:
+ - 152876
+pr: 152877
+summary: Fix errors/warnings with spatial functions that parse invalid BBOX
+type: bug

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/CartesianValidator.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/CartesianValidator.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.geometry.utils;
+
+import org.elasticsearch.geometry.Circle;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.GeometryVisitor;
+import org.elasticsearch.geometry.Line;
+import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.MultiPolygon;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
+
+/**
+ * Validator for cartesian (non-geographic) coordinates. Its one job today is
+ * {@link #validateBBox(double, double, double, double)}: unlike geographic coordinates, cartesian coordinates
+ * have no antimeridian-crossing concept, so a rectangle's x-ordinates must be consistent (maxX cannot be less
+ * than minX), in addition to the same y-ordinate check ({@link GeographyValidator} also applies to geographic
+ * coordinates. This is deliberately a separate class from {@link StandardValidator}, even though the two
+ * currently look similar in scope: {@link StandardValidator} is CRS-agnostic and is relied on by real
+ * geographic production code paths (e.g. {@code GeometryParser}) that must tolerate antimeridian-crossing
+ * envelopes, so it cannot safely gain this check.
+ */
+public class CartesianValidator implements GeometryValidator {
+
+    public static final GeometryValidator INSTANCE = new CartesianValidator();
+
+    private CartesianValidator() {}
+
+    @Override
+    public void validateBBox(double minX, double maxX, double maxY, double minY) {
+        if (maxX < minX) {
+            throw new IllegalArgumentException("max x cannot be less than min x");
+        }
+        GeometryValidator.super.validateBBox(minX, maxX, maxY, minY);
+    }
+
+    @Override
+    public void validate(Geometry geometry) {
+        geometry.visit(new GeometryVisitor<Void, RuntimeException>() {
+
+            @Override
+            public Void visit(Circle circle) throws RuntimeException {
+                return null;
+            }
+
+            @Override
+            public Void visit(GeometryCollection<?> collection) throws RuntimeException {
+                for (Geometry g : collection) {
+                    g.visit(this);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visit(Line line) throws RuntimeException {
+                return null;
+            }
+
+            @Override
+            public Void visit(LinearRing ring) throws RuntimeException {
+                return null;
+            }
+
+            @Override
+            public Void visit(MultiLine multiLine) throws RuntimeException {
+                return visit((GeometryCollection<?>) multiLine);
+            }
+
+            @Override
+            public Void visit(MultiPoint multiPoint) throws RuntimeException {
+                return visit((GeometryCollection<?>) multiPoint);
+            }
+
+            @Override
+            public Void visit(MultiPolygon multiPolygon) throws RuntimeException {
+                return visit((GeometryCollection<?>) multiPolygon);
+            }
+
+            @Override
+            public Void visit(Point point) throws RuntimeException {
+                return null;
+            }
+
+            @Override
+            public Void visit(Polygon polygon) throws RuntimeException {
+                polygon.getPolygon().visit(this);
+                for (int i = 0; i < polygon.getNumberOfHoles(); i++) {
+                    polygon.getHole(i).visit(this);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visit(Rectangle rectangle) throws RuntimeException {
+                validateBBox(rectangle.getMinX(), rectangle.getMaxX(), rectangle.getMaxY(), rectangle.getMinY());
+                return null;
+            }
+        });
+    }
+}

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeographyValidator.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeographyValidator.java
@@ -24,7 +24,9 @@ import org.elasticsearch.geometry.Rectangle;
 
 /**
  * Validator that checks that lats are between -90 and +90 and lons are between -180 and +180 and altitude is present only if
- * ignoreZValue is set to true
+ * ignoreZValue is set to true. It also validates a rectangle/envelope's y-ordinates (maxY cannot be less than minY),
+ * but deliberately does not validate x-ordinate ordering: unlike {@link CartesianValidator}, a geographic envelope may
+ * legitimately have minX greater than maxX, to represent one that crosses the antimeridian.
  */
 public class GeographyValidator implements GeometryValidator {
 
@@ -88,6 +90,10 @@ public class GeographyValidator implements GeometryValidator {
             throw new IllegalArgumentException("found Z value [" + zValue + "] but [ignore_z_value] parameter is [" + ignoreZValue + "]");
         }
     }
+
+    // validateBBox is intentionally not overridden here: the default implementation (maxY >= minY only,
+    // no x-ordinate check) is exactly the geographic policy, since minX may exceed maxX for an
+    // antimeridian-crossing envelope.
 
     @Override
     public void validate(Geometry geometry) {
@@ -169,6 +175,7 @@ public class GeographyValidator implements GeometryValidator {
                 checkLongitude(rectangle.getMaxX());
                 checkAltitude(rectangle.getMinZ());
                 checkAltitude(rectangle.getMaxZ());
+                validateBBox(rectangle.getMinX(), rectangle.getMaxX(), rectangle.getMaxY(), rectangle.getMinY());
                 return null;
             }
         });

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeometryValidator.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/GeometryValidator.java
@@ -23,4 +23,17 @@ public interface GeometryValidator {
      */
     void validate(Geometry geometry);
 
+    /**
+     * Validates the ordinate ordering of a rectangle/envelope, throwing IllegalArgumentException if the
+     * envelope is invalid. The default implementation only checks that maxY is not less than minY, since that
+     * is always invalid, regardless of CRS. It deliberately does not check x-ordinate ordering: geographic
+     * coordinates allow minX to legitimately exceed maxX, to represent an envelope that crosses the
+     * antimeridian, so only implementations for CRSes without that concept (e.g. {@link CartesianValidator})
+     * need to additionally check that maxX is not less than minX.
+     */
+    default void validateBBox(double minX, double maxX, double maxY, double minY) {
+        if (maxY < minY) {
+            throw new IllegalArgumentException("max y cannot be less than min y");
+        }
+    }
 }

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/StandardValidator.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/StandardValidator.java
@@ -23,7 +23,12 @@ import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 
 /**
- * Validator that only checks that altitude only shows up if ignoreZValue is set to true.
+ * Validator that only checks that altitude only shows up if ignoreZValue is set to true. Despite the name,
+ * this is not a generic "default" validator: it is CRS-agnostic, and used to parse both geographic and
+ * cartesian WKT/GeoJSON (see e.g. server's {@code GeometryParser}, used by both {@code geo_shape} and
+ * {@code shape} field mapping/queries). Because of that, it must not gain any check that differs between
+ * CRSes -- e.g. rectangle/envelope ordinate ordering, which {@link GeographyValidator} and
+ * {@link CartesianValidator} each enforce differently. Add such checks to those classes instead.
  */
 public class StandardValidator implements GeometryValidator {
 

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryValidatorTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryValidatorTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.geometry;
 
+import org.elasticsearch.geometry.utils.CartesianValidator;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
@@ -119,5 +120,24 @@ public class GeometryValidatorTests extends ESTestCase {
         assertEquals("invalid latitude 1.5; must be between -1.0 and 1.0", ex.getMessage());
         ex = expectThrows(IllegalArgumentException.class, () -> WellKnownText.fromWKT(validator, true, "MULTIPOINT (0 1, -2 1)"));
         assertEquals("invalid longitude -2.0; must be between -1.0 and 1.0", ex.getMessage());
+    }
+
+    public void testGeographyValidatorAllowsAntimeridianCrossingBBox() throws Exception {
+        // minX > maxX is a legitimate encoding of an envelope crossing the antimeridian; it must not be rejected.
+        GeometryValidator validator = GeographyValidator.instance(true);
+        WellKnownText.fromWKT(validator, false, "BBOX (170.0, -170.0, 10.0, -10.0)");
+    }
+
+    public void testCartesianValidatorRejectsInvertedXBBox() throws Exception {
+        GeometryValidator validator = CartesianValidator.INSTANCE;
+        // A valid envelope is unaffected.
+        WellKnownText.fromWKT(validator, false, "BBOX (0.0, 12.0, 60.0, 30.0)");
+
+        // maxX < minX has no antimeridian-crossing meaning for cartesian coordinates and must be rejected.
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> WellKnownText.fromWKT(validator, false, "BBOX (12.0, 0.0, 60.0, 30.0)")
+        );
+        assertEquals("max x cannot be less than min x", ex.getMessage());
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial-grid.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial-grid.csv-spec
@@ -292,6 +292,7 @@ count:long | centroid:geo_point                            | geohashString:keywo
 
 gridGeohashInvalidBoundsLiteral
 required_capability: spatial_grid_types
+required_capability: spatial_bbox_validation_fix
 
 // An inverted BBOX (maxY < minY) is an invalid envelope. The literal fails to parse into a geo_shape,
 // so it folds to null (with a warning), and ST_GEOHASH returns null for every row rather than failing the query.
@@ -308,6 +309,7 @@ total:long | nonNull:long
 
 gridGeotileInvalidBoundsLiteral
 required_capability: spatial_grid_types
+required_capability: spatial_bbox_validation_fix
 
 FROM airports
 | EVAL geotile = ST_GEOTILE(location, 3, TO_GEOSHAPE("BBOX(0.0, 12.0, 30.0, 60.0)"))
@@ -322,6 +324,7 @@ total:long | nonNull:long
 
 gridGeohexInvalidBoundsLiteral
 required_capability: spatial_grid_types
+required_capability: spatial_bbox_validation_fix
 
 FROM airports
 | EVAL geohex = ST_GEOHEX(location, 1, TO_GEOSHAPE("BBOX(0.0, 12.0, 30.0, 60.0)"))

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial-grid.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial-grid.csv-spec
@@ -290,6 +290,50 @@ count:long | centroid:geo_point                            | geohashString:keywo
 2          | POINT (16.706149326637387 32.37822346854955)  | sm                    | POLYGON((11.25 28.125, 22.5 28.125, 22.5 33.75, 11.25 33.75, 11.25 28.125))
 ;
 
+gridGeohashInvalidBoundsLiteral
+required_capability: spatial_grid_types
+
+// An inverted BBOX (maxY < minY) is an invalid envelope. The literal fails to parse into a geo_shape,
+// so it folds to null (with a warning), and ST_GEOHASH returns null for every row rather than failing the query.
+FROM airports
+| EVAL geohash = ST_GEOHASH(location, 2, TO_GEOSHAPE("BBOX(0.0, 12.0, 30.0, 60.0)"))
+| STATS total = COUNT(*), nonNull = COUNT(geohash)
+;
+warningRegex:evaluation of \[TO_GEOSHAPE.*\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max y cannot be less than min y.*
+
+total:long | nonNull:long
+891        | 0
+;
+
+gridGeotileInvalidBoundsLiteral
+required_capability: spatial_grid_types
+
+FROM airports
+| EVAL geotile = ST_GEOTILE(location, 3, TO_GEOSHAPE("BBOX(0.0, 12.0, 30.0, 60.0)"))
+| STATS total = COUNT(*), nonNull = COUNT(geotile)
+;
+warningRegex:evaluation of \[TO_GEOSHAPE.*\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max y cannot be less than min y.*
+
+total:long | nonNull:long
+891        | 0
+;
+
+gridGeohexInvalidBoundsLiteral
+required_capability: spatial_grid_types
+
+FROM airports
+| EVAL geohex = ST_GEOHEX(location, 1, TO_GEOSHAPE("BBOX(0.0, 12.0, 30.0, 60.0)"))
+| STATS total = COUNT(*), nonNull = COUNT(geohex)
+;
+warningRegex:evaluation of \[TO_GEOSHAPE.*\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max y cannot be less than min y.*
+
+total:long | nonNull:long
+891        | 0
+;
+
 gridGeohashStatsByBoundsEnvelope
 required_capability: spatial_grid_types
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -492,6 +492,22 @@ centroid:geo_point                              | count:long
 POINT (-2.597342072712148 54.33551226578214)    | 17
 ;
 
+countFromAirportsAfterIntersectsPredicateInvalidBoundsLiteral
+required_capability: st_intersects
+
+// An inverted BBOX (maxY < minY) is an invalid envelope. The literal fails to parse into a geo_shape,
+// so it folds to null (with a warning), and ST_INTERSECTS(field, NULL) matches no rows rather than failing the query.
+FROM airports
+| WHERE ST_INTERSECTS(location, TO_GEOSHAPE("BBOX(0.0, 12.0, 30.0, 60.0)"))
+| STATS count=COUNT()
+;
+warningRegex:evaluation of \[TO_GEOSHAPE.*\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max y cannot be less than min y.*
+
+count:long
+0
+;
+
 centroidFromAirportsAfterContainsPredicateCountryUK
 required_capability: st_contains_within
 
@@ -1391,6 +1407,24 @@ wkt:keyword    | pt:geo_point  | distance:double
 "POINT(-1 0)"  | POINT(-1 0)   | 111195.08242688453
 "POINT(0 1)"   | POINT(0 1)    | 111195.07776676829
 "POINT(0 -1)"  | POINT(0 -1)   | 111195.08242688453
+;
+
+literalGeoPointDistanceInvalidLiteralPoint
+required_capability: st_distance
+
+// An out-of-range point literal fails to parse into a geo_point, so it folds to null (with a warning),
+// and ST_DISTANCE returns null for every row rather than failing the query.
+ROW wkt = ["POINT(1 1)", "POINT(-1 -1)"]
+| MV_EXPAND wkt
+| EVAL pt = TO_GEOPOINT(wkt)
+| EVAL distance = ST_DISTANCE(pt, TO_GEOPOINT("POINT(200 100)"))
+;
+warningRegex:evaluation of \[TO_GEOPOINT\("POINT\(200 100\)"\)\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*
+
+wkt:keyword    | pt:geo_point  | distance:double
+"POINT(1 1)"   | POINT(1 1)    | null
+"POINT(-1 -1)" | POINT(-1 -1)  | null
 ;
 
 twoCitiesPointDistanceGeo

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -494,6 +494,7 @@ POINT (-2.597342072712148 54.33551226578214)    | 17
 
 countFromAirportsAfterIntersectsPredicateInvalidBoundsLiteral
 required_capability: st_intersects
+required_capability: spatial_bbox_validation_fix
 
 // An inverted BBOX (maxY < minY) is an invalid envelope. The literal fails to parse into a geo_shape,
 // so it folds to null (with a warning), and ST_INTERSECTS(field, NULL) matches no rows rather than failing the query.
@@ -1411,6 +1412,7 @@ wkt:keyword    | pt:geo_point  | distance:double
 
 literalGeoPointDistanceInvalidLiteralPoint
 required_capability: st_distance
+required_capability: spatial_bbox_validation_fix
 
 // An out-of-range point literal fails to parse into a geo_point, so it folds to null (with a warning),
 // and ST_DISTANCE returns null for every row rather than failing the query.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
@@ -320,6 +320,7 @@ wkt:keyword                               |pt:geo_shape
 
 convertFromStringInvertedBBoxRuntime
 required_capability: spatial_shapes
+required_capability: spatial_bbox_validation_fix
 
 // An inverted BBOX (maxY < minY) computed per-row from a field is a runtime failure: it fails to
 // parse, and to_geoshape returns null for that row (with a warning), while other rows are unaffected.
@@ -338,6 +339,7 @@ wkt:keyword                     |shape:geo_shape
 
 convertFromStringInvertedBBoxLiteralFold
 required_capability: spatial_shapes
+required_capability: spatial_bbox_validation_fix
 
 // The same invalid envelope, but as a pure literal: this is folded at plan time rather than evaluated
 // per row, and must behave identically -- null result plus a registered warning, not a query failure.
@@ -646,6 +648,7 @@ wkt:keyword          | point:cartesian_point | shape:cartesian_shape
 
 convertCartesianFromStringInvertedXBBoxRuntime
 required_capability: spatial_shapes
+required_capability: spatial_bbox_validation_fix
 
 // A BBOX with maxX < minX has no antimeridian-crossing meaning for cartesian coordinates and is invalid.
 // Computed per-row from a field, this is a runtime failure: it fails to parse, and to_cartesianshape
@@ -665,6 +668,7 @@ wkt:keyword                   |shape:cartesian_shape
 
 convertCartesianFromStringInvertedXBBoxLiteralFold
 required_capability: spatial_shapes
+required_capability: spatial_bbox_validation_fix
 
 // The same invalid envelope, but as a pure literal: this is folded at plan time rather than evaluated
 // per row, and must behave identically -- null result plus a registered warning, not a query failure.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
@@ -318,6 +318,39 @@ wkt:keyword                               |pt:geo_shape
 "POINT(111)"                              |null
 ;
 
+convertFromStringInvertedBBoxRuntime
+required_capability: spatial_shapes
+
+// An inverted BBOX (maxY < minY) computed per-row from a field is a runtime failure: it fails to
+// parse, and to_geoshape returns null for that row (with a warning), while other rows are unaffected.
+row wkt = ["BBOX(0.0, 12.0, 60.0, 30.0)", "BBOX(0.0, 12.0, 30.0, 60.0)"]
+| mv_expand wkt
+| eval shape = to_geoshape(wkt)
+;
+
+warningRegex:evaluation of \[to_geoshape\(wkt\)\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max y cannot be less than min y.*
+
+wkt:keyword                     |shape:geo_shape
+"BBOX(0.0, 12.0, 60.0, 30.0)"   |BBOX(0.0, 12.0, 60.0, 30.0)
+"BBOX(0.0, 12.0, 30.0, 60.0)"   |null
+;
+
+convertFromStringInvertedBBoxLiteralFold
+required_capability: spatial_shapes
+
+// The same invalid envelope, but as a pure literal: this is folded at plan time rather than evaluated
+// per row, and must behave identically -- null result plus a registered warning, not a query failure.
+row shape = to_geoshape("BBOX(0.0, 12.0, 30.0, 60.0)")
+;
+
+warningRegex:evaluation of \[to_geoshape.*\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max y cannot be less than min y.*
+
+shape:geo_shape
+null
+;
+
 ###############################################
 # Tests for GEO_SHAPE type with ST_ENVELOPE, ST_XMIN, etc.
 #
@@ -609,6 +642,40 @@ ROW wkt = "POINT (3010 -1010)"
 
 wkt:keyword          | point:cartesian_point | shape:cartesian_shape
 "POINT (3010 -1010)" | POINT (3010 -1010)    | POINT (3010 -1010)
+;
+
+convertCartesianFromStringInvertedXBBoxRuntime
+required_capability: spatial_shapes
+
+// A BBOX with maxX < minX has no antimeridian-crossing meaning for cartesian coordinates and is invalid.
+// Computed per-row from a field, this is a runtime failure: it fails to parse, and to_cartesianshape
+// returns null for that row (with a warning), while other rows are unaffected.
+row wkt = ["BBOX(0.0, 12.0, 60.0, 30.0)", "BBOX(12.0, 0.0, 60.0, 30.0)"]
+| mv_expand wkt
+| eval shape = to_cartesianshape(wkt)
+;
+
+warningRegex:evaluation of \[to_cartesianshape\(wkt\)\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max x cannot be less than min x.*
+
+wkt:keyword                   |shape:cartesian_shape
+"BBOX(0.0, 12.0, 60.0, 30.0)" |BBOX(0.0, 12.0, 60.0, 30.0)
+"BBOX(12.0, 0.0, 60.0, 30.0)" |null
+;
+
+convertCartesianFromStringInvertedXBBoxLiteralFold
+required_capability: spatial_shapes
+
+// The same invalid envelope, but as a pure literal: this is folded at plan time rather than evaluated
+// per row, and must behave identically -- null result plus a registered warning, not a query failure.
+row shape = to_cartesianshape("BBOX(12.0, 0.0, 60.0, 30.0)")
+;
+
+warningRegex:evaluation of \[to_cartesianshape.*\] failed, treating result as null. Only first 20 failures recorded
+warningRegex:.*max x cannot be less than min x.*
+
+shape:cartesian_shape
+null
 ;
 
 # need to work out how to upload WKT

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2641,6 +2641,16 @@ public class EsqlCapabilities {
          */
         EMPTY_LIST_PARAM_AS_NULL,
 
+        /**
+         * Invalid BBOX envelopes (e.g. maxY &lt; minY, or maxX &lt; minX for cartesian coordinates) are now
+         * consistently handled as a null result with a registered warning, both at fold time and at
+         * runtime, instead of either being silently accepted (cartesian x-ordering was never validated) or
+         * causing an uncaught exception in downstream consumers (ST_GEOHASH/ST_GEOTILE/ST_GEOHEX bounds,
+         * ST_DISTANCE, ST_INTERSECTS/ST_DISJOINT/etc. pushdown to Lucene).
+         * See <a href="https://github.com/elastic/elasticsearch/pull/152877">#152877</a>.
+         */
+        SPATIAL_BBOX_VALIDATION_FIX,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/util/SpatialCoordinateTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/util/SpatialCoordinateTypes.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.utils.CartesianValidator;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
@@ -85,6 +86,11 @@ public enum SpatialCoordinateTypes {
             final long xi = XYEncodingUtils.encode((float) x);
             final long yi = XYEncodingUtils.encode((float) y);
             return (yi & 0xFFFFFFFFL) | xi << 32;
+        }
+
+        @Override
+        public GeometryValidator validator() {
+            return CartesianValidator.INSTANCE;
         }
     },
     UNSPECIFIED {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -31,6 +31,8 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.TypedAttribute;
+import org.elasticsearch.xpack.esql.core.querydsl.query.MatchAll;
+import org.elasticsearch.xpack.esql.core.querydsl.query.NotQuery;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -97,7 +99,11 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
 
     protected Object foldGeoGrid(FoldContext ctx, Expression spatialExp, Expression gridExp, DataType gridType) {
         long gridId = (Long) valueOf(ctx, gridExp);
-        return getSpatialRelations().compareGeometryAndGrid(makeGeometryFromLiteral(ctx, spatialExp), gridId, gridType);
+        Geometry geometry = makeGeometryFromLiteral(ctx, spatialExp);
+        if (geometry == null) {
+            return null;
+        }
+        return getSpatialRelations().compareGeometryAndGrid(geometry, gridId, gridType);
     }
 
     /** This exposes class-level static information within objects and should only be used for folding optimizations */
@@ -363,6 +369,11 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
         try {
             // TODO: Support geo-grid query pushdown
             Geometry shape = SpatialRelatesUtils.makeGeometryFromLiteral(constantExpression);
+            if (shape == null) {
+                // The constant geometry literal failed to parse; it already folded to null with a registered warning.
+                // ST_<relation>(field, NULL) is NULL for every row, so the filter matches nothing.
+                return new NotQuery(source(), new MatchAll(source()));
+            }
             return new SpatialRelatesQuery(source(), name, queryRelation(), shape, attribute.dataType());
         } catch (IllegalArgumentException e) {
             throw new QlIllegalArgumentException(e.getMessage(), e);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
@@ -321,7 +322,9 @@ public class StDistance extends BinarySpatialFunction implements EvaluatorMapper
     }
 
     private ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator, Expression field, Geometry geometry, boolean docValues) {
-        if (geometry instanceof Point point) {
+        if (geometry == null) {
+            return ConstantEvaluators.CONSTANT_NULL_FACTORY;
+        } else if (geometry instanceof Point point) {
             return toEvaluator(toEvaluator, field, point, docValues);
         } else {
             throw new IllegalArgumentException("Unsupported geometry type for ST_DISTANCE: " + geometry.type().name());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohash.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohash.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.geometry.Point;
@@ -195,7 +196,11 @@ public class StGeohash extends SpatialGridFunction implements EvaluatorMapper {
             if (bounds.foldable() == false) {
                 throw new IllegalArgumentException("bounds must be foldable");
             }
-            GeoBoundingBox bbox = asGeoBoundingBox(bounds.fold(toEvaluator.foldCtx()));
+            Object boundsValue = bounds.fold(toEvaluator.foldCtx());
+            if (boundsValue == null) {
+                return ConstantEvaluators.CONSTANT_NULL_FACTORY;
+            }
+            GeoBoundingBox bbox = asGeoBoundingBox(boundsValue);
             int precision = (int) parameter.fold(toEvaluator.foldCtx());
             GeoHashBoundedGrid.Factory bounds = new GeoHashBoundedGrid.Factory(precision, bbox);
             return spatialDocValues
@@ -216,11 +221,18 @@ public class StGeohash extends SpatialGridFunction implements EvaluatorMapper {
     @Override
     public Object fold(FoldContext ctx) {
         var point = (BytesRef) spatialField().fold(ctx);
+        if (point == null) {
+            return null;
+        }
         int precision = (int) parameter().fold(ctx);
         if (bounds() == null) {
             return unboundedGrid.calculateGridId(GEO.wkbAsPoint(point), precision);
         } else {
-            GeoBoundingBox bbox = asGeoBoundingBox(bounds().fold(ctx));
+            Object boundsValue = bounds().fold(ctx);
+            if (boundsValue == null) {
+                return null;
+            }
+            GeoBoundingBox bbox = asGeoBoundingBox(boundsValue);
             GeoHashBoundedGrid bounds = new GeoHashBoundedGrid(precision, bbox);
             long gridId = bounds.calculateGridId(GEO.wkbAsPoint(point));
             return gridId < 0 ? null : gridId;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohex.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohex.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.geometry.LinearRing;
@@ -201,7 +202,11 @@ public class StGeohex extends SpatialGridFunction implements EvaluatorMapper {
             if (bounds.foldable() == false) {
                 throw new IllegalArgumentException("bounds must be foldable");
             }
-            GeoBoundingBox bbox = asGeoBoundingBox(bounds.fold(toEvaluator.foldCtx()));
+            Object boundsValue = bounds.fold(toEvaluator.foldCtx());
+            if (boundsValue == null) {
+                return ConstantEvaluators.CONSTANT_NULL_FACTORY;
+            }
+            GeoBoundingBox bbox = asGeoBoundingBox(boundsValue);
             int precision = (int) parameter.fold(toEvaluator.foldCtx());
             GeoHexBoundedGrid.Factory bounds = new GeoHexBoundedGrid.Factory(precision, bbox);
             return spatialDocValues
@@ -222,11 +227,18 @@ public class StGeohex extends SpatialGridFunction implements EvaluatorMapper {
     @Override
     public Object fold(FoldContext ctx) {
         var point = (BytesRef) spatialField().fold(ctx);
+        if (point == null) {
+            return null;
+        }
         int precision = checkPrecisionRange((int) parameter().fold(ctx));
         if (bounds() == null) {
             return unboundedGrid.calculateGridId(GEO.wkbAsPoint(point), precision);
         } else {
-            GeoBoundingBox bbox = asGeoBoundingBox(bounds().fold(ctx));
+            Object boundsValue = bounds().fold(ctx);
+            if (boundsValue == null) {
+                return null;
+            }
+            GeoBoundingBox bbox = asGeoBoundingBox(boundsValue);
             GeoHexBoundedGrid bounds = new GeoHexBoundedGrid(precision, bbox);
             long gridId = bounds.calculateGridId(GEO.wkbAsPoint(point));
             return gridId < 0 ? null : gridId;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotile.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotile.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.geometry.LinearRing;
@@ -192,7 +193,11 @@ public class StGeotile extends SpatialGridFunction implements EvaluatorMapper {
             if (bounds.foldable() == false) {
                 throw new IllegalArgumentException("bounds must be foldable");
             }
-            GeoBoundingBox bbox = asGeoBoundingBox(bounds.fold(toEvaluator.foldCtx()));
+            Object boundsValue = bounds.fold(toEvaluator.foldCtx());
+            if (boundsValue == null) {
+                return ConstantEvaluators.CONSTANT_NULL_FACTORY;
+            }
+            GeoBoundingBox bbox = asGeoBoundingBox(boundsValue);
             int precision = (int) parameter.fold(toEvaluator.foldCtx());
             GeoTileBoundedGrid.Factory bounds = new GeoTileBoundedGrid.Factory(precision, bbox);
             return spatialDocValues
@@ -213,11 +218,18 @@ public class StGeotile extends SpatialGridFunction implements EvaluatorMapper {
     @Override
     public Object fold(FoldContext ctx) {
         var point = (BytesRef) spatialField().fold(ctx);
+        if (point == null) {
+            return null;
+        }
         int precision = checkPrecisionRange((int) parameter().fold(ctx));
         if (bounds() == null) {
             return unboundedGrid.calculateGridId(GEO.wkbAsPoint(point), precision);
         } else {
-            GeoBoundingBox bbox = asGeoBoundingBox(bounds().fold(ctx));
+            Object boundsValue = bounds().fold(ctx);
+            if (boundsValue == null) {
+                return null;
+            }
+            GeoBoundingBox bbox = asGeoBoundingBox(boundsValue);
             GeoTileBoundedGrid bounds = new GeoTileBoundedGrid(precision, bbox);
             long gridId = bounds.calculateGridId(GEO.wkbAsPoint(point));
             return gridId < 0 ? null : gridId;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -137,6 +137,7 @@ import static org.elasticsearch.xpack.esql.core.util.NumericUtils.ZERO_AS_UNSIGN
 import static org.elasticsearch.xpack.esql.core.util.NumericUtils.asLongUnsigned;
 import static org.elasticsearch.xpack.esql.core.util.NumericUtils.asUnsignedLong;
 import static org.elasticsearch.xpack.esql.core.util.NumericUtils.unsignedLongAsNumber;
+import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.UNSPECIFIED;
 
@@ -645,8 +646,12 @@ public class EsqlDataTypeConverter {
         return GEO.wktToWkb(field);
     }
 
+    /**
+     * Anything spatial that isn't geo (i.e. anything not caught by {@link DataType#isSpatialGeo}) is assumed
+     * to be cartesian.
+     */
     public static BytesRef stringToSpatial(String field) {
-        return UNSPECIFIED.wktToWkb(field);
+        return CARTESIAN.wktToWkb(field);
     }
 
     public static long dateTimeToLong(String dateTime) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -104,6 +104,7 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateNanosT
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToLong;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.longToUnsignedLong;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.parseDateRange;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToGeo;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToIP;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToSpatial;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToVersion;
@@ -1484,8 +1485,11 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                             throw new UncheckedIOException(e);
                         }
                     }
-                    case GEO_POINT, GEO_SHAPE, CARTESIAN_POINT, CARTESIAN_SHAPE -> {
-                        // This just converts WKT to WKB, so does not need CRS knowledge, we could merge GEO and CARTESIAN here
+                    case GEO_POINT, GEO_SHAPE -> {
+                        BytesRef wkb = stringToGeo(value.toString());
+                        ((BytesRefBlock.Builder) builder).appendBytesRef(wkb);
+                    }
+                    case CARTESIAN_POINT, CARTESIAN_SHAPE -> {
                         BytesRef wkb = stringToSpatial(value.toString());
                         ((BytesRefBlock.Builder) builder).appendBytesRef(wkb);
                     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeTests.java
@@ -11,7 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -63,7 +63,7 @@ public class ToCartesianShapeTests extends AbstractScalarFunctionTestCase {
                 List.of(
                     new TestCaseSupplier.TypedDataSupplier(
                         "<cartesian_shape as string>",
-                        () -> new BytesRef(CARTESIAN.asWkt(GeometryTestUtils.randomGeometry(randomBoolean()))),
+                        () -> new BytesRef(CARTESIAN.asWkt(ShapeTestUtils.randomGeometry(randomBoolean()))),
                         dt
                     )
                 ),


### PR DESCRIPTION
This is a manual backport of https://github.com/elastic/elasticsearch/pull/152877. That PR fixed an error that should be a warning, found due to an update that is 9.5 specific, but also widened the scope to a number of errors that should be warnings, which can all be considered bug-fixes. This PR includes all the tests and fixes that are applicable to versions older than 9.5.
