### PR TITLE
[DOCS] Add ES|QL FIELD_EXTRACT function page

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/lists/string-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/string-functions.md
@@ -16,6 +16,9 @@
 * [`ENDS_WITH`](../../functions-operators/string-functions/ends_with.md)
   :::{include} ../generated/x-pack-esql/functions/briefSummary/ends_with.md
   :::
+* [`FIELD_EXTRACT`](../../functions-operators/string-functions/field_extract.md) {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview`
+  :::{include} ../generated/x-pack-esql/functions/briefSummary/field_extract.md
+  :::
 * [`FROM_BASE64`](../../functions-operators/string-functions/from_base64.md)
   :::{include} ../generated/x-pack-esql/functions/briefSummary/from_base64.md
   :::

--- a/docs/reference/query-languages/esql/functions-operators/string-functions/field_extract.md
+++ b/docs/reference/query-languages/esql/functions-operators/string-functions/field_extract.md
@@ -1,0 +1,8 @@
+---
+navigation_title: "FIELD_EXTRACT"
+---
+
+# ES|QL `FIELD_EXTRACT` function [esql-field_extract]
+
+:::{include} ../../_snippets/generated/x-pack-esql/functions/layout/field_extract.md
+:::

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -301,6 +301,7 @@ toc:
                   - file: esql/functions-operators/string-functions/concat.md
                   - file: esql/functions-operators/string-functions/contains.md
                   - file: esql/functions-operators/string-functions/ends_with.md
+                  - file: esql/functions-operators/string-functions/field_extract.md
                   - file: esql/functions-operators/string-functions/from_base64.md
                   - file: esql/functions-operators/string-functions/hash.md
                   - file: esql/functions-operators/string-functions/json_extract.md


### PR DESCRIPTION
Follow-up to #151841, which released the `FIELD_EXTRACT` ES|QL string function and generated its doc snippets (`layout`, `types`, `briefSummary`, definition JSON, SVG) but never wired up the actual page. As a result the generated content was orphaned and the function was missing from the docs nav.

This PR adds the missing wiring:

- New page `functions-operators/string-functions/field_extract.md` that includes the generated `layout/field_extract.md` snippet (matching the pattern of the other string function pages).
- `toc.yml` entry, alphabetically between `ends_with` and `from_base64`.
- Entry on the string functions list page (`_snippets/lists/string-functions.md`), with `{applies_to}` preview tags matching the function's `preview 9.5` / serverless preview lifecycle.