### PR TITLE
[9.4] Roll reindexed ML state indices in daily maintenance (#149555)

### DIFF
--- a/docs/changelog/149555.yaml
+++ b/docs/changelog/149555.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 149555
+summary: Roll reindexed ML state indices in daily maintenance
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -89,11 +89,29 @@ public final class AnomalyDetectorsIndex {
     }
 
     /**
-     * The name pattern to capture all .ml-state prefixed indices
-     * @return The .ml-state index pattern
+     * Index patterns for ML state indices, including those created by major-version system-index
+     * reindex migration (for example {@code .reindexed-v8-ml-state-000001}).
+     * <p>
+     * Use this array with {@link IndexNameExpressionResolver#concreteIndexNames}. A single
+     * comma-separated string is not equivalent: the resolver treats it as one expression.
+     */
+    public static String[] jobStateIndexPatterns() {
+        return new String[] {
+            AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "*",
+            AnomalyDetectorsIndexFields.REINDEXED_V7_STATE_INDEX_PREFIX + "*",
+            AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX + "*" };
+    }
+
+    /**
+     * Comma-separated index patterns for ML state indices for REST query strings that split on commas.
+     * <p>
+     * Do not pass this value as a single argument to Java client methods that accept one index expression
+     * (for example {@code prepareSearch(String)}); use {@link #jobStateIndexPatterns()} instead.
+     *
+     * @return index patterns for ML state indices
      */
     public static String jobStateIndexPattern() {
-        return AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "*";
+        return String.join(",", jobStateIndexPatterns());
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndexFields.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndexFields.java
@@ -10,6 +10,14 @@ public final class AnomalyDetectorsIndexFields {
 
     public static final String STATE_INDEX_PREFIX = ".ml-state";
 
+    /**
+     * Prefix for ML state indices created by major-version system-index reindex migration.
+     * See {@link AnomalyDetectorsIndex#jobStateIndexPattern()}.
+     */
+    public static final String REINDEXED_V7_STATE_INDEX_PREFIX = ".reindexed-v7-ml-state";
+
+    public static final String REINDEXED_V8_STATE_INDEX_PREFIX = ".reindexed-v8-ml-state";
+
     public static final String RESULTS_INDEX_PREFIX = ".ml-anomalies-";
     // ".write" rather than simply "write" to avoid the danger of clashing
     // with the read alias of a job whose name begins with "write-"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -81,10 +81,16 @@ public final class MlIndexAndAlias {
     private static final Logger logger = LogManager.getLogger(MlIndexAndAlias.class);
     private static final Predicate<String> HAS_SIX_DIGIT_SUFFIX = Pattern.compile("\\d{6}").asMatchPredicate();
     private static final Predicate<String> IS_ANOMALIES_SHARED_INDEX = Pattern.compile(
-        AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT + "-\\d{6}"
+        Pattern.quote(AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX) + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT + "-\\d{6}"
     ).asMatchPredicate();
     private static final Predicate<String> IS_ANOMALIES_STATE_INDEX = Pattern.compile(
-        AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-\\d{6}"
+        "(?:"
+            + Pattern.quote(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX)
+            + "|"
+            + Pattern.quote(AnomalyDetectorsIndexFields.REINDEXED_V7_STATE_INDEX_PREFIX)
+            + "|"
+            + Pattern.quote(AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX)
+            + ")-\\d{6}"
     ).asMatchPredicate();
     public static final String ROLLOVER_ALIAS_SUFFIX = ".rollover_alias";
 
@@ -508,7 +514,8 @@ public final class MlIndexAndAlias {
     }
 
     /**
-     * Checks if an index name matches the pattern for the ML anomalies state indices  (e.g., ".ml-state-000001").
+     * Checks if an index name matches the pattern for ML anomalies state indices (for example
+     * {@code .ml-state-000001} or {@code .reindexed-v8-ml-state-000001}).
      *
      * @param indexName The name of the index to check.
      * @return {@code true} if the index is an anomalies state index, {@code false} otherwise.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.AdminClient;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ClusterAdminClient;
@@ -57,10 +58,12 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
@@ -418,6 +421,28 @@ public class MlIndexAndAliasTests extends ESTestCase {
         assertFalse(MlIndexAndAlias.isAnomaliesSharedIndex(".ml-anomalies-state-000007"));
         assertFalse(MlIndexAndAlias.isAnomaliesSharedIndex(".ml-anomalies-annotations-000007"));
         assertFalse(MlIndexAndAlias.isAnomaliesSharedIndex(".ml-anomalies-stats-000007"));
+    }
+
+    public void testIsAnomaliesStateIndex() {
+        assertTrue(MlIndexAndAlias.isAnomaliesStateIndex(".ml-state-000001"));
+        assertTrue(MlIndexAndAlias.isAnomaliesStateIndex(".reindexed-v7-ml-state-000001"));
+        assertTrue(MlIndexAndAlias.isAnomaliesStateIndex(".reindexed-v8-ml-state-000042"));
+        assertFalse(MlIndexAndAlias.isAnomaliesStateIndex(".reindexed-v8-ml-state"));
+        assertFalse(MlIndexAndAlias.isAnomaliesStateIndex("xml-state-000001"));
+        assertFalse(MlIndexAndAlias.isAnomaliesStateIndex(".ml-anomalies-shared-000001"));
+    }
+
+    public void testJobStateIndexPatternsResolveReindexedStateIndex() {
+        String reindexedIndex = ".reindexed-v8-ml-state-000001";
+        ClusterState clusterState = createClusterState(Map.of(reindexedIndex, createIndexMetadata(reindexedIndex)));
+        var resolver = TestIndexNameExpressionResolver.newInstance();
+        String[] indices = resolver.concreteIndexNames(
+            clusterState,
+            IndicesOptions.lenientExpandOpenHidden(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns()
+        );
+        assertThat(indices, arrayContainingInAnyOrder(reindexedIndex));
+        assertThat(indices.length, is(1));
     }
 
     public void testCreateRolloverAliasAndNewIndexName() {

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/state_index_template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/state_index_template.json
@@ -2,7 +2,9 @@
   "priority": 2147483647,
   "version" : ${xpack.ml.version.id},
   "index_patterns" : [
-    ".ml-state*"
+    ".ml-state*",
+    ".reindexed-v7-ml-state*",
+    ".reindexed-v8-ml-state*"
   ],
   "template" : {
     "settings" : {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CategorizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CategorizationIT.java
@@ -305,7 +305,7 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         // end of lookback rather than when the job was closed.
         assertBusy(() -> {
             assertResponse(
-                prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+                prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setQuery(
                     QueryBuilders.idsQuery().addIds(CategorizerState.documentId(job.getId(), 1))
                 ),
                 stateDocsResponse -> {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -341,7 +341,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
         // Verify .ml-state doesn't contain unused state documents
         assertResponse(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
             stateDocsResponse -> {
                 assertThat(stateDocsResponse.getHits().getTotalHits().value(), greaterThanOrEqualTo(5L));
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -280,7 +280,7 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
 
     protected void assertStoredProgressHits(String jobId, int hitCount) {
         assertHitCount(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setQuery(
                 QueryBuilders.idsQuery().addIds(StoredProgress.documentId(jobId))
             ),
             hitCount
@@ -451,7 +451,7 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
 
     protected static void assertModelStatePersisted(String stateDocId) {
         assertHitCount(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(QueryBuilders.idsQuery().addIds(stateDocId)),
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setQuery(QueryBuilders.idsQuery().addIds(stateDocId)),
             1
         );
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotRetentionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotRetentionIT.java
@@ -180,7 +180,7 @@ public class ModelSnapshotRetentionIT extends MlNativeAutodetectIntegTestCase {
 
     private List<String> getAvailableModelStateDocIds() throws Exception {
         SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(AnomalyDetectorsIndex.jobStateIndexPattern());
+        searchRequest.indices(AnomalyDetectorsIndex.jobStateIndexPatterns());
         searchRequest.source(new SearchSourceBuilder().size(10000));
 
         return getDocIdsFromSearch(searchRequest);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
@@ -65,7 +65,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
 
         // Check that state has been persisted
         assertResponse(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
             stateDocsResponse1 -> {
                 int numQuantileRecords = 0;
                 int numStateRecords = 0;
@@ -104,7 +104,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
 
         // Check that a new state record exists.
         assertResponse(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
             stateDocsResponse2 -> {
                 int numQuantileRecords = 0;
                 int numStateRecords = 0;
@@ -142,7 +142,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
 
         // Check that state has been persisted
         assertResponse(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
             stateDocsResponse -> {
                 int numQuantileRecords = 0;
                 int numStateRecords = 0;
@@ -168,7 +168,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         deleteJob(jobId);
 
         assertResponse(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
             stateDocsResponse -> {
                 int numQuantileRecords = 0;
                 int numStateRecords = 0;
@@ -195,7 +195,7 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         closeJob(jobId);
 
         // Check that state has not been persisted
-        assertHitCount(prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()), 0);
+        assertHitCount(prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()), 0);
 
         // Check that results have not been persisted
         assertHitCount(prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)), 0);

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
@@ -164,10 +165,10 @@ public class AnomalyJobCRUDIT extends MlSingleNodeTestCase {
         client().admin().indices().prepareCreate(".ml-state-000001").get();
         client().admin().indices().prepareClose(".ml-state-000001").setWaitForActiveShards(0).get();
         ElasticsearchStatusException ex = expectThrows(ElasticsearchStatusException.class, () -> createJob(jobId));
-        assertThat(
-            ex.getMessage(),
-            containsString("Cannot create job [job-with-closed-results-index] as it requires closed index [.ml-state*]")
-        );
+        assertThat(ex.getMessage(), containsString("Cannot create job [job-with-closed-results-index] as it requires closed index ["));
+        for (String stateIndexPattern : AnomalyDetectorsIndex.jobStateIndexPatterns()) {
+            assertThat(ex.getMessage(), containsString(stateIndexPattern));
+        }
         client().admin().indices().prepareDelete(".ml-state-000001").get();
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/IndexLayoutIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/IndexLayoutIT.java
@@ -63,7 +63,7 @@ public class IndexLayoutIT extends BaseMlIntegTestCase {
             client.admin()
                 .indices()
                 .prepareGetIndex(TEST_REQUEST_TIMEOUT)
-                .addIndices(AnomalyDetectorsIndex.jobStateIndexPattern())
+                .addIndices(AnomalyDetectorsIndex.jobStateIndexPatterns())
                 .get()
                 .indices(),
             arrayContaining(".ml-state-000001")
@@ -71,7 +71,7 @@ public class IndexLayoutIT extends BaseMlIntegTestCase {
         assertThat(
             client.admin()
                 .indices()
-                .prepareGetAliases(TEST_REQUEST_TIMEOUT, AnomalyDetectorsIndex.jobStateIndexPattern())
+                .prepareGetAliases(TEST_REQUEST_TIMEOUT, AnomalyDetectorsIndex.jobStateIndexPatterns())
                 .get()
                 .getAliases()
                 .get(".ml-state-000001")
@@ -145,13 +145,13 @@ public class IndexLayoutIT extends BaseMlIntegTestCase {
             client.admin()
                 .indices()
                 .prepareGetIndex(TEST_REQUEST_TIMEOUT)
-                .addIndices(AnomalyDetectorsIndex.jobStateIndexPattern())
+                .addIndices(AnomalyDetectorsIndex.jobStateIndexPatterns())
                 .get()
                 .indices(),
             arrayContaining(".ml-state-000001")
         );
 
-        assertHitCount(client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setTrackTotalHits(true), 0);
+        assertHitCount(client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setTrackTotalHits(true), 0);
     }
 
 }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -805,8 +805,12 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
                 {"job_id":"other_job","snapshot_id":"11", "snapshot_doc_count":1,"retain":false}""", XContentType.JSON)
             .get();
 
-        indicesAdmin().prepareRefresh(AnomalyDetectorsIndex.jobStateIndexPattern(), AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*")
-            .get();
+        indicesAdmin().prepareRefresh(
+            Strings.concatStringArrays(
+                AnomalyDetectorsIndex.jobStateIndexPatterns(),
+                new String[] { AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*" }
+            )
+        ).get();
 
         PlainActionFuture<QueryPage<ModelSnapshot>> future = new PlainActionFuture<>();
         jobProvider.modelSnapshots(jobId, 0, 4, "9", "15", "", false, "snap_2,snap_1", null, future::onResponse, future::onFailure);
@@ -908,9 +912,13 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         indexQuantiles(quantiles);
 
         indicesAdmin().prepareRefresh(
-            MlMetaIndex.indexName(),
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
-            AnomalyDetectorsIndex.jobResultsAliasedName(jobId)
+            Strings.concatStringArrays(
+                new String[] { MlMetaIndex.indexName() },
+                Strings.concatStringArrays(
+                    AnomalyDetectorsIndex.jobStateIndexPatterns(),
+                    new String[] { AnomalyDetectorsIndex.jobResultsAliasedName(jobId) }
+                )
+            )
         ).get();
 
         AutodetectParams params = getAutodetectParams(job.build(new Date()));

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDailyMaintenanceServiceRolloverIndicesIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDailyMaintenanceServiceRolloverIndicesIT.java
@@ -7,10 +7,12 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterName;
@@ -117,21 +119,22 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // It's not the conditions or even the rollover itself we are testing but the state of the indices and aliases afterwards.
         maintenanceService.setRolloverMaxSize(ByteSizeValue.ZERO);
 
-        Map<String, Consumer<ActionListener<AcknowledgedResponse>>> params = Map.of(
-            AnomalyDetectorsIndex.jobResultsIndexPattern(),
-            (listener) -> maintenanceService.triggerRollResultsIndicesIfNecessaryTask(listener),
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
-            (listener) -> maintenanceService.triggerRollStateIndicesIfNecessaryTask(listener)
+        List<Map.Entry<String[], Consumer<ActionListener<AcknowledgedResponse>>>> params = List.of(
+            Map.entry(
+                new String[] { AnomalyDetectorsIndex.jobResultsIndexPattern() },
+                maintenanceService::triggerRollResultsIndicesIfNecessaryTask
+            ),
+            Map.entry(AnomalyDetectorsIndex.jobStateIndexPatterns(), maintenanceService::triggerRollStateIndicesIfNecessaryTask)
         );
 
-        for (Map.Entry<String, Consumer<ActionListener<AcknowledgedResponse>>> param : params.entrySet()) {
-            String indexPattern = param.getKey();
+        for (Map.Entry<String[], Consumer<ActionListener<AcknowledgedResponse>>> param : params) {
+            String[] indexPatterns = param.getKey();
             Consumer<ActionListener<AcknowledgedResponse>> function = param.getValue();
             {
                 GetIndexResponse getIndexResponse = client().admin()
                     .indices()
                     .prepareGetIndex(TEST_REQUEST_TIMEOUT)
-                    .setIndices(indexPattern)
+                    .setIndices(indexPatterns)
                     .get();
                 assertThat(getIndexResponse.toString(), getIndexResponse.getIndices().length, is(0));
                 var aliases = getIndexResponse.getAliases();
@@ -144,7 +147,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
                 GetIndexResponse getIndexResponse = client().admin()
                     .indices()
                     .prepareGetIndex(TEST_REQUEST_TIMEOUT)
-                    .setIndices(indexPattern)
+                    .setIndices(indexPatterns)
                     .get();
                 assertThat(getIndexResponse.toString(), getIndexResponse.getIndices().length, is(0));
                 var aliases = getIndexResponse.getAliases();
@@ -439,7 +442,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // 2. Check the state index exists and has the expected write alias
         assertIndicesAndAliases(
             "Before rollover (state)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001", List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias()))
         );
 
@@ -449,7 +452,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // 4. Verify state index was rolled over correctly
         assertIndicesAndAliases(
             "After rollover (state)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
                 List.of(),
@@ -464,7 +467,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // 6. Verify state index was rolled over correctly
         assertIndicesAndAliases(
             "After rollover (state)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
                 List.of(),
@@ -473,6 +476,44 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000003",
                 List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias())
             )
+        );
+    }
+
+    public void testTriggerRollReindexedV8StateIndicesIfNecessaryTask() throws Exception {
+        maintenanceService.setRolloverMaxSize(ByteSizeValue.ZERO);
+
+        String reindexedIndex = AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX + "-000001";
+        String rolledIndex = AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX + "-000002";
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .delete(new DeleteIndexRequest(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001"))
+                .actionGet()
+        );
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .create(
+                    new CreateIndexRequest(reindexedIndex).settings(Settings.builder().put("index.hidden", true).build())
+                        .alias(new Alias(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).writeIndex(true).isHidden(true))
+                )
+                .actionGet()
+        );
+
+        assertIndicesAndAliases(
+            "Before rollover (reindexed-v8 state)",
+            new String[] { AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX + "*" },
+            Map.of(reindexedIndex, List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias()))
+        );
+
+        blockingCall(maintenanceService::triggerRollStateIndicesIfNecessaryTask);
+
+        assertIndicesAndAliases(
+            "After rollover (reindexed-v8 state)",
+            new String[] { AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX + "*" },
+            Map.of(reindexedIndex, List.of(), rolledIndex, List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias()))
         );
     }
 
@@ -485,12 +526,12 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
             GetIndexResponse getIndexResponse = client().admin()
                 .indices()
                 .prepareGetIndex(TEST_REQUEST_TIMEOUT)
-                .setIndices(AnomalyDetectorsIndex.jobStateIndexPattern())
+                .setIndices(AnomalyDetectorsIndex.jobStateIndexPatterns())
                 .get();
             logger.warn("get_index_response: {}", getIndexResponse.toString());
             assertIndicesAndAliases(
                 "Before rollover (state)",
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
+                AnomalyDetectorsIndex.jobStateIndexPatterns(),
                 Map.of(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001", List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias()))
             );
         }
@@ -500,7 +541,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         {
             assertIndicesAndAliases(
                 "After rollover (state)",
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
+                AnomalyDetectorsIndex.jobStateIndexPatterns(),
                 Map.of(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001", List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias()))
             );
         }
@@ -519,7 +560,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
 
         assertIndicesAndAliases(
             "Before rollover (state, missing alias)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001", List.of())
         );
 
@@ -529,7 +570,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // 4. Verify the index rolled over correctly and the write alias was added
         assertIndicesAndAliases(
             "After rollover (state, missing alias)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
                 List.of(),
@@ -549,7 +590,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // 3. Verify the initial state (write alias is on the older index)
         assertIndicesAndAliases(
             "Before rollover (state, alias on wrong index)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
                 List.of(AnomalyDetectorsIndex.jobStateIndexWriteAlias()),
@@ -565,7 +606,7 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         // 5. Verify the index rolled over correctly and the write alias was moved to the latest index
         assertIndicesAndAliases(
             "After rollover (state, alias on wrong index)",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             Map.of(
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
                 List.of(),
@@ -822,11 +863,16 @@ public class MlDailyMaintenanceServiceRolloverIndicesIT extends BaseMlIntegTestC
         );
     }
 
-    private void assertIndicesAndAliases(String context, String indexWildcard, Map<String, List<String>> expectedAliases) {
+    private void assertIndicesAndAliases(String context, String indexPattern, Map<String, List<String>> expectedAliases) {
+        assertIndicesAndAliases(context, new String[] { indexPattern }, expectedAliases);
+    }
+
+    private void assertIndicesAndAliases(String context, String[] indexPatterns, Map<String, List<String>> expectedAliases) {
         GetIndexResponse getIndexResponse = client().admin()
             .indices()
             .prepareGetIndex(TEST_REQUEST_TIMEOUT)
-            .setIndices(indexWildcard)
+            .setIndices(indexPatterns)
+            .setIndicesOptions(IndicesOptions.lenientExpandOpenHidden())
             .get();
 
         var indices = Arrays.asList(getIndexResponse.getIndices());

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -85,7 +85,7 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
 
         // The job running on the original node should have been killed, and hence should not have persisted quantiles
         assertHitCount(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setQuery(
                 QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()))
             ).setTrackTotalHits(true).setIndicesOptions(IndicesOptions.lenientExpandOpen()),
             0
@@ -97,7 +97,7 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
 
         // The relocated job was closed rather than killed, and hence should have persisted quantiles
         assertHitCount(
-            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns()).setQuery(
                 QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()))
             ).setTrackTotalHits(true).setIndicesOptions(IndicesOptions.lenientExpandOpen()),
             1

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -470,6 +470,8 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields.REINDEXED_V7_STATE_INDEX_PREFIX;
+import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields.REINDEXED_V8_STATE_INDEX_PREFIX;
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX;
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX;
 import static org.elasticsearch.xpack.core.ml.utils.InferenceProcessorInfoExtractor.countInferenceProcessors;
@@ -1348,8 +1350,13 @@ public class MachineLearning extends Plugin
                 new DatafeedConfigAutoUpdater(datafeedConfigProvider, indexNameExpressionResolver),
                 new MlIndexRollover(
                     List.of(
+                        new MlIndexRollover.IndexPatternAndAlias(STATE_INDEX_PREFIX + "*", AnomalyDetectorsIndex.jobStateIndexWriteAlias()),
                         new MlIndexRollover.IndexPatternAndAlias(
-                            AnomalyDetectorsIndex.jobStateIndexPattern(),
+                            REINDEXED_V7_STATE_INDEX_PREFIX + "*",
+                            AnomalyDetectorsIndex.jobStateIndexWriteAlias()
+                        ),
+                        new MlIndexRollover.IndexPatternAndAlias(
+                            REINDEXED_V8_STATE_INDEX_PREFIX + "*",
                             AnomalyDetectorsIndex.jobStateIndexWriteAlias()
                         ),
                         new MlIndexRollover.IndexPatternAndAlias(MlStatsIndex.indexPattern(), MlStatsIndex.writeAlias()),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -387,11 +387,14 @@ public class MlDailyMaintenanceService implements Releasable {
         MlIndexAndAlias.createAliasForRollover(originSettingClient, index, rolloverAlias, getIndicesAliasesListener);
     }
 
-    private String[] findIndicesMatchingPattern(ClusterState clusterState, String indexPattern) {
-        // list all indices matching the given index pattern
-        String[] indices = expressionResolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpenHidden(), indexPattern);
+    private String[] findIndicesMatchingPatterns(ClusterState clusterState, String[] indexPatterns) {
+        String[] indices = expressionResolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpenHidden(), indexPatterns);
         if (logger.isTraceEnabled()) {
-            logger.trace("findIndicesMatchingPattern: indices found: {} matching pattern [{}]", Arrays.toString(indices), indexPattern);
+            logger.trace(
+                "findIndicesMatchingPatterns: indices found: {} matching patterns [{}]",
+                Arrays.toString(indices),
+                Arrays.toString(indexPatterns)
+            );
         }
         return indices;
     }
@@ -456,14 +459,14 @@ public class MlDailyMaintenanceService implements Releasable {
 
     private void triggerRollIndicesIfNecessaryTask(
         String taskName,
-        String indexPattern,
+        String[] indexPatterns,
         ActionListener<AcknowledgedResponse> finalListener
     ) {
-        logger.info("[ML] maintenance task: [{}] for index pattern [{}]", taskName, indexPattern);
+        logger.info("[ML] maintenance task: [{}] for index patterns [{}]", taskName, Arrays.toString(indexPatterns));
 
         ClusterState clusterState = clusterService.state();
 
-        String[] indices = findIndicesMatchingPattern(clusterState, indexPattern);
+        String[] indices = findIndicesMatchingPatterns(clusterState, indexPatterns);
         if (rolloverMaxSize == ByteSizeValue.MINUS_ONE || indices.length == 0) {
             // Early bath
             finalListener.onResponse(AcknowledgedResponse.TRUE);
@@ -490,12 +493,16 @@ public class MlDailyMaintenanceService implements Releasable {
 
     // public for testing
     public void triggerRollResultsIndicesIfNecessaryTask(ActionListener<AcknowledgedResponse> finalListener) {
-        triggerRollIndicesIfNecessaryTask("roll-results-indices", AnomalyDetectorsIndex.jobResultsIndexPattern(), finalListener);
+        triggerRollIndicesIfNecessaryTask(
+            "roll-results-indices",
+            new String[] { AnomalyDetectorsIndex.jobResultsIndexPattern() },
+            finalListener
+        );
     }
 
     // public for testing
     public void triggerRollStateIndicesIfNecessaryTask(ActionListener<AcknowledgedResponse> finalListener) {
-        triggerRollIndicesIfNecessaryTask("roll-state-indices", AnomalyDetectorsIndex.jobStateIndexPattern(), finalListener);
+        triggerRollIndicesIfNecessaryTask("roll-state-indices", AnomalyDetectorsIndex.jobStateIndexPatterns(), finalListener);
     }
 
     private void triggerDeleteExpiredDataTask(ActionListener<AcknowledgedResponse> finalListener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -42,8 +42,9 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
      * add a comment with a reason each time the base number is incremented.
      *
      * 10000001: ".reindexed-v7-ml-anomalies-*" added to ml-anomalies index pattern
+     * 10000002: ".reindexed-v7-ml-state*" and ".reindexed-v8-ml-state*" added to ml-state index pattern
      */
-    public static final int ML_INDEX_TEMPLATE_VERSION = 10000001 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
+    public static final int ML_INDEX_TEMPLATE_VERSION = 10000002 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_TEMPLATE_VERSION;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/dataframe/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/dataframe/TransportGetDataFrameAnalyticsStatsAction.java
@@ -328,7 +328,7 @@ public class TransportGetDataFrameAnalyticsStatsAction extends TransportTasksAct
     }
 
     private static SearchRequest buildStoredProgressSearch(String configId) {
-        SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern());
+        SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPatterns());
         searchRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
         searchRequest.source().size(1);
         searchRequest.source().query(QueryBuilders.idsQuery().addIds(StoredProgress.documentId(configId)));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/dataframe/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/dataframe/TransportStartDataFrameAnalyticsAction.java
@@ -832,7 +832,12 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
 
         @Override
         protected String[] indicesOfInterest(TaskParams params) {
-            return new String[] { MlConfigIndex.indexName(), MlStatsIndex.indexPattern(), AnomalyDetectorsIndex.jobStateIndexPattern() };
+            String[] statePatterns = AnomalyDetectorsIndex.jobStateIndexPatterns();
+            String[] indices = new String[statePatterns.length + 2];
+            System.arraycopy(statePatterns, 0, indices, 0, statePatterns.length);
+            indices[statePatterns.length] = MlStatsIndex.indexPattern();
+            indices[statePatterns.length + 1] = MlConfigIndex.indexName();
+            return indices;
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -273,7 +273,7 @@ public class DataFrameAnalyticsTask extends LicensedAllocatedPersistentTask impl
 
         // Step 2: Search for existing progress document in .ml-state*
         ActionListener<Void> stepProgressUpdateListener = ActionListener.wrap(aVoid -> {
-            SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).source(
+            SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPatterns()).source(
                 new SearchSourceBuilder().size(1).query(new IdsQueryBuilder().addIds(progressDocId))
             );
             executeAsyncWithOrigin(clientToUse, ML_ORIGIN, TransportSearchAction.TYPE, searchRequest, searchFormerProgressDocListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsDeleter.java
@@ -168,7 +168,12 @@ public class DataFrameAnalyticsDeleter {
         );
     }
 
-    private void executeDeleteByQuery(String[] indices, QueryBuilder query, TimeValue timeout, ActionListener<BulkByScrollResponse> listener) {
+    private void executeDeleteByQuery(
+        String[] indices,
+        QueryBuilder query,
+        TimeValue timeout,
+        ActionListener<BulkByScrollResponse> listener
+    ) {
         DeleteByQueryRequest request = new DeleteByQueryRequest(indices);
         request.setQuery(query);
         request.setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsDeleter.java
@@ -128,7 +128,7 @@ public class DataFrameAnalyticsDeleter {
     private void deleteState(DataFrameAnalyticsConfig config, TimeValue timeout, ActionListener<BulkByScrollResponse> listener) {
         ActionListener<Boolean> deleteModelStateListener = listener.delegateFailureAndWrap(
             (l, r) -> executeDeleteByQuery(
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
+                AnomalyDetectorsIndex.jobStateIndexPatterns(),
                 QueryBuilders.idsQuery().addIds(StoredProgress.documentId(config.getId())),
                 timeout,
                 l
@@ -146,7 +146,7 @@ public class DataFrameAnalyticsDeleter {
 
         IdsQueryBuilder query = QueryBuilders.idsQuery().addIds(config.getAnalysis().getStateDocIdPrefix(config.getId()) + docNum);
         executeDeleteByQuery(
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             query,
             timeout,
             listener.delegateFailureAndWrap((l, response) -> {
@@ -161,15 +161,15 @@ public class DataFrameAnalyticsDeleter {
 
     private void deleteStats(String jobId, TimeValue timeout, ActionListener<BulkByScrollResponse> listener) {
         executeDeleteByQuery(
-            MlStatsIndex.indexPattern(),
+            new String[] { MlStatsIndex.indexPattern() },
             QueryBuilders.termQuery(Fields.JOB_ID.getPreferredName(), jobId),
             timeout,
             listener
         );
     }
 
-    private void executeDeleteByQuery(String index, QueryBuilder query, TimeValue timeout, ActionListener<BulkByScrollResponse> listener) {
-        DeleteByQueryRequest request = new DeleteByQueryRequest(index);
+    private void executeDeleteByQuery(String[] indices, QueryBuilder query, TimeValue timeout, ActionListener<BulkByScrollResponse> listener) {
+        DeleteByQueryRequest request = new DeleteByQueryRequest(indices);
         request.setQuery(query);
         request.setIndicesOptions(MlIndicesUtils.addIgnoreUnavailable(IndicesOptions.lenientExpandOpen()));
         request.setSlices(AbstractBulkByScrollRequest.AUTO_SLICES);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -166,7 +166,7 @@ public class AnalyticsProcessManager {
         }
 
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
-            SearchResponse searchResponse = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern())
+            SearchResponse searchResponse = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns())
                 .setSize(1)
                 .setFetchSource(false)
                 .setQuery(QueryBuilders.idsQuery().addIds(config.getAnalysis().getStateDocIdPrefix(config.getId()) + "1"))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcess.java
@@ -81,7 +81,7 @@ public class NativeAnalyticsProcess extends AbstractNativeAnalyticsProcess<Analy
                 }
 
                 // We fetch the documents one at a time because all together they can amount to too much memory
-                SearchResponse stateResponse = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern())
+                SearchResponse stateResponse = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns())
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(stateDocIdPrefix + ++docNum))
                     .get();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
@@ -85,11 +85,11 @@ public class FinalStep extends AbstractDataFrameAnalyticsStep {
     }
 
     private void refreshIndices(ActionListener<BroadcastResponse> listener) {
-        RefreshRequest refreshRequest = new RefreshRequest(
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
-            MlStatsIndex.indexPattern(),
-            config.getDest().getIndex()
-        );
+        String[] statePatterns = AnomalyDetectorsIndex.jobStateIndexPatterns();
+        String[] indices = Arrays.copyOf(statePatterns, statePatterns.length + 2);
+        indices[statePatterns.length] = MlStatsIndex.indexPattern();
+        indices[statePatterns.length + 1] = config.getDest().getIndex();
+        RefreshRequest refreshRequest = new RefreshRequest(indices);
         refreshRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
 
         LOGGER.debug(() -> format("[%s] Refreshing indices %s", config.getId(), Arrays.toString(refreshRequest.indices())));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedStateDocIdsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedStateDocIdsIterator.java
@@ -17,8 +17,8 @@ import org.elasticsearch.xpack.ml.utils.persistence.BatchedDocumentsIterator;
  */
 public class BatchedStateDocIdsIterator extends BatchedDocumentsIterator<String> {
 
-    public BatchedStateDocIdsIterator(OriginSettingClient client, String index) {
-        super(client, index);
+    public BatchedStateDocIdsIterator(OriginSettingClient client, String... indices) {
+        super(client, indices);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -74,6 +74,7 @@ import org.elasticsearch.xpack.ml.job.retention.WritableIndexExpander;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -116,11 +117,9 @@ public class JobDataDeleter {
             return;
         }
 
-        String stateIndexName = AnomalyDetectorsIndex.jobStateIndexPattern();
-
         List<String> idsToDelete = new ArrayList<>();
         Set<String> indices = new HashSet<>();
-        indices.add(stateIndexName);
+        Collections.addAll(indices, AnomalyDetectorsIndex.jobStateIndexPatterns());
         indices.add(AnnotationIndex.READ_ALIAS_NAME);
         for (ModelSnapshot modelSnapshot : modelSnapshots) {
             idsToDelete.addAll(modelSnapshot.stateDocumentIds());
@@ -602,7 +601,7 @@ public class JobDataDeleter {
         IdsQueryBuilder query = new IdsQueryBuilder().addIds(Quantiles.documentId(jobId));
 
         String[] indicesToQuery = removeReadOnlyIndices(
-            List.of(AnomalyDetectorsIndex.jobStateIndexPattern()),
+            Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns()),
             finishedHandler,
             "quantiles",
             () -> finishedHandler.onResponse(true)
@@ -640,7 +639,7 @@ public class JobDataDeleter {
         // Just use ID here, not type, as trying to delete different types spams the logs with an exception stack trace
         IdsQueryBuilder query = new IdsQueryBuilder().addIds(CategorizerState.documentId(jobId, docNum));
         String[] indicesToQuery = removeReadOnlyIndices(
-            List.of(AnomalyDetectorsIndex.jobStateIndexPattern()),
+            Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns()),
             finishedHandler,
             "categorizer state",
             () -> finishedHandler.onResponse(true)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -371,7 +371,7 @@ public class JobResultsPersister {
     }
 
     private static SearchRequest buildQuantilesDocIdSearch(String quantilesDocId) {
-        return new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).allowPartialSearchResults(false)
+        return new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPatterns()).allowPartialSearchResults(false)
             .source(
                 new SearchSourceBuilder().size(1)
                     .fetchSource(false)
@@ -469,7 +469,7 @@ public class JobResultsPersister {
             indexNames.add(AnomalyDetectorsIndex.jobResultsAliasedName(jobId));
         }
         if (commitTypes.contains(CommitType.STATE)) {
-            indexNames.add(AnomalyDetectorsIndex.jobStateIndexPattern());
+            Collections.addAll(indexNames, AnomalyDetectorsIndex.jobStateIndexPatterns());
         }
         if (commitTypes.contains(CommitType.ANNOTATIONS)) {
             // We refresh using the read alias in order to ensure all indices will

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -197,14 +197,14 @@ public class JobResultsProvider {
      */
     public void checkForLeftOverDocuments(Job job, ActionListener<Boolean> listener) {
 
-        SearchRequestBuilder stateDocSearch = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern())
+        SearchRequestBuilder stateDocSearch = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns())
             .setQuery(
                 QueryBuilders.idsQuery().addIds(CategorizerState.documentId(job.getId(), 1), CategorizerState.v54DocumentId(job.getId(), 1))
             )
             .setTrackTotalHits(false)
             .setIndicesOptions(IndicesOptions.strictExpand());
 
-        SearchRequestBuilder quantilesDocSearch = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern())
+        SearchRequestBuilder quantilesDocSearch = client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPatterns())
             .setQuery(QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()), Quantiles.v54DocumentId(job.getId())))
             .setTrackTotalHits(false)
             .setIndicesOptions(IndicesOptions.strictExpand());
@@ -737,8 +737,6 @@ public class JobResultsProvider {
 
         AutodetectParams.Builder paramsBuilder = new AutodetectParams.Builder(job.getId());
         String resultsIndex = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);
-        String stateIndex = AnomalyDetectorsIndex.jobStateIndexPattern();
-
         MultiSearchRequestBuilder msearch = client.prepareMultiSearch()
             .add(createLatestDataCountsSearch(resultsIndex, jobId))
             .add(createLatestModelSizeStatsSearch(resultsIndex))
@@ -746,7 +744,7 @@ public class JobResultsProvider {
 
         if (snapshotId != null) {
             msearch.add(createDocIdSearch(resultsIndex, ModelSnapshot.documentId(jobId, snapshotId)));
-            msearch.add(createDocIdSearch(stateIndex, Quantiles.documentId(jobId)));
+            msearch.add(createDocIdSearch(AnomalyDetectorsIndex.jobStateIndexPatterns(), Quantiles.documentId(jobId)));
         }
 
         for (String filterId : job.getAnalysisConfig().extractReferencedFilters()) {
@@ -812,7 +810,11 @@ public class JobResultsProvider {
     }
 
     private SearchRequestBuilder createDocIdSearch(String index, String id) {
-        return client.prepareSearch(index)
+        return createDocIdSearch(new String[] { index }, id);
+    }
+
+    private SearchRequestBuilder createDocIdSearch(String[] indices, String id) {
+        return client.prepareSearch(indices)
             .setSize(1)
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(QueryBuilders.idsQuery().addIds(id))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamer.java
@@ -61,7 +61,7 @@ public class StateStreamer {
      * @param restoreStream the stream to write the state to
      */
     public void restoreStateToStream(String jobId, ModelSnapshot modelSnapshot, OutputStream restoreStream) throws IOException {
-        String indexName = AnomalyDetectorsIndex.jobStateIndexPattern();
+        String[] stateIndexPatterns = AnomalyDetectorsIndex.jobStateIndexPatterns();
 
         // First try to restore model state.
         for (String stateDocId : modelSnapshot.stateDocumentIds()) {
@@ -69,10 +69,10 @@ public class StateStreamer {
                 return;
             }
 
-            LOGGER.trace("ES API CALL: get ID {} from index {}", stateDocId, indexName);
+            LOGGER.trace("ES API CALL: get ID {} from index {}", stateDocId, AnomalyDetectorsIndex.jobStateIndexPattern());
 
             try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
-                SearchResponse stateResponse = client.prepareSearch(indexName)
+                SearchResponse stateResponse = client.prepareSearch(stateIndexPatterns)
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(stateDocId))
                     .get();
@@ -105,10 +105,10 @@ public class StateStreamer {
 
             String docId = CategorizerState.documentId(jobId, ++docNum);
 
-            LOGGER.trace("ES API CALL: get ID {} from index {}", docId, indexName);
+            LOGGER.trace("ES API CALL: get ID {} from index {}", docId, AnomalyDetectorsIndex.jobStateIndexPattern());
 
             try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
-                SearchResponse stateResponse = client.prepareSearch(indexName)
+                SearchResponse stateResponse = client.prepareSearch(stateIndexPatterns)
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(docId))
                     .get();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/EmptyStateIndexRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/EmptyStateIndexRemover.java
@@ -63,7 +63,7 @@ public class EmptyStateIndexRemover implements MlDataRemover {
     }
 
     private void getEmptyStateIndices(ActionListener<Set<String>> listener) {
-        IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest().indices(AnomalyDetectorsIndex.jobStateIndexPattern());
+        IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest().indices(AnomalyDetectorsIndex.jobStateIndexPatterns());
         indicesStatsRequest.setParentTask(parentTaskId);
         client.admin()
             .indices()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -256,11 +257,9 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
             return;
         }
 
-        String stateIndexName = AnomalyDetectorsIndex.jobStateIndexPattern();
-
         List<String> idsToDelete = new ArrayList<>();
         Set<String> indices = new HashSet<>();
-        indices.add(stateIndexName);
+        Collections.addAll(indices, AnomalyDetectorsIndex.jobStateIndexPatterns());
         indices.add(AnnotationIndex.READ_ALIAS_NAME);
         for (ModelSnapshot modelSnapshot : modelSnapshots) {
             idsToDelete.addAll(modelSnapshot.stateDocumentIds());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
@@ -80,7 +80,7 @@ public class UnusedStateRemover implements MlDataRemover {
         List<String> stateDocIdsToDelete = new ArrayList<>();
         BatchedStateDocIdsIterator stateDocIdsIterator = new BatchedStateDocIdsIterator(
             client,
-            AnomalyDetectorsIndex.jobStateIndexPattern()
+            AnomalyDetectorsIndex.jobStateIndexPatterns()
         );
         while (stateDocIdsIterator.hasNext()) {
             Deque<String> stateDocIds = stateDocIdsIterator.next();
@@ -138,7 +138,8 @@ public class UnusedStateRemover implements MlDataRemover {
     private void executeDeleteUnusedStateDocs(List<String> unusedDocIds, float requestsPerSec, ActionListener<Boolean> listener) {
         LOGGER.info("Found [{}] unused state documents; attempting to delete", unusedDocIds.size());
 
-        var indicesToQuery = WritableIndexExpander.getInstance().getWritableIndices(AnomalyDetectorsIndex.jobStateIndexPattern());
+        var indicesToQuery = WritableIndexExpander.getInstance()
+            .getWritableIndices(Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns()));
 
         if (indicesToQuery.isEmpty()) {
             LOGGER.info("No writable indices found for unused state documents");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradeTaskExecutor.java
@@ -257,10 +257,12 @@ public class SnapshotUpgradeTaskExecutor extends AbstractJobPersistentTasksExecu
 
     @Override
     protected String[] indicesOfInterest(SnapshotUpgradeTaskParams params) {
-        return new String[] {
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
-            MlConfigIndex.indexName(),
-            AnomalyDetectorsIndex.resultsWriteAlias(params.getJobId()) };
+        String[] statePatterns = AnomalyDetectorsIndex.jobStateIndexPatterns();
+        String[] indices = new String[statePatterns.length + 2];
+        System.arraycopy(statePatterns, 0, indices, 0, statePatterns.length);
+        indices[statePatterns.length] = MlConfigIndex.indexName();
+        indices[statePatterns.length + 1] = AnomalyDetectorsIndex.resultsWriteAlias(params.getJobId());
+        return indices;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -84,13 +84,21 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
 
     public static String[] indicesOfInterest(String resultsIndex) {
         if (resultsIndex == null) {
-            return new String[] { AnomalyDetectorsIndex.jobStateIndexPattern(), MlMetaIndex.indexName(), MlConfigIndex.indexName() };
+            return concatIndexPatterns(AnomalyDetectorsIndex.jobStateIndexPatterns(), MlMetaIndex.indexName(), MlConfigIndex.indexName());
         }
-        return new String[] {
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
+        return concatIndexPatterns(
+            AnomalyDetectorsIndex.jobStateIndexPatterns(),
             resultsIndex,
             MlMetaIndex.indexName(),
-            MlConfigIndex.indexName() };
+            MlConfigIndex.indexName()
+        );
+    }
+
+    private static String[] concatIndexPatterns(String[] indexPatterns, String... otherIndices) {
+        String[] indices = new String[indexPatterns.length + otherIndices.length];
+        System.arraycopy(indexPatterns, 0, indices, 0, indexPatterns.length);
+        System.arraycopy(otherIndices, 0, indices, indexPatterns.length, otherIndices.length);
+        return indices;
     }
 
     private final AutodetectProcessManager autodetectProcessManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
@@ -215,7 +215,7 @@ public class IndexingStateProcessor implements StateProcessor {
 
     private String getConcreteIndexOrWriteAlias(String documentId) {
         Objects.requireNonNull(documentId);
-        SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).allowPartialSearchResults(false)
+        SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPatterns()).allowPartialSearchResults(false)
             .source(
                 new SearchSourceBuilder().size(1)
                     .fetchSource(false)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIterator.java
@@ -37,15 +37,18 @@ public abstract class BatchedDocumentsIterator<T> implements BatchedIterator<T> 
     private static final int BATCH_SIZE = 10000;
 
     private final OriginSettingClient client;
-    private final String index;
+    private final String[] indices;
     private volatile long count;
     private volatile long totalHits;
     private volatile String scrollId;
     private volatile boolean isScrollInitialised;
 
-    protected BatchedDocumentsIterator(OriginSettingClient client, String index) {
+    protected BatchedDocumentsIterator(OriginSettingClient client, String... indices) {
         this.client = Objects.requireNonNull(client);
-        this.index = Objects.requireNonNull(index);
+        this.indices = Objects.requireNonNull(indices);
+        if (indices.length == 0) {
+            throw new IllegalArgumentException("indices must not be empty");
+        }
         this.totalHits = 0;
         this.count = 0;
         this.isScrollInitialised = false;
@@ -95,11 +98,11 @@ public abstract class BatchedDocumentsIterator<T> implements BatchedIterator<T> 
     }
 
     private SearchResponse initScroll() {
-        LOGGER.trace("ES API CALL: search index {}", index);
+        LOGGER.trace("ES API CALL: search indices {}", String.join(",", indices));
 
         isScrollInitialised = true;
 
-        SearchRequest searchRequest = new SearchRequest(index);
+        SearchRequest searchRequest = new SearchRequest(indices);
         searchRequest.indicesOptions(MlIndicesUtils.addIgnoreUnavailable(SearchRequest.DEFAULT_INDICES_OPTIONS));
         searchRequest.scroll(CONTEXT_ALIVE_DURATION);
         searchRequest.source(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
@@ -103,6 +104,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
             .findFirst()
             .orElseThrow(() -> new AssertionError("expected the ml state index template to be put"));
         ComposableIndexTemplate indexTemplate = req.indexTemplate();
+        assertThat(indexTemplate.indexPatterns(), containsInAnyOrder(".ml-state*", ".reindexed-v7-ml-state*", ".reindexed-v8-ml-state*"));
     }
 
     public void testStatsTemplate() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -111,6 +111,14 @@ public class MockClientBuilder {
     }
 
     /**
+     * Mocks sequential {@link Client#prepareSearch(String...)} calls with the given index patterns as varargs.
+     */
+    public MockClientBuilder prepareSearches(String[] indices, SearchRequestBuilder first, SearchRequestBuilder... searches) {
+        when(client.prepareSearch(indices)).thenReturn(first, searches);
+        return this;
+    }
+
+    /**
      * Creates a {@link SearchResponse} with a {@link SearchHit} for each element of {@code docs}
      * @param indexName Index being searched
      * @param docs Returned in the SearchResponse

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamerTests.java
@@ -71,7 +71,7 @@ public class StateStreamerTests extends ESTestCase {
         );
 
         MockClientBuilder clientBuilder = new MockClientBuilder(CLUSTER_NAME).addClusterStatusYellowResponse()
-            .prepareSearches(AnomalyDetectorsIndex.jobStateIndexPattern(), builder1, builder2, builder3, builder4);
+            .prepareSearches(AnomalyDetectorsIndex.jobStateIndexPatterns(), builder1, builder2, builder3, builder4);
 
         ModelSnapshot modelSnapshot = new ModelSnapshot.Builder(JOB_ID).setSnapshotId(snapshotId).setSnapshotDocCount(2).build();
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemoverTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
@@ -47,12 +48,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.ml.job.retention.AbstractExpiredJobDataRemoverTests.TestListener;
-import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -142,11 +143,16 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         assertThat(capturedDeleteModelSnapshotRequests.size(), equalTo(1));
         DeleteByQueryRequest deleteSnapshotRequest = capturedDeleteModelSnapshotRequests.get(0);
         assertThat(
-            deleteSnapshotRequest.indices(),
-            arrayContainingInAnyOrder(
-                AnomalyDetectorsIndex.jobResultsAliasedName("job-1"),
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
-                AnnotationIndex.READ_ALIAS_NAME
+            Set.copyOf(Arrays.asList(deleteSnapshotRequest.indices())),
+            equalTo(
+                Set.copyOf(
+                    Arrays.asList(
+                        Strings.concatStringArrays(
+                            new String[] { AnomalyDetectorsIndex.jobResultsAliasedName("job-1"), AnnotationIndex.READ_ALIAS_NAME },
+                            AnomalyDetectorsIndex.jobStateIndexPatterns()
+                        )
+                    )
+                )
             )
         );
         assertThat(deleteSnapshotRequest.getSearchRequest().source().query() instanceof IdsQueryBuilder, is(true));
@@ -238,11 +244,16 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         assertThat(capturedDeleteModelSnapshotRequests.size(), equalTo(1));
         DeleteByQueryRequest deleteSnapshotRequest = capturedDeleteModelSnapshotRequests.get(0);
         assertThat(
-            deleteSnapshotRequest.indices(),
-            arrayContainingInAnyOrder(
-                AnomalyDetectorsIndex.jobResultsAliasedName("snapshots-1"),
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
-                AnnotationIndex.READ_ALIAS_NAME
+            Set.copyOf(Arrays.asList(deleteSnapshotRequest.indices())),
+            equalTo(
+                Set.copyOf(
+                    Arrays.asList(
+                        Strings.concatStringArrays(
+                            new String[] { AnomalyDetectorsIndex.jobResultsAliasedName("snapshots-1"), AnnotationIndex.READ_ALIAS_NAME },
+                            AnomalyDetectorsIndex.jobStateIndexPatterns()
+                        )
+                    )
+                )
             )
         );
         assertThat(deleteSnapshotRequest.getSearchRequest().source().query() instanceof IdsQueryBuilder, is(true));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutorTests.java
@@ -56,10 +56,11 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
                 cs,
                 resolver,
                 true,
-                ".ml-anomalies-shared-000001",
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
-                MlMetaIndex.indexName(),
-                MlConfigIndex.indexName()
+                concat(
+                    new String[] { ".ml-anomalies-shared-000001" },
+                    AnomalyDetectorsIndex.jobStateIndexPatterns(),
+                    new String[] { MlMetaIndex.indexName(), MlConfigIndex.indexName() }
+                )
             ).size()
         );
 
@@ -69,10 +70,11 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
             resolver.concreteIndexNames(
                 cs,
                 IndicesOptions.lenientExpandOpen(),
-                ".ml-anomalies-shared-000001",
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
-                MlMetaIndex.indexName(),
-                MlConfigIndex.indexName()
+                concat(
+                    new String[] { ".ml-anomalies-shared-000001" },
+                    AnomalyDetectorsIndex.jobStateIndexPatterns(),
+                    new String[] { MlMetaIndex.indexName(), MlConfigIndex.indexName() }
+                )
             )
         );
         if (randomBoolean()) {
@@ -100,10 +102,11 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
             csBuilder.build(),
             resolver,
             true,
-            ".ml-anomalies-shared-000001",
-            AnomalyDetectorsIndex.jobStateIndexPattern(),
-            MlMetaIndex.indexName(),
-            MlConfigIndex.indexName()
+            concat(
+                new String[] { ".ml-anomalies-shared-000001" },
+                AnomalyDetectorsIndex.jobStateIndexPatterns(),
+                new String[] { MlMetaIndex.indexName(), MlConfigIndex.indexName() }
+            )
         );
         assertEquals(1, result.size());
         assertEquals(indexToRemove, result.get(0));
@@ -144,6 +147,14 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
                 IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
+    }
+
+    private static String[] concat(String[] first, String[] second, String[] third) {
+        String[] indices = new String[first.length + second.length + third.length];
+        System.arraycopy(first, 0, indices, 0, first.length);
+        System.arraycopy(second, 0, indices, first.length, second.length);
+        System.arraycopy(third, 0, indices, first.length + second.length, third.length);
+        return indices;
     }
 
 }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -10,14 +10,17 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
+import org.elasticsearch.xpack.core.ml.MlStatsIndex;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
 import org.elasticsearch.xpack.test.rest.IndexMappingTemplateAsserter;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +38,14 @@ import static org.hamcrest.Matchers.nullValue;
 public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final String JOB_ID = "ml-mappings-upgrade-job";
+
+    /**
+     * Mirrors {@code MlIndexTemplateRegistry#ML_INDEX_TEMPLATE_VERSION}; kept here because rolling-upgrade
+     * tests cannot depend on the ML plugin module.
+     */
+    private static final int ML_INDEX_TEMPLATE_VERSION = 10000002 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
+        + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
+        + NotificationsIndex.NOTIFICATIONS_INDEX_TEMPLATE_VERSION;
 
     @BeforeClass
     public static void maybeSkip() {
@@ -76,8 +87,16 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
                     () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
                         client(),
                         ".ml-anomalies-",
-                        10000005,
+                        ML_INDEX_TEMPLATE_VERSION,
                         List.of(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*")
+                    )
+                );
+                assertBusy(
+                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
+                        client(),
+                        ".ml-state",
+                        ML_INDEX_TEMPLATE_VERSION,
+                        Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns())
                     )
                 );
                 break;
@@ -110,23 +129,44 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
+    /**
+     * Opens the test job if it was closed during rolling upgrade so results write aliases exist.
+     * The job must already exist from the {@code OLD} cluster phase.
+     */
+    private void ensureTestJobIsOpen() throws IOException {
+        Request getJob = new Request("GET", "_ml/anomaly_detectors/" + JOB_ID);
+        Response response = client().performRequest(getJob);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> jobs = (List<Map<String, Object>>) entityAsMap(response).get("jobs");
+        assertThat(jobs, hasSize(1));
+        if ("closed".equals(jobs.get(0).get("state"))) {
+            openTestJob();
+        }
+    }
+
     // Doing this should force the config index mappings to be upgraded,
     // when the finished time is cleared on reopening the job
+    private void openTestJob() throws IOException {
+        Request openJob = new Request("POST", "_ml/anomaly_detectors/" + JOB_ID + "/_open");
+        Response response = client().performRequest(openJob);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
     private void closeAndReopenTestJob() throws IOException {
 
         Request closeJob = new Request("POST", "_ml/anomaly_detectors/" + JOB_ID + "/_close");
         Response response = client().performRequest(closeJob);
         assertEquals(200, response.getStatusLine().getStatusCode());
 
-        Request openJob = new Request("POST", "_ml/anomaly_detectors/" + JOB_ID + "/_open");
-        response = client().performRequest(openJob);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        openTestJob();
     }
 
     @SuppressWarnings("unchecked")
     private void assertUpgradedResultsMappings() throws Exception {
 
         assertBusy(() -> {
+            ensureTestJobIsOpen();
             Request getMappings = new Request("GET", XPackRestTestHelper.resultsWriteAlias(JOB_ID) + "/_mappings");
             Response response = client().performRequest(getMappings);
 


### PR DESCRIPTION
Backport of #149555 to `9.4`.

ML daily maintenance only matched `.ml-state*` when rolling state indices, so clusters using reindexed system indices such as `.reindexed-v8-ml-state-000001` were never rolled over (nor cleaned up). This extends the patterns, resolver usage, template `index_patterns`, and `isAnomaliesStateIndex` to cover v7/v8 reindexed state names.

Conflicts resolved manually:
- `DataFrameAnalyticsDeleter.java`: kept 9.4's `BulkByScrollResponse`/`AbstractBulkByScrollRequest` types while applying the `String` -> `String[]` `executeDeleteByQuery` change (the `BulkByPaginatedSearchResponse` refactor is main-only).
- `MlMappingsUpgradeIT.java`: used the `ML_INDEX_TEMPLATE_VERSION` constant instead of the stale hardcoded literal, matching the template-version bump.

Verified with `:x-pack:plugin:core`, `:x-pack:plugin:ml` (main/test/internalClusterTest) and `:x-pack:qa:rolling-upgrade` compilation.

Made with [Cursor](https://cursor.com)