### PR TITLE
Fix LuceneTests testSearchWithoutBulkScorer

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -770,9 +770,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.integration.TransformIT
   method: testStopWaitForCheckpoint
   issue: https://github.com/elastic/elasticsearch/issues/149663
-- class: org.elasticsearch.common.lucene.LuceneTests
-  method: testSearchWithoutBulkScorer
-  issue: https://github.com/elastic/elasticsearch/issues/152898
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
   issue: https://github.com/elastic/elasticsearch/issues/152904

--- a/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -714,7 +714,11 @@ public class LuceneTests extends ESTestCase {
                 w.addDocument(new Document());
             }
             try (DirectoryReader reader = DirectoryReader.open(dir)) {
-                IndexSearcher searcher = newSearcher(reader);
+                // Use a plain IndexSearcher (not newSearcher) to guarantee a deterministic single-threaded
+                // search path that always routes through ScorerSupplier.bulkScorer(). The randomized
+                // newSearcher() may wrap weights in an assertions layer or use concurrent slicing, which
+                // can bypass ThrowingBulkScorerQuery's custom bulkScorer() path.
+                IndexSearcher searcher = new IndexSearcher(reader);
 
                 // A query that throws AssertionError if bulkScorer() is called from its weight directly
                 Query throwingQuery = new ThrowingBulkScorerQuery(Queries.ALL_DOCS_INSTANCE);

--- a/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/LuceneTests.java
@@ -714,7 +714,9 @@ public class LuceneTests extends ESTestCase {
                 w.addDocument(new Document());
             }
             try (DirectoryReader reader = DirectoryReader.open(dir)) {
-                IndexSearcher searcher = newSearcher(reader);
+                // Use a plain IndexSearcher (not newSearcher) to guarantee a deterministic single-threaded
+                // search path that always routes through ScorerSupplier.bulkScorer().
+                IndexSearcher searcher = new IndexSearcher(reader);
 
                 // A query that throws AssertionError if bulkScorer() is called from its weight directly
                 Query throwingQuery = new ThrowingBulkScorerQuery(Queries.ALL_DOCS_INSTANCE);


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/152898