### PR TITLE
ESQL: preserve empty CSV/TSV text fields as empty string

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-csv/qa/build.gradle
@@ -54,12 +54,47 @@ def serverProject = project(xpackModule('esql:qa:server'))
 def csvIcebergFixtureRoot = file("${buildDir}/csv-iceberg-fixtures")
 def tsvFixtureOutputRoot = file("${buildDir}/generated-tsv-fixtures")
 
+// The source-of-truth CSVs spell null as an empty (or whitespace-only, for padding) cell — the ingested
+// CsvTestsDataLoader convention. CsvFormatReader reads an empty field as the EMPTY STRING on text columns
+// (only the literal `null` token — or a configured null_value — is null), so an untransformed copy would
+// turn every null keyword into "" and break the csv-spec expectations that pin those values as null.
+// Rewrite whitespace-only top-level cells to the literal `null` token when syncing. Bracket [a,b] content
+// is left untouched; none of the synced fixtures use quoted cells. Comment lines pass through unchanged,
+// and header cells (`name:type`) are never blank, so the transform applies uniformly per line.
+def spellNullCells = { String line ->
+  if (line.startsWith('//')) {
+    return line
+  }
+  StringBuilder out = new StringBuilder(line.length() + 16)
+  StringBuilder cell = new StringBuilder()
+  int depth = 0
+  for (int i = 0; i < line.length(); i++) {
+    char c = line.charAt(i)
+    if (c == ('[' as char)) {
+      depth++
+    } else if (c == (']' as char) && depth > 0) {
+      depth--
+    }
+    if (c == (',' as char) && depth == 0) {
+      out.append(cell.toString().trim().isEmpty() ? 'null' : cell.toString()).append(',')
+      cell.setLength(0)
+    } else {
+      cell.append(c)
+    }
+  }
+  // Final cell: only null-substitute when the line actually has cells (a blank line stays blank).
+  out.append(cell.toString().trim().isEmpty() && out.length() > 0 ? 'null' : cell.toString())
+  return out.toString()
+}
+
 tasks.register('syncCsvIcebergFixtures', Sync) {
   dependsOn testFixturesProject.tasks.named('processResources')
   duplicatesStrategy = DuplicatesStrategy.FAIL
   from(testFixturesProject.file('src/main/resources/data')) {
     include 'employees.csv', 'web_logs.csv', 'books.csv', 'apps.csv', 'mv_sample.csv', 'employees_no_mv.csv'
   }
+  filteringCharset = 'UTF-8'
+  filter(spellNullCells)
   into file("${csvIcebergFixtureRoot}/iceberg-fixtures/standalone")
 }
 
@@ -101,8 +136,9 @@ tasks.register('syncCsvIcebergMultifileTypeDriftFixtures', Sync) {
 
 // Generate multifile CSV fixtures by splitting employees.csv into 3 parts (analogous to
 // the Parquet 3-way split in esql-datasource-parquet/qa/build.gradle). This enables the
-// shared external-multifile.csv-spec tests to run for CSV format. The split preserves raw
-// line content (no parsing) so multi-value bracket syntax and typed headers stay intact.
+// shared external-multifile.csv-spec tests to run for CSV format. The split keeps each line
+// intact apart from the spellNullCells empty-cell rewrite, so multi-value bracket syntax and
+// typed headers stay as authored.
 def multifileSplitDir = file("${csvIcebergFixtureRoot}/iceberg-fixtures/multifile_split")
 def multifileEmployeesCsv = testFixturesProject.file('src/main/resources/data/employees.csv')
 def multifileSplitParts = 3
@@ -132,7 +168,8 @@ tasks.register('generateMultifileCsvSplit_employees') {
       out.withWriter('UTF-8') { w ->
         w.writeLine(header)
         for (int i = from; i < to; i++) {
-          w.writeLine(data[i])
+          // Same empty-cell → literal `null` rewrite as syncCsvIcebergFixtures (see spellNullCells).
+          w.writeLine(spellNullCells(data[i]))
         }
       }
     }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -251,6 +251,27 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private static final String[] EMPTY_ROW = new String[0];
 
     /**
+     * The value produced for an empty ({@code ""}) field on a text-typed column: a real, zero-length string.
+     * Shared and immutable — its byte payload is empty, so the append path copies nothing and no aliasing is
+     * possible across rows or columns. See {@link #isTextType} for why an empty field is a string here rather
+     * than null.
+     */
+    private static final BytesRef EMPTY_BYTES_REF = new BytesRef(BytesRef.EMPTY_BYTES);
+
+    /**
+     * Whether {@code dt} carries string values, i.e. an empty field is a genuine empty string rather than null.
+     * CSV/TSV cannot spell "null" and "empty string" differently at the byte level — an empty field is just two
+     * adjacent delimiters — so the reader picks a convention per type: for {@code KEYWORD}/{@code TEXT} an empty
+     * field is the empty string (matching the ndjson and parquet readers, which preserve an explicit empty
+     * string, and ClickHouse's CSV/TSV convention where only {@code \N} is null); for every other type an empty
+     * field has no valid empty-string value and stays null. Keeping the empty string is what makes
+     * {@code COUNT(DISTINCT)} / {@code VALUES()} over a text column with empty values agree across formats.
+     */
+    private static boolean isTextType(DataType dt) {
+        return dt == DataType.KEYWORD || dt == DataType.TEXT;
+    }
+
+    /**
      * Reused {@link DateFormatter} that delegates to ES's hand-rolled
      * {@code Iso8601DateTimeParser}: covers the {@code YYYY-MM-DDTHH:MM:SS[.fff][Z|+HH:MM]} family
      * (plus date-only inputs like {@code YYYY-MM-DD}) without the {@link DateTimeFormatter}
@@ -1122,7 +1143,16 @@ public class CsvFormatReader implements SegmentableFormatReader {
      * as data so e.g. a Windows path inside quotes survives intact.
      */
     private CsvSchema newCsvSchema() {
-        CsvSchema schema = CsvSchema.emptySchema().withColumnSeparator(options.delimiter()).withNullValue(options.nullValue());
+        CsvSchema schema = CsvSchema.emptySchema().withColumnSeparator(options.delimiter());
+        // Register a Jackson null token ONLY for a user-configured, non-empty null_value. Passing the default
+        // empty null_value would make Jackson tokenize every empty field as VALUE_NULL, nulling empty strings
+        // before tryConvertValue can preserve them for text columns (matching the ndjson/parquet readers and
+        // ClickHouse's CSV convention where an empty field is the empty string). With no null token registered,
+        // an empty field arrives as "" and tryConvertValue decides empty-string (text) vs null (other types),
+        // exactly as the direct-to-block path does via stageEmptyField.
+        if (options.nullValue().isEmpty() == false) {
+            schema = schema.withNullValue(options.nullValue());
+        }
         if (options.quoting() == false) {
             return schema.withoutQuoteChar();
         }
@@ -4243,6 +4273,19 @@ public class CsvFormatReader implements SegmentableFormatReader {
             stageNull[bufIdx] = true;
         }
 
+        /**
+         * Stages an empty ({@code ""}) field: the empty string for a text column, null otherwise. Mirrors the
+         * empty-value branch of {@link #tryConvertValue} so the direct-block hot path and the Jackson conversion
+         * path stay in agreement (see {@link #isTextType}).
+         */
+        private void stageEmptyField(int bufIdx, DataType dt) {
+            if (isTextType(dt)) {
+                stageRefValue(bufIdx, EMPTY_BYTES_REF);
+            } else {
+                stageNullValue(bufIdx);
+            }
+        }
+
         private void stageLongValue(int bufIdx, long value) {
             stageLong[bufIdx] = value;
             stageNull[bufIdx] = false;
@@ -4447,10 +4490,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             int len = end - start;
-            // Null classification mirrors tryConvertValue: empty, the literal "null" (any case), or the
-            // configured null marker all become null.
+            // Classification mirrors tryConvertValue: an empty field is the empty string for a text column and
+            // null otherwise; the literal "null" (any case) and the configured null marker always become null.
             if (len == 0) {
-                stageNullValue(bufIdx);
+                stageEmptyField(bufIdx, dt);
                 return true;
             }
             if (len == 4 && regionEqualsIgnoreCase(buf, start, "null")) {
@@ -4710,7 +4753,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     if (projected) {
                         if (value.length() == 0) {
-                            stageNullValue(bufIdx); // empty quoted field is null
+                            stageEmptyField(bufIdx, dt); // empty quoted field: empty string for text, else null
                         } else if (emitConvertedStageField(value.toString(), bufIdx, dt) == false) {
                             return false;
                         }
@@ -4806,7 +4849,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             if (start == end) {
-                stageNullValue(bufIdx);
+                stageEmptyField(bufIdx, dt);
                 return true;
             }
             final char esc = options.escapeChar();
@@ -4831,7 +4874,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             if (trimEnd == 0) {
-                stageNullValue(bufIdx);
+                stageEmptyField(bufIdx, dt);
                 return true;
             }
             // Cap on the tokenized value (full decoded length under no-trim, trimmed under trim_spaces).
@@ -5172,7 +5215,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Object tryConvertValue(String value, DataType dataType) {
-            if (value == null || value.isEmpty() || value.equalsIgnoreCase("null")) {
+            if (value == null) {
+                return null;
+            }
+            if (value.isEmpty()) {
+                // An empty field is the empty string for a text column, null otherwise (see isTextType).
+                return isTextType(dataType) ? EMPTY_BYTES_REF : null;
+            }
+            if (value.equalsIgnoreCase("null")) {
                 return null;
             }
             if (hasCustomNullValue && value.equals(nullValueStr)) {

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -117,7 +117,9 @@ import java.util.regex.Pattern;
  * <ul>
  *   <li>First non-comment line: schema — {@code column:type} pairs separated by the delimiter
  *   <li>Subsequent lines: data rows
- *   <li>Empty/missing values → {@code null}
+ *   <li>Empty values → the empty string on {@code keyword}/{@code text} columns, {@code null} on every other
+ *       type (see {@link #isTextType}); the literal {@code null} (any case) and a configured {@code null_value}
+ *       are always {@code null}; missing trailing values are {@code null}
  *   <li>Lines starting with the comment prefix (default {@code //}) are skipped
  * </ul>
  *
@@ -145,7 +147,8 @@ import java.util.regex.Pattern;
  *   <tr><td>{@code escape}</td><td>{@code \}</td><td>Escape character; setting it turns escaping on
  *           regardless of {@code mode}, the literal {@code none} turns it off (overrides the preset)</td></tr>
  *   <tr><td>{@code comment}</td><td>{@code //}</td><td>Line comment prefix</td></tr>
- *   <tr><td>{@code null_value}</td><td>(empty)</td><td>String representation of null</td></tr>
+ *   <tr><td>{@code null_value}</td><td>(unset)</td><td>String representation of null; when unset, an empty
+ *           field is not a null token (it reads as the empty string on text columns)</td></tr>
  *   <tr><td>{@code encoding}</td><td>{@code UTF-8}</td><td>Character encoding</td></tr>
  *   <tr><td>{@code datetime_format}</td><td>ISO-8601 / epoch</td><td>Custom datetime pattern</td></tr>
  *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>OOM protection; max bytes per field</td></tr>
@@ -4662,7 +4665,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
          * is decoded with Jackson's quoted-escape rule; quoted content (including inner whitespace and embedded newlines) is preserved
          * verbatim, while unquoted fields are trimmed only for typed columns (a keyword keeps its bytes
          * unless trim_spaces). Non-whitespace after a closing quote is a row error, and an empty quoted field
-         * ({@code ""}) is null. Simple unquoted fields (no escape) take the same char-range fast path as
+         * ({@code ""}) yields the empty string on a text column and null otherwise (see {@link #stageEmptyField}).
+         * Simple unquoted fields (no escape) take the same char-range fast path as
          * {@link #splitAndConvertPlain}; quoted or escaped fields are assembled into a reused buffer.
          *
          * @return {@code true} if the row was accepted, {@code false} if rejected by the error policy

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -395,6 +395,17 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row(br("alpha"), 1L), row(br(""), 2L), row(br("beta"), 3L)), read(true, Map.of(), tsv));
     }
 
+    public void testWhitespaceOnlyCellIsEmptyStringForTextNullOtherwise() throws IOException {
+        // With trim_spaces on, a whitespace-only unquoted cell reduces to empty, which then follows the same
+        // convention as a truly empty cell: the empty string for a text column, null for other types. This is
+        // the shape of column-padded CSV files whose null cells are all spaces. (The default is no-trim, where
+        // a text column keeps its bytes, so trim_spaces must be set to collapse the padding to empty.)
+        List<List<Object>> rows = read(false, Map.of("trim_spaces", true), "a:keyword,b:long\n   ,5\nx,   \n");
+        assertEquals(List.of(row(br(""), 5L), row(br("x"), null)), rows);
+        List<List<Object>> tsvRows = read(true, Map.of("trim_spaces", true), "a:keyword\tb:long\n   \t5\nx\t   \n");
+        assertEquals(List.of(row(br(""), 5L), row(br("x"), null)), tsvRows);
+    }
+
     public void testCustomNullValue() throws IOException {
         List<List<Object>> rows = read(false, Map.of("null_value", "NULL"), "a:keyword,b:long\nNULL,NULL\nx,5\n");
         assertEquals(List.of(row(null, null), row(br("x"), 5L)), rows);

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -354,20 +355,44 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row(br("line1\nline2"), br("tail"))), rows);
     }
 
-    public void testEmptyQuotedFieldIsNull() throws IOException {
-        // The current parser collapses an empty quoted field "" to null, exactly like an empty
-        // unquoted cell; pin that so the direct-block parser must match.
+    public void testEmptyQuotedTextFieldIsEmptyString() throws IOException {
+        // An empty quoted field "" on a text column is a genuine empty string (matching the ndjson/parquet
+        // readers and ClickHouse's CSV convention), not null; pin that so the direct-block parser must match.
         List<List<Object>> rows = read(false, Map.of(), "a:keyword,b:keyword\n\"\",x\n");
-        assertEquals(List.of(row(null, br("x"))), rows);
+        assertEquals(List.of(row(br(""), br("x"))), rows);
     }
 
     // ---------------------------------------------------------------------------------------------
     // Null handling
     // ---------------------------------------------------------------------------------------------
 
-    public void testEmptyUnquotedCellIsNull() throws IOException {
+    public void testEmptyUnquotedCellIsEmptyStringForTextNullOtherwise() throws IOException {
+        // An empty unquoted text field is the empty string; an empty unquoted numeric field is null (it has
+        // no empty-string value).
         List<List<Object>> rows = read(false, Map.of(), "a:keyword,b:long\n,5\nx,\n");
-        assertEquals(List.of(row(null, 5L), row(br("x"), null)), rows);
+        assertEquals(List.of(row(br(""), 5L), row(br("x"), null)), rows);
+    }
+
+    public void testEmptyTextFieldSurvivesAsDistinctValue() throws IOException {
+        // Reproduces the csv/tsv COUNT(DISTINCT)/VALUES() off-by-one vs the ndjson/parquet readers: an empty
+        // text field must survive as the empty string so it is one of the distinct values, not dropped as null.
+        // Two columns so the empty text field is a real empty cell (`,2`) rather than a blank line (which the
+        // reader filters).
+        String csv = "k:keyword,n:long\nalpha,1\n,2\nbeta,3\n,4\nalpha,5\n";
+        List<List<Object>> rows = read(false, Map.of(), csv);
+        assertEquals(List.of(row(br("alpha"), 1L), row(br(""), 2L), row(br("beta"), 3L), row(br(""), 4L), row(br("alpha"), 5L)), rows);
+        LinkedHashSet<Object> distinct = new LinkedHashSet<>();
+        for (List<Object> r : rows) {
+            distinct.add(r.get(0));
+        }
+        assertEquals(
+            "the empty string is a distinct value alongside the non-empty ones (matches ndjson/parquet)",
+            new LinkedHashSet<>(List.of(br("alpha"), br(""), br("beta"))),
+            distinct
+        );
+        // Same via TSV (shares CsvFormatReader), so the fix covers both text formats.
+        String tsv = "k:keyword\tn:long\nalpha\t1\n\t2\nbeta\t3\n";
+        assertEquals(List.of(row(br("alpha"), 1L), row(br(""), 2L), row(br("beta"), 3L)), read(true, Map.of(), tsv));
     }
 
     public void testCustomNullValue() throws IOException {
@@ -503,9 +528,9 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         assertEquals(List.of(row(br("\u00a0x\u00a0"))), rows);
     }
 
-    public void testTsvPlainEmptyCellIsNull() throws IOException {
+    public void testTsvPlainEmptyTextCellIsEmptyStringEmptyNumericIsNull() throws IOException {
         List<List<Object>> rows = read(true, Map.of(), "a:keyword\tb:long\n\t5\nx\t\n");
-        assertEquals(List.of(row(null, 5L), row(br("x"), null)), rows);
+        assertEquals(List.of(row(br(""), 5L), row(br("x"), null)), rows);
     }
 
     public void testTsvPlainCustomNullValue() throws IOException {
@@ -649,13 +674,13 @@ public class CsvDirectBlockParityTests extends ESTestCase {
         // the comment prefix follows: Jackson classifies comments on the first parsed cell, so the
         // direct path must keep this as a two-column data row rather than dropping it.
         List<List<Object>> rows = read(true, Map.of("comment", "//"), "a:keyword\tb:keyword\nx\ty\n\t// c\n");
-        assertEquals(List.of(row(br("x"), br("y")), row((Object) null, br("// c"))), rows);
+        assertEquals(List.of(row(br("x"), br("y")), row(br(""), br("// c"))), rows);
     }
 
     public void testCommaLeadingDelimiterBeforeCommentPrefixIsDataRow() throws IOException {
         // Same first-cell rule for CSV: an empty first cell before the comment prefix is a data row.
         List<List<Object>> rows = read(false, Map.of("comment", "//"), "a:keyword,b:keyword\nx,y\n,// c\n");
-        assertEquals(List.of(row(br("x"), br("y")), row((Object) null, br("// c"))), rows);
+        assertEquals(List.of(row(br("x"), br("y")), row(br(""), br("// c"))), rows);
     }
 
     public void testQuotedFirstCellThatDecodesToCommentIsSkipped() throws IOException {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -417,12 +417,13 @@ public class CsvFormatReaderTests extends ESTestCase {
             assertFalse(page.getBlock(1).isNull(0));
             assertFalse(page.getBlock(2).isNull(0));
 
-            // Second row: name is null
+            // Second row: name is the empty string (empty text field, not null); score present
             assertFalse(page.getBlock(0).isNull(1));
-            assertTrue(page.getBlock(1).isNull(1));
+            assertFalse(page.getBlock(1).isNull(1));
+            assertEquals(new BytesRef(""), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
             assertFalse(page.getBlock(2).isNull(1));
 
-            // Third row: score is null
+            // Third row: score is null (empty numeric field has no empty-string value)
             assertFalse(page.getBlock(0).isNull(2));
             assertFalse(page.getBlock(1).isNull(2));
             assertTrue(page.getBlock(2).isNull(2));
@@ -1439,7 +1440,7 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     // --- Empty and null value handling ---
 
-    public void testEmptyFieldsTreatedAsNull() throws IOException {
+    public void testEmptyTextFieldIsEmptyStringEmptyNumericIsNull() throws IOException {
         String csv = "id:long,name:keyword,score:double\n1,,95.5\n2,Bob,\n";
 
         StorageObject object = createStorageObject(csv);
@@ -1449,7 +1450,10 @@ public class CsvFormatReaderTests extends ESTestCase {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
             assertEquals(2, page.getPositionCount());
-            assertTrue(page.getBlock(1).isNull(0));
+            // Empty text field -> empty string (matches ndjson/parquet), not null.
+            assertFalse(page.getBlock(1).isNull(0));
+            assertEquals(new BytesRef(""), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            // Empty numeric field -> null (no empty-string value for a double).
             assertTrue(page.getBlock(2).isNull(1));
         }
     }

--- a/x-pack/plugin/esql/qa/server/src/tsvFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/TsvFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/tsvFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/TsvFixtureGenerator.java
@@ -149,7 +149,11 @@ public final class TsvFixtureGenerator {
             return formatScalar(type, value);
         }
         if (value == null) {
-            return "";
+            // Spell null explicitly: CsvFormatReader reads an empty field as the empty string on text
+            // columns (only the literal `null` token — or a configured null_value — is null), so an
+            // empty cell would silently turn a null keyword into "" and break the shared csv-spec
+            // expectations that pin these values as null across formats.
+            return "null";
         }
         return formatScalar(type, value);
     }


### PR DESCRIPTION
### What this is about

Reading external CSV/TSV, an empty field on a text column (`KEYWORD`/`TEXT`) is dropped to `null`. The ndjson and parquet readers keep it as the empty string. So `COUNT(DISTINCT phrase)` / `MV_COUNT(VALUES(phrase))` over a text column that has empty values comes back one short on CSV/TSV versus the same query on ndjson or parquet (and versus ClickHouse, whose CSV convention is that only `\N` is null — an empty field is the empty string). The empty string is a real, distinct value; it was silently disappearing.

CSV/TSV can't spell "null" and "empty string" differently at the byte level — an empty field is just two adjacent delimiters — so the reader has to pick a convention per type. The old convention (empty → null for every type) is what diverges.

### What this PR does

An empty field on a `KEYWORD`/`TEXT` column now reads as the empty string; on every other type it stays `null` (a number or date has no empty-string value). This aligns CSV/TSV with the ndjson and parquet readers and with ClickHouse. The literal token `null` (case-insensitive) and a user-configured `null_value` still map to `null` — unchanged. A whitespace-only unquoted field trims to empty and follows the same per-type convention.

The reader has two code paths that must agree (an explicit parity test binds them): the direct-to-block char walker and the Jackson-backed path. Both are fixed at their shared decision point:

- `CsvFormatReader.tryConvertValue` now returns the empty `BytesRef` for an empty text field instead of `null` (gated by a new `isTextType` helper); the direct walkers route their empty-field branches through a matching `stageEmptyField`.
- `CsvFormatReader.newCsvSchema` no longer hands Jackson the default empty `null_value`. Passing an empty null token made Jackson tokenize *every* empty field as `VALUE_NULL` before `tryConvertValue` ever saw it; without it, an empty field arrives as `""` and the same per-type decision applies. A non-empty configured `null_value` is still registered.

The QA fixtures needed a companion change. The shared datasets spell null as an empty (or padding-whitespace) cell — the ingested loader's convention — so under the new reader convention every null keyword in them would have read back as `""` and flipped the `10 | null` gender expectations that `csv-basic`, `csv-multifile*`, and the shared `external-multifile*` specs pin across all formats. The text-format fixtures now spell null explicitly with the literal `null` token: `TsvFixtureGenerator` writes it for null scalars, and the CSV qa fixture sync rewrites whitespace-only top-level cells to it (bracket content untouched). Expectations stay `null` everywhere, and the parquet/ndjson/orc fixtures — whose generators encode null natively — are untouched.

### Does it work?

`:x-pack:plugin:esql-datasource-csv:test` is green, including the direct-vs-Jackson parity suite. The new tests fail against the pre-fix reader and pass after it: an empty text field is the empty string on both paths (unquoted, quoted, and whitespace-only — the padded-fixture shape) and `COUNT(DISTINCT)`-style value sets count it, while an empty numeric field stays null and `null` / custom `null_value` / `\N` still null out. `:x-pack:plugin:esql-datasource-csv:qa:javaRestTest` is green end-to-end — `CsvFormatSpecIT`/`TsvFormatSpecIT` `aggregateByGenderScalar` (the test the fixture change protects) passes on all five storage backends for both formats. Module and qa `precommit` are green. Warm-stats stay consistent with scans: the stats harvest routes through the same `tryConvertValue` decision, so cached COUNT/MIN/MAX see the identical empty-string values.

### What's out of scope

- The literal `null` token (any case) stays a null spelling. ClickHouse would read that text as a string, but dropping the token is a separate, deliberate convention change — and it is now the one way a CSV/TSV cell can spell a null text value, which the QA fixtures rely on.
- Jackson `TRIM_SPACES` stays on for both CSV and TSV. It matches ClickHouse's CSV trimming; ClickHouse's TSV keeps whitespace, but that divergence predates this change and is not the source of the distinct-count drift.
- Bracket multi-value syntax: an empty element inside `[...]` (and the empty list `[]`) still contributes no value, unlike an ndjson array's explicit `""` element. Separate convention decision for the opt-in brackets mode.
- A single-column file still can't express the empty string on an unquoted line — blank lines are skipped (`SKIP_EMPTY_LINES`), pre-existing.
