### PR TITLE
ESQL: strict declared-schema text reads gzip and warms COUNT(*)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
@@ -18,6 +18,8 @@ import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
+import org.elasticsearch.cluster.metadata.DatasetMapping;
 import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -45,6 +47,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -216,6 +219,40 @@ public abstract class AbstractExternalDataSourceIT extends AbstractEsqlIntegTest
             registerDataSource(SHARED_TEST_DATA_SOURCE, Map.of());
         }
         registerDataset(name, SHARED_TEST_DATA_SOURCE, resourceUri, settings);
+        return name;
+    }
+
+    /**
+     * Registers a STRICT ({@code dynamic:false}) dataset with a declared mapping against the shared data source,
+     * creating it on first use, and records it for teardown. The declared columns are the entire schema — strict
+     * resolution reads no file to infer it. Used by the strict declared-schema tests.
+     */
+    protected String registerStrictDataset(
+        String name,
+        String resourceUri,
+        LinkedHashMap<String, DatasetFieldMapping> properties,
+        Map<String, Object> settings
+    ) {
+        if (registeredDataSources.contains(SHARED_TEST_DATA_SOURCE) == false) {
+            registerDataSource(SHARED_TEST_DATA_SOURCE, Map.of());
+        }
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    name,
+                    SHARED_TEST_DATA_SOURCE,
+                    resourceUri,
+                    null,
+                    new HashMap<>(settings),
+                    mapping
+                )
+            )
+        );
+        registeredDatasets.add(name);
         return name;
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvAggregatePushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvAggregatePushdownIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,6 +83,263 @@ public class ExternalCsvAggregatePushdownIT extends AbstractExternalDataSourceIT
             }
         } finally {
             Files.deleteIfExists(csvFile);
+        }
+    }
+
+    /**
+     * The strict declared-schema twin of {@link #testCountStarColdThenWarmShortCircuits}. A strict
+     * ({@code dynamic:false}) CSV dataset reads no file body at resolution, so it cannot harvest the row-count itself;
+     * {@code ExternalSourceResolver.strictSingleFileMetadata} seeds a schema-cache entry that the cold scan's capture
+     * hook enriches with the count, so the warm run folds {@code COUNT(*)} to {@code LocalSourceExec}. Before the seed
+     * fix, strict full-scanned on every run (regression guard for the strict declared-schema warm-COUNT fix).
+     */
+    public void testStrictCountStarColdThenWarmShortCircuits() throws Exception {
+        int totalRows = 200;
+        Path csvFile = writeCsvFile(totalRows);
+        try {
+            String dataset = registerStrictDataset("csv_strict_agg", StoragePath.fileUri(csvFile), declaredColumns(), Map.of());
+            String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+
+            // Cold: strict text has no row-count at resolve, so it full-scans; the capture hook enriches the seed.
+            try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+                assertCount(response, totalRows);
+                assertThat("cold strict execution must scan rows", response.documentsFound(), equalTo((long) totalRows));
+            }
+            // Warm: seeded + reconciled entry serves the count → LocalSourceExec → no data-node scan.
+            try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+                assertCount(response, totalRows);
+                assertNoPushdownBypass(response);
+                assertThat("warm strict execution must not scan (LocalSourceExec)", response.documentsFound(), equalTo(0L));
+            }
+        } finally {
+            Files.deleteIfExists(csvFile);
+        }
+    }
+
+    /** TSV twin of {@link #testStrictCountStarColdThenWarmShortCircuits} — TSV shares the CSV reader and the same seam. */
+    public void testStrictCountStarColdThenWarmShortCircuitsTsv() throws Exception {
+        int totalRows = 150;
+        Path tsvFile = writeTsvFile(totalRows);
+        try {
+            String dataset = registerStrictDataset("tsv_strict_agg", StoragePath.fileUri(tsvFile), declaredColumns(), Map.of());
+            String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+
+            try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+                assertCount(response, totalRows);
+                assertThat("cold strict execution must scan rows", response.documentsFound(), equalTo((long) totalRows));
+            }
+            try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+                assertCount(response, totalRows);
+                assertNoPushdownBypass(response);
+                assertThat("warm strict execution must not scan (LocalSourceExec)", response.documentsFound(), equalTo(0L));
+            }
+        } finally {
+            Files.deleteIfExists(tsvFile);
+        }
+    }
+
+    /**
+     * The gz × warm intersection the title advertises: a strict single-file {@code .csv.gz} {@code COUNT(*)} warms
+     * exactly like its plain twin (the strict {@code sourceType} is {@code "csv"} for both, and the served count comes
+     * from the real decompressed scan), folding to {@code LocalSourceExec} on the warm run with the same count.
+     */
+    public void testStrictCountStarColdThenWarmShortCircuitsGzip() throws Exception {
+        int totalRows = 120;
+        Path csvGz = writeGzippedCsvFile(totalRows);
+        try {
+            String dataset = registerStrictDataset("csv_gz_strict_agg", StoragePath.fileUri(csvGz), declaredColumns(), Map.of());
+            String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+            try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+                assertCount(response, totalRows);
+                assertThat("cold strict gz execution must scan rows", response.documentsFound(), equalTo((long) totalRows));
+            }
+            try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+                assertCount(response, totalRows);
+                assertNoPushdownBypass(response);
+                assertThat("warm strict gz execution must not scan (LocalSourceExec)", response.documentsFound(), equalTo(0L));
+            }
+        } finally {
+            Files.deleteIfExists(csvGz);
+        }
+    }
+
+    /**
+     * Two strict datasets over the SAME file+config declare column {@code v} differently (integer vs keyword) and so
+     * share one file+config stats-cache entry. A's {@code MIN(v)} harvests the numeric min (9); B's {@code MIN(v)} must
+     * return the keyword min ("10", lexicographic) by re-scanning, never fold A's numeric 9. This is the strict-vs-strict
+     * cross-declaration hazard — the strict warm serve strips per-column stats so a foreign declaration's MIN/MAX is
+     * never folded. Correctness guard (independent of warm/cold).
+     */
+    public void testStrictConflictingDeclaredTypesServeCorrectMin() throws Exception {
+        Path csv = createTempDir().resolve("conflict.csv");
+        Files.writeString(csv, "9\n10\n", StandardCharsets.UTF_8);
+        String uri = StoragePath.fileUri(csv);
+        String asInt = registerStrictDataset("conflict_int", uri, declaredColumn("v", "integer"), Map.of("header_row", false));
+        String asKeyword = registerStrictDataset("conflict_kw", uri, declaredColumn("v", "keyword"), Map.of("header_row", false));
+
+        // A (integer): MIN = 9. Run twice so any per-column harvest is reconciled into the shared entry.
+        for (int i = 0; i < 2; i++) {
+            try (var r = run(syncEsqlQueryRequest("FROM " + asInt + " | STATS m = MIN(v)"))) {
+                assertThat(((Number) getValuesList(r).get(0).get(0)).longValue(), equalTo(9L));
+            }
+        }
+        // B (keyword): MIN = "10" (lexicographic). Must NOT serve A's numeric 9.
+        try (var r = run(syncEsqlQueryRequest("FROM " + asKeyword + " | STATS m = MIN(v)"))) {
+            assertThat(getValuesList(r).get(0).get(0).toString(), equalTo("10"));
+        }
+    }
+
+    /**
+     * Inferred-victim twin of {@link #testStrictAndInferredOverSameFileServeCorrectMin}: the INFERRED dataset reads a
+     * cache entry a strict sibling over the same file+config harvested with a different declared type. A {@code boolean}
+     * column must never serve a foreign keyword {@code BytesRef} min through {@code buildBlock}'s BOOLEAN arm
+     * ({@code Booleans.parseBoolean(bytesRef.toString())}, whose {@code toString()} is the byte-hex form → an
+     * {@code IllegalArgumentException} crash). {@code servableExtremum} must safe-miss the foreign value so the warm
+     * {@code MIN(v)} re-scans and answers correctly.
+     */
+    public void testInferredBooleanNotCrashedByStrictKeywordHarvest() throws Exception {
+        Path csv = createTempDir().resolve("mixed_bool.csv");
+        Files.writeString(csv, "v:boolean\ntrue\nfalse\n", StandardCharsets.UTF_8);
+        String uri = StoragePath.fileUri(csv);
+        String inferred = registerDataset("bool_inferred", uri, Map.of());
+        String strict = registerStrictDataset("bool_strict", uri, declaredColumn("v", "keyword"), Map.of());
+
+        String q = "FROM " + inferred + " | STATS m = MIN(v)";
+        for (int i = 0; i < 2; i++) {
+            try (var r = run(syncEsqlQueryRequest(q))) {
+                assertThat(getValuesList(r).get(0).get(0), equalTo(false)); // MIN(boolean) = false
+            }
+        }
+        // Strict sibling scans + harvests a keyword BytesRef min, reconciled onto the shared file+config entry.
+        try (var r = run(syncEsqlQueryRequest("FROM " + strict + " | STATS m = MIN(v)"))) {
+            getValuesList(r);
+        }
+        // Warm inferred MIN must still answer false — never crash on the foreign BytesRef parked in the entry.
+        try (var r = run(syncEsqlQueryRequest(q))) {
+            assertThat(getValuesList(r).get(0).get(0), equalTo(false));
+        }
+    }
+
+    /**
+     * Inferred-victim wrong-answer twin: an inferred {@code keyword} column must never serve a strict sibling's foreign
+     * {@code Integer} min through {@code buildBlock}'s BYTES_REF arm ({@code toBytesRef(number.toString())}). Lexicographic
+     * {@code MIN("9","10")} is {@code "10"} ('1' &lt; '9'); serving the numeric {@code 9} would answer {@code "9"}.
+     * {@code servableExtremum} must safe-miss the foreign Number so the warm {@code MIN(v)} re-scans to {@code "10"}.
+     */
+    public void testInferredKeywordNotPollutedByStrictNumericHarvest() throws Exception {
+        Path csv = createTempDir().resolve("mixed_kw.csv");
+        Files.writeString(csv, "v:keyword\n9\n10\n", StandardCharsets.UTF_8);
+        String uri = StoragePath.fileUri(csv);
+        String inferred = registerDataset("kw_inferred", uri, Map.of());
+        String strict = registerStrictDataset("kw_strict", uri, declaredColumn("v", "integer"), Map.of());
+
+        String q = "FROM " + inferred + " | STATS m = MIN(v)";
+        for (int i = 0; i < 2; i++) {
+            try (var r = run(syncEsqlQueryRequest(q))) {
+                assertThat(getValuesList(r).get(0).get(0).toString(), equalTo("10"));
+            }
+        }
+        // Strict sibling scans + harvests an Integer min, reconciled onto the shared entry.
+        try (var r = run(syncEsqlQueryRequest("FROM " + strict + " | STATS m = MIN(v)"))) {
+            getValuesList(r);
+        }
+        // Warm inferred MIN must still answer "10" — never serve the strict sibling's numeric 9.
+        try (var r = run(syncEsqlQueryRequest(q))) {
+            assertThat(getValuesList(r).get(0).get(0).toString(), equalTo("10"));
+        }
+    }
+
+    /**
+     * An inferred dataset and a strict dataset over the same file+config must not serve each other's per-column stats.
+     * The reconcile is schema-agnostic (matches path+mtime+fingerprint, not the schema-cache marker), so the inferred
+     * numeric min can reach the strict entry — but the strict serve strips per-column stats, so strict {@code MIN(v)}
+     * re-scans and returns the correct keyword min.
+     */
+    public void testStrictAndInferredOverSameFileServeCorrectMin() throws Exception {
+        // A typed header names the inferred column `v` (type integer) and is skipped by the strict read too, so both
+        // datasets share the same file+config (no header_row override → identical fingerprint).
+        Path csv = createTempDir().resolve("mixed.csv");
+        Files.writeString(csv, "v:integer\n9\n10\n", StandardCharsets.UTF_8);
+        String uri = StoragePath.fileUri(csv);
+        String inferred = registerDataset("mixed_inferred", uri, Map.of());
+        String strict = registerStrictDataset("mixed_strict", uri, declaredColumn("v", "keyword"), Map.of());
+
+        // Inferred infers v numeric → MIN = 9; run twice to reconcile the numeric per-column min into the cache.
+        for (int i = 0; i < 2; i++) {
+            try (var r = run(syncEsqlQueryRequest("FROM " + inferred + " | STATS m = MIN(v)"))) {
+                assertThat(((Number) getValuesList(r).get(0).get(0)).longValue(), equalTo(9L));
+            }
+        }
+        // Strict declares v:keyword → MIN = "10"; must not fold the inferred numeric 9.
+        try (var r = run(syncEsqlQueryRequest("FROM " + strict + " | STATS m = MIN(v)"))) {
+            assertThat(getValuesList(r).get(0).get(0).toString(), equalTo("10"));
+        }
+    }
+
+    /**
+     * A non-{@code FAIL_FAST} error policy ({@code skip_row} AND {@code null_field}) drops structurally-malformed
+     * (width-overflow) rows — the CSV reader drops such a row "even under NULL_FIELD" — and the drop count depends on the
+     * declared column count, so the harvested row-count is not guaranteed independent of the declaration. The strict warm
+     * seed is therefore skipped for every non-{@code FAIL_FAST} policy: {@code COUNT(*)} re-scans on every query
+     * ({@code documentsFound == totalRows}) rather than fold a possibly cross-declaration row-count. Guards the
+     * {@code warmsRowCountSafely} gate (contrast {@link #testStrictCountStarColdThenWarmShortCircuits}, which warms with
+     * the default {@code FAIL_FAST} policy).
+     */
+    public void testStrictNonFailFastErrorModesAreNeverWarmed() throws Exception {
+        for (String mode : new String[] { "skip_row", "null_field" }) {
+            int totalRows = 100;
+            Path csv = writeCsvFile(totalRows);
+            try {
+                String dataset = registerStrictDataset(
+                    "nff_" + mode,
+                    StoragePath.fileUri(csv),
+                    declaredColumns(),
+                    Map.of("error_mode", mode)
+                );
+                String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+                // Both runs must scan — a non-FAIL_FAST policy is excluded from the warm path, so COUNT never folds.
+                for (int i = 0; i < 2; i++) {
+                    try (var r = run(syncEsqlQueryRequest(query).profile(true))) {
+                        assertCount(r, totalRows);
+                        assertThat(mode + " must never warm", r.documentsFound(), equalTo((long) totalRows));
+                    }
+                }
+            } finally {
+                Files.deleteIfExists(csv);
+            }
+        }
+    }
+
+    private static LinkedHashMap<String, DatasetFieldMapping> declaredColumn(String name, String type) {
+        LinkedHashMap<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put(name, new DatasetFieldMapping(type, null));
+        return properties;
+    }
+
+    /**
+     * {@code warmsRowCountSafely} must never turn an invalid {@code error_mode} into a plan-time failure: it is an
+     * optimization decision, not a validation gate. Before the {@code try/catch} around
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy#fromConfig}, an unparseable policy (here
+     * {@code error_mode: bogus}) would throw {@code IllegalArgumentException} straight out of resolution — reached by
+     * every query against the dataset, including one like {@code LIMIT 0} that the optimizer prunes to an empty plan
+     * before ever touching the data node. That regressed a query that succeeded before the strict warm-COUNT path
+     * existed, since the malformed config was previously only validated inside {@code FileSourceFactory}'s data-node
+     * operator factory, which {@code LIMIT 0} never reaches.
+     */
+    public void testStrictBogusErrorModeDoesNotFailLimitZero() throws Exception {
+        Path csv = writeCsvFile(10);
+        try {
+            String dataset = registerStrictDataset(
+                "bogus_error_mode",
+                StoragePath.fileUri(csv),
+                declaredColumns(),
+                Map.of("error_mode", "bogus")
+            );
+            try (var r = run(syncEsqlQueryRequest("FROM " + dataset + " | LIMIT 0"))) {
+                assertThat(getValuesList(r), equalTo(List.of()));
+            }
+        } finally {
+            Files.deleteIfExists(csv);
         }
     }
 
@@ -348,5 +607,36 @@ public class ExternalCsvAggregatePushdownIT extends AbstractExternalDataSourceIT
         Path tempFile = createTempDir().resolve("count_pushdown_test.csv");
         Files.writeString(tempFile, sb.toString(), StandardCharsets.UTF_8);
         return tempFile;
+    }
+
+    private Path writeGzippedCsvFile(int rowCount) throws IOException {
+        StringBuilder sb = new StringBuilder("id:integer,name:keyword,value:integer\n");
+        for (int i = 0; i < rowCount; i++) {
+            sb.append(i).append(",row_").append(i).append(',').append(i * 10).append('\n');
+        }
+        Path tempFile = createTempDir().resolve("count_pushdown_test.csv.gz");
+        try (var out = new java.util.zip.GZIPOutputStream(Files.newOutputStream(tempFile))) {
+            out.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+        }
+        return tempFile;
+    }
+
+    private Path writeTsvFile(int rowCount) throws IOException {
+        StringBuilder sb = new StringBuilder("id:integer\tname:keyword\tvalue:integer\n");
+        for (int i = 0; i < rowCount; i++) {
+            sb.append(i).append("\trow_").append(i).append('\t').append(i * 10).append('\n');
+        }
+        Path tempFile = createTempDir().resolve("count_pushdown_test.tsv");
+        Files.writeString(tempFile, sb.toString(), StandardCharsets.UTF_8);
+        return tempFile;
+    }
+
+    /** The strict declaration matching {@link #writeCsvFile}/{@link #writeTsvFile}: the entire schema, no inference. */
+    private static LinkedHashMap<String, DatasetFieldMapping> declaredColumns() {
+        LinkedHashMap<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("id", new DatasetFieldMapping("integer", null));
+        properties.put("name", new DatasetFieldMapping("keyword", null));
+        properties.put("value", new DatasetFieldMapping("integer", null));
+        return properties;
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -183,6 +183,10 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         "logs_ndjson",
         "logs_csv_rename",
         "logs_csv_gz",
+        "logs_csv_gz_strict",
+        "logs_tsv_gz_strict",
+        "logs_ndjson_gz_strict",
+        "logs_csv_gz_strict_multi",
         "logs_parquet_strict_format",
         "logs_noext_strict",
         "employees_extensionless",
@@ -798,9 +802,9 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         try (var out = new java.util.zip.GZIPOutputStream(Files.newOutputStream(gz))) {
             out.write(csv);
         }
-        // Non-strict so the format/sourceType is inferred through the extension-based reader (the strict path derives the
-        // sourceType from the file extension and doesn't yet see through a compound `.csv.gz` — a separate, pre-existing
-        // gap unrelated to declared date formats). The overlay retypes the inferred `ts` to a date with the format.
+        // Non-strict here so this test stays focused on the declared date format; the strict path over a compound
+        // `.csv.gz` is covered separately by testStrictOverGzipCsvReads (and its tsv/ndjson twins). The overlay retypes
+        // the inferred `ts` to a date with the format.
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
         properties.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
@@ -824,6 +828,104 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         try (var response = run(syncEsqlQueryRequest("FROM logs_csv_gz | EVAL ms = ts::long | KEEP ms | LIMIT 1"), TIMEOUT)) {
             List<List<Object>> rows = getValuesList(response);
             assertThat(rows.get(0).get(0), equalTo(ACCESS_LOG_EPOCH_MILLIS));
+        }
+    }
+
+    public void testStrictOverGzipCsvReads() throws Exception {
+        // A strict (dynamic:false) mapping over compound-compressed .csv.gz. The strict path derives the reader
+        // sourceType from the file name; before the compound-extension fix it last-dotted to "gz" and the query failed
+        // with "No operator factory for sourceType: gz". It must now resolve to "csv" (through the compression-unwrapping
+        // registry) and read the row. Regression guard for the strict compound-extension read fix.
+        assertStrictGzippedTextReads("logs_csv_gz_strict", ".csv.gz", "some_ts,alpha\n", Map.of("header_row", false));
+    }
+
+    public void testStrictOverGzipTsvReads() throws Exception {
+        assertStrictGzippedTextReads("logs_tsv_gz_strict", ".tsv.gz", "some_ts\talpha\n", Map.of("header_row", false));
+    }
+
+    public void testStrictOverGzipNdjsonReads() throws Exception {
+        // NDJSON is read by JSON key, so no header_row setting applies; the compound `.ndjson.gz` must still resolve
+        // through the compression-unwrapping registry to the "ndjson" reader rather than last-dotting to "gz".
+        assertStrictGzippedTextReads("logs_ndjson_gz_strict", ".ndjson.gz", "{\"ts\":\"some_ts\",\"note\":\"alpha\"}\n", Map.of());
+    }
+
+    public void testStrictOverGzipCsvGlobReads() throws Exception {
+        // The multi-file half of the fix: resolveStrictMultiFile must derive the reader from a CONCRETE listed file name
+        // (listing.path(0)) through the compression-unwrapping registry — not last-dot the raw `*.csv.gz` glob string to
+        // "gz" (which would fail with "No operator factory for sourceType: gz"). Regression guard for the multi-file
+        // portion of the strict compound-extension read fix.
+        Path root = createTempDir();
+        writeGzip(root.resolve("part1.csv.gz"), "ts_a,alpha\nts_b,beta\n");
+        writeGzip(root.resolve("part2.csv.gz"), "ts_c,gamma\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("ts", new DatasetFieldMapping("keyword", null));
+        properties.put("note", new DatasetFieldMapping("keyword", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "logs_csv_gz_strict_multi",
+                    "local_ds",
+                    root.toUri() + "*.csv.gz",
+                    null,
+                    new HashMap<>(Map.of("header_row", false)),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM logs_csv_gz_strict_multi | STATS c = COUNT(*)"), TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo(3L)); // 2 rows from part1 + 1 from part2
+        }
+    }
+
+    private static void writeGzip(Path target, String content) throws Exception {
+        try (var out = new java.util.zip.GZIPOutputStream(Files.newOutputStream(target))) {
+            out.write(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Registers a strict (dynamic:false) two-column {@code ts,note} dataset over a gzipped text file of the given
+     * compound extension and asserts {@code note} reads back as {@code alpha} — i.e. the strict path resolved the
+     * reader through the compound extension (not the "gz" codec suffix).
+     */
+    private void assertStrictGzippedTextReads(String datasetName, String ext, String content, Map<String, Object> settings)
+        throws Exception {
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Path gz = createTempFile("dataset-strict-", ext);
+        writeGzip(gz, content);
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("ts", new DatasetFieldMapping("keyword", null));
+        properties.put("note", new DatasetFieldMapping("keyword", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    datasetName,
+                    "local_ds",
+                    gz.toUri().toString(),
+                    null,
+                    new HashMap<>(settings),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM " + datasetName + " | KEEP note | LIMIT 1"), TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(1));
+            assertThat(rows.get(0).get(0).toString(), equalTo("alpha"));
         }
     }
 
@@ -864,9 +966,10 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
     public void testStrictDatasetWithUnknowableFormatFailsCleanlyNotNpe() throws Exception {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
 
-        // A strict dataset over an extensionless path with no `format` setting has an unknowable sourceType (null). The
-        // columnar-format reject must guard that null (an immutable Set throws on contains(null)) so the query keeps its
-        // prior clean failure instead of an NPE-wrapped 500 — even though no date format is declared here.
+        // A strict dataset over an extensionless path with no `format` setting cannot resolve a reader. Strict now
+        // derives the sourceType through the registry (FormatNameResolver.resolveFormatName -> byExtension), which fails
+        // loud at resolution with a clean IllegalArgumentException ("Cannot infer format from object name without
+        // extension") — propagated unwrapped as a 4xx, never an NPE-wrapped 500.
         Path noExt = createTempFile("dataset-noext-", "");
         Files.writeString(noExt, "id\n1\n");
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
@@ -891,6 +994,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
 
         Exception e = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest("FROM logs_noext_strict | LIMIT 1"), TIMEOUT).close());
         assertThat(e.getMessage(), not(containsString("NullPointerException")));
+        assertThat(e.getMessage(), containsString("without extension"));
     }
 
     public void testNdJsonRenameStrictReadsByPhysicalJsonKey() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheEntry;
 import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheKey;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -62,6 +63,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -950,22 +952,31 @@ public class ExternalSourceResolver {
      * when it carries no stripe keys (no copy on the common already-folded warm-serve path).
      */
     private static Map<String, Object> stripStripeBookkeeping(Map<String, Object> safeMetadata) {
-        if (safeMetadata == null || safeMetadata.isEmpty()) {
-            return safeMetadata;
+        return withoutKeys(safeMetadata, ExternalSourceResolver::isStripeBookkeeping);
+    }
+
+    /**
+     * Returns {@code map} without the entries whose key matches {@code drop}, or the input unchanged when nothing
+     * matches (no allocation on the common no-match path). Shared by the source-metadata filters that must not mutate a
+     * possibly-shared cache map ({@link #stripStripeBookkeeping}, {@link #rowCountOnlyStats}).
+     */
+    private static Map<String, Object> withoutKeys(Map<String, Object> map, Predicate<String> drop) {
+        if (map == null || map.isEmpty()) {
+            return map;
         }
-        boolean hasStripeKeys = false;
-        for (String k : safeMetadata.keySet()) {
-            if (isStripeBookkeeping(k)) {
-                hasStripeKeys = true;
+        boolean anyMatch = false;
+        for (String k : map.keySet()) {
+            if (drop.test(k)) {
+                anyMatch = true;
                 break;
             }
         }
-        if (hasStripeKeys == false) {
-            return safeMetadata;
+        if (anyMatch == false) {
+            return map;
         }
-        Map<String, Object> filtered = new HashMap<>(safeMetadata.size());
-        for (Map.Entry<String, Object> e : safeMetadata.entrySet()) {
-            if (isStripeBookkeeping(e.getKey()) == false) {
+        Map<String, Object> filtered = new HashMap<>(map.size());
+        for (Map.Entry<String, Object> e : map.entrySet()) {
+            if (drop.test(e.getKey()) == false) {
                 filtered.put(e.getKey(), e.getValue());
             }
         }
@@ -1933,25 +1944,25 @@ public class ExternalSourceResolver {
         List<Attribute> logicalSchema = DeclaredSchemaResolver.declaredAttributes(declaredMapping);
         // sourceType drives operator-factory dispatch (OperatorFactoryRegistry keys on it), so it must equal the
         // reader's formatName() the inferred path would have produced — derive it without reading the file via
-        // FormatNameResolver, which applies the same reader-then-format-then-extension precedence (and lowercasing)
-        // as the inferred path. A hand-rolled `format` check here would miss both and mis-key the dispatch.
-        String sourceType = FormatNameResolver.resolve(config, path);
+        // FormatNameResolver.resolveFormatName, which routes through the registry (reader-then-format-then-extension
+        // precedence, and compound-extension aware, so hits.csv.gz -> "csv" not the "gz" codec suffix). A hand-rolled
+        // `format` check or the last-dot FormatNameResolver.resolve here would mis-key the dispatch on compressed text.
+        String sourceType = FormatNameResolver.resolveFormatName(config, storagePath.objectName(), dataSourceModule.formatReaderRegistry());
         // Cheap no-I/O guard first (no partitions on a single file), then the columnar coercibility check which reads
         // this file's footer (cached when the provider is).
         rejectDeclaredMappingViolations(null, declaredMapping);
         Instant singleMtime = object.lastModified();
-        rejectStrictColumnarUncoercibleTypes(
-            sourceType,
-            provider,
+        long mtimeMillis = singleMtime != null ? singleMtime.toEpochMilli() : Instant.EPOCH.toEpochMilli();
+        rejectStrictColumnarUncoercibleTypes(sourceType, provider, storagePath, mtimeMillis, config, declaredMapping);
+        ExternalSourceMetadata extMetadata = strictSingleFileMetadata(
+            path,
             storagePath,
-            singleMtime != null ? singleMtime.toEpochMilli() : Instant.EPOCH.toEpochMilli(),
+            provider,
             config,
-            declaredMapping
-        );
-        ExternalSourceMetadata extMetadata = wrapAsExternalSourceMetadata(
-            new SimpleSourceMetadata(logicalSchema, sourceType, path),
-            config,
-            declaredReadSpecOf(declaredMapping)
+            declaredMapping,
+            logicalSchema,
+            sourceType,
+            mtimeMillis
         );
         FileList singletonList = GlobExpander.fileListOf(
             List.of(new StorageEntry(storagePath, object.length(), object.lastModified())),
@@ -1959,6 +1970,140 @@ public class ExternalSourceResolver {
         );
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = singleEntrySchemaMap(storagePath, logicalSchema);
         return new ExternalSourceResolution.ResolvedSource(extMetadata, singletonList, schemaMap);
+    }
+
+    /**
+     * Marker appended to the strict single-file schema-cache key's format-type component so a strict (declared-schema)
+     * entry never shares a {@code getOrComputeSchema} slot with an inferred (discovered-schema) entry over the same
+     * file+config: the two hold different schemas and neither may be served the other's. This disambiguates ONLY the
+     * schema-cache lookup — the post-query stats reconcile keys on path+mtime+config_fingerprint (NOT the format-type),
+     * so the harvested row-count still lands on this entry. It does NOT isolate the *stats* across declarations; that is
+     * why {@link #strictSingleFileMetadata} serves only the declaration-independent row-count (see there).
+     */
+    private static final String STRICT_DECLARED_SCHEMA_MARKER = "#strict-declared";
+
+    /**
+     * Builds the strict single-file source metadata, warming the ungrouped-{@code COUNT(*)} metadata fast path for
+     * footerless text. Strict resolution reads no file body, so it cannot harvest the row-count itself; instead it seeds
+     * a schema-cache entry (keyed via {@link #STRICT_DECLARED_SCHEMA_MARKER}) that the first query's data-node stats
+     * capture enriches with the row-count, so query 2+ folds {@code COUNT(*)} to a {@code LocalSourceOperator} instead
+     * of re-scanning + type-coercing every declared column.
+     * <p>
+     * The stats cache is keyed by file+config, NOT by the declared schema, so one entry can be shared by datasets that
+     * declare the same file's columns differently (strict-vs-strict under the marker, or strict-vs-inferred via the
+     * schema-agnostic reconcile). Two guards keep the served row-count VALUE correct — a shared entry never serves a
+     * declaration-DEPENDENT statistic to a foreign declaration:
+     * <ul>
+     *   <li>the returned schema is always the declaration ({@code logicalSchema}), never the entry's, and only the
+     *       ROW-COUNT is served back ({@link #rowCountOnlyStats} strips the per-column {@code _stats.columns.*}). A
+     *       column MIN/MAX value depends on the declared column type (numeric vs lexicographic order), so it is never
+     *       folded from a possibly differently-declared harvest — strict MIN/MAX re-scans instead of warming;</li>
+     *   <li>the row-count is served only under a {@link ErrorPolicy.Mode#FAIL_FAST} error policy — the one policy where
+     *       a SUCCESSFUL scan's row-count equals the physical record count for ANY declaration (any structural error,
+     *       e.g. a row wider than the declared column count, aborts the query before publish; width underflow keeps the
+     *       row). Under {@code skip_row} or {@code null_field} a width-overflow row is DROPPED (the drop is declaration-
+     *       independent of value coercion but NOT of the declared column count), so the row-count would become
+     *       declaration-dependent; {@link #warmsRowCountSafely} keeps those off the warm path — they re-scan, still
+     *       returning the correct count.</li>
+     * </ul>
+     * The two guards make the served row-count a correct NUMBER for every declaration, but the file+config key leaves one
+     * residual — disclosed here, closed only by the fingerprint follow-up: a strict dataset that declares FEWER columns
+     * than the file has (a legal narrower binding) would on its own ERROR on {@code COUNT(*)} (its rows overflow its
+     * declared width under {@code FAIL_FAST}); once a wider — or inferred — dataset over the same file+config has warmed
+     * the shared entry, that dataset's {@code COUNT(*)} folds to the physical row-count instead of erroring. That is a
+     * masked abort, not a wrong count (every materializing query on such a mis-bound dataset still fails loudly), and it
+     * flaps with cache state. Weaving the declared schema into the cross-node stats fingerprint (see the follow-up) is the
+     * complete closure; a width-equality serve gate would close only the strict-vs-strict half (the entry does not record
+     * who harvested it, so it cannot gate the inferred-vs-strict half).
+     * <p>
+     * File-typed (columnar) formats are excluded: they already warm via split-discovery per-split stats, and the strict
+     * columnar coercibility check seeds a physical-schema entry under the inferred key. The non-cacheable branch (e.g.
+     * HTTP, no stable mtime) keeps the stat-less metadata: there is nothing to warm from. Warming MIN/MAX and the
+     * multi-file glob correctly needs the declared schema woven into the cross-node stats fingerprint (a larger change);
+     * tracked separately.
+     */
+    private ExternalSourceMetadata strictSingleFileMetadata(
+        String path,
+        StoragePath storagePath,
+        StorageProvider provider,
+        Map<String, Object> config,
+        DatasetMapping declaredMapping,
+        List<Attribute> logicalSchema,
+        String sourceType,
+        long mtimeMillis
+    ) throws Exception {
+        if (isCacheable(provider) && FILE_TYPED_FORMATS.contains(sourceType) == false && warmsRowCountSafely(sourceType, config)) {
+            String formatType = detectFormatType(storagePath) + STRICT_DECLARED_SCHEMA_MARKER;
+            SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtimeMillis, formatType, config);
+            // Seed only mtime + config fingerprint; the row-count is absent until the first query's data node harvests
+            // it (reconcileSourceStats matches on those two + the path, then overlays STATS_ROW_COUNT). Store no
+            // connector config (Map.of()): the inferred text rail stores none either, and the schema cache is shared
+            // across users, so the seed must not retain the dataset's credentials. buildMetadataFromCache re-merges the
+            // live query config on read. Build the seed inside the loader so its buildFormatConfig runs only on a cache
+            // MISS, not on every (mostly warm) resolve.
+            SchemaCacheEntry entry = cacheService.getOrComputeSchema(
+                schemaKey,
+                k -> SchemaCacheEntry.from(
+                    logicalSchema,
+                    sourceType,
+                    path,
+                    Map.of(
+                        ExternalStats.MTIME_MILLIS_KEY,
+                        mtimeMillis,
+                        ExternalStats.CONFIG_FINGERPRINT_KEY,
+                        SchemaCacheKey.buildFormatConfig(config)
+                    ),
+                    Map.of()
+                )
+            );
+            // Schema stays the declaration; serve ONLY the (declaration-independent) row-count, never per-column stats.
+            // Mirror the cold branch's wrapAsExternalSourceMetadata schema guard here — buildMetadataFromCache does not
+            // validate — so warm and cold enforce the same invariant.
+            validateSchemaUsesOnlyReferenceAttributes(logicalSchema);
+            ExternalSourceMetadata full = buildMetadataFromCache(entry, logicalSchema, config);
+            return replaceSourceMetadata(full, rowCountOnlyStats(full.sourceMetadata()));
+        }
+        return wrapAsExternalSourceMetadata(
+            new SimpleSourceMetadata(logicalSchema, sourceType, path),
+            config,
+            declaredReadSpecOf(declaredMapping)
+        );
+    }
+
+    /**
+     * Returns {@code sourceMetadata} without any per-column statistic ({@code _stats.columns.*}). A strict dataset
+     * shares its file+config cache entry with other declarations of the same file, so it may fold back only the
+     * declaration-independent row-count; a per-column MIN/MAX — whose value depends on the declared column type — must
+     * be re-scanned rather than served from a foreign declaration's harvest. Returns the input unchanged when it has no
+     * per-column keys (the common cold path).
+     */
+    private static Map<String, Object> rowCountOnlyStats(Map<String, Object> sourceMetadata) {
+        return withoutKeys(sourceMetadata, k -> k.startsWith(SourceStatisticsSerializer.STATS_COL_PREFIX));
+    }
+
+    /**
+     * True when a successful scan's row-count is INDEPENDENT of the declared schema, so it is safe to serve from a
+     * file+config-shared cache entry. This holds only under a {@link ErrorPolicy.Mode#FAIL_FAST} policy: any structural
+     * error (e.g. a row wider than the declared column count) aborts the query before publish, and width underflow keeps
+     * the row, so a committed {@code FAIL_FAST} row-count equals the physical record count for any declaration. Under
+     * {@link ErrorPolicy.Mode#SKIP_ROW} or {@link ErrorPolicy.Mode#NULL_FIELD} a width-overflow row is DROPPED (the CSV
+     * reader drops a structurally-malformed row "even under NULL_FIELD"), and the width depends on the declared column
+     * count, so the row-count becomes declaration-dependent — a shared entry could then serve a wrong {@code COUNT(*)} to
+     * a differently-declared dataset. Resolved through {@link ErrorPolicy#fromConfig} against the reader's own default so
+     * it is format-agnostic (and catches the implicit {@code SKIP_ROW} a bare {@code max_errors} selects).
+     */
+    private boolean warmsRowCountSafely(String sourceType, Map<String, Object> config) {
+        FormatReader reader = dataSourceModule.formatReaderRegistry().findByName(sourceType);
+        ErrorPolicy defaultPolicy = reader != null ? reader.defaultErrorPolicy() : ErrorPolicy.STRICT;
+        try {
+            return ErrorPolicy.fromConfig(config, defaultPolicy).isStrict();
+        } catch (IllegalArgumentException e) {
+            // The warm decision is an optimization and must NOT introduce a plan-time failure. An invalid error policy
+            // (e.g. error_mode=bogus, or fail_fast + a budget) is left for the data node's operator factory to reject at
+            // scan time — exactly as it was before this warm path existed — so a query that prunes the scan away (e.g.
+            // LIMIT 0) still succeeds rather than erroring during resolution. Conservatively do not warm.
+            return false;
+        }
     }
 
     /**
@@ -2002,8 +2147,17 @@ public class ExternalSourceResolver {
         // Declared mapping is the whole schema, in LOGICAL names; a `path` rename is applied at the reader, so the
         // operator (and file schema) work purely in logical names.
         List<Attribute> logicalSchema = DeclaredSchemaResolver.declaredAttributes(declaredMapping);
-        // Same reader-then-format-then-extension dispatch as the single-file strict path above.
-        String sourceType = FormatNameResolver.resolve(config, path);
+        // Same compound-extension-aware dispatch as the single-file strict path above. Derive from a CONCRETE listed
+        // object name (listing.path(0)), not the raw glob string: a pattern like `*.csv.gz` and a comma-separated path
+        // list both make the raw path unreliable for extension parsing, whereas a listed entry is a real file name.
+        // Like the inferred FIRST_FILE_WINS path, the anchor's format governs every file with no cross-listing format
+        // check — so a heterogeneous, extension-less glob (e.g. `logs/*` matching mixed formats) reads through the
+        // first file's reader rather than failing; consistent with the pre-existing multi-file design, not validated here.
+        String sourceType = FormatNameResolver.resolveFormatName(
+            config,
+            listing.path(0).objectName(),
+            dataSourceModule.formatReaderRegistry()
+        );
 
         // Partition columns are path-derived (no file I/O), so strict mode surfaces them exactly like the inferred
         // path does. One divergence: the inferred path SHADOWS a physical column that collides with a partition key
@@ -2128,6 +2282,9 @@ public class ExternalSourceResolver {
         Map<String, Object> config,
         DatasetMapping declaredMapping
     ) throws Exception {
+        // The strict callers now derive sourceType via FormatNameResolver.resolveFormatName, which returns non-null or
+        // throws, so the null branch is defensive-only today; it is kept so a future null-returning resolution path
+        // cannot silently NPE on Set.contains(null) and resurrect the earlier NPE-wrapped-500.
         if (sourceType == null || FILE_TYPED_FORMATS.contains(sourceType) == false || declaredMapping.mappings() == null) {
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolver.java
@@ -106,6 +106,13 @@ public final class FormatNameResolver {
 
     /**
      * Resolves the format name from the WITH config map and/or the source path.
+     * <p>
+     * <b>Not compound-extension aware:</b> the extension fallback here is a naive last-dot, so a compound name like
+     * {@code hits.csv.gz} resolves to the codec suffix {@code "gz"}, not {@code "csv"}. A caller that keys operator
+     * dispatch or reader lookup on the format over a possibly-compressed resource must use {@link #resolveFormatName}
+     * (or {@link #resolveReader}), which routes through the compound-aware registry. Kept for the config-override-only
+     * path ({@code FileSourceFactory} passes an empty source path); {@code PushFiltersToSource} still calls it over the
+     * exec source path and so misses filter pushdown on compressed text — migrating that caller is tracked separately.
      *
      * @return the format name (e.g. "parquet", "parquet-rs", "orc"), or null if undetermined
      */
@@ -138,6 +145,20 @@ public final class FormatNameResolver {
 
     public static Set<String> supportedReaderAliases() {
         return READER_ALIAS_TO_FORMAT.keySet();
+    }
+
+    /**
+     * Resolves the format <em>name</em> (e.g. {@code "csv"}, {@code "parquet"}) using config and source path, routed
+     * through the registry so it is compound-extension aware. Unlike {@link #resolve}, which last-dots the path and
+     * would yield the compression codec suffix ({@code "gz"}) for a compound name like {@code hits.csv.gz}, this
+     * delegates to {@link #resolveReader} and reads back {@link FormatReader#formatName()} —
+     * {@link CompressionDelegatingFormatReader#formatName()} returns the wrapped format, so the result equals the
+     * format name the inferred read path ({@code FileSourceFactory}) would produce. The strict resolver keys
+     * operator-factory dispatch on the result, so it uses this rather than {@link #resolve} to avoid diverging from the
+     * read path over a compressed resource.
+     */
+    public static String resolveFormatName(Map<String, Object> config, String objectName, FormatReaderRegistry registry) {
+        return resolveReader(config, objectName, registry).formatName();
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -540,6 +540,19 @@ public class ExternalSourceCacheService implements Closeable {
                 String key = pair[0];
                 Object value = statsMap.get(key);
                 if (value instanceof Number == false) {
+                    // A non-null, non-Number extremum on a numeric-typed column is cross-declaration garbage — e.g. a
+                    // keyword min reconciled (the reconcile matches on path+mtime+config, never the declared type) onto a
+                    // column another dataset over the same file declares numeric. It can never be served: buildBlock
+                    // casts the extremum to (Number) and would ClassCastException. Drop it and mark the extremum
+                    // unservable so the serve safe-misses (re-scans) rather than crashing. (value == null is a genuinely
+                    // absent stat — nothing to do.)
+                    if (value != null) {
+                        if (out == null) {
+                            out = new HashMap<>(statsMap);
+                        }
+                        out.remove(key);
+                        out.put(pair[1], Boolean.TRUE);
+                    }
                     continue;
                 }
                 Object coerced = coerceNumberToType((Number) value, type); // null => not representable in `type`

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
@@ -125,9 +125,35 @@ public final class ExternalSourceAggregatePushdown {
         return switch (support.blockKind()) {
             case INT -> exactIntegerInRange(value, Integer.MIN_VALUE, Integer.MAX_VALUE) ? value : null;
             case LONG -> exactIntegerInRange(value, Long.MIN_VALUE, Long.MAX_VALUE) ? value : null;
-            // The non-integral buildBlock arms coerce without integral truncation, so these serve as-is.
-            case DOUBLE, BOOLEAN, BYTES_REF -> value;
+            // A shared file+config cache entry can be cross-pollinated by a sibling dataset that declares this column a
+            // DIFFERENT type (the stats reconcile matches path+mtime+config only, never the declared type), so the value
+            // here may not be this arm's harvested Java type (ColumnStatsAccumulator emits Boolean / Integer / Long /
+            // Double / BytesRef). Serve only the representation buildBlock's matching arm can materialize without a crash
+            // (BOOLEAN: parseBoolean(BytesRef.toString()=hex); BYTES_REF: toBytesRef((Number).toString()); DOUBLE:
+            // (Number) cast) or a silent wrong answer; anything else safe-misses so the aggregate re-scans and is correct.
+            // This gate cannot catch a foreign value of the SAME Java type (a sibling column's Long min on a LONG column,
+            // or a keyword min that is exactly this IP column's 16 bytes): that wrong-VALUE channel closes only when the
+            // declared schema enters the cross-node stats fingerprint (tracked in the declared-schema-fingerprint follow-up).
+            case DOUBLE -> value instanceof Number ? value : null;
+            case BOOLEAN -> value instanceof Boolean ? value : null;
+            case BYTES_REF -> servableBytesRef(value, type);
         };
+    }
+
+    /**
+     * A BYTES_REF extremum is servable only as the harvested representation for the column's type: a variable-length
+     * {@link BytesRef} (or String) for KEYWORD/TEXT, or the fixed 16-byte {@code InetAddressPoint} encoding for IP (an
+     * ES|QL IP block holds exactly 16 bytes, so an ascii keyword {@code BytesRef} cross-pollinated onto an IP column
+     * would mis-decode at response rendering). A foreign {@link Number}/{@link Boolean} would be {@code toString()}'d
+     * into a bogus keyword. Serve only a matching representation; anything else safe-misses (re-scan). The 16-byte gate
+     * for IP is a representation check, not provenance: a foreign keyword min that is coincidentally 16 bytes still
+     * serves and mis-decodes — that same-representation residual closes only with the declared-schema fingerprint.
+     */
+    private static Object servableBytesRef(Object value, DataType type) {
+        if (type == DataType.IP) {
+            return value instanceof BytesRef b && b.length == 16 ? value : null;
+        }
+        return value instanceof BytesRef || value instanceof String ? value : null;
     }
 
     /** True iff {@code value} is an exact integer in {@code [min, max]}; false for fractional, out-of-range, or non-numeric. */

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolverTests.java
@@ -7,9 +7,18 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 
+import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FormatNameResolverTests extends ESTestCase {
 
@@ -98,5 +107,68 @@ public class FormatNameResolverTests extends ESTestCase {
         assertEquals(FormatNameResolver.FORMAT_PARQUET, FormatNameResolver.readerAliasToFormat(FormatNameResolver.READER_JAVA));
         assertEquals(FormatNameResolver.FORMAT_PARQUET_RS, FormatNameResolver.readerAliasToFormat(FormatNameResolver.READER_PARQUET_RS));
         assertNull(FormatNameResolver.readerAliasToFormat("unknown"));
+    }
+
+    // -- resolveFormatName: registry-routed, compound-extension aware (unlike resolve) --
+
+    /** A compound compression extension resolves to the INNER format, not the codec suffix — the compressed-read fix. */
+    public void testResolveFormatNameIsCompoundExtensionAware() {
+        FormatReaderRegistry registry = csvRegistry();
+        assertEquals("csv", FormatNameResolver.resolveFormatName(null, "hits.csv.gz", registry));
+        assertEquals("csv", FormatNameResolver.resolveFormatName(Map.of(), "s3://b/hits.csv.gz", registry));
+        assertEquals("csv", FormatNameResolver.resolveFormatName(null, "hits.csv", registry));
+        // contrast: the non-compound-aware resolve() answers the codec suffix on the same input
+        assertEquals("gz", FormatNameResolver.resolve(null, "hits.csv.gz"));
+    }
+
+    /** An explicit {@code format} override wins over the extension entirely (no registry extension lookup). */
+    public void testResolveFormatNameConfigOverrideBeatsExtension() {
+        FormatReaderRegistry registry = csvRegistry();
+        assertEquals("csv", FormatNameResolver.resolveFormatName(Map.of("format", "csv"), "hits.parquet.gz", registry));
+    }
+
+    /** An extensionless, format-less strict resource fails loud at the registry rather than resolving null. */
+    public void testResolveFormatNameThrowsOnExtensionless() {
+        FormatReaderRegistry registry = csvRegistry();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FormatNameResolver.resolveFormatName(null, "no_extension", registry)
+        );
+        assertThat(e.getMessage(), containsString("without extension"));
+    }
+
+    /**
+     * A registry with a single csv reader registered for {@code .csv}. A Mockito stub (not a real reader or a simplified
+     * subclass) is used deliberately: {@code resolveFormatName} touches only {@link FormatReader#formatName()},
+     * {@link FormatReader#fileExtensions()}, and {@link FormatReader#supportsWholeFileCompression()} (the last consulted
+     * by the compound-extension wrapping), so a full {@link FormatReader} implementation ({@code metadata}/{@code read}/
+     * {@code withConfigTrackingConsumedKeys}/{@code rowPositionStrategy}) would be far larger for zero added coverage.
+     */
+    private static FormatReaderRegistry csvRegistry() {
+        FormatReader csv = mock(FormatReader.class);
+        when(csv.formatName()).thenReturn("csv");
+        when(csv.fileExtensions()).thenReturn(List.of(".csv"));
+        when(csv.supportsWholeFileCompression()).thenReturn(true);
+        DecompressionCodecRegistry codecs = new DecompressionCodecRegistry();
+        codecs.register(new DecompressionCodec() {
+            @Override
+            public String name() {
+                return "gzip";
+            }
+
+            @Override
+            public List<String> extensions() {
+                return List.of(".gz");
+            }
+
+            @Override
+            public InputStream decompress(InputStream raw) {
+                return raw;
+            }
+        });
+        FormatReaderRegistry registry = new FormatReaderRegistry(codecs);
+        registry.registerLazy("csv", (s, bf) -> csv, Settings.EMPTY, null);
+        registry.registerExtension(".csv", "csv");
+        return registry;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -867,6 +867,34 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         );
     }
 
+    /**
+     * A NON-Number extremum on a numeric-typed column — cross-declaration garbage, e.g. a keyword min reconciled onto a
+     * column another dataset over the same file declares DOUBLE (the reconcile matches on path+mtime+config, never the
+     * declared type). It must be DROPPED and marked unservable so the serve safe-misses, never left in the map where
+     * {@code buildBlock}'s {@code (Number)} cast would {@code ClassCastException}. Holds on both the stripe path and the
+     * whole-file path — a non-Number extremum is never servable on a numeric column.
+     */
+    public void testCoerceColumnStatsToResolvedTypesDropsNonNumberOnNumericColumn() {
+        String[] names = { "v" };
+        DataType[] types = { DataType.DOUBLE };
+        for (boolean dropUnrepresentable : new boolean[] { false, true }) {
+            Map<String, Object> in = new LinkedHashMap<>();
+            in.put(SourceStatisticsSerializer.columnMinKey("v"), "alpha"); // keyword min landed on a DOUBLE column
+            in.put(SourceStatisticsSerializer.columnMaxKey("v"), 42.0);    // a valid Double max — must survive untouched
+            Map<String, Object> out = ExternalSourceCacheService.coerceColumnStatsToResolvedTypes(in, names, types, dropUnrepresentable);
+            assertFalse(
+                "non-Number min must be dropped (dropUnrepresentable=" + dropUnrepresentable + ")",
+                out.containsKey(SourceStatisticsSerializer.columnMinKey("v"))
+            );
+            assertEquals(
+                "and marked unservable so the serve safe-misses",
+                Boolean.TRUE,
+                out.get(SourceStatisticsSerializer.columnMinUnservableKey("v"))
+            );
+            assertEquals("a valid Double max is left intact", Double.valueOf(42.0), out.get(SourceStatisticsSerializer.columnMaxKey("v")));
+        }
+    }
+
     public void testColumnValueCountFoldsAcrossStripesAsSum() throws Exception {
         // COUNT(col) is served from the harvested value count. Across stripes it must SUM (each stripe holds
         // the non-null value count of its own rows), so a multivalued column's whole-file COUNT is the total

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdownTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdownTests.java
@@ -112,6 +112,35 @@ public class ExternalSourceAggregatePushdownTests extends ESTestCase {
         assertEquals(true, ExternalSourceAggregatePushdown.servableExtremum(true, DataType.BOOLEAN));
     }
 
+    /**
+     * Cross-declaration type-mismatch guard: a shared file+config cache entry can be pollinated by a sibling dataset
+     * declaring a column a DIFFERENT type (the reconcile matches path+mtime+config, never the declared type), so each
+     * non-integral {@code servableExtremum} arm must safe-miss (null) a value that is not its harvested Java type —
+     * otherwise {@code buildBlock} crashes ({@code (Number)} cast / {@code parseBoolean(BytesRef.toString()=hex)}) or
+     * serves a bogus keyword ({@code toBytesRef(Number.toString())}). The IP arm additionally requires the fixed
+     * 16-byte {@code InetAddressPoint} encoding a variable-length keyword {@code BytesRef} would violate.
+     */
+    public void testServableExtremumSafeMissesCrossDeclarationForeignTypes() {
+        // DOUBLE arm serves only a Number; a foreign BytesRef/Boolean safe-misses.
+        assertEquals(5.0, ExternalSourceAggregatePushdown.servableExtremum(5.0, DataType.DOUBLE));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(new BytesRef("5.0"), DataType.DOUBLE));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(true, DataType.DOUBLE));
+        // BOOLEAN arm serves only a Boolean; a foreign BytesRef/Number safe-misses.
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(new BytesRef("true"), DataType.BOOLEAN));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(1L, DataType.BOOLEAN));
+        // KEYWORD (BYTES_REF) arm serves BytesRef/String; a foreign Number/Boolean safe-misses.
+        assertEquals(new BytesRef("a"), ExternalSourceAggregatePushdown.servableExtremum(new BytesRef("a"), DataType.KEYWORD));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(9, DataType.KEYWORD));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(9L, DataType.KEYWORD));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(true, DataType.KEYWORD));
+        // IP (BYTES_REF) arm serves ONLY the fixed 16-byte encoding; variable-length BytesRef / String / Number safe-miss.
+        BytesRef ip16 = new BytesRef(new byte[16]);
+        assertEquals(ip16, ExternalSourceAggregatePushdown.servableExtremum(ip16, DataType.IP));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(new BytesRef("1.2.3.4"), DataType.IP));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum("1.2.3.4", DataType.IP));
+        assertNull(ExternalSourceAggregatePushdown.servableExtremum(9L, DataType.IP));
+    }
+
     public void testBuildBlockServesIpAsEncodedBytesRefNotNull() {
         // IP is in MIN_MAX_TYPES and harvested as its 16-byte InetAddressPoint encoding. buildBlock must
         // reconstruct a real IP block from it -- before the IP arm existed it fell to the default and, since


### PR DESCRIPTION
## What this is about

Two defects in the **strict user-declared-mapping** path of ES|QL external datasets (`mappings.dynamic: false`) over footerless text (CSV/TSV/NDJSON). Both are limitations of the new strict path — the inferred path is unaffected.

1. **A strict mapping over compressed text cannot be read at all.** `FROM gz_strict | LIMIT 1` fails with `No operator factory for sourceType: gz`. There is no working configuration.
2. **A strict mapping never warms `COUNT(*)`.** It full-scans + type-coerces every declared column on every query (~740 ms on a 442K-row file) where the inferred path serves a ~1.5 ms metadata read.

## What this PR does

**Compressed-text reads (defect 1).** Strict resolution derived the reader `sourceType` with a naive last-dot on the path, so `hits.csv.gz` became the codec suffix `"gz"` — never a registered format name, so operator dispatch threw. We route it through the compound-aware `FormatReaderRegistry.byExtension` (via a new `FormatNameResolver.resolveFormatName`), exactly as the inferred read path does: `CompressionDelegatingFormatReader.formatName()` returns the wrapped format, so `.csv.gz` resolves to `"csv"`. The multi-file path derives from a concrete listed file name, not the raw glob string (`*.csv.gz` and comma-lists both last-dot wrong).

**Warm `COUNT(*)` (defect 2).** Strict resolution reads no file body, so it never seeded the schema-cache entry the post-query stats reconcile enriches with the row-count — the metadata fast path could never fire. `strictSingleFileMetadata` now seeds that entry, so the first query's harvest lands and query 2+ folds `COUNT(*)` to a `LocalSourceExec`.

The stats cache is keyed by *file + config*, not by the declared schema, so one entry can be shared by datasets that declare the same file's columns differently. We keep that sharing correct by serving back **only the declaration-independent row-count**:
- per-column stats are stripped from the strict serve, so a column `MIN`/`MAX` — whose value depends on the declared type (numeric vs lexicographic order) — is re-scanned, never folded from a foreign declaration's harvest;
- only a `FAIL_FAST` error policy warms — the one policy where a successful scan's row-count equals the physical record count for any declaration (a structural error aborts before publish). Under `skip_row`/`null_field` a width-overflow row is dropped in a way that depends on the declared column count, so those re-scan (still returning the correct count).

**Cross-declaration serve safety.** Because that entry is keyed by file+config and not declared type, a sibling declaring a column a *different* type can cross-pollinate its per-column `MIN`/`MAX` into the shared entry. We make the serve total against that: `ExternalSourceAggregatePushdown.servableExtremum` type-guards every arm — a `DOUBLE`/`BOOLEAN`/`KEYWORD`/`IP` column serves a cached extremum only when it is that arm's harvested Java type — and the reconcile drops a non-`Number` extremum on a numeric column. A foreign-typed value safe-misses (re-scans) instead of crashing (`buildBlock`'s `(Number)` cast, `parseBoolean(BytesRef.toString())` on a hex string) or serving a bogus value. A *same-Java-type* cross-pollination (a sibling column's value; a `skip_row` sibling's row-count) is invisible to a type check and is the residual the declared-schema-fingerprint follow-up closes.

## Does it work?

Yes — `internalClusterTest`, all green:
- **Reads:** strict `.csv.gz` / `.tsv.gz` / `.ndjson.gz` single-file + a `*.csv.gz` multi-file glob return rows (were `sourceType: gz`).
- **Warm:** strict CSV + TSV `COUNT(*)` run twice — the second run scans zero documents (`LocalSourceExec`).
- **Cross-declaration safety:** two strict datasets over one file declaring a column integer vs keyword each return the correct `MIN` (never each other's); strict + inferred over one file likewise; an inferred `boolean` / `keyword` column reading a strict sibling's foreign-typed harvest safe-misses instead of crashing / serving the wrong value; a non-`FAIL_FAST` (`skip_row`/`null_field`) strict dataset never warms.

Touched-module `precommit` (forbiddenApis, checkstyle, licenseHeaders, spotless) is green locally.

## What's out of scope

- **Warming strict `MIN`/`MAX`** and **warming the multi-file glob** both need the declared schema woven into the cross-node stats fingerprint on both the coordinator and the data-node reader — a larger change tracked for GA. Until then those correctly re-scan (right answer, not yet fast).
- Filter pushdown over compressed text is a separate pre-existing miss (affects the inferred path too) and is not touched here.

