### PR TITLE
Don't generate zero-magnitude byte vectors in vector tests

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AbstractVectorTestCase.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AbstractVectorTestCase.java
@@ -83,6 +83,14 @@ public abstract class AbstractVectorTestCase extends ESTestCase {
         }
     }
 
+    public static byte[] randomNonZeroByteArray(int dims) {
+        byte[] vec;
+        do {
+            vec = randomByteArrayOfLength(dims);
+        } while (Arrays.equals(vec, new byte[dims]));
+        return vec;
+    }
+
     static IntFunction<float[]> FLOAT_ARRAY_RANDOM_FUNC = size -> {
         float[] fa = new float[size];
         for (int i = 0; i < size; i++) {

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int7uOSQVectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int7uOSQVectorScorerFactoryTests.java
@@ -791,14 +791,6 @@ public class Int7uOSQVectorScorerFactoryTests extends org.elasticsearch.simdvec.
         return ba;
     }
 
-    static IntFunction<float[]> FLOAT_ARRAY_RANDOM_FUNC = size -> {
-        float[] fa = new float[size];
-        for (int i = 0; i < size; i++) {
-            fa[i] = randomFloat();
-        }
-        return fa;
-    };
-
     static IntFunction<byte[]> BYTE_ARRAY_RANDOM_INT7_FUNC = size -> {
         byte[] ba = new byte[size];
         randomBytesBetween(ba, MIN_INT7_VALUE, MAX_INT7_VALUE);

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int8VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int8VectorScorerFactoryTests.java
@@ -19,7 +19,6 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectoryFactory;
 import org.junit.BeforeClass;
 
@@ -55,13 +54,13 @@ public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
 
     public void testRandomMMap() throws IOException {
         try (Directory dir = new MMapDirectory(createTempDir("testRandomMMap"), MMapDirectory.DEFAULT_MAX_CHUNK_SIZE)) {
-            testRandomSupplier(dir, ESTestCase::randomByteArrayOfLength, VectorSimilarityType.values());
+            testRandomSupplier(dir, AbstractVectorTestCase::randomNonZeroByteArray, VectorSimilarityType.values());
         }
     }
 
     public void testRandomNIO() throws IOException {
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomNIO"))) {
-            testRandomSupplier(dir, ESTestCase::randomByteArrayOfLength, VectorSimilarityType.values());
+            testRandomSupplier(dir, AbstractVectorTestCase::randomNonZeroByteArray, VectorSimilarityType.values());
         }
     }
 
@@ -69,7 +68,7 @@ public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
         try (Directory dir = new MMapDirectory(createTempDir("testRandomMaxChunkSizeSmall"), maxChunkSize)) {
-            testRandomSupplier(dir, ESTestCase::randomByteArrayOfLength, VectorSimilarityType.values());
+            testRandomSupplier(dir, AbstractVectorTestCase::randomNonZeroByteArray, VectorSimilarityType.values());
         }
     }
 
@@ -166,7 +165,7 @@ public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
         logger.info("Testing " + fileName);
         try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
             for (int i = 0; i < size; i++) {
-                byte[] vec = randomByteArrayOfLength(dims);
+                byte[] vec = randomNonZeroByteArray(dims);
                 out.writeBytes(vec, vec.length);
                 vectors[i] = vec;
             }
@@ -220,12 +219,13 @@ public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
         final int dims = randomIntBetween(1, 4096);
         final int size = randomIntBetween(2, 100);
         final byte[][] vectors = new byte[size][];
-        final byte[] queryVector = randomByteArrayOfLength(dims);
+        final byte[] queryVector = randomNonZeroByteArray(dims);
 
         String fileName = "testScorerImpl-" + dir.getClass().getSimpleName() + "-" + dims;
         try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
             for (int i = 0; i < size; i++) {
-                byte[] vec = randomByteArrayOfLength(dims);
+                // cosine doesn't like zero-length vectors
+                byte[] vec = randomNonZeroByteArray(dims);
                 out.writeBytes(vec, vec.length);
                 vectors[i] = vec;
             }
@@ -272,12 +272,12 @@ public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
         final int dims = randomIntBetween(64, 4096);
         final int size = randomIntBetween(2, 100);
         final byte[][] vectors = new byte[size][];
-        final byte[] queryVector = randomByteArrayOfLength(dims);
+        final byte[] queryVector = randomNonZeroByteArray(dims);
 
         String fileName = "testScorerBulk-" + dir.getClass().getSimpleName() + "-" + dims;
         try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
             for (int i = 0; i < size; i++) {
-                byte[] vec = randomByteArrayOfLength(dims);
+                byte[] vec = randomNonZeroByteArray(dims);
                 out.writeBytes(vec, vec.length);
                 vectors[i] = vec;
             }
@@ -313,13 +313,13 @@ public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
         assumeTrue("scorer only supported on JDK 22+", Runtime.version().feature() >= 22);
         final int dims = randomIntBetween(64, 4096);
         final int size = randomIntBetween(2, 100);
-        final byte[] queryVector = randomByteArrayOfLength(dims);
+        final byte[] queryVector = randomNonZeroByteArray(dims);
 
         try (var dir = new MMapDirectory(createTempDir("testScorerBulkWithZeroNodes"))) {
             String fileName = "testScorerBulkWithZeroNodes-" + dims;
             try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
                 for (int i = 0; i < size; i++) {
-                    byte[] vec = randomByteArrayOfLength(dims);
+                    byte[] vec = randomNonZeroByteArray(dims);
                     out.writeBytes(vec, vec.length);
                 }
                 CodecUtil.writeFooter(out);

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -785,9 +785,6 @@ tests:
 - class: org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTests
   method: testFetchRegion
   issue: https://github.com/elastic/elasticsearch/issues/153058
-- class: org.elasticsearch.simdvec.Int8VectorScorerFactoryTests
-  method: testScorerWithSNAP
-  issue: https://github.com/elastic/elasticsearch/issues/153060
 - class: org.elasticsearch.xpack.transform.integration.TransformTaskFailedStateIT
   method: testStartFailedTransform
   issue: https://github.com/elastic/elasticsearch/issues/153065


### PR DESCRIPTION
Fixes #153060

Cosine doesn't like zero-length vectors