### PR TITLE
Introduce isTsdb helpers

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -94,7 +94,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
             // First backing index is created and then data stream is rolled over (in a single cluster state update).
             // So at this point we can't check index_mode==time_series,
             // so checking that index_mode==null|standard and templateIndexMode == TIME_SERIES
-            boolean isMigratingToTimeSeries = templateIndexMode == IndexMode.TIME_SERIES;
+            boolean isMigratingToTimeSeries = IndexMode.isTsdb(templateIndexMode);
             boolean migrating = dataStream != null
                 && (dataStream.getIndexMode() == null || dataStream.getIndexMode() == IndexMode.STANDARD)
                 && isMigratingToTimeSeries;
@@ -109,7 +109,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                 indexMode = null;
             }
             if (indexMode != null) {
-                if (indexMode == IndexMode.TIME_SERIES) {
+                if (indexMode.isTsdb()) {
                     TimeValue lookAheadTime = DataStreamsPlugin.getLookAheadTime(indexTemplateAndCreateRequestSettings);
                     TimeValue lookBackTime = DataStreamsPlugin.LOOK_BACK_TIME.get(indexTemplateAndCreateRequestSettings);
                     final Instant start;
@@ -197,7 +197,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
         if (indexDimensions.isEmpty()) {
             return;
         }
-        assert indexMetadata.getIndexMode() == IndexMode.TIME_SERIES;
+        assert IndexMode.isTsdb(indexMetadata.getIndexMode());
         List<String> newIndexDimensions = new ArrayList<>(indexDimensions.size());
         boolean matchesAllDimensions = findDimensionFields(newIndexDimensions, documentMapper);
         boolean hasChanges = indexDimensions.size() != newIndexDimensions.size()

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeService.java
@@ -118,7 +118,7 @@ public class UpdateTimeSeriesRangeService extends AbstractLifecycleComponent imp
     private ProjectMetadata.Builder updateTimeSeriesTemporalRange(ProjectMetadata project, Instant now) {
         ProjectMetadata.Builder mBuilder = null;
         for (DataStream dataStream : project.dataStreams().values()) {
-            if (dataStream.getIndexMode() != IndexMode.TIME_SERIES) {
+            if (IndexMode.isTsdb(dataStream.getIndexMode()) == false) {
                 continue;
             }
             if (dataStream.isReplicated()) {

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -332,7 +332,7 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
             }
 
             GetDataStreamAction.Response.TimeSeries timeSeries = null;
-            if (dataStream.getIndexMode() == IndexMode.TIME_SERIES) {
+            if (IndexMode.isTsdb(dataStream.getIndexMode())) {
                 record IndexInfo(String name, Instant timeSeriesStart, Instant timeSeriesEnd) implements Comparable<IndexInfo> {
                     @Override
                     public int compareTo(IndexInfo o) {
@@ -350,7 +350,7 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
                 var sortedRanges = dataStream.getIndices()
                     .stream()
                     .map(metadata::index)
-                    .filter(m -> m.getIndexMode() == IndexMode.TIME_SERIES)
+                    .filter(m -> IndexMode.isTsdb(m.getIndexMode()))
                     .map(m -> new IndexInfo(m.getIndex().getName(), m.getTimeSeriesStart(), m.getTimeSeriesEnd()))
                     .sorted()
                     .toList();

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportPastTimeSeriesIndexCreationAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportPastTimeSeriesIndexCreationAction.java
@@ -471,7 +471,7 @@ public class TransportPastTimeSeriesIndexCreationAction extends TransportMasterN
             List<CoveredTimeWindow> coveredTimeWindows = new ArrayList<>();
             for (Index existingIndex : dataStream.getIndices()) {
                 IndexMetadata im = currentProject.index(existingIndex);
-                if (im == null || im.getIndexMode() != IndexMode.TIME_SERIES) {
+                if (im == null || IndexMode.isTsdb(im.getIndexMode()) == false) {
                     continue;
                 }
                 assert im.getTimeSeriesStart() != null && im.getTimeSeriesEnd() != null : "TSDB indices always have start and end time";
@@ -525,7 +525,7 @@ public class TransportPastTimeSeriesIndexCreationAction extends TransportMasterN
             throw new IllegalArgumentException("Cannot create past TSDB backing index for system data stream [" + dataStreamName + "]");
         }
 
-        if (dataStream.getIndexMode() != IndexMode.TIME_SERIES) {
+        if (IndexMode.isTsdb(dataStream.getIndexMode()) == false) {
             throw new IllegalArgumentException(
                 "Cannot create past TSDB backing index for data stream ["
                     + dataStreamName
@@ -536,7 +536,7 @@ public class TransportPastTimeSeriesIndexCreationAction extends TransportMasterN
         }
         Index writeIndex = dataStream.getWriteIndex();
         IndexMetadata writeIndexMetadata = writeIndex == null ? null : project.index(writeIndex);
-        if (writeIndexMetadata == null || writeIndexMetadata.getIndexMode() != IndexMode.TIME_SERIES) {
+        if (writeIndexMetadata == null || IndexMode.isTsdb(writeIndexMetadata.getIndexMode()) == false) {
             throw new IllegalStateException(
                 "Cannot create past TSDB backing index for data stream ["
                     + dataStreamName

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
@@ -78,7 +78,6 @@ import org.elasticsearch.datastreams.lifecycle.transitions.steps.MarkIndexForDLM
 import org.elasticsearch.dlm.DataStreamLifecycleErrorStore;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MergePolicyConfig;
@@ -665,7 +664,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
         for (Index index : targetIndices) {
             IndexMetadata backingIndex = project.index(index);
             assert backingIndex != null : "the data stream backing indices must exist";
-            if (IndexSettings.MODE.get(backingIndex.getSettings()) == IndexMode.TIME_SERIES) {
+            if (IndexSettings.MODE.get(backingIndex.getSettings()).isTsdb()) {
                 Instant configuredEndTime = IndexSettings.TIME_SERIES_END_TIME.get(backingIndex.getSettings());
                 assert configuredEndTime != null
                     : "a time series index must have an end time configured but [" + index.getName() + "] does not";

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -56,7 +56,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -850,7 +849,7 @@ public class PainlessExecuteAction {
                     BytesReference document = request.contextSetup.document;
                     XContentType xContentType = request.contextSetup.xContentType;
 
-                    SourceToParse sourceToParse = (indexService.getIndexSettings().getMode() == IndexMode.TIME_SERIES)
+                    SourceToParse sourceToParse = (indexService.getIndexSettings().getMode().isTsdb())
                         ? new SourceToParse(
                             null,
                             document,

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -162,7 +162,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                     return false;
                 }
 
-                if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
+                if (indexSettings.getMode().isTsdb()) {
                     var metricType = getMetric().getValue();
                     return metricType != TimeSeriesParams.MetricType.COUNTER && metricType != TimeSeriesParams.MetricType.GAUGE;
                 } else {
@@ -408,7 +408,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            if (indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER) {
+            if (IndexMode.isTsdb(indexMode) && metricType == TimeSeriesParams.MetricType.COUNTER) {
                 // Counters are not supported by ESQL so we load them in null
                 return ConstantNull.INSTANCE;
             }
@@ -496,7 +496,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER
+            ValuesSourceType valuesSourceType = IndexMode.isTsdb(indexMode) && metricType == TimeSeriesParams.MetricType.COUNTER
                 ? TimeSeriesValuesSourceType.COUNTER
                 : IndexNumericFieldData.NumericType.LONG.getValuesSourceType();
             if ((operation == FielddataOperation.SEARCH || operation == FielddataOperation.SCRIPT) && hasDocValues()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -476,7 +476,7 @@ public class MetadataRolloverService {
             var index = projectBuilder.getSafe(indexName);
             final Settings originalSettings = index.getSettings();
             if (index.getCreationVersion().before(IndexVersions.FIRST_DETACHED_INDEX_VERSION)
-                && index.getIndexMode() == IndexMode.TIME_SERIES
+                && IndexMode.isTsdb(index.getIndexMode())
                 && originalSettings.keySet().contains(IndexSettings.TIME_SERIES_START_TIME.getKey()) == false
                 && originalSettings.keySet().contains(IndexSettings.TIME_SERIES_END_TIME.getKey()) == false) {
                 final Settings.Builder settingsBuilder = Settings.builder()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -609,7 +609,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             Index index = backingIndices.indices.get(i);
             IndexMetadata im = project.index(index);
 
-            if (im.getIndexMode() != IndexMode.TIME_SERIES) {
+            if (IndexMode.isTsdb(im.getIndexMode()) == false) {
                 // Not a tsdb backing index, so skip.
                 // (This can happen if this is a migrated tsdb data stream)
                 continue;
@@ -633,7 +633,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
      * @param imSupplier Function that supplies {@link IndexMetadata} instances based on the provided index name
      */
     public void validate(Function<String, IndexMetadata> imSupplier) {
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (IndexMode.isTsdb(indexMode)) {
             // Get a sorted overview of each backing index with there start and end time range:
             var startAndEndTimes = backingIndices.indices.stream().map(index -> {
                 IndexMetadata im = imSupplier.apply(index.getName());
@@ -883,8 +883,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             );
         }
         if (dsIndexMode != indexModeFromTemplate) {
-            if (indexModeFromTemplate == IndexMode.TIME_SERIES
-                && (dsIndexMode == IndexMode.LOGSDB || dsIndexMode == IndexMode.LOGSDB_COLUMNAR)) {
+            if (IndexMode.isTsdb(indexModeFromTemplate) && (dsIndexMode == IndexMode.LOGSDB || dsIndexMode == IndexMode.LOGSDB_COLUMNAR)) {
                 LOGGER.warn("Changing [{}] index mode from [{}] to [{}]", name, indexModeFromTemplate, dsIndexMode);
             }
             dsIndexMode = indexModeFromTemplate;
@@ -1327,7 +1326,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         }
 
         IndexMetadata indexMetadata = indexMetadataSupplier.apply(index.getName());
-        if (indexMetadata == null || IndexSettings.MODE.get(indexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
+        if (indexMetadata == null || IndexSettings.MODE.get(indexMetadata.getSettings()).isTsdb() == false) {
             return List.of();
         }
         TimeValue indexGenerationTime = getGenerationLifecycleDate(indexMetadata);
@@ -1782,7 +1781,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             return getWriteIndex();
         }
 
-        if (getIndexMode() != IndexMode.TIME_SERIES) {
+        if (IndexMode.isTsdb(getIndexMode()) == false) {
             return getWriteIndex();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2584,7 +2584,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final boolean isSearchableSnapshot = SearchableSnapshotsSettings.isSearchableSnapshotStore(settings);
             String indexModeString = settings.get(IndexSettings.MODE.getKey());
             final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
-            final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
+            final boolean isTsdb = IndexMode.isTsdb(indexMode);
             boolean useTimeSeriesSyntheticId = shouldUseTimeSeriesSyntheticId(isTsdb, indexCreatedVersion, settings);
             final boolean sequenceNumbersDisabled = indexCreatedVersion.onOrAfter(
                 IndexVersions.TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -84,7 +84,7 @@ public abstract class IndexRouting {
         RoutingFunction routingFunction,
         IndexReshardingMetadata reshardingMetadata
     ) {
-        if (metadata.getIndexMode() == IndexMode.TIME_SERIES
+        if (IndexMode.isTsdb(metadata.getIndexMode())
             && metadata.getTimeSeriesDimensions().isEmpty() == false
             && metadata.getCreationVersion().onOrAfter(IndexVersions.TSID_CREATED_DURING_ROUTING)) {
             return new ExtractFromSource.ForIndexDimensions(metadata, routingFunction, reshardingMetadata);
@@ -411,7 +411,7 @@ public abstract class IndexRouting {
             }
             indexMode = metadata.getIndexMode();
             assert indexMode != null : "Index mode must be set for ExtractFromSource routing";
-            this.trackTimeSeriesRoutingHash = indexMode == IndexMode.TIME_SERIES
+            this.trackTimeSeriesRoutingHash = indexMode.isTsdb()
                 && metadata.getCreationVersion().onOrAfter(IndexVersions.TIME_SERIES_ROUTING_HASH_IN_ID);
             this.useTimeSeriesSyntheticId = metadata.useTimeSeriesSyntheticId();
             addIdWithRoutingHash = (indexMode == IndexMode.LOGSDB
@@ -629,7 +629,7 @@ public abstract class IndexRouting {
 
             ForIndexDimensions(IndexMetadata metadata, RoutingFunction routingFunction, IndexReshardingMetadata reshardingMetadata) {
                 super(metadata, routingFunction, reshardingMetadata, metadata.getTimeSeriesDimensions());
-                assert metadata.getIndexMode() == IndexMode.TIME_SERIES : "Index mode must be time_series for ForIndexDimensions routing";
+                assert IndexMode.isTsdb(metadata.getIndexMode()) : "Index mode must be time_series for ForIndexDimensions routing";
                 assert metadata.getCreationVersion().onOrAfter(IndexVersions.TSID_CREATED_DURING_ROUTING)
                     : "Index version must be at least "
                         + IndexVersions.TSID_CREATED_DURING_ROUTING

--- a/server/src/main/java/org/elasticsearch/dlm/TimeSeriesEligibleWriteWindowLocator.java
+++ b/server/src/main/java/org/elasticsearch/dlm/TimeSeriesEligibleWriteWindowLocator.java
@@ -58,7 +58,7 @@ public class TimeSeriesEligibleWriteWindowLocator {
         long requestStartTimestamp
     ) {
         // Eligible write window is only applicable for time series data streams
-        if (dataStream.getIndexMode() != IndexMode.TIME_SERIES || dataStream.isSystem()) {
+        if (IndexMode.isTsdb(dataStream.getIndexMode()) == false || dataStream.isSystem()) {
             return -1;
         }
         String ilmPolicy = getEffectiveIlmPolicy(dataStream, projectMetadata);

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -968,6 +968,31 @@ public enum IndexMode {
     }
 
     /**
+     * Whether this index mode represents a time series (tsdb) index.
+     */
+    public boolean isTsdb() {
+        return this == TIME_SERIES;
+    }
+
+    /**
+     * Null-safe variant of {@link #isTsdb()} for callers holding a possibly-{@code null}
+     * {@link IndexMode} (e.g. a {@code @Nullable} field that defaults to {@code null} rather
+     * than {@link #STANDARD}).
+     */
+    public static boolean isTsdb(@Nullable IndexMode mode) {
+        return mode != null && mode.isTsdb();
+    }
+
+    /**
+     * Whether the given raw {@code index.mode} setting value names a time series (tsdb) index
+     * mode, case-insensitively. Use this instead of comparing against {@link #TIME_SERIES}'s
+     * {@link #getName()} directly when the value hasn't been parsed with {@link #fromString} yet.
+     */
+    public static boolean isTsdbName(@Nullable String name) {
+        return name != null && TIME_SERIES.getName().equalsIgnoreCase(name);
+    }
+
+    /**
      * Parse a string into an {@link IndexMode}.
      */
     public static IndexMode fromString(String value) {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -724,14 +724,14 @@ public final class IndexSettings {
         public void validate(Boolean enabled, Map<Setting<?>, Object> settings) {
             if (enabled) {
                 var indexMode = (IndexMode) settings.get(MODE);
-                if (indexMode == IndexMode.TIME_SERIES) {
+                if (IndexMode.isTsdb(indexMode)) {
                     throw new IllegalArgumentException(
                         String.format(
                             Locale.ROOT,
                             "The setting [%s] cannot be used with [%s=%s].",
                             SLICE_ENABLED.getKey(),
                             MODE.getKey(),
-                            IndexMode.TIME_SERIES.getName()
+                            indexMode.getName()
                         )
                     );
                 }
@@ -767,7 +767,7 @@ public final class IndexSettings {
 
     public static final Setting<Boolean> SYNTHETIC_ID = Setting.boolSetting("index.mapping.synthetic_id", settings -> {
         IndexVersion indexVersion = SETTING_INDEX_VERSION_CREATED.get(settings);
-        boolean isTimeSeries = IndexMode.TIME_SERIES.equals(MODE.get(settings));
+        boolean isTimeSeries = MODE.get(settings).isTsdb();
         boolean isValidCodec = isValidCodecForSyntheticId(INDEX_CODEC_SETTING.get(settings), indexVersion);
         boolean onByDefault = indexVersion.onOrAfter(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID_DEFAULT_PROD);
         return isTimeSeries && isValidCodec && onByDefault ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
@@ -780,7 +780,7 @@ public final class IndexSettings {
             if (enabled) {
                 // Verify if index mode is TIME_SERIES
                 var indexMode = (IndexMode) settings.get(MODE);
-                if (indexMode != IndexMode.TIME_SERIES) {
+                if (indexMode.isTsdb() == false) {
                     throw new IllegalArgumentException(
                         String.format(
                             Locale.ROOT,
@@ -850,7 +850,7 @@ public final class IndexSettings {
     public static final Setting<Boolean> USE_DOC_VALUES_SKIPPER = Setting.boolSetting("index.mapping.use_doc_values_skipper", s -> {
         IndexVersion iv = SETTING_INDEX_VERSION_CREATED.get(s);
         var indexMode = MODE.get(s);
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (indexMode.isTsdb()) {
             return Boolean.toString(iv.onOrAfter(IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB));
         }
         if (indexMode == IndexMode.LOGSDB || indexMode.isStrictColumnar()) {
@@ -985,7 +985,7 @@ public final class IndexSettings {
                 return Boolean.FALSE.toString();
             }
             var indexMode = IndexSettings.MODE.get(settings);
-            return Boolean.toString(indexMode == IndexMode.TIME_SERIES);
+            return Boolean.toString(indexMode.isTsdb());
         },
         Property.IndexScope,
         Property.Final
@@ -1039,7 +1039,7 @@ public final class IndexSettings {
                 return Boolean.FALSE.toString();
             }
             IndexVersion indexVersion = SETTING_INDEX_VERSION_CREATED.get(settings);
-            boolean isTimeSeries = IndexMode.TIME_SERIES.equals(MODE.get(settings));
+            boolean isTimeSeries = MODE.get(settings).isTsdb();
             boolean onByDefault = indexVersion.onOrAfter(IndexVersions.TIME_SERIES_ES95_CODEC_DEFAULT_FEATURE_FLAG);
             return Boolean.toString(isTimeSeries && onByDefault);
         },
@@ -1145,7 +1145,7 @@ public final class IndexSettings {
         if (indexMode.isStrictColumnar()) {
             return true;
         }
-        return (indexMode == IndexMode.LOGSDB || indexMode == IndexMode.TIME_SERIES)
+        return (indexMode == IndexMode.LOGSDB || indexMode.isTsdb())
             && (indexVersionCreated.onOrAfter(IndexVersions.SEQ_NO_WITHOUT_POINTS) || indexVersionCreated.equals(IndexVersions.ZERO));
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -182,7 +182,7 @@ public final class IndexSortConfig {
                 indexMode = indexMode.toLowerCase(Locale.ROOT);
             }
 
-            if (IndexMode.TIME_SERIES.getName().equals(indexMode)) {
+            if (IndexMode.isTsdbName(indexMode)) {
                 return TIME_SERIES_SORT;
             } else if (IndexMode.LOGSDB.getName().equals(indexMode) || IndexMode.LOGSDB_COLUMNAR.getName().equals(indexMode)) {
                 var version = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings);
@@ -426,8 +426,8 @@ public final class IndexSortConfig {
                 );
             if (ft == null) {
                 String err = "unknown index sort field:[" + sortSpec.field + "]";
-                if (this.indexMode == IndexMode.TIME_SERIES) {
-                    err += " required by [" + IndexSettings.MODE.getKey() + "=time_series]";
+                if (this.indexMode.isTsdb()) {
+                    err += " required by [" + IndexSettings.MODE.getKey() + "=" + this.indexMode.getName() + "]";
                 }
                 throw new IllegalArgumentException(err);
             }

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -15,7 +15,6 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat;
@@ -197,7 +196,7 @@ public class PerFieldFormatSupplier {
             // but based on dimension fields and timestamp field, so during indexing
             // version/seq_no/term needs to be looked up and having a bloom filter
             // can speed this up significantly.
-            return indexSettings.getMode() == IndexMode.TIME_SERIES
+            return indexSettings.getMode().isTsdb()
                 && IdFieldMapper.NAME.equals(field)
                 && IndexSettings.BLOOM_FILTER_ID_FIELD_ENABLED_SETTING.get(indexSettings.getSettings());
         } else {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatSelector.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatSelector.java
@@ -12,7 +12,6 @@ package org.elasticsearch.index.codec.tsdb;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -42,7 +41,7 @@ public final class TSDBDocValuesFormatSelector {
         final IndexVersion indexCreatedVersion = indexSettings.getIndexVersionCreated();
         final boolean useLargeNumericBlockSize = indexSettings.isUseTimeSeriesDocValuesFormatLargeNumericBlockSize();
         final boolean useLargeBinaryBlockSize = indexSettings.isUseTimeSeriesDocValuesFormatLargeBinaryBlockSize();
-        final boolean writePartitions = indexSettings.getMode() == IndexMode.TIME_SERIES
+        final boolean writePartitions = indexSettings.getMode().isTsdb()
             && TsidBuilder.useSingleBytePrefixLayout(indexCreatedVersion)
             && indexCreatedVersion.onOrAfter(IndexVersions.WRITE_TSID_PREFIX_PARTITION);
 
@@ -63,7 +62,7 @@ public final class TSDBDocValuesFormatSelector {
     }
 
     static boolean useES95(final IndexSettings indexSettings) {
-        return indexSettings.getMode() == IndexMode.TIME_SERIES
+        return indexSettings.getMode().isTsdb()
             && indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.ES95_TSDB_CODEC_FEATURE_FLAG)
             && indexSettings.isTimeSeriesEs95CodecEnabled();
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -77,7 +77,6 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -1096,7 +1095,7 @@ public class InternalEngine extends Engine {
         if (versionValue == null) {
             assert incrementIndexVersionLookup(); // used for asserting in tests
             final DocIdAndVersion docIdAndVersion = performActionWithDirectoryReader(SearcherScope.INTERNAL, directoryReader -> {
-                if (engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES) {
+                if (engineConfig.getIndexSettings().getMode().isTsdb()) {
                     assert engineConfig.getLeafSorter() == DataStream.TIMESERIES_LEAF_READERS_SORTER;
                     return VersionsAndSeqNoResolver.timeSeriesLoadDocIdAndVersion(
                         directoryReader,
@@ -1707,7 +1706,7 @@ public class InternalEngine extends Engine {
         // Phase 2: single Lucene reader acquisition for all versionMap misses.
         // Collect misses into flat arrays and resolve them all in one sorted segment scan.
         if (anyNeedsLucene) {
-            final boolean isTimeSeries = engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES;
+            final boolean isTimeSeries = engineConfig.getIndexSettings().getMode().isTsdb();
             int luceneCount = 0;
             for (int i = 0; i < count; i++) {
                 if (needsLucene[i]) luceneCount++;
@@ -3337,7 +3336,7 @@ public class InternalEngine extends Engine {
             engineConfig.getIndexSettings().isRecoverySourceSyntheticEnabled()
                 ? SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME
                 : SourceFieldMapper.RECOVERY_SOURCE_NAME,
-            engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES,
+            engineConfig.getIndexSettings().getMode().isTsdb(),
             pruneSeqNo,
             () -> softDeletesPolicy.getRetentionQuery(seqNoIndexOptions),
             new SoftDeletesRetentionMergePolicy(

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -433,7 +433,7 @@ public final class DateFieldMapper extends FieldMapper {
                     return IndexType.skippers();
                 }
                 // Otherwise if field name @timestamp and it is part of index sorting and index mode is either logsdb and tsdb use skippers:
-                if ((indexSettings.getMode() == IndexMode.TIME_SERIES || indexSettings.getMode() == IndexMode.LOGSDB)
+                if ((indexSettings.getMode().isTsdb() || indexSettings.getMode() == IndexMode.LOGSDB)
                     && indexSettings.getIndexSortConfig() != null
                     && indexSettings.getIndexSortConfig().hasSortOnField(fullFieldName)
                     && DataStreamTimestampFieldMapper.DEFAULT_PATH.equals(fullFieldName)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -202,7 +202,7 @@ public class DocumentMapper {
         }
         List<String> routingPaths = settings.getIndexMetadata().getRoutingPaths();
         for (String path : routingPaths) {
-            if (settings.getMode() == IndexMode.TIME_SERIES) {
+            if (settings.getMode().isTsdb()) {
                 for (String match : mappingLookup.getMatchingFieldNames(path)) {
                     mappingLookup.getFieldType(match).validateMatchedRoutingPath(path);
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -1194,7 +1194,7 @@ public final class DocumentParser {
             IndexSettings indexSettings = mappingParserContext.getIndexSettings();
             BytesRef tsid = source.tsid();
             if (tsid == null
-                && indexSettings.getMode() == IndexMode.TIME_SERIES
+                && indexSettings.getMode().isTsdb()
                 && indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource.ForIndexDimensions forIndexDimensions) {
                 // the tsid is normally set on the coordinating node during shard routing and passed to the data node via the index request
                 // but when applying a translog operation, shard routing is not happening, and we have to create the tsid from source
@@ -1203,8 +1203,7 @@ public final class DocumentParser {
                 tsid = forIndexDimensions.buildTsid(sourceObject.xContentType(), sourceObject.originalBytes());
             }
             this.tsid = tsid;
-            assert this.tsid == null || indexSettings.getMode() == IndexMode.TIME_SERIES
-                : "tsid should only be set for time series indices";
+            assert this.tsid == null || indexSettings.getMode().isTsdb() : "tsid should only be set for time series indices";
             XContentParserDecorator parserDecorator = source.getMeteringParserDecorator();
             Mapping mapping = mappingLookup.getMapping();
             if (mapping.getRoot().subobjects() == ObjectMapper.Subobjects.ENABLED) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.SliceIndexing;
@@ -395,7 +394,7 @@ public abstract class DocumentParserContext {
     }
 
     public final String routing() {
-        return mappingParserContext.getIndexSettings().getMode() == IndexMode.TIME_SERIES ? null : sourceToParse.routing();
+        return mappingParserContext.getIndexSettings().getMode().isTsdb() ? null : sourceToParse.routing();
     }
 
     /**
@@ -1009,7 +1008,7 @@ public abstract class DocumentParserContext {
             // We just need to store the id as indexed field, so that IndexWriter#deleteDocuments(term) can then
             // delete it when the root document is deleted too.
             doc.add(standardIdField(idField.binaryValue(), Field.Store.NO));
-        } else if (indexSettings().getMode() == IndexMode.TIME_SERIES) {
+        } else if (indexSettings().getMode().isTsdb()) {
             // For time series indices, the _id is generated from the _tsid, which in turn is generated from the values of the configured
             // routing fields. At this point in document parsing, we can't guarantee that we've parsed all the routing fields yet, so the
             // parent document's _id is not yet available.

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1438,7 +1438,7 @@ public abstract class FieldMapper extends Mapper {
             if (indexSettings.useDocValuesSkipper() == false) {
                 return false;
             }
-            if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
+            if (indexSettings.getMode().isTsdb()) {
                 if (isDimension) {
                     return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.TIME_SERIES_DIMENSIONS_USE_SKIPPERS);
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -136,7 +136,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
                     return false;
                 }
 
-                return indexSettings.getMode() != IndexMode.TIME_SERIES || getMetric().getValue() != TimeSeriesParams.MetricType.POSITION;
+                return indexSettings.getMode().isTsdb() == false || getMetric().getValue() != TimeSeriesParams.MetricType.POSITION;
             });
             addScriptValidation(script, indexed, hasDocValues);
 
@@ -482,7 +482,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.POSITION
+            ValuesSourceType valuesSourceType = IndexMode.isTsdb(indexMode) && metricType == TimeSeriesParams.MetricType.POSITION
                 ? TimeSeriesValuesSourceType.POSITION
                 : CoreValuesSourceType.GEOPOINT;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -16,7 +16,6 @@ import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
@@ -36,7 +35,7 @@ public abstract class IdFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(mappingParserContext -> {
         var indexMode = mappingParserContext.getIndexSettings().getMode();
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (indexMode.isTsdb()) {
             return new ConstantBuilder(TsidExtractingIdFieldMapper.INSTANCE);
         } else {
             boolean useColumnarIdByDefault = mappingParserContext.getIndexSettings().isUseColumnarIdByDefault();
@@ -47,7 +46,7 @@ public abstract class IdFieldMapper extends MetadataFieldMapper {
         @Override
         public Builder parse(String name, Map<String, Object> node, MappingParserContext parserContext) throws MapperParsingException {
             var indexMode = parserContext.getIndexSettings().getMode();
-            if (indexMode == IndexMode.TIME_SERIES) {
+            if (indexMode.isTsdb()) {
                 throw new MapperParsingException(name + " is not configurable if index mode is time_series");
             }
             Builder builder = super.parse(name, node, parserContext);

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.routing.RoutingHashBuilder;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
@@ -51,7 +50,7 @@ public sealed interface IdLoader permits IdLoader.TsIdLoader, IdLoader.StoredIdL
      * @return returns an {@link IdLoader} instance to load the value of the _id field.
      */
     static IdLoader create(IndexSettings indexSettings, MappingLookup mappingLookup) {
-        if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
+        if (indexSettings.getMode().isTsdb()) {
             IndexRouting.ExtractFromSource.ForRoutingPath indexRouting = null;
             List<String> routingPaths = null;
             if (indexSettings.getIndexVersionCreated().before(IndexVersions.TIME_SERIES_ROUTING_HASH_IN_ID)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -722,7 +722,7 @@ public final class MappingLookup {
         if (shadowed == null) {
             return;
         }
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (indexMode.isTsdb()) {
             if (shadowed.isDimension()) {
                 throw new MapperParsingException("Field [" + name + "] attempted to shadow a time_series_dimension");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -202,7 +202,7 @@ public class NumberFieldMapper extends FieldMapper {
                 if (useTimeSeriesDocValuesSkippers(indexSettings, dimension.get())) {
                     return false;
                 }
-                if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
+                if (indexSettings.getMode().isTsdb()) {
                     var metricType = getMetric().getValue();
                     return metricType != MetricType.COUNTER && metricType != MetricType.GAUGE;
                 } else {
@@ -2343,7 +2343,7 @@ public class NumberFieldMapper extends FieldMapper {
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER
+            ValuesSourceType valuesSourceType = IndexMode.isTsdb(indexMode) && metricType == TimeSeriesParams.MetricType.COUNTER
                 ? TimeSeriesValuesSourceType.COUNTER
                 : type.numericType.getValuesSourceType();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesMetadataFieldBlockLoader.java
@@ -43,7 +43,7 @@ public final class TimeSeriesMetadataFieldBlockLoader implements BlockLoader {
     private static Set<String> lookupTimeSeriesMetadataFieldNames(MappedFieldType.BlockLoaderContext context, boolean loadMetrics) {
         assert context.blockLoaderFunctionConfig() instanceof BlockLoaderFunctionConfig.TimeSeriesMetadata;
 
-        if (context.indexSettings().getMode() != IndexMode.TIME_SERIES) {
+        if (context.indexSettings().getMode().isTsdb() == false) {
             throw new IllegalStateException("TimeSeriesMetadataFieldBlockLoader requires index mode: [ " + IndexMode.TIME_SERIES + " ]");
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
@@ -15,7 +15,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ByteUtils;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -120,7 +119,7 @@ public class TimeSeriesRoutingHashFieldMapper extends MetadataFieldMapper {
 
     @Override
     public void postParse(DocumentParserContext context) {
-        if (context.indexSettings().getMode() == IndexMode.TIME_SERIES
+        if (context.indexSettings().getMode().isTsdb()
             && context.indexSettings().getIndexVersionCreated().onOrAfter(IndexVersions.TIME_SERIES_ROUTING_HASH_IN_ID)) {
             String routingHash = context.sourceToParse().routing();
             if (routingHash == null) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1387,7 +1387,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         final var storedFieldLoader = StoredFieldLoader.create(true, sourceLoader.requiredStoredFields());
 
         // Some indices merge away the _id field
-        final var pruneIdField = engineConfig.getIndexSettings().getMode() == IndexMode.TIME_SERIES;
+        final var pruneIdField = engineConfig.getIndexSettings().getMode().isTsdb();
         final var idLoader = IdLoader.create(mapperService.getIndexSettings(), mapperService.mappingLookup());
 
         // Some integration tests merge away the _seq_no field, in which case this method sets all _seq_no to UNASSIGNED_SEQ_NO
@@ -2910,7 +2910,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                     combinedTemplateMappings,
                     indexVersion,
                     additionalSettings) -> {
-                    if (templateIndexMode == IndexMode.TIME_SERIES) {
+                    if (IndexMode.isTsdb(templateIndexMode)) {
                         // Don't randomly enable columnar id mode, if time series index mode has been enabled.
                         // Enabling columnar id isn't possible because tsdb always uses synthetic id.
                         return;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TimeSeriesUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TimeSeriesUsageTransportAction.java
@@ -86,7 +86,7 @@ public class TimeSeriesUsageTransportAction extends XPackUsageFeatureTransportAc
 
         for (DataStream ds : dataStreams.values()) {
             // We choose to not count time series backing indices that do not belong to a time series data stream.
-            if (ds.getIndexMode() != IndexMode.TIME_SERIES) {
+            if (IndexMode.isTsdb(ds.getIndexMode()) == false) {
                 continue;
             }
             tsDataStreamCount++;
@@ -96,7 +96,7 @@ public class TimeSeriesUsageTransportAction extends XPackUsageFeatureTransportAc
 
             for (Index backingIndex : ds.getIndices()) {
                 IndexMetadata indexMetadata = projectMetadata.index(backingIndex);
-                if (indexMetadata.getIndexMode() != IndexMode.TIME_SERIES) {
+                if (IndexMode.isTsdb(indexMetadata.getIndexMode()) == false) {
                     continue;
                 }
                 tsIndexCount++;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -220,7 +219,7 @@ public class DownsampleAction implements LifecycleAction {
             (index, project) -> {
                 IndexMetadata indexMetadata = project.index(index);
                 assert indexMetadata != null : "invalid cluster metadata. index [" + index.getName() + "] metadata not found";
-                if (IndexSettings.MODE.get(indexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
+                if (IndexSettings.MODE.get(indexMetadata.getSettings()).isTsdb() == false) {
                     return false;
                 }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
@@ -10,7 +10,6 @@ import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
 import org.elasticsearch.xpack.core.ilm.step.info.SingleMessageFieldInfo;
@@ -44,7 +43,7 @@ public class WaitUntilTimeSeriesEndTimePassesStep extends AsyncWaitStep {
     @Override
     public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
         String indexName = indexMetadata.getIndex().getName();
-        if (IndexSettings.MODE.get(indexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
+        if (IndexSettings.MODE.get(indexMetadata.getSettings()).isTsdb() == false) {
             // this index is not a time series index so no need to wait
             listener.onResponse(true, EmptyInfo.INSTANCE);
             return;

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -282,7 +282,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
         }
 
         // Assert source index is a time_series index
-        if (IndexSettings.MODE.get(sourceIndexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
+        if (IndexSettings.MODE.get(sourceIndexMetadata.getSettings()).isTsdb() == false) {
             recordInvalidConfigurationMetrics(startTime);
             listener.onFailure(
                 new ElasticsearchException(

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -886,7 +886,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
             config.startObject("settings");
             config.startObject("index");
             config.field("mode", mode);
-            if (mode == IndexMode.TIME_SERIES) {
+            if (mode.isTsdb()) {
                 config.field("routing_path", "f_keyword");
             }
             if (nodeId != null) {
@@ -945,7 +945,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
             case NULL -> config.field("type", "keyword");
             case KEYWORD -> {
                 config.field("type", type.esType());
-                if (indexMode == IndexMode.TIME_SERIES) {
+                if (indexMode.isTsdb()) {
                     config.field("time_series_dimension", true);
                 }
             }
@@ -1331,7 +1331,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
     ) {
         return switch (type) {
             case COUNTER_DOUBLE, COUNTER_LONG, COUNTER_INTEGER -> {
-                if (indexMode == IndexMode.TIME_SERIES) {
+                if (indexMode.isTsdb()) {
                     yield equalTo(type.esType());
                 }
                 yield equalTo(type.esType().replace("counter_", ""));
@@ -1518,7 +1518,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
 
         expected = expected.entry(
             "_id",
-            indexMode == IndexMode.TIME_SERIES ? matchesList().item("column_at_a_time:TsIdFieldReader")
+            indexMode.isTsdb() ? matchesList().item("column_at_a_time:TsIdFieldReader")
                 : indexMode.isStrictColumnar() ? matchesList().item("column_at_a_time:IdDocValuesReader")
                 : matchesList().item("column_at_a_time:null").item("row_stride:BlockStoredFieldsReader.Id")
         )

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2535,7 +2535,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return limit;
             }
 
-            boolean hasTimeSeries = child.collect(EsRelation.class, r -> r.indexMode() == IndexMode.TIME_SERIES).isEmpty() == false;
+            boolean hasTimeSeries = child.collect(EsRelation.class, r -> r.indexMode().isTsdb()).isEmpty() == false;
             if (hasTimeSeries == false) {
                 return limit;
             }
@@ -2544,7 +2544,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             return limit.transformDown(Limit.class, l -> {
                 if (l.child().collect(Limit.class).isEmpty()) {
                     var localChild = l.child();
-                    var localTimestampAttr = localChild.collect(EsRelation.class, r -> r.indexMode() == IndexMode.TIME_SERIES)
+                    var localTimestampAttr = localChild.collect(EsRelation.class, r -> r.indexMode().isTsdb())
                         .stream()
                         .findFirst()
                         .flatMap(r -> r.output().stream().filter(a -> MetadataAttribute.TIMESTAMP_FIELD.equals(a.name())).findFirst())
@@ -3455,7 +3455,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         public LogicalPlan apply(LogicalPlan plan, AnalyzerContext context) {
             Holder<IndexMode> indexMode = new Holder<>(IndexMode.STANDARD);
             plan.forEachUp(EsRelation.class, esRelation -> { indexMode.set(esRelation.indexMode()); });
-            isTimeSeries = indexMode.get() == IndexMode.TIME_SERIES;
+            isTimeSeries = indexMode.get().isTsdb();
             return plan.transformUp(LogicalPlan.class, p -> doRule(p, context));
         }
 
@@ -3711,7 +3711,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         private LogicalPlan doRule(Aggregate plan) {
             Holder<IndexMode> indexMode = new Holder<>(IndexMode.STANDARD);
             plan.forEachUp(EsRelation.class, esRelation -> { indexMode.set(esRelation.indexMode()); });
-            final boolean isTimeSeries = indexMode.get() == IndexMode.TIME_SERIES;
+            final boolean isTimeSeries = indexMode.get().isTsdb();
             return plan.transformExpressionsOnly(AggregateFunction.class, aggFunc -> {
                 if (ImplicitCastAggregateMetricDoubles.hasNativeSupport(aggFunc, isTimeSeries)) {
                     return aggFunc;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/PreAnalyzer.java
@@ -146,7 +146,7 @@ public class PreAnalyzer {
         Holder<Boolean> useAggregateMetricDoubleWhenNotSupported = new Holder<>(false);
         Holder<Boolean> useDenseVectorWhenNotSupported = new Holder<>(false);
         indexes.forEach((ip, mode) -> {
-            if (mode == IndexMode.TIME_SERIES) {
+            if (mode.isTsdb()) {
                 useAggregateMetricDoubleWhenNotSupported.set(true);
             }
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
@@ -359,7 +359,7 @@ public class ResolveUnmapped extends AnalyzerRules.ParameterizedAnalyzerRule<Log
         switch (source) {
             case EsRelation esRelation -> {
                 IndexMode mode = esRelation.indexMode();
-                if ((mode == IndexMode.STANDARD || mode == IndexMode.TIME_SERIES) == false) {
+                if ((mode == IndexMode.STANDARD || mode.isTsdb()) == false) {
                     throw new EsqlIllegalArgumentException(
                         "invalid source type [{}] for unmapped field resolution",
                         esRelation.indexMode()

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneUnusedIndexMode.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneUnusedIndexMode.java
@@ -24,7 +24,7 @@ public final class PruneUnusedIndexMode extends OptimizerRules.OptimizerRule<EsR
 
     @Override
     protected LogicalPlan rule(EsRelation r) {
-        if (r.indexMode() == IndexMode.TIME_SERIES) {
+        if (r.indexMode().isTsdb()) {
             if (Expressions.anyMatch(r.output(), a -> MetadataAttribute.TSID_FIELD.equals(((Attribute) a).name())) == false) {
                 return r.withIndexMode(IndexMode.STANDARD);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/IgnoreNullMetrics.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/IgnoreNullMetrics.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.logical.local;
 
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
@@ -62,10 +61,10 @@ public final class IgnoreNullMetrics extends OptimizerRules.OptimizerRule<TimeSe
      */
     private static boolean isMetricsQuery(LogicalPlan logicalPlan) {
         if (logicalPlan instanceof EsRelation r) {
-            return r.indexMode() == IndexMode.TIME_SERIES;
+            return r.indexMode().isTsdb();
         }
         if (logicalPlan instanceof UnresolvedRelation r) {
-            return r.indexMode() == IndexMode.TIME_SERIES;
+            return r.indexMode().isTsdb();
         }
         return false;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
@@ -208,7 +208,7 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
          * not just {@code TS} command queries.
          */
         private boolean hasTimeSeriesShards() {
-            return context.searchStats().targetShards().values().stream().anyMatch(imd -> imd.getIndexMode() == IndexMode.TIME_SERIES);
+            return context.searchStats().targetShards().values().stream().anyMatch(imd -> IndexMode.isTsdb(imd.getIndexMode()));
         }
 
         private Expression replaceFieldsForFieldTransformations(Expression e, BlockLoaderExpression.PushedBlockLoaderExpression fuse) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
@@ -344,8 +344,8 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
                 // prefixes. When prefix partitioning is not available (old codec), we fall back to replacing round_to
                 // with QueryAndTags.
                 if (((FieldAttribute) roundTo.field()).name().equals(MetadataAttribute.TIMESTAMP_FIELD)
-                    && ctx.searchStats().targetShards().values().stream().allMatch(imd -> imd.getIndexMode() == IndexMode.TIME_SERIES)) {
-                    if (queryExec.indexMode() != IndexMode.TIME_SERIES) {
+                    && ctx.searchStats().targetShards().values().stream().allMatch(imd -> IndexMode.isTsdb(imd.getIndexMode()))) {
+                    if (queryExec.indexMode().isTsdb() == false) {
                         return evalExec;
                     }
                     // prefer partitioning by tsid prefixes
@@ -569,7 +569,7 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
      */
     static int adjustedRoundingPointsThreshold(SearchStats stats, int threshold, QueryBuilder query, IndexMode indexMode) {
         int clauses = estimateQueryClauses(stats, query) + 1;
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (indexMode.isTsdb()) {
             // No doc partitioning for time_series sources; increase the threshold to trade overhead for parallelism.
             threshold *= 2;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
@@ -53,7 +52,7 @@ public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRul
         final List<Attribute> attributes = new ArrayList<>();
         attributes.add(getDocAttribute(plan));
 
-        if (plan.indexMode() == IndexMode.TIME_SERIES) {
+        if (plan.indexMode().isTsdb()) {
             for (EsField field : EsQueryExec.TIME_SERIES_SOURCE_FIELDS) {
                 attributes.add(new FieldAttribute(plan.source(), null, null, field.getName(), field));
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -729,7 +729,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         return input -> {
             boolean hasAggregate = input.anyMatch(p -> p instanceof Aggregate);
             boolean hasPromqlCommand = input.anyMatch(p -> p instanceof PromqlCommand);
-            boolean hasTimeSeries = input.anyMatch(p -> p instanceof UnresolvedRelation ur && ur.indexMode() == IndexMode.TIME_SERIES);
+            boolean hasTimeSeries = input.anyMatch(p -> p instanceof UnresolvedRelation ur && ur.indexMode().isTsdb());
             boolean hasInfoCommand = input.anyMatch(p -> p instanceof MetricsInfo || p instanceof TsInfo);
 
             if (hasAggregate == false && hasPromqlCommand == false && hasTimeSeries && hasInfoCommand == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -10,7 +10,6 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -280,7 +279,7 @@ public class Aggregate extends UnaryPlan
     protected void checkTimeSeriesAggregates(Failures failures) {
         Holder<Boolean> isTimeSeriesIndexMode = new Holder<>(false);
         child().forEachDown(p -> {
-            if (p instanceof EsRelation er && er.indexMode() == IndexMode.TIME_SERIES) {
+            if (p instanceof EsRelation er && er.indexMode().isTsdb()) {
                 isTimeSeriesIndexMode.set(true);
             }
         });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/InlineStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/InlineStats.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -186,7 +185,7 @@ public class InlineStats extends UnaryPlan
                         } else {
                             foundPreviousStats.set(true);
                         }
-                    } else if (lp instanceof EsRelation er && er.indexMode() == IndexMode.TIME_SERIES) {
+                    } else if (lp instanceof EsRelation er && er.indexMode().isTsdb()) {
                         isTimeSeries.set(true);
                     }
                 });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MetricsInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MetricsInfo.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -138,7 +137,7 @@ public class MetricsInfo extends UnaryPlan implements TelemetryAware, PostAnalys
         if (failures.hasFailures()) {
             return;
         }
-        boolean hasTsSource = child().anyMatch(p -> p instanceof EsRelation er && er.indexMode() == IndexMode.TIME_SERIES);
+        boolean hasTsSource = child().anyMatch(p -> p instanceof EsRelation er && er.indexMode().isTsdb());
         if (hasTsSource == false) {
             failures.add(fail(this, "METRICS_INFO can only be used with TS source command"));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TsInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TsInfo.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
@@ -138,7 +137,7 @@ public class TsInfo extends UnaryPlan implements TelemetryAware, PostAnalysisVer
         if (failures.hasFailures()) {
             return;
         }
-        boolean hasTsSource = child().anyMatch(p -> p instanceof EsRelation er && er.indexMode() == IndexMode.TIME_SERIES);
+        boolean hasTsSource = child().anyMatch(p -> p instanceof EsRelation er && er.indexMode().isTsdb());
         if (hasTsSource == false) {
             failures.add(fail(this, "TS_INFO can only be used with TS source command"));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
@@ -204,6 +204,6 @@ public final class UnresolvedRelation extends LeafPlan implements Unresolvable, 
      *         which changes a number of behaviors in the planner.
      */
     public boolean isTimeSeriesMode() {
-        return indexMode == IndexMode.TIME_SERIES;
+        return indexMode.isTsdb();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -253,11 +253,11 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize, DataSourc
     }
 
     public boolean canPushSorts() {
-        return indexMode != IndexMode.TIME_SERIES;
+        return indexMode.isTsdb() == false;
     }
 
     public EsQueryExec withSorts(List<Sort> sorts) {
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (indexMode.isTsdb()) {
             assert false : "time-series index mode doesn't support sorts";
             throw new UnsupportedOperationException("time-series index mode doesn't support sorts");
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -41,7 +41,6 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -486,7 +485,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
                 scoring,
                 directoryBytesRead
             );
-        } else if (esQueryExec.indexMode() == IndexMode.TIME_SERIES) {
+        } else if (esQueryExec.indexMode().isTsdb()) {
             luceneFactory = new TimeSeriesSourceOperator.Factory(
                 shardContexts,
                 querySupplier(esQueryExec.queryBuilderAndTags()),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1773,7 +1773,7 @@ public class LocalExecutionPlanner {
     private MetricsInfoOperator.MetricFieldLookup createMetricFieldLookup(IndexedByShardId<? extends ShardContext> shardContexts) {
         Map<String, MappingLookup> mappingsByIndex = new HashMap<>();
         for (ShardContext shard : shardContexts.iterable()) {
-            if (shard.indexSettings().getMode() == IndexMode.TIME_SERIES) {
+            if (shard.indexSettings().getMode().isTsdb()) {
                 mappingsByIndex.putIfAbsent(shard.indexSettings().getIndex().getName(), shard.mappingLookup());
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -1867,7 +1867,7 @@ public class EsqlSession {
                 indexPattern.indexPattern(),
                 result.fieldNames,
                 createQueryFilter(indexMode, requestFilter),
-                indexMode == IndexMode.TIME_SERIES,
+                indexMode.isTsdb(),
                 // TODO: In case of subqueries, the different main index resolutions don't know about each other's minimum version.
                 // This is bad because `FROM (FROM remote1:*) (FROM remote2:*)` can have different minimum versions
                 // while resolving each subquery's main index pattern. We'll determine the correct overall minimum transport version
@@ -1963,7 +1963,7 @@ public class EsqlSession {
             projectRouting,
             result.fieldNames,
             createQueryFilter(indexMode, requestFilter),
-            indexMode == IndexMode.TIME_SERIES,
+            indexMode.isTsdb(),
             // TODO: Same problem with subqueries as preAnalyzeMainIndices, see above.
             result.minimumTransportVersion(),
             preAnalysis.useAggregateMetricDoubleWhenNotSupported(),
@@ -2009,7 +2009,7 @@ public class EsqlSession {
 
     // visible for testing
     static boolean shouldRetryConcreteTimeSeriesResolution(IndexMode indexMode, IndexResolution resolution, IndexPattern indexPattern) {
-        return indexMode == IndexMode.TIME_SERIES
+        return indexMode.isTsdb()
             && resolution.isValid()
             && resolution.resolvedIndices().isEmpty()
             && EsqlCCSUtils.concreteIndexRequested(indexPattern.indexPattern());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/telemetry/FeatureMetric.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/telemetry/FeatureMetric.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.telemetry;
 
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
@@ -99,8 +98,8 @@ public enum FeatureMetric {
     MV_EXPAND(MvExpand.class::isInstance),
     SHOW(ShowInfo.class::isInstance),
     ROW(Row.class::isInstance),
-    FROM(x -> x instanceof EsRelation relation && relation.indexMode() != IndexMode.TIME_SERIES),
-    TS(x -> x instanceof EsRelation relation && relation.indexMode() == IndexMode.TIME_SERIES),
+    FROM(x -> x instanceof EsRelation relation && relation.indexMode().isTsdb() == false),
+    TS(x -> x instanceof EsRelation relation && relation.indexMode().isTsdb()),
     EXTERNAL(plan -> plan instanceof org.elasticsearch.xpack.esql.plan.logical.ExternalRelation),
     DROP(Drop.class::isInstance),
     KEEP(Keep.class::isInstance),

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -269,7 +269,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
             if (IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.exists(tmpIndexMetadata.getSettings())
                 || indexMode == IndexMode.LOGSDB
                 || indexMode == IndexMode.LOGSDB_COLUMNAR
-                || indexMode == IndexMode.TIME_SERIES) {
+                || IndexMode.isTsdb(indexMode)) {
                 // In case when index mode is tsdb or logsdb and only _source.mode mapping attribute is specified, then the default
                 // could be wrong. However, it doesn't really matter, because if the _source.mode mapping attribute is set to stored,
                 // then configuring the index.mapping.source.mode setting to stored has no effect. Additionally _source.mode can't be set
@@ -385,8 +385,8 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
             .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
             .put(IndexSettings.INDEX_FAST_REFRESH_SETTING.getKey(), false);  // Avoid warnings for non-system indexes.
 
-        if (templateIndexMode == IndexMode.TIME_SERIES) {
-            finalResolvedSettings.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES);
+        if (IndexMode.isTsdb(templateIndexMode)) {
+            finalResolvedSettings.put(IndexSettings.MODE.getKey(), templateIndexMode);
             // Avoid failing because index.routing_path is missing (in case fields are marked as dimension)
             finalResolvedSettings.putList(INDEX_ROUTING_PATH.getKey(), List.of("path"));
         }
@@ -413,7 +413,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
      * The GA-ed use cases in which synthetic source usage is allowed with gold or platinum license.
      */
     private boolean isLegacyLicensedUsageOfSyntheticSourceAllowed(IndexMode templateIndexMode, String indexName, String dataStreamName) {
-        if (templateIndexMode == IndexMode.TIME_SERIES) {
+        if (IndexMode.isTsdb(templateIndexMode)) {
             return true;
         }
 

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -146,7 +146,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 if (useTimeSeriesDocValuesSkippers(indexSettings, dimension.get())) {
                     return false;
                 }
-                if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
+                if (indexSettings.getMode().isTsdb()) {
                     var metricType = getMetric().getValue();
                     return metricType != MetricType.COUNTER && metricType != MetricType.GAUGE;
                 } else {
@@ -400,7 +400,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            if (indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER) {
+            if (IndexMode.isTsdb(indexMode) && metricType == TimeSeriesParams.MetricType.COUNTER) {
                 // Counters are not supported by ESQL so we load them in null
                 return ConstantNull.INSTANCE;
             }
@@ -509,7 +509,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER
+            ValuesSourceType valuesSourceType = IndexMode.isTsdb(indexMode) && metricType == TimeSeriesParams.MetricType.COUNTER
                 ? TimeSeriesValuesSourceType.COUNTER
                 : IndexNumericFieldData.NumericType.LONG.getValuesSourceType();
 


### PR DESCRIPTION
## Summary
Pure, no-op refactor: adds `IndexMode#isTsdb()` and the null-safe static
`isTsdb(IndexMode)` / `isTsdbName(String)` helpers, and replaces every
`== IndexMode.TIME_SERIES` comparison (and equivalent `.equals()`/switch
checks) across the codebase with a call to one of them.

`isTsdb()` currently only matches `TIME_SERIES`, so there is no behavior
change here — just centralizing the check.

This is prep work to shrink the diff of a follow-up PR that adds a new
`IndexMode.TSDB` constant as a preferred alternative spelling of
`time_series`. Once every call site already goes through `isTsdb()`,
that PR only needs to add the enum constant itself and flip `isTsdb()`'s
body to match both `TIME_SERIES` and `TSDB`.

## Test plan
- [x] Compiles cleanly across all touched modules
- [x] Existing unit tests for touched files pass unchanged (no test files were modified, since behavior is unchanged)

Related to https://github.com/elastic/elasticsearch/issues/152902