### PR TITLE
[9.4] [ML] Fix ML jobs stuck in starting state on Serverless trial projects (#150362)

### DIFF
--- a/docs/changelog/150362.yaml
+++ b/docs/changelog/150362.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 150362
+summary: Fix ML jobs stuck in starting state on Serverless trial projects
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/dataframe/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/dataframe/TransportStartDataFrameAnalyticsAction.java
@@ -718,7 +718,7 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
                 params.getId(),
                 MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
                 memoryTracker,
-                params.isAllowLazyStart() ? Integer.MAX_VALUE : maxLazyMLNodes,
+                JobNodeSelector.effectiveMaxLazyNodes(maxLazyMLNodes, params.isAllowLazyStart()),
                 node -> nodeFilter(node, params)
             );
             // Pass an effectively infinite value for max concurrent opening jobs, because data frame analytics jobs do

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -64,6 +64,20 @@ public class JobNodeSelector {
         return preamble + format(msg, params);
     }
 
+    /**
+     * Resolves the effective number of lazy ML nodes to consider during assignment.
+     *
+     * <p>When a job/task is started with {@code allow_lazy_open} / {@code allow_lazy_start} and no explicit
+     * {@code xpack.ml.max_lazy_ml_nodes} cap is configured ({@code configuredMaxLazyNodes == 0}), lazy
+     * assignment is treated as unbounded ({@link Integer#MAX_VALUE}) so autoscaling can provision a new ML
+     * node. When a positive cap is configured (e.g. trial serverless pins a single ~4Gi ML node via
+     * {@code max_lazy_ml_nodes=1}), the configured cap is honoured so assignment fails fast rather than
+     * waiting indefinitely for capacity that cannot be provisioned.
+     */
+    public static int effectiveMaxLazyNodes(int configuredMaxLazyNodes, boolean allowLazyAssignment) {
+        return (configuredMaxLazyNodes == 0 && allowLazyAssignment) ? Integer.MAX_VALUE : configuredMaxLazyNodes;
+    }
+
     private final String jobId;
     private final String taskName;
     private final ClusterState clusterState;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -150,7 +150,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             params.getJobId(),
             MlTasks.JOB_TASK_NAME,
             memoryTracker,
-            job.allowLazyOpen() ? Integer.MAX_VALUE : maxLazyMLNodes,
+            JobNodeSelector.effectiveMaxLazyNodes(maxLazyMLNodes, job.allowLazyOpen()),
             node -> nodeFilter(node, job)
         );
         Assignment assignment = jobNodeSelector.selectNode(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/dataframe/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/dataframe/TransportStartDataFrameAnalyticsActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -35,6 +36,7 @@ import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction.Task
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.action.dataframe.TransportStartDataFrameAnalyticsAction.TaskExecutor;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsManager;
+import org.elasticsearch.xpack.ml.job.JobNodeSelector;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 
@@ -48,7 +50,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -123,6 +128,29 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
         assertThat(assignment.getExplanation(), is(emptyString()));
     }
 
+    public void testGetAssignmentGivenLazyStartAtNodeCapShouldFail() {
+        MlMemoryTracker memoryTracker = mock(MlMemoryTracker.class);
+        when(memoryTracker.isRecentlyRefreshed()).thenReturn(true);
+        when(memoryTracker.getDataFrameAnalyticsJobMemoryRequirement(eq(JOB_ID))).thenReturn(ByteSizeValue.ofGb(10).getBytes());
+        when(memoryTracker.getJobMemoryRequirement(anyString(), eq(JOB_ID))).thenReturn(ByteSizeValue.ofGb(10).getBytes());
+
+        Settings settings = Settings.builder()
+            .put(MachineLearningField.MAX_LAZY_ML_NODES.getKey(), 1)
+            .put(MachineLearning.MAX_ML_NODE_SIZE.getKey(), "4gb")
+            .build();
+        TaskExecutor executor = createTaskExecutor(settings, memoryTracker);
+        TaskParams params = new TaskParams(JOB_ID, MlConfigVersion.CURRENT, true);
+        long trialNodeMemoryBytes = ByteSizeUnit.GB.toBytes(4);
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().build()))
+            .nodes(DiscoveryNodes.builder().add(createNode(0, true, Version.CURRENT, MlConfigVersion.CURRENT, trialNodeMemoryBytes)))
+            .build();
+
+        Assignment assignment = executor.getAssignment(params, clusterState.nodes().getAllNodes(), clusterState, ProjectId.DEFAULT);
+        assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(assignment.getExplanation(), is(not(equalTo(JobNodeSelector.AWAITING_LAZY_ASSIGNMENT.getExplanation()))));
+    }
+
     public void testTooManyDocumentsForAnalysis_FullTrainingPercentBelowLimit() {
         assertFalse(tooManyDocumentsForAnalysis(50_000_000L, 100.0));
     }
@@ -152,6 +180,10 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
     }
 
     private static TaskExecutor createTaskExecutor() {
+        return createTaskExecutor(Settings.EMPTY, mock(MlMemoryTracker.class));
+    }
+
+    private static TaskExecutor createTaskExecutor(Settings settings, MlMemoryTracker memoryTracker) {
         ClusterService clusterService = mock(ClusterService.class);
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
@@ -168,18 +200,28 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
         when(clusterService.threadPool()).thenReturn(mock(ThreadPool.class));
 
         return new TaskExecutor(
-            Settings.EMPTY,
+            settings,
             mock(Client.class),
             clusterService,
             mock(DataFrameAnalyticsManager.class),
             mock(DataFrameAnalyticsAuditor.class),
-            mock(MlMemoryTracker.class),
+            memoryTracker,
             TestIndexNameExpressionResolver.newInstance(),
             mock(XPackLicenseState.class)
         );
     }
 
     private static DiscoveryNode createNode(int i, boolean isMlNode, Version nodeVersion, MlConfigVersion mlConfigVersion) {
+        return createNode(i, isMlNode, nodeVersion, mlConfigVersion, ByteSizeValue.ofGb(1).getBytes());
+    }
+
+    private static DiscoveryNode createNode(
+        int i,
+        boolean isMlNode,
+        Version nodeVersion,
+        MlConfigVersion mlConfigVersion,
+        long machineMemoryBytes
+    ) {
         return DiscoveryNodeUtils.builder("_node_id" + i)
             .name("_node_name" + i)
             .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300 + i))
@@ -187,9 +229,9 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
                 isMlNode
                     ? Map.of(
                         "ml.machine_memory",
-                        String.valueOf(ByteSizeValue.ofGb(1).getBytes()),
+                        String.valueOf(machineMemoryBytes),
                         "ml.max_jvm_size",
-                        String.valueOf(ByteSizeValue.ofMb(400).getBytes()),
+                        String.valueOf(machineMemoryBytes / 2),
                         MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR,
                         mlConfigVersion.toString()
                     )

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.Tuple;
@@ -1296,6 +1297,55 @@ public class JobNodeSelectorTests extends ESTestCase {
             ByteSizeValue.ofGb(64).getBytes()
         );
         assertEquals(JobNodeSelector.AWAITING_LAZY_ASSIGNMENT.getExplanation(), result.getExplanation());
+        assertNull(result.getExecutorNode());
+    }
+
+    public void testEffectiveMaxLazyNodesGivenNoCapAndLazyAssignmentShouldBeUnbounded() {
+        assertEquals(Integer.MAX_VALUE, JobNodeSelector.effectiveMaxLazyNodes(0, true));
+    }
+
+    public void testEffectiveMaxLazyNodesGivenPositiveCapShouldHonourCap() {
+        assertEquals(1, JobNodeSelector.effectiveMaxLazyNodes(1, true));
+        assertEquals(1, JobNodeSelector.effectiveMaxLazyNodes(1, false));
+    }
+
+    public void testConsiderLazyAssignmentGivenNodeCapShouldFail() {
+        long trialNodeMemoryBytes = ByteSizeUnit.GB.toBytes(4);
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(
+                DiscoveryNodeUtils.create(
+                    "trial_ml_node",
+                    "trial_ml_node_id",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                    Map.of(
+                        MachineLearning.MACHINE_MEMORY_NODE_ATTR,
+                        Long.toString(trialNodeMemoryBytes),
+                        MachineLearning.MAX_JVM_SIZE_NODE_ATTR,
+                        Long.toString(trialNodeMemoryBytes / 2)
+                    ),
+                    ROLES_WITH_ML
+                )
+            )
+            .build();
+
+        ClusterState.Builder cs = ClusterState.builder(new ClusterName("_name"));
+        cs.nodes(nodes);
+
+        Job job = BaseMlIntegTestCase.createFareQuoteJob("job_id1000", JOB_MEMORY_REQUIREMENT).build(new Date());
+        JobNodeSelector jobNodeSelector = new JobNodeSelector(
+            cs.build(),
+            shuffled(cs.nodes().getAllNodes()),
+            job.getId(),
+            MlTasks.JOB_TASK_NAME,
+            memoryTracker,
+            1,
+            node -> nodeFilter(node, job)
+        );
+        PersistentTasksCustomMetadata.Assignment result = jobNodeSelector.considerLazyAssignment(
+            new PersistentTasksCustomMetadata.Assignment(null, "foo"),
+            ByteSizeValue.ofGb(4).getBytes()
+        );
+        assertEquals("foo", result.getExplanation());
         assertNull(result.getExecutorNode());
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -16,6 +16,9 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.OperationRouting;
@@ -28,6 +31,9 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
@@ -42,6 +48,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
+import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
@@ -66,8 +73,10 @@ import org.elasticsearch.xpack.ml.job.JobNodeSelector;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 import org.junit.Before;
 
+import java.net.InetAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,10 +84,14 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.validateJobAndId;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -211,6 +224,62 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         assertNotNull(assignment);
         assertNull(assignment.getExecutorNode());
         assertEquals(JobNodeSelector.AWAITING_LAZY_ASSIGNMENT.getExplanation(), assignment.getExplanation());
+    }
+
+    public void testGetAssignmentGivenLazyJobAtNodeCapShouldFail() {
+        Settings settings = Settings.builder()
+            .put(MachineLearningField.MAX_LAZY_ML_NODES.getKey(), 1)
+            .put(MachineLearning.MAX_ML_NODE_SIZE.getKey(), "4gb")
+            .build();
+        long trialNodeMemoryBytes = ByteSizeUnit.GB.toBytes(4);
+        Map<String, String> nodeAttributes = Map.of(
+            MachineLearning.MACHINE_MEMORY_NODE_ATTR,
+            Long.toString(trialNodeMemoryBytes),
+            MachineLearning.MAX_JVM_SIZE_NODE_ATTR,
+            Long.toString(trialNodeMemoryBytes / 2),
+            MlConfigVersion.ML_CONFIG_VERSION_NODE_ATTR,
+            MlConfigVersion.CURRENT.toString()
+        );
+        Set<DiscoveryNodeRole> mlRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE);
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(
+                DiscoveryNodeUtils.create(
+                    "trial_ml_node",
+                    "trial_ml_node_id",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                    nodeAttributes,
+                    mlRoles
+                )
+            )
+            .build();
+
+        ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
+        Metadata.Builder metadata = Metadata.builder();
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        addIndices(metadata, routingTable);
+        csBuilder.metadata(metadata);
+        csBuilder.routingTable(routingTable.build());
+        csBuilder.nodes(nodes);
+
+        when(mlMemoryTracker.isRecentlyRefreshed()).thenReturn(true);
+        when(mlMemoryTracker.getJobMemoryRequirement(anyString(), eq("lazy_job_at_cap"))).thenReturn(ByteSizeValue.ofGb(10).getBytes());
+
+        OpenJobPersistentTasksExecutor executor = createExecutor(settings);
+
+        Job job = BaseMlIntegTestCase.createFareQuoteJob("lazy_job_at_cap", ByteSizeValue.ofGb(10))
+            .setAllowLazyOpen(true)
+            .build(new Date());
+        OpenJobAction.JobParams params = new OpenJobAction.JobParams("lazy_job_at_cap");
+        params.setJob(job);
+        PersistentTasksCustomMetadata.Assignment assignment = executor.getAssignment(
+            params,
+            csBuilder.nodes().getAllNodes(),
+            csBuilder.build(),
+            ProjectId.DEFAULT
+        );
+        assertNotNull(assignment);
+        assertNull(assignment.getExecutorNode());
+        assertNotEquals(JobNodeSelector.AWAITING_LAZY_ASSIGNMENT.getExplanation(), assignment.getExplanation());
     }
 
     public void testGetAssignment_GivenResetInProgress() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ML] Fix ML jobs stuck in starting state on Serverless trial projects (#150362)](https://github.com/elastic/elasticsearch/pull/150362)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)