### PR TITLE
[ESQL] ESQL: fix external text-read drain deadlock

### DIFF
--- a/docs/changelog/153074.yaml
+++ b/docs/changelog/153074.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153074
+summary: Fix external text-read drain deadlock
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -332,6 +332,15 @@ public final class DataSourceModule implements Closeable {
         return externalSourceMetrics;
     }
 
+    /**
+     * Convenience overload that backs BOTH registry roles with a single executor. This collapses the
+     * page-consumer/coordination role and the read/parse role onto one pool, which is the exact wiring that
+     * deadlocks multi-file text reads in production (a full pool of blocked parser workers with no free thread
+     * left to run the drain that consumes them). It is safe only for synchronous / single-threaded callers
+     * (e.g. {@code Runnable::run} in tests). Production wiring must use
+     * {@link #createOperatorFactoryRegistry(Executor, Executor)} with two distinct pools —
+     * see {@code TransportEsqlQueryAction}.
+     */
     public OperatorFactoryRegistry createOperatorFactoryRegistry(Executor executor) {
         return createOperatorFactoryRegistry(executor, executor);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -120,6 +121,17 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page>, ColumnExt
     @Override
     public boolean hasNext() {
         return delegate.hasNext();
+    }
+
+    /**
+     * Forward the async-ready signal so the producer-loop drain parks (rather than blocking in a
+     * parser-backed {@code hasNext()}) across the inter-chunk gap. Without this the default
+     * immediately-done {@link CloseableIterator#waitForReady()} would swallow the delegate's real
+     * signal — the multi-file text-read deadlock.
+     */
+    @Override
+    public SubscribableListener<Void> waitForReady() {
+        return delegate.waitForReady();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -999,19 +999,53 @@ public final class StreamingParallelParsingCoordinator {
 
         /**
          * Returns {@code true} when {@link #hasNext()} can run without blocking on upstream
-         * production: a page is already buffered, the current slot has a page or POISON, EOF has
-         * been reached, an error has been recorded, or the iterator is closed.
+         * production: a real page is available at the head of the current slot, EOF has been reached,
+         * an error has been recorded, or the iterator is closed.
+         * <p>
+         * A lone {@code POISON} end-of-chunk marker is <em>not</em> readiness. Reporting ready on a
+         * bare POISON was the multi-file text-read deadlock: the async producer-loop drain saw
+         * {@code waitForReady().isDone()}, called {@link #hasNext()}, which advanced past the POISON
+         * into an empty, still-parsing slot and BLOCKED on the parser latch — pinning its executor
+         * thread while the parser it waited for was queued behind it on the same pool. We instead
+         * {@link #skipDrainedPoison() consume the POISON here} (advancing and freeing a dispatch permit
+         * exactly as {@code takeNextPage} would) so readiness reflects a genuine page or terminal EOF;
+         * the drain then parks on {@link #waitForReady()} across the inter-chunk gap rather than
+         * blocking, and resumes via {@link #signalReady()} when the next chunk's first page lands.
          */
         private boolean isReadyNow() {
             if (closed || buffered != null || firstError.get() != null) {
                 return true;
             }
+            skipDrainedPoison();
             int slot = currentChunk % pageQueueRingSize;
             if (pageQueues[slot].peek() != null) {
                 return true;
             }
             // EOF: consumer has drained every dispatched chunk AND every producer has exited.
             return currentChunk >= chunksDispatched.get() && tasksOutstanding.get() == 0;
+        }
+
+        /**
+         * Non-blocking: consumes any {@code POISON} end-of-chunk markers currently at the head of the
+         * consumer's slot, advancing {@link #currentChunk} and releasing one {@link #dispatchPermits}
+         * permit per marker — identical accounting to {@link #takeNextPage()}'s POISON branch. Stops at
+         * the first real page, an empty slot, or once no chunk is dispatched for the slot. Only ever
+         * called on the single consumer thread (via {@link #waitForReady()} / {@link #hasNext()}), so the
+         * unsynchronized peek/poll/advance is safe: producers only append to the tail and never advance
+         * {@code currentChunk}. Releasing the permit here (rather than deferring to {@code takeNextPage})
+         * keeps the segmentator unblocked even when the async drain parks across the inter-chunk gap.
+         */
+        private void skipDrainedPoison() {
+            while (currentChunk < chunksDispatched.get()) {
+                int slot = currentChunk % pageQueueRingSize;
+                Page head = pageQueues[slot].peek();
+                if (head == null || head != POISON) {
+                    return;
+                }
+                pageQueues[slot].poll();
+                currentChunk++;
+                dispatchPermits.release();
+            }
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.cache;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
@@ -63,6 +64,19 @@ public final class StatsCapturingIterator implements CloseableIterator<Page>, Co
     @Override
     public Page next() {
         return delegate.next();
+    }
+
+    /**
+     * Forward the async-ready signal to the delegate. This wrapper is a thin pass-through for
+     * {@code hasNext}/{@code next}, so it must be one for readiness too: the producer-loop drain calls
+     * {@code waitForReady()} on the outermost iterator and parks the executor thread while it is not
+     * done. Without this override the default {@link CloseableIterator#waitForReady()} (immediately
+     * done) would swallow the delegate's real signal, and the drain would fall through to a blocking
+     * {@code hasNext()} on a parser-backed delegate — the multi-file text-read deadlock.
+     */
+    @Override
+    public SubscribableListener<Void> waitForReady() {
+        return delegate.waitForReady();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/NullSpliceRowPositionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/NullSpliceRowPositionStrategy.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -81,6 +82,17 @@ public final class NullSpliceRowPositionStrategy implements RowPositionStrategy 
         @Override
         public boolean hasNext() {
             return inner.hasNext();
+        }
+
+        /**
+         * Forward the async-ready signal so the producer-loop drain parks (rather than blocking in a
+         * parser-backed {@code hasNext()}) across the inter-chunk gap. Without this the default
+         * immediately-done {@link CloseableIterator#waitForReady()} would swallow the inner signal —
+         * the multi-file text-read deadlock.
+         */
+        @Override
+        public SubscribableListener<Void> waitForReady() {
+            return inner.waitForReady();
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -219,9 +219,17 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         );
 
         var dataSourceModule = planExecutor.dataSourceModule();
-        // External source coordination and blocking file reads both run on the external blob-store pool, so a single
-        // executor backs both roles of the registry.
-        OperatorFactoryRegistry operatorFactoryRegistry = dataSourceModule.createOperatorFactoryRegistry(externalBlobStoreExecutor());
+        // Two deliberately-distinct pools so the external parse pipeline can never starve its own consumer.
+        // Arg 1 (registry.executor()) is the page-consumer / coordination role: the esql_worker compute pool that
+        // also runs the drivers polling the source buffer, so the non-blocking producer-loop drain runs there.
+        // Arg 2 (registry.fileReadExecutor()) is the read/parse role: the dedicated esql_external_io pool that runs
+        // the blocking opens, the segmentator, and the one-shot parser workers. Collapsing both onto one pool
+        // deadlocks multi-file text reads — a full I/O pool of blocked parsers with no free thread to run the drain
+        // that must consume them (see AsyncExternalSourceOperatorFactory + StreamingParallelParsingCoordinator).
+        OperatorFactoryRegistry operatorFactoryRegistry = dataSourceModule.createOperatorFactoryRegistry(
+            threadPool.executor(EsqlPlugin.computePool()),
+            externalBlobStoreExecutor()
+        );
         this.computeService = new ComputeService(
             services,
             enrichLookupService,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
@@ -17,6 +20,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -797,6 +801,222 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         }
     }
 
+    /**
+     * Faithful reproduction of the production multi-file text-read deadlock (elastic/elasticsearch#153056),
+     * draining the RAW coordinator iterator. {@code F} real streaming iterators, each multi-chunk (small
+     * chunkSize, large content), are drained by a producer-loop emulator that mirrors
+     * {@code AsyncExternalSourceOperatorFactory#drainHotPath} and runs on the SAME bounded pool as each
+     * coordinator's segmentator + one-shot parser tasks — the production wiring collapse. A big machine's
+     * saturation is emulated with a deliberately small pool.
+     * <p>
+     * Pre-fix, the emulator saw {@code waitForReady().isDone()} on a lone {@code POISON} end-of-chunk marker,
+     * called {@code hasNext()}, and BLOCKED on the parser latch across the inter-chunk gap — pinning pool
+     * threads until every thread was wedged and no parser could run. Post-fix ({@code isReadyNow} consumes the
+     * POISON so readiness reflects a real page or EOF) the drain parks instead, freeing the thread. Timed out
+     * (deadlocked) on {@code main} before the fix; completes after.
+     */
+    public void testConcurrentProducerLoopsOnSharedPoolDoNotDeadlock() throws Exception {
+        assertConcurrentProducerLoopsDrainWithoutDeadlock(false);
+    }
+
+    /**
+     * Same deadlock reproduction, but draining THROUGH {@link StatsCapturingIterator} — the production drain
+     * path wraps the coordinator in pass-through iterators. Those wrappers inherit the default immediately-done
+     * {@link CloseableIterator#waitForReady()}, which would swallow the coordinator's honest signal and send the
+     * drain straight into a blocking {@code hasNext()}. This exercises the wrapper {@code waitForReady()}
+     * forwarding (Fix 2b): without it, this deadlocks even with the coordinator-level fix.
+     */
+    public void testConcurrentProducerLoopsThroughStatsCapturingWrapperDoNotDeadlock() throws Exception {
+        assertConcurrentProducerLoopsDrainWithoutDeadlock(true);
+    }
+
+    private void assertConcurrentProducerLoopsDrainWithoutDeadlock(boolean wrapWithStatsCapturing) throws Exception {
+        int fileCount = 4;
+        int parsingParallelism = 4;
+        int poolSize = 6;
+        int linesPerFile = 4000;
+        int chunkSize = 64; // many chunks per file → long-lived segmentators + real POISON gaps
+        int batchSize = 8;
+
+        ExecutorService pool = Executors.newFixedThreadPool(poolSize);
+        List<CloseableIterator<Page>> iterators = new ArrayList<>();
+        List<PlainActionFuture<Integer>> dones = new ArrayList<>();
+        try {
+            for (int f = 0; f < fileCount; f++) {
+                InputStream s = new ByteArrayInputStream(buildContent(linesPerFile).getBytes(StandardCharsets.UTF_8));
+                LineFormatReader reader = new LineFormatReader(chunkSize);
+                CloseableIterator<Page> raw = StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    s,
+                    List.of("line"),
+                    batchSize,
+                    parsingParallelism,
+                    pool,
+                    ErrorPolicy.STRICT
+                );
+                CloseableIterator<Page> it = wrapWithStatsCapturing
+                    ? StatsCapturingIterator.wrap(raw, ExternalStatsCapture.newSink())
+                    : raw;
+                iterators.add(it);
+                PlainActionFuture<Integer> done = new PlainActionFuture<>();
+                dones.add(done);
+                pool.execute(() -> drainViaProducerLoop(it, pool, new AtomicInteger(), done));
+            }
+            int totalRows = 0;
+            for (PlainActionFuture<Integer> d : dones) {
+                totalRows += d.actionGet(TimeValue.timeValueSeconds(30)); // deadlock => timeout => failure
+            }
+            assertEquals(fileCount * linesPerFile, totalRows);
+        } finally {
+            for (CloseableIterator<Page> it : iterators) {
+                try {
+                    it.close();
+                } catch (IOException ignored) {}
+            }
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * Proves the "EOF-drop" scenario cannot occur in the real coordinator, deterministically. A gated reader
+     * blocks the parse of chunk index 1 until the test releases it, so the producer-loop drain is forced to the
+     * exact inter-chunk gap the draft feared: chunk 0 fully drained (its POISON at the slot head), chunk 1 still
+     * parsing. While the gate is held the drain must NOT conclude EOF (which would drop every later chunk); it
+     * must park and wait. After release, every row of every chunk must be delivered in order.
+     */
+    public void testProducerLoopDoesNotDropRowsAcrossDeterministicPoisonGap() throws Exception {
+        int linesPerFile = 2000;
+        int chunkSize = 64; // many chunks; chunk index 1 is gated
+        int batchSize = 8;
+        int parsingParallelism = 4;
+
+        CountDownLatch gate = new CountDownLatch(1);
+        CountDownLatch gatedReached = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(6);
+        OrderCapturingSink rows = new OrderCapturingSink();
+        PlainActionFuture<Integer> done = new PlainActionFuture<>();
+        CloseableIterator<Page> it = null;
+        try {
+            GatedLineFormatReader reader = new GatedLineFormatReader(chunkSize, 1, gate, gatedReached);
+            InputStream s = new ByteArrayInputStream(buildContent(linesPerFile).getBytes(StandardCharsets.UTF_8));
+            it = StreamingParallelParsingCoordinator.parallelRead(
+                reader,
+                s,
+                List.of("line"),
+                batchSize,
+                parsingParallelism,
+                pool,
+                ErrorPolicy.STRICT
+            );
+            CloseableIterator<Page> iter = it;
+            pool.execute(() -> drainViaProducerLoopCollecting(iter, pool, rows, done));
+
+            // Chunk 1's parser has entered read() and is blocked on the gate: the drain is now at (or racing into)
+            // the chunk-0→chunk-1 POISON gap with more chunks still to come.
+            assertTrue("gated chunk parser never reached", gatedReached.await(30, TimeUnit.SECONDS));
+            // The drain must not have concluded EOF while chunk 1 (and everything after it) is still unparsed —
+            // that is exactly the silent EOF-drop the draft feared. Give it a beat to (wrongly) finish if it would.
+            Thread.sleep(200);
+            assertFalse("producer-loop drain wrongly concluded EOF at a mid-stream POISON gap", done.isDone());
+
+            gate.countDown();
+            int total = done.actionGet(TimeValue.timeValueSeconds(30));
+            assertEquals("every row across the gated gap must be delivered", linesPerFile, total);
+            for (int i = 0; i < linesPerFile; i++) {
+                assertEquals("row order preserved across the gap", "line-" + String.format(Locale.ROOT, "%04d", i), rows.lines.get(i));
+            }
+        } finally {
+            gate.countDown();
+            if (it != null) {
+                try {
+                    it.close();
+                } catch (IOException ignored) {}
+            }
+            pool.shutdownNow();
+        }
+    }
+
+    /** Mirrors {@code AsyncExternalSourceOperatorFactory#drainHotPath}: yields the pool thread on not-ready. */
+    private static void drainViaProducerLoop(
+        CloseableIterator<Page> it,
+        Executor pool,
+        AtomicInteger rows,
+        PlainActionFuture<Integer> done
+    ) {
+        try {
+            while (true) {
+                SubscribableListener<Void> ready = it.waitForReady();
+                if (ready.isDone() == false) {
+                    ready.addListener(
+                        ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoop(it, pool, rows, done)), done::onFailure)
+                    );
+                    return;
+                }
+                if (it.hasNext() == false) { // pre-fix: BLOCKS here on a POISON gap (isReadyNow reports ready on POISON)
+                    SubscribableListener<Void> recheck = it.waitForReady();
+                    if (recheck.isDone()) {
+                        done.onResponse(rows.get());
+                        return;
+                    }
+                    recheck.addListener(
+                        ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoop(it, pool, rows, done)), done::onFailure)
+                    );
+                    return;
+                }
+                Page p = it.next();
+                rows.addAndGet(p.getPositionCount());
+                p.releaseBlocks();
+            }
+        } catch (Exception e) {
+            done.onFailure(e);
+        }
+    }
+
+    /** As {@link #drainViaProducerLoop} but records the decoded lines (order-preserving) for the EOF-drop assertions. */
+    private static void drainViaProducerLoopCollecting(
+        CloseableIterator<Page> it,
+        Executor pool,
+        OrderCapturingSink sink,
+        PlainActionFuture<Integer> done
+    ) {
+        try {
+            BytesRef scratch = new BytesRef();
+            while (true) {
+                SubscribableListener<Void> ready = it.waitForReady();
+                if (ready.isDone() == false) {
+                    ready.addListener(
+                        ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoopCollecting(it, pool, sink, done)), done::onFailure)
+                    );
+                    return;
+                }
+                if (it.hasNext() == false) {
+                    SubscribableListener<Void> recheck = it.waitForReady();
+                    if (recheck.isDone()) {
+                        done.onResponse(sink.lines.size());
+                        return;
+                    }
+                    recheck.addListener(
+                        ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoopCollecting(it, pool, sink, done)), done::onFailure)
+                    );
+                    return;
+                }
+                Page p = it.next();
+                BytesRefBlock block = p.getBlock(0);
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    sink.lines.add(block.getBytesRef(i, scratch).utf8ToString());
+                }
+                p.releaseBlocks();
+            }
+        } catch (Exception e) {
+            done.onFailure(e);
+        }
+    }
+
+    /** Order-preserving row sink; only the single producer-loop consumer appends, so a plain list suffices. */
+    private static final class OrderCapturingSink {
+        private final List<String> lines = new ArrayList<>();
+    }
+
     private static String buildContent(int lineCount) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lineCount; i++) {
@@ -1553,6 +1773,98 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public void close() {}
+    }
+
+    /**
+     * Wraps {@link LineFormatReader} and blocks the parse of one chosen chunk index on a latch, so a test can
+     * deterministically hold the consumer at the inter-chunk POISON gap. The chunk index is recovered from the
+     * per-chunk storage path the coordinator synthesizes ({@code mem://chunk-<index>}). Gating survives
+     * {@link #withSchema} (the coordinator swaps to the schema-bound reader after chunk 0), so a gated middle
+     * chunk stays gated.
+     */
+    private static final class GatedLineFormatReader implements SegmentableFormatReader, NoConfigFormatReader {
+        private final LineFormatReader delegate;
+        private final int gatedChunkIndex;
+        private final CountDownLatch gate;
+        private final CountDownLatch gatedReached;
+
+        GatedLineFormatReader(long minSegment, int gatedChunkIndex, CountDownLatch gate, CountDownLatch gatedReached) {
+            this(new LineFormatReader(minSegment), gatedChunkIndex, gate, gatedReached);
+        }
+
+        private GatedLineFormatReader(LineFormatReader delegate, int gatedChunkIndex, CountDownLatch gate, CountDownLatch gatedReached) {
+            this.delegate = delegate;
+            this.gatedChunkIndex = gatedChunkIndex;
+            this.gate = gate;
+            this.gatedReached = gatedReached;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            if (chunkIndexOf(object) == gatedChunkIndex) {
+                gatedReached.countDown();
+                try {
+                    gate.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("interrupted waiting on gate", e);
+                }
+            }
+            return delegate.read(object, context);
+        }
+
+        private static int chunkIndexOf(StorageObject object) {
+            String p = object.path().toString();
+            int at = p.lastIndexOf("chunk-");
+            if (at < 0) {
+                return -1;
+            }
+            try {
+                return Integer.parseInt(p.substring(at + "chunk-".length()));
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+
+        @Override
+        public FormatReader withSchema(List<Attribute> schema) {
+            return new GatedLineFormatReader((LineFormatReader) delegate.withSchema(schema), gatedChunkIndex, gate, gatedReached);
+        }
+
+        @Override
+        public RowPositionStrategy rowPositionStrategy() {
+            return delegate.rowPositionStrategy();
+        }
+
+        @Override
+        public RecordSplitter recordSplitter(int maxRecordBytes) {
+            return delegate.recordSplitter(maxRecordBytes);
+        }
+
+        @Override
+        public long minimumSegmentSize() {
+            return delegate.minimumSegmentSize();
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return delegate.metadata(object);
+        }
+
+        @Override
+        public String formatName() {
+            return delegate.formatName();
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return delegate.fileExtensions();
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes a deadlock in ESQL external multi-file text reads. Two bugs
collapsed the concurrency model: `TransportEsqlQueryAction` wired the
drain and parsers onto the same `esql_external_io` pool, and
`StreamingParallelParsingCoordinator.isReadyNow()` reported ready on a
bare end-of-chunk POISON marker — so the producer-loop drain entered a
blocking `hasNext()` across the inter-chunk gap, pinning every pool
thread until no parser could run. Fix: restore the two-pool split,
consume POISON non-blockingly so readiness is honest, and forward
`waitForReady()` through the pass-through wrappers.

Supersedes #153056, which fixed the same deadlock via a new
`pollNext`/`isExhausted` iterator SPI; this keeps the existing
`CloseableIterator` contract and targets the two precise blocking
points instead of a cross-cutting API change.