### PR TITLE
[9.4] Ignore dot agent older used by codex (#152917)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Prefix slash ensures these are only ignored at the same level as this file
 /.cursor/
 
+# codex
+.agent
+
 # pi agent harness
 .pi
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Ignore dot agent older used by codex (#152917)