### PR TITLE
[9.4] [Gradle] Allow disabling muted tests via -Dtests.mutes.enabled=false (#152948)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
@@ -56,8 +56,7 @@ class BuildPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
         THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripIndent()
 
     def setup() {
-        // checkstyle task references LegacyConfiguration class. Revisit after checkstyle update
-        configurationCacheCompatible = false
+        disableConfigurationCache("checkstyle task references LegacyConfiguration class; revisit after checkstyle update")
         // elasticsearch.build (BuildPlugin) and elasticsearch.global-build-info are applied by
         // AbstractGradleInternalPluginFuncTest; we only add the java plugin and project config here.
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
@@ -17,7 +17,7 @@ class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
     Class<? extends org.gradle.api.Plugin> pluginClassUnderTest = org.elasticsearch.gradle.internal.InternalBwcGitPlugin
 
     def setup() {
-        configurationCacheCompatible = false
+        disableConfigurationCache("InternalBwcGitPlugin runs git commands at configuration time")
         internalBuild()
         buildFile << """
             import org.elasticsearch.gradle.Version;

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -30,8 +30,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleF
     WireMockServer wireMock
 
     def setup() {
-        // Cannot serialize BwcSetupExtension containing project object
-        configurationCacheCompatible = false
+        disableConfigurationCache("cannot serialize BwcSetupExtension containing project object")
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.internal-distribution-bwc-setup'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -45,7 +45,7 @@ class JdkDownloadPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
     private static final Pattern JDK_HOME_LOGLINE = Pattern.compile("JDK HOME: (.*)")
 
     def setup() {
-        configurationCacheCompatible = false // JDK class references configurations which break configuration cache
+        disableConfigurationCache("JDK class references configurations which break configuration cache")
     }
 
     @Unroll

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/archunit/IntegTestCoverageArchUnitSpec.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/archunit/IntegTestCoverageArchUnitSpec.groovy
@@ -21,6 +21,11 @@ import com.tngtech.archunit.lang.SimpleConditionEvent
 import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
 import org.gradle.api.Plugin
 import org.gradle.api.Task
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Handle
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -65,6 +70,23 @@ class IntegTestCoverageArchUnitSpec extends Specification {
      * not be added here — add a test instead. Existing entries should be removed as coverage is
      * filled in (the staleness test enforces this).
      */
+    /**
+     * Subclasses of {@link AbstractGradleInternalPluginFuncTest} that legitimately call
+     * {@code disableConfigurationCache()} because the plugin under test has a known
+     * configuration-cache incompatibility. New entries must not be added here without
+     * first filing a follow-up to fix the underlying incompatibility.
+     */
+    private static final Set<String> KNOWN_CC_INCOMPATIBLE = [
+        "BuildPluginFuncTest",
+        "DraResolvePluginFuncTest",
+        "ElasticsearchDistributionPluginFuncTest",
+        "GlobalBuildInfoPluginFuncTest",
+        "InternalBwcGitPluginFuncTest",
+        "InternalDistributionBwcSetupPluginFuncTest",
+        "JdkDownloadPluginFuncTest",
+        "SnykDependencyMonitoringGradlePluginFuncTest",
+    ] as Set
+
     private static final Set<String> KNOWN_UNCOVERED = [
         // --- plugins lacking a *FuncTest ---
         "org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin",
@@ -97,7 +119,6 @@ class IntegTestCoverageArchUnitSpec extends Specification {
         "org.elasticsearch.gradle.internal.test.DistroTestPlugin",
         "org.elasticsearch.gradle.internal.test.InternalClusterTestPlugin",
         "org.elasticsearch.gradle.internal.test.LegacyRestTestBasePlugin",
-        "org.elasticsearch.gradle.internal.test.MutedTestPlugin",
         "org.elasticsearch.gradle.internal.test.StandaloneRestTestPlugin",
         "org.elasticsearch.gradle.internal.test.StandaloneTestPlugin",
         "org.elasticsearch.gradle.internal.test.TestWithDependenciesPlugin",
@@ -188,6 +209,37 @@ class IntegTestCoverageArchUnitSpec extends Specification {
 
         expect:
         rule.check(productionClasses)
+    }
+
+    def "no new AbstractGradleInternalPluginFuncTest subclass disables configuration cache"() {
+        given:
+        List<String> violations = productionClasses
+            .findAll { JavaClass c ->
+                c.isAssignableTo(AbstractGradleInternalPluginFuncTest)
+                && c.modifiers.contains(JavaModifier.ABSTRACT) == false
+                && KNOWN_CC_INCOMPATIBLE.contains(c.simpleName) == false
+                && callsDisableConfigurationCache(c)
+            }
+            .collect { it.fullName }
+            .sort()
+
+        expect:
+        assert violations.isEmpty(), "These AbstractGradleInternalPluginFuncTest subclasses call disableConfigurationCache() -- fix the underlying plugin incompatibility instead:\n  ${violations.join('\n  ')}"
+    }
+
+    def "the cc-incompatible baseline contains no stale entries"() {
+        given:
+        Map<String, JavaClass> bySimpleName = productionClasses.collectEntries { [(it.simpleName): it] }
+
+        when:
+        List<String> stale = KNOWN_CC_INCOMPATIBLE.findAll { String name ->
+            JavaClass c = bySimpleName[name]
+            c == null || callsDisableConfigurationCache(c) == false
+        }.sort()
+
+        then:
+        assert stale.isEmpty(),
+            "Stale KNOWN_CC_INCOMPATIBLE entries (fixed or removed) — delete them:\n  " + stale.join("\n  ")
     }
 
     def "the known-uncovered allowlist contains no stale entries"() {
@@ -282,6 +334,41 @@ class IntegTestCoverageArchUnitSpec extends Specification {
             }
         }
         return names
+    }
+
+    /**
+     * Returns {@code true} if the compiled class for {@code javaClass} contains an
+     * {@code invokedynamic} call to {@code disableConfigurationCache}.
+     *
+     * <p>Groovy compiles {@code disableConfigurationCache(...)} to an {@code invokedynamic}
+     * instruction whose Groovy {@code IndyInterface} bootstrap receives the actual method
+     * name as its first static argument. ASM's {@code visitInvokeDynamicInsn} exposes that
+     * argument directly, making the detection bytecode-precise and comment-proof.
+     */
+    private static boolean callsDisableConfigurationCache(JavaClass javaClass) {
+        String classPath = javaClass.fullName.replace('.', '/') + '.class'
+        URL resource = Thread.currentThread().contextClassLoader.getResource(classPath)
+        if (resource == null) return false
+        boolean[] found = [false]
+        resource.openStream().withCloseable { InputStream stream ->
+            new ClassReader(stream).accept(new ClassVisitor(Opcodes.ASM9) {
+                @Override
+                MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exceptions) {
+                    return new MethodVisitor(Opcodes.ASM9) {
+                        @Override
+                        void visitInvokeDynamicInsn(String name2, String desc2, Handle bsm, Object... bsmArgs) {
+                            if (bsm.owner == 'org/codehaus/groovy/vmplugin/v8/IndyInterface'
+                                    && bsm.name == 'bootstrap'
+                                    && bsmArgs.length > 0
+                                    && bsmArgs[0] == 'disableConfigurationCache') {
+                                found[0] = true
+                            }
+                        }
+                    }
+                }
+            }, 0)
+        }
+        return found[0]
     }
 
     private static List<File> testSourceRoots() {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -19,8 +19,7 @@ class ElasticsearchDistributionPluginFuncTest extends AbstractGradleInternalPlug
     
     def "copied modules are resolved from explodedBundleZip"() {
         given:
-        // we use the esplugin plugin in this test that is not configuration cache compatible yet
-        configurationCacheCompatible = false
+        disableConfigurationCache("esplugin plugin is not configuration cache compatible yet")
         moduleSubProject()
 
         // elasticsearch.distro is applied by AbstractGradleInternalPluginFuncTest

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
@@ -21,7 +21,6 @@ class DocsTestPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
         docDir.mkdirs()
         addSampleDoc(docDir)
         buildApiRestrictionsDisabled = true
-        disableConfigurationCache("DocsTestPlugin uses project references that are not configuration-cache safe")
         configureBwcVersions()
 
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
@@ -21,7 +21,9 @@ class DocsTestPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
         docDir.mkdirs()
         addSampleDoc(docDir)
         buildApiRestrictionsDisabled = true
-        configurationCacheCompatible = false
+        disableConfigurationCache("DocsTestPlugin uses project references that are not configuration-cache safe")
+        configureBwcVersions()
+
         buildFile << """
 tasks.named('listSnippets') {
    docs = fileTree('doc')

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/dra/DraResolvePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/dra/DraResolvePluginFuncTest.groovy
@@ -27,7 +27,7 @@ class DraResolvePluginFuncTest extends AbstractGradleInternalPluginFuncTest {
     public LocalRepositoryFixture repository = new LocalRepositoryFixture()
 
     def setup() {
-        configurationCacheCompatible = false
+        disableConfigurationCache("DraResolvePlugin resolves artifacts at configuration time")
 
         // elasticsearch.dra-artifacts is applied by AbstractGradleInternalPluginFuncTest
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPluginFuncTest.groovy
@@ -23,9 +23,7 @@ class GlobalBuildInfoPluginFuncTest extends AbstractGradleInternalPluginFuncTest
 
         def "offline mode falls back to workspace root branches.json for http(s) branches location"() {
         given:
-        // This test's build script uses task actions that aren't configuration-cache safe.
-        // The behavior under test here is Gradle offline mode fallback, not configuration cache.
-        configurationCacheCompatible = false
+        disableConfigurationCache("test build script uses task actions that are not configuration-cache safe; behavior under test is offline mode fallback")
 
         propertiesFile << """
             org.elasticsearch.build.branches-file-location=https://example.invalid/branches.json
@@ -76,7 +74,7 @@ class GlobalBuildInfoPluginFuncTest extends AbstractGradleInternalPluginFuncTest
 
     def "retries branches.json download from flaky http endpoint"() {
         given:
-        configurationCacheCompatible = false
+        disableConfigurationCache("test build script uses task actions that are not configuration-cache safe")
         writeBwcVersionSource()
         writeBuildThatResolvesBwcVersions()
 
@@ -118,7 +116,7 @@ class GlobalBuildInfoPluginFuncTest extends AbstractGradleInternalPluginFuncTest
 
     def "exhausts retries when branches.json http endpoint keeps failing"() {
         given:
-        configurationCacheCompatible = false
+        disableConfigurationCache("test build script uses task actions that are not configuration-cache safe")
         writeBwcVersionSource()
         writeBuildThatResolvesBwcVersions()
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
@@ -27,7 +27,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
     Class<? extends Plugin> pluginClassUnderTest = SnykDependencyMonitoringGradlePlugin.class
 
     def setup() {
-        configurationCacheCompatible = false // configuration is not cc compliant
+        disableConfigurationCache("SnykDependencyMonitoringGradlePlugin configuration is not cc compliant")
     }
 
     @Unroll

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/MutedTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/MutedTestPluginFuncTest.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
+import org.gradle.api.Plugin
+import org.gradle.testkit.runner.TaskOutcome
+
+class MutedTestPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
+
+    Class<? extends Plugin> pluginClassUnderTest = MutedTestPlugin
+
+    def setup() {
+        buildFile << """
+            apply plugin: 'java'
+            repositories { mavenCentral() }
+            dependencies { testImplementation 'junit:junit:4.13.1' }
+            tasks.named("test").configure {
+                testLogging { events "started" }
+            }
+        """
+    }
+
+    def "muted tests are excluded by default"() {
+        given:
+        muteTest("org.acme.SomeTest", "someMutedTest")
+        testClazz("org.acme.SomeTest") {
+            """
+            @org.junit.Test public void someMutedTest() {}
+            @org.junit.Test public void someUnmutedTest() {}
+            """
+        }
+
+        when:
+        def result = gradleRunner("test").build()
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        result.output.contains("someMutedTest STARTED") == false
+        result.output.contains("someUnmutedTest STARTED")
+    }
+
+    def "tests.mutes.enabled=true applies mutes explicitly"() {
+        given:
+        muteTest("org.acme.SomeTest", "someMutedTest")
+        testClazz("org.acme.SomeTest") {
+            """
+            @org.junit.Test public void someMutedTest() {}
+            @org.junit.Test public void someUnmutedTest() {}
+            """
+        }
+
+        when:
+        def result = gradleRunner("test", "-Dtests.mutes.enabled=true").build()
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        result.output.contains("someMutedTest STARTED") == false
+        result.output.contains("someUnmutedTest STARTED")
+    }
+
+    def "tests.mutes.enabled=false runs all tests including muted ones"() {
+        given:
+        muteTest("org.acme.SomeTest", "someMutedTest")
+        testClazz("org.acme.SomeTest") {
+            """
+            @org.junit.Test public void someMutedTest() {}
+            @org.junit.Test public void someUnmutedTest() {}
+            """
+        }
+
+        when:
+        def result = gradleRunner("test", "-Dtests.mutes.enabled=false").build()
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        result.output.contains("someMutedTest STARTED")
+        result.output.contains("someUnmutedTest STARTED")
+    }
+
+    private void muteTest(String className, String method) {
+        file("muted-tests.yml").text = """
+tests:
+- class: ${className}
+  method: ${method}
+  issue: https://github.com/elastic/elasticsearch/issues/1
+"""
+    }
+}

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestCompatTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestCompatTestPluginFuncTest.groovy
@@ -30,9 +30,7 @@ class LegacyYamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTe
 
     def setup() {
         // not cc compatible due to:
-        // 1. TestClustersPlugin not cc compatible due to listener registration
-        // 2. RestIntegTestTask not cc compatible due to
-        configurationCacheCompatible = false
+        disableConfigurationCache("TestClustersPlugin not cc compatible due to listener registration; RestIntegTestTask not cc compatible")
         buildApiRestrictionsDisabled = true
     }
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.testkit.runner.TaskOutcome
 class LegacyYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def setup() {
-        configurationCacheCompatible = true
         buildApiRestrictionsDisabled = true
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/MutedTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/MutedTestPlugin.java
@@ -24,6 +24,7 @@ import static org.elasticsearch.gradle.internal.util.ParamsUtils.loadBuildParams
 
 public class MutedTestPlugin implements Plugin<Project> {
     private static final String ADDITIONAL_FILES_PROPERTY = "org.elasticsearch.additional.muted.tests";
+    static final String MUTED_TESTS_ENABLED_PROPERTY = "tests.mutes.enabled";
 
     @Override
     public void apply(Project project) {
@@ -39,6 +40,11 @@ public class MutedTestPlugin implements Plugin<Project> {
             .map(p -> project.getLayout().getSettingsDirectory().file(p))
             .toList();
 
+        String mutedTestsEnabledValue = project.hasProperty(MUTED_TESTS_ENABLED_PROPERTY)
+            ? project.property(MUTED_TESTS_ENABLED_PROPERTY).toString()
+            : System.getProperty(MUTED_TESTS_ENABLED_PROPERTY);
+        boolean mutedTestsEnabled = mutedTestsEnabledValue == null || mutedTestsEnabledValue.equalsIgnoreCase("true");
+
         Provider<MutedTestsBuildService> mutedTestsProvider = project.getGradle()
             .getSharedServices()
             .registerIfAbsent("mutedTests", MutedTestsBuildService.class, spec -> {
@@ -46,15 +52,19 @@ public class MutedTestPlugin implements Plugin<Project> {
                 spec.getParameters().getAdditionalFiles().set(additionalFiles);
             });
 
-        project.getTasks().withType(Test.class).configureEach(test -> {
-            test.filter(filter -> {
-                for (String exclude : mutedTestsProvider.get().getExcludePatterns()) {
-                    filter.excludeTestsMatching(exclude);
-                }
-
-                // Don't fail when all tests are ignored when running in CI
-                filter.setFailOnNoMatchingTests(buildParams.getCi() == false);
+        if (mutedTestsEnabled) {
+            project.getTasks().withType(Test.class).configureEach(test -> {
+                test.filter(filter -> {
+                    for (String exclude : mutedTestsProvider.get().getExcludePatterns()) {
+                        filter.excludeTestsMatching(exclude);
+                    }
+                });
             });
+        }
+
+        // Don't fail when all tests are ignored when running in CI
+        project.getTasks().withType(Test.class).configureEach(test -> {
+            test.filter(filter -> filter.setFailOnNoMatchingTests(buildParams.getCi() == false));
         });
     }
 }

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/test/MutedTestsBuildServiceTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/test/MutedTestsBuildServiceTests.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.gradle.internal.test;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+public class MutedTestsBuildServiceTests {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private MutedTestsBuildService registerService(File infoDir) {
+        return registerService(infoDir, Collections.emptyList());
+    }
+
+    private MutedTestsBuildService registerService(File infoDir, java.util.List<org.gradle.api.file.RegularFile> additionalFiles) {
+        Project project = ProjectBuilder.builder().build();
+        Provider<MutedTestsBuildService> provider = project.getGradle()
+            .getSharedServices()
+            .registerIfAbsent("mutedTests", MutedTestsBuildService.class, spec -> {
+                spec.getParameters().getInfoPath().fileValue(infoDir);
+                spec.getParameters().getAdditionalFiles().set(additionalFiles);
+            });
+        return provider.get();
+    }
+
+    private void writeMutedTestsYaml(File dir, String yaml) throws IOException {
+        Files.write(new File(dir, "muted-tests.yml").toPath(), yaml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    /**
+     * A single-method mute produces two patterns: the exact method and a wildcard suffix for parameterized runners.
+     */
+    @Test
+    public void testSingleMethodMute() throws IOException {
+        File dir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(dir, """
+            tests:
+            - class: org.elasticsearch.SomeTest
+              method: testFoo
+              issue: https://github.com/elastic/elasticsearch/issues/1
+            """);
+
+        Set<String> patterns = registerService(dir).getExcludePatterns();
+
+        assertThat(patterns, hasItems("org.elasticsearch.SomeTest.testFoo", "org.elasticsearch.SomeTest.testFoo *"));
+    }
+
+    /**
+     * Multiple methods listed under {@code methods} are each expanded to the same pair of patterns.
+     */
+    @Test
+    public void testMultipleMethodsMute() throws IOException {
+        File dir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(dir, """
+            tests:
+            - class: org.elasticsearch.SomeTest
+              methods:
+              - testFoo
+              - testBar
+              issue: https://github.com/elastic/elasticsearch/issues/1
+            """);
+
+        Set<String> patterns = registerService(dir).getExcludePatterns();
+
+        assertThat(
+            patterns,
+            hasItems(
+                "org.elasticsearch.SomeTest.testFoo",
+                "org.elasticsearch.SomeTest.testFoo *",
+                "org.elasticsearch.SomeTest.testBar",
+                "org.elasticsearch.SomeTest.testBar *"
+            )
+        );
+    }
+
+    /**
+     * A parameterized method (name contains " {") produces the full name pattern AND the bare method-name pattern,
+     * because the randomised runner checks both.
+     */
+    @Test
+    public void testParameterizedMethodMute() throws IOException {
+        File dir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(dir, """
+            tests:
+            - class: org.elasticsearch.yaml.SuiteIT
+              method: "test {yaml=analysis-common/30_tokenizers/letter}"
+              issue: https://github.com/elastic/elasticsearch/issues/2
+            """);
+
+        Set<String> patterns = registerService(dir).getExcludePatterns();
+
+        assertThat(
+            patterns,
+            hasItems(
+                "org.elasticsearch.yaml.SuiteIT.test {yaml=analysis-common/30_tokenizers/letter}",
+                "org.elasticsearch.yaml.SuiteIT.test"
+            )
+        );
+    }
+
+    /**
+     * A class-level mute (no method) produces a single wildcard pattern covering all methods in that class.
+     */
+    @Test
+    public void testClassLevelMute() throws IOException {
+        File dir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(dir, """
+            tests:
+            - class: org.elasticsearch.EntireClassTest
+              issue: https://github.com/elastic/elasticsearch/issues/3
+            """);
+
+        Set<String> patterns = registerService(dir).getExcludePatterns();
+
+        assertThat(patterns, hasItems("org.elasticsearch.EntireClassTest.*"));
+    }
+
+    /**
+     * An empty {@code tests} list in the YAML produces no exclude patterns.
+     */
+    @Test
+    public void testEmptyTestsListYieldsNoPatterns() throws IOException {
+        File dir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(dir, "tests:\n");
+
+        Set<String> patterns = registerService(dir).getExcludePatterns();
+
+        assertThat(patterns, is(empty()));
+    }
+
+    /**
+     * An additional muted-tests file is merged with the primary file.
+     */
+    @Test
+    public void testAdditionalFileIsMerged() throws IOException {
+        File primaryDir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(primaryDir, """
+            tests:
+            - class: org.elasticsearch.PrimaryTest
+              method: testPrimary
+              issue: https://github.com/elastic/elasticsearch/issues/10
+            """);
+
+        File additionalDir = temporaryFolder.newFolder();
+        writeMutedTestsYaml(additionalDir, """
+            tests:
+            - class: org.elasticsearch.AdditionalTest
+              method: testAdditional
+              issue: https://github.com/elastic/elasticsearch/issues/11
+            """);
+
+        Project project = ProjectBuilder.builder().build();
+        org.gradle.api.file.RegularFile additionalFile = project.getLayout()
+            .getProjectDirectory()
+            .file(new File(additionalDir, "muted-tests.yml").getAbsolutePath());
+
+        Set<String> patterns = registerService(primaryDir, java.util.List.of(additionalFile)).getExcludePatterns();
+
+        assertThat(
+            patterns,
+            hasItems(
+                "org.elasticsearch.PrimaryTest.testPrimary",
+                "org.elasticsearch.AdditionalTest.testAdditional"
+            )
+        );
+    }
+}

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -36,8 +36,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
     }
 
     def setup() {
-        // TestClusterPlugin with adding task listeners is not cc compatible
-        configurationCacheCompatible = false
+        disableConfigurationCache("TestClustersPlugin with adding task listeners is not cc compatible")
         buildFile << """
             import org.elasticsearch.gradle.testclusters.TestClustersAware
             import org.elasticsearch.gradle.testclusters.ElasticsearchCluster

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
@@ -20,8 +20,7 @@ import java.util.stream.Collectors
 class PluginBuildPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
-        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
-        configurationCacheCompatible = false
+        disableConfigurationCache("underlying TestClustersPlugin and StandaloneRestIntegTestTask are not cc compatible")
     }
 
     def "can assemble plugin via #taskName"() {

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/StablePluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/StablePluginBuildPluginFuncTest.groovy
@@ -46,8 +46,7 @@ class StablePluginBuildPluginFuncTest extends AbstractGradleFuncTest {
             }
             """
 
-        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
-        configurationCacheCompatible = false
+        disableConfigurationCache("underlying TestClustersPlugin and StandaloneRestIntegTestTask are not cc compatible")
 
         def version = VersionProperties.elasticsearch
         setupNamedComponentScanner(dir("local-repo/org/elasticsearch/elasticsearch-plugin-scanner/${version}/"), version)

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
@@ -17,8 +17,7 @@ import spock.lang.Ignore
 class JavaRestTestPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
-        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
-        configurationCacheCompatible = false
+        disableConfigurationCache("underlying TestClustersPlugin and StandaloneRestIntegTestTask are not cc compatible")
     }
 
     @Ignore('https://github.com/gradle/gradle/issues/21868')

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/YamlRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/YamlRestTestPluginFuncTest.groovy
@@ -17,8 +17,7 @@ import spock.lang.Ignore
 class YamlRestTestPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
-        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
-        configurationCacheCompatible = false
+        disableConfigurationCache("underlying TestClustersPlugin and StandaloneRestIntegTestTask are not cc compatible")
     }
 
     @Ignore('https://github.com/gradle/gradle/issues/21868')

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -49,6 +49,14 @@ abstract class AbstractGradleFuncTest extends Specification {
     protected boolean configurationCacheCompatible = true
     protected boolean buildApiRestrictionsDisabled = false
 
+    /**
+     * Opt out of configuration-cache compatibility checking for this test class.
+     * The {@code reason} must explain the root cause so it can be tracked and fixed.
+     */
+    void disableConfigurationCache(String reason) {
+        configurationCacheCompatible = false
+    }
+
     def setup() {
         projectDir = testProjectDir.root
         settingsFile = testProjectDir.newFile('settings.gradle')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Gradle] Allow disabling muted tests via -Dtests.mutes.enabled=false (#152948)](https://github.com/elastic/elasticsearch/pull/152948)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)