### PR TITLE
Fix flaky RRF min_score total_hits test with deterministic scoring

### DIFF
--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/700_rrf_retriever_search_api_compatibility.yml
@@ -1154,6 +1154,7 @@ setup:
       search:
         index: test
         body:
+          track_total_hits: true
           retriever:
             rrf:
               retrievers:
@@ -1166,9 +1167,27 @@ setup:
                               retriever: {
                                 standard: {
                                   query: {
-                                    query_string: {
-                                      query: "term1 OR term2 OR term3",
-                                      default_field: "text"
+                                    bool: {
+                                      should: [
+                                        {
+                                          constant_score: {
+                                            filter: { term: { text: "term1" } },
+                                            boost: 10.0
+                                          }
+                                        },
+                                        {
+                                          constant_score: {
+                                            filter: { term: { text: "term2" } },
+                                            boost: 5.0
+                                          }
+                                        },
+                                        {
+                                          constant_score: {
+                                            filter: { term: { text: "term3" } },
+                                            boost: 1.0
+                                          }
+                                        }
+                                      ]
                                     }
                                   }
                                 }
@@ -1176,15 +1195,14 @@ setup:
                             }
                           ]
                           rank_window_size: 100
-                          min_score: 0.5
+                          min_score: 0.1
                     rank_window_size: 100
               rank_window_size: 100
           size: 10
 
-  - match: { hits.total.value: 3 }
+  - match: { hits.total.value: 2 }
   - match: { hits.total.relation: "eq" }
-  - length: { hits.hits: 3 }
+  - length: { hits.hits: 2 }
   - match: { hits.hits.0._id: "1" }
   - match: { hits.hits.1._id: "2" }
-  - match: { hits.hits.2._id: "3" }
 


### PR DESCRIPTION
Backport of test fix from #143160 to 8.19. The test used a `query_string` query that could produce tied scores, leading to non-deterministic result ordering. Replace it with `constant_score` queries that assign distinct boost values (10.0, 5.0, 1.0) to each term, ensuring stable ranking.

Also adjusts `min_score` from 0.5 to 0.1 and expected `total_hits` from 3 to 2 to match the behavior with the new scoring, and adds `track_total_hits: true`.

Closes #153087