### PR TITLE
ESQL: Chunk final time-series aggregation output

### DIFF
--- a/docs/changelog/152990.yaml
+++ b/docs/changelog/152990.yaml
@@ -1,0 +1,5 @@
+area: TSDB
+issues: []
+pr: 152990
+summary: Chunk final time-series aggregation output
+type: feature

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
 
 import java.util.function.IntConsumer;
 
@@ -27,8 +28,20 @@ public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends Grou
         return allGroupIds;
     }
 
+    /**
+     * Stores the full set of group IDs so window aggregators can reach every internal group during output filtering.
+     * The context takes its own reference to {@code allGroupIds} and releases it in {@link #close()}, so the caller may
+     * release its own reference independently.
+     */
     public void setAllGroupIds(IntVector allGroupIds) {
+        allGroupIds.incRef();
+        Releasables.close(this.allGroupIds);
         this.allGroupIds = allGroupIds;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(allGroupIds, super::close);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -548,11 +548,17 @@ public class HashAggregationOperator implements Operator {
     }
 
     /**
-     * Target number of rows per emitted output page. Subclasses that build their own output iterator use this to slice a
-     * large result into multiple pages, matching the chunking the base operator applies on its own emit path.
+     * Selects which group ids ("keys") to emit, given the full set of non-empty groups. The default emits every group.
+     * Subclasses can override to emit a subset: the time-series operator emits only the groups aligned to the output
+     * time bucket, while still exposing the full group set to window aggregators through the evaluation context.
+     * <p>
+     * The returned vector is owned by the caller. {@code allKeys} remains owned by the caller and is released right after
+     * this method returns, so an implementation that needs to retain it (e.g. by stashing it in {@code ctx}) must
+     * increment its reference count.
      */
-    protected int maxPageSize() {
-        return maxPageSize;
+    protected IntVector selectedKeysForEmit(GroupingAggregatorEvaluationContext ctx, IntVector allKeys) {
+        allKeys.incRef();
+        return allKeys;
     }
 
     protected boolean shouldEmitPartialResultsPeriodically() {
@@ -886,7 +892,9 @@ public class HashAggregationOperator implements Operator {
                             .selectTopN(allKeys, topAggregation.limit(), topAggregation.asc());
                     }
                 } else {
-                    keys = blockHash.nonEmpty();
+                    try (var allKeys = blockHash.nonEmpty()) {
+                        keys = selectedKeysForEmit(ctx, allKeys);
+                    }
                 }
                 selected = new Selected(keys, new IntVector[count]);
                 for (int a = 0; a < count; a++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -547,6 +547,14 @@ public class HashAggregationOperator implements Operator {
         return selected;
     }
 
+    /**
+     * Target number of rows per emitted output page. Subclasses that build their own output iterator use this to slice a
+     * large result into multiple pages, matching the chunking the base operator applies on its own emit path.
+     */
+    protected int maxPageSize() {
+        return maxPageSize;
+    }
+
     protected boolean shouldEmitPartialResultsPeriodically() {
         if (aggregatorMode.isOutputPartial() == false) {
             return false;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -23,18 +23,14 @@ import org.elasticsearch.compute.aggregation.TimeSeriesGroupingAggregatorEvaluat
 import org.elasticsearch.compute.aggregation.WindowGroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.TimeSeriesBlockHash;
-import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -163,126 +159,30 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         super.finish();
     }
 
+    /**
+     * On the output-filtered (sub-bucketed) final/SINGLE path, emit only the groups whose timestamp aligns to an output
+     * bucket boundary, and stash the full group set on the evaluation context so window aggregators can still reach every
+     * internal group through {@link TimeSeriesGroupingAggregatorEvaluationContext#allGroupIds()}. The base operator then
+     * slices this reduced selection into pages, so the sub-bucketed path is chunked the same way as the non-filtered path.
+     */
     @Override
-    protected void emit() {
-        if (rowsAddedInCurrentBatch == 0) {
-            return;
-        }
+    protected IntVector selectedKeysForEmit(GroupingAggregatorEvaluationContext ctx, IntVector allKeys) {
         if (needsOutputFiltering() == false) {
-            super.emit();
-            return;
+            return super.selectedKeysForEmit(ctx, allKeys);
         }
         TimeSeriesBlockHash tsBlockHash = (TimeSeriesBlockHash) blockHash;
         int[] outputPositions = computeOutputAlignedPositions(tsBlockHash);
         if (outputPositions == null) {
-            super.emit();
-            return;
+            return super.selectedKeysForEmit(ctx, allKeys);
         }
-        long startInNanos = System.nanoTime();
-        try {
-            output = new OutputFilteredResult(outputPositions);
-        } finally {
-            rowsAddedInCurrentBatch = 0;
-            emitNanos += System.nanoTime() - startInNanos;
-            emitCount++;
+        if (ctx instanceof TimeSeriesGroupingAggregatorEvaluationContext tsCtx) {
+            tsCtx.setAllGroupIds(allKeys);
         }
-    }
-
-    /**
-     * Multi-page output for the output-filtered (sub-bucketed) final/SINGLE path. Each aggregator is prepared once over
-     * the full output-aligned selection so that window aggregators can still see every internal group through
-     * {@link TimeSeriesGroupingAggregatorEvaluationContext#allGroupIds()}; the selection is then sliced into pages of about
-     * {@link #maxPageSize()} rows, emitting one page per slice. This bounds the coordinator's peak memory the same way the
-     * generic {@link HashAggregationOperator} chunking does for the non-filtered path (before this the whole result was
-     * built as a single, potentially jumbo, page).
-     */
-    private final class OutputFilteredResult implements ReleasableIterator<Page> {
-        private final GroupingAggregatorEvaluationContext ctx;
-        // The full set of internal groups; kept for the window aggregators via ctx#allGroupIds and closed here (not owned
-        // by ctx, matching the previous emit path).
-        private final IntVector allSelected;
-        private final IntVector outputSelected;
-        private final IntVector[] aggsSelected;
-        private final List<GroupingAggregatorFunction.PreparedForEvaluation> preparedAggregators;
-        private final int[] aggBlockCounts;
-        private int rowOffset = 0;
-
-        OutputFilteredResult(int[] outputPositions) {
-            this.aggBlockCounts = aggregators.stream().mapToInt(GroupingAggregator::evaluateBlockCount).toArray();
-            final int count = aggregators.size();
-            GroupingAggregatorEvaluationContext ctx = null;
-            IntVector allSelected = null;
-            IntVector outputSelected = null;
-            IntVector[] aggsSelected = new IntVector[count];
-            List<GroupingAggregatorFunction.PreparedForEvaluation> prepared = new ArrayList<>(count);
-            boolean success = false;
-            try {
-                allSelected = blockHash.nonEmpty();
-                try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(outputPositions.length)) {
-                    for (int i = 0; i < outputPositions.length; i++) {
-                        builder.appendInt(i, outputPositions[i]);
-                    }
-                    outputSelected = builder.build();
-                }
-                ctx = evaluationContext(blockHash);
-                if (ctx instanceof TimeSeriesGroupingAggregatorEvaluationContext tsCtx) {
-                    tsCtx.setAllGroupIds(allSelected);
-                }
-                for (int i = 0; i < count; i++) {
-                    aggsSelected[i] = customizeSelected(aggregators.get(i), outputSelected);
-                    prepared.add(aggregators.get(i).prepareForEvaluate(aggsSelected[i], ctx));
-                }
-                success = true;
-            } finally {
-                if (success == false) {
-                    Releasables.close(ctx, allSelected, outputSelected, Releasables.wrap(aggsSelected), Releasables.wrap(prepared));
-                }
+        try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(outputPositions.length)) {
+            for (int i = 0; i < outputPositions.length; i++) {
+                builder.appendInt(i, outputPositions[i]);
             }
-            this.ctx = ctx;
-            this.allSelected = allSelected;
-            this.outputSelected = outputSelected;
-            this.aggsSelected = aggsSelected;
-            this.preparedAggregators = prepared;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return rowOffset < outputSelected.getPositionCount();
-        }
-
-        @Override
-        public Page next() {
-            long startInNanos = System.nanoTime();
-            int endOffset = Math.min(maxPageSize() + rowOffset, outputSelected.getPositionCount());
-            try (IntVector keySlice = outputSelected.slice(rowOffset, endOffset)) {
-                Block[] keys = blockHash.getKeys(keySlice);
-                Block[] blocks = new Block[keys.length + Arrays.stream(aggBlockCounts).sum()];
-                System.arraycopy(keys, 0, blocks, 0, keys.length);
-                try {
-                    int offset = keys.length;
-                    for (int i = 0; i < preparedAggregators.size(); i++) {
-                        try (IntVector aggSlice = aggsSelected[i].slice(rowOffset, endOffset)) {
-                            preparedAggregators.get(i).evaluate(blocks, offset, aggSlice);
-                        }
-                        offset += aggBlockCounts[i];
-                    }
-                    Page page = new Page(blocks);
-                    blocks = null;
-                    rowOffset = endOffset;
-                    return page;
-                } finally {
-                    if (blocks != null) {
-                        Releasables.closeExpectNoException(blocks);
-                    }
-                }
-            } finally {
-                emitNanos += System.nanoTime() - startInNanos;
-            }
-        }
-
-        @Override
-        public void close() {
-            Releasables.close(ctx, allSelected, outputSelected, Releasables.wrap(aggsSelected), Releasables.wrap(preparedAggregators));
+            return builder.build();
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -34,6 +34,7 @@ import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -48,17 +49,19 @@ import static java.util.stream.Collectors.joining;
 public class TimeSeriesAggregationOperator extends HashAggregationOperator {
 
     /**
-     * Default target rows per output page when chunking partial/intermediate output, i.e. the default of the
-     * {@code esql.time_series.target_chunk_rows} setting. In partial/intermediate mode the operator slices its single
-     * emitted result into pages of about this many rows, bounding the size of each page sent to the coordinator. A
-     * {@code _tsid} may straddle a page boundary; the coordinator re-merges groups by key.
+     * Default target rows per output page when chunking the operator's output, i.e. the default of the
+     * {@code esql.time_series.target_chunk_rows} setting. The operator slices its single emitted result into pages of
+     * about this many rows, bounding the size of each page. The same target applies to both partial/intermediate output
+     * (bounding pages sent to the coordinator) and final output (bounding the coordinator's peak memory during final
+     * evaluation and the page sizes handed to downstream operators). A {@code _tsid} may straddle a page boundary; the
+     * coordinator re-merges groups by key.
      */
     public static final int DEFAULT_TARGET_CHUNK_ROWS = 100_000;
 
     /**
-     * @param targetChunkRows target number of rows per output page when chunking partial/intermediate output. The
-     *        operator slices its emitted result into pages of about this many rows. Only takes effect in
-     *        partial/intermediate mode; final output is not chunked here.
+     * @param targetChunkRows target number of rows per output page when chunking output. The operator slices its emitted
+     *        result into pages of about this many rows. The same target applies to both partial/intermediate and final
+     *        output.
      */
     public record Factory(
         Rounding.Prepared timeBucket,
@@ -96,9 +99,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
 
         @Override
         public Operator get(DriverContext driverContext) {
-            final boolean outputPartial = aggregatorMode.isOutputPartial();
-            final boolean outputFinal = outputPartial == false;
-            final int effectiveTargetChunkRows = outputPartial ? targetChunkRows : Integer.MAX_VALUE;
+            final boolean outputFinal = aggregatorMode.isOutputPartial() == false;
             return new TimeSeriesAggregationOperator(
                 timeBucket,
                 dateNanos ? DateFieldMapper.Resolution.NANOSECONDS : DateFieldMapper.Resolution.MILLISECONDS,
@@ -119,7 +120,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                     return BlockHash.build(groups, driverContext.blockFactory(), aggregationBatchSize, true);
                 },
                 outputTimeBucket,
-                effectiveTargetChunkRows,
+                targetChunkRows,
                 driverContext
             );
         }
@@ -177,72 +178,111 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             super.emit();
             return;
         }
-        Block[] blocks = null;
-        Block[] outputKeys = null;
-        IntVector allSelected = null;
-        IntVector outputSelected = null;
         long startInNanos = System.nanoTime();
-        boolean success = false;
-        boolean keysFiltered = false;
         try {
-            allSelected = blockHash.nonEmpty();
+            output = new OutputFilteredResult(outputPositions);
+        } finally {
+            rowsAddedInCurrentBatch = 0;
+            emitNanos += System.nanoTime() - startInNanos;
+            emitCount++;
+        }
+    }
 
-            Block[] fullKeys = blockHash.getKeys(allSelected);
-            outputKeys = new Block[fullKeys.length];
+    /**
+     * Multi-page output for the output-filtered (sub-bucketed) final/SINGLE path. Each aggregator is prepared once over
+     * the full output-aligned selection so that window aggregators can still see every internal group through
+     * {@link TimeSeriesGroupingAggregatorEvaluationContext#allGroupIds()}; the selection is then sliced into pages of about
+     * {@link #maxPageSize()} rows, emitting one page per slice. This bounds the coordinator's peak memory the same way the
+     * generic {@link HashAggregationOperator} chunking does for the non-filtered path (before this the whole result was
+     * built as a single, potentially jumbo, page).
+     */
+    private final class OutputFilteredResult implements ReleasableIterator<Page> {
+        private final GroupingAggregatorEvaluationContext ctx;
+        // The full set of internal groups; kept for the window aggregators via ctx#allGroupIds and closed here (not owned
+        // by ctx, matching the previous emit path).
+        private final IntVector allSelected;
+        private final IntVector outputSelected;
+        private final IntVector[] aggsSelected;
+        private final List<GroupingAggregatorFunction.PreparedForEvaluation> preparedAggregators;
+        private final int[] aggBlockCounts;
+        private int rowOffset = 0;
+
+        OutputFilteredResult(int[] outputPositions) {
+            this.aggBlockCounts = aggregators.stream().mapToInt(GroupingAggregator::evaluateBlockCount).toArray();
+            final int count = aggregators.size();
+            GroupingAggregatorEvaluationContext ctx = null;
+            IntVector allSelected = null;
+            IntVector outputSelected = null;
+            IntVector[] aggsSelected = new IntVector[count];
+            List<GroupingAggregatorFunction.PreparedForEvaluation> prepared = new ArrayList<>(count);
+            boolean success = false;
             try {
-                for (int b = 0; b < fullKeys.length; b++) {
-                    outputKeys[b] = fullKeys[b].filter(false, outputPositions);
+                allSelected = blockHash.nonEmpty();
+                try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(outputPositions.length)) {
+                    for (int i = 0; i < outputPositions.length; i++) {
+                        builder.appendInt(i, outputPositions[i]);
+                    }
+                    outputSelected = builder.build();
                 }
-                keysFiltered = true;
-            } finally {
-                Releasables.close(fullKeys);
-                if (keysFiltered == false) {
-                    Releasables.closeExpectNoException(outputKeys);
-                }
-            }
-
-            try (var builder = driverContext.blockFactory().newIntVectorFixedBuilder(outputPositions.length)) {
-                for (int i = 0; i < outputPositions.length; i++) {
-                    builder.appendInt(i, outputPositions[i]);
-                }
-                outputSelected = builder.build();
-            }
-
-            int[] aggBlockCounts = aggregators.stream().mapToInt(GroupingAggregator::evaluateBlockCount).toArray();
-            int keyBlockCount = outputKeys.length;
-            blocks = new Block[keyBlockCount + Arrays.stream(aggBlockCounts).sum()];
-            System.arraycopy(outputKeys, 0, blocks, 0, outputKeys.length);
-            outputKeys = null;
-            int offset = keyBlockCount;
-
-            try (var ctx = evaluationContext(blockHash)) {
+                ctx = evaluationContext(blockHash);
                 if (ctx instanceof TimeSeriesGroupingAggregatorEvaluationContext tsCtx) {
                     tsCtx.setAllGroupIds(allSelected);
                 }
-                for (int i = 0; i < aggregators.size(); i++) {
-                    try (
-                        var customizeSelected = customizeSelected(aggregators.get(i), outputSelected);
-                        var prepared = aggregators.get(i).prepareForEvaluate(customizeSelected, ctx)
-                    ) {
-                        prepared.evaluate(blocks, offset, customizeSelected);
-                    }
-                    offset += aggBlockCounts[i];
+                for (int i = 0; i < count; i++) {
+                    aggsSelected[i] = customizeSelected(aggregators.get(i), outputSelected);
+                    prepared.add(aggregators.get(i).prepareForEvaluate(aggsSelected[i], ctx));
                 }
-                output = ReleasableIterator.single(new Page(blocks));
                 success = true;
-            }
-        } finally {
-            rowsAddedInCurrentBatch = 0;
-            Releasables.close(allSelected, outputSelected);
-            if (success == false) {
-                if (blocks != null) {
-                    Releasables.closeExpectNoException(blocks);
-                } else if (keysFiltered) {
-                    Releasables.closeExpectNoException(outputKeys);
+            } finally {
+                if (success == false) {
+                    Releasables.close(ctx, allSelected, outputSelected, Releasables.wrap(aggsSelected), Releasables.wrap(prepared));
                 }
             }
-            emitNanos += System.nanoTime() - startInNanos;
-            emitCount++;
+            this.ctx = ctx;
+            this.allSelected = allSelected;
+            this.outputSelected = outputSelected;
+            this.aggsSelected = aggsSelected;
+            this.preparedAggregators = prepared;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return rowOffset < outputSelected.getPositionCount();
+        }
+
+        @Override
+        public Page next() {
+            long startInNanos = System.nanoTime();
+            int endOffset = Math.min(maxPageSize() + rowOffset, outputSelected.getPositionCount());
+            try (IntVector keySlice = outputSelected.slice(rowOffset, endOffset)) {
+                Block[] keys = blockHash.getKeys(keySlice);
+                Block[] blocks = new Block[keys.length + Arrays.stream(aggBlockCounts).sum()];
+                System.arraycopy(keys, 0, blocks, 0, keys.length);
+                try {
+                    int offset = keys.length;
+                    for (int i = 0; i < preparedAggregators.size(); i++) {
+                        try (IntVector aggSlice = aggsSelected[i].slice(rowOffset, endOffset)) {
+                            preparedAggregators.get(i).evaluate(blocks, offset, aggSlice);
+                        }
+                        offset += aggBlockCounts[i];
+                    }
+                    Page page = new Page(blocks);
+                    blocks = null;
+                    rowOffset = endOffset;
+                    return page;
+                } finally {
+                    if (blocks != null) {
+                        Releasables.closeExpectNoException(blocks);
+                    }
+                }
+            } finally {
+                emitNanos += System.nanoTime() - startInNanos;
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(ctx, allSelected, outputSelected, Releasables.wrap(aggsSelected), Releasables.wrap(preparedAggregators));
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -62,7 +62,6 @@ import static org.elasticsearch.compute.test.BlockTestUtils.append;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 
 /**
  * Shared tests for testing grouped aggregations.
@@ -351,6 +350,33 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
             simpleWithMode(AggregatorMode.FINAL)
         );
         assertSimpleOutput(runner.deepCopy(), results);
+    }
+
+    /**
+     * Forces output chunking through the whole {@code INITIAL -> INTERMEDIATE -> FINAL} pipeline by pinning
+     * {@code maxPageSize == 1}, so each stage's {@code evaluate()} is invoked once per single-group slice rather than
+     * once over all groups. This guards every aggregator against evaluators that assume a single evaluate call covering
+     * all groups and against page-local key building that only works for the full, in-order selection.
+     */
+    public final void testChunkedEvaluationAcrossModes() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        int end = between(50, 60);
+        runner.input(simpleInput(runner.blockFactory(), end));
+        List<Page> results = runner.run(
+            chunkedFactory(AggregatorMode.INITIAL),
+            chunkedFactory(AggregatorMode.INTERMEDIATE),
+            chunkedFactory(AggregatorMode.FINAL)
+        );
+        assertSimpleOutput(runner.deepCopy(), results);
+    }
+
+    private Operator.OperatorFactory chunkedFactory(AggregatorMode mode) {
+        return HashAggregationOperatorTests.randomBuilder()
+            .groups(List.of(new BlockHash.GroupSpec(0, ElementType.LONG)))
+            .mode(mode)
+            .aggregators(List.of(aggregatorFunction().groupingAggregatorFactory(mode, channels(mode))))
+            .maxPageSize(1)
+            .build();
     }
 
     private SourceOperator nullValues(SourceOperator source, BlockFactory blockFactory) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -2169,6 +2169,47 @@ public class BlockHashTests extends BlockHashTestCase {
         }
     }
 
+    /**
+     * Final mode uses {@code reverseOutput == true}: the output key order is swapped to (timestamp, tsid). A chunked
+     * page (a strict subset of groups) must build a correct page-local tsid dictionary and then apply the reverse swap,
+     * so the tsid ends up as the second key block, is ordinal-encoded, and its page-local dictionary holds each
+     * referenced tsid exactly once.
+     */
+    public void testTimeSeriesBlockHashReverseOutputChunkedPageDeduplicatesTsids() {
+        BytesRef tsidA = new BytesRef("id-a");
+        BytesRef tsidB = new BytesRef("id-b");
+        int pairs = 10;
+        try (var hash = new TimeSeriesBlockHash(0, 1, true, false, blockFactory)) {
+            // Interleave two tsids across single-row pages so the tsid ordinals alternate by group id (A, B, A, B, ...).
+            for (int t = 0; t < pairs; t++) {
+                addSingleTsidRow(hash, tsidA, t);
+                addSingleTsidRow(hash, tsidB, t);
+            }
+            int totalGroups = 2 * pairs;
+            int pageSize = totalGroups - 1; // a strict subset, so we take the chunked page-local dictionary path
+            Block[] keys = null;
+            try (IntVector selected = blockFactory.newIntRangeVector(0, pageSize)) {
+                keys = hash.getKeys(selected);
+                // reverseOutput swaps the key order to (timestamp, tsid): the tsid is now the second key block.
+                assertThat(keys.length, equalTo(2));
+                BytesRefBlock tsids = (BytesRefBlock) keys[1];
+                BytesRef scratch = new BytesRef();
+                for (int p = 0; p < pageSize; p++) {
+                    assertThat(tsids.getBytesRef(p, scratch), equalTo(p % 2 == 0 ? tsidA : tsidB));
+                }
+                OrdinalBytesRefBlock ordinals = tsids.asOrdinals();
+                assertNotNull("a dense page should be ordinal-encoded", ordinals);
+                assertThat(
+                    "page-local dictionary must hold each referenced tsid once",
+                    ordinals.getDictionaryVector().getPositionCount(),
+                    equalTo(2)
+                );
+            } finally {
+                Releasables.close(keys);
+            }
+        }
+    }
+
     private void addSingleTsidRow(TimeSeriesBlockHash hash, BytesRef tsid, long timestamp) {
         try (
             BytesRefVector.Builder tsidBuilder = blockFactory.newBytesRefVectorBuilder(1);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -589,13 +589,337 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
         }
     }
 
+    /**
+     * With the single {@code targetChunkRows} knob applied to final mode too, a FINAL aggregation whose selected group
+     * count exceeds the target must slice its output into multiple pages, each no larger than the target, and the
+     * concatenation of those pages must equal the result produced when the output is emitted as a single page. This
+     * bounds the coordinator's peak memory during final evaluation.
+     */
+    public void testFinalOutputIsChunkedIntoMultiplePages() {
+        int targetChunkRows = 5;
+        int groupsPerTsid = 4;
+        List<String> tsids = List.of("a", "b", "c", "d", "e");
+        List<List<Object>> rows = new ArrayList<>();
+        Map<String, Long> expected = new HashMap<>();
+        for (String tsid : tsids) {
+            for (int t = 0; t < groupsPerTsid; t++) {
+                rows.add(List.of(tsid, (long) t, 3)); // distinct timestamps => distinct groups; tsids * groupsPerTsid > targetChunkRows
+                expected.put(tsid + "/" + t, 3L);
+            }
+        }
+
+        List<Page> chunked = new ArrayList<>();
+        List<Page> single = new ArrayList<>();
+        try {
+            chunked.addAll(runInitialThenFinal(targetChunkRows, rows));
+            assertThat("final output larger than the chunk size must be chunked", chunked.size(), greaterThan(1));
+            for (Page page : chunked) {
+                assertThat("no final chunk exceeds targetChunkRows", page.getPositionCount(), lessThanOrEqualTo(targetChunkRows));
+            }
+
+            single.addAll(runInitialThenFinal(Integer.MAX_VALUE, rows));
+            assertThat("unchunked final output is a single page", single.size(), equalTo(1));
+
+            assertThat("chunked final output has the expected values", toValueMap(chunked), equalTo(expected));
+            assertThat("chunking does not change the final result", toValueMap(chunked), equalTo(toValueMap(single)));
+        } finally {
+            releasePages(chunked);
+            releasePages(single);
+        }
+    }
+
+    /**
+     * Final chunking must compose with window-bucket expansion. {@code expandWindowBuckets} materializes extra groups
+     * and {@code customizeSelected} remaps the VALUES-like aggregator's selection back to the source groups; chunking
+     * then slices that remapped selection. The chunked output must equal the single-page output, and every (expanded)
+     * group must keep its own tsid dimension.
+     */
+    public void testFinalChunkingWithWindowExpansion() {
+        Rounding.Prepared oneMinBucket = Rounding.builder(TimeValue.timeValueMinutes(1)).build().prepareForUnknown();
+        Duration windowDuration = Duration.ofMinutes(7);
+        List<List<Object>> rows = sparseWindowRows();
+
+        List<Page> chunked = new ArrayList<>();
+        List<Page> single = new ArrayList<>();
+        try {
+            chunked.addAll(runWindowedSingle(7, oneMinBucket, windowSumAndValues(windowDuration), rows));
+            assertThat("window-expanded output larger than the chunk size must be chunked", chunked.size(), greaterThan(1));
+            for (Page page : chunked) {
+                assertThat("no chunk exceeds targetChunkRows", page.getPositionCount(), lessThanOrEqualTo(7));
+            }
+
+            single.addAll(runWindowedSingle(Integer.MAX_VALUE, oneMinBucket, windowSumAndValues(windowDuration), rows));
+            assertThat("unchunked output is a single page", single.size(), equalTo(1));
+
+            List<WindowedRow> chunkedRows = extractWindowedRows(chunked);
+            assertThat("chunking preserves the window-expanded result", asMap(chunkedRows), equalTo(asMap(extractWindowedRows(single))));
+            for (WindowedRow row : chunkedRows) {
+                assertThat("each expanded group keeps its own tsid dimension across chunks", row.dimension(), equalTo(row.tsid()));
+            }
+        } finally {
+            releasePages(chunked);
+            releasePages(single);
+        }
+    }
+
+    /**
+     * When window expansion is active the VALUES-like aggregator receives a selection that repeats/reorders group ids
+     * (expanded groups remapped to their source group). Combined with chunking, {@link DimensionValuesByteRefGroupingAggregatorFunction}'s
+     * {@code incRef} identity fast path must not fire for a partial slice, so each chunk copies the correct dimension
+     * for every position.
+     */
+    public void testFinalChunkingWithReorderedSelection() {
+        Rounding.Prepared oneMinBucket = Rounding.builder(TimeValue.timeValueMinutes(1)).build().prepareForUnknown();
+        Duration windowDuration = Duration.ofMinutes(7);
+        List<List<Object>> rows = sparseWindowRows();
+
+        List<Page> chunked = new ArrayList<>();
+        List<Page> single = new ArrayList<>();
+        try {
+            chunked.addAll(runWindowedSingle(7, oneMinBucket, windowSumAndDimensionValues(windowDuration), rows));
+            assertThat("window-expanded output larger than the chunk size must be chunked", chunked.size(), greaterThan(1));
+            for (Page page : chunked) {
+                assertThat("no chunk exceeds targetChunkRows", page.getPositionCount(), lessThanOrEqualTo(7));
+            }
+
+            single.addAll(runWindowedSingle(Integer.MAX_VALUE, oneMinBucket, windowSumAndDimensionValues(windowDuration), rows));
+            assertThat("unchunked output is a single page", single.size(), equalTo(1));
+
+            List<WindowedRow> chunkedRows = extractWindowedRows(chunked);
+            assertThat(
+                "chunking preserves DimensionValues over the remapped selection",
+                asMap(chunkedRows),
+                equalTo(asMap(extractWindowedRows(single)))
+            );
+            for (WindowedRow row : chunkedRows) {
+                assertThat(
+                    "expanded/remapped group keeps its own tsid, so the incRef fast path must not leak across chunks",
+                    row.dimension(),
+                    equalTo(row.tsid())
+                );
+            }
+        } finally {
+            releasePages(chunked);
+            releasePages(single);
+        }
+    }
+
+    /**
+     * The output-filtered emit path (sub-bucketing: {@code outputTimeBucket} coarser than the internal bucket, with a
+     * window aggregator) previously built the whole result as a single page, ignoring {@code targetChunkRows}. It now
+     * slices that output-aligned selection into pages. Verify the chunked output is split into multiple pages and equals
+     * the single-page result.
+     */
+    public void testFinalChunkingOnOutputFilteredPath() {
+        Rounding.Prepared oneMinBucket = Rounding.builder(TimeValue.timeValueMinutes(1)).build().prepareForUnknown();
+        Rounding.Prepared fiveMinBucket = Rounding.builder(TimeValue.timeValueMinutes(5)).build().prepareForUnknown();
+        Duration windowDuration = Duration.ofMinutes(7);
+        List<List<Object>> rows = sparseWindowRows();
+
+        List<Page> chunked = new ArrayList<>();
+        List<Page> single = new ArrayList<>();
+        try {
+            chunked.addAll(runPipeline(oneMinBucket, fiveMinBucket, windowDuration, rows, 3));
+            assertThat("output-filtered result larger than the chunk size must be chunked", chunked.size(), greaterThan(1));
+            for (Page page : chunked) {
+                assertThat("no chunk exceeds targetChunkRows", page.getPositionCount(), lessThanOrEqualTo(3));
+            }
+
+            single.addAll(runPipeline(oneMinBucket, fiveMinBucket, windowDuration, rows, Integer.MAX_VALUE));
+            assertThat("unchunked output-filtered result is a single page", single.size(), equalTo(1));
+
+            assertThat("chunking preserves the sub-bucketed result", toValueMap(chunked), equalTo(toValueMap(single)));
+        } finally {
+            releasePages(chunked);
+            releasePages(single);
+        }
+    }
+
     // --- helpers ---
+
+    /**
+     * Produces unchunked partial (INITIAL) output and re-aggregates it in FINAL mode with the given
+     * {@code finalTargetChunkRows}. This is the canonical two-stage path (data node -> coordinator), so it exercises
+     * final-output chunking end to end.
+     */
+    private List<Page> runInitialThenFinal(int finalTargetChunkRows, List<List<Object>> rows) {
+        List<Page> partial = runInitialPages(1_000_000, rows);
+        Rounding.Prepared oneMinBucket = Rounding.builder(TimeValue.timeValueMinutes(1)).build().prepareForUnknown();
+        var finalFactory = new TimeSeriesAggregationOperator.Factory(
+            oneMinBucket,
+            false,
+            List.of(
+                new BlockHash.GroupSpec(0, ElementType.BYTES_REF, null, null),
+                new BlockHash.GroupSpec(1, ElementType.LONG, null, null)
+            ),
+            AggregatorMode.FINAL,
+            List.of(new SumIntAggregatorFunctionSupplier().groupingAggregatorFactory(AggregatorMode.FINAL, List.of(2, 3))),
+            1024,
+            null,
+            finalTargetChunkRows
+        );
+        BlockFactory bf = blockFactory();
+        var driverCtx = new DriverContext(bf.bigArrays(), bf, null);
+        List<Page> collected = new ArrayList<>();
+        boolean success = false;
+        try (Operator op = finalFactory.get(driverCtx)) {
+            while (partial.isEmpty() == false) {
+                op.addInput(partial.remove(0));
+            }
+            op.finish();
+            drainInto(op, collected);
+            assertTrue("final operator should be finished once drained", op.isFinished());
+            success = true;
+            return collected;
+        } finally {
+            if (success == false) {
+                releasePages(collected);
+                releasePages(partial);
+            }
+        }
+    }
+
+    /**
+     * Runs a windowed {@link AggregatorMode#SINGLE} time-series aggregation with {@code outputTimeBucket == null}, so the
+     * output stays on the {@code super.emit()} path. Window-bucket expansion still runs, letting tests exercise expansion
+     * + {@code customizeSelected} remapping under output chunking. (The sub-bucketed output-filtered emit path is covered
+     * separately by {@code testFinalChunkingOnOutputFilteredPath}.)
+     */
+    private List<Page> runWindowedSingle(
+        int targetChunkRows,
+        Rounding.Prepared internalBucket,
+        List<GroupingAggregator.Factory> aggregators,
+        List<List<Object>> rows
+    ) {
+        var operatorFactory = new TimeSeriesAggregationOperator.Factory(
+            internalBucket,
+            false,
+            List.of(
+                new BlockHash.GroupSpec(0, ElementType.BYTES_REF, null, null),
+                new BlockHash.GroupSpec(1, ElementType.LONG, null, null)
+            ),
+            AggregatorMode.SINGLE,
+            aggregators,
+            10_000,
+            null,
+            targetChunkRows
+        );
+        BlockFactory bf = blockFactory();
+        var driverCtx = new DriverContext(bf.bigArrays(), bf, null);
+        var source = new ListRowsBlockSourceOperator(
+            driverCtx.blockFactory(),
+            List.of(ElementType.BYTES_REF, ElementType.LONG, ElementType.INT),
+            rows
+        );
+        List<Page> results = new ArrayList<>();
+        try (
+            var driver = TestDriverFactory.create(
+                driverCtx,
+                source,
+                List.of(operatorFactory.get(driverCtx)),
+                new TestResultPageSinkOperator(results::add)
+            )
+        ) {
+            new TestDriverRunner().run(driver);
+        }
+        return results;
+    }
+
+    private List<GroupingAggregator.Factory> windowSumAndValues(Duration window) {
+        return List.of(
+            new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), window).groupingAggregatorFactory(
+                AggregatorMode.SINGLE,
+                List.of(HASH_CHANNEL_COUNT)
+            ),
+            new ValuesBytesRefAggregatorFunctionSupplier().groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(0))
+        );
+    }
+
+    private List<GroupingAggregator.Factory> windowSumAndDimensionValues(Duration window) {
+        return List.of(
+            new WindowAggregatorFunctionSupplier(new SumIntAggregatorFunctionSupplier(), window).groupingAggregatorFactory(
+                AggregatorMode.SINGLE,
+                List.of(HASH_CHANNEL_COUNT)
+            ),
+            new DimensionValuesByteRefGroupingAggregatorFunction.FunctionSupplier().groupingAggregatorFactory(
+                AggregatorMode.SINGLE,
+                List.of(0)
+            )
+        );
+    }
+
+    /**
+     * Sparse data (points at minute 2 and 8 for each of several tsids) with a 7m window so window expansion creates new
+     * groups that must be remapped. The total (original + expanded) group count comfortably exceeds the chunk size used
+     * by the window-expansion tests, forcing multi-page output.
+     */
+    private static List<List<Object>> sparseWindowRows() {
+        Rounding.Prepared oneMinBucket = Rounding.builder(TimeValue.timeValueMinutes(1)).build().prepareForUnknown();
+        long baseTime = oneMinBucket.round(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2025-11-13"));
+        List<List<Object>> rows = new ArrayList<>();
+        for (String tsid : List.of("a", "b", "c", "d", "e", "f", "g", "h")) {
+            rows.add(List.of(tsid, baseTime + TimeValue.timeValueMinutes(2).millis(), 1));
+            rows.add(List.of(tsid, baseTime + TimeValue.timeValueMinutes(8).millis(), 1));
+        }
+        return rows;
+    }
+
+    private static Map<String, Long> toValueMap(List<Page> pages) {
+        Map<String, Long> map = new HashMap<>();
+        for (OutputRow row : extractRows(pages)) {
+            map.put(row.tsid() + "/" + row.bucket(), row.value());
+        }
+        return map;
+    }
+
+    private static void releasePages(List<Page> pages) {
+        for (Page page : pages) {
+            page.releaseBlocks();
+        }
+    }
+
+    private record WindowedRow(String tsid, long bucket, long sum, String dimension) {}
+
+    private static List<WindowedRow> extractWindowedRows(List<Page> pages) {
+        List<WindowedRow> out = new ArrayList<>();
+        var scratch = new BytesRef();
+        for (Page page : pages) {
+            BytesRefBlock tsids = page.getBlock(0);
+            LongBlock buckets = page.getBlock(1);
+            LongBlock sums = page.getBlock(2);
+            BytesRefBlock dims = page.getBlock(3);
+            for (int p = 0; p < page.getPositionCount(); p++) {
+                String tsid = tsids.getBytesRef(tsids.getFirstValueIndex(p), scratch).utf8ToString();
+                String dim = dims.isNull(p) ? null : dims.getBytesRef(dims.getFirstValueIndex(p), scratch).utf8ToString();
+                out.add(new WindowedRow(tsid, buckets.getLong(p), sums.getLong(p), dim));
+            }
+        }
+        return out;
+    }
+
+    private static Map<String, WindowedRow> asMap(List<WindowedRow> rows) {
+        Map<String, WindowedRow> map = new HashMap<>();
+        for (WindowedRow row : rows) {
+            map.put(row.tsid() + "/" + row.bucket(), row);
+        }
+        return map;
+    }
 
     private List<Page> runPipeline(
         Rounding.Prepared internalBucket,
         Rounding.Prepared outputBucket,
         Duration windowDuration,
         List<List<Object>> rows
+    ) {
+        return runPipeline(internalBucket, outputBucket, windowDuration, rows, Integer.MAX_VALUE);
+    }
+
+    private List<Page> runPipeline(
+        Rounding.Prepared internalBucket,
+        Rounding.Prepared outputBucket,
+        Duration windowDuration,
+        List<List<Object>> rows,
+        int targetChunkRows
     ) {
         var operatorFactory = new TimeSeriesAggregationOperator.Factory(
             internalBucket,
@@ -612,7 +936,8 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
                 )
             ),
             10_000,
-            outputBucket
+            outputBucket,
+            targetChunkRows
         );
 
         BlockFactory bf = blockFactory();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
@@ -189,6 +189,59 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
         client().admin().indices().prepareRefresh("hosts").get();
     }
 
+    /**
+     * End-to-end check that final-result chunking is transparent: driving the coordinator's final aggregation with a tiny
+     * {@code esql.time_series.target_chunk_rows} (so the final output is split into many pages) must produce the same
+     * result set as the default (single-page) run. The queries route the chunked final output through downstream
+     * operators — {@code SORT} (TopN) and a following {@code STATS ... BY <dimension>} — so this also covers downstream
+     * multi-page consumption. Results are compared as canonicalized multisets because chunking only changes pagination,
+     * not the rows produced (row ordering for tied sort keys is not guaranteed to match across two independent runs).
+     * Floating-point values are rounded before comparison: chunking changes the order in which partial sums are combined
+     * (e.g. {@code sum(rate(...))}), so results may differ in the last ULP, which is expected and not a correctness issue.
+     */
+    public void testFinalChunkingMatchesUnchunked() {
+        assumeTrue("query pragmas require a snapshot build", canUseQueryPragmas());
+        client().admin().indices().prepareRefresh("hosts").get();
+        List<String> queries = List.of(
+            "TS hosts | STATS load=avg(cpu) BY cluster, bucket(@timestamp, 1 minute) | SORT cluster, load",
+            "TS hosts | STATS r=sum(rate(request_count)) BY cluster, bucket(@timestamp, 1 minute) | SORT cluster, r",
+            "TS hosts | STATS load=avg(cpu) BY host, tbucket=bucket(@timestamp, 1 minute) | STATS peak=max(load) BY host | SORT host"
+        );
+        for (String query : queries) {
+            List<List<Object>> unchunked = runWithChunkRows(query, 100_000);
+            List<List<Object>> chunked = runWithChunkRows(query, 1);
+            assertThat(
+                "chunked final output must match unchunked for [" + query + "]",
+                canonicalize(chunked),
+                equalTo(canonicalize(unchunked))
+            );
+        }
+    }
+
+    private List<List<Object>> runWithChunkRows(String query, int targetChunkRows) {
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query(query);
+        request.acceptedPragmaRisks(true);
+        request.pragmas(
+            new QueryPragmas(Settings.builder().put(PlannerSettings.TIME_SERIES_TARGET_CHUNK_ROWS.getKey(), targetChunkRows).build())
+        );
+        try (EsqlQueryResponse resp = run(request)) {
+            return EsqlTestUtils.getValuesList(resp);
+        }
+    }
+
+    /**
+     * Rounds floating-point cells (to absorb summation-order differences) and sorts rows into a stable order, so two runs
+     * are compared as multisets independent of tied-sort-key row ordering.
+     */
+    private static List<List<Object>> canonicalize(List<List<Object>> rows) {
+        return rows.stream().map(TimeSeriesIT::roundDoubles).sorted(Comparator.comparing(Objects::toString)).toList();
+    }
+
+    private static List<Object> roundDoubles(List<Object> row) {
+        return row.stream().map(v -> v instanceof Double d ? (Object) (Math.round(d * 1_000_000d) / 1_000_000d) : v).toList();
+    }
+
     public void testWithoutStats() {
         try (EsqlQueryResponse resp = run("TS hosts | SORT @timestamp DESC, host | KEEP @timestamp, host, cpu | LIMIT 5")) {
             List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
@@ -150,10 +150,9 @@ public class PlannerSettings {
     );
 
     /**
-     * Target number of rows per output page when the time-series aggregation operator chunks its partial/intermediate
-     * output. Each partial/intermediate emission is sliced into pages of about this many rows, bounding the size of
-     * each page sent to the coordinator. Specific to the time-series operator and independent of the regular
-     * aggregation emit settings.
+     * Target number of rows per output page when the time-series aggregation operator chunks its output. The same target
+     * applies to partial/intermediate output sent to the coordinator and final output emitted by the coordinator.
+     * Specific to the time-series operator and independent of the regular aggregation emit settings.
      */
     public static final Setting<Integer> TIME_SERIES_TARGET_CHUNK_ROWS = Setting.intSetting(
         "esql.time_series.target_chunk_rows",


### PR DESCRIPTION
Previously only the partial/intermediate output of the time-series aggregation was chunked. The final output was always built as a single page. In this PR we are adding chunking for the final output.

Apply `esql.time_series.target_chunk_rows` to the final stage as well:
- Factory.get no longer forces the chunk size to Integer.MAX_VALUE in final mode, so the shared HashAggregationOperator slicing machinery chunks the normal emit path with no further changes.
- The output-filtered emit path (sub-bucketed window queries) built its own single page and ignored the chunk size. Rewrite it as a page- slicing iterator (OutputFilteredResult) that prepares each aggregator once over the full output-aligned selection and then slices the output into pages of maxPageSize rows. Window aggregators still see every internal group via ctx.allGroupIds(), which is never sliced, so the window computation is unaffected by pagination.
- Add HashAggregationOperator#maxPageSize() for the subclass iterator.