### PR TITLE
[Inference API] Info logging on region policy PUT/DELETE

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyAction.java
@@ -17,30 +17,39 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.inference.action.DeleteRegionPolicyAction;
 import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
 import org.elasticsearch.xpack.core.inference.regionpolicy.RegionPolicyDoc;
+import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.inference.InferenceIndex;
 import org.elasticsearch.xpack.inference.common.InferencePreferencesCache;
+
+import java.util.Optional;
 
 public class TransportDeleteRegionPolicyAction extends HandledTransportAction<DeleteRegionPolicyAction.Request, AcknowledgedResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportDeleteRegionPolicyAction.class);
 
     private final OriginSettingClient client;
+    private final Optional<SecurityContext> securityContext;
     private final InferencePreferencesCache inferencePreferencesCache;
 
     @Inject
     public TransportDeleteRegionPolicyAction(
+        Settings settings,
         TransportService transportService,
+        ThreadPool threadPool,
         ActionFilters actionFilters,
         Client client,
         InferencePreferencesCache inferencePreferencesCache
@@ -53,11 +62,15 @@ public class TransportDeleteRegionPolicyAction extends HandledTransportAction<De
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.client = new OriginSettingClient(client, ClientHelper.INFERENCE_ORIGIN);
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
+            ? Optional.of(new SecurityContext(settings, threadPool.getThreadContext()))
+            : Optional.empty();
         this.inferencePreferencesCache = inferencePreferencesCache;
     }
 
     @Override
     protected void doExecute(Task task, DeleteRegionPolicyAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        String username = securityContext.map(ctx -> ctx.getUser()).map(user -> user.principal()).orElse(null);
         client.prepareDelete(InferenceIndex.INDEX_NAME, RegionPolicyDoc.DOCUMENT_ID)
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .execute(new ActionListener<>() {
@@ -66,6 +79,7 @@ public class TransportDeleteRegionPolicyAction extends HandledTransportAction<De
                     if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
                         listener.onFailure(TransportGetRegionPolicyAction.noRegionPolicyConfiguredException());
                     } else {
+                        logger.info("Region policy deleted by [{}]", username);
                         inferencePreferencesCache.invalidate(
                             ActionListener.runAfter(
                                 ActionListener.wrap(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutRegionPolicyAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
@@ -154,6 +155,12 @@ public class TransportPutRegionPolicyAction extends HandledTransportAction<PutRe
         indexRequestBuilder.execute(new ActionListener<>() {
             @Override
             public void onResponse(DocWriteResponse docWriteResponse) {
+                logger.info(
+                    "Region policy [{}] by [{}]: {}",
+                    existingRegionPolicyDoc == null ? "created" : "updated",
+                    existingRegionPolicyDoc == null ? doc.createdBy() : doc.updatedBy(),
+                    Strings.toString(doc.regionPolicy())
+                );
                 inferencePreferencesCache.invalidate(
                     ActionListener.runAfter(
                         ActionListener.wrap(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportDeleteRegionPolicyActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -83,7 +84,14 @@ public class TransportDeleteRegionPolicyActionTests extends ESTestCase {
             }
         };
 
-        var action = new TransportDeleteRegionPolicyAction(mock(TransportService.class), mock(ActionFilters.class), client, cache);
+        var action = new TransportDeleteRegionPolicyAction(
+            Settings.EMPTY,
+            mock(TransportService.class),
+            threadPool,
+            mock(ActionFilters.class),
+            client,
+            cache
+        );
 
         var listener = new TestPlainActionFuture<AcknowledgedResponse>();
         action.doExecute(mock(Task.class), new DeleteRegionPolicyAction.Request(), listener);
@@ -121,7 +129,14 @@ public class TransportDeleteRegionPolicyActionTests extends ESTestCase {
             }
         };
 
-        var action = new TransportDeleteRegionPolicyAction(mock(TransportService.class), mock(ActionFilters.class), client, cache);
+        var action = new TransportDeleteRegionPolicyAction(
+            Settings.EMPTY,
+            mock(TransportService.class),
+            threadPool,
+            mock(ActionFilters.class),
+            client,
+            cache
+        );
 
         var listener = new TestPlainActionFuture<AcknowledgedResponse>();
         action.doExecute(mock(Task.class), new DeleteRegionPolicyAction.Request(), listener);
@@ -157,7 +172,14 @@ public class TransportDeleteRegionPolicyActionTests extends ESTestCase {
             }
         };
 
-        var action = new TransportDeleteRegionPolicyAction(mock(TransportService.class), mock(ActionFilters.class), client, cache);
+        var action = new TransportDeleteRegionPolicyAction(
+            Settings.EMPTY,
+            mock(TransportService.class),
+            threadPool,
+            mock(ActionFilters.class),
+            client,
+            cache
+        );
 
         var listener = new TestPlainActionFuture<AcknowledgedResponse>();
         action.doExecute(mock(Task.class), new DeleteRegionPolicyAction.Request(), listener);
@@ -183,7 +205,14 @@ public class TransportDeleteRegionPolicyActionTests extends ESTestCase {
             }
         };
 
-        var action = new TransportDeleteRegionPolicyAction(mock(TransportService.class), mock(ActionFilters.class), client, cache);
+        var action = new TransportDeleteRegionPolicyAction(
+            Settings.EMPTY,
+            mock(TransportService.class),
+            threadPool,
+            mock(ActionFilters.class),
+            client,
+            cache
+        );
 
         var listener = new TestPlainActionFuture<AcknowledgedResponse>();
         action.doExecute(mock(Task.class), new DeleteRegionPolicyAction.Request(), listener);


### PR DESCRIPTION
Adds INFO logging when a region policy is created/updated/deleted.
