### PR TITLE
ESQL: Fix Attribute#withQualifier ignoring the new qualifier

### DIFF
--- a/docs/changelog/152921.yaml
+++ b/docs/changelog/152921.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 152920
+pr: 152921
+summary: Fix no-op `Attribute#withQualifier`
+type: bug

--- a/docs/changelog/152921.yaml
+++ b/docs/changelog/152921.yaml
@@ -1,6 +1,0 @@
-area: ES|QL
-issues:
- - 152920
-pr: 152921
-summary: Fix no-op `Attribute#withQualifier`
-type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
@@ -151,7 +151,9 @@ public abstract class Attribute extends NamedExpression {
     }
 
     public Attribute withQualifier(String qualifier) {
-        return Objects.equals(qualifier, qualifier) ? this : clone(source(), qualifier, name(), dataType(), nullable(), id(), synthetic());
+        return Objects.equals(qualifier(), qualifier)
+            ? this
+            : clone(source(), qualifier, name(), dataType(), nullable(), id(), synthetic());
     }
 
     public Attribute withName(String name) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/ReferenceAttributeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/ReferenceAttributeTests.java
@@ -47,6 +47,17 @@ public class ReferenceAttributeTests extends AbstractNamedExpressionSerializatio
         return (ReferenceAttribute) instance.withId(new NameId());
     }
 
+    /**
+     * Ensures {@code withQualifier} applies the new qualifier rather than returning
+     * the unchanged attribute, and still avoids cloning when the qualifier is equal.
+     */
+    public void testWithQualifier() {
+        ReferenceAttribute attribute = randomReferenceAttribute(false);
+        String newQualifier = randomValueOtherThan(attribute.qualifier(), () -> randomBoolean() ? null : randomAlphaOfLength(5));
+        assertEquals(newQualifier, attribute.withQualifier(newQualifier).qualifier());
+        assertSame(attribute, attribute.withQualifier(attribute.qualifier()));
+    }
+
     @Override
     protected boolean equalityIgnoresId() {
         return false;


### PR DESCRIPTION
Fixes #152920

`Attribute.withQualifier(String qualifier)` compared the method parameter to
itself (`Objects.equals(qualifier, qualifier)` — the parameter shadows the
field of the same name), which is always `true`. As a result the method
unconditionally returned `this` and silently never applied the new qualifier.

All sibling methods (`withName`, `withLocation`, `withDataType`) compare the
accessor against the parameter; this change makes `withQualifier` do the same:

```java
return Objects.equals(qualifier(), qualifier)
    ? this
    : clone(source(), qualifier, name(), dataType(), nullable(), id(), synthetic());
```

There are no callers of `withQualifier` in `main` yet, so there is no
user-visible impact today — but qualifiers in attributes are under active
development (`esql_qualifiers_in_attributes`), and the first caller would have
silently received the original, unqualified attribute back.

Also adds a regression test (`ReferenceAttributeTests#testWithQualifier`)
asserting that the new qualifier is applied and that passing an equal
qualifier still returns the same instance without cloning.

Verified locally with `:x-pack:plugin:esql:test --tests "...ReferenceAttributeTests"`
(9/9 passing) and `:x-pack:plugin:esql:spotlessJavaCheck`.
