### PR TITLE
[9.4] Fork ensureShardSearchActive callbacks off the refresh thread (#152509)

### DIFF
--- a/docs/changelog/152509.yaml
+++ b/docs/changelog/152509.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 97280
+pr: 152509
+summary: Fork `ensureShardSearchActive` callbacks off the refresh thread
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -4610,6 +4610,31 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Variant of {@link #ensureShardSearchActive(Consumer)} that dispatches the listener on {@code responseExecutor} when a refresh was
+     * pending, keeping non-trivial search-side work off the refresh-completing thread (often an indexing or recovery thread). When no
+     * refresh is pending the listener runs inline on the calling thread; if dispatching fails it is invoked inline with {@code true}.
+     *
+     * @param responseExecutor the executor on which to invoke the listener when it was registered to wait for a refresh
+     * @param listener         the listener to invoke once the pending refresh location is visible. The listener will be called with
+     *                         <code>true</code> if the listener was registered to wait for a refresh.
+     */
+    public final void ensureShardSearchActive(Executor responseExecutor, Consumer<Boolean> listener) {
+        Objects.requireNonNull(responseExecutor);
+        ensureShardSearchActive(wasRegistered -> {
+            if (wasRegistered) {
+                try {
+                    responseExecutor.execute(() -> listener.accept(true));
+                } catch (Exception e) {
+                    logger.warn(() -> format("ensureShardSearchActive could not dispatch to [%s], running inline", responseExecutor), e);
+                    listener.accept(true);
+                }
+            } else {
+                listener.accept(false);
+            }
+        });
+    }
+
+    /**
      * Add a listener for refreshes.
      *
      * @param location the location to listen for

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1607,7 +1607,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         final IndexShard shard = indexService.getShard(shardId.id());
         final SearchOperationListener searchOperationListener = shard.getSearchOperationListener();
-        shard.ensureShardSearchActive(ignored -> {
+        shard.ensureShardSearchActive(threadPool.executor(Names.SEARCH), ignored -> {
             Engine.SearcherSupplier searcherSupplier = null;
             ReaderContext readerContext = null;
             try {
@@ -2526,8 +2526,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             request.getRewriteable(),
             indicesService.getDataRewriteContext(request::nowInMillis),
             threadPool.executor(Names.SEARCH),
+
             request.readerId() == null
-                ? listener.delegateFailureAndWrap((l, r) -> shard.ensureShardSearchActive(b -> l.onResponse(request)))
+                ? listener.delegateFailureAndWrap((l, r) -> shard.ensureShardSearchActive(threadPool.executor(Names.SEARCH), b -> l.onResponse(request)))
                 : listener.safeMap(r -> request)
         );
     }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -2528,7 +2528,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             threadPool.executor(Names.SEARCH),
 
             request.readerId() == null
-                ? listener.delegateFailureAndWrap((l, r) -> shard.ensureShardSearchActive(threadPool.executor(Names.SEARCH), b -> l.onResponse(request)))
+                ? listener.delegateFailureAndWrap(
+                    (l, r) -> shard.ensureShardSearchActive(threadPool.executor(Names.SEARCH), b -> l.onResponse(request))
+                )
                 : listener.safeMap(r -> request)
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -162,6 +162,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -4175,6 +4176,133 @@ public class IndexShardTests extends IndexShardTestCase {
         assertBusy(() -> assertThat(primary.refreshStats().getExternalTotal(), equalTo(externalRefreshesBefore + 1)));
         try (Engine.Searcher searcher = primary.acquireSearcher("test")) {
             assertEquals(3, searcher.getIndexReader().numDocs());
+        }
+        closeShards(primary);
+    }
+
+    public void testEnsureShardSearchActiveDispatchesListenerOffRefreshThread() throws Exception {
+        IndexMetadata metadata = newTestIndexMetadata();
+        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
+        recoverShardFromStore(primary);
+        indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
+        PlainActionFuture<Boolean> refreshed = new PlainActionFuture<>();
+        primary.scheduledRefresh(refreshed);
+        assertTrue(refreshed.actionGet());
+
+        Settings searchIdleSettings = Settings.builder()
+            .put(primary.indexSettings().getSettings())
+            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.ZERO)
+            .build();
+        primary.indexSettings().getScopedSettings().applySettings(searchIdleSettings);
+        indexDoc(primary, "_doc", "1", "{\"foo\" : \"bar\"}");
+        PlainActionFuture<Boolean> deferred = new PlainActionFuture<>();
+        primary.scheduledRefresh(deferred);
+        assertFalse(deferred.actionGet());
+        assertTrue("a refresh should be pending while the shard is search idle", primary.hasRefreshPending());
+
+        final String executorName = "ensure-search-active-test";
+        final ExecutorService responseExecutor = Executors.newSingleThreadExecutor(
+            EsExecutors.daemonThreadFactory("test-node", executorName)
+        );
+        try {
+            final AtomicReference<String> listenerThreadName = new AtomicReference<>();
+            final AtomicBoolean registered = new AtomicBoolean();
+            final CountDownLatch latch = new CountDownLatch(1);
+            primary.ensureShardSearchActive(responseExecutor, wasRegistered -> {
+                registered.set(wasRegistered);
+                listenerThreadName.set(Thread.currentThread().getName());
+                latch.countDown();
+            });
+            safeAwait(latch);
+            assertTrue("a refresh was pending so the listener must have been registered as a refresh listener", registered.get());
+            assertThat(
+                "listener must be dispatched to the provided executor",
+                listenerThreadName.get(),
+                containsString("[" + executorName + "]")
+            );
+            assertThat(
+                "listener must not run on a refresh thread",
+                listenerThreadName.get(),
+                not(containsString("[" + ThreadPool.Names.REFRESH + "]"))
+            );
+        } finally {
+            ThreadPool.terminate(responseExecutor, 10, TimeUnit.SECONDS);
+        }
+        closeShards(primary);
+    }
+
+    public void testEnsureShardSearchActiveRunsInlineWhenNoRefreshPending() throws Exception {
+        IndexMetadata metadata = newTestIndexMetadata();
+        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
+        recoverShardFromStore(primary);
+        indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
+        PlainActionFuture<Boolean> refreshed = new PlainActionFuture<>();
+        primary.scheduledRefresh(refreshed);
+        assertTrue(refreshed.actionGet());
+        assertFalse(primary.hasRefreshPending());
+
+        final ExecutorService responseExecutor = Executors.newSingleThreadExecutor(
+            EsExecutors.daemonThreadFactory("test-node", "ensure-search-active-test")
+        );
+        try {
+            final String callingThreadName = Thread.currentThread().getName();
+            final AtomicReference<String> listenerThreadName = new AtomicReference<>();
+            final AtomicBoolean registered = new AtomicBoolean(true);
+            primary.ensureShardSearchActive(responseExecutor, wasRegistered -> {
+                registered.set(wasRegistered);
+                listenerThreadName.set(Thread.currentThread().getName());
+            });
+            assertFalse("no refresh was pending so the listener must not have been registered", registered.get());
+            assertEquals("listener must run inline on the calling thread", callingThreadName, listenerThreadName.get());
+        } finally {
+            ThreadPool.terminate(responseExecutor, 10, TimeUnit.SECONDS);
+        }
+        closeShards(primary);
+    }
+
+    public void testEnsureShardSearchActiveRunsInlineWhenDispatchRejected() throws Exception {
+        IndexMetadata metadata = newTestIndexMetadata();
+        IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
+        recoverShardFromStore(primary);
+        indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
+        PlainActionFuture<Boolean> refreshed = new PlainActionFuture<>();
+        primary.scheduledRefresh(refreshed);
+        assertTrue(refreshed.actionGet());
+
+        Settings searchIdleSettings = Settings.builder()
+            .put(primary.indexSettings().getSettings())
+            .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.ZERO)
+            .build();
+        primary.indexSettings().getScopedSettings().applySettings(searchIdleSettings);
+        indexDoc(primary, "_doc", "1", "{\"foo\" : \"bar\"}");
+        PlainActionFuture<Boolean> deferred = new PlainActionFuture<>();
+        primary.scheduledRefresh(deferred);
+        assertFalse(deferred.actionGet());
+        assertTrue("a refresh should be pending while the shard is search idle", primary.hasRefreshPending());
+
+        final Executor rejectingExecutor = command -> { throw new EsRejectedExecutionException("rejected for test"); };
+        try (var mockLog = MockLog.capture(IndexShard.class)) {
+            mockLog.addExpectation(
+                new MockLog.SeenEventExpectation(
+                    "dispatch failure warning",
+                    IndexShard.class.getCanonicalName(),
+                    Level.WARN,
+                    "ensureShardSearchActive could not dispatch to [*], running inline"
+                )
+            );
+
+            final AtomicInteger invocations = new AtomicInteger();
+            final AtomicBoolean registered = new AtomicBoolean();
+            final CountDownLatch latch = new CountDownLatch(1);
+            primary.ensureShardSearchActive(rejectingExecutor, wasRegistered -> {
+                registered.set(wasRegistered);
+                invocations.incrementAndGet();
+                latch.countDown();
+            });
+            safeAwait(latch);
+            assertTrue("a refresh was pending so the listener must have been registered as a refresh listener", registered.get());
+            assertEquals("listener must be invoked exactly once when dispatch is rejected", 1, invocations.get());
+            mockLog.assertAllExpectationsMatched();
         }
         closeShards(primary);
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -66,6 +66,7 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.core.Assertions;
@@ -4181,7 +4182,9 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     public void testEnsureShardSearchActiveDispatchesListenerOffRefreshThread() throws Exception {
-        IndexMetadata metadata = newTestIndexMetadata();
+        Settings settings = indexSettings(IndexVersion.current(), 1, 1).build();
+        IndexMetadata metadata = IndexMetadata.builder("test").putMapping("""
+            { "properties": { "foo":  { "type": "text"}}}""").settings(settings).primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
         recoverShardFromStore(primary);
         indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
@@ -4232,7 +4235,9 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     public void testEnsureShardSearchActiveRunsInlineWhenNoRefreshPending() throws Exception {
-        IndexMetadata metadata = newTestIndexMetadata();
+        Settings settings = indexSettings(IndexVersion.current(), 1, 1).build();
+        IndexMetadata metadata = IndexMetadata.builder("test").putMapping("""
+            { "properties": { "foo":  { "type": "text"}}}""").settings(settings).primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
         recoverShardFromStore(primary);
         indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");
@@ -4261,7 +4266,9 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     public void testEnsureShardSearchActiveRunsInlineWhenDispatchRejected() throws Exception {
-        IndexMetadata metadata = newTestIndexMetadata();
+        Settings settings = indexSettings(IndexVersion.current(), 1, 1).build();
+        IndexMetadata metadata = IndexMetadata.builder("test").putMapping("""
+            { "properties": { "foo":  { "type": "text"}}}""").settings(settings).primaryTerm(0, 1).build();
         IndexShard primary = newShard(new ShardId(metadata.getIndex(), 0), true, "n1", metadata, null);
         recoverShardFromStore(primary);
         indexDoc(primary, "_doc", "0", "{\"foo\" : \"bar\"}");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fork ensureShardSearchActive callbacks off the refresh thread (#152509)](https://github.com/elastic/elasticsearch/pull/152509)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)