### PR TITLE
[9.3] [ML] Fix test ClassificationIT#testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsKeyword (#144917)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
@@ -145,6 +145,8 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
                 if (indexAndAliasCreationInProgress.compareAndSet(false, true)) {
                     installTemplateAndCreateIndex(createListener);
                 }
+            } else {
+                writeDoc(toXContent);
             }
         }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ML] Fix test ClassificationIT#testWithOnlyTrainingRowsAndTrainingPercentIsFifty_DependentVariableIsKeyword (#144917)](https://github.com/elastic/elasticsearch/pull/144917)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)