### PR TITLE
[9.3] [Gradle] Simplify build tool test setup (#152919)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
@@ -29,9 +29,26 @@ abstract class AbstractGitAwareGradleFuncTest extends AbstractGradleInternalPlug
     @Shared
     File preparedRemoteGitDir
 
+    @TempDir
+    File gradleUserHome
+
     File remoteGitRepo
 
+    @Override
+    protected File customGradleUserHome() {
+        return gradleUserHome
+    }
+
     def setup() {
+        // Pre-populate the TestKit Gradle user home with the locally cached Gradle wrapper
+        // distribution. TestKit sets GRADLE_USER_HOME=<gradleUserHome> in every forked process,
+        // including the ./gradlew subprocesses spawned by BWC build tasks. Without this copy
+        // those subprocesses would download the Gradle distribution on every test run.
+        File localWrapperDir = new File(System.getProperty("user.home"), ".gradle/wrapper")
+        if (localWrapperDir.exists()) {
+            FileUtils.copyDirectory(localWrapperDir, new File(gradleUserHome, "wrapper"))
+        }
+
         if (preparedRemoteGitDir == null) {
             preparedRemoteGitDir = setupGitRemote()
         }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
@@ -26,7 +26,7 @@ class BuildPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
 
     Class<? extends org.gradle.api.Plugin> pluginClassUnderTest = org.elasticsearch.gradle.internal.BuildPlugin
 
-    
+
     @Shared
     @ClassRule
     public LocalRepositoryFixture repository = new LocalRepositoryFixture()
@@ -56,6 +56,7 @@ class BuildPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
         THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripIndent()
 
     def setup() {
+        // checkstyle task references LegacyConfiguration class. Revisit after checkstyle update
         configurationCacheCompatible = false
         // elasticsearch.build (BuildPlugin) and elasticsearch.global-build-info are applied by
         // AbstractGradleInternalPluginFuncTest; we only add the java plugin and project config here.

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
@@ -17,7 +17,6 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleInternalPluginFun
 
     Class<? extends org.gradle.api.Plugin> pluginClassUnderTest = org.elasticsearch.gradle.internal.ElasticsearchJavadocPlugin
 
-    
     @Unroll
     def "#versionType created javadoc with inter project linking"() {
         given:

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -50,51 +50,39 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
     }
 
     def "builds distribution from branches via archives extractedAssemble"() {
-        given:
-        buildFile.text = ""
-        internalBuild()
-        buildFile << """
-            apply plugin: 'elasticsearch.internal-distribution-bwc-setup'
-        """
+        // A single BWC branch is sufficient to verify that buildBwcDarwinTar triggers
+        // extractedAssemble — the plugin logic is identical for all supported branches.
         when:
-        def result = gradleRunner(":distribution:bwc:${bwcProject}:buildBwcDarwinTar",
-                ":distribution:bwc:${bwcProject}:buildBwcDarwinTar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dbwc.dist.version=${bwcDistVersion}-SNAPSHOT")
-                .build()
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcDarwinTar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dbwc.dist.version=8.4.0-SNAPSHOT"
+        )
+            .build()
         then:
-        result.task(":distribution:bwc:${bwcProject}:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
+        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
 
         and: "assemble task triggered"
-        assertOutputContains(result.output, "[$bwcDistVersion] > Task :distribution:archives:darwin-tar:${expectedAssembleTaskName}")
-
-        where:
-        bwcDistVersion | bwcProject | expectedAssembleTaskName
-        "8.4.0"        | "major1"   | "extractedAssemble"
-        "8.3.0"        | "major2"   | "extractedAssemble"
-        "8.2.1"        | "major3"   | "extractedAssemble"
-        "8.1.3"        | "major4"   | "extractedAssemble"
+        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
     }
 
-    @Unroll
-    def "supports #platform aarch distributions"() {
+    def "supports linux aarch distributions"() {
+        // One aarch64 platform is sufficient to verify the feature; the same plugin
+        // logic handles both darwin and linux aarch64 targets.
         when:
-        def result = gradleRunner(":distribution:bwc:major1:buildBwc${platform.capitalize()}Aarch64Tar",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin",
-                "-Dbwc.dist.version=${bwcDistVersion}-SNAPSHOT")
-                .build()
+        def result = gradleRunner(
+            ":distribution:bwc:major1:buildBwcLinuxAarch64Tar",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin",
+            "-Dbwc.dist.version=8.4.0-SNAPSHOT"
+        )
+            .build()
         then:
-        result.task(":distribution:bwc:major1:buildBwc${platform.capitalize()}Aarch64Tar").outcome == TaskOutcome.SUCCESS
+        result.task(":distribution:bwc:major1:buildBwcLinuxAarch64Tar").outcome == TaskOutcome.SUCCESS
 
         and: "assemble tasks triggered"
-        assertOutputContains(result.output, "[$bwcDistVersion] > Task :distribution:archives:${platform}-aarch64-tar:extractedAssemble")
-
-        where:
-        bwcDistVersion | platform
-        "8.4.0"       | "darwin"
-        "8.4.0"       | "linux"
+        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:linux-aarch64-tar:extractedAssemble")
     }
 
     def "downloads distribution from DRA snapshot when mode=dra and hash override is set"() {
@@ -127,9 +115,11 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         result.output.contains("DRA snapshot ${buildId}")
 
         and: "the distribution directory was created at the expected path"
-        file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
-            "distribution/archives/darwin-tar/build/install/" +
-            "elasticsearch-${bwcVersion}-SNAPSHOT").exists()
+        file(
+            "cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+                "distribution/archives/darwin-tar/build/install/" +
+                "elasticsearch-${bwcVersion}-SNAPSHOT"
+        ).exists()
     }
 
     def "resolveByLatest falls back to origin remote when configured remote ref is absent (CI scenario)"() {
@@ -203,23 +193,11 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         result.output.contains("DRA snapshot ${buildId}")
 
         and: "the JDBC jar was created at the expected path"
-        file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
-            "x-pack/plugin/sql/jdbc/build/distributions/" +
-            "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar").exists()
-    }
-
-    def "builds from source when mode is gradle (default)"() {
-        when:
-        def result = gradleRunner(":distribution:bwc:major1:buildBwcDarwinTar",
-            "-DtestRemoteRepo=" + remoteGitRepo,
-            "-Dbwc.remote=origin",
-            "-Dbwc.dist.version=8.4.0-SNAPSHOT")
-            .build()
-        then:
-        result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
-
-        and: "local nested build was triggered"
-        assertOutputContains(result.output, "[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
+        file(
+            "cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+                "x-pack/plugin/sql/jdbc/build/distributions/" +
+                "x-pack-sql-jdbc-${bwcVersion}-SNAPSHOT.jar"
+        ).exists()
     }
 
     def "falls back to local gradle build when DRA manifest returns 404"() {
@@ -351,9 +329,11 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         result.output.contains("DRA snapshot ${buildId}")
 
         and: "the distribution directory was created at the expected path"
-        file("cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
-            "distribution/archives/darwin-tar/build/install/" +
-            "elasticsearch-${bwcVersion}-SNAPSHOT").exists()
+        file(
+            "cloned/distribution/bwc/major1/build/bwc/checkout-${bwcBranch}/" +
+                "distribution/archives/darwin-tar/build/install/" +
+                "elasticsearch-${bwcVersion}-SNAPSHOT"
+        ).exists()
     }
 
     def "falls back to source build with warning when mode=dra but DRA snapshot is unavailable (distribution archive)"() {
@@ -406,19 +386,25 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
         }
         """
         when:
-        def result = gradleRunner(":resolveExpandedDistribution",
-                "-DtestRemoteRepo=" + remoteGitRepo,
-                "-Dbwc.remote=origin")
-                .build()
+        def result = gradleRunner(
+            ":resolveExpandedDistribution",
+            "-DtestRemoteRepo=" + remoteGitRepo,
+            "-Dbwc.remote=origin"
+        )
+            .build()
         then:
         result.task(":resolveExpandedDistribution").outcome == TaskOutcome.SUCCESS
         result.task(":distribution:bwc:major1:buildBwcDarwinTar").outcome == TaskOutcome.SUCCESS
         and: "assemble task triggered"
         result.output.contains("[8.4.0] > Task :distribution:archives:darwin-tar:extractedAssemble")
-        result.output.contains("expandedRootPath /distribution/bwc/major1/build/bwc/checkout-8.x/" +
-                        "distribution/archives/darwin-tar/build/install")
-        result.output.contains("nested folder /distribution/bwc/major1/build/bwc/checkout-8.x/" +
-                        "distribution/archives/darwin-tar/build/install/elasticsearch-8.4.0-SNAPSHOT")
+        result.output.contains(
+            "expandedRootPath /distribution/bwc/major1/build/bwc/checkout-8.x/" +
+                "distribution/archives/darwin-tar/build/install"
+        )
+        result.output.contains(
+            "nested folder /distribution/bwc/major1/build/bwc/checkout-8.x/" +
+                "distribution/archives/darwin-tar/build/install/elasticsearch-8.4.0-SNAPSHOT"
+        )
     }
 
     // -------------------------------------------------------------------------
@@ -472,9 +458,13 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
     /** Stubs HEAD+GET for a manifest path, returning HTTP 200 with the given commit hash in the body. */
     private static void stubManifestWithCommit(WireMockServer wireMock, String path, String commitHash) {
         wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
-        wireMock.stubFor(get(urlEqualTo(path))
-            .willReturn(aResponse().withStatus(200)
-                .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${commitHash}"}}}""")))
+        wireMock.stubFor(
+            get(urlEqualTo(path))
+                .willReturn(
+                    aResponse().withStatus(200)
+                        .withBody("""{"projects": {"elasticsearch": {"commit_hash": "${commitHash}"}}}""")
+                )
+        )
     }
 
     /** Stubs HEAD+GET for a manifest path to return HTTP 404, triggering source-build fallback. */
@@ -485,22 +475,28 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
 
     /** Stubs GET for the DRA "latest" endpoint, returning a JSON body with the given build ID. */
     private static void stubLatest(WireMockServer wireMock, String path, String buildId) {
-        wireMock.stubFor(get(urlEqualTo(path))
-            .willReturn(aResponse().withStatus(200).withBody("""{"build_id": "${buildId}"}""")))
+        wireMock.stubFor(
+            get(urlEqualTo(path))
+                .willReturn(aResponse().withStatus(200).withBody("""{"build_id": "${buildId}"}"""))
+        )
     }
 
     /** Stubs HEAD+GET for a distribution tar.gz artifact path, serving a minimal extractable archive. */
     private static void stubTarArtifact(WireMockServer wireMock, String path, String bwcVersion) {
         wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
-        wireMock.stubFor(get(urlEqualTo(path))
-            .willReturn(aResponse().withStatus(200).withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT"))))
+        wireMock.stubFor(
+            get(urlEqualTo(path))
+                .willReturn(aResponse().withStatus(200).withBody(minimalElasticsearchTarGz("${bwcVersion}-SNAPSHOT")))
+        )
     }
 
     /** Stubs HEAD+GET for a Maven JAR artifact path, serving a minimal fake JAR body. */
     private static void stubJarArtifact(WireMockServer wireMock, String path, byte[] content = "fake-jar-content".bytes) {
         wireMock.stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200)))
-        wireMock.stubFor(get(urlEqualTo(path))
-            .willReturn(aResponse().withStatus(200).withBody(content)))
+        wireMock.stubFor(
+            get(urlEqualTo(path))
+                .willReturn(aResponse().withStatus(200).withBody(content))
+        )
     }
 
     // -------------------------------------------------------------------------

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -13,9 +13,13 @@ import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.TempDir
 
 
 class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
+
+    @TempDir
+    File gradleUserHome
 
     def "resolves current version from local build"() {
         given:

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.gradle.internal
 
+import spock.lang.TempDir
 import spock.lang.Unroll
 import com.github.tomakehurst.wiremock.WireMockServer
 
@@ -28,6 +29,9 @@ import static org.elasticsearch.gradle.internal.JdkDownloadPlugin.*
 class JdkDownloadPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
 
     Class<? extends org.gradle.api.Plugin> pluginClassUnderTest = JdkDownloadPlugin
+
+    @TempDir
+    File gradleUserHome
 
     
     private static final String OPENJDK_VERSION_OLD = "1+99"

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -24,8 +24,6 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
     def setup() {
         // required for JarHell to work
         subProject(":libs:core") << "apply plugin:'java'"
-
-        configurationCacheCompatible = false
     }
 
     def "project with plugin applied is considered for maven central publication"() {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginFuncTest.groovy
@@ -16,7 +16,6 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
 
     Class<? extends org.gradle.api.Plugin> pluginClassUnderTest = org.elasticsearch.gradle.internal.StringTemplatePlugin
 
-    
     def setup() {
         configureBwcVersions()
     }
@@ -54,7 +53,7 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         """
 
         when:
-        def result = gradleRunner("stringTemplates", '-g', gradleUserHome).build()
+        def result = gradleRunner("stringTemplates").build()
 
         then:
         result.task(":stringTemplates").outcome == TaskOutcome.SUCCESS
@@ -103,7 +102,7 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         """
 
         when:
-        def result = gradleRunner("stringTemplates", '-g', gradleUserHome).build()
+        def result = gradleRunner("stringTemplates").build()
 
         then:
         result.task(":stringTemplates").outcome == TaskOutcome.SUCCESS
@@ -138,7 +137,7 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         """
 
         when:
-        def result = gradleRunner("stringTemplates", '-g', gradleUserHome).build()
+        def result = gradleRunner("stringTemplates").build()
 
         then:
         result.task(":stringTemplates").outcome == TaskOutcome.SUCCESS
@@ -173,7 +172,7 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         """
 
         when:
-        def result = gradleRunner("stringTemplates", '-g', gradleUserHome).build()
+        def result = gradleRunner("stringTemplates").build()
 
         then:
         result.task(":stringTemplates").outcome == TaskOutcome.SUCCESS
@@ -208,7 +207,7 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         """
 
         when:
-        def result = gradleRunner("stringTemplates", '-g', gradleUserHome).build()
+        def result = gradleRunner("stringTemplates").build()
 
         then:
         result.task(":stringTemplates").outcome == TaskOutcome.SUCCESS
@@ -235,7 +234,7 @@ class StringTemplatePluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         """
 
         when:
-        def result = gradleRunner("stringTemplates", '-g', gradleUserHome).build()
+        def result = gradleRunner("stringTemplates").build()
 
         then:
         result.task(":stringTemplates").outcome == TaskOutcome.SUCCESS

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/archunit/IntegTestCoverageArchUnitSpec.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/archunit/IntegTestCoverageArchUnitSpec.groovy
@@ -55,7 +55,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
  * the integTest classpath, so a filesystem scan is the simplest self-contained way to index it.
  * No extra build wiring is required: everything needed lives under {@code src/integTest}.
  */
-class TestCoverageArchUnitSpec extends Specification {
+class IntegTestCoverageArchUnitSpec extends Specification {
 
     /** Test class name suffixes accepted as coverage for a task. */
     private static final List<String> TEST_SUFFIXES = ["Tests", "Test", "Spec", "FuncTest", "IT"]

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
@@ -109,7 +109,6 @@ class AbstractTransportVersionFuncTest extends AbstractGradleFuncTest {
     }
 
     def setup() {
-        configurationCacheCompatible = false
         internalBuild()
         settingsFile << """
             include ':myserver'

--- a/build-tools-internal/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/gradle.properties
+++ b/build-tools-internal/src/integTest/resources/org/elasticsearch/gradle/internal/fake_git/remote/gradle.properties
@@ -12,4 +12,4 @@
 systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # java homes resolved by environment variables
-org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSource.java
@@ -137,7 +137,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
         }
     }
 
-    private static String resolveByHash(HttpClient client, String baseUrl, String version, String hash) throws Exception {
+    static String resolveByHash(HttpClient client, String baseUrl, String version, String hash) throws Exception {
         String buildId = version + "-" + hash;
         String manifestUrl = baseUrl + "/elasticsearch/" + buildId + "/manifest-" + version + "-SNAPSHOT.json";
         HttpResponse<String> response = client.send(
@@ -151,7 +151,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
      * Fetches the latest DRA snapshot build ID for {@code branch} without comparing commit hashes.
      * Used for {@code dra} mode where the caller always wants the newest pre-built snapshot.
      */
-    private static String resolveLatestBuildId(HttpClient client, ObjectMapper mapper, String baseUrl, String version, String branch)
+    static String resolveLatestBuildId(HttpClient client, ObjectMapper mapper, String baseUrl, String version, String branch)
         throws Exception {
         String latestUrl = baseUrl + "/elasticsearch/latest/" + branch + ".json";
         HttpResponse<String> latestResponse = client.send(
@@ -179,7 +179,7 @@ public abstract class DraSnapshotBuildIdValueSource implements ValueSource<Strin
      * {@code auto} mode so that a stale snapshot does not silently replace a newer
      * local build.
      */
-    private static String resolveByLatest(
+    static String resolveByLatest(
         HttpClient client,
         ObjectMapper mapper,
         String baseUrl,

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSourceSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/DraSnapshotBuildIdValueSourceSpec.groovy
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sun.net.httpserver.HttpServer
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.http.HttpClient
+
+/**
+ * Unit tests for the HTTP resolution helpers in {@link DraSnapshotBuildIdValueSource}.
+ *
+ * <p>Each method under test is package-private and takes an {@link HttpClient} as its first
+ * argument, so we can point it at a lightweight in-process {@link HttpServer} without
+ * WireMock or any other external dependency.  Git remote-tracking refs are supplied by
+ * writing plain files under a temporary {@code .git/refs/remotes/} directory.
+ *
+ * <p>The mode-dispatch logic in {@code obtain()} and the full Gradle task wiring are
+ * covered by {@code InternalDistributionBwcSetupPluginFuncTest}.
+ */
+class DraSnapshotBuildIdValueSourceSpec extends Specification {
+
+    @TempDir
+    File repoDir
+
+    private HttpServer server
+    private HttpClient httpClient
+    private ObjectMapper mapper
+    private String baseUrl
+
+    def setup() {
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0)
+        server.start()
+        baseUrl = "http://${server.address.address.hostAddress}:${server.address.port}"
+        httpClient = HttpClient.newHttpClient()
+        mapper = new ObjectMapper()
+        // Minimal .git directory so GitInfo.remoteRefRevision() recognises repoDir as a git repo.
+        new File(repoDir, ".git").mkdir()
+    }
+
+    def cleanup() {
+        server?.stop(0)
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveByHash
+    // -------------------------------------------------------------------------
+
+    def "resolveByHash returns build ID when manifest endpoint returns 200"() {
+        given:
+        stubGet("/elasticsearch/8.4.0-abc12345/manifest-8.4.0-SNAPSHOT.json", 200, "{}")
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByHash(httpClient, baseUrl, "8.4.0", "abc12345") == "8.4.0-abc12345"
+    }
+
+    def "resolveByHash returns empty string when manifest endpoint returns 404"() {
+        given:
+        stubGet("/elasticsearch/8.4.0-notfound/manifest-8.4.0-SNAPSHOT.json", 404, null)
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByHash(httpClient, baseUrl, "8.4.0", "notfound") == ""
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveLatestBuildId
+    // -------------------------------------------------------------------------
+
+    def "resolveLatestBuildId returns build ID for a valid latest response"() {
+        given:
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "8.4.0-abc12345"}')
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveLatestBuildId(httpClient, mapper, baseUrl, "8.4.0", "8.x") == "8.4.0-abc12345"
+    }
+
+    def "resolveLatestBuildId returns empty string when latest endpoint returns 404"() {
+        given:
+        stubGet("/elasticsearch/latest/8.x.json", 404, null)
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveLatestBuildId(httpClient, mapper, baseUrl, "8.4.0", "8.x") == ""
+    }
+
+    def "resolveLatestBuildId returns empty string when the build_id field is absent from the response"() {
+        given:
+        stubGet("/elasticsearch/latest/8.x.json", 200, "{}")
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveLatestBuildId(httpClient, mapper, baseUrl, "8.4.0", "8.x") == ""
+    }
+
+    def "resolveLatestBuildId returns empty string when build_id version prefix does not match the requested version"() {
+        given:
+        // DRA returned a build for a different branch — version guard must reject it.
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "9.0.0-abc12345"}')
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveLatestBuildId(httpClient, mapper, baseUrl, "8.4.0", "8.x") == ""
+    }
+
+    def "resolveLatestBuildId returns empty string when build_id contains no dash (malformed)"() {
+        given:
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "malformed"}')
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveLatestBuildId(httpClient, mapper, baseUrl, "8.4.0", "8.x") == ""
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveByLatest
+    // -------------------------------------------------------------------------
+
+    def "resolveByLatest returns build ID when local ref and DRA manifest commit match"() {
+        given:
+        def hash = "a" * 40
+        writeRemoteRef("origin", "8.x", hash)
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "8.4.0-abc12345"}')
+        stubGet("/elasticsearch/8.4.0-abc12345/manifest-8.4.0-SNAPSHOT.json", 200,
+            """{"projects": {"elasticsearch": {"commit_hash": "${hash}"}}}""")
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByLatest(
+            httpClient, mapper, baseUrl, "8.4.0", "8.x", repoDir, "elastic"
+        ) == "8.4.0-abc12345"
+    }
+
+    def "resolveByLatest returns empty string when DRA commit hash differs from local ref"() {
+        given:
+        writeRemoteRef("origin", "8.x", "a" * 40)
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "8.4.0-abc12345"}')
+        stubGet("/elasticsearch/8.4.0-abc12345/manifest-8.4.0-SNAPSHOT.json", 200,
+            """{"projects": {"elasticsearch": {"commit_hash": "${"b" * 40}"}}}""")
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByLatest(
+            httpClient, mapper, baseUrl, "8.4.0", "8.x", repoDir, "elastic"
+        ) == ""
+    }
+
+    def "resolveByLatest returns empty string when no remote ref exists for either origin or the configured remote"() {
+        // No ref files written — remoteRefRevision returns null for both remotes.
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByLatest(
+            httpClient, mapper, baseUrl, "8.4.0", "8.x", repoDir, "elastic"
+        ) == ""
+    }
+
+    def "resolveByLatest falls back to origin ref when the configured remote has no ref for the branch"() {
+        given:
+        def hash = "c" * 40
+        writeRemoteRef("origin", "8.x", hash)   // only origin, not 'elastic'
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "8.4.0-abc12345"}')
+        stubGet("/elasticsearch/8.4.0-abc12345/manifest-8.4.0-SNAPSHOT.json", 200,
+            """{"projects": {"elasticsearch": {"commit_hash": "${hash}"}}}""")
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByLatest(
+            httpClient, mapper, baseUrl, "8.4.0", "8.x", repoDir, "elastic"
+        ) == "8.4.0-abc12345"
+    }
+
+    def "resolveByLatest returns empty string when manifest endpoint returns 404"() {
+        given:
+        writeRemoteRef("origin", "8.x", "d" * 40)
+        stubGet("/elasticsearch/latest/8.x.json", 200, '{"build_id": "8.4.0-abc12345"}')
+        stubGet("/elasticsearch/8.4.0-abc12345/manifest-8.4.0-SNAPSHOT.json", 404, null)
+
+        expect:
+        DraSnapshotBuildIdValueSource.resolveByLatest(
+            httpClient, mapper, baseUrl, "8.4.0", "8.x", repoDir, "elastic"
+        ) == ""
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void stubGet(String path, int status, String body) {
+        server.createContext(path) { exchange ->
+            if (body != null) {
+                byte[] bytes = body.getBytes("UTF-8")
+                exchange.sendResponseHeaders(status, bytes.length)
+                exchange.responseBody.withStream { it.write(bytes) }
+            } else {
+                exchange.sendResponseHeaders(status, -1)
+            }
+            exchange.close()
+        }
+    }
+
+    private void writeRemoteRef(String remote, String branch, String hash) {
+        File refFile = new File(repoDir, ".git/refs/remotes/${remote}/${branch}")
+        refFile.parentFile.mkdirs()
+        refFile.text = hash + "\n"
+    }
+}

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
@@ -11,11 +11,20 @@ package org.elasticsearch.gradle
 
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 import static org.elasticsearch.gradle.fixtures.DistributionDownloadFixture.withMockedDistributionDownload
 
 class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
+
+    @TempDir
+    File gradleUserHome
+
+    @Override
+    protected File customGradleUserHome() {
+        return gradleUserHome
+    }
 
     @Unroll
     def "extracted #distType version can be resolved"() {

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -10,6 +10,7 @@
 package org.elasticsearch.gradle
 
 import spock.lang.IgnoreIf
+import spock.lang.TempDir
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
 
@@ -25,6 +26,14 @@ import static org.elasticsearch.gradle.fixtures.JdkToolchainTestFixture.withMock
  * */
 @IgnoreIf({ os.isWindows() })
 class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
+
+    @TempDir
+    File gradleUserHome
+
+    @Override
+    protected File customGradleUserHome() {
+        return gradleUserHome
+    }
 
     def setup() {
         // TestClusterPlugin with adding task listeners is not cc compatible

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/GradleTestPolicySetupPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/GradleTestPolicySetupPluginFuncTest.groovy
@@ -11,8 +11,17 @@ package org.elasticsearch.gradle.test
 
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.TempDir
 
 class GradleTestPolicySetupPluginFuncTest extends AbstractGradleFuncTest {
+
+    @TempDir
+    File gradleUserHome
+
+    @Override
+    protected File customGradleUserHome() {
+        return gradleUserHome
+    }
 
     def "configures test tasks"() {
         given:

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -40,9 +40,6 @@ abstract class AbstractGradleFuncTest extends Specification {
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
-    @TempDir
-    File gradleUserHome
-
     File settingsFile
     File buildFile
     File propertiesFile
@@ -134,20 +131,34 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     GradleRunner gradleRunner(File projectDir, Object... arguments) {
+        def runner = GradleRunner.create()
+                .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
+                        .toString().indexOf("-agentlib:jdwp") > 0
+                )
+                .withProjectDir(projectDir)
+                .withPluginClasspath()
+                .forwardOutput()
+        File userHome = customGradleUserHome()
+        if (userHome != null) {
+            runner = runner.withTestKitDir(userHome)
+        }
         return new NormalizeOutputGradleRunner(
             new BuildConfigurationAwareGradleRunner(
-                    new InternalAwareGradleRunner(
-                        GradleRunner.create()
-                                .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
-                                        .toString().indexOf("-agentlib:jdwp") > 0
-                                )
-                                .withProjectDir(projectDir)
-                                .withPluginClasspath()
-                                .withTestKitDir(gradleUserHome)
-                                .forwardOutput()
-            ), configurationCacheCompatible,
-                buildApiRestrictionsDisabled)
+                    new InternalAwareGradleRunner(runner),
+                    configurationCacheCompatible,
+                    buildApiRestrictionsDisabled)
         ).withArguments(arguments.collect { it.toString() } + "--full-stacktrace")
+    }
+
+    /**
+     * Override to supply a custom Gradle user home directory for the TestKit runner.
+     * TestKit will set {@code GRADLE_USER_HOME} to this directory for every forked
+     * Gradle process, including any {@code ./gradlew} subprocesses spawned by build
+     * logic.  Returns {@code null} by default, letting TestKit manage its own
+     * temporary directory.
+     */
+    protected File customGradleUserHome() {
+        return null
     }
 
     def assertOutputContains(String givenOutput, String expected) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Gradle] Simplify build tool test setup (#152919)](https://github.com/elastic/elasticsearch/pull/152919)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)