### PR TITLE
ESQL: Solves NoSuchElementException in ViewUnionAll analyzer retries

### DIFF
--- a/docs/changelog/152867.yaml
+++ b/docs/changelog/152867.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152867
+summary: Solves `NoSuchElementException` in `ViewUnionAll` analyzer retries
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewUnionAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ViewUnionAll.java
@@ -10,11 +10,11 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.SequencedSet;
 
 /**
  * A {@link UnionAll} produced by view resolution, as opposed to user-written subqueries.
@@ -56,11 +56,18 @@ public class ViewUnionAll extends UnionAll {
     }
 
     private LinkedHashMap<String, LogicalPlan> asSubqueryMap(List<LogicalPlan> children) {
-        SequencedSet<String> names = namedSubqueries.sequencedKeySet();
-        assert children.size() == names.size();
+        if (children.size() != namedSubqueries.size()) {
+            throw new IllegalArgumentException(
+                "ViewUnionAll.replaceChildren expects a 1:1 positional replacement; use pruneEmptyBranches"
+                    + " to drop branches and preserve the named-subqueries invariant."
+            );
+        }
+        // Read-only iterator: unlike sequencedKeySet(), calling next() here does not remove
+        // entries from (and therefore does not corrupt) this instance's own namedSubqueries.
+        Iterator<String> names = namedSubqueries.keySet().iterator();
         LinkedHashMap<String, LogicalPlan> newSubqueries = new LinkedHashMap<>();
         for (LogicalPlan child : children) {
-            newSubqueries.put(names.removeFirst(), child);
+            newSubqueries.put(names.next(), child);
         }
         return newSubqueries;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ViewUnionAllTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ViewUnionAllTests.java
@@ -91,6 +91,28 @@ public class ViewUnionAllTests extends ESTestCase {
         assertEquals(a.hashCode(), d.hashCode());
     }
 
+    /**
+     * {@code asSubqueryMap} used to read a live view over {@code namedSubqueries} and drain it as
+     * a side effect of {@code replaceChildren}, corrupting the <em>original</em> instance. That
+     * mattered because {@code EsqlSession.analyzeWithRetry} can re-run {@code Analyzer.analyze} on
+     * the same parsed plan a second time (the "second attempt, without filter" retry after a
+     * {@code VerificationException}), revisiting the same instance. Pins that {@code replaceChildren}
+     * leaves the original instance untouched and can be called repeatedly.
+     */
+    public void testReplaceChildrenDoesNotMutateOriginalInstance() {
+        LogicalPlan child1 = relation("index1");
+        LogicalPlan child2 = relation("index2");
+        ViewUnionAll original = new ViewUnionAll(Source.EMPTY, viewMap(child1, child2), List.of());
+
+        original.replaceChildren(List.of(child1, child2));
+        assertThat(original.namedSubqueries(), equalTo(Map.of("view_0", child1, "view_1", child2)));
+
+        // Re-analyzing the same instance a second time (what analyzeWithRetry does) still works.
+        LogicalPlan replaced = original.replaceChildren(List.of(child1, child2));
+        assertThat(replaced, instanceOf(ViewUnionAll.class));
+        assertEquals(List.of(child1, child2), replaced.children());
+    }
+
     public void testNotEqualToPlainUnionAll() {
         LogicalPlan child = relation("index1");
 


### PR DESCRIPTION
Backports #152867

I got this stacktrace from serverless today:

```
java.util.NoSuchElementException
    at java.base/java.util.LinkedHashMap.nsee(LinkedHashMap.java:656)
    at java.base/java.util.LinkedHashMap$LinkedKeySet.removeFirst(LinkedHashMap.java:740)
    at org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll.asSubqueryMap(ViewUnionAll.java:67)
    at org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll.replaceChildren(ViewUnionAll.java:37)
    at org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll.replaceChildren(ViewUnionAll.java:27)
    at org.elasticsearch.xpack.esql.core.tree.Node.replaceChildrenSameSize(Node.java:376)
    at org.elasticsearch.xpack.esql.core.tree.Node.transformChildren(Node.java:367)
    at org.elasticsearch.xpack.esql.core.tree.Node.transformUp(Node.java:331)
    at org.elasticsearch.xpack.esql.core.tree.Node.lambda$transformUp$18(Node.java:331)
    at org.elasticsearch.xpack.esql.core.tree.Node.transformChildren(Node.java:356)
    at org.elasticsearch.xpack.esql.core.tree.Node.transformUp(Node.java:331)
    at org.elasticsearch.xpack.esql.core.tree.Node.transformUp(Node.java:338)
    at org.elasticsearch.xpack.esql.analysis.AnalyzerRules$ParameterizedAnalyzerRule.apply(AnalyzerRules.java:50)
```

In a `asSubqueryMap` we were creating a view that we were iterating and deleting elements from the original underlying collection. On a second pass we would find an empty collection because of that.

This could happen when we retry a query with multiple views (`ViewUnionAll`) that have a filter and a verification error on the first pass. We'll make a second pass on the analyzer (`analyzeWithRetry`) without the filter and then we'd get the exception.