### PR TITLE
[Inference API] Fix compilation errors after fallback region removal

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyActionTests.java
@@ -103,7 +103,7 @@ public class TransportPutRegionPolicyActionTests extends ESTestCase {
         );
 
         var listener = new TestPlainActionFuture<RegionPolicyResponse>();
-        action.doExecute(mock(Task.class), new PutRegionPolicyAction.Request(new RegionPolicy(List.of("eu"), null, null)), listener);
+        action.doExecute(mock(Task.class), new PutRegionPolicyAction.Request(new RegionPolicy(List.of("eu"), null)), listener);
 
         listener.actionGet(TEST_REQUEST_TIMEOUT);
         assertThat(invalidateCount.get(), is(1));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ClearInferencePreferencesCacheActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ClearInferencePreferencesCacheActionTests.java
@@ -51,7 +51,7 @@ public class ClearInferencePreferencesCacheActionTests extends ESTestCase {
     }
 
     public void testReceiveMessage_InvalidatesLocalCacheEntry() {
-        var regionPolicy = new RegionPolicy(List.of("eu"), null, null);
+        var regionPolicy = new RegionPolicy(List.of("eu"), null);
         var callCount = new AtomicInteger();
         var clusterService = mockClusterService();
         var cache = new InferencePreferencesCache(
@@ -86,7 +86,7 @@ public class ClearInferencePreferencesCacheActionTests extends ESTestCase {
     }
 
     public void testGettingTwiceWithoutClearingDoesNotRefetch() {
-        var regionPolicy = new RegionPolicy(List.of("eu"), null, null);
+        var regionPolicy = new RegionPolicy(List.of("eu"), null);
         var callCount = new AtomicInteger();
         var cache = new InferencePreferencesCache(
             TestProjectResolvers.DEFAULT_PROJECT_ONLY,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/InferencePreferencesCacheTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/InferencePreferencesCacheTests.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 public class InferencePreferencesCacheTests extends ESTestCase {
 
     public void testCacheMiss_FetchesAndCaches() {
-        var regionPolicy = new RegionPolicy(null, List.of(new CspRegion("aws", "eu-west-1")), null);
+        var regionPolicy = new RegionPolicy(null, List.of(new CspRegion("aws", "eu-west-1")));
         var fetchCount = new AtomicInteger();
         var cache = createCache(listener -> {
             fetchCount.incrementAndGet();
@@ -99,7 +99,7 @@ public class InferencePreferencesCacheTests extends ESTestCase {
     }
 
     public void testInvalidateLocal_ForcesRefetch() {
-        var regionPolicy = new RegionPolicy(List.of("eu"), null, null);
+        var regionPolicy = new RegionPolicy(List.of("eu"), null);
         var fetchCount = new AtomicInteger();
         var cache = createCache(listener -> {
             fetchCount.incrementAndGet();
@@ -147,7 +147,7 @@ public class InferencePreferencesCacheTests extends ESTestCase {
     }
 
     public void testCacheDisabled_AlwaysFetchesAndNeverCaches() {
-        var regionPolicy = new RegionPolicy(List.of("eu"), null, null);
+        var regionPolicy = new RegionPolicy(List.of("eu"), null);
         var fetchCount = new AtomicInteger();
         var cache = new InferencePreferencesCache(
             TestProjectResolvers.DEFAULT_PROJECT_ONLY,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/InferencePreferencesTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/InferencePreferencesTests.java
@@ -22,7 +22,7 @@ public class InferencePreferencesTests extends ESTestCase {
     }
 
     public void testRegionPolicy_IsRetained() {
-        var regionPolicy = new RegionPolicy(List.of("eu"), null, null);
+        var regionPolicy = new RegionPolicy(List.of("eu"), null);
         var preferences = new InferencePreferences(regionPolicy);
         assertThat(preferences.regionPolicy(), is(regionPolicy));
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
@@ -232,7 +232,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             var model = ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(getUrl(webServer), "my-model-id");
-            var regionPolicy = new RegionPolicy(List.of("eu"), null, null);
+            var regionPolicy = new RegionPolicy(List.of("eu"), null);
             var cache = new InferencePreferencesCache(
                 TestProjectResolvers.DEFAULT_PROJECT_ONLY,
                 mock(Client.class),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
@@ -88,7 +88,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
     }
 
     public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithAllowedRegionsHeader() {
-        var regionPolicy = new RegionPolicy(null, List.of(new CspRegion("aws", "eu-west-1"), new CspRegion("aws", "us-east-1")), null);
+        var regionPolicy = new RegionPolicy(null, List.of(new CspRegion("aws", "eu-west-1"), new CspRegion("aws", "us-east-1")));
         var elasticInferenceServiceRequestWrapper = getDummyElasticInferenceServiceRequest(
             new ElasticInferenceServiceRequestMetadata(InferenceProductContext.EMPTY, null),
             new InferencePreferences(regionPolicy),
@@ -103,7 +103,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
     }
 
     public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithAllowedGeosHeader() {
-        var regionPolicy = new RegionPolicy(List.of("eu", "us"), null, null);
+        var regionPolicy = new RegionPolicy(List.of("eu", "us"), null);
         var elasticInferenceServiceRequestWrapper = getDummyElasticInferenceServiceRequest(
             new ElasticInferenceServiceRequestMetadata(InferenceProductContext.EMPTY, null),
             new InferencePreferences(regionPolicy),


### PR DESCRIPTION
Fixes compilation errors after merging https://github.com/elastic/elasticsearch/pull/152796 and https://github.com/elastic/elasticsearch/pull/152798.