### PR TITLE
ESQL: release external-Parquet page decompress buffers per page, not per row group

### DIFF
--- a/docs/changelog/153038.yaml
+++ b/docs/changelog/153038.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153038
+summary: Release external-Parquet page decompress buffers per page, not per row group
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -105,12 +105,18 @@ final class PrefetchedPageReader implements PageReader, Releasable {
             // it) until close() releases it; there is no new page to decode, so nothing to release.
             return null;
         }
-        // Per-page release. parquet-mr consumes pages strictly sequentially: the sole caller,
-        // PageColumnReader#loadNextPage, finishes decoding the current page's bytes (its
-        // remainder-skip runs off the current value/def-level buffers) BEFORE calling readPage()
-        // for the next page, and reassigns those buffers to the new page immediately after. So the
-        // previously returned page's decompress buffer is dead the moment the consumer asks for the
-        // next page. Release it now rather than parking every page's buffer until close(): otherwise
+        // Per-page release. Both consumers of this reader ask for pages strictly sequentially and
+        // are done with the current page's bytes before they ask for the next one:
+        // - PageColumnReader#loadNextPage (flat columns) runs its remainder-skip off the current
+        // value/def-level buffers BEFORE calling readPage(), and reassigns those buffers to the
+        // new page immediately after;
+        // - parquet-mr's ColumnReaderBase (list columns, via ColumnReadStoreImpl) calls readPage()
+        // only from checkRead() once the current page is fully consumed, re-initializes all of
+        // its level/value readers from the new page before any further read, and its consumers
+        // (ParquetColumnDecoding#readListRow) copy each value to the heap before the consume()
+        // that can cross a page boundary.
+        // So the previously returned page's decompress buffer is dead the moment the consumer asks
+        // for the next page. Release it now rather than parking every page's buffer until close(): otherwise
         // the live decompressed working set per (column, reader) is O(uncompressed column chunk)
         // instead of O(one page), and — one such reader per projected column, up to 48 concurrent
         // read streams — the accumulation climbs until the OS OOM-killer takes the node, invisible
@@ -351,7 +357,9 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         if (closed.compareAndSet(false, true) == false) {
             return;
         }
-        // Drop the cached dictionary BytesInput; it aliases an ArrowBuf we're about to release.
+        // Drop the cached dictionary page reference. It is deliberately heap-backed (see
+        // readDictionaryPage), so this is reference hygiene, not a buffer-lifetime requirement —
+        // in particular it is NOT in livePageBuffers and is never touched by the per-page release.
         cachedDictionaryPage = null;
         // Release the tail page's buffer(s). Every earlier page was already released by the
         // readPage() call that superseded it, so at most one page's buffer remains here.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -42,10 +42,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Decompression buffers are allocated as {@link ArrowBuf}s from the supplied
  * {@link BufferAllocator}, exposed to the codec via {@link ArrowBuf#nioBuffer(long, int)} to
- * preserve the direct-to-direct JNI fast path. The reader owns these buffers; {@link #close()}
- * releases them back to the allocator (which routes the accounting through the circuit breaker).
- * The {@link DataPage}s and {@link BytesInput}s returned from {@link #readPage()} alias these
- * buffers and must not be used after the reader is closed.
+ * preserve the direct-to-direct JNI fast path. The reader owns these buffers. A page's buffer is
+ * released back to the allocator (which routes the accounting through the circuit breaker) as soon
+ * as the consumer asks for the next page — see {@link #readPage()} — so only ONE page's
+ * decompressed bytes are live per (column, reader) at a time; {@link #close()} releases whatever
+ * remains (the tail page). The {@link DataPage}s and {@link BytesInput}s returned from
+ * {@link #readPage()} alias the current page's buffer and must not be used after the next
+ * {@link #readPage()} call or after the reader is closed.
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
 
@@ -63,7 +66,11 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     private final long valueCount;
     private final Deque<CompressedPage> compressedPages;
     private final DictionaryPage compressedDictionaryPage;
-    private final List<Releasable> ownedBuffers = new ArrayList<>();
+    // Decompress-output buffer(s) of the page returned by the most recent readPage() call. Bounded
+    // to one page: readPage() releases the previous page's buffers before decoding the next, and
+    // close() releases the tail page. Named for that lifetime rather than "owned for the reader's
+    // life" — parking every page's buffer until close() was the native-memory leak this reader had.
+    private final List<Releasable> livePageBuffers = new ArrayList<>();
 
     private DictionaryPage cachedDictionaryPage;
     private boolean dictionaryDecompressed;
@@ -94,8 +101,21 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     public DataPage readPage() {
         CompressedPage entry = compressedPages.poll();
         if (entry == null) {
+            // Queue drained. The last page returned stays live (the consumer may still be decoding
+            // it) until close() releases it; there is no new page to decode, so nothing to release.
             return null;
         }
+        // Per-page release. parquet-mr consumes pages strictly sequentially: the sole caller,
+        // PageColumnReader#loadNextPage, finishes decoding the current page's bytes (its
+        // remainder-skip runs off the current value/def-level buffers) BEFORE calling readPage()
+        // for the next page, and reassigns those buffers to the new page immediately after. So the
+        // previously returned page's decompress buffer is dead the moment the consumer asks for the
+        // next page. Release it now rather than parking every page's buffer until close(): otherwise
+        // the live decompressed working set per (column, reader) is O(uncompressed column chunk)
+        // instead of O(one page), and — one such reader per projected column, up to 48 concurrent
+        // read streams — the accumulation climbs until the OS OOM-killer takes the node, invisible
+        // to every heap-only circuit breaker.
+        releaseLivePageBuffers();
         DataPage page = entry.page();
         if (page instanceof DataPageV1 v1) {
             return decompressV1(v1);
@@ -266,7 +286,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // Scratch buffer used only when the input is on the heap and must be copied to direct
         // memory to take the codec's direct-to-direct JNI fast path. decompress() consumes it
         // synchronously, so it is released in the finally below rather than registered with the
-        // reader — otherwise it would sit in ownedBuffers for the rest of the row group.
+        // reader — otherwise it would sit in livePageBuffers until the next page is decoded.
         ArrowBuf scratch = null;
         try {
             if (input.isDirect() == false) {
@@ -290,7 +310,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     /**
      * Allocate a direct {@link ByteBuffer} of the requested size, backed by an {@link ArrowBuf}
      * owned by this reader. The buffer is breaker-accounted via the allocator's listener and is
-     * released on {@link #close()}.
+     * released when the consumer asks for the next page (see {@link #readPage()}) or, for the tail
+     * page, on {@link #close()} — whichever comes first.
      */
     private ByteBuffer allocateDirect(int size) {
         ArrowBuf buf = allocator.buffer(size);
@@ -298,12 +319,31 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // codec's size sanity check expects remaining() == declared decompressed size.
         ByteBuffer view = buf.nioBuffer(0, size);
         // Poison the region just before release (assertions only) so a decompressed-page BytesInput
-        // that aliases this buffer and is read after the reader is closed fails deterministically.
-        ownedBuffers.add(() -> {
+        // that aliases this buffer and is read after the buffer is released (next readPage() /
+        // close()) fails deterministically.
+        livePageBuffers.add(() -> {
             DirectMemoryDebug.poison(view);
             buf.close();
         });
         return view;
+    }
+
+    /**
+     * Release the decompress-output buffer(s) of the page returned by the previous
+     * {@link #readPage()} call back to the allocator. Called at the top of {@link #readPage()}
+     * before decoding the next page, and by {@link #close()} for the tail page. Idempotent and a
+     * no-op when nothing is live (e.g. the uncompressed short-circuit that aliases the caller's
+     * input buffer without allocating).
+     */
+    private void releaseLivePageBuffers() {
+        if (livePageBuffers.isEmpty()) {
+            return;
+        }
+        try {
+            Releasables.close(livePageBuffers);
+        } finally {
+            livePageBuffers.clear();
+        }
     }
 
     @Override
@@ -313,10 +353,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
         // Drop the cached dictionary BytesInput; it aliases an ArrowBuf we're about to release.
         cachedDictionaryPage = null;
-        try {
-            Releasables.close(ownedBuffers);
-        } finally {
-            ownedBuffers.clear();
-        }
+        // Release the tail page's buffer(s). Every earlier page was already released by the
+        // readPage() call that superseded it, so at most one page's buffer remains here.
+        releaseLivePageBuffers();
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * Pins the per-page release bound on {@link PrefetchedPageReader}: the native memory backing a
+ * decompressed page must be returned to the allocator no later than the next
+ * {@link PrefetchedPageReader#readPage()} call, so the live decompressed working set per
+ * (column, reader) is O(one page), not O(uncompressed column chunk).
+ *
+ * <p>Before the fix, every {@code decompressToDirectBuffer} output was parked until
+ * {@link PrefetchedPageReader#close()} at row-group rollover — the whole column chunk's
+ * decompressed bytes were held live simultaneously and, multiplied across projected columns and
+ * concurrent read streams, climbed until the OS OOM-killer took the node (invisible to every
+ * heap-only circuit breaker). These tests FAIL on that behavior: the allocator balance grows by
+ * one page per {@code readPage()}. They PASS once {@code readPage()} releases the previous page's
+ * buffer before decompressing the next.
+ *
+ * <p>Both a zstd {@link DataPageV2} (the canonical bench case, direct-to-direct JNI fast path) and
+ * a gzip {@link DataPageV1} (the codec-uniformity twin, heap-staged, no native-library dependency)
+ * are covered — the direct decompress-output buffer is allocated by {@code decompressToDirectBuffer}
+ * identically for every codec, so the fix must bound the working set uniformly.
+ */
+public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
+
+    private static final int PAGE_PAYLOAD_BYTES = 64 * 1024; // power of two: Arrow capacity rounding is exact
+    private static final int PAGES = 4;
+
+    /**
+     * Canonical case from the leak investigation: zstd {@link DataPageV2}, decompressed through the
+     * direct-to-direct fast path. Asserts the live allocator balance stays bounded by one page as
+     * pages are read, and returns to zero at {@code close()}.
+     */
+    public void testZstdV2DecompressBufferReleasedPerPageAndOnClose() throws IOException {
+        assertPerPageReleaseAndZeroOnClose(buildZstdV2Pages());
+    }
+
+    /**
+     * Codec-uniformity twin: gzip {@link DataPageV1}, heap-staged into the direct output buffer.
+     * GZIP has no native-library dependency, so this covers the release bound on platforms without
+     * native zstd and confirms the fix is codec-agnostic (same {@code decompressToDirectBuffer}
+     * output buffer for every codec).
+     */
+    public void testGzipV1DecompressBufferReleasedPerPageAndOnClose() throws IOException {
+        assertPerPageReleaseAndZeroOnClose(buildGzipV1Pages());
+    }
+
+    private void assertPerPageReleaseAndZeroOnClose(PagesFixture fixture) {
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            PrefetchedPageReader reader = new PrefetchedPageReader(
+                fixture.codecFactory.getDecompressor(fixture.codec),
+                allocator,
+                fixture.pages,
+                null,
+                (long) PAGE_PAYLOAD_BYTES * PAGES
+            );
+            try {
+                assertNotNull(reader.readPage());
+                long oneLivePage = allocator.getAllocatedMemory();
+                assertThat(
+                    "one decompressed page must be live after the first readPage()",
+                    oneLivePage,
+                    greaterThanOrEqualTo((long) PAGE_PAYLOAD_BYTES)
+                );
+
+                for (int p = 1; p < PAGES; p++) {
+                    assertNotNull(reader.readPage());
+                    // Per-page bound: the previous page's decompress buffer is dead the moment the
+                    // consumer asks for the next page. FAILS pre-fix — the balance grows by one page
+                    // per readPage() until close(), which is the accumulation the bench OOM surfaced.
+                    assertThat(
+                        "live decompressed memory must stay bounded by one page after readPage() #" + (p + 1),
+                        allocator.getAllocatedMemory(),
+                        lessThanOrEqualTo(oneLivePage)
+                    );
+                }
+                // Reader drained: the tail page stays live until close().
+                assertNull(reader.readPage());
+            } finally {
+                reader.close();
+            }
+            assertEquals("close() must return every decompress buffer to the allocator", 0L, allocator.getAllocatedMemory());
+        } finally {
+            fixture.codecFactory.release();
+        }
+    }
+
+    private PagesFixture buildZstdV2Pages() throws IOException {
+        PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
+        BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
+        List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(PAGES);
+        for (int p = 0; p < PAGES; p++) {
+            byte[] data = randomByteArrayOfLength(PAGE_PAYLOAD_BYTES);
+            byte[] compressedData = compressor.compress(BytesInput.from(data)).toByteArray();
+            // Empty repetition/definition levels, so uncompressedSize == the decompressed data size
+            // (decompressV2 subtracts the rl/dl byte counts to derive the data-only size).
+            DataPageV2 v2 = new DataPageV2(
+                PAGE_PAYLOAD_BYTES / 4,
+                0,
+                PAGE_PAYLOAD_BYTES / 4,
+                BytesInput.empty(),
+                BytesInput.empty(),
+                Encoding.PLAIN,
+                BytesInput.from(compressedData),
+                PAGE_PAYLOAD_BYTES,
+                new IntStatistics(),
+                true
+            );
+            pages.add(new PrefetchedPageReader.CompressedPage(v2, -1L));
+        }
+        return new PagesFixture(codecFactory, CompressionCodecName.ZSTD, pages);
+    }
+
+    private PagesFixture buildGzipV1Pages() throws IOException {
+        PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
+        BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.GZIP);
+        List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(PAGES);
+        for (int p = 0; p < PAGES; p++) {
+            byte[] payload = randomByteArrayOfLength(PAGE_PAYLOAD_BYTES);
+            byte[] compressed = compressor.compress(BytesInput.from(payload)).toByteArray();
+            DataPageV1 v1 = new DataPageV1(
+                BytesInput.from(compressed),
+                PAGE_PAYLOAD_BYTES / 4,
+                payload.length,
+                new IntStatistics(),
+                Encoding.RLE,
+                Encoding.RLE,
+                Encoding.PLAIN
+            );
+            pages.add(new PrefetchedPageReader.CompressedPage(v1, -1L));
+        }
+        return new PagesFixture(codecFactory, CompressionCodecName.GZIP, pages);
+    }
+
+    private record PagesFixture(
+        PlainCompressionCodecFactory codecFactory,
+        CompressionCodecName codec,
+        List<PrefetchedPageReader.CompressedPage> pages
+    ) {}
+}


### PR DESCRIPTION
## What this is about

Running the 43-query ClickBench-100M battery against external Parquet (zstd, 50-files layout) on a 32 GB box OS-OOM-kills the Elasticsearch node around query 23. `RssAnon` climbs ~0.4 GB per query and is never released; the heap stays healthy (old-gen ~1.7 GB, ~0 full GCs), so nothing triggers collection and no circuit breaker sees the growth — the off-heap native RSS is invisible to every heap-only breaker. `async-profiler -e nativemem --live` attributes the dominant net-unfreed native memory to the external-Parquet page-decompression path.

The mechanism: `PrefetchedPageReader` decompresses each column-chunk page into a direct Arrow buffer and parks that buffer for the whole row-group lifetime, releasing only at `close()`. So the live decompressed working set per (column, reader) is O(uncompressed column chunk), not O(one page) — multiplied across projected columns and across the concurrent read streams. #152771 (external-Parquet read concurrency 16→48) tripled those streams and pushed the per-battery accumulation past the OOM line; it is the amplifier, not the cause (the leaking path is byte-identical before it), so this fixes the leak rather than reverting the concurrency bump.

## What this PR does

`PrefetchedPageReader.readPage()` now releases the previous page's decompress-output buffer(s) before decompressing the next page — uniformly for the V1, V2, and uncompressed-short-circuit paths, so it is codec-agnostic. This bounds the live decompressed working set to O(one page) per (column, reader). `close()` still releases whatever remains (the tail page), so the reader's external contract is unchanged.

This is safe because both consumers of the reader ask for pages strictly sequentially and finish with the current page's bytes before they ask for the next one. The flat path (`PageColumnReader.loadNextPage`) runs its remainder-skip off the current value/def-level buffers *before* it calls `readPage()`, and rebinds its decoders to the new page immediately after. The list path (parquet-mr's `ColumnReaderBase`, driven via `ColumnReadStoreImpl` over the prefetched store) calls `readPage()` only once the current page is fully consumed and copies each value to the heap before the `consume()` that can cross a page boundary. So the previously returned page's buffer is dead the moment the consumer asks for the next page. Every value that escapes into a `Block` is deep-copied to heap at read time — and the one decode path that could alias page bytes, `PlainValueDecoder.readBinaries`, copies rather than aliases whenever the value buffer is direct (`hasArray() == false`), which is exactly the prefetched ArrowBuf-backed case — so no returned block ever points into a released buffer. The returned `DataPage`/`BytesInput` alias the current page's buffer and, as before, must not be used after the reader is closed; they now also must not be used after the next `readPage()` (documented on the method and the class).

## Does it work?

New unit test `PrefetchedPageReaderPerPageReleaseTests` asserts, over a 4-page reader, that the allocator balance stays bounded by one page after each `readPage()` and returns to zero at `close()` — for a zstd `DataPageV2` (the canonical case, direct-to-direct JNI path) and a gzip `DataPageV1` twin (codec-uniformity, no native-library dependency).

- On the unfixed reader both tests FAIL: `live decompressed memory must stay bounded by one page after readPage() #2` — the balance grows by one page per `readPage()`.
- With the fix both tests PASS, and the balance is zero at `close()`.

Module `precommit` (`spotlessApply`, `forbiddenApis` Main+Test, `licenseHeaders`, `checkstyle`) is green locally.

End-to-end, the fix flattens the per-query `RssAnon` growth on the zstd/50-files cell (previously ~0.4 GB/query, monotonic) and removes the OOM-kill that took the node at ~query 23; the slower-leaking zstd/1-file and zstd/1rg layouts stop accreting RSS too.

## What's in the diff

- `PrefetchedPageReader` — per-page release in `readPage()`; the buffer list is renamed to reflect its now-single-page lifetime; `close()` releases the tail page via the shared helper.
- `PrefetchedPageReaderPerPageReleaseTests` — the failing-before / passing-after test (zstd V2 + gzip V1).

## What's out of scope (follow-ups)

The investigation identified two regression-proofing changes that are deliberately not in this PR because both need integration-level validation this change does not:

- **Per-query child Arrow allocator with a leak check.** The `BlockFactory.arrowAllocator()` TODO — one child `BufferAllocator` per query, closed at query end, so any unreleased native buffer throws with Arrow's outstanding-ledger instead of silently accreting node RSS. This needs a query-end lifecycle hook `BlockFactory` currently lacks (it is not `Releasable`), touching the compute engine broadly; it turns this class of leak into a loud test/CI failure and is worth its own PR.
- **A real native budget on the root allocator.** Replace the `RootAllocator`'s `Long.MAX_VALUE` limit with a setting-derived budget (a fraction of `MaxDirectMemorySize`) and map overshoot to a catchable `CircuitBreakingException`, so a future overshoot fails the query instead of the node. This needs a default-sizing decision and end-to-end validation of the overshoot path.

This PR lands the primary fix that stops the OOM; the two follow-ups close the "no breaker sees native memory" gap that made the leak a node-killer rather than a failed query.

