### PR TITLE
[Test] Improve GCP `testWriteFileMultipleOfChunkSize`

### DIFF
--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/AbstractGoogleCloudStorageBlobStoreRepositoryTestCase.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/AbstractGoogleCloudStorageBlobStoreRepositoryTestCase.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories.gcs;
+
+import fixture.gcs.FakeOAuth2HttpHandler;
+import fixture.gcs.GoogleCloudStorageHttpHandler;
+import fixture.gcs.TestUtils;
+
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.StorageRetryStrategy;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.BackoffPolicy;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesMetrics;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.SnapshotMetrics;
+import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.threeten.bp.Duration;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.CREDENTIALS_FILE_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.ENDPOINT_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.MAX_RETRIES_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.RESUMABLE_WRITE_BUFFER_SIZE_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.TOKEN_URI_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.BASE_PATH;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.BUCKET;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CLIENT_NAME;
+
+/// Shared infrastructure for the GCS blob-store repository integration tests: the mock GCS
+/// HTTP handlers, the erroneous (fault-injecting) handler, the node/repository settings and the
+/// test [GoogleCloudStoragePlugin]. It is deliberately `abstract` and declares no `@Test` methods
+/// so the runner never instantiates it and concrete subclasses do not double-run inherited tests.
+///
+/// Concrete subclasses tune behaviour through three small hooks:
+///  - [#resumableWriteBufferSize()] pins the resumable-write buffer size (default: production 16MB).
+///  - [#maybeWrapForRecording(HttpHandler)] optionally wraps the blob handler to observe chunk sizes.
+///  - [#suppressErrorInjection()] disables fault injection (used while recording exact chunk sizes).
+///
+/// The split exists because [GoogleCloudStorageResumableWriteBufferTests] needs a 1mb buffer to assert
+/// exact chunk sizes, but that pin turned other tests' large uploads into dozens of tiny chunks and
+/// amplified injected-error retry storms (see #152286).
+@SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
+public abstract class AbstractGoogleCloudStorageBlobStoreRepositoryTestCase extends ESMockAPIBasedRepositoryIntegTestCase {
+
+    private static final String CLIENT_ID_HEADER = "x-es-test-client-id";
+
+    @Override
+    protected String repositoryType() {
+        return GoogleCloudStorageRepository.TYPE;
+    }
+
+    @Override
+    protected Settings repositorySettings(String repoName) {
+        Settings.Builder settingsBuilder = Settings.builder()
+            .put(super.repositorySettings(repoName))
+            .put(BUCKET.getKey(), "bucket")
+            .put(CLIENT_NAME.getKey(), "test");
+        if (randomBoolean()) {
+            settingsBuilder.put(BASE_PATH.getKey(), randomFrom("test", "test/1"));
+        }
+        return settingsBuilder.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(TestGoogleCloudStoragePlugin.class);
+    }
+
+    /// The resumable-write buffer size to pin for the "test" client, or [Optional#empty()] to keep the
+    /// production default (16MB). Overridden by the buffer test that needs a deterministic chunk size.
+    protected Optional<ByteSizeValue> resumableWriteBufferSize() {
+        return Optional.empty();
+    }
+
+    /// Hook to optionally wrap the blob-store handler, e.g. to record uploaded chunk sizes. The default
+    /// returns the handler unchanged; keeping the handler classes private to this base class.
+    protected HttpHandler maybeWrapForRecording(HttpHandler blobStoreHandler) {
+        return blobStoreHandler;
+    }
+
+    /// Whether the erroneous handler should skip injecting errors. Overridden while recording chunk
+    /// sizes so the GCS SDK never issues a resumable-upload status check against the mock server.
+    protected boolean suppressErrorInjection() {
+        return false;
+    }
+
+    @Override
+    protected Map<String, HttpHandler> createHttpHandlers() {
+        final HttpHandler blob = maybeWrapForRecording(new GoogleCloudStorageBlobStoreHttpHandler("bucket"));
+        return Map.of("/", new GoogleCloudStorageStatsCollectorHttpHandler(blob), "/token", new FakeOAuth2HttpHandler());
+    }
+
+    // GCP Oauth2 client uses own retries: 1-second initial delay, 3-tries, 2x multiplier
+    // it can take long time to pass through(>10s) from multiple nodes, and trip tests with timeouts
+    // https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java#L115-L118
+    @Override
+    protected HttpHandler createErroneousHttpHandler(final HttpHandler delegate) {
+        if (delegate instanceof FakeOAuth2HttpHandler) {
+            return new GoogleErroneousHttpHandler(delegate, 1);
+        } else {
+            return new GoogleCloudStorageStatsCollectorHttpHandler(new GoogleErroneousHttpHandler(delegate, randomIntBetween(2, 3)));
+        }
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        final Settings.Builder settings = Settings.builder();
+        settings.put(super.nodeSettings(nodeOrdinal, otherSettings));
+        settings.put(ENDPOINT_SETTING.getConcreteSettingForNamespace("test").getKey(), httpServerUrl());
+        settings.put(TOKEN_URI_SETTING.getConcreteSettingForNamespace("test").getKey(), httpServerUrl() + "/token");
+        settings.put(MAX_RETRIES_SETTING.getConcreteSettingForNamespace("test").getKey(), 6);
+        // Multiple nodes (6 for nightly) with up to 2-3 injected failures per request and only 2 threads for the HTTP
+        // mock GCS server can lead to timeouts when reading the response after writing (or draining) large buffers
+        // (up to the 16MB production default). Kept defensively; reducing it is out of scope.
+        settings.put(READ_TIMEOUT_SETTING.getConcreteSettingForNamespace("test").getKey(), "60s");
+        // Subclasses may pin the resumable-write buffer size (e.g. to assert exact chunk sizes); by default the
+        // production 16MB default is left in place so uploads are not shredded into many tiny chunks.
+        resumableWriteBufferSize().ifPresent(
+            size -> settings.put(RESUMABLE_WRITE_BUFFER_SIZE_SETTING.getConcreteSettingForNamespace("test").getKey(), size)
+        );
+
+        final MockSecureSettings secureSettings = new MockSecureSettings();
+        final byte[] serviceAccount = TestUtils.createServiceAccount(random());
+        secureSettings.setFile(CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("test").getKey(), serviceAccount);
+        settings.setSecureSettings(secureSettings);
+        return settings.build();
+    }
+
+    public static class TestGoogleCloudStoragePlugin extends GoogleCloudStoragePlugin {
+
+        public TestGoogleCloudStoragePlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        protected GoogleCloudStorageService createStorageService(ClusterService clusterService, ProjectResolver projectResolver) {
+            // We generate the client ID here, otherwise it gets generated on each nodes' snapshot thread(s)
+            // and the chance of collision is greatly increased because of deterministic randomness
+            final String clientId = randomUUID();
+            return new GoogleCloudStorageService(clusterService, projectResolver) {
+                @Override
+                StorageOptions createStorageOptions(
+                    final GoogleCloudStorageClientSettings gcsClientSettings,
+                    final HttpTransportOptions httpTransportOptions
+                ) {
+                    StorageOptions options = super.createStorageOptions(gcsClientSettings, httpTransportOptions);
+                    return options.toBuilder()
+                        .setStorageRetryStrategy(StorageRetryStrategy.getLegacyStorageRetryStrategy())
+                        .setRetrySettings(
+                            options.getRetrySettings()
+                                .toBuilder()
+                                .setInitialRetryDelay(Duration.ofMillis(10L))
+                                .setMaxRetryDelay(Duration.ofSeconds(1L))
+                                // Tests use flat retry backoff (1.0) instead of the SDK default exponential (2.0). Combined
+                                // with the small initial/max delays above this keeps injected-error retries fast and
+                                // deterministic; exponential backoff let accumulated sleeps across many retried chunk
+                                // uploads exceed the 60s read timeout under CI contention (#152286). Production keeps the
+                                // SDK default via ServiceOptions.getDefaultRetrySettings().
+                                .setRetryDelayMultiplier(1.0d)
+                                .setJittered(false)
+                                .build()
+                        )
+                        .setHeaderProvider(new HeaderProvider() {
+                            /**
+                             * GCS client doesn't implement any way of identifying the client making the request.
+                             * Adding this header makes it easier for us to know how many times it's safe to fail
+                             * a request without exceeding the configured max retries.
+                             */
+                            @Override
+                            public Map<String, String> getHeaders() {
+                                return Map.of(CLIENT_ID_HEADER, clientId);
+                            }
+                        })
+                        .build();
+                }
+            };
+        }
+
+        @Override
+        public Map<String, Repository.Factory> getRepositories(
+            Environment env,
+            NamedXContentRegistry registry,
+            ClusterService clusterService,
+            BigArrays bigArrays,
+            RecoverySettings recoverySettings,
+            RepositoriesMetrics repositoriesMetrics,
+            SnapshotMetrics snapshotMetrics
+        ) {
+            return Collections.singletonMap(
+                GoogleCloudStorageRepository.TYPE,
+                (projectId, metadata) -> new GoogleCloudStorageRepository(
+                    projectId,
+                    metadata,
+                    registry,
+                    this.storageService.get(),
+                    clusterService,
+                    bigArrays,
+                    recoverySettings,
+                    new GcsRepositoryStatsCollector(),
+                    snapshotMetrics
+                ) {
+                    @Override
+                    protected GoogleCloudStorageBlobStore createBlobStore() {
+                        return new GoogleCloudStorageBlobStore(
+                            getProjectId(),
+                            metadata.settings().get("bucket"),
+                            "test",
+                            metadata.name(),
+                            storageService.get(),
+                            bigArrays,
+                            randomIntBetween(1, 8) * 1024,
+                            BackoffPolicy.noBackoff(),
+                            this.statsCollector(),
+                            null,
+                            null
+                        ) {
+                            @Override
+                            long getLargeBlobThresholdInBytes() {
+                                return ByteSizeUnit.MB.toBytes(1);
+                            }
+                        };
+                    }
+                }
+            );
+        }
+    }
+
+    @SuppressForbidden(reason = "this test uses a HttpHandler to emulate a Google Cloud Storage endpoint")
+    private static class GoogleCloudStorageBlobStoreHttpHandler extends GoogleCloudStorageHttpHandler implements BlobStoreHttpHandler {
+
+        GoogleCloudStorageBlobStoreHttpHandler(final String bucket) {
+            super(bucket);
+        }
+
+        @Override
+        public Set<String> blobsKeyset() {
+            return blobs().keySet();
+        }
+    }
+
+    /**
+     * HTTP handler that injects random  Google Cloud Storage service errors
+     *
+     * Note: it is not a good idea to allow this handler to simulate too many errors as it would
+     * slow down the test suite.
+     */
+    @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
+    private class GoogleErroneousHttpHandler extends ErroneousHttpHandler {
+
+        private static final Logger logger = LogManager.getLogger(GoogleErroneousHttpHandler.class);
+        private static final String IDEMPOTENCY_TOKEN = "x-goog-gcs-idempotency-token";
+
+        GoogleErroneousHttpHandler(final HttpHandler delegate, final int maxErrorsPerRequest) {
+            super(delegate, maxErrorsPerRequest);
+        }
+
+        @Override
+        protected String requestUniqueId(HttpExchange exchange) {
+            if ("/token".equals(exchange.getRequestURI().getPath())) {
+                try {
+                    // token content is unique per node (not per request)
+                    return Streams.readFully(Streams.noCloseStream(exchange.getRequestBody())).utf8ToString();
+                } catch (IOException e) {
+                    throw new AssertionError("Unable to read token request body", e);
+                }
+            }
+
+            if (exchange.getRequestHeaders().containsKey(IDEMPOTENCY_TOKEN)) {
+                String idempotencyToken = exchange.getRequestHeaders().getFirst(IDEMPOTENCY_TOKEN);
+                // In the event of a resumable retry, the GCS client uses the same idempotency token for
+                // the retry status check and the subsequent retries.
+                // Including the range header allows us to disambiguate between the requests
+                // see https://github.com/googleapis/java-storage/issues/3040
+                if (exchange.getRequestHeaders().containsKey("Content-Range")) {
+                    idempotencyToken += " " + exchange.getRequestHeaders().getFirst("Content-Range");
+                }
+                return idempotencyToken;
+            }
+
+            String clientId = exchange.getRequestHeaders().getFirst(CLIENT_ID_HEADER);
+            if (clientId == null) {
+                if (exchange.getRequestURI().toString().startsWith("/batch/") == false) {
+                    final String message = Strings.format(
+                        "Missing %s on non-batch request, this may cause issues with fault injection: %s",
+                        CLIENT_ID_HEADER,
+                        exchange.getRequestURI()
+                    );
+                    ExceptionsHelper.maybeDieOnAnotherThread(new AssertionError(message));
+                }
+                clientId = exchange.getRemoteAddress().toString();
+            }
+            final String range = exchange.getRequestHeaders().getFirst("Content-Range");
+            return clientId + " " + exchange.getRequestMethod() + " " + exchange.getRequestURI() + (range != null ? " " + range : "");
+        }
+
+        @Override
+        protected boolean canFailRequest(final HttpExchange exchange) {
+            // Subclasses can suppress error injection (e.g. while recording chunk sizes) so the GCS SDK
+            // never needs to issue a resumable-upload status check against the mock server.
+            if (suppressErrorInjection()) {
+                return false;
+            }
+            // Batch requests are not retried so we don't want to fail them
+            // The batched request are supposed to be retried (not tested here)
+            return exchange.getRequestURI().toString().startsWith("/batch/") == false;
+        }
+    }
+
+    /**
+     * HTTP handler that keeps track of requests performed against GCP.
+     */
+    @SuppressForbidden(reason = "this tests uses a HttpServer to emulate an GCS endpoint")
+    private static class GoogleCloudStorageStatsCollectorHttpHandler extends HttpStatsCollectorHandler {
+
+        GoogleCloudStorageStatsCollectorHttpHandler(final HttpHandler delegate) {
+            super(delegate, Arrays.stream(StorageOperation.values()).map(StorageOperation::key).toArray(String[]::new));
+        }
+
+        @Override
+        public void maybeTrack(HttpExchange exchange) {
+            final String request = exchange.getRequestMethod() + " " + exchange.getRequestURI().toString();
+            if (Regex.simpleMatch("GET */storage/v1/b/*/o/*", request)) {
+                trackRequest(StorageOperation.GET.key());
+            } else if (Regex.simpleMatch("GET /storage/v1/b/*/o*", request)) {
+                trackRequest(StorageOperation.LIST.key());
+            } else if (Regex.simpleMatch("POST /upload/storage/v1/b/*uploadType=resumable*", request)) {
+                trackRequest(StorageOperation.INSERT.key());
+            } else if (Regex.simpleMatch("PUT /upload/storage/v1/b/*uploadType=resumable*", request)) {
+                trackRequest(StorageOperation.INSERT.key());
+            } else if (Regex.simpleMatch("POST /upload/storage/v1/b/*uploadType=multipart*", request)) {
+                trackRequest(StorageOperation.INSERT.key());
+            } else if (Regex.simpleMatch("POST /storage/v1/b/*/o/*/rewriteTo/b/*/o/*", request)) {
+                trackRequest(StorageOperation.COPY.key());
+            }
+        }
+    }
+}

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -9,148 +9,38 @@
 
 package org.elasticsearch.repositories.gcs;
 
-import fixture.gcs.FakeOAuth2HttpHandler;
-import fixture.gcs.GoogleCloudStorageHttpHandler;
-import fixture.gcs.TestUtils;
-
-import com.google.api.gax.rpc.HeaderProvider;
-import com.google.cloud.http.HttpTransportOptions;
-import com.google.cloud.storage.StorageOptions;
-import com.google.cloud.storage.StorageRetryStrategy;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
-import org.elasticsearch.cluster.project.ProjectResolver;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.BackoffPolicy;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Iterators;
-import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.indices.recovery.RecoverySettings;
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.repositories.RepositoriesMetrics;
 import org.elasticsearch.repositories.RepositoriesService;
-import org.elasticsearch.repositories.Repository;
-import org.elasticsearch.repositories.SnapshotMetrics;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
-import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.threeten.bp.Duration;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.io.Streams.readFully;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.CREDENTIALS_FILE_SETTING;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.ENDPOINT_SETTING;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.MAX_RETRIES_SETTING;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.RESUMABLE_WRITE_BUFFER_SIZE_SETTING;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.TOKEN_URI_SETTING;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.BASE_PATH;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.BUCKET;
-import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CLIENT_NAME;
 
-@SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
-public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTestCase {
-
-    private static final String CLIENT_ID_HEADER = "x-es-test-client-id";
-
-    @Override
-    protected String repositoryType() {
-        return GoogleCloudStorageRepository.TYPE;
-    }
-
-    @Override
-    protected Settings repositorySettings(String repoName) {
-        Settings.Builder settingsBuilder = Settings.builder()
-            .put(super.repositorySettings(repoName))
-            .put(BUCKET.getKey(), "bucket")
-            .put(CLIENT_NAME.getKey(), "test");
-        if (randomBoolean()) {
-            settingsBuilder.put(BASE_PATH.getKey(), randomFrom("test", "test/1"));
-        }
-        return settingsBuilder.build();
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singletonList(TestGoogleCloudStoragePlugin.class);
-    }
-
-    private ChunkRecordingHttpHandler chunkRecordingHandler;
-
-    @Override
-    protected Map<String, HttpHandler> createHttpHandlers() {
-        final GoogleCloudStorageBlobStoreHttpHandler blobHandler = new GoogleCloudStorageBlobStoreHttpHandler("bucket");
-        chunkRecordingHandler = new ChunkRecordingHttpHandler(blobHandler);
-        return Map.of("/", new GoogleCloudStorageStatsCollectorHttpHandler(chunkRecordingHandler), "/token", new FakeOAuth2HttpHandler());
-    }
-
-    // GCP Oauth2 client uses own retries: 1-second initial delay, 3-tries, 2x multiplier
-    // it can take long time to pass through(>10s) from multiple nodes, and trip tests with timeouts
-    // https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java#L115-L118
-    @Override
-    protected HttpHandler createErroneousHttpHandler(final HttpHandler delegate) {
-        if (delegate instanceof FakeOAuth2HttpHandler) {
-            return new GoogleErroneousHttpHandler(delegate, 1);
-        } else {
-            return new GoogleCloudStorageStatsCollectorHttpHandler(new GoogleErroneousHttpHandler(delegate, randomIntBetween(2, 3)));
-        }
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        final Settings.Builder settings = Settings.builder();
-        settings.put(super.nodeSettings(nodeOrdinal, otherSettings));
-        settings.put(ENDPOINT_SETTING.getConcreteSettingForNamespace("test").getKey(), httpServerUrl());
-        settings.put(TOKEN_URI_SETTING.getConcreteSettingForNamespace("test").getKey(), httpServerUrl() + "/token");
-        settings.put(MAX_RETRIES_SETTING.getConcreteSettingForNamespace("test").getKey(), 6);
-        // multiple nodes (6 for nightly) with multiple failures per request (2) and with only 2 threads for the HTTP mock GCS server,
-        // might lead to timeouts when reading the response after writing (or draining) large buffers (16 MB)
-        settings.put(READ_TIMEOUT_SETTING.getConcreteSettingForNamespace("test").getKey(), "60s");
-        // fixed 1mb buffer to allow testResumableWriteBufferInAction to verify chunk sizes
-        settings.put(RESUMABLE_WRITE_BUFFER_SIZE_SETTING.getConcreteSettingForNamespace("test").getKey(), "1mb");
-
-        final MockSecureSettings secureSettings = new MockSecureSettings();
-        final byte[] serviceAccount = TestUtils.createServiceAccount(random());
-        secureSettings.setFile(CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("test").getKey(), serviceAccount);
-        settings.setSecureSettings(secureSettings);
-        return settings.build();
-    }
+/// GCS blob-store repository integration tests that exercise the production-default 16MB resumable
+/// write buffer. Shared infrastructure lives in [AbstractGoogleCloudStorageBlobStoreRepositoryTestCase];
+/// tests that need a fixed small buffer to assert exact chunk sizes live in
+/// [GoogleCloudStorageResumableWriteBufferTests].
+public class GoogleCloudStorageBlobStoreRepositoryTests extends AbstractGoogleCloudStorageBlobStoreRepositoryTestCase {
 
     public void testDeleteItems() throws IOException {
         final var repoName = createRepository(randomRepositoryName(), false);
@@ -228,32 +118,6 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         assertEquals("failed to parse value [6tb] for setting [chunk_size], must be <= [5tb]", e.getMessage());
     }
 
-    public void testResumableWriteBufferInAction() throws Exception {
-        // buffer size is fixed at 1mb by nodeSettings() for the "test" client
-        final int bufferSizeBytes = Math.toIntExact(ByteSizeValue.ofMb(1).getBytes());
-        final int numFullChunks = randomIntBetween(2, 4);
-        // lastChunkSize < bufferSizeBytes to guarantee numFullChunks non-final chunks
-        final int lastChunkSize = randomIntBetween(1, bufferSizeBytes - 1);
-        final int blobSize = bufferSizeBytes * numFullChunks + lastChunkSize;
-
-        final String repoName = createRepository(randomRepositoryName(), false);
-
-        chunkRecordingHandler.recording = true;
-        try (BlobStore store = newBlobStore(repoName)) {
-            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
-            container.writeBlob(randomPurpose(), "test-resumable-write-buffer", new BytesArray(randomByteArrayOfLength(blobSize)), true);
-            // Verify chunk sizes before deleting
-            final List<Integer> sizes = new ArrayList<>(chunkRecordingHandler.recordedNonFinalChunkSizes);
-            assertTrue("expected at least " + numFullChunks + " non-final chunks, got " + sizes, sizes.size() >= numFullChunks);
-            for (final int size : sizes) {
-                assertEquals("each non-final chunk must be exactly " + bufferSizeBytes + " bytes", bufferSizeBytes, size);
-            }
-            container.delete(randomPurpose());
-        } finally {
-            chunkRecordingHandler.recording = false;
-        }
-    }
-
     public void testWriteReadLarge() throws IOException {
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
@@ -279,6 +143,9 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         }
     }
 
+    /// Exercises the production-default 16MB resumable write buffer by uploading a blob that is an exact
+    /// multiple of the SDK default chunk size (so it splits into 2-4 full chunks). Assertions about exact
+    /// per-chunk sizes under a pinned small buffer live in [GoogleCloudStorageResumableWriteBufferTests].
     public void testWriteFileMultipleOfChunkSize() throws IOException {
         final int uploadSize = randomIntBetween(2, 4) * GoogleCloudStorageBlobStore.SDK_DEFAULT_CHUNK_SIZE;
         try (BlobStore store = newBlobStore()) {
@@ -317,237 +184,5 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     @Override
     public void testRequestStats() throws Exception {
         super.testRequestStats();
-    }
-
-    public static class TestGoogleCloudStoragePlugin extends GoogleCloudStoragePlugin {
-
-        public TestGoogleCloudStoragePlugin(Settings settings) {
-            super(settings);
-        }
-
-        @Override
-        protected GoogleCloudStorageService createStorageService(ClusterService clusterService, ProjectResolver projectResolver) {
-            // We generate the client ID here, otherwise it gets generated on each nodes' snapshot thread(s)
-            // and the chance of collision is greatly increased because of deterministic randomness
-            final String clientId = randomUUID();
-            return new GoogleCloudStorageService(clusterService, projectResolver) {
-                @Override
-                StorageOptions createStorageOptions(
-                    final GoogleCloudStorageClientSettings gcsClientSettings,
-                    final HttpTransportOptions httpTransportOptions
-                ) {
-                    StorageOptions options = super.createStorageOptions(gcsClientSettings, httpTransportOptions);
-                    return options.toBuilder()
-                        .setStorageRetryStrategy(StorageRetryStrategy.getLegacyStorageRetryStrategy())
-                        .setRetrySettings(
-                            options.getRetrySettings()
-                                .toBuilder()
-                                .setInitialRetryDelay(Duration.ofMillis(10L))
-                                .setMaxRetryDelay(Duration.ofSeconds(1L))
-                                .setJittered(false)
-                                .build()
-                        )
-                        .setHeaderProvider(new HeaderProvider() {
-                            /**
-                             * GCS client doesn't implement any way of identifying the client making the request.
-                             * Adding this header makes it easier for us to know how many times it's safe to fail
-                             * a request without exceeding the configured max retries.
-                             */
-                            @Override
-                            public Map<String, String> getHeaders() {
-                                return Map.of(CLIENT_ID_HEADER, clientId);
-                            }
-                        })
-                        .build();
-                }
-            };
-        }
-
-        @Override
-        public Map<String, Repository.Factory> getRepositories(
-            Environment env,
-            NamedXContentRegistry registry,
-            ClusterService clusterService,
-            BigArrays bigArrays,
-            RecoverySettings recoverySettings,
-            RepositoriesMetrics repositoriesMetrics,
-            SnapshotMetrics snapshotMetrics
-        ) {
-            return Collections.singletonMap(
-                GoogleCloudStorageRepository.TYPE,
-                (projectId, metadata) -> new GoogleCloudStorageRepository(
-                    projectId,
-                    metadata,
-                    registry,
-                    this.storageService.get(),
-                    clusterService,
-                    bigArrays,
-                    recoverySettings,
-                    new GcsRepositoryStatsCollector(),
-                    snapshotMetrics
-                ) {
-                    @Override
-                    protected GoogleCloudStorageBlobStore createBlobStore() {
-                        return new GoogleCloudStorageBlobStore(
-                            getProjectId(),
-                            metadata.settings().get("bucket"),
-                            "test",
-                            metadata.name(),
-                            storageService.get(),
-                            bigArrays,
-                            randomIntBetween(1, 8) * 1024,
-                            BackoffPolicy.noBackoff(),
-                            this.statsCollector(),
-                            null,
-                            null
-                        ) {
-                            @Override
-                            long getLargeBlobThresholdInBytes() {
-                                return ByteSizeUnit.MB.toBytes(1);
-                            }
-                        };
-                    }
-                }
-            );
-        }
-    }
-
-    @SuppressForbidden(reason = "this test uses a HttpHandler to emulate a Google Cloud Storage endpoint")
-    private static class GoogleCloudStorageBlobStoreHttpHandler extends GoogleCloudStorageHttpHandler implements BlobStoreHttpHandler {
-
-        GoogleCloudStorageBlobStoreHttpHandler(final String bucket) {
-            super(bucket);
-        }
-
-        @Override
-        public Set<String> blobsKeyset() {
-            return blobs().keySet();
-        }
-    }
-
-    /**
-     * HTTP handler that injects random  Google Cloud Storage service errors
-     *
-     * Note: it is not a good idea to allow this handler to simulate too many errors as it would
-     * slow down the test suite.
-     */
-    @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
-    private class GoogleErroneousHttpHandler extends ErroneousHttpHandler {
-
-        private static final Logger logger = LogManager.getLogger(GoogleErroneousHttpHandler.class);
-        private static final String IDEMPOTENCY_TOKEN = "x-goog-gcs-idempotency-token";
-
-        GoogleErroneousHttpHandler(final HttpHandler delegate, final int maxErrorsPerRequest) {
-            super(delegate, maxErrorsPerRequest);
-        }
-
-        @Override
-        protected String requestUniqueId(HttpExchange exchange) {
-            if ("/token".equals(exchange.getRequestURI().getPath())) {
-                try {
-                    // token content is unique per node (not per request)
-                    return Streams.readFully(Streams.noCloseStream(exchange.getRequestBody())).utf8ToString();
-                } catch (IOException e) {
-                    throw new AssertionError("Unable to read token request body", e);
-                }
-            }
-
-            if (exchange.getRequestHeaders().containsKey(IDEMPOTENCY_TOKEN)) {
-                String idempotencyToken = exchange.getRequestHeaders().getFirst(IDEMPOTENCY_TOKEN);
-                // In the event of a resumable retry, the GCS client uses the same idempotency token for
-                // the retry status check and the subsequent retries.
-                // Including the range header allows us to disambiguate between the requests
-                // see https://github.com/googleapis/java-storage/issues/3040
-                if (exchange.getRequestHeaders().containsKey("Content-Range")) {
-                    idempotencyToken += " " + exchange.getRequestHeaders().getFirst("Content-Range");
-                }
-                return idempotencyToken;
-            }
-
-            String clientId = exchange.getRequestHeaders().getFirst(CLIENT_ID_HEADER);
-            if (clientId == null) {
-                if (exchange.getRequestURI().toString().startsWith("/batch/") == false) {
-                    final String message = Strings.format(
-                        "Missing %s on non-batch request, this may cause issues with fault injection: %s",
-                        CLIENT_ID_HEADER,
-                        exchange.getRequestURI()
-                    );
-                    ExceptionsHelper.maybeDieOnAnotherThread(new AssertionError(message));
-                }
-                clientId = exchange.getRemoteAddress().toString();
-            }
-            final String range = exchange.getRequestHeaders().getFirst("Content-Range");
-            return clientId + " " + exchange.getRequestMethod() + " " + exchange.getRequestURI() + (range != null ? " " + range : "");
-        }
-
-        @Override
-        protected boolean canFailRequest(final HttpExchange exchange) {
-            // Suppress error injection while recording chunk sizes so the GCS SDK never
-            // needs to issue a resumable-upload status check against the mock server.
-            if (chunkRecordingHandler != null && chunkRecordingHandler.recording) {
-                return false;
-            }
-            // Batch requests are not retried so we don't want to fail them
-            // The batched request are supposed to be retried (not tested here)
-            return exchange.getRequestURI().toString().startsWith("/batch/") == false;
-        }
-    }
-
-    /**
-     * HTTP handler that keeps track of requests performed against GCP.
-     */
-    @SuppressForbidden(reason = "this tests uses a HttpServer to emulate an GCS endpoint")
-    private static class GoogleCloudStorageStatsCollectorHttpHandler extends HttpStatsCollectorHandler {
-
-        GoogleCloudStorageStatsCollectorHttpHandler(final HttpHandler delegate) {
-            super(delegate, Arrays.stream(StorageOperation.values()).map(StorageOperation::key).toArray(String[]::new));
-        }
-
-        @Override
-        public void maybeTrack(HttpExchange exchange) {
-            final String request = exchange.getRequestMethod() + " " + exchange.getRequestURI().toString();
-            if (Regex.simpleMatch("GET */storage/v1/b/*/o/*", request)) {
-                trackRequest(StorageOperation.GET.key());
-            } else if (Regex.simpleMatch("GET /storage/v1/b/*/o*", request)) {
-                trackRequest(StorageOperation.LIST.key());
-            } else if (Regex.simpleMatch("POST /upload/storage/v1/b/*uploadType=resumable*", request)) {
-                trackRequest(StorageOperation.INSERT.key());
-            } else if (Regex.simpleMatch("PUT /upload/storage/v1/b/*uploadType=resumable*", request)) {
-                trackRequest(StorageOperation.INSERT.key());
-            } else if (Regex.simpleMatch("POST /upload/storage/v1/b/*uploadType=multipart*", request)) {
-                trackRequest(StorageOperation.INSERT.key());
-            } else if (Regex.simpleMatch("POST /storage/v1/b/*/o/*/rewriteTo/b/*/o/*", request)) {
-                trackRequest(StorageOperation.COPY.key());
-            }
-        }
-    }
-
-    @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
-    private static class ChunkRecordingHttpHandler implements DelegatingHttpHandler {
-        private final HttpHandler delegate;
-        private volatile boolean recording = false;
-        final Queue<Integer> recordedNonFinalChunkSizes = new ConcurrentLinkedQueue<>();
-
-        ChunkRecordingHttpHandler(HttpHandler delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void handle(HttpExchange exchange) throws IOException {
-            if (recording && "PUT".equals(exchange.getRequestMethod())) {
-                final String contentRange = exchange.getRequestHeaders().getFirst("Content-Range");
-                if (contentRange != null && contentRange.endsWith("/*")) {
-                    // "bytes start-end/*", split on '-' and '/'
-                    final String[] parts = contentRange.substring("bytes ".length()).split("[-/]");
-                    recordedNonFinalChunkSizes.add(Integer.parseInt(parts[1]) - Integer.parseInt(parts[0]) + 1);
-                }
-            }
-            delegate.handle(exchange);
-        }
-
-        @Override
-        public HttpHandler getDelegate() {
-            return delegate;
-        }
     }
 }

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageResumableWriteBufferTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageResumableWriteBufferTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories.gcs;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
+
+/// Isolates the tests that need a small, fixed resumable-write buffer so they can assert exact chunk
+/// sizes. The 1mb pin is deliberately kept out of [AbstractGoogleCloudStorageBlobStoreRepositoryTestCase]:
+/// applied class-wide it shreds every large upload into dozens of 1mb chunks (16x the round-trips) and
+/// amplifies injected-error retry storms, which is what tripped `testWriteFileMultipleOfChunkSize` in
+/// #152286. Only this class overrides the buffer size (and records chunk sizes), so the other tests keep
+/// the production-default 16MB buffer.
+@SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
+public class GoogleCloudStorageResumableWriteBufferTests extends AbstractGoogleCloudStorageBlobStoreRepositoryTestCase {
+
+    private ChunkRecordingHttpHandler chunkRecordingHandler;
+
+    @Override
+    protected Optional<ByteSizeValue> resumableWriteBufferSize() {
+        return Optional.of(ByteSizeValue.ofMb(1));
+    }
+
+    @Override
+    protected HttpHandler maybeWrapForRecording(HttpHandler blobStoreHandler) {
+        chunkRecordingHandler = new ChunkRecordingHttpHandler(blobStoreHandler);
+        return chunkRecordingHandler;
+    }
+
+    @Override
+    protected boolean suppressErrorInjection() {
+        return chunkRecordingHandler != null && chunkRecordingHandler.recording;
+    }
+
+    public void testResumableWriteBufferInAction() throws Exception {
+        // buffer size is fixed at 1mb by resumableWriteBufferSize() for the "test" client
+        final int bufferSizeBytes = Math.toIntExact(ByteSizeValue.ofMb(1).getBytes());
+        final int numFullChunks = randomIntBetween(2, 4);
+        // lastChunkSize < bufferSizeBytes to guarantee numFullChunks non-final chunks
+        final int lastChunkSize = randomIntBetween(1, bufferSizeBytes - 1);
+        final int blobSize = bufferSizeBytes * numFullChunks + lastChunkSize;
+
+        final String repoName = createRepository(randomRepositoryName(), false);
+
+        chunkRecordingHandler.recording = true;
+        try (BlobStore store = newBlobStore(repoName)) {
+            final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
+            container.writeBlob(randomPurpose(), "test-resumable-write-buffer", new BytesArray(randomByteArrayOfLength(blobSize)), true);
+            // Verify chunk sizes before deleting
+            final List<Integer> sizes = new ArrayList<>(chunkRecordingHandler.recordedNonFinalChunkSizes);
+            assertTrue("expected at least " + numFullChunks + " non-final chunks, got " + sizes, sizes.size() >= numFullChunks);
+            for (final int size : sizes) {
+                assertEquals("each non-final chunk must be exactly " + bufferSizeBytes + " bytes", bufferSizeBytes, size);
+            }
+            container.delete(randomPurpose());
+        } finally {
+            chunkRecordingHandler.recording = false;
+        }
+    }
+
+    @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
+    private static class ChunkRecordingHttpHandler implements DelegatingHttpHandler {
+        private final HttpHandler delegate;
+        private volatile boolean recording = false;
+        final Queue<Integer> recordedNonFinalChunkSizes = new ConcurrentLinkedQueue<>();
+
+        ChunkRecordingHttpHandler(HttpHandler delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (recording && "PUT".equals(exchange.getRequestMethod())) {
+                final String contentRange = exchange.getRequestHeaders().getFirst("Content-Range");
+                if (contentRange != null && contentRange.endsWith("/*")) {
+                    // "bytes start-end/*", split on '-' and '/'
+                    final String[] parts = contentRange.substring("bytes ".length()).split("[-/]");
+                    recordedNonFinalChunkSizes.add(Integer.parseInt(parts[1]) - Integer.parseInt(parts[0]) + 1);
+                }
+            }
+            delegate.handle(exchange);
+        }
+
+        @Override
+        public HttpHandler getDelegate() {
+            return delegate;
+        }
+    }
+}

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -563,9 +563,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDifferenceTests
   method: testFold {TestCase=geo_shape and geo_shape}
   issue: https://github.com/elastic/elasticsearch/issues/152281
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-  method: testWriteFileMultipleOfChunkSize
-  issue: https://github.com/elastic/elasticsearch/issues/152286
 - class: org.elasticsearch.reindex.management.CancelTasksRelocationIT
   method: testCancelAllReindexTasksByActionWithMixedRelocationState
   issue: https://github.com/elastic/elasticsearch/issues/152291


### PR DESCRIPTION
## Notes
- Spent a lot of time here without a strong root-cause fix. Opening this as (a) a concrete test
  improvement (faster for the worst case randomization) and (b) a request for help and some fresh eyes on the actual timeout from the last 2 people to touch this class 😄 , to unblock myself and not continue sinking time into this. If y'all don't have the time to have a scan, no worries, i'll see whether i can rubber-ducky with someone during EMEA hours :D 
- Open question: the `SocketTimeoutException` is a per-request 60s stall that backoff does **not**
  explain — one PUT whose response never arrives. This PR shrinks the
  retry storm, but does not pin its trigger. Suspects if it recurs:
  the mock's 2-thread executor head-of-line blocking, keep-alive connection reuse, or simply that a
  60s `read_timeout` × 7 attempts turns any single stall into a multi-minute hang.
- Assisted with Claude

## Goal
- `testWriteFileMultipleOfChunkSize` is slow/flaky on CPU-busy CI (times out: `StorageException: Unknown
  Error` ← `SocketTimeoutException: Read timed out`). This test failure has happened before [here](https://github.com/elastic/elasticsearch/pull/144856). This PR **cuts total test runtime** by (a)
  stopping retry backoff from growing and (b) keeping the test on the larger chunk size. It reduces
  the runtime; it does **not** change `read_timeout` or `max_retries`, and does not by
  itself fix the socket-timeout stall (see Notes).

## Context (knobs)
- **Fault injection** (`ErroneousHttpHandler`): injects HTTP 500 on a unique request key until its
  hit-count reaches `maxErrorsPerRequest` (`randomIntBetween(2, 3)`) — then lets
  it through and resets the key. Drains the full request body on error.
- **Resumable upload**: chunks are uploaded **sequentially** (never concurrent AFAIK). Each failed chunk
  PUT triggers a status-query PUT (`bytes */*`, its own key) to find the resume offset — so
  status-queries dominate traffic ~2:1.
- **Number of 500s scales with chunk count** = `upload_size / resumable_write_buffer_size`:
  64MB @ 16MB → 4 chunks → ~83 round-trips / ~52 injected 500s; @ 1MB → 64 chunks → ~625 / ~413 (≈16×).
- **Backoff** (`retryDelayMultiplier`): SDK default **2.0 (exponential)**. Test already shrinks it
  (`initialRetryDelay=10ms`, `maxRetryDelay=1s`, no jitter; `max_retries=6` ⇒ 7 attempts). Each 500
  = one sleep; within a retry loop sleeps grow `10→20→40→80→160→320ms` (the 7-attempt cap keeps them
  below the 1s ceiling). Over hundreds of failures that averages ~100ms/sleep = **tens of seconds
  asleep**.

## Change
- **Flat backoff in the test**: set `retryDelayMultiplier=1.0` once in the shared test plugin, so
  every sleep stays at 10ms instead of climbing. Retry path is still exercised; production keeps
  SDK-default exponential.
- **Split the suite**: `resumable_write_buffer_size` is `NodeScope` (can't vary per method), so
  extract an abstract base and put the 1MB-only `testResumableWriteBufferInAction` in its own class
  (it was introduced after the test was muted); general tests (incl.
  `testWriteFileMultipleOfChunkSize`) stay on the default 16MB buffer / 4 chunks.
- **Unmute** `testWriteFileMultipleOfChunkSize`.

## Evidence (local, temporary instrumentation — not in this PR)
| Config | Chunks | Round-trips | Injected 500s | Per-iter |
|---|---|---|---|---|
| 1MB buffer, exponential (2.0) | 64 | ~625 | ~413 | ~45s |
| 1MB buffer, flat (1.0) | 64 | ~625 | ~413 | ~6.6s |
| 16MB buffer, exponential (~2.0) | 4 | ~83 | ~52 | ~4s |
| 16MB buffer, flat (1.0) — this PR | 4 | ~83 | ~52 | ~1.8s |

- Takeaway: **chunk count (buffer size) is the dominant lever** (~11× at exponential backoff); the
  multiplier compounds it (~2× at 16MB, ~7× at 1MB). The split keeps the test at 16MB; flat backoff
  is insurance, strongest when chunk counts are high.

Closes https://github.com/elastic/elasticsearch/issues/152286