### PR TITLE
ES|QL: Fix MATCH_PHRASE name

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -919,7 +919,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     }
 
     private static final Pattern FULL_TEXT_AFTER_SUBQUERY_IN_FROM_PATTERN = Pattern.compile(
-        ".*(?:(?:\\[(?:KQL|QSTR|MATCH|MatchPhrase)] function)|(?:\\[:\\] operator)) cannot be used after "
+        ".*(?:(?:\\[(?:KQL|QSTR|MATCH|MATCH_PHRASE)] function)|(?:\\[:\\] operator)) cannot be used after "
             + "(?:LIMIT|INLINE|LOOKUP|MV_EXPAND|STATS|CHANGE_POINT|DEDUP|LIMIT BY|TOP|[^\\n]*,\\s*\\(\\s*FROM\\b|"
             + "\\(\\s*FROM\\b).*",
         Pattern.DOTALL | Pattern.CASE_INSENSITIVE

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
@@ -23,7 +23,7 @@ public class GenerativeRestTestTests extends ESTestCase {
 
     public void testFullTextAfterSubqueryMatchesMultiSourceSubqueryMessage() {
         String query = "FROM all_types, (FROM colors | MV_EXPAND hex_code) | WHERE match_phrase(hex_code, \"world search\")";
-        String error = "verification_exception: line 1:973: [MatchPhrase] function cannot be used after "
+        String error = "verification_exception: line 1:973: [MATCH_PHRASE] function cannot be used after "
             + "all_types,(from colors | mv_expand hex_code)";
 
         assertTrue(GenerativeRestTest.isFullTextAfterSubqueryInFromBug(error, query));
@@ -32,7 +32,7 @@ public class GenerativeRestTestTests extends ESTestCase {
     public void testFullTextAfterSubqueryMatchesSubqueryFirstMultiSourceMessage() {
         String query = "FROM (FROM message_types | KEEP type | DROP type),no_mapping_sample_data,service_owners "
             + "| WHERE match_phrase(service_id, \"fox world\")";
-        String error = "verification_exception: line 1:91: [MatchPhrase] function cannot be used after "
+        String error = "verification_exception: line 1:91: [MATCH_PHRASE] function cannot be used after "
             + "(from message_types | keep type | drop type),no_mapping_sample_data,service_owners";
 
         assertTrue(GenerativeRestTest.isFullTextAfterSubqueryInFromBug(error, query));
@@ -44,7 +44,7 @@ public class GenerativeRestTestTests extends ESTestCase {
             + "| where match_phrase(registered_domain, \"test data\")";
         // The UnionAll source text in the verifier message is truncated to Node.TO_STRING_MAX_WIDTH chars + "...",
         // so it can be cut off mid-branch, before the comma separating the union branches.
-        String error = "verification_exception: line 1:1800: [MatchPhrase] function cannot be used after "
+        String error = "verification_exception: line 1:1800: [MATCH_PHRASE] function cannot be used after "
             + "(from all_types_short_as_long | enrich languages_policy on wildcard | dissect language_name \"%{HkOuTBPphONE} %...";
 
         assertTrue(GenerativeRestTest.isFullTextAfterSubqueryInFromBug(error, query));
@@ -52,7 +52,7 @@ public class GenerativeRestTestTests extends ESTestCase {
 
     public void testFullTextAfterSubqueryRequiresKnownErrorShape() {
         String query = "FROM all_types, (FROM colors | MV_EXPAND hex_code) | WHERE match_phrase(hex_code, \"world search\")";
-        String error = "verification_exception: line 1:973: [MatchPhrase] function cannot be used after field "
+        String error = "verification_exception: line 1:973: [MATCH_PHRASE] function cannot be used after field "
             + "with details (from an unrelated diagnostic)";
 
         assertFalse(GenerativeRestTest.isFullTextAfterSubqueryInFromBug(error, query));

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetSubqueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetSubqueryIT.java
@@ -924,7 +924,10 @@ public class FromDatasetSubqueryIT extends AbstractExternalDataSourceIT {
             Exception.class,
             () -> run(syncEsqlQueryRequest("FROM (FROM employees | WHERE MATCH_PHRASE(first_name, \"Alice\"))"), TIMEOUT)
         );
-        assertCauseMessageContains(ex, "[MatchPhrase] function cannot operate on [first_name], which is not a field from an index mapping");
+        assertCauseMessageContains(
+            ex,
+            "[MATCH_PHRASE] function cannot operate on [first_name], which is not a field from an index mapping"
+        );
     }
 
     public void testKQLOnDatasetRejected() {
@@ -954,7 +957,10 @@ public class FromDatasetSubqueryIT extends AbstractExternalDataSourceIT {
         Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest("""
             FROM (FROM employees), (FROM employees_alt) | WHERE MATCH_PHRASE(first_name, "Alice")
             """), TIMEOUT));
-        assertCauseMessageContains(ex, "[MatchPhrase] function cannot operate on [first_name], which is not a field from an index mapping");
+        assertCauseMessageContains(
+            ex,
+            "[MATCH_PHRASE] function cannot operate on [first_name], which is not a field from an index mapping"
+        );
     }
 
     // Mixed data types across subquery branches

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -115,7 +115,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             """;
 
         var error = expectThrows(ElasticsearchException.class, () -> run(query));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after LIMIT"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function cannot be used after LIMIT"));
     }
 
     public void testNotWhereMatchPhrase() {
@@ -218,7 +218,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
         var error = expectThrows(VerificationException.class, () -> run(query));
         assertThat(
             error.getMessage(),
-            containsString("[MatchPhrase] function cannot operate on [upper_content], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [upper_content], which is not a field from an index mapping")
         );
     }
 
@@ -233,7 +233,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
         var error = expectThrows(VerificationException.class, () -> run(query));
         assertThat(
             error.getMessage(),
-            containsString("[MatchPhrase] function cannot operate on [content], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [content], which is not a field from an index mapping")
         );
     }
 
@@ -272,7 +272,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
         var error = expectThrows(ElasticsearchException.class, () -> run(query));
         assertThat(
             error.getMessage(),
-            containsString("line 2:22: [MatchPhrase] function cannot operate on [content], which is not a field from an index mapping")
+            containsString("line 2:22: [MATCH_PHRASE] function cannot operate on [content], which is not a field from an index mapping")
         );
     }
 
@@ -283,7 +283,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             """;
 
         var error = expectThrows(ElasticsearchException.class, () -> run(errorQuery));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function is only supported in WHERE and STATS commands"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function is only supported in WHERE and STATS commands"));
 
         var query = """
             FROM test
@@ -319,7 +319,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             """;
 
         var error = expectThrows(VerificationException.class, () -> run(query));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function is only supported in WHERE and STATS commands"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function is only supported in WHERE and STATS commands"));
     }
 
     public void testMatchPhraseAfterMvExpand() {
@@ -330,7 +330,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             """;
 
         var error = expectThrows(VerificationException.class, () -> run(query));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after MV_EXPAND"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function cannot be used after MV_EXPAND"));
     }
 
     public void testMatchPhraseAfterMvExpandWithIntermediateCommands() {
@@ -340,7 +340,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             | EVAL upper_content = to_upper(content)
             | WHERE match_phrase(content, "brown fox")
             """));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after MV_EXPAND"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function cannot be used after MV_EXPAND"));
 
         error = expectThrows(VerificationException.class, () -> run("""
             FROM test
@@ -349,7 +349,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             | KEEP id, content
             | WHERE match_phrase(content, "brown fox")
             """));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after MV_EXPAND"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function cannot be used after MV_EXPAND"));
     }
 
     public void testWhereFalseBeforeInlineStatsWithMatchPhrase() {
@@ -361,7 +361,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             """;
 
         var error = expectThrows(VerificationException.class, () -> run(query));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after INLINE"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function cannot be used after INLINE"));
     }
 
     public void testWhereFalseWithEvalBeforeInlineStatsAndMatchPhrase() {
@@ -374,7 +374,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
             """;
 
         var error = expectThrows(VerificationException.class, () -> run(query));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after INLINE"));
+        assertThat(error.getMessage(), containsString("[MATCH_PHRASE] function cannot be used after INLINE"));
     }
 
     public void testMatchPhraseWithLookupJoin() {
@@ -388,7 +388,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
         assertThat(
             error.getMessage(),
             containsString(
-                "line 3:33: [MatchPhrase] function cannot operate on [lookup_content], supplied by an index [test_lookup] "
+                "line 3:33: [MATCH_PHRASE] function cannot operate on [lookup_content], supplied by an index [test_lookup] "
                     + "in non-STANDARD mode [lookup]"
             )
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
@@ -163,7 +163,7 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
 
     @Override
     public String functionName() {
-        return ENTRY.name;
+        return "MATCH_PHRASE";
     }
 
     private static MatchPhrase readFrom(StreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2009,7 +2009,7 @@ public class VerifierTests extends ESTestCase {
         );
         fullText().error(
             "from test metadata _id, _index, _score | fork (where true) (where true) | keep title | where match_phrase(title, \"data\")",
-            containsString("[MatchPhrase] function cannot be used after FORK")
+            containsString("[MATCH_PHRASE] function cannot be used after FORK")
         );
         fullText().stripErrorPrefix(false)
             .error(
@@ -2344,7 +2344,7 @@ public class VerifierTests extends ESTestCase {
         // match_phrase still requires an index field
         fullText().error(
             "from test | eval name = title | where match_phrase(name, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [name], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [name], which is not a field from an index mapping")
         );
     }
 
@@ -2359,23 +2359,23 @@ public class VerifierTests extends ESTestCase {
         // MATCH_PHRASE still requires an argument that is a field from an index mapping
         fullText().error(
             "from test | eval text = concat(title, body) | rename text as content | where match_phrase(content, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [content], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [content], which is not a field from an index mapping")
         );
         fullText().error(
             "from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [x], which is not a field from an index mapping")
         );
         fullText().error(
             "from test | grok body \"%{WORD:extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [x], which is not a field from an index mapping")
         );
         fullText().error(
             "from test | dissect title \"%{extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [x], which is not a field from an index mapping")
         );
         fullText().error(
             "from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match_phrase(y, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [y], which is not a field from an index mapping")
+            containsString("[MATCH_PHRASE] function cannot operate on [y], which is not a field from an index mapping")
         );
 
     }

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testSingleTypeTextUnmappedWithMatchPhraseFunctionLoadOnly/load/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testSingleTypeTextUnmappedWithMatchPhraseFunctionLoadOnly/load/analysis.expected
@@ -1,4 +1,4 @@
 Limit[1000[INTEGER],false,false]
 \_Project[[txt{f}#0]]
-  \_Filter[MatchPhrase(txt{f}#0,William Faulkner[KEYWORD])]
+  \_Filter[MATCH_PHRASE(txt{f}#0,William Faulkner[KEYWORD])]
     \_EsRelation[text_state_mapped,text_state_unmapped][doc_id{f}#1, txt{f}#0]


### PR DESCRIPTION
Does what it says.
Usually when a function name contains more than one term, we override the `functionName` function to make sure our error messages contain the correct user facing name.
`MatchPhrase` returned the wrong name.

As a side note, it would be nice if we didn't have to override the `functionName` method, and to just take the name from `DEFINITION`. Or the existing `functionName` to properly handle the case when the class name contains more than one term.