### PR TITLE
Add YAML hex number parsing regression test

### DIFF
--- a/docs/changelog/152924.yaml
+++ b/docs/changelog/152924.yaml
@@ -2,5 +2,5 @@ area: Infra/Core
 issues:
  - 66555
 pr: 152924
-summary: Parse YAML hexadecimal values as numbers
+summary: Add regression coverage for YAML hexadecimal number parsing
 type: bug

--- a/docs/changelog/152924.yaml
+++ b/docs/changelog/152924.yaml
@@ -1,0 +1,6 @@
+area: Infra/Core
+issues:
+ - 66555
+pr: 152924
+summary: Parse YAML hexadecimal values as numbers
+type: bug

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -719,16 +719,19 @@ public class XContentParserTests extends ESTestCase {
             assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
             assertEquals("number_base10", parser.currentName());
             assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+            assertEquals(XContentParser.NumberType.INT, parser.numberType());
             assertEquals(1, parser.intValue());
 
             assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
             assertEquals("number_base16", parser.currentName());
             assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+            assertEquals(XContentParser.NumberType.INT, parser.numberType());
             assertEquals(1, parser.intValue());
 
             assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
             assertEquals("number_base16_uppercase", parser.currentName());
             assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+            assertEquals(XContentParser.NumberType.INT, parser.numberType());
             assertEquals(255, parser.intValue());
 
             assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -706,6 +706,41 @@ public class XContentParserTests extends ESTestCase {
         }
     }
 
+    public void testYamlHexNumbersAreParsedAsNumbers() throws IOException {
+        String yaml = """
+            number_base10: 1
+            number_base16: 0x1
+            number_base16_uppercase: 0xFF
+            quoted_hex: "0x1"
+            """;
+        try (XContentParser parser = decorateParser(XContentType.YAML.xContent().createParser(XContentParserConfiguration.EMPTY, yaml))) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals("number_base10", parser.currentName());
+            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+            assertEquals(1, parser.intValue());
+
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals("number_base16", parser.currentName());
+            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+            assertEquals(1, parser.intValue());
+
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals("number_base16_uppercase", parser.currentName());
+            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+            assertEquals(255, parser.intValue());
+
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals("quoted_hex", parser.currentName());
+            assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
+            assertEquals("0x1", parser.text());
+
+            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
+    }
+
     public void testCborHasByteOffsets() throws IOException {
         byte[] json = "{\"k\":1}".getBytes(StandardCharsets.UTF_8);
         byte[] cbor;


### PR DESCRIPTION
## Summary
- Add regression coverage for YAML hexadecimal scalar parsing
- Assert unquoted hex scalars parse as numbers
- Assert quoted hex scalars remain strings

## Validation
- `./gradlew :libs:x-content:test --tests org.elasticsearch.xcontent.XContentParserTests.testYamlHexNumbersAreParsedAsNumbers`
- `./gradlew :libs:x-content:spotlessJavaCheck`
- `git diff --check`

Relates #66555