### PR TITLE
Fix DiversifyingParentBlockQueryTests flaky test (backport #145825 to 9.3)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,9 +358,6 @@ tests:
 - class: org.elasticsearch.packaging.test.PackageUpgradeTests
   method: test21CheckUpgradedVersion
   issue: https://github.com/elastic/elasticsearch/issues/152909
-- class: org.elasticsearch.search.vectors.DiversifyingParentBlockQueryTests
-  method: testRandom
-  issue: https://github.com/elastic/elasticsearch/issues/153089
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingParentBlockQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingParentBlockQueryTests.java
@@ -22,13 +22,14 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
@@ -69,10 +70,10 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
 
         int numQueries = randomIntBetween(1, 3);
         float[][] queries = new float[numQueries][];
-        List<TreeMap<Float, String>> expectedTopDocs = new ArrayList<>();
+        List<Map<String, Float>> expectedTopDocs = new ArrayList<>();
         for (int i = 0; i < numQueries; i++) {
             queries[i] = randomVector(dims);
-            expectedTopDocs.add(new TreeMap<>((o1, o2) -> -Float.compare(o1, o2)));
+            expectedTopDocs.add(new HashMap<>());
         }
 
         withLuceneIndex(mapperService, iw -> {
@@ -84,13 +85,15 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
                     vectors[j] = randomVector(dims);
                 }
 
-                for (int k = 0; k < numQueries; k++) {
-                    float maxScore = Float.MIN_VALUE;
-                    for (int j = 0; j < numVectors; j++) {
-                        float score = EUCLIDEAN.compare(vectors[j], queries[k]);
-                        maxScore = Math.max(score, maxScore);
+                if (numVectors > 0) {
+                    for (int k = 0; k < numQueries; k++) {
+                        float maxScore = Float.MIN_VALUE;
+                        for (int j = 0; j < numVectors; j++) {
+                            float score = EUCLIDEAN.compare(vectors[j], queries[k]);
+                            maxScore = Math.max(score, maxScore);
+                        }
+                        expectedTopDocs.get(k).put(Integer.toString(i), maxScore);
                     }
-                    expectedTopDocs.get(k).put(maxScore, Integer.toString(i));
                 }
 
                 SourceToParse source = randomSource(Integer.toString(i), vectors);
@@ -128,11 +131,11 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
                 var nestedQuery = new ToParentBlockJoinQuery(knnQuery, bitSetproducer, ScoreMode.Total);
                 var topDocs = searcher.search(nestedQuery, 10);
                 for (var doc : topDocs.scoreDocs) {
-                    var entry = expectedTopDocs.get(i).pollFirstEntry();
-                    assertNotNull(entry);
-                    assertThat(doc.score, equalTo(entry.getKey()));
                     var storedDoc = storedFields.document(doc.doc, Set.of("id"));
-                    assertThat(storedDoc.getField("id").binaryValue().utf8ToString(), equalTo(entry.getValue()));
+                    var docId = storedDoc.getField("id").binaryValue().utf8ToString();
+                    var expectedScore = expectedTopDocs.get(i).get(docId);
+                    assertNotNull("unexpected doc id: " + docId, expectedScore);
+                    assertThat((double) doc.score, closeTo(expectedScore, 1e-5));
                 }
             }
         });
@@ -143,9 +146,9 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
             builder.startObject();
             builder.field("id", id);
             builder.startArray("nested");
-            for (int i = 0; i < vectors.length; i++) {
+            for (float[] vector : vectors) {
                 builder.startObject();
-                builder.field("emb", vectors[i]);
+                builder.field("emb", vector);
                 builder.endObject();
             }
             builder.endArray();


### PR DESCRIPTION
## Summary

Backports the test fix from #145825 to the 9.3 branch.

## Root Cause

The `DiversifyingParentBlockQueryTests.testRandom` test was flaky due to its use of a `TreeMap<Float, String>` keyed by score with a reverse comparator. This caused failures when two documents had near-equal scores:

1. **TreeMap key collisions**: When two docs have identical float scores, the TreeMap treats them as equal keys — one overwrites the other
2. **Positional ordering mismatches**: The test asserts strict positional ordering (`pollFirstEntry()` + `equalTo`), but floating-point differences between `EUCLIDEAN.compare()` (used in the test) and the KNN index's internal scoring can produce slightly different orderings for near-equal scores

## Fix

The test now:
- Uses `HashMap<String, Float>` (docId → score) instead of `TreeMap<Float, String>`
- Skips documents with zero vectors (they can't match KNN queries anyway)
- Asserts each returned document's score matches with `closeTo(score, 1e-5)` tolerance, without enforcing positional ordering

## History

This is the same failure class as #141878 (fixed by #141905) and #145732 (fixed by #145825). The fix in #145825 was merged to `main` targeting v9.4.0 but was never backported to 9.3.

Closes #153089