### PR TITLE
ES|QL: implement watchdog timeout for GROK (#152851) (#152944) (#152949)

### DIFF
--- a/docs/changelog/152851.yaml
+++ b/docs/changelog/152851.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 152851
+summary: Implement watchdog timeout for GROK
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/GrokWatchdogIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.junit.After;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Verifies that {@link EsqlPlugin#GROK_WATCHDOG_MAX_EXECUTION_TIME} is honored at execution time.
+ * The setting is {@code NodeScope} (every node reads its own value when it builds the GROK matcher
+ * used against real data, see {@code LocalExecutionPlanner#planGrok} — no need to carry it in the
+ * ES|QL wire format) and {@code Dynamic} (it can be changed via the cluster settings API without a
+ * node restart, since {@code ComputeService} re-resolves it from the live {@code ClusterSettings}
+ * for every query).
+ */
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class GrokWatchdogIT extends AbstractEsqlIntegTestCase {
+
+    @After
+    public void resetWatchdogSetting() {
+        updateClusterSettings(Settings.builder().putNull(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey()));
+    }
+
+    public void testCatastrophicBacktrackingPatternIsInterruptedAfterLiveSettingUpdate() {
+        prepareIndex("test").setId("1").setSource("message", "a".repeat(30) + "X").get();
+        refresh("test");
+
+        // No restart: the setting is dynamic, so this update must take effect on the very next query.
+        updateClusterSettings(Settings.builder().put(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey(), TimeValue.timeValueMillis(1)));
+
+        Exception e = expectThrows(Exception.class, () -> run("FROM test | GROK message \"(?<a>a+)+b\" | KEEP a"));
+        assertThat(ExceptionsHelper.stackTrace(e), containsString("interrupted"));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.grok.GrokBuiltinPatterns;
 import org.elasticsearch.grok.GrokCaptureConfig;
 import org.elasticsearch.grok.GrokCaptureType;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
@@ -72,9 +73,19 @@ public class Grok extends RegexExtract implements TelemetryAware {
     }
 
     public static Parser pattern(Source source, String pattern) {
+        return pattern(source, pattern, MatcherWatchdog.noop());
+    }
+
+    /**
+     * Builds a parser using the given watchdog to interrupt expensive matches. Used by the local execution
+     * planner to bind the node-local {@code esql.grok.watchdog.max_execution_time} setting to the matcher
+     * that will actually run against real data; parsing/deserialization use the no-op watchdog above since
+     * they never execute the pattern against untrusted input.
+     */
+    public static Parser pattern(Source source, String pattern, MatcherWatchdog matcherWatchdog) {
         try {
             var builtinPatterns = GrokBuiltinPatterns.get(true);
-            org.elasticsearch.grok.Grok grok = new org.elasticsearch.grok.Grok(builtinPatterns, pattern, logger::warn);
+            org.elasticsearch.grok.Grok grok = new org.elasticsearch.grok.Grok(builtinPatterns, pattern, matcherWatchdog, logger::warn);
             return new Parser(pattern, grok);
         } catch (IllegalArgumentException e) {
             throw new ParsingException(source, "Invalid pattern [{}] for grok: {}", pattern, e.getMessage());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -52,6 +52,7 @@ import org.elasticsearch.compute.operator.topn.TopNOperator;
 import org.elasticsearch.compute.operator.topn.TopNOperator.TopNOperatorFactory;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -84,6 +85,7 @@ import org.elasticsearch.xpack.esql.inference.InferenceRunner;
 import org.elasticsearch.xpack.esql.inference.XContentRowEncoder;
 import org.elasticsearch.xpack.esql.inference.completion.CompletionOperator;
 import org.elasticsearch.xpack.esql.inference.rerank.RerankOperator;
+import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
@@ -154,6 +156,7 @@ public class LocalExecutionPlanner {
     private final InferenceRunner inferenceRunner;
     private final PhysicalOperationProviders physicalOperationProviders;
     private final List<ShardContext> shardContexts;
+    private final MatcherWatchdog grokMatcherWatchdog;
 
     public LocalExecutionPlanner(
         String sessionId,
@@ -169,7 +172,8 @@ public class LocalExecutionPlanner {
         LookupFromIndexService lookupFromIndexService,
         InferenceRunner inferenceRunner,
         PhysicalOperationProviders physicalOperationProviders,
-        List<ShardContext> shardContexts
+        List<ShardContext> shardContexts,
+        MatcherWatchdog grokMatcherWatchdog
     ) {
 
         this.sessionId = sessionId;
@@ -186,6 +190,10 @@ public class LocalExecutionPlanner {
         this.physicalOperationProviders = physicalOperationProviders;
         this.configuration = configuration;
         this.shardContexts = shardContexts;
+        // Resolved once by the caller from the live ClusterSettings (the setting is dynamic), then shared
+        // by every GROK matcher this planner builds — MatcherWatchdog.Default is a stateless, immutable
+        // wrapper around a single timeout value.
+        this.grokMatcherWatchdog = grokMatcherWatchdog;
     }
 
     /**
@@ -501,11 +509,14 @@ public class LocalExecutionPlanner {
         }
 
         Layout layout = layoutBuilder.build();
+        // Rebind the matcher to this node's own grok.watchdog.max_execution_time setting instead of the
+        // no-op watchdog it was parsed/deserialized with, since the pattern is about to run against real data.
+        org.elasticsearch.grok.Grok watchdogGrok = Grok.pattern(grok.source(), grok.pattern().pattern(), grokMatcherWatchdog).grok();
         source = source.with(
             new ColumnExtractOperator.Factory(
                 types,
                 EvalMapper.toEvaluator(context.foldCtx(), grok.inputExpression(), layout),
-                () -> new GrokEvaluatorExtracter(grok.pattern().grok(), grok.pattern().pattern(), fieldToPos, fieldToType)
+                () -> new GrokEvaluatorExtracter(watchdogGrok, grok.pattern().pattern(), fieldToPos, fieldToType)
             ),
             layout
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -25,7 +25,9 @@ import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -69,9 +71,11 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
+import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME;
 
 /**
  * Computes the result of a {@link PhysicalPlan}.
@@ -98,6 +102,9 @@ public class ComputeService {
     private final ExchangeService exchangeService;
     private final PhysicalSettings physicalSettings;
     private final Executor searchExecutor;
+    // Single shared instance, refreshed in place whenever the dynamic setting changes, rather than
+    // re-resolving it from ClusterSettings for every query.
+    private final AtomicReference<MatcherWatchdog> grokMatcherWatchdog = new AtomicReference<>();
 
     @SuppressWarnings("this-escape")
     public ComputeService(
@@ -119,6 +126,22 @@ public class ComputeService {
         this.lookupFromIndexService = lookupFromIndexService;
         this.inferenceRunner = transportActionServices.inferenceRunner();
         this.clusterService = transportActionServices.clusterService();
+        // 9.3 backport note: unlike main/9.4, this branch doesn't have the joni Matcher#setTimeout-based
+        // MatcherWatchdog (elastic/elasticsearch#139405), only the older thread-polling implementation.
+        // We reuse the configured max execution time as the poll interval too, so a stuck matcher is
+        // interrupted roughly once per max-execution-time window rather than needing a second setting.
+        this.clusterService.getClusterSettings()
+            .initializeAndWatch(
+                GROK_WATCHDOG_MAX_EXECUTION_TIME,
+                timeValue -> grokMatcherWatchdog.set(
+                    MatcherWatchdog.newInstance(
+                        timeValue.millis(),
+                        timeValue.millis(),
+                        threadPool.relativeTimeInMillisSupplier(),
+                        (delay, command) -> threadPool.schedule(command, TimeValue.timeValueMillis(delay), threadPool.generic())
+                    )
+                )
+            );
         this.dataNodeComputeHandler = new DataNodeComputeHandler(
             this,
             clusterService,
@@ -475,7 +498,8 @@ public class ComputeService {
                 lookupFromIndexService,
                 inferenceRunner,
                 physicalOperationProviders,
-                contexts
+                contexts,
+                grokMatcherWatchdog.get()
             );
 
             LOGGER.debug("Received physical plan:\n{}", plan);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -157,6 +157,22 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
     );
 
     /**
+     * Maximum time (in milliseconds) that a GROK matcher is allowed to run before being interrupted.
+     * Limits how long a GROK matcher can run to protect against expensive regex patterns. Read directly
+     * from each node's own {@link org.elasticsearch.common.settings.ClusterSettings} wherever the matcher
+     * is built for execution (see {@code LocalExecutionPlanner#planGrok}) rather than being carried in the
+     * ES|QL {@code Configuration} wire format, since every node can resolve this node-scoped setting on
+     * its own — including live updates, since it is also dynamic.
+     */
+    public static final Setting<TimeValue> GROK_WATCHDOG_MAX_EXECUTION_TIME = Setting.timeSetting(
+        "esql.grok.watchdog.max_execution_time",
+        TimeValue.timeValueMillis(1000),
+        TimeValue.timeValueMillis(0),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Tuning parameter for deciding when to use the "merge" stored field loader.
      * Think of it as "how similar to a sequential block of documents do I have to
      * be before I'll use the merge reader?" So a value of {@code 1} means I have to
@@ -245,7 +261,8 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
             PhysicalSettings.DEFAULT_DATA_PARTITIONING,
             PhysicalSettings.VALUES_LOADING_JUMBO_SIZE,
             STORED_FIELDS_SEQUENTIAL_PROPORTION,
-            EsqlFlags.ESQL_STRING_LIKE_ON_INDEX
+            EsqlFlags.ESQL_STRING_LIKE_ON_INDEX,
+            GROK_WATCHDOG_MAX_EXECUTION_TIME
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.compute.querydsl.query.SingleValueMatchQuery;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -668,7 +669,8 @@ public class CsvTests extends ESTestCase {
             Mockito.mock(LookupFromIndexService.class),
             Mockito.mock(InferenceRunner.class),
             physicalOperationProviders,
-            List.of()
+            List.of(),
+            MatcherWatchdog.noop()
         );
 
         List<Page> collectedPages = Collections.synchronizedList(new ArrayList<>());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.ShapeType;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -7915,7 +7916,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
                 null,
                 new PhysicalSettings(DataPartitioning.AUTO, ByteSizeValue.ofMb(1))
             ),
-            List.of()
+            List.of(),
+            MatcherWatchdog.noop()
         );
 
         return planner.plan("test", FoldContext.small(), plan);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.grok.MatcherWatchdog;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class GrokTests extends ESTestCase {
+
+    public void testWatchdogInterruptsBacktracking() {
+        // This branch predates elastic/elasticsearch#139405, so MatcherWatchdog only has the older
+        // thread-polling implementation (it interrupts a stuck matcher the next time the poll thread
+        // wakes up, rather than via an exact joni-level timeout). Use a pattern whose catastrophic
+        // backtracking (2^30 steps) vastly outlasts the short poll interval below, so the interrupt is
+        // guaranteed to fire long before the match could ever complete on its own.
+        AtomicBoolean keepPolling = new AtomicBoolean(true);
+        MatcherWatchdog watchdog = MatcherWatchdog.newInstance(5, 5, System::currentTimeMillis, (delay, command) -> {
+            Thread thread = new Thread(() -> {
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+                if (keepPolling.get()) {
+                    command.run();
+                }
+            });
+            thread.start();
+        });
+        try {
+            Grok.Parser parser = Grok.pattern(Source.EMPTY, "(?<a>a+)+b", watchdog);
+            // match(String) treats a timeout as "no match" (see its javadoc); captures(String) is the
+            // path that actually surfaces a timeout as an exception, same as production GROK execution.
+            RuntimeException ex = expectThrows(RuntimeException.class, () -> parser.grok().captures("a".repeat(30) + "X"));
+            assertThat(ex.getMessage(), containsString("interrupted"));
+        } finally {
+            keepPolling.set(false);
+        }
+    }
+
+    public void testNoopWatchdogDoesNotInterruptSimplePattern() {
+        Grok.Parser parser = Grok.pattern(Source.EMPTY, "%{IP:client_ip}", MatcherWatchdog.noop());
+        assertNotNull(parser.grok().captures("192.168.1.1"));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
@@ -208,7 +209,8 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             null,
             null,
             esPhysicalOperationProviders(shardContexts),
-            shardContexts
+            shardContexts,
+            MatcherWatchdog.noop()
         );
     }
 


### PR DESCRIPTION
Manual backport of #152851