### PR TITLE
[8.19] Aggs: Avoid OOMs by accounting memory on cardinality agg reduction phase

### DIFF
--- a/docs/changelog/152773.yaml
+++ b/docs/changelog/152773.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 150290
+pr: 152773
+summary: "Aggs: Avoid OOMs by accounting memory on cardinality agg reduction phase"
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -153,6 +153,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         Releasables.close(algorithm, hll, lc);
     }
 
+    long ramBytesUsed() {
+        return algorithm.ramBytesUsed() + hll.ramBytesUsed() + lc.ramBytesUsed();
+    }
+
     protected void addRunLen(long bucketOrd, int register, int runLen) {
         if (algorithm.get(bucketOrd) == LINEAR_COUNTING) {
             upgradeToHll(bucketOrd);
@@ -290,6 +294,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         @Override
         public void close() {
             Releasables.close(runLens);
+        }
+
+        long ramBytesUsed() {
+            return runLens.ramBytesUsed();
         }
     }
 
@@ -498,6 +506,10 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         public void close() {
             breaker.addWithoutBreaking(-bytesUsed);
             Releasables.close(cells);
+        }
+
+        long ramBytesUsed() {
+            return cells.ramBytesUsed() + bytesUsed;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
@@ -9,9 +9,11 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -87,7 +89,7 @@ public class InternalCardinality extends InternalNumericMetricsAggregation.Singl
                 final InternalCardinality cardinality = (InternalCardinality) aggregation;
                 if (cardinality.counts != null) {
                     if (reduced == null) {
-                        reduced = new HyperLogLogPlusPlus(cardinality.counts.precision(), BigArrays.NON_RECYCLING_INSTANCE, 1);
+                        reduced = new HyperLogLogPlusPlus(cardinality.counts.precision(), reduceContext.bigArrays(), 1);
                     }
                     reduced.merge(0, cardinality.counts, 0);
                 }
@@ -95,7 +97,33 @@ public class InternalCardinality extends InternalNumericMetricsAggregation.Singl
 
             @Override
             public InternalAggregation get() {
-                return new InternalCardinality(name, reduced, getMetadata());
+                if (reduced == null) {
+                    return new InternalCardinality(name, null, getMetadata());
+                }
+                long cloneBytes = reduced.ramBytesUsed();
+                CircuitBreaker breaker = reduceContext.bigArrays().breakerService() == null
+                    ? null
+                    : reduceContext.bigArrays().breakerService().getBreaker(CircuitBreaker.REQUEST);
+                if (breaker != null) {
+                    breaker.addEstimateBytesAndMaybeBreak(cloneBytes, "cardinality reduce result clone");
+                }
+                try {
+                    AbstractHyperLogLogPlusPlus result = reduced.clone(0, BigArrays.NON_RECYCLING_INSTANCE);
+                    // Avoid closing again from close().
+                    HyperLogLogPlusPlus toRelease = reduced;
+                    reduced = null;
+                    Releasables.close(toRelease);
+                    return new InternalCardinality(name, result, getMetadata());
+                } finally {
+                    if (breaker != null) {
+                        breaker.addWithoutBreaking(-cloneBytes);
+                    }
+                }
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(reduced);
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
@@ -11,13 +11,22 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import com.carrotsearch.hppc.BitMixer;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.junit.After;
 
@@ -26,7 +35,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class InternalCardinalityTests extends InternalAggregationTestCase<InternalCardinality> {
     private static List<HyperLogLogPlusPlus> algos;
@@ -75,6 +87,98 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
         return new BuilderAndToReduce<>(mock(AggregationBuilder.class), result);
     }
 
+    public void testReduceUsesRequestCircuitBreaker() {
+        int precision = AbstractHyperLogLog.MAX_PRECISION;
+        InternalCardinality input = createTestInstance("cardinality", null, precision);
+        CircuitBreakerService breakerService = limitedBreakerService(ByteSizeValue.ofBytes(1));
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService).withCircuitBreaking();
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArrays,
+            null,
+            () -> false,
+            AggregatorFactories.builder(),
+            b -> {}
+        );
+
+        CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> {
+            try (AggregatorReducer reducer = input.getReducer(reduceContext, 1)) {
+                reducer.accept(input);
+            }
+        });
+        assertThat(e.getMessage(), equalTo(MockBigArrays.ERROR_MESSAGE));
+        assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+    }
+
+    public void testReduceAccountsForResultClonePeakMemory() {
+        int precision = AbstractHyperLogLog.MAX_PRECISION;
+        InternalCardinality input = createTestInstance("cardinality", null, precision);
+        long reducedHllBytes;
+        try (
+            HyperLogLogPlusPlus reduced = new HyperLogLogPlusPlus(
+                precision,
+                new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking(),
+                1
+            )
+        ) {
+            reduced.merge(0, input.getCounts(), 0);
+            reducedHllBytes = reduced.ramBytesUsed();
+        }
+        CircuitBreakerService breakerService = limitedBreakerService(ByteSizeValue.ofBytes(reducedHllBytes * 3 / 2));
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService).withCircuitBreaking();
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArrays,
+            null,
+            () -> false,
+            AggregatorFactories.builder(),
+            b -> {}
+        );
+
+        CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> {
+            try (AggregatorReducer reducer = input.getReducer(reduceContext, 1)) {
+                reducer.accept(input);
+                assertThat(breaker.getUsed(), greaterThan(0L));
+                reducer.get();
+            }
+        });
+        assertThat(e.getMessage(), equalTo(MockBigArrays.ERROR_MESSAGE));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testReduceSucceedsWithBreakerLimitAboveResultClonePeakMemory() {
+        int precision = AbstractHyperLogLog.MAX_PRECISION;
+        InternalCardinality input = createTestInstance("cardinality", null, precision);
+        long reducedHllBytes;
+        try (
+            HyperLogLogPlusPlus reduced = new HyperLogLogPlusPlus(
+                precision,
+                new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking(),
+                1
+            )
+        ) {
+            reduced.merge(0, input.getCounts(), 0);
+            reducedHllBytes = reduced.ramBytesUsed();
+        }
+        CircuitBreakerService breakerService = limitedBreakerService(ByteSizeValue.ofBytes(reducedHllBytes * 3));
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService).withCircuitBreaking();
+        AggregationReduceContext reduceContext = new AggregationReduceContext.ForFinal(
+            bigArrays,
+            null,
+            () -> false,
+            AggregatorFactories.builder(),
+            b -> {}
+        );
+
+        try (AggregatorReducer reducer = input.getReducer(reduceContext, 1)) {
+            reducer.accept(input);
+            assertThat(breaker.getUsed(), greaterThan(0L));
+            InternalCardinality result = (InternalCardinality) reducer.get();
+            assertThat(result.value(), equalTo(input.value()));
+        }
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
     @Override
     protected void assertReduced(InternalCardinality reduced, List<InternalCardinality> inputs) {
         HyperLogLogPlusPlus[] algos = inputs.stream().map(InternalCardinality::getState).toArray(size -> new HyperLogLogPlusPlus[size]);
@@ -85,6 +189,13 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
             }
             assertEquals(result.cardinality(0), reduced.value(), 0);
         }
+    }
+
+    private static CircuitBreakerService limitedBreakerService(ByteSizeValue max) {
+        CircuitBreaker breaker = new MockBigArrays.LimitedBreaker(CircuitBreaker.REQUEST, max);
+        CircuitBreakerService breakerService = mock(CircuitBreakerService.class);
+        when(breakerService.getBreaker(CircuitBreaker.REQUEST)).thenReturn(breaker);
+        return breakerService;
     }
 
     @Override


### PR DESCRIPTION
Manual 8.19 backport of https://github.com/elastic/elasticsearch/pull/152773