### PR TITLE
[Backport] Fix NodesCachesStatsIntegTests.testNodesCachesStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -173,9 +173,6 @@ tests:
 - class: org.elasticsearch.compute.aggregation.SumLongGroupingAggregatorFunctionTests
   method: testOverflowInGroupingProducesNullAndWarning
   issue: https://github.com/elastic/elasticsearch/issues/150769
-- class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
-  method: testNodesCachesStats
-  issue: https://github.com/elastic/elasticsearch/issues/150770
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148619

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.BaseFrozenSearchableSnapshotsIntegTestCase;
@@ -28,9 +29,8 @@ import org.elasticsearch.xpack.searchablesnapshots.action.cache.TransportSearcha
 import org.elasticsearch.xpack.searchablesnapshots.action.cache.TransportSearchableSnapshotsNodeCachesStatsAction.NodesCachesStatsResponse;
 import org.elasticsearch.xpack.searchablesnapshots.action.cache.TransportSearchableSnapshotsNodeCachesStatsAction.NodesRequest;
 
-import java.util.stream.Collectors;
-
 import static java.util.stream.Collectors.toSet;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest.Storage;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -97,15 +97,19 @@ public class NodesCachesStatsIntegTests extends BaseFrozenSearchableSnapshotsInt
             assertThat(nodeCachesStats.getSize(), equalTo(cacheSize));
 
             final long regionSize = SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.get(clusterService.getSettings()).getBytes();
-            assertThat(nodeCachesStats.getRegionSize(), equalTo(regionSize));
 
+            assertThat(nodeCachesStats.getRegionSize(), equalTo(regionSize));
             assertThat(nodeCachesStats.getNumRegions(), equalTo(Math.toIntExact(cacheSize / regionSize)));
             assertThat(nodeCachesStats.getWrites(), equalTo(0L));
             assertThat(nodeCachesStats.getBytesWritten(), equalTo(0L));
             assertThat(nodeCachesStats.getReads(), equalTo(0L));
             assertThat(nodeCachesStats.getBytesRead(), equalTo(0L));
-            assertThat(nodeCachesStats.getEvictions(), equalTo(0L));
         }
+
+        // Make sure we have at least one query that matches docs on all shards.
+        prepareSearch(mountedIndex).addAggregation(
+            AggregationBuilders.global("all").subAggregation(AggregationBuilders.histogram("by_id").field("id").interval(100))
+        ).setSize(0).get().decRef();
 
         for (int i = 0; i < 20; i++) {
             prepareSearch(mountedIndex).setQuery(
@@ -124,7 +128,7 @@ public class NodesCachesStatsIntegTests extends BaseFrozenSearchableSnapshotsInt
         assertThat(clearCacheResponse.getSuccessfulShards(), greaterThan(0));
         assertThat(clearCacheResponse.getFailedShards(), equalTo(0));
 
-        final String[] dataNodesWithFrozenShards = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+        final String[] nodesWithFrozenShards = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .routingTable()
@@ -136,34 +140,60 @@ public class NodesCachesStatsIntegTests extends BaseFrozenSearchableSnapshotsInt
             .collect(toSet())
             .toArray(String[]::new);
 
-        // We've seen `getWrites` inexplicably return zero. `assertBusy` to test the theory of it being due
-        // to contention on the `LongAdder` at `SharedBlobCacheService#writeCount`.
-        assertBusy(() -> {
-            final NodesCachesStatsResponse response = client().execute(
-                TransportSearchableSnapshotsNodeCachesStatsAction.TYPE,
-                new NodesRequest(dataNodesWithFrozenShards)
-            ).actionGet();
-            assertThat(
-                response.getNodes().stream().map(r -> r.getNode().getId()).collect(Collectors.toList()),
-                containsInAnyOrder(dataNodesWithFrozenShards)
-            );
-            assertThat(response.hasFailures(), equalTo(false));
+        final var response = client().execute(
+            TransportSearchableSnapshotsNodeCachesStatsAction.TYPE,
+            new NodesRequest(nodesWithFrozenShards)
+        ).actionGet();
+        assertThat(response.getNodes().stream().map(r -> r.getNode().getId()).toList(), containsInAnyOrder(nodesWithFrozenShards));
+        assertThat(response.hasFailures(), equalTo(false));
 
-            for (NodeCachesStatsResponse nodeCachesStats : response.getNodes()) {
-                if (nodeCachesStats.getNumRegions() > 0) {
-                    assertThat(nodeCachesStats.getWrites(), greaterThan(0L));
-                    assertThat(nodeCachesStats.getBytesWritten(), greaterThan(0L));
-                    assertThat(nodeCachesStats.getReads(), greaterThan(0L));
-                    assertThat(nodeCachesStats.getBytesRead(), greaterThan(0L));
-                    assertThat(nodeCachesStats.getEvictions(), greaterThan(0L));
-                } else {
-                    assertThat(nodeCachesStats.getWrites(), equalTo(0L));
-                    assertThat(nodeCachesStats.getBytesWritten(), equalTo(0L));
-                    assertThat(nodeCachesStats.getReads(), equalTo(0L));
-                    assertThat(nodeCachesStats.getBytesRead(), equalTo(0L));
-                    assertThat(nodeCachesStats.getEvictions(), equalTo(0L));
-                }
-            }
+        // include all nodes' stats in the assertion message so that any failure
+        // provides enough context to debug edge cases not captured in #129863
+        final var allNodesStats = String.join(
+            ",",
+            response.getNodes()
+                .stream()
+                .map(
+                    nodeStats -> format(
+                        "[node=[%s], numRegions=[%d], writes=[%d], bytesWritten=[%d], reads=[%d], bytesRead=[%d], evictions=[%d]]",
+                        nodeStats.getNode().getName(),
+                        nodeStats.getNumRegions(),
+                        nodeStats.getWrites(),
+                        nodeStats.getBytesWritten(),
+                        nodeStats.getReads(),
+                        nodeStats.getBytesRead(),
+                        nodeStats.getEvictions()
+                    )
+                )
+                .toList()
+        );
+        response.getNodes().forEach(nodeStats -> {
+            final var nodeName = nodeStats.getNode().getName();
+            assertThat(
+                format("unexpected write stats for node [%s], all stats: [%s]", nodeName, allNodesStats),
+                nodeStats.getWrites(),
+                nodeStats.getNumRegions() > 0 ? greaterThan(0L) : equalTo(0L)
+            );
+            assertThat(
+                format("unexpected bytes written stats for node [%s], all stats: [%s]", nodeName, allNodesStats),
+                nodeStats.getBytesWritten(),
+                nodeStats.getNumRegions() > 0 ? greaterThan(0L) : equalTo(0L)
+            );
+            assertThat(
+                format("unexpected read stats for node [%s], all stats: [%s]", nodeName, allNodesStats),
+                nodeStats.getReads(),
+                nodeStats.getNumRegions() > 0 ? greaterThan(0L) : equalTo(0L)
+            );
+            assertThat(
+                format("unexpected bytes read stats for node [%s], all stats: [%s]", nodeName, allNodesStats),
+                nodeStats.getBytesRead(),
+                nodeStats.getNumRegions() > 0 ? greaterThan(0L) : equalTo(0L)
+            );
+            assertThat(
+                format("unexpected evictions stats for node [%s], all stats: [%s]", nodeName, allNodesStats),
+                nodeStats.getEvictions(),
+                nodeStats.getNumRegions() > 0 ? greaterThan(0L) : equalTo(0L)
+            );
         });
     }
 }


### PR DESCRIPTION
The issue was fixed in main by https://github.com/elastic/elasticsearch/pull/147708, the test was unmuted in https://github.com/elastic/elasticsearch/pull/150731, but the fix was not backported. This backports the fix into `9.4`.

Closes https://github.com/elastic/elasticsearch/issues/150770