### PR TITLE
[ESQL] Bound concurrent streaming segmentators

### DIFF
--- a/docs/changelog/153120.yaml
+++ b/docs/changelog/153120.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153120
+summary: Bound concurrent streaming segmentators
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -69,6 +69,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -236,6 +237,14 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final long statsStripeSize;
     /** How much per-stripe statistics a fresh scan harvests (row count only / + projected / + all / nothing). */
     private final StripeColumnScope statsColumnScope;
+    /**
+     * Node-level gate bounding concurrent streaming (stream-only compressed) segmentators on the shared
+     * {@code esql_external_io} pool so their per-chunk parser tasks are never starved of a thread. Shared across
+     * queries/operators (see {@link StreamingSegmentatorAdmission}). Never {@code null}: production threads the
+     * per-node controller from {@link FileSourceFactory}; test builders default to
+     * {@link StreamingSegmentatorAdmission#unbounded()}, which dispatches immediately.
+     */
+    private final StreamingSegmentatorAdmission streamingSegmentatorAdmission;
     private final List<Expression> pushedExpressions;
     private final FilterPushdownSupport pushdownSupport;
     private final Closeable onClose;
@@ -325,6 +334,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         int maxRecordBytes,
         long statsStripeSize,
         StripeColumnScope statsColumnScope,
+        StreamingSegmentatorAdmission streamingSegmentatorAdmission,
         @Nullable List<Expression> pushedExpressions,
         @Nullable FilterPushdownSupport pushdownSupport,
         @Nullable Closeable onClose,
@@ -428,6 +438,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
         this.maxConcurrentOpenSegments = Math.max(1, maxConcurrentOpenSegments);
         this.maxRecordBytes = maxRecordBytes;
+        this.streamingSegmentatorAdmission = streamingSegmentatorAdmission;
         this.pushedExpressions = pushedExpressions != null ? pushedExpressions : List.of();
         this.pushdownSupport = pushdownSupport;
         this.onClose = onClose;
@@ -518,6 +529,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         private int maxRecordBytes = SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES;
         private long statsStripeSize = -1L;
         private StripeColumnScope statsColumnScope = StripeColumnScope.PROJECTED;
+        // Non-null default: test builders that never set one still get an (unbounded) controller, so the streaming
+        // coordinator's admission is never null. Production (FileSourceFactory) overrides with the per-node gate.
+        private StreamingSegmentatorAdmission streamingSegmentatorAdmission = StreamingSegmentatorAdmission.unbounded();
         private List<Expression> pushedExpressions;
         private FilterPushdownSupport pushdownSupport;
         private Closeable onClose;
@@ -730,6 +744,16 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return this;
         }
 
+        /**
+         * Node-level gate bounding concurrent streaming segmentators on the shared {@code esql_external_io} pool
+         * (see {@link StreamingSegmentatorAdmission}). Set by {@link FileSourceFactory} from node settings; when
+         * unset the builder keeps its {@link StreamingSegmentatorAdmission#unbounded()} default.
+         */
+        public Builder streamingSegmentatorAdmission(StreamingSegmentatorAdmission streamingSegmentatorAdmission) {
+            this.streamingSegmentatorAdmission = Objects.requireNonNull(streamingSegmentatorAdmission, "admission");
+            return this;
+        }
+
         public AsyncExternalSourceOperatorFactory build() {
             return new AsyncExternalSourceOperatorFactory(
                 storageProvider,
@@ -757,6 +781,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 maxRecordBytes,
                 statsStripeSize,
                 statsColumnScope,
+                streamingSegmentatorAdmission,
                 pushedExpressions,
                 pushdownSupport,
                 onClose,
@@ -2563,7 +2588,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         captureSink,
                         statsStripeSize,
                         statsColumnScope,
-                        partialResultsWarningSink
+                        partialResultsWarningSink,
+                        streamingSegmentatorAdmission
                     );
                 } catch (Exception e) {
                     try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettings.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 
 import java.util.List;
 
@@ -27,6 +29,8 @@ import java.util.List;
  * overwhelming storage backends.
  */
 public final class ExternalSourceSettings {
+
+    private static final Logger logger = LogManager.getLogger(ExternalSourceSettings.class);
 
     private ExternalSourceSettings() {}
 
@@ -125,6 +129,61 @@ public final class ExternalSourceSettings {
         500,
         Setting.Property.NodeScope
     );
+
+    /**
+     * Upper bound on how many stream-only-compressed (gzip/zstd) segmentators may occupy the
+     * {@code esql_external_io} pool at once, across all queries and operators on the node. Each open streaming read
+     * runs one long-lived segmentator that pins a pool thread while it blocks on its chunk/buffer queues and the
+     * upstream decompress stream; its per-chunk parser tasks run on the same pool. Without a cap, enough
+     * concurrently-open reads pin every pool thread and their parser tasks — queued behind the segmentators — never
+     * get a thread, deadlocking the reads (elastic/esql-planning #1093, item 4). Bounding concurrent segmentators
+     * below the pool size guarantees threads remain free for parser tasks.
+     * <p>
+     * Default {@code 0} means "derive": the effective cap tracks the {@code esql_external_io} pool size
+     * ({@link #externalIoThreads(Settings)}), clamped to {@code poolSize - 1} so at least one pool thread always
+     * remains for parser tasks. An explicit positive value overrides the derivation (still clamped below the pool
+     * size). Node-scoped: the pool is sized at startup.
+     */
+    public static final Setting<Integer> MAX_CONCURRENT_SEGMENTATORS = Setting.intSetting(
+        "esql.external.max_concurrent_segmentators",
+        0,
+        0,
+        4096,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Effective cap on concurrent stream-only-compressed segmentators for a node, resolving {@link #MAX_CONCURRENT_SEGMENTATORS}
+     * ({@code 0} = derive) and clamping the result to {@code [1, poolSize - 1]} so at least one {@code esql_external_io}
+     * thread always remains for the one-shot parser tasks that a segmentator depends on. The pool size is
+     * {@link #externalIoThreads(Settings)}, which sizes that pool; the derived default tracks it, so the cap is
+     * {@code poolSize - 1} unless an operator sets a lower explicit value. An explicit value above {@code poolSize - 1}
+     * is clamped and logged at WARN so the operator sees it was ineffective.
+     * <p>
+     * Degenerate case: a {@code poolSize == 1} pool (only reachable by explicitly setting
+     * {@code esql.external.max_concurrent_requests=1}) floors the cap at 1, which cannot leave a free parser thread —
+     * parallel streaming needs {@code poolSize >= 2} to be deadlock-free. At that size the deadlock-free path is the
+     * single-pass fallback (parallelism {@code <= 1}), which runs no segmentator; a parallel streaming read on a
+     * one-thread pool is a misconfiguration this cap cannot rescue.
+     */
+    public static int maxConcurrentSegmentators(Settings settings) {
+        int poolSize = externalIoThreads(settings);
+        int configured = MAX_CONCURRENT_SEGMENTATORS.get(settings);
+        int desired = configured > 0 ? configured : poolSize;
+        int cap = Math.max(1, Math.min(desired, poolSize - 1));
+        if (configured > 0 && configured > poolSize - 1) {
+            logger.warn(
+                "[{}]=[{}] exceeds the esql_external_io pool headroom and was clamped to [{}] (pool size [{}] - 1) "
+                    + "so a thread stays free for parser tasks; lower the setting or raise [{}] to make it effective",
+                MAX_CONCURRENT_SEGMENTATORS.getKey(),
+                configured,
+                cap,
+                poolSize,
+                MAX_CONCURRENT_REQUESTS.getKey()
+            );
+        }
+        return cap;
+    }
 
     /**
      * Maximum total time (in seconds) to spend retrying throttled cloud API requests
@@ -237,6 +296,7 @@ public final class ExternalSourceSettings {
     public static List<Setting<?>> settings() {
         return List.of(
             MAX_CONCURRENT_REQUESTS,
+            MAX_CONCURRENT_SEGMENTATORS,
             THROTTLE_MAX_RETRY_DURATION,
             MAX_DISCOVERED_FILES,
             MAX_GLOB_EXPANSION,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -112,6 +112,13 @@ final class FileSourceFactory implements ExternalSourceFactory {
     private final LocalFileAccess localFileAccess;
     // Node telemetry sink, threaded into the operator factory so opened storage objects publish read metrics.
     private final ExternalSourceMetrics externalSourceMetrics;
+    /**
+     * Per-node gate bounding concurrent stream-only-compressed segmentators on the shared {@code esql_external_io}
+     * pool so their per-chunk parser tasks always have a free thread (elastic/esql-planning #1093, item 4). This
+     * factory is a per-node singleton (built once in {@link DataSourceModule}) and every read resolves to the same
+     * node-level pool, so one controller here is shared across all queries/operators — no external registry needed.
+     */
+    private final StreamingSegmentatorAdmission segmentatorAdmission;
 
     FileSourceFactory(
         StorageProviderRegistry storageRegistry,
@@ -190,6 +197,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
         this.blockFactory = blockFactory;
         this.localFileAccess = localFileAccess != null ? localFileAccess : LocalFileAccess.UNRESTRICTED;
         this.externalSourceMetrics = externalSourceMetrics != null ? externalSourceMetrics : ExternalSourceMetrics.NOOP;
+        this.segmentatorAdmission = new StreamingSegmentatorAdmission(ExternalSourceSettings.maxConcurrentSegmentators(this.settings));
     }
 
     @Override
@@ -477,6 +485,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 .maxRecordBytes(context.maxRecordBytes())
                 .statsStripeSize(ExternalSourceCacheSettings.STRIPE_SIZE.get(settings).getBytes())
                 .statsColumnScope(ExternalSourceCacheSettings.STRIPE_COLUMNS.get(settings))
+                .streamingSegmentatorAdmission(segmentatorAdmission)
                 .parallelism(context.parallelism())
                 .pushedExpressions(pushedExpressions)
                 .pushdownSupport(pushdownSupport)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -117,7 +117,8 @@ public final class StreamingParallelParsingCoordinator {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
-            null
+            null,
+            StreamingSegmentatorAdmission.unbounded()
         );
     }
 
@@ -164,7 +165,8 @@ public final class StreamingParallelParsingCoordinator {
         @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
         long statsStripeSize,
         StripeColumnScope statsColumnScope,
-        @Nullable Consumer<String> partialResultsWarningSink
+        @Nullable Consumer<String> partialResultsWarningSink,
+        StreamingSegmentatorAdmission admission
     ) throws IOException {
         if (logger.isDebugEnabled()) {
             logger.debug(
@@ -210,7 +212,51 @@ public final class StreamingParallelParsingCoordinator {
             captureSink,
             statsStripeSize,
             statsColumnScope,
-            partialResultsWarningSink
+            partialResultsWarningSink,
+            admission
+        );
+    }
+
+    /**
+     * Convenience overload that supplies an {@link StreamingSegmentatorAdmission#unbounded()} controller: the
+     * segmentator is dispatched immediately, matching the pre-admission behavior. Retained for tests and benchmarks
+     * running on an isolated, generously-sized pool where segmentator saturation cannot arise; production always
+     * threads the per-node admission gate.
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        InputStream decompressedStream,
+        @Nullable StorageObject storageObject,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy,
+        @Nullable List<Attribute> readSchema,
+        long baseFileOffset,
+        int maxRecordBytes,
+        @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
+        long statsStripeSize,
+        StripeColumnScope statsColumnScope,
+        @Nullable Consumer<String> partialResultsWarningSink
+    ) throws IOException {
+        return parallelRead(
+            reader,
+            decompressedStream,
+            storageObject,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            errorPolicy,
+            readSchema,
+            baseFileOffset,
+            maxRecordBytes,
+            captureSink,
+            statsStripeSize,
+            statsColumnScope,
+            partialResultsWarningSink,
+            StreamingSegmentatorAdmission.unbounded()
         );
     }
 
@@ -255,6 +301,13 @@ public final class StreamingParallelParsingCoordinator {
         /** Compressed file being decompressed; {@code null} in tests that only supply a stream. */
         @Nullable
         private final StorageObject storageObject;
+        /**
+         * Node-level gate bounding how many segmentators occupy the shared {@code esql_external_io} pool at once,
+         * so parser tasks are never starved of a thread (see {@link StreamingSegmentatorAdmission}). Never
+         * {@code null}: production threads the per-node controller; tests/benchmarks on an isolated, generously-sized
+         * pool pass {@link StreamingSegmentatorAdmission#unbounded()}, which dispatches immediately.
+         */
+        private final StreamingSegmentatorAdmission admission;
 
         private final ArrayBlockingQueue<byte[]> bufferPool;
         private final ArrayBlockingQueue<Chunk> chunkQueue;
@@ -329,6 +382,11 @@ public final class StreamingParallelParsingCoordinator {
          */
         private final AtomicReference<SubscribableListener<Void>> pendingReady = new AtomicReference<>();
 
+        /**
+         * Convenience overload for tests/benchmarks that supplies an {@link StreamingSegmentatorAdmission#unbounded()}
+         * controller, so the segmentator is dispatched immediately (matching the pre-admission behavior) on an
+         * isolated, generously-sized pool where saturation cannot arise.
+         */
         StreamingParallelIterator(
             SegmentableFormatReader reader,
             InputStream decompressedStream,
@@ -346,6 +404,45 @@ public final class StreamingParallelParsingCoordinator {
             StripeColumnScope statsColumnScope,
             @Nullable Consumer<String> partialResultsWarningSink
         ) {
+            this(
+                reader,
+                decompressedStream,
+                storageObject,
+                projectedColumns,
+                batchSize,
+                parallelism,
+                executor,
+                errorPolicy,
+                readSchema,
+                baseFileOffset,
+                maxRecordBytes,
+                captureSink,
+                statsStripeSize,
+                statsColumnScope,
+                partialResultsWarningSink,
+                StreamingSegmentatorAdmission.unbounded()
+            );
+        }
+
+        StreamingParallelIterator(
+            SegmentableFormatReader reader,
+            InputStream decompressedStream,
+            @Nullable StorageObject storageObject,
+            List<String> projectedColumns,
+            int batchSize,
+            int parallelism,
+            Executor executor,
+            ErrorPolicy errorPolicy,
+            @Nullable List<Attribute> readSchema,
+            long baseFileOffset,
+            int maxRecordBytes,
+            @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
+            long statsStripeSize,
+            StripeColumnScope statsColumnScope,
+            @Nullable Consumer<String> partialResultsWarningSink,
+            StreamingSegmentatorAdmission admission
+        ) {
+            this.admission = admission;
             this.reader = reader;
             this.storageObject = storageObject;
             this.projectedColumns = projectedColumns;
@@ -387,13 +484,23 @@ public final class StreamingParallelParsingCoordinator {
             // where producer-loop drivers and sub-tasks of other iterators competed for the same slots.
             this.tasksOutstanding = new AtomicInteger(1);
 
-            try {
-                executor.execute(() -> runSegmentator(decompressedStream, this.chunkSize));
-            } catch (RejectedExecutionException e) {
-                firstError.compareAndSet(null, e);
-                if (tasksOutstanding.decrementAndGet() == 0) {
-                    signalReady();
-                }
+            // Gate the segmentator through the node-level admission controller so it is handed to the pool only when
+            // a thread will remain free for its parser tasks; a rejection is surfaced through the firstError /
+            // signalReady path. Tests that run on an isolated, generously-sized pool pass an unbounded controller,
+            // which dispatches immediately (see StreamingSegmentatorAdmission#unbounded).
+            Runnable segmentatorTask = () -> runSegmentator(decompressedStream, this.chunkSize);
+            admission.submit(segmentatorTask, executor, this::onSegmentatorLaunchRejected);
+        }
+
+        /**
+         * Records a segmentator that never started (the executor rejected it) and wakes the consumer. The
+         * segmentator is counted in {@link #tasksOutstanding} at construction, so failing to launch must decrement
+         * it or the consumer's EOF predicate never fires. Invoked by the admission controller on a rejection.
+         */
+        private void onSegmentatorLaunchRejected(RejectedExecutionException e) {
+            firstError.compareAndSet(null, e);
+            if (tasksOutstanding.decrementAndGet() == 0) {
+                signalReady();
             }
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingSegmentatorAdmission.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingSegmentatorAdmission.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Consumer;
+
+/**
+ * Node-level admission controller that caps how many {@link StreamingParallelParsingCoordinator} segmentators
+ * may occupy the shared {@code esql_external_io} pool at once, guaranteeing that pool threads always remain free
+ * to run the one-shot parser tasks a segmentator depends on.
+ * <p>
+ * <strong>The hazard it closes.</strong> Each open stream-only compressed read runs a single long-lived
+ * segmentator task on {@code esql_external_io}; that task blocks on {@code chunkQueue.put},
+ * {@code dispatchPermits.acquire}, {@code bufferPool.take}, and the upstream decompress {@code InputStream.read},
+ * so it pins a pool thread for as long as the read is open. Its per-chunk parser tasks are submitted to the
+ * <em>same</em> pool. When the number of concurrently-open segmentators reaches the pool size, every thread is
+ * pinned by a segmentator that is itself waiting for a parser task to drain its queues — but those parser tasks
+ * are stuck behind the segmentators in the pool's work queue and never get a thread. The off-pool consumers then
+ * wait forever for pages that never arrive: a producer-side thread-footprint deadlock (elastic/esql-planning
+ * #1093, structural-fix item 4), independent of the drain-side fix in #153074.
+ * <p>
+ * <strong>Why the gate must precede submission.</strong> A semaphore acquired <em>inside</em> the segmentator
+ * task would not help: a segmentator blocked on {@code acquire()} still holds its pool thread. This controller
+ * therefore gates <em>before</em> handing the task to the executor. When the concurrency budget is exhausted the
+ * segmentator is queued here (holding no pool thread) and dispatched only once a running segmentator completes
+ * and frees its slot. Because at most {@link #maxConcurrentSegmentators} segmentators are ever handed to the pool,
+ * at least {@code poolSize - maxConcurrentSegmentators} threads always remain available to run parser tasks, which
+ * are short-lived and self-terminating, so the read always makes progress.
+ * <p>
+ * A single instance is created once per node and held by {@link FileSourceFactory} (itself a per-node singleton),
+ * so every coordinator submitting to the shared read pool shares one budget — the hazard spans operators and
+ * queries, not a single read. The submitting executor is supplied per {@link #submit} call rather than stored,
+ * so the controller holds no reference to the pool. Use {@link #unbounded()} on test/benchmark paths that run on
+ * an isolated, generously-sized pool where segmentator saturation cannot arise.
+ */
+final class StreamingSegmentatorAdmission {
+
+    private final int maxConcurrentSegmentators;
+
+    /** Segmentators currently handed to the pool (running or queued in the pool's own work queue). Guarded by {@code this}. */
+    private int running = 0;
+    /** Segmentators admitted here but not yet handed to the pool because the budget was full. Guarded by {@code this}. */
+    private final ArrayDeque<Deferred> pending = new ArrayDeque<>();
+
+    private record Deferred(Runnable segmentator, Executor executor, Consumer<RejectedExecutionException> onReject) {}
+
+    /**
+     * An effectively-unbounded controller ({@link Integer#MAX_VALUE} budget) that dispatches every segmentator
+     * immediately. Test/benchmark-only: use on isolated, generously-sized pools where the saturation hazard cannot
+     * arise. Production always constructs a controller with a real, pool-derived cap.
+     */
+    static StreamingSegmentatorAdmission unbounded() {
+        return new StreamingSegmentatorAdmission(Integer.MAX_VALUE);
+    }
+
+    StreamingSegmentatorAdmission(int maxConcurrentSegmentators) {
+        this.maxConcurrentSegmentators = Math.max(1, maxConcurrentSegmentators);
+    }
+
+    /**
+     * Admits a segmentator: runs it on {@code executor} immediately if the concurrency budget allows, otherwise
+     * queues it until a running segmentator completes. {@code onReject} runs (on some pool thread, possibly later)
+     * if the executor refuses the task — the coordinator uses it to record the failure and wake its consumer,
+     * exactly as the pre-admission direct-{@code execute} path did on a {@link RejectedExecutionException}. All
+     * coordinators sharing this controller submit to the same node-level pool, so the executor is stable across
+     * calls; it is passed per call so the controller need not hold a reference to it.
+     */
+    void submit(Runnable segmentator, Executor executor, Consumer<RejectedExecutionException> onReject) {
+        Deferred toDispatch;
+        synchronized (this) {
+            if (running < maxConcurrentSegmentators) {
+                running++;
+                toDispatch = new Deferred(segmentator, executor, onReject);
+            } else {
+                pending.add(new Deferred(segmentator, executor, onReject));
+                return;
+            }
+        }
+        dispatch(toDispatch);
+    }
+
+    /**
+     * Hands {@code d} to its executor, wrapping it so the slot is released and the next pending segmentator promoted
+     * when it completes. On a {@link RejectedExecutionException} the reserved slot is freed and any promoted-then-
+     * rejected successor is handled in the same loop, so a cascade of rejections (e.g. pool shutdown) unwinds
+     * iteratively rather than recursively.
+     */
+    private void dispatch(Deferred d) {
+        while (d != null) {
+            try {
+                Deferred toRun = d;
+                toRun.executor().execute(() -> {
+                    try {
+                        toRun.segmentator().run();
+                    } finally {
+                        dispatch(releaseAndPromote());
+                    }
+                });
+                return;
+            } catch (RejectedExecutionException e) {
+                d.onReject().accept(e);
+                d = releaseAndPromote();
+            }
+        }
+    }
+
+    /** Frees the slot held by a just-finished (or rejected) segmentator and returns the next pending one to dispatch, if any. */
+    private synchronized Deferred releaseAndPromote() {
+        running--;
+        Deferred next = pending.poll();
+        if (next != null) {
+            running++;
+        }
+        return next;
+    }
+
+    int maxConcurrentSegmentators() {
+        return maxConcurrentSegmentators;
+    }
+
+    /** Test-only: segmentators currently handed to the pool (running or queued in the pool). */
+    synchronized int running() {
+        return running;
+    }
+
+    /** Test-only: segmentators admitted but not yet handed to the pool because the budget was full. */
+    synchronized int pending() {
+        return pending.size();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceSettingsTests.java
@@ -127,8 +127,42 @@ public class ExternalSourceSettingsTests extends ESTestCase {
 
     public void testSettingsListNotEmpty() {
         assertFalse(ExternalSourceSettings.settings().isEmpty());
-        assertEquals(8, ExternalSourceSettings.settings().size());
+        assertEquals(9, ExternalSourceSettings.settings().size());
         assertTrue(ExternalSourceSettings.settings().contains(ExternalSourceSettings.MAX_CONCURRENT_REQUESTS));
+    }
+
+    public void testMaxConcurrentSegmentatorsDefaultDerivesBelowPoolSize() {
+        // Default (0) derives the cap from the pool size (externalIoThreads) and clamps it to poolSize - 1, so a
+        // pool thread always remains for the one-shot parser tasks a segmentator depends on.
+        Settings settings = Settings.builder().put("node.processors", 4).build();
+        int poolSize = ExternalSourceSettings.externalIoThreads(settings);
+        assertEquals(poolSize - 1, ExternalSourceSettings.maxConcurrentSegmentators(settings));
+        assertTrue("cap must leave a pool thread for parsers", ExternalSourceSettings.maxConcurrentSegmentators(settings) < poolSize);
+    }
+
+    public void testMaxConcurrentSegmentatorsExplicitOverride() {
+        // A pool large enough that the explicit value is not clamped.
+        Settings settings = Settings.builder()
+            .put("esql.external.max_concurrent_requests", 64)
+            .put("esql.external.max_concurrent_segmentators", 24)
+            .build();
+        assertEquals(24, ExternalSourceSettings.maxConcurrentSegmentators(settings));
+    }
+
+    public void testMaxConcurrentSegmentatorsClampedBelowPoolSize() {
+        // A tiny pool forces the cap down to poolSize - 1 so at least one thread stays free for parser tasks.
+        Settings settings = Settings.builder()
+            .put("esql.external.max_concurrent_requests", 4)
+            .put("esql.external.max_concurrent_segmentators", 100)
+            .build();
+        assertEquals(3, ExternalSourceSettings.maxConcurrentSegmentators(settings));
+    }
+
+    public void testMaxConcurrentSegmentatorsAtLeastOne() {
+        // Degenerate single-thread pool: the cap floors at 1 (streaming parallel parsing needs >= 2 threads to be
+        // deadlock-free, but the cap must never be zero).
+        Settings settings = Settings.builder().put("esql.external.max_concurrent_requests", 1).build();
+        assertEquals(1, ExternalSourceSettings.maxConcurrentSegmentators(settings));
     }
 
     public void testManagedIdentityDefaultFalse() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -1017,6 +1017,115 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         private final List<String> lines = new ArrayList<>();
     }
 
+    /**
+     * Evidence-first repro for the {@code esql_external_io} segmentator-saturation hazard
+     * (elastic/esql-planning #1093, structural-fix item 4). Faithfully mirrors the post-#153074 two-pool
+     * wiring: segmentators <em>and</em> their one-shot parser tasks share a single bounded pool of size
+     * {@code K} (the production {@code esql_external_io} pool), while the consumer drains run on a
+     * <strong>separate</strong> pool (the production {@code esql_worker} producer-loop drivers).
+     * <p>
+     * With {@code F >= K} concurrently-open streaming reads over content large enough that each segmentator
+     * stays alive across many chunks, every pool thread could be pinned by a segmentator that is itself
+     * blocked — on {@code chunkQueue.put}, {@code dispatchPermits.acquire}, or {@code bufferPool.take} —
+     * waiting for a parser task to drain its per-iterator queues. Those parser tasks are queued behind
+     * the segmentators on the same pool and would never get a thread; the off-pool consumers would then wait
+     * forever for pages that never arrive — a producer-side thread-footprint deadlock, independent of the
+     * #153074 drain-side fix.
+     * <p>
+     * The {@link StreamingSegmentatorAdmission} gate closes it: sized to {@code poolSize - 1} here, it lets at
+     * most {@code K - 1} segmentators occupy the pool at once, keeping a thread free for parser tasks; the
+     * remaining segmentators are queued in the controller (holding no pool thread) and dispatched as running
+     * ones finish. The test drives {@code F == K} readers with large per-file content and asserts every read
+     * drains within a generous deadline. Without the admission gate this hangs (caught by the deadline, not an
+     * infinite suite stall — {@code shutdownNow} in the finally unwinds any parked threads); a
+     * {@code sharedIoPool}-sized admission proves the fix restores liveness.
+     */
+    public void testConcurrentSegmentatorsSaturatingSharedPoolDoNotDeadlock() throws Exception {
+        int sharedPoolSize = 4;
+        int fileCount = sharedPoolSize; // F == K: enough segmentators to pin every shared-pool thread
+        int parsingParallelism = 4;
+        int lineCount = 20_000; // large enough that each segmentator loops across hundreds of chunks
+        int chunkSize = 128;    // tiny chunks force the segmentator to stay alive and keep dispatching
+        byte[] contentBytes = buildContent(lineCount).getBytes(StandardCharsets.UTF_8);
+
+        // Segmentators + parser tasks share this bounded pool (production: esql_external_io).
+        ExecutorService sharedIoPool = Executors.newFixedThreadPool(sharedPoolSize);
+        // Consumer drains run here (production: esql_worker producer-loop drivers), one per reader.
+        ExecutorService drainPool = Executors.newFixedThreadPool(fileCount);
+        // Cap concurrent segmentators one below the pool size so a thread always remains for parser tasks.
+        StreamingSegmentatorAdmission admission = new StreamingSegmentatorAdmission(sharedPoolSize - 1);
+        List<CloseableIterator<Page>> iterators = new ArrayList<>();
+        try {
+            for (int f = 0; f < fileCount; f++) {
+                LineFormatReader reader = new LineFormatReader(chunkSize);
+                iterators.add(
+                    StreamingParallelParsingCoordinator.parallelRead(
+                        reader,
+                        new ByteArrayInputStream(contentBytes),
+                        null,
+                        List.of("line"),
+                        50,
+                        parsingParallelism,
+                        sharedIoPool,
+                        ErrorPolicy.STRICT,
+                        null,
+                        0L,
+                        SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                        null,
+                        -1L,
+                        StripeColumnScope.PROJECTED,
+                        null,
+                        admission
+                    )
+                );
+            }
+
+            CountDownLatch done = new CountDownLatch(fileCount);
+            List<Throwable> failures = new CopyOnWriteArrayList<>();
+            AtomicInteger totalRows = new AtomicInteger();
+            for (CloseableIterator<Page> it : iterators) {
+                drainPool.execute(() -> {
+                    try {
+                        int rows = 0;
+                        while (it.hasNext()) {
+                            Page page = it.next();
+                            rows += page.getPositionCount();
+                            page.releaseBlocks();
+                        }
+                        totalRows.addAndGet(rows);
+                    } catch (Throwable t) {
+                        failures.add(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            boolean completed = done.await(30, TimeUnit.SECONDS);
+            assertTrue(
+                "F("
+                    + fileCount
+                    + ") concurrent streaming segmentators on a shared pool of size "
+                    + sharedPoolSize
+                    + " never drained: their parser tasks starved. The admission gate ("
+                    + admission.maxConcurrentSegmentators()
+                    + " concurrent segmentators) must keep a pool thread free for parsers "
+                    + "(regression of the esql-planning #1093 item 4 fix).",
+                completed
+            );
+            assertTrue("no drain thread should have failed: " + failures, failures.isEmpty());
+            assertEquals("every reader must deliver all rows", fileCount * lineCount, totalRows.get());
+        } finally {
+            for (CloseableIterator<Page> it : iterators) {
+                try {
+                    it.close();
+                } catch (IOException ignored) {}
+            }
+            drainPool.shutdownNow();
+            sharedIoPool.shutdownNow();
+        }
+    }
+
     private static String buildContent(int lineCount) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lineCount; i++) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingSegmentatorAdmissionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingSegmentatorAdmissionTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StreamingSegmentatorAdmissionTests extends ESTestCase {
+
+    /**
+     * The controller must never hand more than {@code maxConcurrentSegmentators} tasks to the pool at once, even
+     * when the pool itself has spare threads: excess submissions are queued in the controller (holding no pool
+     * thread) and dispatched only as running ones complete. This is the invariant that keeps pool threads free for
+     * the parser tasks a segmentator depends on.
+     */
+    public void testCapsConcurrentSegmentatorsBelowPoolSize() throws Exception {
+        int cap = 2;
+        int submissions = 5;
+        // Pool larger than the cap so the CONTROLLER, not the pool, is the limiter.
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        try {
+            StreamingSegmentatorAdmission admission = new StreamingSegmentatorAdmission(cap);
+            CountDownLatch release = new CountDownLatch(1);
+            CountDownLatch allDone = new CountDownLatch(submissions);
+            AtomicInteger concurrent = new AtomicInteger();
+            AtomicInteger maxConcurrent = new AtomicInteger();
+
+            for (int i = 0; i < submissions; i++) {
+                admission.submit(() -> {
+                    int now = concurrent.incrementAndGet();
+                    maxConcurrent.accumulateAndGet(now, Math::max);
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        concurrent.decrementAndGet();
+                        allDone.countDown();
+                    }
+                }, pool, e -> fail("no submission should have been rejected: " + e));
+            }
+
+            // Exactly `cap` tasks run; the rest are held in the controller, not the pool.
+            assertBusy(() -> assertEquals(cap, concurrent.get()), 5, TimeUnit.SECONDS);
+            assertEquals("controller must hold the excess submissions", submissions - cap, admission.pending());
+            assertEquals(cap, admission.running());
+
+            release.countDown();
+            assertTrue("all submissions must run once slots free up", allDone.await(10, TimeUnit.SECONDS));
+            assertEquals("the cap must never be exceeded", cap, maxConcurrent.get());
+            assertBusy(() -> {
+                assertEquals(0, admission.running());
+                assertEquals(0, admission.pending());
+            }, 5, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /** Queued segmentators are promoted in submission (FIFO) order as running ones complete. */
+    public void testPendingSegmentatorsRunInSubmissionOrder() throws Exception {
+        int submissions = 6;
+        // Single-permit controller on a single-thread pool forces strictly serial execution, so completion order
+        // equals dispatch order equals the controller's promotion order.
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            StreamingSegmentatorAdmission admission = new StreamingSegmentatorAdmission(1);
+            List<Integer> order = new CopyOnWriteArrayList<>();
+            CountDownLatch allDone = new CountDownLatch(submissions);
+            for (int i = 0; i < submissions; i++) {
+                final int id = i;
+                admission.submit(() -> {
+                    order.add(id);
+                    allDone.countDown();
+                }, pool, e -> fail("no submission should have been rejected: " + e));
+            }
+            assertTrue(allDone.await(10, TimeUnit.SECONDS));
+            for (int i = 0; i < submissions; i++) {
+                assertEquals("segmentators must be promoted FIFO", Integer.valueOf(i), order.get(i));
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * When the executor rejects a segmentator, the controller must run the caller's reject callback and free the
+     * slot it reserved (promoting any successor) so the budget is not permanently consumed by a task that never ran.
+     */
+    public void testRejectionFreesSlotAndInvokesCallback() {
+        Executor rejecting = command -> { throw new RejectedExecutionException("pool closed"); };
+        StreamingSegmentatorAdmission admission = new StreamingSegmentatorAdmission(2);
+        AtomicInteger rejected = new AtomicInteger();
+        for (int i = 0; i < 5; i++) {
+            admission.submit(() -> fail("a rejected task must never run"), rejecting, e -> rejected.incrementAndGet());
+        }
+        assertEquals("every submission's reject callback must fire", 5, rejected.get());
+        assertEquals("rejected slots must be freed, not leaked", 0, admission.running());
+        assertEquals(0, admission.pending());
+    }
+
+    /** The unbounded controller dispatches every segmentator immediately and never queues. */
+    public void testUnboundedDispatchesImmediately() throws Exception {
+        int submissions = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(submissions);
+        try {
+            StreamingSegmentatorAdmission admission = StreamingSegmentatorAdmission.unbounded();
+            CountDownLatch release = new CountDownLatch(1);
+            CountDownLatch running = new CountDownLatch(submissions);
+            for (int i = 0; i < submissions; i++) {
+                admission.submit(() -> {
+                    running.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }, pool, e -> fail("no submission should have been rejected: " + e));
+            }
+            assertTrue("unbounded must run all submissions at once", running.await(10, TimeUnit.SECONDS));
+            assertEquals("unbounded must never queue", 0, admission.pending());
+            release.countDown();
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
#152771 sizes the esql_external_io pool to exactly the blob-store
concurrency (pool == permits, no headroom), arguing it is safe because
every task on the pool is a permit-gated reader and the page consumer
drains on esql_worker. Stream-only compressed reads break that: each
open read runs one long-lived segmentator on the pool, and its per-chunk
parser tasks run on the same pool but are not permit-gated (file:// is
not permit-wrapped at all). With enough concurrently-open reads the
segmentators pin every pool thread and their parser tasks, queued behind
them, never get a thread, so the reads deadlock (esql-planning #1093,
item 4). A repro with F>=poolSize readers confirms the hang.

Add a node-level admission gate keyed to the read pool that caps
concurrent segmentators at poolSize-1, deferring a segmentator start
(holding no pool thread) until a running one completes. This keeps a
thread free for parser tasks, restoring liveness. The cap tracks the
pool size by default and is overridable via
esql.external.max_concurrent_segmentators.