### PR TITLE
[9.3] [CI] Increase Buildkite GCP disk size to 250 GB in PR and intake pipelines (#152860)

### DIFF
--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -6,6 +6,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - wait
   - label: build-logic
@@ -15,6 +16,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
@@ -23,6 +25,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart2
@@ -31,6 +34,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart3
@@ -39,6 +43,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart4
@@ -47,6 +52,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart5
@@ -55,6 +61,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part6
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart6
@@ -63,6 +70,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
 
   - group: bwc-snapshots
@@ -77,6 +85,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -99,6 +108,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
@@ -110,6 +120,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - wait
   - trigger: elasticsearch-dra-workflow

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -7,6 +7,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - wait
   - label: build-logic
@@ -16,6 +17,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
@@ -24,6 +26,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart2
@@ -32,6 +35,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart3
@@ -40,6 +44,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart4
@@ -48,6 +53,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart5
@@ -56,6 +62,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part6
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart6
@@ -64,6 +71,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
 
   - group: bwc-snapshots
@@ -78,6 +86,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -100,6 +109,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
@@ -111,6 +121,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - wait
   - trigger: elasticsearch-dra-workflow

--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -26,4 +26,5 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -20,6 +20,7 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
@@ -35,6 +36,7 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
@@ -50,6 +52,7 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
@@ -65,6 +68,7 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
@@ -80,6 +84,7 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
@@ -95,4 +100,5 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -12,4 +12,5 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -16,4 +16,5 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -13,6 +13,7 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-16
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -18,6 +18,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: n4-standard-8
           diskType: hyperdisk-balanced
+          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -11,6 +11,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -9,6 +9,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -11,6 +11,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -11,6 +11,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -9,6 +9,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -11,6 +11,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -9,6 +9,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -11,6 +11,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -9,6 +9,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-16
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-6-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips.yml
@@ -11,6 +11,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -8,6 +8,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-16
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -13,4 +13,5 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/rest-compatibility.yml
+++ b/.buildkite/pipelines/pull-request/rest-compatibility.yml
@@ -9,6 +9,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -9,4 +9,5 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
+      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -71,6 +71,7 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-16
           diskType: hyperdisk-balanced
+          diskSize: 250GB
           buildDirectory: /dev/shm/bk
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -37,6 +37,7 @@ steps:
             image: family/elasticsearch-ubuntu-2404
             machineType: n4-standard-16
             diskType: hyperdisk-balanced
+            diskSizeGb: 250
             buildDirectory: /dev/shm/bk
             preemptible: true
             spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Increase Buildkite GCP disk size to 250 GB in PR and intake pipelines (#152860)](https://github.com/elastic/elasticsearch/pull/152860)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)