### PR TITLE
[9.4] Bump CCS YAML suite timeouts on encryption-at-rest (#147719)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -266,9 +266,6 @@ tests:
 - class: org.elasticsearch.index.rankeval.RankEvalRequestIT
   method: testIndicesOptions
   issue: https://github.com/elastic/elasticsearch/issues/152936
-- class: org.elasticsearch.test.rest.yaml.RcsCcsSearchYamlTestSuiteIT
-  method: test {p0=search/110_field_collapsing/field collapsing on a field alias}
-  issue: https://github.com/elastic/elasticsearch/issues/152937
 
 # Examples:
 #

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsCommonYamlTestSuiteIT.java
@@ -72,7 +72,7 @@ import static java.util.Collections.unmodifiableList;
  * by subclassing this class then add an entry to {@link TestSuiteApiCheck} mapping the API
  * name(s) to the new class.
  */
-@TimeoutSuite(millis = 20 * TimeUnits.MINUTE) // to account for slow as hell VMs
+@TimeoutSuite(millis = 25 * TimeUnits.MINUTE) // to account for slow as hell VMs
 public class CcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final Logger logger = LogManager.getLogger(CcsCommonYamlTestSuiteIT.class);

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -68,7 +68,7 @@ import static org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT.rewrite;
  * by subclassing this class then add an entry to {@link TestSuiteApiCheck} mapping the API
  * name(s) to the new class.
  */
-@TimeoutSuite(millis = 25 * TimeUnits.MINUTE) // to account for slow as hell VMs
+@TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // to account for slow as hell VMs
 public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final Logger logger = LogManager.getLogger(RcsCcsCommonYamlTestSuiteIT.class);


### PR DESCRIPTION
The two CCS "common" YAML suites run the whole search/msearch 
corpus across two secured CCS clusters under a single 
`@TimeoutSuite`, and tip over under the encryption-at-rest step on slow VMs. 
This is the failure mode tracked by #133409.                                                                    
                                                                              
9.4 still runs the pre-bump budgets (`CcsCommon` 20m, `RcsCcsCommon` 25m) 
while main is at 25m/30m, because #147719 was labeled v9.5.0 and 
never got backported.                                                                 
                                                                              
This restores parity:                                                       
  - `CcsCommonYamlTestSuiteIT`: 20 -> 25 min                                   
  - `RcsCcsCommonYamlTestSuiteIT`: 25 -> 30 min (inherited by                  
  `RcsCcsSearchYamlTestSuiteIT`)
                                               
Also unmutes the field-collapsing test from #152937
                                                                        
Closes #152937                                                              
Relates to #133409