### PR TITLE
[9.3] [ML] Fix test DatafeedJobsIT#testStopLookback_forceTrue_closeJobFalse (#144918)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -571,7 +571,16 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         assertTrue(stopDatafeedResponse.isStopped());
 
         // Check the job state is as expected
-        assertBusy(() -> assertEquals(jobState, getJobStats(jobId).get(0).getState()), 2, TimeUnit.SECONDS);
+        assertBusy(() -> {
+            JobState actualState = getJobStats(jobId).get(0).getState();
+            if (jobState == JobState.OPENED && actualState == JobState.CLOSED) {
+                // The lookback may have completed naturally before the stop was issued, causing auto-close.
+                // This is legitimate if all docs were processed.
+                assertEquals(numDocs, getDataCounts(jobId).getProcessedRecordCount());
+            } else {
+                assertEquals(jobState, actualState);
+            }
+        }, 2, TimeUnit.SECONDS);
     }
 
     public void testStopLookback_closeJobTrue() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ML] Fix test DatafeedJobsIT#testStopLookback_forceTrue_closeJobFalse (#144918)](https://github.com/elastic/elasticsearch/pull/144918)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)