### PR TITLE
PromQL: Add release highlight for histogram support

### DIFF
--- a/docs/changelog/152171.yaml
+++ b/docs/changelog/152171.yaml
@@ -2,7 +2,7 @@ area: PromQL
 highlight:
   body: |-
     You can now query exponential_histogram fields with PromQL syntax for native histograms.
-    The supported functions are `increase()`, `sum()`, `histogram_quantile()`, `histogram_avg()`, `histogram_count()` and `histogram_avg()`.
+    The supported functions are `increase()`, `sum()`, `histogram_quantile()`, `histogram_avg()`, `histogram_count()` and `histogram_sum()`.
   notable: true
 issues:
  - 150074

--- a/docs/changelog/152171.yaml
+++ b/docs/changelog/152171.yaml
@@ -1,6 +1,11 @@
 area: PromQL
+highlight:
+  body: |-
+    You can now query exponential_histogram fields with PromQL syntax for native histograms.
+    The supported functions are `increase()`, `sum()`, `histogram_quantile()`, `histogram_avg()`, `histogram_count()` and `histogram_avg()`.
+  notable: true
 issues:
  - 150074
 pr: 152171
-summary: "PromQL: Support `histogram_quantile` for exponential histograms"
+summary: "PromQL: Add basic support for native (exponential) histograms"
 type: enhancement

--- a/docs/changelog/152171.yaml
+++ b/docs/changelog/152171.yaml
@@ -4,8 +4,9 @@ highlight:
     You can now query exponential_histogram fields with PromQL syntax for native histograms.
     The supported functions are `increase()`, `sum()`, `histogram_quantile()`, `histogram_avg()`, `histogram_count()` and `histogram_sum()`.
   notable: true
+  title: "PromQL: Add basic support for native (exponential) histograms"
 issues:
  - 150074
 pr: 152171
-summary: "PromQL: Add basic support for native (exponential) histograms"
+summary: "PromQL: Support `histogram_quantile` for exponential histograms"
 type: enhancement


### PR DESCRIPTION
Hijacks the changelog of last PR of the PromQL histogram support (https://github.com/elastic/elasticsearch/pull/152171) work as a release highlight.