### PR TITLE
Unmute CoreWithSecurityClientYamlTestSuiteIT synthetic source multi-field test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -352,9 +352,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlDisruptionIT
   method: testFromStatsGroupingByDate
   issue: https://github.com/elastic/elasticsearch/issues/152475
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=mapping/20_synthetic_source/synthetic_source text as multi-field}
-  issue: https://github.com/elastic/elasticsearch/issues/152827
 - class: org.elasticsearch.packaging.test.PackageUpgradeTests
   method: test12SetupBwcVersion
   issue: https://github.com/elastic/elasticsearch/issues/152819


### PR DESCRIPTION
## Summary
- Unmute `CoreWithSecurityClientYamlTestSuiteIT` test `{yaml=mapping/20_synthetic_source/synthetic_source text as multi-field}`
- The CI failure was a suite timeout (`Test abandoned because suite timeout was reached`), not a test assertion failure, so there is no underlying bug to fix

## Test plan
- [ ] CI runs the unmuted YAML test on 9.3

Fixes https://github.com/elastic/elasticsearch/issues/152827

Made with [Cursor](https://cursor.com)