### PR TITLE
ESQL:DS: Fix dataset resolution for co-resident resources

### DIFF
--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -2597,6 +2597,39 @@ public class EsqlSecurityIT extends ESRestTestCase {
     }
 
     /**
+     * Explicit-name counterpart of {@link #testListDatasetsAsNonSuperuserWithCoresidentHiddenDataStream}: a user
+     * authorized on the co-resident data stream asks for it by its literal name, not via a wildcard. Dataset
+     * resolution must preserve explicit-name not-found semantics instead of treating the foreign resource like a
+     * wildcard-expanded value that can be silently filtered away.
+     */
+    public void testGetDatasetByExplicitNameOfCoresidentHiddenDataStream() throws IOException {
+        assumeTrue("data_sources REST API not supported by cluster", dataSourcesApiSupported());
+
+        Request tmpl = new Request("PUT", "/_index_template/entities-updates-tmpl");
+        tmpl.setJsonEntity("{\"index_patterns\":[\"entities-updates-*\"],\"data_stream\":{\"hidden\":true}}");
+        setUser(tmpl, "test-admin");
+        assertOK(client().performRequest(tmpl));
+        Request createDs = new Request("PUT", "/_data_stream/entities-updates-default");
+        setUser(createDs, "test-admin");
+        assertOK(client().performRequest(createDs));
+
+        try {
+            Request get = new Request("GET", "/_query/dataset/entities-updates-default");
+            setUser(get, "ds_repro_broad_reader");
+            ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(get));
+            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(ex.getMessage(), containsString("dataset [entities-updates-default] not found"));
+        } finally {
+            Request delDs = new Request("DELETE", "/_data_stream/entities-updates-default");
+            setUser(delDs, "test-admin");
+            client().performRequest(delDs);
+            Request delTmpl = new Request("DELETE", "/_index_template/entities-updates-tmpl");
+            setUser(delTmpl, "test-admin");
+            client().performRequest(delTmpl);
+        }
+    }
+
+    /**
      * {@code FROM <dataset>} requires the index {@code read} privilege on the dataset name — the name is routed
      * through the security filter before the rewrite strips it from the plan. A principal without read on the name
      * gets the same {@code Unknown index} error a missing index produces — like unauthorized indices and views,

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
@@ -412,11 +412,13 @@ ds_dataset_read_metadata:
 
 # Repro for the GET _query/dataset 404: a broad, Kibana-like reader that can both list datasets and read an
 # unrelated (Entity-Store-style) data stream, so the dataset list's wildcard expands across both namespaces.
+# read_dataset_metadata on the data stream mirrors a role authorized for the dataset get/list action there too
+# (e.g. via a broad "manage"/"all" grant), which is what lets the co-resident name reach dataset resolution.
 ds_repro_broad_reader:
   cluster: []
   indices:
     - names: [ 'entities-updates-*' ]
-      privileges: [ 'read' ]
+      privileges: [ 'read', 'read_dataset_metadata' ]
     - names: [ 'security_it_ds_*' ]
       privileges: [ 'read_dataset_metadata' ]
   global:

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceCrudIT.java
@@ -778,15 +778,19 @@ public class DataSourceCrudIT extends ESIntegTestCase {
     }
 
     /**
-     * A concrete delete of a name that exists but is not a dataset (here, a real index) is a no-op ack, not a
-     * 404: the type filter drops the non-dataset and the index is never touched. Mirrors view delete.
+     * A concrete delete of a name that exists but is not a dataset (here, a real index) preserves explicit-name
+     * not-found semantics and leaves the index untouched.
      */
-    public void testDeleteConcreteNonDatasetNameIsNoOp() throws Exception {
+    public void testDeleteConcreteNonDatasetNameIsNotFound() throws Exception {
         final String indexName = "not_a_dataset_index";
         assertAcked(client().execute(TransportCreateIndexAction.TYPE, new CreateIndexRequest(indexName)).get(30, TimeUnit.SECONDS));
 
-        // DELETE /_query/dataset/<index>: the name resolves to an index, gets type-filtered out, and acks empty.
-        assertAcked(client().execute(DeleteDatasetAction.INSTANCE, deleteDatasetRequest(indexName)));
+        ExecutionException err = expectThrows(
+            ExecutionException.class,
+            () -> client().execute(DeleteDatasetAction.INSTANCE, deleteDatasetRequest(indexName)).get()
+        );
+        assertThat(err.getCause(), instanceOf(ResourceNotFoundException.class));
+        assertThat(err.getCause().getMessage(), containsString("dataset [" + indexName + "] not found"));
 
         // The index is untouched.
         assertThat(indexExists(indexName), equalTo(true));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetResolutionService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetResolutionService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.dataset;
+
+import org.elasticsearch.action.ResolvedIndexExpression;
+import org.elasticsearch.action.ResolvedIndexExpressions;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.IndexAbstractionResolver;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.IndexNotFoundException;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.action.ResolvedIndexExpression.LocalIndexResolutionResult.CONCRETE_RESOURCE_NOT_VISIBLE;
+
+/**
+ * Resolves dataset name expressions (including wildcards) to {@link Dataset} instances, mirroring
+ * {@link org.elasticsearch.xpack.esql.view.ViewResolutionService}. Wildcards may expand across the wider
+ * index namespace and are filtered down to datasets, while an explicit name must resolve to a dataset;
+ * explicit missing, hidden, or co-resident foreign resources are reported as not-found.
+ */
+public class DatasetResolutionService {
+
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+
+    public DatasetResolutionService(IndexNameExpressionResolver indexNameExpressionResolver) {
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+    }
+
+    public DatasetResolutionResult resolveDatasets(
+        ProjectState projectState,
+        String[] indexPatterns,
+        IndicesOptions indicesOptions,
+        ResolvedIndexExpressions resolvedIndexExpressions
+    ) {
+        if (indexPatterns == null || indexPatterns.length == 0) {
+            return new DatasetResolutionResult(new Dataset[0], resolvedIndexExpressions);
+        }
+
+        IndexAbstractionResolver indexAbstractionResolver = new IndexAbstractionResolver(indexNameExpressionResolver);
+        var indicesLookup = projectState.metadata().getIndicesLookup();
+
+        if (resolvedIndexExpressions == null) {
+            resolvedIndexExpressions = indexAbstractionResolver.resolveIndexAbstractions(
+                List.of(indexPatterns),
+                indicesOptions,
+                projectState.metadata(),
+                componentSelector -> indicesLookup.keySet(),
+                (index, selector) -> true, // Assume that a dataset is its own data component but has no failure component
+                true
+            );
+        }
+        checkDatasetsExist(resolvedIndexExpressions, indicesOptions, indicesLookup);
+        Dataset[] datasets = resolvedIndexExpressions.getLocalIndicesList()
+            .stream()
+            .map(indicesLookup::get)
+            .filter(indexAbstraction -> indexAbstraction != null && indexAbstraction.getType() == IndexAbstraction.Type.DATASET)
+            .map(indexAbstraction -> (Dataset) indexAbstraction)
+            .toArray(Dataset[]::new);
+
+        return new DatasetResolutionResult(datasets, resolvedIndexExpressions);
+    }
+
+    private void checkDatasetsExist(
+        ResolvedIndexExpressions resolvedIndexExpressions,
+        IndicesOptions indicesOptions,
+        Map<String, IndexAbstraction> indicesLookup
+    ) {
+        if (indicesOptions.ignoreUnavailable()) {
+            return;
+        }
+        for (ResolvedIndexExpression expression : resolvedIndexExpressions.expressions()) {
+            if (expression.localExpressions().localIndexResolutionResult() == CONCRETE_RESOURCE_NOT_VISIBLE) {
+                throw new IndexNotFoundException(expression.original());
+            }
+            if (Regex.isSimpleMatchPattern(expression.original()) == false
+                && expression.localExpressions().indices().isEmpty() == false
+                && expression.localExpressions()
+                    .indices()
+                    .stream()
+                    .map(indicesLookup::get)
+                    .noneMatch(indexAbstraction -> indexAbstraction != null && indexAbstraction.getType() == IndexAbstraction.Type.DATASET)) {
+                throw new IndexNotFoundException(expression.original());
+            }
+        }
+    }
+
+    public record DatasetResolutionResult(Dataset[] datasets, ResolvedIndexExpressions resolvedIndexExpressions) {}
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetResolutionService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetResolutionService.java
@@ -89,7 +89,9 @@ public class DatasetResolutionService {
                     .indices()
                     .stream()
                     .map(indicesLookup::get)
-                    .noneMatch(indexAbstraction -> indexAbstraction != null && indexAbstraction.getType() == IndexAbstraction.Type.DATASET)) {
+                    .noneMatch(
+                        indexAbstraction -> indexAbstraction != null && indexAbstraction.getType() == IndexAbstraction.Type.DATASET
+                    )) {
                 throw new IndexNotFoundException(expression.original());
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DeleteDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DeleteDatasetAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources.dataset;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.ResolvedIndexExpressions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -40,6 +41,7 @@ public class DeleteDatasetAction extends ActionType<AcknowledgedResponse> {
 
     public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest.Replaceable {
         private String[] names;
+        private ResolvedIndexExpressions resolvedIndexExpressions;
 
         public Request(TimeValue masterNodeTimeout, TimeValue ackTimeout, String[] names) {
             super(masterNodeTimeout, ackTimeout);
@@ -83,6 +85,23 @@ public class DeleteDatasetAction extends ActionType<AcknowledgedResponse> {
         @Override
         public IndicesOptions indicesOptions() {
             return DEFAULT_INDICES_OPTIONS;
+        }
+
+        @Override
+        public boolean includeDataStreams() {
+            // Resolution must be able to see co-resident data streams (e.g. Security's entities-metadata-default)
+            // in order to distinguish existing non-datasets from genuinely missing or hidden resources.
+            return true;
+        }
+
+        @Override
+        public void setResolvedIndexExpressions(ResolvedIndexExpressions expressions) {
+            this.resolvedIndexExpressions = expressions;
+        }
+
+        @Override
+        public ResolvedIndexExpressions getResolvedIndexExpressions() {
+            return this.resolvedIndexExpressions;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/GetDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/GetDatasetAction.java
@@ -70,6 +70,13 @@ public class GetDatasetAction extends ActionType<GetDatasetAction.Response> {
         }
 
         @Override
+        public boolean includeDataStreams() {
+            // Resolution must be able to see co-resident data streams (e.g. Security's entities-metadata-default)
+            // in order to distinguish existing non-datasets from genuinely missing or hidden resources.
+            return true;
+        }
+
+        @Override
         public IndicesRequest indices(String... indices) {
             this.indices = indices;
             return this;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportDeleteDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportDeleteDatasetAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodePr
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.Dataset;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -25,11 +26,12 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class TransportDeleteDatasetAction extends AcknowledgedTransportMasterNodeProjectAction<DeleteDatasetAction.Request> {
     private final DatasetService datasetService;
-    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final DatasetResolutionService datasetResolutionService;
     private final DestructiveOperations destructiveOperations;
 
     @Inject
@@ -54,7 +56,7 @@ public class TransportDeleteDatasetAction extends AcknowledgedTransportMasterNod
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.datasetService = datasetService;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.datasetResolutionService = new DatasetResolutionService(indexNameExpressionResolver);
         this.destructiveOperations = destructiveOperations;
     }
 
@@ -72,19 +74,26 @@ public class TransportDeleteDatasetAction extends AcknowledgedTransportMasterNod
         ActionListener<AcknowledgedResponse> listener
     ) {
         // Resolve to datasets only: `resolveDatasets` is additive, so a wildcard expands across the whole
-        // namespace — without this filter index names reach the registry. Mirrors TransportDeleteViewAction.
-        final List<String> datasetNames;
+        // namespace — without this filter index names reach the registry. Explicit names must still resolve to
+        // datasets; missing, hidden, or co-resident foreign resources are reported as not-found.
+        final DatasetResolutionService.DatasetResolutionResult result;
         try {
-            datasetNames = indexNameExpressionResolver.datasets(state.metadata(), request.indicesOptions(), request);
+            result = datasetResolutionService.resolveDatasets(
+                state,
+                request.indices(),
+                request.indicesOptions(),
+                request.getResolvedIndexExpressions()
+            );
         } catch (IndexNotFoundException e) {
             final String missing = e.getIndex() != null ? e.getIndex().getName() : String.join(",", request.names());
             listener.onFailure(new ResourceNotFoundException("dataset [{}] not found", missing));
             return;
         }
-        if (datasetNames.isEmpty()) {
+        if (result.datasets().length == 0) {
             listener.onResponse(AcknowledgedResponse.TRUE);
             return;
         }
+        final List<String> datasetNames = Arrays.stream(result.datasets()).map(Dataset::name).toList();
         datasetService.deleteDatasets(state.projectId(), request.masterNodeTimeout(), request.ackTimeout(), datasetNames, listener);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportGetDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/TransportGetDatasetAction.java
@@ -13,8 +13,6 @@ import org.elasticsearch.action.support.local.TransportLocalProjectMetadataActio
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.Dataset;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -24,13 +22,12 @@ import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /** Local transport handler for {@link GetDatasetAction}. */
 public class TransportGetDatasetAction extends TransportLocalProjectMetadataAction<GetDatasetAction.Request, GetDatasetAction.Response> {
 
-    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final DatasetResolutionService datasetResolutionService;
 
     @Inject
     public TransportGetDatasetAction(
@@ -48,7 +45,7 @@ public class TransportGetDatasetAction extends TransportLocalProjectMetadataActi
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             projectResolver
         );
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.datasetResolutionService = new DatasetResolutionService(indexNameExpressionResolver);
     }
 
     @Override
@@ -58,29 +55,23 @@ public class TransportGetDatasetAction extends TransportLocalProjectMetadataActi
         ProjectState project,
         ActionListener<GetDatasetAction.Response> listener
     ) {
-        final DatasetMetadata metadata = DatasetMetadata.get(project.metadata());
-        // Resolve + type-filter against the local project's cluster state. We don't consume
-        // request.getResolvedIndexExpressions(): datasets have no cross-project resolution today, so
-        // re-resolving from indices() is equivalent — revisit (like view GET) when datasets become remotable.
-        // `resolveDatasets` is additive: an explicit name that resolves to a non-dataset abstraction (e.g. a data
-        // stream) throws IndexNotFoundException before the Type.DATASET filter runs. Translate it to a dataset-shaped
-        // not-found instead of leaking a raw index_not_found_exception, mirroring TransportDeleteDatasetAction.
-        final List<String> resolved;
+        // An explicit name that doesn't exist, isn't visible, or exists only as a co-resident foreign resource
+        // (e.g. a data stream) throws IndexNotFoundException. Translate it to a dataset-shaped not-found instead
+        // of leaking a raw index_not_found_exception, mirroring TransportDeleteDatasetAction.
+        final DatasetResolutionService.DatasetResolutionResult result;
         try {
-            resolved = indexNameExpressionResolver.datasets(project.metadata(), request.indicesOptions(), request);
+            result = datasetResolutionService.resolveDatasets(
+                project,
+                request.indices(),
+                request.indicesOptions(),
+                request.getResolvedIndexExpressions()
+            );
         } catch (IndexNotFoundException e) {
             final String missing = e.getIndex() != null ? e.getIndex().getName() : String.join(",", request.indices());
             listener.onFailure(new ResourceNotFoundException("dataset [{}] not found", missing));
             return;
         }
-        final List<Dataset> hits = new ArrayList<>();
-        for (String name : resolved) {
-            Dataset ds = metadata.get(name);
-            if (ds != null) {
-                hits.add(ds);
-            }
-        }
-        listener.onResponse(new GetDatasetAction.Response(hits));
+        listener.onResponse(new GetDatasetAction.Response(List.of(result.datasets())));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetResolutionServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetResolutionServiceTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.dataset;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DataSourceReference;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.indices.EmptySystemIndices;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.elasticsearch.action.support.IndicesOptions.ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS;
+import static org.hamcrest.Matchers.equalTo;
+
+public class DatasetResolutionServiceTests extends ESTestCase {
+
+    private static final IndicesOptions DATASET_OPTIONS = IndicesOptions.builder()
+        .indexAbstractionOptions(IndicesOptions.IndexAbstractionOptions.builder().resolveDatasets(true).build())
+        .concreteTargetOptions(ERROR_WHEN_UNAVAILABLE_TARGETS)
+        .build();
+
+    public void testResolveMissing() {
+        DatasetResolutionService service = newService();
+        ClusterState clusterState = emptyClusterState();
+        assertThrows(
+            IndexNotFoundException.class,
+            () -> service.resolveDatasets(clusterState.projectState(ProjectId.DEFAULT), new String[] { "missing" }, DATASET_OPTIONS, null)
+        );
+    }
+
+    public void testResolveExplicitCoresidentForeignResourceIsNotFound() {
+        // Repro for https://github.com/elastic/elasticsearch/issues/152980: an explicit name that exists but as a
+        // non-dataset resource (here a plain index, standing in for e.g. a co-resident data stream like Security's
+        // entities-metadata-default) must retain explicit-name not-found semantics.
+        final String foreignIndexName = "entities-metadata-default";
+        IndexMetadata foreignIndex = IndexMetadata.builder(foreignIndexName)
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .putProjectMetadata(ProjectMetadata.builder(ProjectId.DEFAULT).put(foreignIndex, false).build())
+            .build();
+
+        DatasetResolutionService service = newService();
+        assertThrows(
+            IndexNotFoundException.class,
+            () -> service.resolveDatasets(
+                clusterState.projectState(ProjectId.DEFAULT),
+                new String[] { foreignIndexName },
+                DATASET_OPTIONS,
+                null
+            )
+        );
+    }
+
+    public void testResolveListIgnoresCoresidentForeignResource() {
+        final String datasetName = "cloudtrail_logs";
+        Dataset dataset = new Dataset(
+            datasetName,
+            new DataSourceReference("aws_s3_logs"),
+            "s3://bucket/cloudtrail/*.json.gz",
+            null,
+            Map.of()
+        );
+        IndexMetadata foreignIndex = IndexMetadata.builder("entities-metadata-default")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .putProjectMetadata(
+                ProjectMetadata.builder(ProjectId.DEFAULT).put(foreignIndex, false).datasets(Map.of(datasetName, dataset)).build()
+            )
+            .build();
+
+        DatasetResolutionService service = newService();
+        DatasetResolutionService.DatasetResolutionResult result = service.resolveDatasets(
+            clusterState.projectState(ProjectId.DEFAULT),
+            new String[] { "*" },
+            DATASET_OPTIONS,
+            null
+        );
+        assertThat(result.datasets().length, equalTo(1));
+        assertThat(result.datasets()[0].name(), equalTo(datasetName));
+    }
+
+    private static DatasetResolutionService newService() {
+        IndexNameExpressionResolver resolver = new IndexNameExpressionResolver(
+            new ThreadContext(Settings.EMPTY),
+            EmptySystemIndices.INSTANCE,
+            TestProjectResolvers.DEFAULT_PROJECT_ONLY
+        );
+        return new DatasetResolutionService(resolver);
+    }
+
+    private static ClusterState emptyClusterState() {
+        return ClusterState.builder(ClusterName.DEFAULT).putProjectMetadata(ProjectMetadata.builder(ProjectId.DEFAULT).build()).build();
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -554,10 +554,13 @@ class IndicesAndAliasesResolver {
     }
 
     private boolean shouldSetResolvedIndexExpressions(IndicesRequest.Replaceable replaceable, ResolvedIndexExpressions resolved) {
-        // Only store resolved expressions if cross-project mode or if views should be resolved, to avoid unnecessary memory
-        // usage. Once we've migrated from `indices()` to using resolved expressions holistically, we will always store them.
+        // Only store resolved expressions if cross-project mode or if views/datasets should be resolved, to avoid
+        // unnecessary memory usage. Once we've migrated from `indices()` to using resolved expressions
+        // holistically, we will always store them.
+        var indexAbstractionOptions = replaceable.indicesOptions().indexAbstractionOptions();
         if (crossProjectModeDecider.crossProjectEnabled() == false
-            && replaceable.indicesOptions().indexAbstractionOptions().resolveViews() == false) {
+            && indexAbstractionOptions.resolveViews() == false
+            && indexAbstractionOptions.resolveDatasets() == false) {
             return false;
         }
 


### PR DESCRIPTION
Fix dataset GET/DELETE resolution so explicit names that resolve only to non-dataset resources preserve dataset-shaped 404 semantics, while wildcard dataset listings/deletes still filter out co-resident foreign resources. Also keeps security’s pre-resolved dataset expressions available and adds regressions for the security/data-stream edge cases.

Closes #152980
