### PR TITLE
ES|QL: implement watchdog timeout for GROK (#152851) (#152944)

### DIFF
--- a/.cursor/rules/shell-commands.mdc
+++ b/.cursor/rules/shell-commands.mdc
@@ -1,1 +1,0 @@
-/Users/luigidellaquila/.local/share/estc/cursor/rules/shell-commands.mdc

--- a/.cursor/rules/shell-commands.mdc
+++ b/.cursor/rules/shell-commands.mdc
@@ -1,0 +1,1 @@
+/Users/luigidellaquila/.local/share/estc/cursor/rules/shell-commands.mdc

--- a/docs/changelog/152851.yaml
+++ b/docs/changelog/152851.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152851
+summary: Implement watchdog timeout for GROK
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.junit.After;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Verifies that {@link EsqlPlugin#GROK_WATCHDOG_MAX_EXECUTION_TIME} is honored at execution time.
+ * The setting is {@code NodeScope} (every node reads its own value when it builds the GROK matcher
+ * used against real data, see {@code LocalExecutionPlanner#planGrok} — no need to carry it in the
+ * ES|QL wire format) and {@code Dynamic} (it can be changed via the cluster settings API without a
+ * node restart, since {@code ComputeService} re-resolves it from the live {@code ClusterSettings}
+ * for every query).
+ */
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class GrokWatchdogIT extends AbstractEsqlIntegTestCase {
+
+    @After
+    public void resetWatchdogSetting() {
+        updateClusterSettings(Settings.builder().putNull(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey()));
+    }
+
+    public void testCatastrophicBacktrackingPatternIsInterruptedAfterLiveSettingUpdate() {
+        prepareIndex("test").setId("1").setSource("message", "a".repeat(30) + "X").get();
+        refresh("test");
+
+        // No restart: the setting is dynamic, so this update must take effect on the very next query.
+        updateClusterSettings(Settings.builder().put(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey(), TimeValue.timeValueMillis(1)));
+
+        Exception e = expectThrows(Exception.class, () -> run("FROM test | GROK message \"(?<a>a+)+b\" | KEEP a"));
+        assertThat(ExceptionsHelper.stackTrace(e), containsString("interrupted"));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.grok.GrokBuiltinPatterns;
 import org.elasticsearch.grok.GrokCaptureConfig;
 import org.elasticsearch.grok.GrokCaptureType;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
@@ -72,9 +73,19 @@ public class Grok extends RegexExtract implements TelemetryAware, SortPreserving
     }
 
     public static Parser pattern(Source source, String pattern) {
+        return pattern(source, pattern, MatcherWatchdog.noop());
+    }
+
+    /**
+     * Builds a parser using the given watchdog to interrupt expensive matches. Used by the local execution
+     * planner to bind the node-local {@code esql.grok.watchdog.max_execution_time} setting to the matcher
+     * that will actually run against real data; parsing/deserialization use the no-op watchdog above since
+     * they never execute the pattern against untrusted input.
+     */
+    public static Parser pattern(Source source, String pattern, MatcherWatchdog matcherWatchdog) {
         try {
             var builtinPatterns = GrokBuiltinPatterns.get(true);
-            org.elasticsearch.grok.Grok grok = new org.elasticsearch.grok.Grok(builtinPatterns, pattern, logger::warn);
+            org.elasticsearch.grok.Grok grok = new org.elasticsearch.grok.Grok(builtinPatterns, pattern, matcherWatchdog, logger::warn);
             return new Parser(pattern, grok);
         } catch (IllegalArgumentException e) {
             throw new ParsingException(source, "Invalid pattern [{}] for grok: {}", pattern, e.getMessage());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -62,6 +62,7 @@ import org.elasticsearch.compute.operator.topn.TopNOperator.TopNOperatorFactory;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.logging.LogManager;
@@ -99,6 +100,7 @@ import org.elasticsearch.xpack.esql.inference.XContentRowEncoder;
 import org.elasticsearch.xpack.esql.inference.completion.CompletionOperator;
 import org.elasticsearch.xpack.esql.inference.rerank.RerankOperator;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
@@ -171,6 +173,7 @@ public class LocalExecutionPlanner {
     private final LookupFromIndexService lookupFromIndexService;
     private final InferenceService inferenceService;
     private final PhysicalOperationProviders physicalOperationProviders;
+    private final MatcherWatchdog grokMatcherWatchdog;
 
     public LocalExecutionPlanner(
         String sessionId,
@@ -185,7 +188,8 @@ public class LocalExecutionPlanner {
         EnrichLookupService enrichLookupService,
         LookupFromIndexService lookupFromIndexService,
         InferenceService inferenceService,
-        PhysicalOperationProviders physicalOperationProviders
+        PhysicalOperationProviders physicalOperationProviders,
+        MatcherWatchdog grokMatcherWatchdog
     ) {
 
         this.sessionId = sessionId;
@@ -201,6 +205,10 @@ public class LocalExecutionPlanner {
         this.lookupFromIndexService = lookupFromIndexService;
         this.inferenceService = inferenceService;
         this.physicalOperationProviders = physicalOperationProviders;
+        // Resolved once by the caller from the live ClusterSettings (the setting is dynamic), then shared
+        // by every GROK matcher this planner builds — MatcherWatchdog.Default is a stateless, immutable
+        // wrapper around a single timeout value.
+        this.grokMatcherWatchdog = grokMatcherWatchdog;
     }
 
     /**
@@ -592,11 +600,14 @@ public class LocalExecutionPlanner {
         }
 
         Layout layout = layoutBuilder.build();
+        // Rebind the matcher to this node's own grok.watchdog.max_execution_time setting instead of the
+        // no-op watchdog it was parsed/deserialized with, since the pattern is about to run against real data.
+        org.elasticsearch.grok.Grok watchdogGrok = Grok.pattern(grok.source(), grok.pattern().pattern(), grokMatcherWatchdog).grok();
         source = source.with(
             new ColumnExtractOperator.Factory(
                 types,
                 EvalMapper.toEvaluator(context.foldCtx(), grok.inputExpression(), layout),
-                () -> new GrokEvaluatorExtracter(grok.pattern().grok(), grok.pattern().pattern(), fieldToPos, fieldToType)
+                () -> new GrokEvaluatorExtracter(watchdogGrok, grok.pattern().pattern(), fieldToPos, fieldToType)
             ),
             layout
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -33,7 +33,9 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.SearchService;
@@ -78,11 +80,13 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.action.EsqlExecutionInfo.IncludeExecutionMetadata.ALWAYS;
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME;
 
 /**
  * Once query is parsed and validated it is scheduled for execution by {@code org.elasticsearch.xpack.esql.plugin.ComputeService#execute}
@@ -150,6 +154,9 @@ public class ComputeService {
     private final ExchangeService exchangeService;
     private final PlannerSettings plannerSettings;
     private final Executor searchExecutor;
+    // Single shared instance, refreshed in place whenever the dynamic setting changes, rather than
+    // re-resolving it from ClusterSettings for every query.
+    private final AtomicReference<MatcherWatchdog> grokMatcherWatchdog = new AtomicReference<>();
 
     @SuppressWarnings("this-escape")
     public ComputeService(
@@ -172,6 +179,22 @@ public class ComputeService {
         this.inferenceService = transportActionServices.inferenceService();
         this.clusterService = transportActionServices.clusterService();
         this.projectResolver = transportActionServices.projectResolver();
+        // 9.3 backport note: unlike main/9.4, this branch doesn't have the joni Matcher#setTimeout-based
+        // MatcherWatchdog (elastic/elasticsearch#139405), only the older thread-polling implementation.
+        // We reuse the configured max execution time as the poll interval too, so a stuck matcher is
+        // interrupted roughly once per max-execution-time window rather than needing a second setting.
+        this.clusterService.getClusterSettings()
+            .initializeAndWatch(
+                GROK_WATCHDOG_MAX_EXECUTION_TIME,
+                timeValue -> grokMatcherWatchdog.set(
+                    MatcherWatchdog.newInstance(
+                        timeValue.millis(),
+                        timeValue.millis(),
+                        threadPool.relativeTimeInMillisSupplier(),
+                        (delay, command) -> threadPool.schedule(command, TimeValue.timeValueMillis(delay), threadPool.generic())
+                    )
+                )
+            );
         this.dataNodeComputeHandler = new DataNodeComputeHandler(
             this,
             clusterService,
@@ -677,7 +700,8 @@ public class ComputeService {
                 enrichLookupService,
                 lookupFromIndexService,
                 inferenceService,
-                physicalOperationProviders
+                physicalOperationProviders,
+                grokMatcherWatchdog.get()
             );
 
             LOGGER.debug("Received physical plan for {}:\n{}", context.description(), plan);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -163,6 +163,22 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
     );
 
     /**
+     * Maximum time (in milliseconds) that a GROK matcher is allowed to run before being interrupted.
+     * Limits how long a GROK matcher can run to protect against expensive regex patterns. Read directly
+     * from each node's own {@link org.elasticsearch.common.settings.ClusterSettings} wherever the matcher
+     * is built for execution (see {@code LocalExecutionPlanner#planGrok}) rather than being carried in the
+     * ES|QL {@code Configuration} wire format, since every node can resolve this node-scoped setting on
+     * its own — including live updates, since it is also dynamic.
+     */
+    public static final Setting<TimeValue> GROK_WATCHDOG_MAX_EXECUTION_TIME = Setting.timeSetting(
+        "esql.grok.watchdog.max_execution_time",
+        TimeValue.timeValueMillis(1000),
+        TimeValue.timeValueMillis(0),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Tuning parameter for deciding when to use the "merge" stored field loader.
      * Think of it as "how similar to a sequential block of documents do I have to
      * be before I'll use the merge reader?" So a value of {@code 1} means I have to
@@ -260,7 +276,8 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
                 PlannerSettings.REDUCTION_LATE_MATERIALIZATION,
                 STORED_FIELDS_SEQUENTIAL_PROPORTION,
                 EsqlFlags.ESQL_STRING_LIKE_ON_INDEX,
-                EsqlFlags.ESQL_ROUNDTO_PUSHDOWN_THRESHOLD
+                EsqlFlags.ESQL_ROUNDTO_PUSHDOWN_THRESHOLD,
+                GROK_WATCHDOG_MAX_EXECUTION_TIME
             )
         );
         if (ESQL_VIEWS_FEATURE_FLAG.isEnabled()) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.compute.querydsl.query.SingleValueMatchQuery;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -837,7 +838,8 @@ public class CsvTests extends ESTestCase {
             mock(EnrichLookupService.class),
             mock(LookupFromIndexService.class),
             mock(InferenceService.class),
-            physicalOperationProviders
+            physicalOperationProviders,
+            MatcherWatchdog.noop()
         );
 
         List<Page> collectedPages = Collections.synchronizedList(new ArrayList<>());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.ShapeType;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -8549,7 +8550,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             null,
             null,
             null,
-            new EsPhysicalOperationProviders(FoldContext.small(), EmptyIndexedByShardId.instance(), null, TEST_PLANNER_SETTINGS)
+            new EsPhysicalOperationProviders(FoldContext.small(), EmptyIndexedByShardId.instance(), null, TEST_PLANNER_SETTINGS),
+            MatcherWatchdog.noop()
         );
 
         return planner.plan("test", FoldContext.small(), plannerSettings, plan, EmptyIndexedByShardId.instance());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.grok.MatcherWatchdog;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class GrokTests extends ESTestCase {
+
+    public void testWatchdogInterruptsBacktracking() {
+        // This branch predates elastic/elasticsearch#139405, so MatcherWatchdog only has the older
+        // thread-polling implementation (it interrupts a stuck matcher the next time the poll thread
+        // wakes up, rather than via an exact joni-level timeout). Use a pattern whose catastrophic
+        // backtracking (2^30 steps) vastly outlasts the short poll interval below, so the interrupt is
+        // guaranteed to fire long before the match could ever complete on its own.
+        AtomicBoolean keepPolling = new AtomicBoolean(true);
+        MatcherWatchdog watchdog = MatcherWatchdog.newInstance(5, 5, System::currentTimeMillis, (delay, command) -> {
+            Thread thread = new Thread(() -> {
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+                if (keepPolling.get()) {
+                    command.run();
+                }
+            });
+            thread.start();
+        });
+        try {
+            Grok.Parser parser = Grok.pattern(Source.EMPTY, "(?<a>a+)+b", watchdog);
+            // match(String) treats a timeout as "no match" (see its javadoc); captures(String) is the
+            // path that actually surfaces a timeout as an exception, same as production GROK execution.
+            RuntimeException ex = expectThrows(RuntimeException.class, () -> parser.grok().captures("a".repeat(30) + "X"));
+            assertThat(ex.getMessage(), containsString("interrupted"));
+        } finally {
+            keepPolling.set(false);
+        }
+    }
+
+    public void testNoopWatchdogDoesNotInterruptSimplePattern() {
+        Grok.Parser parser = Grok.pattern(Source.EMPTY, "%{IP:client_ip}", MatcherWatchdog.noop());
+        assertNotNull(parser.grok().captures("192.168.1.1"));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -351,7 +352,8 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             null,
             null,
             null,
-            esPhysicalOperationProviders(shardContexts)
+            esPhysicalOperationProviders(shardContexts),
+            MatcherWatchdog.noop()
         );
     }
 


### PR DESCRIPTION
Manual backport to 9.3 of #152851