### PR TITLE
Fix flattened field array-offset corruption with preserve_leaf_arrays: exact

### DIFF
--- a/docs/changelog/153043.yaml
+++ b/docs/changelog/153043.yaml
@@ -1,0 +1,6 @@
+area: Mapping
+issues:
+ - 153014
+pr: 153043
+summary: "Fix flattened field array-offset corruption with preserve_leaf_arrays: exact"
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -694,12 +694,7 @@ public abstract class DocumentParserContext {
 
     /**
      * Like {@link #getOffSetContext()}, but for mappers — such as flattened — that need a dedicated
-     * {@link FieldArrayContext} per mapped field rather than sharing the single document-wide one, because they encode
-     * multiple keys into one sidecar doc-values field named after the mapped field itself. The context for {@code key} is
-     * created via {@code factory} on first access and reused by every subsequent call with the same {@code key} for the
-     * rest of this document, so offset ordinals stay consistent with the document-wide value set the field writes even
-     * when a field's {@code parseCreateField} runs more than once for the same document (e.g. field supplied as an array
-     * of objects).
+     * {@link FieldArrayContext} per mapped field rather than sharing the single document-wide one.
      */
     public FieldArrayContext getOffSetContext(String key, Supplier<? extends FieldArrayContext> factory) {
         if (namedFieldArrayContexts == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.index.mapper.IdFieldMapper.standardIdField;
 
@@ -134,6 +135,13 @@ public abstract class DocumentParserContext {
         }
 
         @Override
+        public FieldArrayContext getOffSetContext(String key, Supplier<? extends FieldArrayContext> factory) {
+            FieldArrayContext offsetContext = in.getOffSetContext(key, factory);
+            offsetContext.setCurrentDoc(doc());
+            return offsetContext;
+        }
+
+        @Override
         public void setImmediateXContentParent(XContentParser.Token token) {
             in.setImmediateXContentParent(token);
         }
@@ -226,6 +234,7 @@ public abstract class DocumentParserContext {
     private final Set<String> fieldsAppliedFromTemplates;
 
     private FieldArrayContext fieldArrayContext;
+    private Map<String, FieldArrayContext> namedFieldArrayContexts;
 
     private final ObjectArrayElementCounter objectArrayElementCounter;
 
@@ -668,6 +677,11 @@ public abstract class DocumentParserContext {
         if (fieldArrayContext != null) {
             fieldArrayContext.addToLuceneDocument(context);
         }
+        if (namedFieldArrayContexts != null) {
+            for (FieldArrayContext arrayContext : namedFieldArrayContexts.values()) {
+                arrayContext.addToLuceneDocument(context);
+            }
+        }
     }
 
     public FieldArrayContext getOffSetContext() {
@@ -676,6 +690,24 @@ public abstract class DocumentParserContext {
         }
         fieldArrayContext.setCurrentDoc(doc());
         return fieldArrayContext;
+    }
+
+    /**
+     * Like {@link #getOffSetContext()}, but for mappers — such as flattened — that need a dedicated
+     * {@link FieldArrayContext} per mapped field rather than sharing the single document-wide one, because they encode
+     * multiple keys into one sidecar doc-values field named after the mapped field itself. The context for {@code key} is
+     * created via {@code factory} on first access and reused by every subsequent call with the same {@code key} for the
+     * rest of this document, so offset ordinals stay consistent with the document-wide value set the field writes even
+     * when a field's {@code parseCreateField} runs more than once for the same document (e.g. field supplied as an array
+     * of objects).
+     */
+    public FieldArrayContext getOffSetContext(String key, Supplier<? extends FieldArrayContext> factory) {
+        if (namedFieldArrayContexts == null) {
+            namedFieldArrayContexts = new HashMap<>();
+        }
+        FieldArrayContext arrayContext = namedFieldArrayContexts.computeIfAbsent(key, ignored -> factory.get());
+        arrayContext.setCurrentDoc(doc());
+        return arrayContext;
     }
 
     private XContentParser.Token lastSetToken;

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldArrayContext.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldArrayContext;
+import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.simdvec.ESVectorUtil;
 
@@ -53,13 +54,18 @@ public final class FlattenedFieldArrayContext extends FieldArrayContext {
 
     @Override
     public void addToLuceneDocument(DocumentParserContext context) throws IOException {
-        // Offset ordinals are only valid relative to the values this context instance observed. A second write would mean
-        // parseCreateField ran more than once for this field in the same document (e.g. field supplied as an array of
-        // objects), which silently corrupts array reconstruction since offsets from different instances target the same
-        // document-wide sorted-unique value set. See https://github.com/elastic/elasticsearch/issues/153014.
-        assert context.doc().getField(offsetsFieldName) == null;
-        for (var docOffsets : offsetsPerDoc.values()) {
-            for (var entry : docOffsets.entrySet()) {
+        // This context instance is shared by every parseCreateField call for this field within the document (see
+        // DocumentParserContext#getOffSetContext(String, java.util.function.Supplier)) and flushed exactly once, after all
+        // of them have run. That keeps offset ordinals consistent with the document-wide sorted-unique value set they are
+        // decoded against; flushing per call (one context per call) previously encoded ordinals relative to only the
+        // values a single call observed, silently corrupting reconstruction when a field's value was an array of objects.
+        // See https://github.com/elastic/elasticsearch/issues/153014.
+        for (var docEntry : offsetsPerDoc.entrySet()) {
+            // A null key means no document was set while recording (e.g. direct unit-test usage); fall back to the document
+            // being flushed.
+            LuceneDocument doc = docEntry.getKey() != null ? docEntry.getKey() : context.doc();
+            assert doc.getField(offsetsFieldName) == null;
+            for (var entry : docEntry.getValue().entrySet()) {
                 String fieldName = entry.getKey();
                 var offsets = entry.getValue();
 
@@ -67,7 +73,7 @@ public final class FlattenedFieldArrayContext extends FieldArrayContext {
 
                 if (encoded != null) {
                     MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
-                        context.doc(),
+                        doc,
                         offsetsFieldName,
                         encoded,
                         MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldArrayContext.java
@@ -53,6 +53,11 @@ public final class FlattenedFieldArrayContext extends FieldArrayContext {
 
     @Override
     public void addToLuceneDocument(DocumentParserContext context) throws IOException {
+        // Offset ordinals are only valid relative to the values this context instance observed. A second write would mean
+        // parseCreateField ran more than once for this field in the same document (e.g. field supplied as an array of
+        // objects), which silently corrupts array reconstruction since offsets from different instances target the same
+        // document-wide sorted-unique value set. See https://github.com/elastic/elasticsearch/issues/153014.
+        assert context.doc().getField(offsetsFieldName) == null;
         for (var docOffsets : offsetsPerDoc.values()) {
             for (var entry : docOffsets.entrySet()) {
                 String fieldName = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldArrayContext.java
@@ -54,16 +54,11 @@ public final class FlattenedFieldArrayContext extends FieldArrayContext {
 
     @Override
     public void addToLuceneDocument(DocumentParserContext context) throws IOException {
-        // This context instance is shared by every parseCreateField call for this field within the document (see
-        // DocumentParserContext#getOffSetContext(String, java.util.function.Supplier)) and flushed exactly once, after all
-        // of them have run. That keeps offset ordinals consistent with the document-wide sorted-unique value set they are
-        // decoded against; flushing per call (one context per call) previously encoded ordinals relative to only the
-        // values a single call observed, silently corrupting reconstruction when a field's value was an array of objects.
-        // See https://github.com/elastic/elasticsearch/issues/153014.
         for (var docEntry : offsetsPerDoc.entrySet()) {
             // A null key means no document was set while recording (e.g. direct unit-test usage); fall back to the document
             // being flushed.
             LuceneDocument doc = docEntry.getKey() != null ? docEntry.getKey() : context.doc();
+            // Offsets must only be encoded and recorded once
             assert doc.getField(offsetsFieldName) == null;
             for (var entry : docEntry.getValue().entrySet()) {
                 String fieldName = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1678,11 +1678,6 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         if (preserveLeafArrays == PreserveLeafArrays.LOSSY) {
             arrayContext = null;
         } else {
-            // Shared across every parseCreateField call for this field within the document (e.g. field supplied as an
-            // array of objects) and flushed once, via DocumentParserContext#processArrayOffsets, after parsing completes.
-            // A context created and flushed per call would encode offset ordinals relative to only the values that call
-            // observed, while the keyed values themselves accumulate across all calls into one document-wide sorted-unique
-            // set — corrupting reconstruction. See https://github.com/elastic/elasticsearch/issues/153014.
             arrayContext = (FlattenedFieldArrayContext) context.getOffSetContext(
                 mappedFieldType.name(),
                 () -> new FlattenedFieldArrayContext(mappedFieldType.name())

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1678,7 +1678,15 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         if (preserveLeafArrays == PreserveLeafArrays.LOSSY) {
             arrayContext = null;
         } else {
-            arrayContext = new FlattenedFieldArrayContext(mappedFieldType.name());
+            // Shared across every parseCreateField call for this field within the document (e.g. field supplied as an
+            // array of objects) and flushed once, via DocumentParserContext#processArrayOffsets, after parsing completes.
+            // A context created and flushed per call would encode offset ordinals relative to only the values that call
+            // observed, while the keyed values themselves accumulate across all calls into one document-wide sorted-unique
+            // set — corrupting reconstruction. See https://github.com/elastic/elasticsearch/issues/153014.
+            arrayContext = (FlattenedFieldArrayContext) context.getOffSetContext(
+                mappedFieldType.name(),
+                () -> new FlattenedFieldArrayContext(mappedFieldType.name())
+            );
         }
 
         try {
@@ -1687,10 +1695,6 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             fieldParser.parse(context, arrayContext);
         } finally {
             context.path().setWithinLeafObject(false);
-        }
-
-        if (arrayContext != null) {
-            arrayContext.addToLuceneDocument(context);
         }
 
         if (mappedFieldType.hasDocValues() == false) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldRootBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldRootBlockLoaderTests.java
@@ -261,6 +261,35 @@ public class FlattenedFieldRootBlockLoaderTests extends BinaryDVBlockLoaderTestC
         runner.run(new BytesRef("{\"a\":[\"1\",\"4\"],\"b\":\"2\",\"c\":\"3\"}"));
     }
 
+    /**
+     * With {@code preserve_leaf_arrays: exact}, array-order offsets for a key are encoded relative to the
+     * values seen by a single {@code parseCreateField} call. When the flattened field's top-level value is an
+     * array of objects (field multiplicity), {@code parseCreateField} runs once per array element, each time
+     * with a fresh offsets-tracking context, while the keyed values across all elements are merged into one
+     * document-wide sorted-unique set. The offsets from one element are then decoded against a value set they
+     * were never computed against, silently dropping values from other elements. The block loader shares the
+     * same reconstruction path ({@link org.elasticsearch.index.mapper.flattened.FlattenedFieldSyntheticWriterHelper})
+     * as synthetic source, so it is affected identically. See
+     * <a href="https://github.com/elastic/elasticsearch/issues/153014">#153014</a>.
+     */
+    public void testBlockLoaderPreserveLeafArraysExactWithFieldMultiplicity() throws IOException {
+        runner.breaker(newLimitedBreaker(TEST_BREAKER_SIZE));
+        runner.document(Map.of("field", List.of(Map.of("key", List.of("b", "a")), Map.of("key", "c"))));
+        runner.fieldName("field");
+
+        Map<String, Object> flattenedMapping = Map.of("type", "flattened", "preserve_leaf_arrays", "exact");
+        Mapping mapping = new Mapping(
+            Map.of("_doc", Map.of("properties", Map.of("field", flattenedMapping))),
+            Map.of("field", flattenedMapping)
+        );
+
+        String expected = "{\"key\":[\"b\",\"a\",\"c\"]}";
+
+        var settings = getSettingsForParams();
+        runner.mapperService(createMapperService(settings.build(), XContentFactory.jsonBuilder().map(mapping.raw())));
+        runner.run(new BytesRef(expected));
+    }
+
     public void testBlockLoaderDottedKeyAndNestedObject() throws IOException {
         runner.breaker(newLimitedBreaker(TEST_BREAKER_SIZE));
         // "a.b" as a dotted key and "a":{"b":...} as a nested object both flatten to the same key.

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
@@ -1817,6 +1817,36 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         assertThat(syntheticSource(mapper, example), equalTo("{\"field\":{\"sub1\":{\"sub2\":[\"foo\",\"bar\",\"baz\",\"bat\"]}}}"));
     }
 
+    /**
+     * With {@code preserve_leaf_arrays: exact}, array-order offsets for a key are encoded relative to the
+     * values seen by a single {@code parseCreateField} call. When the flattened field's top-level value is an
+     * array of objects (field multiplicity), {@code parseCreateField} runs once per array element, each time
+     * with a fresh offsets-tracking context, while the keyed values across all elements are merged into one
+     * document-wide sorted-unique set. The offsets from one element are then decoded against a value set they
+     * were never computed against, silently dropping values from other elements. See
+     * <a href="https://github.com/elastic/elasticsearch/issues/153014">#153014</a>.
+     */
+    public void testPreserveLeafArraysExactWithFieldMultiplicity() throws IOException {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("field").field("type", "flattened").field("preserve_leaf_arrays", "exact").endObject();
+        })).documentMapper();
+
+        CheckedConsumer<XContentBuilder, IOException> example = b -> {
+            b.startArray("field");
+            {
+                b.startObject();
+                b.array("key", "b", "a");
+                b.endObject();
+                b.startObject();
+                b.field("key", "c");
+                b.endObject();
+            }
+            b.endArray();
+        };
+
+        assertThat(syntheticSource(mapper, example), equalTo("{\"field\":{\"key\":[\"b\",\"a\",\"c\"]}}"));
+    }
+
     public void testPreserveLeafArraysExactWithAllNulls() throws IOException {
         DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field").field("type", "flattened").field("preserve_leaf_arrays", "exact").endObject();


### PR DESCRIPTION
## Summary

Fixes #153014.

With `preserve_leaf_arrays: exact`, `FlattenedFieldMapper` tracked array-order offsets in a `FlattenedFieldArrayContext` that was created fresh and flushed to the Lucene document on every `parseCreateField` call. When a flattened field's value is supplied as an array of objects, `parseCreateField` runs once per array element, so each call encoded offset ordinals relative to only the values *it* observed. The keyed values themselves, however, accumulate across all calls into one document-wide sorted-unique doc-values field. Decoding then applied offsets against a value set they were never computed against, silently dropping values during synthetic source and block-loader reconstruction.

For example, indexing:
```json
{ "field": [ { "key": ["b", "a"] }, { "key": "c" } ] }
```
with `preserve_leaf_arrays: exact` reconstructed `field.key` as `["b","a"]` instead of `["b","a","c"]` — `"c"` was silently lost.

### Fix

`DocumentParserContext` already has a mechanism for this: a single, document-scoped `FieldArrayContext` shared across every call, flushed once after the whole document has been parsed (`processArrayOffsets`). Regular field types (`keyword`, `numeric`, `date`, etc.) use it via `getOffSetContext()`. Flattened fields need a context per mapped field (since they multiplex several keys into one sidecar doc-values field), so this adds an overload, `getOffSetContext(String key, Supplier<...> factory)`, that lazily creates and caches one `FieldArrayContext` per key for the document. `FlattenedFieldMapper` now uses this instead of instantiating and flushing its own context per call, so offset ordinals stay consistent with the document-wide value set regardless of how many times `parseCreateField` runs for a field within a document.

`FlattenedFieldArrayContext#addToLuceneDocument` was also updated to resolve the target Lucene document per recorded entry (matching the base class's existing behavior) instead of always using the context's current document, since the flush is no longer guaranteed to happen while that document is still current.