### PR TITLE
ESQL: external — non-blocking pipeline drain + two-pool wiring, so multi-file text reads can't deadlock

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/CloseableIterator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/CloseableIterator.java
@@ -20,6 +20,15 @@ import java.util.Iterator;
  * always be called without blocking on upstream production. Iterators whose {@code hasNext()} would
  * otherwise spin or block (e.g. waiting on parser threads, network I/O) should override this so
  * the consumer can yield the calling thread back to its executor and resume when work is available.
+ *
+ * <p>The non-blocking drain contract is three methods: {@link #waitForReady()} (when to retry),
+ * {@link #pollNext()} (pull a page if one is available <em>now</em>, never blocking), and
+ * {@link #isExhausted()} (the single terminal predicate). A consumer that never wants to pin its
+ * executor thread polls with {@link #pollNext()} and, on a {@code null} return, concludes EOF
+ * <em>only</em> when {@link #isExhausted()} is {@code true} — never on {@code pollNext()==null}
+ * paired with a done {@link #waitForReady()}, since a done ready-signal can mean an internal
+ * end-of-chunk marker rather than a page. For synchronous iterators the defaults reduce to the
+ * ordinary {@link #hasNext()}/{@link #next()} contract.
  */
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
 
@@ -29,5 +38,30 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
      */
     default SubscribableListener<Void> waitForReady() {
         return SubscribableListener.newSucceeded(null);
+    }
+
+    /**
+     * Non-blocking pull: returns the next element if one is available <em>right now</em>, or {@code null}
+     * if none is currently available. Must never block on upstream production (parser threads, network I/O).
+     * A {@code null} return is <em>not</em> an EOF signal — it can mean "no page yet, more coming"; the caller
+     * decides between retry (via {@link #waitForReady()}) and termination (via {@link #isExhausted()}).
+     * The default — appropriate for synchronous iterators whose {@link #hasNext()} cannot block — is
+     * {@code hasNext() ? next() : null}. Async iterators (parser-thread backed) must override so the
+     * consumer never pins its executor thread.
+     */
+    default T pollNext() {
+        return hasNext() ? next() : null;
+    }
+
+    /**
+     * The terminal predicate: {@code true} only when the iterator is genuinely drained <em>and</em> no
+     * further element will ever be produced. Must never return {@code true} while a page is still in
+     * flight or a producer is still running. This is the ONLY signal on which a non-blocking drain may
+     * conclude EOF; concluding EOF on {@code pollNext()==null && waitForReady().isDone()} would silently
+     * drop elements at a genuine mid-stream gap. The default — appropriate for synchronous iterators — is
+     * {@code hasNext() == false}.
+     */
+    default boolean isExhausted() {
+        return hasNext() == false;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1593,9 +1593,19 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     }
 
     /**
-     * Drain pages from the currently-open iterator into the buffer.
-     * Runs synchronously while the buffer has space; when full, registers a callback that
-     * re-submits {@link #runProducerLoop} via the executor and returns {@link DrainResult#BLOCKED}.
+     * Drain pages from the currently-open iterator into the buffer, poll-then-park and strictly non-blocking.
+     * Each step reserves buffer space, then pulls one page via the iterator's non-blocking
+     * {@link CloseableIterator#pollNext()}. When no page is available right now it consults
+     * {@link CloseableIterator#isExhausted()}: only that predicate concludes {@link DrainResult#EOF}. Otherwise
+     * it {@linkplain #parkUntilReady parks} on {@link CloseableIterator#waitForReady()} — releasing the executor
+     * slot so a full I/O pool of blocked parser workers can never starve this drain — and returns
+     * {@link DrainResult#BLOCKED}. When the buffer is full it parks the same way on {@link AsyncExternalSourceBuffer#waitForSpace()}.
+     * <p>
+     * <strong>EOF is derived from {@code isExhausted()} alone, never from {@code pollNext()==null} paired with a
+     * done {@code waitForReady()}.</strong> An async iterator's readiness can be done because a POISON / end-of-chunk
+     * marker sits in the current slot rather than a real page; treating that as EOF would silently drop the chunks
+     * still parsing behind it (partial results, no error). The terminal signal is the parser-side task/chunk
+     * accounting exposed through {@code isExhausted()}.
      */
     private DrainResult drainHotPath(ProducerState state, ActionListener<Void> completionListener) {
         CloseableIterator<Page> pages = state.pages;
@@ -1610,32 +1620,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             if (rowLimit != FormatReader.NO_LIMIT && state.rowsRemaining <= 0) {
                 return DrainResult.DONE;
             }
-            // Yield on upstream-blocked (e.g. streaming-parallel iterator waiting on parser threads)
-            // — symmetric to the downstream-buffer-full yield below. Without this the producer-loop
-            // would spin inside {@code hasNext()} holding its executor slot while the iterator's
-            // segmenter/parser sub-tasks compete for slots on the same pool: with default
-            // {@code parsing_parallelism = cores} and F concurrent file readers we'd need
-            // F + F + F×cores slots, exhausting the generic pool on multi-file gzip globs.
-            // Synchronous iterators ({@code CloseableIterator}'s default) return an
-            // immediately-completed listener and fall straight through.
-            SubscribableListener<Void> ready = pages.waitForReady();
-            if (ready.isDone() == false) {
-                return parkUntilReady(ready, state, completionListener);
-            }
-            if (pages.hasNext() == false) {
-                // Race: waitForReady reported done (page available or EOF), but by the time we
-                // called hasNext the state advanced (e.g. another consumer drained, or POISON
-                // got handled inside hasNext and the next slot is not yet populated). For
-                // synchronous iterators where the default waitForReady returns immediately-done,
-                // hasNext=false truly means EOF and the recheck remains done. For async iterators
-                // like {@code StreamingParallelIterator}, a non-done recheck means the iterator
-                // is still producing — yield and let the parser-side {@code signalReady()} wake us.
-                SubscribableListener<Void> recheck = pages.waitForReady();
-                if (recheck.isDone()) {
-                    return DrainResult.EOF;
-                }
-                return parkUntilReady(recheck, state, completionListener);
-            }
+            // Reserve buffer space BEFORE pulling a page, so we never hold a polled page we cannot deliver.
+            // A full buffer yields the executor slot until the downstream driver frees space.
             SubscribableListener<Void> space = buffer.waitForSpace();
             if (space.isDone() == false) {
                 return parkUntilReady(space, state, completionListener);
@@ -1643,7 +1629,20 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             if (buffer.noMoreInputs()) {
                 return DrainResult.DONE;
             }
-            Page page = pages.next();
+            // Non-blocking pull. pollNext() never blocks on the parser threads; null means "no page right now",
+            // which is NOT an EOF signal on its own — the parser may simply not have published the next chunk yet.
+            Page page = pages.pollNext();
+            if (page == null) {
+                if (pages.isExhausted()) {
+                    // The ONLY terminal signal: every dispatched chunk drained and every parser task exited.
+                    return DrainResult.EOF;
+                }
+                // Still producing but nothing available this instant: yield the executor slot and resume when
+                // the parser side signals readiness. Synchronous iterators return an immediately-done listener,
+                // so parkUntilReady re-submits promptly. Crucially we do NOT conclude EOF here even if the
+                // readiness signal is already done — a done signal can mean an end-of-chunk marker, not a page.
+                return parkUntilReady(pages.waitForReady(), state, completionListener);
+            }
             int rows = page.getPositionCount();
             page.allowPassingToDifferentDriver();
             buffer.addPage(page);
@@ -2511,7 +2510,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         captureSink,
                         statsStripeSize,
                         statsColumnScope,
-                        partialResultsWarningSink
+                        partialResultsWarningSink,
+                        // A stream-only compressed file is read whole (never macro-split), so this stream is
+                        // always the file's final split — its last chunk closes the file's terminal stripe.
+                        true
                     );
                 } catch (Exception e) {
                     try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -332,10 +332,16 @@ public final class DataSourceModule implements Closeable {
         return externalSourceMetrics;
     }
 
-    public OperatorFactoryRegistry createOperatorFactoryRegistry(Executor executor) {
-        return createOperatorFactoryRegistry(executor, executor);
-    }
-
+    /**
+     * Builds the operator-factory registry with the two distinct executors the external parse pipeline needs.
+     * There is deliberately NO single-executor overload: collapsing both roles onto one pool is the exact
+     * footgun that deadlocks multi-file text reads, so every caller must name both pools explicitly.
+     *
+     * @param executor         page-consumer / coordination pool ({@link OperatorFactoryRegistry#executor()}) — the
+     *                         compute pool ({@code esql_worker}) that also runs the drivers draining the source buffer.
+     * @param fileReadExecutor read/parse pool ({@link OperatorFactoryRegistry#fileReadExecutor()}) — the dedicated
+     *                         {@code esql_external_io} pool that runs the blocking opens, segmentator, and parser workers.
+     */
     public OperatorFactoryRegistry createOperatorFactoryRegistry(Executor executor, Executor fileReadExecutor) {
         return new OperatorFactoryRegistry(sourceFactories, pluginFactories, executor, fileReadExecutor);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Nullable;
@@ -624,6 +625,12 @@ public final class ParallelParsingCoordinator {
         // reads the parked page rather than a stale value, so its blocks are released rather than leaked.
         private volatile Page buffered = null;
         private volatile boolean closed = false;
+        /**
+         * Single-shot readiness listener for the non-blocking drain contract ({@link #waitForReady()}). Workers
+         * fire it on every state change (page enqueued, segment finished, error, close) so a consumer that
+         * yielded its executor thread resumes promptly instead of pinning the thread on the 200ms poll.
+         */
+        private final AtomicReference<SubscribableListener<Void>> pendingReady = new AtomicReference<>();
 
         AsReadyParallelIterator(
             SegmentableFormatReader reader,
@@ -822,6 +829,8 @@ public final class ParallelParsingCoordinator {
                     return;
                 }
                 if (sharedQueue.offer(page, 500, TimeUnit.MILLISECONDS)) {
+                    // Wake a consumer parked on waitForReady() now that a page is available.
+                    signalReady();
                     return;
                 }
             }
@@ -835,6 +844,9 @@ public final class ParallelParsingCoordinator {
         private void finishSegment() {
             allDone.countDown();
             remainingSegments.decrementAndGet();
+            // A finished segment can flip the iterator to ready (EOF when it was the last, or an error was just
+            // recorded); wake any consumer parked on waitForReady() so it re-evaluates instead of pinning a thread.
+            signalReady();
         }
 
         @Override
@@ -862,6 +874,78 @@ public final class ParallelParsingCoordinator {
             Page result = buffered;
             buffered = null;
             return result;
+        }
+
+        // Non-blocking drain contract. hasNext()/takeNextPage() poll the shared queue with a 200ms timeout and
+        // PIN the calling thread across the gap between segment pages; the async producer-loop drain instead
+        // uses pollNext() (a single non-blocking poll) + waitForReady() (yield the executor slot until a worker
+        // enqueues a page / finishes a segment / records an error) + isExhausted() (the sole EOF signal).
+        @Override
+        public Page pollNext() {
+            if (closed) {
+                return null;
+            }
+            if (buffered != null) {
+                Page p = buffered;
+                buffered = null;
+                return p;
+            }
+            checkError();
+            return sharedQueue.poll(); // non-blocking; null when no page is available at this instant
+        }
+
+        @Override
+        public boolean isExhausted() {
+            if (closed) {
+                return true;
+            }
+            checkError();
+            if (buffered != null || sharedQueue.peek() != null) {
+                return false;
+            }
+            // Terminal only when every segment worker has finished AND the shared queue is fully drained.
+            return remainingSegments.get() == 0 && sharedQueue.isEmpty();
+        }
+
+        @Override
+        public SubscribableListener<Void> waitForReady() {
+            if (isReadyNow()) {
+                return SubscribableListener.newSucceeded(null);
+            }
+            SubscribableListener<Void> existing = pendingReady.get();
+            if (existing != null) {
+                return existing;
+            }
+            SubscribableListener<Void> fresh = new SubscribableListener<>();
+            if (pendingReady.compareAndSet(null, fresh) == false) {
+                return pendingReady.get();
+            }
+            // Re-check after install to close the race where a worker flipped the iterator to ready between
+            // the first isReadyNow() and the CAS.
+            if (isReadyNow()) {
+                signalReady();
+                return SubscribableListener.newSucceeded(null);
+            }
+            return fresh;
+        }
+
+        /** Ready when a page is available now, EOF has been reached, an error is recorded, or the iterator is closed. */
+        private boolean isReadyNow() {
+            if (closed || buffered != null || firstError.get() != null) {
+                return true;
+            }
+            if (sharedQueue.peek() != null) {
+                return true;
+            }
+            return remainingSegments.get() == 0 && sharedQueue.isEmpty();
+        }
+
+        /** Fires the pending readiness listener (if any). Called from every worker-side state-change site. */
+        private void signalReady() {
+            SubscribableListener<Void> listener = pendingReady.getAndSet(null);
+            if (listener != null) {
+                listener.onResponse(null);
+            }
         }
 
         /**
@@ -904,6 +988,8 @@ public final class ParallelParsingCoordinator {
             // accept as complete and cache as an under-count. So a non-clean scan poisons the file.
             boolean cleanCompletion = firstError.get() == null && remainingSegments.get() == 0 && sharedQueue.isEmpty() && buffered == null;
             closed = true;
+            // isReadyNow() returns true once closed; wake any consumer parked on waitForReady() so it unwinds.
+            signalReady();
             // Release the page parked by a hasNext() with no following next(); drainQueue() only sees the shared
             // queue, so without this its Blocks leak against the breaker on every early close.
             if (buffered != null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -127,7 +128,29 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page>, ColumnExt
         if (delegate.hasNext() == false) {
             throw new NoSuchElementException();
         }
-        Page filePage = delegate.next();
+        return adapt(delegate.next());
+    }
+
+    // Non-blocking drain contract — forward the readiness/exhaustion signals and apply the schema
+    // adaptation to whatever page the delegate yields, sharing adapt() with next().
+    @Override
+    public SubscribableListener<Void> waitForReady() {
+        return delegate.waitForReady();
+    }
+
+    @Override
+    public Page pollNext() {
+        Page filePage = delegate.pollNext();
+        return filePage == null ? null : adapt(filePage);
+    }
+
+    @Override
+    public boolean isExhausted() {
+        return delegate.isExhausted();
+    }
+
+    /** Runs one reader-emitted page through the {@link ColumnMapping} (and splices {@code _rowPosition} when configured). */
+    private Page adapt(Page filePage) {
         try {
             Page schemaAdapted = mapping.mapPage(filePage, blockFactory, perFileColumnTypes);
             if (rowPositionInputIndex < 0) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -117,7 +117,8 @@ public final class StreamingParallelParsingCoordinator {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
-            null
+            null,
+            true
         );
     }
 
@@ -164,7 +165,8 @@ public final class StreamingParallelParsingCoordinator {
         @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
         long statsStripeSize,
         StripeColumnScope statsColumnScope,
-        @Nullable Consumer<String> partialResultsWarningSink
+        @Nullable Consumer<String> partialResultsWarningSink,
+        boolean splitIsFileFinal
     ) throws IOException {
         if (logger.isDebugEnabled()) {
             logger.debug(
@@ -178,10 +180,11 @@ public final class StreamingParallelParsingCoordinator {
 
         if (parallelism <= 1) {
             // Single-pass fallback reads the whole decompressed stream in one shot starting at
-            // baseFileOffset, so per-stripe stats attribution applies exactly as in the parallel branch and
-            // its trailing stripe is always file-final. Thread .stats(...) here too — mirrors the sibling
-            // ParallelParsingCoordinator's single-segment fallback — so a streaming read at parallelism 1
-            // still harvests per-stripe stats instead of silently dropping the capture.
+            // baseFileOffset, so per-stripe stats attribution applies exactly as in the parallel branch.
+            // Thread .stats(...) here too — mirrors the sibling ParallelParsingCoordinator's single-segment
+            // fallback — so a streaming read at parallelism 1 still harvests per-stripe stats instead of
+            // silently dropping the capture. The trailing stripe is file-final only when this split is the
+            // file's final one (splitIsFileFinal); a whole-file compressed stream passes true.
             FormatReadContext ctx = FormatReadContext.builder()
                 .projectedColumns(projectedColumns)
                 .batchSize(batchSize)
@@ -189,7 +192,7 @@ public final class StreamingParallelParsingCoordinator {
                 .readSchema(readSchema)
                 .splitStartByte(baseFileOffset)
                 .maxRecordBytes(maxRecordBytes)
-                .stats(baseFileOffset, statsStripeSize, true)
+                .stats(baseFileOffset, statsStripeSize, splitIsFileFinal)
                 .statsColumnScope(statsColumnScope)
                 .build();
             return reader.read(new InputStreamStorageObject(decompressedStream), ctx);
@@ -210,7 +213,8 @@ public final class StreamingParallelParsingCoordinator {
             captureSink,
             statsStripeSize,
             statsColumnScope,
-            partialResultsWarningSink
+            partialResultsWarningSink,
+            splitIsFileFinal
         );
     }
 
@@ -278,6 +282,14 @@ public final class StreamingParallelParsingCoordinator {
         /** How much per-stripe statistics each chunk harvests (row count only / + projected / + all / nothing). */
         private final StripeColumnScope statsColumnScope;
         /**
+         * Whether this decompressed stream is the file's final split — mirrors
+         * {@link ParallelParsingCoordinator}'s {@code splitIsFileFinal}. A stream-only compressed input is read as
+         * a whole file, so the caller passes {@code true} and the last chunk ({@link Chunk#last()}) is also
+         * file-final. Threaded so a future mid-file split of a streaming read would NOT mark its trailing chunk
+         * file-final (which would close a stripe the next split still owns — a latent stats-attribution hazard).
+         */
+        private final boolean splitIsFileFinal;
+        /**
          * Grow-loop bound. In production it comes from the {@code max_record_size} pragma (default
          * {@link SegmentableFormatReader#DEFAULT_MAX_RECORD_BYTES}); overridable for tests.
          */
@@ -344,7 +356,8 @@ public final class StreamingParallelParsingCoordinator {
             @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
             long statsStripeSize,
             StripeColumnScope statsColumnScope,
-            @Nullable Consumer<String> partialResultsWarningSink
+            @Nullable Consumer<String> partialResultsWarningSink,
+            boolean splitIsFileFinal
         ) {
             this.reader = reader;
             this.storageObject = storageObject;
@@ -358,6 +371,7 @@ public final class StreamingParallelParsingCoordinator {
             this.statsStripeSize = statsStripeSize;
             this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
             this.partialResultsWarningSink = partialResultsWarningSink;
+            this.splitIsFileFinal = splitIsFileFinal;
             this.bufferPoolSize = parallelism + 1;
             this.pageQueueRingSize = parallelism + 1;
 
@@ -757,7 +771,9 @@ public final class StreamingParallelParsingCoordinator {
                     .readSchema(readSchema)
                     .splitStartByte(chunkFileGlobalStart)
                     .maxRecordBytes(maxRecordBytes)
-                    .stats(chunkFileGlobalStart, statsStripeSize, chunk.last())
+                    // File-final only when this is the stream's last chunk AND this split is the file's final
+                    // one — a mid-file split's last chunk ends at the split boundary, not the file's true EOF.
+                    .stats(chunkFileGlobalStart, statsStripeSize, chunk.last() && splitIsFileFinal)
                     .statsColumnScope(statsColumnScope)
                     .build();
                 // Bind the consumer-owned sink on this worker so the reader's close hook reaches the
@@ -995,6 +1011,46 @@ public final class StreamingParallelParsingCoordinator {
             Page result = buffered;
             buffered = null;
             return result;
+        }
+
+        /**
+         * Non-blocking page pull for the async producer-loop drain. Returns a page if one is available in
+         * the current slot right now (advancing past at most one POISON), or {@code null} otherwise — it
+         * NEVER blocks on the parser threads (unlike {@link #hasNext()}, which parks on a latch for
+         * synchronous consumers). A {@code null} return is not EOF: the caller retries via
+         * {@link #waitForReady()} and concludes EOF only when {@link #isExhausted()} is true.
+         */
+        @Override
+        public Page pollNext() {
+            if (closed) {
+                return null;
+            }
+            if (buffered != null) {
+                Page p = buffered;
+                buffered = null;
+                return p;
+            }
+            // takeNextPage surfaces any recorded parser error and is strictly non-blocking.
+            return takeNextPage();
+        }
+
+        /**
+         * Terminal predicate for the async drain: {@code true} only when the consumer has drained every
+         * dispatched chunk AND every parser task (segmentator + per-chunk workers) has exited — the same
+         * condition {@link #hasNext()} uses to return {@code false}. Never {@code true} while a page or
+         * POISON is still buffered or a task is still in flight, so the drain can never conclude EOF while
+         * the pipeline is still producing.
+         */
+        @Override
+        public boolean isExhausted() {
+            if (closed) {
+                return true;
+            }
+            checkError();
+            if (buffered != null) {
+                return false;
+            }
+            return currentChunk >= chunksDispatched.get() && tasksOutstanding.get() == 0;
         }
 
         /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/VirtualColumnIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/VirtualColumnIterator.java
@@ -190,6 +190,19 @@ final class VirtualColumnIterator implements CloseableIterator<Page> {
         return delegate.waitForReady();
     }
 
+    // Non-blocking drain contract — apply inject() to whatever page the delegate yields (sharing the
+    // transform with next()), and forward the exhaustion signal.
+    @Override
+    public Page pollNext() {
+        Page dataPage = delegate.pollNext();
+        return dataPage == null ? null : inject(dataPage);
+    }
+
+    @Override
+    public boolean isExhausted() {
+        return delegate.isExhausted();
+    }
+
     @Override
     public void close() throws IOException {
         delegate.close();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.cache;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
@@ -63,6 +64,22 @@ public final class StatsCapturingIterator implements CloseableIterator<Page>, Co
     @Override
     public Page next() {
         return delegate.next();
+    }
+
+    // Non-blocking drain contract — pure pass-through (this wrapper changes behavior only at close()).
+    @Override
+    public SubscribableListener<Void> waitForReady() {
+        return delegate.waitForReady();
+    }
+
+    @Override
+    public Page pollNext() {
+        return delegate.pollNext();
+    }
+
+    @Override
+    public boolean isExhausted() {
+        return delegate.isExhausted();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/NullSpliceRowPositionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/NullSpliceRowPositionStrategy.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -88,7 +89,29 @@ public final class NullSpliceRowPositionStrategy implements RowPositionStrategy 
             if (inner.hasNext() == false) {
                 throw new NoSuchElementException();
             }
-            Page innerPage = inner.next();
+            return splice(inner.next());
+        }
+
+        // Non-blocking drain contract — forward readiness/exhaustion and apply the null splice to whatever
+        // page the inner iterator yields, sharing splice() with next().
+        @Override
+        public SubscribableListener<Void> waitForReady() {
+            return inner.waitForReady();
+        }
+
+        @Override
+        public Page pollNext() {
+            Page innerPage = inner.pollNext();
+            return innerPage == null ? null : splice(innerPage);
+        }
+
+        @Override
+        public boolean isExhausted() {
+            return inner.isExhausted();
+        }
+
+        /** Splices an all-null {@code _rowPosition} block into {@code innerPage} at the requested output slot. */
+        private Page splice(Page innerPage) {
             int positions = innerPage.getPositionCount();
             int innerBlockCount = innerPage.getBlockCount();
             // The splice loops below only cover slots in [0, innerBlockCount]; today the optimizer

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -415,9 +415,10 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
 
         // Create DataSourceModule with all discovered plugins.
         // This executor backs SPI coordination, decompression, and async-I/O plugin callbacks (e.g. the HTTP
-        // client) — NOT the file-read path. Blocking external reads run on the esql_worker pool via
-        // OperatorFactoryRegistry#fileReadExecutor (wired in TransportEsqlQueryAction), bounded by the per-scheme
-        // permit semaphore in StorageProviderRegistry rather than a dedicated thread pool.
+        // client) — NOT the file-read path. Blocking external reads + the parse pipeline run on the dedicated
+        // esql_external_io pool via OperatorFactoryRegistry#fileReadExecutor, while the non-blocking page-consumer
+        // drain runs on esql_worker via OperatorFactoryRegistry#executor (both wired in TransportEsqlQueryAction),
+        // bounded by the per-scheme permit semaphore in StorageProviderRegistry.
         dataSourceModule = new DataSourceModule(
             allDataSourcePlugins,
             dataSourceCapabilities,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -219,9 +219,16 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         );
 
         var dataSourceModule = planExecutor.dataSourceModule();
-        // External source coordination and blocking file reads both run on the external blob-store pool, so a single
-        // executor backs both roles of the registry.
-        OperatorFactoryRegistry operatorFactoryRegistry = dataSourceModule.createOperatorFactoryRegistry(externalBlobStoreExecutor());
+        // Two pools, deliberately distinct, so the external parse pipeline can never starve its own consumer.
+        // Arg 1 (registry.executor()) is the page-consumer / coordination role — the esql_worker compute pool that
+        // also runs the drivers polling the source buffer, so the non-blocking drain runs there. Arg 2
+        // (registry.fileReadExecutor()) is the read/parse role — the dedicated esql_external_io pool that runs the
+        // blocking opens, segmentator, and parser workers. Collapsing these onto one pool deadlocks multi-file text
+        // reads (a full I/O pool of blocked parsers with no free thread left to run the drain that consumes them).
+        OperatorFactoryRegistry operatorFactoryRegistry = dataSourceModule.createOperatorFactoryRegistry(
+            threadPool.executor(EsqlPlugin.computePool()), // drain / coordination — esql_worker
+            externalBlobStoreExecutor()                    // blocking reads + parse pipeline — esql_external_io
+        );
         this.computeService = new ComputeService(
             services,
             enrichLookupService,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceDrainDeadlockTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceDrainDeadlockTests.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.compute.operator.Driver;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.DriverRunner;
+import org.elasticsearch.compute.operator.PageConsumerOperator;
+import org.elasticsearch.compute.test.TestDriverFactory;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.FixedExecutorBuilder;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.PassThroughRowPositionStrategy;
+import org.elasticsearch.xpack.esql.datasources.spi.RowPositionStrategy;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Regression tests for the multi-file text-read producer/consumer deadlock (elastic/elasticsearch#152771 introduced,
+ * the streaming-parallel-parse drain wedge). Both cover {@link AsyncExternalSourceOperatorFactory}'s producer-loop
+ * drain, driven through a real {@link Driver} on a bounded producer pool.
+ *
+ * <ul>
+ *   <li>{@link #testDrainDoesNotPinPoolThreadInBlockingHasNext} — the DEADLOCK test. The drain must pull pages via
+ *       the non-blocking {@link CloseableIterator#pollNext()} contract and never enter a blocking
+ *       {@link CloseableIterator#hasNext()} on a pool thread. With the pre-fix drain (which called {@code hasNext()}
+ *       after {@code waitForReady().isDone()}), the bounded producer pool's threads pin inside {@code hasNext()} and
+ *       the run never completes — the test times out. With the fix it completes.</li>
+ *   <li>{@link #testDrainDeliversEveryPageAcrossAMidStreamGap} — the EOF-DROP test. A {@code pollNext()==null} paired
+ *       with a done {@code waitForReady()} in the MIDDLE of a stream (a POISON/end-of-chunk marker consumed, next
+ *       chunk still parsing) must NOT be read as EOF. The drain must keep going until {@link CloseableIterator#isExhausted()}
+ *       is true, so every page is delivered. A pre-fix drain that concluded EOF on the done ready-signal drops the
+ *       trailing page(s) — partial results, no error.</li>
+ * </ul>
+ */
+public class AsyncExternalSourceDrainDeadlockTests extends ESTestCase {
+
+    private static final BlockFactory TEST_BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("none"))
+        .build();
+
+    private static final String DRIVER_POOL_NAME = "test-driver";
+
+    private ThreadPool driverThreadPool;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        driverThreadPool = new TestThreadPool(
+            "drain-deadlock-tests",
+            new FixedExecutorBuilder(
+                Settings.EMPTY,
+                DRIVER_POOL_NAME,
+                4,
+                1024,
+                "drain-deadlock-tests." + DRIVER_POOL_NAME,
+                EsExecutors.TaskTrackingConfig.DEFAULT
+            )
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        terminate(driverThreadPool);
+        super.tearDown();
+    }
+
+    /**
+     * DEADLOCK test. {@code k} producer-pool threads run the drain; {@code >= k+1} concurrent single-file units each
+     * present an iterator whose {@code hasNext()} blocks forever (the wedged latch) but whose non-blocking
+     * {@code pollNext()} / {@code waitForReady()} / {@code isExhausted()} contract is correct. A drain that ever calls
+     * {@code hasNext()} pins its pool thread; {@code k} such pins exhaust the pool and the run cannot complete. The
+     * fix drains via {@code pollNext()} and never touches {@code hasNext()}, so it completes.
+     */
+    public void testDrainDoesNotPinPoolThreadInBlockingHasNext() throws Exception {
+        int poolThreads = 2;   // "2k" with k=1 — the single production pool backing both executor + producerExecutor
+        int units = poolThreads + 1;
+        // The latch every unit's hasNext() blocks on. Never released while the test runs — a blocking hasNext on the
+        // producer pool would hang the whole run. Interrupted only at teardown to unwedge a pre-fix run.
+        CountDownLatch wedgedHasNext = new CountDownLatch(1);
+        ExecutorService producerExec = Executors.newFixedThreadPool(
+            poolThreads,
+            EsExecutors.daemonThreadFactory("test", "drain-deadlock-producer")
+        );
+        try {
+            AtomicInteger totalPages = new AtomicInteger();
+            List<Driver> drivers = new ArrayList<>(units);
+            for (int u = 0; u < units; u++) {
+                DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+                // producerExecutor defaults to the builder's executor when not set — i.e. the SINGLE production
+                // topology where drain + read/parse share one pool. That is exactly the wiring the deadlock needs.
+                ExternalSliceQueue sliceQueue = new ExternalSliceQueue(
+                    List.of(new FileSplit("test", StoragePath.of("s3://bucket/u" + u + ".txt"), 0, 100, "text", Map.of(), Map.of()))
+                );
+                AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+                    new StubStorageProvider(),
+                    new SinglecornerFormatReader(() -> new WedgedHasNextIterator(wedgedHasNext)),
+                    StoragePath.of("s3://bucket/u" + u + ".txt"),
+                    singleIntAttribute(),
+                    100,
+                    1,
+                    producerExec
+                ).sliceQueue(sliceQueue).build();
+                drivers.add(TestDriverFactory.create(ctx, factory.get(ctx), List.of(), new PageConsumerOperator(page -> {
+                    totalPages.incrementAndGet();
+                    page.releaseBlocks();
+                })));
+            }
+
+            boolean completed = runDrivers(drivers, TimeValue.timeValueSeconds(15));
+            assertTrue("producer-loop drain wedged: a bounded pool thread pinned in a blocking hasNext()", completed);
+            assertEquals("every unit must deliver its single page", units, totalPages.get());
+        } finally {
+            wedgedHasNext.countDown();
+            producerExec.shutdownNow();
+            assertTrue(producerExec.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * EOF-DROP test. One unit whose iterator yields page1, then a single {@code pollNext()==null} with an
+     * immediately-done {@code waitForReady()} and {@code isExhausted()==false} (a consumed POISON / mid-stream gap),
+     * then page2, then genuine exhaustion. The drain must deliver BOTH pages — concluding EOF on the mid-stream done
+     * ready-signal would silently drop page2.
+     */
+    public void testDrainDeliversEveryPageAcrossAMidStreamGap() throws Exception {
+        ExecutorService producerExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "drain-eof-producer"));
+        try {
+            ExternalSliceQueue sliceQueue = new ExternalSliceQueue(
+                List.of(new FileSplit("test", StoragePath.of("s3://bucket/gap.txt"), 0, 100, "text", Map.of(), Map.of()))
+            );
+            DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+                new StubStorageProvider(),
+                new SinglecornerFormatReader(GapAtMiddleIterator::new),
+                StoragePath.of("s3://bucket/gap.txt"),
+                singleIntAttribute(),
+                100,
+                4,
+                producerExec
+            ).sliceQueue(sliceQueue).build();
+
+            AtomicInteger pageCount = new AtomicInteger();
+            Driver driver = TestDriverFactory.create(ctx, factory.get(ctx), List.of(), new PageConsumerOperator(page -> {
+                pageCount.incrementAndGet();
+                page.releaseBlocks();
+            }));
+
+            boolean completed = runDrivers(List.of(driver), TimeValue.timeValueSeconds(15));
+            assertTrue("drain did not complete", completed);
+            assertEquals("both pages must be delivered — no silent drop at a mid-stream ready-but-empty gap", 2, pageCount.get());
+        } finally {
+            producerExec.shutdownNow();
+            assertTrue(producerExec.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    /** Runs the drivers to completion with a bounded wait. Returns {@code true} on completion, {@code false} on timeout. */
+    private boolean runDrivers(List<Driver> drivers, TimeValue timeout) {
+        DriverRunner runner = new DriverRunner(driverThreadPool.getThreadContext()) {
+            @Override
+            protected void start(Driver driver, ActionListener<Void> driverListener) {
+                Driver.start(
+                    driverThreadPool.getThreadContext(),
+                    driverThreadPool.executor(DRIVER_POOL_NAME),
+                    driver,
+                    between(1, 10_000),
+                    driverListener
+                );
+            }
+        };
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        runner.runToCompletion(drivers, future);
+        try {
+            future.actionGet(timeout);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static List<Attribute> singleIntAttribute() {
+        return List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+    }
+
+    private static Page smallIntPage() {
+        var builder = TEST_BLOCK_FACTORY.newIntBlockBuilder(1);
+        builder.appendInt(1);
+        IntBlock block = builder.build();
+        return new Page(block);
+    }
+
+    /** {@link FormatReader} that returns a caller-supplied fake iterator for every read. */
+    private static final class SinglecornerFormatReader implements NoConfigFormatReader {
+        private final java.util.function.Supplier<CloseableIterator<Page>> iteratorSupplier;
+
+        SinglecornerFormatReader(java.util.function.Supplier<CloseableIterator<Page>> iteratorSupplier) {
+            this.iteratorSupplier = iteratorSupplier;
+        }
+
+        @Override
+        public RowPositionStrategy rowPositionStrategy() {
+            return PassThroughRowPositionStrategy.INSTANCE;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            return iteratorSupplier.get();
+        }
+
+        @Override
+        public String formatName() {
+            return "test-single-corner";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".txt");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Emits one page. {@link #hasNext()} BLOCKS forever on the shared latch (the wedged-latch signature from the
+     * ticket's jstack), while {@link #pollNext()} / {@link #waitForReady()} / {@link #isExhausted()} are correct and
+     * non-blocking. A drain that ever calls {@code hasNext()} pins its pool thread; a poll-based drain sails through.
+     */
+    private static final class WedgedHasNextIterator implements CloseableIterator<Page> {
+        private final CountDownLatch wedged;
+        private boolean delivered = false;
+
+        WedgedHasNextIterator(CountDownLatch wedged) {
+            this.wedged = wedged;
+        }
+
+        @Override
+        public boolean hasNext() {
+            // The bug: a drain that reaches hasNext() blocks here on a pool thread and never returns.
+            try {
+                wedged.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return delivered == false;
+        }
+
+        @Override
+        public Page next() {
+            if (delivered) {
+                throw new NoSuchElementException();
+            }
+            delivered = true;
+            return smallIntPage();
+        }
+
+        @Override
+        public Page pollNext() {
+            if (delivered) {
+                return null;
+            }
+            delivered = true;
+            return smallIntPage();
+        }
+
+        @Override
+        public boolean isExhausted() {
+            return delivered;
+        }
+
+        @Override
+        public SubscribableListener<Void> waitForReady() {
+            return SubscribableListener.newSucceeded(null);
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Emits page1, then a single {@code pollNext()==null} gap with a done {@code waitForReady()} and
+     * {@code isExhausted()==false}, then page2, then exhaustion. Models a consumed POISON / mid-stream chunk boundary.
+     * {@code hasNext()}/{@code next()} exist so a pre-fix (hasNext-based) drain drops page2 by concluding EOF at the gap.
+     */
+    private static final class GapAtMiddleIterator implements CloseableIterator<Page> {
+        // 0=page1 available, 1=gap (one null), 2=page2 available, 3=exhausted
+        private int state = 0;
+
+        @Override
+        public boolean hasNext() {
+            return state == 0 || state == 2;
+        }
+
+        @Override
+        public Page next() {
+            if (state == 0) {
+                state = 1;
+                return smallIntPage();
+            }
+            if (state == 2) {
+                state = 3;
+                return smallIntPage();
+            }
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public Page pollNext() {
+            switch (state) {
+                case 0 -> {
+                    state = 1;
+                    return smallIntPage();
+                }
+                case 1 -> {
+                    // The trap: no page right now, but NOT exhausted; waitForReady is done (POISON consumed).
+                    state = 2;
+                    return null;
+                }
+                case 2 -> {
+                    state = 3;
+                    return smallIntPage();
+                }
+                default -> {
+                    return null;
+                }
+            }
+        }
+
+        @Override
+        public boolean isExhausted() {
+            return state == 3;
+        }
+
+        @Override
+        public SubscribableListener<Void> waitForReady() {
+            // Always "ready" — the exact condition that must NOT be read as EOF at the mid-stream gap.
+            return SubscribableListener.newSucceeded(null);
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class StubStorageProvider implements StorageProvider {
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return new StubStorageObject(path);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return true;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("s3");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private record StubStorageObject(StoragePath path) implements StorageObject {
+        @Override
+        public InputStream newStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public long length() {
+            return 0;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
@@ -585,8 +585,8 @@ public class DataSourceModuleTests extends ESTestCase {
         List<DataSourcePlugin> plugins = List.of(new TestDataSourcePlugin());
         DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
 
-        // Create OperatorFactoryRegistry with a simple executor
-        OperatorFactoryRegistry operatorRegistry = module.createOperatorFactoryRegistry(Runnable::run);
+        // Create OperatorFactoryRegistry with the two-executor (drain, read) factory.
+        OperatorFactoryRegistry operatorRegistry = module.createOperatorFactoryRegistry(Runnable::run, Runnable::run);
         assertNotNull("OperatorFactoryRegistry should be created", operatorRegistry);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DrainContractForwardingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DrainContractForwardingTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.cache.StatsCapturingIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.NullSpliceRowPositionStrategy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Verifies that every wrapper on the external producer-loop drain path forwards the non-blocking drain contract
+ * ({@link CloseableIterator#waitForReady()} / {@link CloseableIterator#pollNext()} / {@link CloseableIterator#isExhausted()})
+ * to its delegate and applies its transform on the polled page — WITHOUT ever touching the delegate's blocking
+ * {@code hasNext()}/{@code next()}. The probe delegate throws from {@code hasNext()}/{@code next()}, so a wrapper that
+ * left {@code pollNext()}/{@code isExhausted()} at the {@code hasNext()}-based default would fail loudly.
+ *
+ * <p>Covered wrappers: {@link StatsCapturingIterator}, {@link SchemaAdaptingIterator}, {@link VirtualColumnIterator},
+ * and {@link NullSpliceRowPositionStrategy}'s {@code NullSplicingIterator}.
+ */
+public class DrainContractForwardingTests extends ESTestCase {
+
+    private final BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("test"))
+        .build();
+
+    public void testStatsCapturingIteratorForwardsContract() {
+        ProbeIterator probe = new ProbeIterator();
+        CloseableIterator<Page> wrapper = StatsCapturingIterator.wrap(probe, new ConcurrentHashMap<>());
+        assertForwardsContract(wrapper, probe, 1 /* pass-through block count */);
+    }
+
+    public void testSchemaAdaptingIteratorForwardsContract() {
+        ProbeIterator probe = new ProbeIterator();
+        List<Attribute> schema = List.of(attr("a", DataType.INTEGER));
+        ColumnMapping identity = new ColumnMapping(new int[] { 0 }, null);
+        CloseableIterator<Page> wrapper = new SchemaAdaptingIterator(probe, schema, identity, blockFactory);
+        assertForwardsContract(wrapper, probe, 1 /* identity mapping keeps one block */);
+    }
+
+    public void testVirtualColumnIteratorForwardsContract() {
+        ProbeIterator probe = new ProbeIterator();
+        // One data column ("a") plus one partition column ("p") → inject() adds a constant block, output width 2.
+        List<Attribute> fullOutput = List.of(attr("a", DataType.INTEGER), attr("p", DataType.INTEGER));
+        CloseableIterator<Page> wrapper = new VirtualColumnIterator(probe, fullOutput, Set.of("p"), Map.of("p", 7), blockFactory);
+        assertForwardsContract(wrapper, probe, 2 /* data + injected partition constant */);
+    }
+
+    public void testNullSplicingIteratorForwardsContract() {
+        ProbeIterator probe = new ProbeIterator();
+        // rowPositionSlot == inner block count (1) → splice appends a trailing null block, output width 2.
+        CloseableIterator<Page> wrapper = new NullSpliceRowPositionStrategy(blockFactory, "test").apply(probe, 1);
+        assertForwardsContract(wrapper, probe, 2 /* original block + null splice */);
+    }
+
+    /**
+     * Drives the three contract methods through {@code wrapper}, asserting each forwards to {@code probe} and applies
+     * the wrapper's transform. Never invokes {@code hasNext()}/{@code next()} (the probe throws from both).
+     */
+    private void assertForwardsContract(CloseableIterator<Page> wrapper, ProbeIterator probe, int expectedOutputBlocks) {
+        // waitForReady forwards the delegate's exact listener instance.
+        SubscribableListener<Void> ready = new SubscribableListener<>();
+        probe.ready = ready;
+        assertSame("waitForReady must forward to the delegate", ready, wrapper.waitForReady());
+
+        // isExhausted forwards the delegate's flag.
+        probe.exhausted = false;
+        assertFalse("isExhausted must forward (false)", wrapper.isExhausted());
+        probe.exhausted = true;
+        assertTrue("isExhausted must forward (true)", wrapper.isExhausted());
+
+        // pollNext == null forwards a delegate null without any transform or blocking call.
+        probe.nextPage = null;
+        assertNull("pollNext must forward a null delegate poll", wrapper.pollNext());
+
+        // pollNext on a real page applies the wrapper's transform and delivers it.
+        probe.nextPage = oneIntBlockPage();
+        Page out = wrapper.pollNext();
+        assertNotNull("pollNext must deliver the transformed page", out);
+        assertEquals("transformed page block count", expectedOutputBlocks, out.getBlockCount());
+        assertEquals("positions preserved by the transform", 3, out.getPositionCount());
+        out.releaseBlocks();
+
+        assertFalse("probe hasNext must never be called on the drain path", probe.hasNextCalled);
+        assertFalse("probe next must never be called on the drain path", probe.nextCalled);
+    }
+
+    private Page oneIntBlockPage() {
+        IntBlock block = blockFactory.newConstantIntBlockWith(42, 3);
+        return new Page(3, new Block[] { block });
+    }
+
+    private static Attribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, name, type);
+    }
+
+    /** Delegate whose blocking {@code hasNext()}/{@code next()} throw; only the non-blocking contract is usable. */
+    private static final class ProbeIterator implements CloseableIterator<Page> {
+        private Page nextPage;
+        private boolean exhausted;
+        private SubscribableListener<Void> ready = SubscribableListener.newSucceeded(null);
+        private boolean hasNextCalled;
+        private boolean nextCalled;
+
+        @Override
+        public boolean hasNext() {
+            hasNextCalled = true;
+            throw new AssertionError("hasNext must not be called on the non-blocking drain path");
+        }
+
+        @Override
+        public Page next() {
+            nextCalled = true;
+            throw new AssertionError("next must not be called on the non-blocking drain path");
+        }
+
+        @Override
+        public Page pollNext() {
+            Page p = nextPage;
+            nextPage = null;
+            return p;
+        }
+
+        @Override
+        public boolean isExhausted() {
+            return exhausted;
+        }
+
+        @Override
+        public SubscribableListener<Void> waitForReady() {
+            return ready;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -182,7 +182,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 sink,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                null,
+                true
             );
             try (CloseableIterator<Page> iter = StatsCapturingIterator.wrap(outer, sink)) {
                 while (iter.hasNext()) {
@@ -242,7 +243,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 sink,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                null,
+                true
             );
             CloseableIterator<Page> iter = StatsCapturingIterator.wrap(outer, sink);
             // Consume one page, then close without draining — an early termination.
@@ -442,7 +444,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     sink,
                     64L, // stripe addressing active
                     StripeColumnScope.PROJECTED,
-                    null
+                    null,
+                    true
                 )
             );
 
@@ -966,7 +969,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                null,
+                true
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(iterator));
             String chain = ex.toString() + (ex.getCause() != null ? " | cause: " + ex.getCause() : "");
@@ -1015,7 +1019,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                null,
+                true
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(strictIterator));
             String chain = ex.toString() + (ex.getCause() != null ? " | cause: " + ex.getCause() : "");
@@ -1046,7 +1051,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                null,
+                true
             );
             List<String> got = collectLines(lenientIterator);
             assertEquals("non-strict policy must return the records parsed before the cap-hit", leadingRecords, got.size());
@@ -1094,7 +1100,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                sink::add
+                sink::add,
+                true
             );
             List<String> got = collectLines(iterator);
             assertEquals("an undelimitable first record yields no rows under truncation", 0, got.size());
@@ -1143,7 +1150,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
-            null
+            null,
+            true
         );
         List<String> got = collectLines(iterator);
         assertEquals("an undelimitable first record yields no rows under truncation", 0, got.size());


### PR DESCRIPTION
## What this is about

Multi-file external **text** reads (CSV / TSV / NDJSON glob over compressed files) can deadlock a node permanently: the query hangs forever, no timeout, no `CircuitBreakingException`, no error reaches the client, and every subsequent external read on that node queues behind the dead tasks until a restart. It reproduces on the `SORT … LIMIT` shape of a multi-file compressed text `FROM <dataset>`.

## What's wrong

Two defects compound:

1. **The producer-loop drain re-enters a blocking `hasNext()`.** `AsyncExternalSourceOperatorFactory.drainHotPath` is meant to be non-blocking: it checks `waitForReady()` and parks (releasing its executor slot) when not ready. But when `waitForReady()` reports *done* it called `hasNext()` — and for the streaming/parallel coordinator iterators a *done* readiness can mean a `POISON`/end-of-chunk marker sits in the current slot, not a page. `hasNext()` then blocks on a parser latch, **on the pool thread**. The async bypass is defeated; the consumer pins its thread waiting for a parser task that can't run.

2. **The read/parse pool and the drain pool were collapsed onto one executor.** `TransportEsqlQueryAction` built the operator-factory registry with a single `externalBlobStoreExecutor()`, so the drain, the segmentator, and the parser workers all share `esql_external_io` — the exact topology three of this code's own javadocs call deadlock-prone. Every concurrently-open unit pins two pool threads (a blocked drain + a blocked segmentator); once concurrently-open units reach `poolSize/2` the pool is 100% pinned pairs and the queued parser tasks — the only thing that could free a thread or produce a page — can never run. Introduced by elastic/elasticsearch#152771, whose own fix mechanism (park-instead-of-spin) this wiring change defeats.

## What this PR does

**Non-blocking drain contract.** `CloseableIterator` gains, alongside the existing `waitForReady()`, a non-blocking `pollNext()` (returns the next page or `null` if none is available *now*, never blocks) and `isExhausted()` (the single terminal predicate — true only when genuinely drained and every producer has exited). The synchronous defaults reduce to `hasNext()`/`next()`. Both async sources override them — `StreamingParallelParsingCoordinator$StreamingParallelIterator` and `ParallelParsingCoordinator$AsReadyParallelIterator` (which additionally gains an event-driven `waitForReady()` so it no longer pins a thread on its 200 ms poll). All four drain-path wrappers — `StatsCapturingIterator`, `SchemaAdaptingIterator`, `VirtualColumnIterator`, `NullSplicingIterator` — forward the three methods and apply their per-wrapper transform to the polled page.

`drainHotPath` is rewritten poll-then-park: reserve buffer space, `pollNext()`, deliver a page or — on `null` — park on `waitForReady()` releasing the slot. **It concludes `EOF` only when `isExhausted()` is true**, never on `pollNext()==null` paired with a done `waitForReady()`. That last point is load-bearing: a done readiness can be a `POISON` marker, so an EOF-on-ready-done drain silently drops the chunks still parsing behind it (partial results, no error).

**Two-pool wiring restored.** `TransportEsqlQueryAction` now wires the drain/coordination role to the `esql_worker` compute pool and only the read/parse role to `esql_external_io`, the split the javadocs promise. The single-executor `DataSourceModule.createOperatorFactoryRegistry(Executor)` overload is removed so the collapse cannot recur; the stale "blocking reads run on esql_worker" / "one executor backs both roles" comments are corrected.

**Consistency change (see "count_hits" below).** `StreamingParallelParsingCoordinator.parallelRead` threads `splitIsFileFinal`, symmetric with `ParallelParsingCoordinator`, so a future mid-file streaming split would not mark its trailing chunk file-final (a latent stats-attribution hazard). A whole-file compressed stream passes `true`; no behavior change today.

## Does it work?

Yes. Two new deterministic tests in `AsyncExternalSourceDrainDeadlockTests` drive the real producer-loop drain through a `Driver` on a bounded pool:

- **Deadlock test** — a single fixed 2-thread pool as both executor and producerExecutor, 3 concurrent single-file units whose iterators block forever in `hasNext()` but expose a correct non-blocking contract. With the pre-fix drain the pool pins and the run times out (`producer-loop drain wedged: a bounded pool thread pinned in a blocking hasNext()`); with the fix it completes.
- **EOF-drop test** — one unit with a mid-stream `pollNext()==null` + done `waitForReady()` + `isExhausted()==false` gap between two pages. Pre-fix drops the second page (`expected:<2> but was:<1>`); with the fix both pages are delivered.

`DrainContractForwardingTests` pins that all four wrappers forward `pollNext`/`waitForReady`/`isExhausted` and apply their transform without ever calling the delegate's blocking `hasNext()`/`next()`. `:x-pack:plugin:esql:precommit` is green; the touched coordinator/registry/factory suites pass.

## count_hits

Framed as a **consistency change + latent-hazard removal, not a certain fix.** The streaming coordinator already derives finality internally via `chunk.last()`, so whether the `splitIsFileFinal` threading resolves the count_hits divergence is A/B-pending. Closes the deadlock; expected to resolve the count_hits consistency item, to be confirmed by the ClickBench count_hits A/B.

## Why this is in draft

- The two-pool wiring is confirmed correct against precedent (`264585b13032` — drain→`esql_worker`, read→`esql_external_io`), but moving the drain back onto the compute pool has a throughput trade-off on low-CPU nodes that wants @costin load-validation before this is marked ready.
- The count_hits resolution is pending the A/B above.

## What's out of scope / follow-ups

- The cold-path `ExternalSourceDrainUtils.drainBatch` is still `hasNext()`-blocking; it is not on the hot multi-file drain path, but should get the same treatment.
- `OperatorFactoryRegistry` still carries a one-arg constructor for test-only callers; a follow-up can collapse it the same way the module overload was removed.
- Defense-in-depth on the segmentator (`StreamingParallelParsingCoordinator.dispatchChunk`'s blocking `chunkQueue.put` with a permit/queue size mismatch) is left for a separate change — the drain + wiring fix alone breaks the cycle.

Introduced by elastic/elasticsearch#152771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
