### PR TITLE
[9.4] Aggs: Avoid OOMs by accounting memory on cardinality agg reduction phase (#152773)

### DIFF
--- a/docs/changelog/152773.yaml
+++ b/docs/changelog/152773.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 150290
+pr: 152773
+summary: "Aggs: Avoid OOMs by accounting memory on cardinality agg reduction phase"
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -156,6 +156,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         Releasables.close(hllBuckets, hll, lc);
     }
 
+    long ramBytesUsed() {
+        return hllBuckets.ramBytesUsed() + hll.ramBytesUsed() + lc.ramBytesUsed();
+    }
+
     void addRunLen(long bucketOrd, int register, int runLen) {
         long hllBucket = bucketOrd < hllBuckets.size() ? hllBuckets.get(bucketOrd) - 1 : -1;
         if (hllBucket < 0) {
@@ -294,6 +298,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         @Override
         public void close() {
             Releasables.close(runLens);
+        }
+
+        long ramBytesUsed() {
+            return runLens.ramBytesUsed();
         }
     }
 
@@ -514,6 +522,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         public void close() {
             breaker.addWithoutBreaking(-bytesUsed);
             Releasables.close(cells);
+        }
+
+        long ramBytesUsed() {
+            return cells.ramBytesUsed() + bytesUsed;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
@@ -9,9 +9,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -87,7 +89,7 @@ public class InternalCardinality extends InternalNumericMetricsAggregation.Singl
                 final InternalCardinality cardinality = (InternalCardinality) aggregation;
                 if (cardinality.counts != null) {
                     if (reduced == null) {
-                        reduced = new HyperLogLogPlusPlus(cardinality.counts.precision(), BigArrays.NON_RECYCLING_INSTANCE, 1);
+                        reduced = new HyperLogLogPlusPlus(cardinality.counts.precision(), reduceContext.bigArrays(), 1);
                     }
                     reduced.merge(0, cardinality.counts, 0);
                 }
@@ -95,7 +97,33 @@ public class InternalCardinality extends InternalNumericMetricsAggregation.Singl
 
             @Override
             public InternalAggregation get() {
-                return new InternalCardinality(name, reduced, getMetadata());
+                if (reduced == null) {
+                    return new InternalCardinality(name, null, getMetadata());
+                }
+                long cloneBytes = reduced.ramBytesUsed();
+                CircuitBreaker breaker = reduceContext.bigArrays().breakerService() == null
+                    ? null
+                    : reduceContext.bigArrays().breakerService().getBreaker(CircuitBreaker.REQUEST);
+                if (breaker != null) {
+                    breaker.addEstimateBytesAndMaybeBreak(cloneBytes, "cardinality reduce result clone");
+                }
+                try {
+                    AbstractHyperLogLogPlusPlus result = reduced.clone(0, BigArrays.NON_RECYCLING_INSTANCE);
+                    // Avoid closing again from close().
+                    HyperLogLogPlusPlus toRelease = reduced;
+                    reduced = null;
+                    Releasables.close(toRelease);
+                    return new InternalCardinality(name, result, getMetadata());
+                } finally {
+                    if (breaker != null) {
+                        breaker.addWithoutBreaking(-cloneBytes);
+                    }
+                }
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(reduced);
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
@@ -11,13 +11,23 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import com.carrotsearch.hppc.BitMixer;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LimitedBreaker;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.junit.After;
 
@@ -26,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.mock;
 
 public class InternalCardinalityTests extends InternalAggregationTestCase<InternalCardinality> {
@@ -73,6 +85,104 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
             result.add(createTestInstance(name, createTestMetadata(), precision));
         }
         return new BuilderAndToReduce<>(mock(AggregationBuilder.class), result);
+    }
+
+    public void testReduceUsesRequestCircuitBreaker() {
+        int precision = AbstractHyperLogLog.MAX_PRECISION;
+        InternalCardinality input = createTestInstance("cardinality", null, precision);
+        CircuitBreakerService breakerService = LimitedBreaker.service(CircuitBreaker.REQUEST, ByteSizeValue.ofBytes(1));
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService).withCircuitBreaking();
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArrays,
+            null,
+            () -> false,
+            AggregatorFactories.builder(),
+            b -> {},
+            null
+        );
+
+        CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> {
+            try (AggregatorReducer reducer = input.getReducer(reduceContext, 1)) {
+                reducer.accept(input);
+            }
+        });
+        assertThat(e.getMessage(), equalTo(MockBigArrays.ERROR_MESSAGE));
+        assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+    }
+
+    public void testReduceAccountsForResultClonePeakMemory() {
+        int precision = AbstractHyperLogLog.MAX_PRECISION;
+        InternalCardinality input = createTestInstance("cardinality", null, precision);
+        long reducedHllBytes;
+        try (
+            HyperLogLogPlusPlus reduced = new HyperLogLogPlusPlus(
+                precision,
+                new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking(),
+                1
+            )
+        ) {
+            reduced.merge(0, input.getCounts(), 0);
+            reducedHllBytes = reduced.ramBytesUsed();
+        }
+        CircuitBreakerService breakerService = LimitedBreaker.service(
+            CircuitBreaker.REQUEST,
+            ByteSizeValue.ofBytes(reducedHllBytes * 3 / 2)
+        );
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService).withCircuitBreaking();
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArrays,
+            null,
+            () -> false,
+            AggregatorFactories.builder(),
+            b -> {},
+            null
+        );
+
+        CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> {
+            try (AggregatorReducer reducer = input.getReducer(reduceContext, 1)) {
+                reducer.accept(input);
+                assertThat(breaker.getUsed(), greaterThan(0L));
+                reducer.get();
+            }
+        });
+        assertThat(e.getMessage(), equalTo(MockBigArrays.ERROR_MESSAGE));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testReduceSucceedsWithBreakerLimitAboveResultClonePeakMemory() {
+        int precision = AbstractHyperLogLog.MAX_PRECISION;
+        InternalCardinality input = createTestInstance("cardinality", null, precision);
+        long reducedHllBytes;
+        try (
+            HyperLogLogPlusPlus reduced = new HyperLogLogPlusPlus(
+                precision,
+                new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking(),
+                1
+            )
+        ) {
+            reduced.merge(0, input.getCounts(), 0);
+            reducedHllBytes = reduced.ramBytesUsed();
+        }
+        CircuitBreakerService breakerService = LimitedBreaker.service(CircuitBreaker.REQUEST, ByteSizeValue.ofBytes(reducedHllBytes * 3));
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService).withCircuitBreaking();
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArrays,
+            null,
+            () -> false,
+            AggregatorFactories.builder(),
+            b -> {},
+            null
+        );
+
+        try (AggregatorReducer reducer = input.getReducer(reduceContext, 1)) {
+            reducer.accept(input);
+            assertThat(breaker.getUsed(), greaterThan(0L));
+            InternalCardinality result = (InternalCardinality) reducer.get();
+            assertThat(result.value(), equalTo(input.value()));
+        }
+        assertThat(breaker.getUsed(), equalTo(0L));
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Aggs: Avoid OOMs by accounting memory on cardinality agg reduction phase (#152773)