### PR TITLE
[9.3] [Inference API] Fix tool_choice for Google Model Garden Anthropic chat completion (#152427)

### DIFF
--- a/docs/changelog/152427.yaml
+++ b/docs/changelog/152427.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues: []
+pr: 152427
+summary: Translate `tools` and `tool_choice` to Anthropic format for Google Model
+  Garden Anthropic chat completion
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtils.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.anthropic.request;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.inference.UnifiedCompletionRequest.Tool;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoice;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoiceObject;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoiceString;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.inference.UnifiedCompletionRequest.DESCRIPTION_FIELD;
+import static org.elasticsearch.inference.UnifiedCompletionRequest.NAME_FIELD;
+import static org.elasticsearch.inference.UnifiedCompletionRequest.TOOL_CHOICE_FIELD;
+import static org.elasticsearch.inference.UnifiedCompletionRequest.TOOL_FIELD;
+import static org.elasticsearch.inference.UnifiedCompletionRequest.TYPE_FIELD;
+
+/**
+ * Serializes the tool-calling portion of a unified {@code chat_completion} request into the shape expected by the
+ * <a href="https://platform.claude.com/docs/en/api/messages/create">Anthropic Messages API</a>.
+ *
+ * <p>The unified API accepts {@code tool_choice} and {@code tools} in OpenAI's vocabulary, which differs from Anthropic's.
+ * These helpers perform that translation so it is implemented in exactly one place. Both the direct Anthropic service and the
+ * Google Model Garden Anthropic provider (which proxies the same Messages API) share this logic.
+ */
+public final class AnthropicToolUtils {
+
+    private static final String TOOL_CHOICE_TOOL_TYPE = "tool";
+    private static final String INPUT_SCHEMA_FIELD = "input_schema";
+    private static final String OBJECT_TYPE = "object";
+    private static final String PROPERTIES_FIELD = "properties";
+    private static final String REQUIRED_FIELD = "required";
+
+    private AnthropicToolUtils() {}
+
+    /**
+     * Writes the {@code tool_choice} field, translating OpenAI's representation into Anthropic's. Does nothing when
+     * {@code toolChoice} is {@code null}.
+     *
+     * <ul>
+     *     <li>Object {@code {"type":"function","function":{"name":"function_name"}}} becomes
+     *         {@code {"type":"tool","name":"function_name"}}.</li>
+     *     <li>String {@code "auto"}/{@code "none"} are passed through and {@code "required"} maps to Anthropic's {@code "any"}.</li>
+     * </ul>
+     *
+     * @throws ElasticsearchStatusException if a string value is not one Anthropic understands.
+     */
+    public static void writeToolChoice(XContentBuilder builder, ToolChoice toolChoice) throws IOException {
+        if (toolChoice == null) {
+            return;
+        }
+        if (toolChoice instanceof ToolChoiceObject toolChoiceObject) {
+            builder.startObject(TOOL_CHOICE_FIELD);
+            builder.field(TYPE_FIELD, TOOL_CHOICE_TOOL_TYPE);
+            if (toolChoiceObject.function() != null) {
+                builder.field(NAME_FIELD, toolChoiceObject.function().name());
+            }
+            builder.endObject();
+        } else if (toolChoice instanceof ToolChoiceString toolChoiceString) {
+            String anthropicType = switch (toolChoiceString.value()) {
+                case "none" -> "none";
+                case "auto" -> "auto";
+                case "required" -> "any";
+                default -> throw new ElasticsearchStatusException(
+                    Strings.format("Unsupported tool_choice value [%s] for the Anthropic chat completion API.", toolChoiceString.value()),
+                    RestStatus.BAD_REQUEST
+                );
+            };
+            builder.startObject(TOOL_CHOICE_FIELD);
+            builder.field(TYPE_FIELD, anthropicType);
+            builder.endObject();
+        }
+    }
+
+    /**
+     * Writes the {@code tools} array, mapping each unified tool's function definition onto Anthropic's
+     * {@code name}/{@code description}/{@code input_schema} shape. Does nothing when {@code tools} is {@code null} or empty.
+     *
+     * <p>The OpenAI {@code strict} field has no Anthropic equivalent and is silently dropped (rather than rejected) so that
+     * OpenAI-shaped requests remain drop-in compatible, for consistency with other inference services.
+     */
+    public static void writeTools(XContentBuilder builder, List<Tool> tools) throws IOException {
+        if (tools == null || tools.isEmpty()) {
+            return;
+        }
+        builder.startArray(TOOL_FIELD);
+        for (var tool : tools) {
+            var function = tool.function();
+            builder.startObject();
+            builder.field(NAME_FIELD, function.name());
+            builder.field(DESCRIPTION_FIELD, function.description());
+            writeInputSchema(builder, function.parameters());
+            builder.endObject();
+        }
+        builder.endArray();
+    }
+
+    /**
+     * Writes a tool's {@code input_schema}. Anthropic requires a JSON-Schema object on every tool, so this always emits an object
+     * schema: {@code type} is forced to {@code "object"}, {@code properties} defaults to an empty object, {@code required} is
+     * copied through when present, and any remaining JSON-Schema keywords are passed through unchanged. When {@code parameters}
+     * is {@code null} (a parameterless tool) the minimal valid schema {@code {"type":"object","properties":{}}} is emitted.
+     */
+    private static void writeInputSchema(XContentBuilder builder, Map<String, Object> parameters) throws IOException {
+        builder.startObject(INPUT_SCHEMA_FIELD);
+        builder.field(TYPE_FIELD, OBJECT_TYPE);
+        if (parameters == null) {
+            builder.startObject(PROPERTIES_FIELD).endObject();
+            builder.endObject();
+            return;
+        }
+        var properties = parameters.get(PROPERTIES_FIELD);
+        if (properties != null) {
+            builder.field(PROPERTIES_FIELD, properties);
+        } else {
+            builder.startObject(PROPERTIES_FIELD).endObject();
+        }
+        var required = parameters.get(REQUIRED_FIELD);
+        if (required != null) {
+            builder.field(REQUIRED_FIELD, required);
+        }
+        // Preserve any other JSON-Schema keywords (e.g. additionalProperties, $defs); the incoming "type" is normalized to object.
+        for (var entry : parameters.entrySet()) {
+            var key = entry.getKey();
+            if (TYPE_FIELD.equals(key) || PROPERTIES_FIELD.equals(key) || REQUIRED_FIELD.equals(key)) {
+                continue;
+            }
+            builder.field(key, entry.getValue());
+        }
+        builder.endObject();
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntity.java
@@ -7,25 +7,19 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.request.completion;
 
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
+import org.elasticsearch.xpack.inference.services.anthropic.request.AnthropicToolUtils;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.GoogleVertexAiChatCompletionTaskSettings;
 
 import java.io.IOException;
 import java.util.Objects;
 
-import static org.elasticsearch.inference.UnifiedCompletionRequest.DESCRIPTION_FIELD;
 import static org.elasticsearch.inference.UnifiedCompletionRequest.MESSAGES_FIELD;
-import static org.elasticsearch.inference.UnifiedCompletionRequest.NAME_FIELD;
 import static org.elasticsearch.inference.UnifiedCompletionRequest.TEMPERATURE_FIELD;
-import static org.elasticsearch.inference.UnifiedCompletionRequest.TOOL_CHOICE_FIELD;
-import static org.elasticsearch.inference.UnifiedCompletionRequest.TOOL_FIELD;
 import static org.elasticsearch.inference.UnifiedCompletionRequest.TOP_P_FIELD;
-import static org.elasticsearch.inference.UnifiedCompletionRequest.TYPE_FIELD;
 import static org.elasticsearch.xpack.inference.services.mistral.MistralConstants.MAX_TOKENS_FIELD;
 
 /**
@@ -38,7 +32,6 @@ public class GoogleModelGardenAnthropicChatCompletionRequestEntity implements To
     // https://console.cloud.google.com/vertex-ai/publishers/anthropic/model-garden/claude-3-5-haiku
     private static final String VERTEX_2023_10_16 = "vertex-2023-10-16";
     private static final String STREAM_FIELD = "stream";
-    private static final String INPUT_SCHEMA_FIELD = "input_schema";
     public static final int DEFAULT_MAX_TOKENS = 1024;
 
     private final UnifiedCompletionRequest unifiedRequest;
@@ -74,35 +67,8 @@ public class GoogleModelGardenAnthropicChatCompletionRequestEntity implements To
         if (unifiedRequest.temperature() != null) {
             builder.field(TEMPERATURE_FIELD, unifiedRequest.temperature());
         }
-        var toolChoice = unifiedRequest.toolChoice();
-        if (toolChoice != null) {
-            if (toolChoice instanceof UnifiedCompletionRequest.ToolChoiceObject) {
-                builder.startObject(TOOL_CHOICE_FIELD);
-                builder.field(TYPE_FIELD, ((UnifiedCompletionRequest.ToolChoiceObject) toolChoice).type());
-                builder.endObject();
-            } else if (toolChoice instanceof UnifiedCompletionRequest.ToolChoiceString) {
-                throw new ElasticsearchStatusException(
-                    "Tool choice value is not supported as string by Google Model Garden Anthropic Chat Completion.",
-                    RestStatus.BAD_REQUEST
-                );
-            }
-        }
-        var tools = unifiedRequest.tools();
-        if (tools != null && (tools.isEmpty() == false)) {
-            builder.startArray(TOOL_FIELD);
-            for (var tool : tools) {
-                var function = tool.function();
-                builder.startObject();
-                builder.field(NAME_FIELD, function.name());
-                builder.field(DESCRIPTION_FIELD, function.description());
-                var parameters = function.parameters();
-                if (parameters != null && parameters.isEmpty() == false) {
-                    builder.field(INPUT_SCHEMA_FIELD, parameters);
-                }
-                builder.endObject();
-            }
-            builder.endArray();
-        }
+        AnthropicToolUtils.writeToolChoice(builder, unifiedRequest.toolChoice());
+        AnthropicToolUtils.writeTools(builder, unifiedRequest.tools());
         if (unifiedRequest.topP() != null) {
             builder.field(TOP_P_FIELD, unifiedRequest.topP());
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtilsTests.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.anthropic.request;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.inference.UnifiedCompletionRequest.Tool;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoice;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoiceObject;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoiceString;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+
+public class AnthropicToolUtilsTests extends ESTestCase {
+
+    private static final String TOOL_NAME = "get_price";
+    private static final String TOOL_DESCRIPTION = "Get the price";
+    private static final Map<String, Object> INPUT_SCHEMA = Map.of(
+        "type",
+        "object",
+        "properties",
+        Map.of("item", Map.of("type", "string"))
+    );
+
+    public void testWriteToolChoice_translatesObjectToToolType() throws IOException {
+        var toolChoice = new ToolChoiceObject("function", new ToolChoiceObject.FunctionField(TOOL_NAME));
+        assertToolChoiceJson(toolChoice, Strings.format("""
+            {
+                "tool_choice": {
+                    "type": "tool",
+                    "name": "%s"
+                }
+            }
+            """, TOOL_NAME));
+    }
+
+    public void testWriteToolChoice_translatesStringValues() throws IOException {
+        assertStringToolChoiceTranslation("auto", "auto");
+        assertStringToolChoiceTranslation("none", "none");
+        // OpenAI's "required" maps to Anthropic's "any".
+        assertStringToolChoiceTranslation("required", "any");
+    }
+
+    public void testWriteToolChoice_objectWithoutFunctionOmitsName() throws IOException {
+        // Defensive branch: a tool_choice object with no function still produces a valid Anthropic {"type":"tool"}.
+        assertToolChoiceJson(new ToolChoiceObject("function", null), """
+            {
+                "tool_choice": {
+                    "type": "tool"
+                }
+            }
+            """);
+    }
+
+    public void testWriteToolChoice_nullWritesNothing() throws IOException {
+        assertToolChoiceJson(null, "{}");
+    }
+
+    public void testWriteToolChoice_unsupportedStringThrows() {
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderToolChoice(new ToolChoiceString("banana")));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(exception.getMessage(), is("Unsupported tool_choice value [banana] for the Anthropic chat completion API."));
+    }
+
+    public void testWriteTools_mapsFunctionToAnthropicShape() throws IOException {
+        var tool = new Tool("function", new Tool.FunctionField(TOOL_DESCRIPTION, TOOL_NAME, INPUT_SCHEMA, null));
+        assertToolsJson(List.of(tool), Strings.format("""
+            {
+                "tools": [
+                    {
+                        "name": "%s",
+                        "description": "%s",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "item": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+            """, TOOL_NAME, TOOL_DESCRIPTION));
+    }
+
+    public void testWriteTools_defaultsInputSchemaWhenNoParameters() throws IOException {
+        // Anthropic requires an object schema on every tool, so a parameterless tool still gets the minimal {"type":"object"} schema.
+        var tool = new Tool("function", new Tool.FunctionField(TOOL_DESCRIPTION, TOOL_NAME, null, null));
+        assertToolsJson(List.of(tool), Strings.format("""
+            {
+                "tools": [
+                    {
+                        "name": "%s",
+                        "description": "%s",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    }
+                ]
+            }
+            """, TOOL_NAME, TOOL_DESCRIPTION));
+    }
+
+    public void testWriteTools_normalizesTypeAndPreservesSchemaKeywords() throws IOException {
+        // Incoming "type" is forced to object; "properties"/"required" are copied and any other keyword is passed through.
+        var parameters = Map.of(
+            "type",
+            "string",
+            "properties",
+            Map.of("item", Map.of("type", "string")),
+            "required",
+            List.of("item"),
+            "additionalProperties",
+            false
+        );
+        var tool = new Tool("function", new Tool.FunctionField(TOOL_DESCRIPTION, TOOL_NAME, parameters, null));
+        assertToolsJson(List.of(tool), Strings.format("""
+            {
+                "tools": [
+                    {
+                        "name": "%s",
+                        "description": "%s",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "item": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["item"],
+                            "additionalProperties": false
+                        }
+                    }
+                ]
+            }
+            """, TOOL_NAME, TOOL_DESCRIPTION));
+    }
+
+    public void testWriteTools_serializesMultipleTools() throws IOException {
+        var first = new Tool("function", new Tool.FunctionField("First", "first", INPUT_SCHEMA, null));
+        var second = new Tool("function", new Tool.FunctionField("Second", "second", null, null));
+        assertToolsJson(List.of(first, second), """
+            {
+                "tools": [
+                    {
+                        "name": "first",
+                        "description": "First",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "item": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "name": "second",
+                        "description": "Second",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteTools_nullOrEmptyWritesNothing() throws IOException {
+        assertToolsJson(null, "{}");
+        assertToolsJson(List.of(), "{}");
+    }
+
+    public void testWriteTools_ignoresStrictField() throws IOException {
+        // The OpenAI "strict" field has no Anthropic equivalent, so it is silently dropped rather than rejected.
+        var tool = new Tool("function", new Tool.FunctionField(TOOL_DESCRIPTION, TOOL_NAME, INPUT_SCHEMA, randomBoolean()));
+        assertToolsJson(List.of(tool), Strings.format("""
+            {
+                "tools": [
+                    {
+                        "name": "%s",
+                        "description": "%s",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "item": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+            """, TOOL_NAME, TOOL_DESCRIPTION));
+    }
+
+    private static void assertStringToolChoiceTranslation(String openAiValue, String anthropicType) throws IOException {
+        assertToolChoiceJson(new ToolChoiceString(openAiValue), Strings.format("""
+            {
+                "tool_choice": {
+                    "type": "%s"
+                }
+            }
+            """, anthropicType));
+    }
+
+    private static void assertToolChoiceJson(ToolChoice toolChoice, String expectedJson) throws IOException {
+        assertThat(renderToolChoice(toolChoice), is(XContentHelper.stripWhitespace(expectedJson)));
+    }
+
+    private static String renderToolChoice(ToolChoice toolChoice) throws IOException {
+        try (var builder = JsonXContent.contentBuilder()) {
+            builder.startObject();
+            AnthropicToolUtils.writeToolChoice(builder, toolChoice);
+            builder.endObject();
+            return Strings.toString(builder);
+        }
+    }
+
+    private static void assertToolsJson(List<Tool> tools, String expectedJson) throws IOException {
+        assertThat(renderTools(tools), is(XContentHelper.stripWhitespace(expectedJson)));
+    }
+
+    private static String renderTools(List<Tool> tools) throws IOException {
+        try (var builder = JsonXContent.contentBuilder()) {
+            builder.startObject();
+            AnthropicToolUtils.writeTools(builder, tools);
+            builder.endObject();
+            return Strings.toString(builder);
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntityTests.java
@@ -7,145 +7,194 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.request.completion;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ContentString;
+import org.elasticsearch.inference.UnifiedCompletionRequest.Message;
+import org.elasticsearch.inference.UnifiedCompletionRequest.Tool;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoice;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoiceObject;
+import org.elasticsearch.inference.UnifiedCompletionRequest.ToolChoiceString;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.GoogleVertexAiChatCompletionTaskSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.ThinkingConfig;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.is;
+
 public class GoogleModelGardenAnthropicChatCompletionRequestEntityTests extends ESTestCase {
 
+    private static final String USER_MESSAGE_CONTENT = "Hello, world!";
+    private static final String ANTHROPIC_VERSION = "vertex-2023-10-16";
+    private static final String TOOL_NAME = "name";
+    private static final String TOOL_DESCRIPTION = "description";
+    private static final Map<String, Object> TOOL_PARAMETERS = Map.of(
+        "type",
+        "object",
+        "properties",
+        Map.of("item", Map.of("type", "string"))
+    );
+
+    private static final GoogleVertexAiChatCompletionTaskSettings EMPTY_SETTINGS = GoogleVertexAiChatCompletionTaskSettings.EMPTY_SETTINGS;
+
+    // OpenAI-shaped tool_choice object {"type":"function","function":{"name":"function_name"}} must be translated to Anthropic's
+    // {"type":"tool","name":"function_name"} form, otherwise Anthropic rejects the request with a 400 (unexpected tag 'function').
+    private static final ToolChoice FUNCTION_TOOL_CHOICE = new ToolChoiceObject("function", new ToolChoiceObject.FunctionField(TOOL_NAME));
+    private static final Tool TOOL = new Tool("function", new Tool.FunctionField(TOOL_DESCRIPTION, TOOL_NAME, TOOL_PARAMETERS, null));
+
+    private static final String TOOL_CHOICE_OBJECT_JSON = Strings.format("""
+        {
+            "type": "tool",
+            "name": "%s"
+        }""", TOOL_NAME);
+
     public void testModelUserFieldsSerializationStreamingWithTemperatureAndTopK() throws IOException {
-        XContentBuilder builder = setUpXContentBuilder(0.2F, 0.2F, 100L, true, GoogleVertexAiChatCompletionTaskSettings.EMPTY_SETTINGS);
-        String expectedJson = """
-            {
-                "anthropic_version": "vertex-2023-10-16",
-                "messages": [{
-                        "content": "Hello, world!",
-                        "role": "user"
-                    }
-                ],
-                "temperature": 0.2,
-                "tool_choice": {
-                    "type": "auto"
-                },
-                "tools": [{
-                        "name": "name",
-                        "description": "description",
-                        "input_schema": {
-                            "parameterName": "parameterValue"
-                        }
-                    }
-                ],
-                "top_p": 0.2,
-                "stream": true,
-                "max_tokens": 100
-            }
-            """;
-        assertEquals(XContentHelper.stripWhitespace(expectedJson), Strings.toString(builder));
+        var actual = render(FUNCTION_TOOL_CHOICE, List.of(TOOL), 0.2F, 0.2F, 100L, true, EMPTY_SETTINGS);
+        assertThat(actual, is(expectedRequestJson(0.2F, TOOL_CHOICE_OBJECT_JSON, 0.2F, true, 100)));
     }
 
     public void testModelUserFieldsSerializationNonStreamDefaultMaxTokens() throws IOException {
-        XContentBuilder builder = setUpXContentBuilder(null, null, null, false, GoogleVertexAiChatCompletionTaskSettings.EMPTY_SETTINGS);
-        String expectedJson = """
-            {
-                "anthropic_version": "vertex-2023-10-16",
-                "messages": [{
-                        "content": "Hello, world!",
-                        "role": "user"
-                    }
-                ],
-                "tool_choice": {
-                    "type": "auto"
-                },
-                "tools": [{
-                        "name": "name",
-                        "description": "description",
-                        "input_schema": {
-                            "parameterName": "parameterValue"
-                        }
-                    }
-                ],
-                "stream": false,
-                "max_tokens": 1024
-            }
-            """;
-        assertEquals(XContentHelper.stripWhitespace(expectedJson), Strings.toString(builder));
+        var actual = render(FUNCTION_TOOL_CHOICE, List.of(TOOL), null, null, null, false, EMPTY_SETTINGS);
+        assertThat(actual, is(expectedRequestJson(null, TOOL_CHOICE_OBJECT_JSON, null, false, 1024)));
     }
 
     public void testModelUserFieldsSerializationNonStreamWithMaxTokensFromTaskSettings() throws IOException {
-        XContentBuilder builder = setUpXContentBuilder(
+        var actual = render(
+            FUNCTION_TOOL_CHOICE,
+            List.of(TOOL),
             null,
             null,
             null,
             false,
             new GoogleVertexAiChatCompletionTaskSettings(new ThinkingConfig(123), 123)
         );
-        String expectedJson = """
-            {
-                "anthropic_version": "vertex-2023-10-16",
-                "messages": [{
-                        "content": "Hello, world!",
-                        "role": "user"
-                    }
-                ],
-                "tool_choice": {
-                    "type": "auto"
-                },
-                "tools": [{
-                        "name": "name",
-                        "description": "description",
-                        "input_schema": {
-                            "parameterName": "parameterValue"
-                        }
-                    }
-                ],
-                "stream": false,
-                "max_tokens": 123
-            }
-            """;
-        assertEquals(XContentHelper.stripWhitespace(expectedJson), Strings.toString(builder));
+        assertThat(actual, is(expectedRequestJson(null, TOOL_CHOICE_OBJECT_JSON, null, false, 123)));
     }
 
-    private static XContentBuilder setUpXContentBuilder(
+    public void testToolChoiceStringAutoIsTranslated() throws IOException {
+        assertToolChoiceStringTranslation("auto", "auto");
+    }
+
+    public void testToolChoiceStringNoneIsTranslated() throws IOException {
+        assertToolChoiceStringTranslation("none", "none");
+    }
+
+    public void testToolChoiceStringRequiredIsTranslatedToAny() throws IOException {
+        assertToolChoiceStringTranslation("required", "any");
+    }
+
+    public void testUnsupportedToolChoiceStringThrows() {
+        var exception = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> render(new ToolChoiceString("unsupported"), List.of(TOOL), null, null, null, false, EMPTY_SETTINGS)
+        );
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(exception.getMessage(), is("Unsupported tool_choice value [unsupported] for the Anthropic chat completion API."));
+    }
+
+    public void testStrictToolFieldIsIgnored() throws IOException {
+        // The OpenAI "strict" field has no Anthropic equivalent, so it is silently dropped: the rendered request is identical to
+        // one built from the same tool without "strict".
+        var strictTool = new Tool("function", new Tool.FunctionField(TOOL_DESCRIPTION, TOOL_NAME, TOOL_PARAMETERS, randomBoolean()));
+        var actual = render(new ToolChoiceString("auto"), List.of(strictTool), null, null, null, false, EMPTY_SETTINGS);
+        var toolChoiceJson = """
+            {
+                "type": "auto"
+            }""";
+        assertThat(actual, is(expectedRequestJson(null, toolChoiceJson, null, false, 1024)));
+    }
+
+    private static void assertToolChoiceStringTranslation(String openAiValue, String anthropicType) throws IOException {
+        var actual = render(new ToolChoiceString(openAiValue), List.of(TOOL), null, null, null, false, EMPTY_SETTINGS);
+        var toolChoiceJson = Strings.format("""
+            {
+                "type": "%s"
+            }""", anthropicType);
+        assertThat(actual, is(expectedRequestJson(null, toolChoiceJson, null, false, 1024)));
+    }
+
+    /**
+     * Builds the expected Anthropic-shaped request body in the field order produced by the entity. {@code temperature} and
+     * {@code topP} segments collapse away when {@code null}, mirroring the optional fields in the real request.
+     */
+    private static String expectedRequestJson(Float temperature, String toolChoiceJson, Float topP, boolean stream, long maxTokens)
+        throws IOException {
+        return XContentHelper.stripWhitespace(
+            Strings.format(
+                """
+                    {
+                        "anthropic_version": "%s",
+                        "messages": [
+                            {
+                                "content": "%s",
+                                "role": "user"
+                            }
+                        ],
+                        %s
+                        "tool_choice": %s,
+                        "tools": [
+                            {
+                                "name": "%s",
+                                "description": "%s",
+                                "input_schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "item": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        %s
+                        "stream": %s,
+                        "max_tokens": %s
+                    }
+                    """,
+                ANTHROPIC_VERSION,
+                USER_MESSAGE_CONTENT,
+                temperature == null ? "" : Strings.format("\"temperature\": %s,", temperature),
+                toolChoiceJson,
+                TOOL_NAME,
+                TOOL_DESCRIPTION,
+                topP == null ? "" : Strings.format("\"top_p\": %s,", topP),
+                stream,
+                maxTokens
+            )
+        );
+    }
+
+    private static String render(
+        ToolChoice toolChoice,
+        List<Tool> tools,
         Float topP,
         Float temperature,
         Long maxCompletionTokens,
         boolean stream,
         GoogleVertexAiChatCompletionTaskSettings taskSettings
     ) throws IOException {
-        var message = new UnifiedCompletionRequest.Message(new UnifiedCompletionRequest.ContentString("Hello, world!"), "user", null, null);
-        var messageList = new ArrayList<UnifiedCompletionRequest.Message>();
-        messageList.add(message);
         var unifiedRequest = new UnifiedCompletionRequest(
-            messageList,
+            List.of(new Message(new ContentString(USER_MESSAGE_CONTENT), "user", null, null)),
             null,
             maxCompletionTokens,
             null,
             temperature,
-            new UnifiedCompletionRequest.ToolChoiceObject("auto", new UnifiedCompletionRequest.ToolChoiceObject.FunctionField("name")),
-            List.of(
-                new UnifiedCompletionRequest.Tool(
-                    "function",
-                    new UnifiedCompletionRequest.Tool.FunctionField("description", "name", Map.of("parameterName", "parameterValue"), null)
-                )
-            ),
+            toolChoice,
+            tools,
             topP
         );
-        var unifiedChatInput = new UnifiedChatInput(unifiedRequest, stream);
-        var entity = new GoogleModelGardenAnthropicChatCompletionRequestEntity(unifiedChatInput.getRequest(), stream, taskSettings);
-        var builder = JsonXContent.contentBuilder();
-        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        return builder;
+        var entity = new GoogleModelGardenAnthropicChatCompletionRequestEntity(unifiedRequest, stream, taskSettings);
+        try (var builder = JsonXContent.contentBuilder()) {
+            entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            return Strings.toString(builder);
+        }
     }
 }


### PR DESCRIPTION
Manual backport of #152427 to `9.3`.

The automatic cherry-pick failed for two reasons: the original PR modifies the standalone `AnthropicUnifiedChatCompletionRequestEntity` (which does not exist on `9.3`), and `9.3` uses an older model API where `Tool`, `ToolChoice`, `ToolChoiceObject/String`, `Message` and `ContentString` are nested inside `UnifiedCompletionRequest` (rather than the `org.elasticsearch.inference.completion.*` package), with the field-name constants on `UnifiedCompletionRequest` instead of `UnifiedCompletionUtils`.

## What this backport includes
- New shared `AnthropicToolUtils` that translates the OpenAI-shaped `tool_choice` and `tools` into the Anthropic Messages API format, adapted to `9.3`'s `UnifiedCompletionRequest` model API.
- `GoogleModelGardenAnthropicChatCompletionRequestEntity` now delegates to `AnthropicToolUtils` (this is the actual bug fix).
- `AnthropicToolUtilsTests` and the updated `GoogleModelGardenAnthropicChatCompletionRequestEntityTests`.
- Changelog `152427.yaml`.

## What is intentionally omitted
- All changes to `AnthropicUnifiedChatCompletionRequestEntity(.java/Tests)` - that standalone unified Anthropic entity does not exist on `9.3`.

## Verification
`./gradlew spotlessApply server:checkstyleMain :x-pack:plugin:inference:test` - BUILD SUCCESSFUL.
