### PR TITLE
[9.3] CompletionSuggestSearchIT runs with a circuit breaker now (#152954)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -88,6 +88,15 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         return List.of(InternalSettingsPlugin.class);
     }
 
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put("indices.breaker.request.type", "memory")
+            .put("indices.breaker.request.limit", "100mb")
+            .build();
+    }
+
     public void testTieBreak() throws Exception {
         final CompletionMappingBuilder mapping = new CompletionMappingBuilder();
         mapping.indexAnalyzer("keyword");


### PR DESCRIPTION
We introduced a new test that expects nodes to be running with a circuot breaker so let add the settings that make sure it is configured properly.

(cherry picked from commit 4e8eb8217b36c672f8ea94b1eee289faaef90bd7)

backport https://github.com/elastic/elasticsearch/pull/152954
