### PR TITLE
CompletionSuggestSearchIT runs with a circuit breaker now

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -757,9 +757,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/kNN search only}
   issue: https://github.com/elastic/elasticsearch/issues/152784
-- class: org.elasticsearch.search.suggest.CompletionSuggestSearchIT
-  method: testBigSizeCircuitBreak
-  issue: https://github.com/elastic/elasticsearch/issues/152785
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/kNN search plus query}
   issue: https://github.com/elastic/elasticsearch/issues/152786

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -88,6 +88,15 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         return List.of(InternalSettingsPlugin.class);
     }
 
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put("indices.breaker.request.type", "memory")
+            .put("indices.breaker.request.limit", "100mb")
+            .build();
+    }
+
     public void testTieBreak() throws Exception {
         final CompletionMappingBuilder mapping = new CompletionMappingBuilder();
         mapping.indexAnalyzer("keyword");


### PR DESCRIPTION
We introduced a new test that expects nodes to be running with a circuot breaker so let add the settings that make sure it is configured properly.

fixes https://github.com/elastic/elasticsearch/issues/152785