### PR TITLE
[9.3] [Transform] Tighten retry startup logic (#152803)

### DIFF
--- a/docs/changelog/152803.yaml
+++ b/docs/changelog/152803.yaml
@@ -1,0 +1,5 @@
+area: Transform
+issues: []
+pr: 152803
+summary: Tighten retry startup logic
+type: bug

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -19,8 +19,12 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -38,6 +42,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.transform.TransformDeprecations;
 import org.elasticsearch.xpack.core.transform.TransformField;
@@ -445,7 +450,8 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
                     l -> transformServices.configManager().getTransformConfiguration(transformId, l),
                     ActionListener.runBefore(listener, () -> scheduler.deregisterTransform(transformId)),
                     retryListener(task),
-                    () -> true, // because we can't determine if this is an unattended transform yet, retry indefinitely
+                    // because we can't determine if this is an unattended transform yet, retry indefinitely.
+                    e -> true,
                     task.getContext()
                 )
             );
@@ -494,9 +500,15 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         Long previousCheckpoint,
         ActionListener<StartTransformAction.Response> listener
     ) {
-        // if we fail the first request, we are going to start retrying until we succeed. when start fails, it is because the cluster state
-        // is not handling updates yet, but the cluster will eventually recover on its own.
+        // if we fail the first request with a retryable error, we are going to start retrying until we succeed. when start fails with
+        // a retryable error, it is because the cluster state is not handling updates yet, but the cluster will eventually recover on
+        // its own. Permanent failures (e.g. the task is in a FAILED state, or its indexer can't be started) are not retried here: they
+        // won't resolve on their own, and looping on them just spams the audit log until the user force-stops the transform.
         var startRetriesOnFirstFailureListener = listener.delegateResponse((l, e) -> {
+            if (isRetryablePersistStateError(e) == false) {
+                l.onFailure(e);
+                return;
+            }
             // copy the params but replace the frequency, this is to prevent every transform from starting and retrying every second,
             // potentially sending many cluster state updates at once. instead, add randomness to spread out the retry requests after the
             // first retry
@@ -529,7 +541,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
                     ll -> buildTask.start(previousCheckpoint, ll),
                     ActionListener.runBefore(l, () -> scheduler.deregisterTransform(paramsWithExtendedTimer.getId())),
                     ActionListener.noop(),
-                    () -> true,
+                    TransformPersistentTasksExecutor::isRetryablePersistStateError,
                     buildTask.getContext()
                 )
             );
@@ -541,6 +553,34 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
             // TransformTask#start will fail if the task state is FAILED
             buildTask.setNumFailureRetries(numFailureRetries).start(previousCheckpoint, startRetriesOnFirstFailureListener);
         });
+    }
+
+    /**
+     * Classes of exception that are known to be transient failures at the cluster-state/master layer
+     * — the kind the retry loop in {@link #startTask} was originally designed for ("cluster state is
+     * not handling updates yet, but the cluster will eventually recover on its own"). Checked via
+     * {@link ExceptionsHelper#unwrap}, so a wrapped cause (e.g. {@code TransformTask#start}'s
+     * persist-failure branch) is still matched.
+     */
+    private static final Class<?>[] RETRYABLE_PERSIST_STATE_EXCEPTIONS = new Class<?>[] {
+        NotMasterException.class,
+        FailedToCommitClusterStateException.class,
+        ProcessClusterEventTimeoutException.class,
+        ConnectTransportException.class };
+
+    /**
+     * Decides whether a failure from starting a transform's persistent task should be retried.
+     * Defaults to false (whitelist): only known-transient cluster-state/master failures are retried.
+     * Permanent failures — e.g. {@code CannotStartFailedTransformException} (the task is in a FAILED
+     * state) or the indexer refusing to start — must not be retried, or the transform loops forever
+     * emitting "Failed while starting Transform. Automatically retrying..." until force-stopped.
+     */
+    private static boolean isRetryablePersistStateError(Exception e) {
+        if (ExceptionsHelper.unwrap(e, RETRYABLE_PERSIST_STATE_EXCEPTIONS) != null) {
+            return true;
+        }
+        ClusterBlockException clusterBlockException = (ClusterBlockException) ExceptionsHelper.unwrap(e, ClusterBlockException.class);
+        return clusterBlockException != null && clusterBlockException.retryable();
     }
 
     private void setNumFailureRetries(int numFailureRetries) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformRetryableStartUpListener.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformRetryableStartUpListener.java
@@ -12,14 +12,14 @@ import org.elasticsearch.xpack.transform.transforms.scheduling.TransformSchedule
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.Predicate;
 
 class TransformRetryableStartUpListener<Response> implements TransformScheduler.Listener {
     private final String transformId;
     private final Consumer<ActionListener<Response>> action;
     private final ActionListener<Response> actionListener;
     private final ActionListener<Boolean> retryScheduledListener;
-    private final Supplier<Boolean> shouldRetry;
+    private final Predicate<Exception> shouldRetry;
     private final TransformContext context;
     private final AtomicBoolean isFirstRun;
     private final AtomicBoolean shouldRunAction;
@@ -33,8 +33,9 @@ class TransformRetryableStartUpListener<Response> implements TransformScheduler.
      *                       invoked.
      * @param retryScheduledListener retryScheduledListener will be notified after the first call. If true, another thread has started the
      *                               retry process. If false, the original call was successful, and no retries will happen.
-     * @param shouldRetry allows an external entity to gracefully stop these retries, invoking the actionListener's #onFailure method.
-     *                    Note that external entities are still required to deregister this listener from the Scheduler.
+     * @param shouldRetry tested against each failure to decide whether to keep retrying. Returning false invokes the
+     *                    actionListener's #onFailure method, ending the retries. Note that external entities are still required to
+     *                    deregister this listener from the Scheduler.
      * @param context the transform's context object. This listener will update the StartUpFailureCount information in the context as it
      *                encounters errors and retries.
      */
@@ -43,7 +44,7 @@ class TransformRetryableStartUpListener<Response> implements TransformScheduler.
         Consumer<ActionListener<Response>> action,
         ActionListener<Response> actionListener,
         ActionListener<Boolean> retryScheduledListener,
-        Supplier<Boolean> shouldRetry,
+        Predicate<Exception> shouldRetry,
         TransformContext context
     ) {
         this.transformId = transformId;
@@ -82,7 +83,7 @@ class TransformRetryableStartUpListener<Response> implements TransformScheduler.
     }
 
     private void actionFailed(Exception e) {
-        if (shouldRetry.get()) {
+        if (shouldRetry.test(e)) {
             maybeNotifyRetryListener(true);
             recordError(e);
             shouldRunAction.set(true);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -86,6 +87,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -445,10 +447,12 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         putTransformConfiguration(transformsConfigManager, transformId);
 
         var task = mockTransformTask();
+        // NotMasterException is a transient cluster-state/master failure -- the kind the startup retry loop is meant to
+        // recover from. See testNodeOperationDoesNotRetryPermanentStartFailure for the permanent-failure counterpart.
         doAnswer(ans -> {
             ActionListener<StartTransformAction.Response> listener = ans.getArgument(1);
             if (failFirstCall.compareAndSet(true, false)) {
-                listener.onFailure(new IllegalStateException("ahhhh"));
+                listener.onFailure(new NotMasterException("not master"));
             } else {
                 listener.onResponse(new StartTransformAction.Response(true));
             }
@@ -465,6 +469,41 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             eq(transformId),
             assertArg(message -> assertThat(message, startsWith("Failed while starting Transform. Automatically retrying")))
         );
+    }
+
+    /**
+     * Regression test for the transform startup retry loop bug: a permanent start failure (the
+     * task's own state, e.g. {@link CannotStartFailedTransformException}) must not be retried --
+     * previously every startup failure was retried forever regardless of type, so a transform that
+     * failed permanently (e.g. from memory pressure) would spam
+     * "Failed while starting Transform. Automatically retrying..." until force-stopped.
+     */
+    public void testNodeOperationDoesNotRetryPermanentStartFailure() throws Exception {
+        var transformsConfigManager = new InMemoryTransformConfigManager();
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var transformServices = transformServices(transformsConfigManager, transformScheduler);
+        var taskExecutor = buildTaskExecutor(transformServices);
+
+        var transformId = "testNodeOperationDoesNotRetryPermanentStartFailure";
+        var params = taskParams(transformId);
+        putTransformConfiguration(transformsConfigManager, transformId);
+
+        var task = mockTransformTask();
+        doAnswer(ans -> {
+            ActionListener<StartTransformAction.Response> listener = ans.getArgument(1);
+            listener.onFailure(new CannotStartFailedTransformException("failed state"));
+            return Void.TYPE;
+        }).when(task).start(any(), any());
+        taskExecutor.nodeOperation(task, params, mock());
+
+        // there is nothing to "skip waiting" for: no retry should have been scheduled at all
+        verify(task, times(1)).start(isNull(), any());
+        assertNull(transformScheduler.getStats().peekTransformName());
+        // the permanent failure still logs once via the pre-existing "please stop and attempt to start again" path...
+        verify(transformServices.auditor(), times(1)).audit(any(), eq(transformId), any());
+        // ...but the "Automatically retrying" loop-warning must never fire, since no retry is scheduled
+        verify(transformServices.auditor(), never()).warning(any(), any());
     }
 
     private Settings fastRetry() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformRetryableStartUpListenerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformRetryableStartUpListenerTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.transform.transforms.scheduling.TransformScheduler;
 
@@ -39,7 +40,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             immediatelyReturn(),
             responseListener(responseResult),
             retryListener(retryResult),
-            () -> true,
+            e -> true,
             context
         );
 
@@ -96,7 +97,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             failOnceThen(immediatelyReturn()),
             responseListener(responseResult),
             retryListener(retryResult),
-            () -> true,
+            e -> true,
             context
         );
 
@@ -111,10 +112,14 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
     }
 
     private Consumer<ActionListener<Void>> failOnceThen(Consumer<ActionListener<Void>> followup) {
+        return failOnceThen(followup, new IllegalStateException("first call fails"));
+    }
+
+    private Consumer<ActionListener<Void>> failOnceThen(Consumer<ActionListener<Void>> followup, Exception firstFailure) {
         var firstRun = new AtomicBoolean(true);
         return l -> {
             if (firstRun.compareAndSet(true, false)) {
-                l.onFailure(new IllegalStateException("first call fails"));
+                l.onFailure(firstFailure);
             } else {
                 followup.accept(l);
             }
@@ -133,7 +138,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             failOnceThen(immediatelyReturn()),
             responseListener(),
             retryListener(),
-            () -> true,
+            e -> true,
             context
         );
 
@@ -165,7 +170,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             failOnceThen(immediatelyReturn()),
             responseListener(responseResult),
             retryListener(retryResult),
-            () -> true,
+            e -> true,
             context
         );
 
@@ -192,7 +197,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             alwaysFail(),
             responseListener(responseResult),
             retryListener(retryResult),
-            () -> runTwice.compareAndSet(true, false),
+            e -> runTwice.compareAndSet(true, false),
             context
         );
 
@@ -225,7 +230,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             alwaysFail(),
             responseListener(responseResult),
             retryListener(retryResult),
-            () -> false,
+            e -> false,
             context
         );
 
@@ -236,6 +241,67 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
         assertNotNull("Retry Listener should be called.", retryResult.get());
         assertFalse("Retries should not be scheduled.", retryResult.get());
         verify(context, only()).resetStartUpFailureCount();
+    }
+
+    /**
+     * Given an action that fails with a permanent exception (e.g. the transform's task is in a
+     * FAILED state and cannot be started again without a force stop)
+     * When shouldRetry inspects the exception and classifies it as non-retryable
+     * Then we should call the actionListener's onFailure handler once, without ever re-arming the
+     * retry. This is the regression case for the startup retry loop bug: previously shouldRetry
+     * could not inspect the exception at all, so a permanent failure retried forever.
+     */
+    public void testCancelRetryOnPermanentException() {
+        var retryResult = new AtomicReference<Boolean>();
+        var responseResult = new AtomicInteger(0);
+        var context = mock(TransformContext.class);
+
+        var listener = new TransformRetryableStartUpListener<>(
+            "transformId",
+            l -> l.onFailure(new CannotStartFailedTransformException("failed state")),
+            responseListener(responseResult),
+            retryListener(retryResult),
+            e -> e instanceof CannotStartFailedTransformException == false,
+            context
+        );
+
+        callThreeTimes("transformId", listener);
+
+        // assert no retries and 1 failure; the permanent exception is never treated as retryable
+        assertEquals("Response Listener should only be called once.", -1, responseResult.get());
+        assertNotNull("Retry Listener should be called.", retryResult.get());
+        assertFalse("Retries should not be scheduled.", retryResult.get());
+        verify(context, only()).resetStartUpFailureCount();
+    }
+
+    /**
+     * Given an action that fails once with a retryable exception (e.g. a transient master
+     * failover) then succeeds
+     * When shouldRetry inspects the exception and classifies it as retryable
+     * Then we should retry once and then succeed.
+     */
+    public void testRetriesOnRetryableException() {
+        var retryResult = new AtomicReference<Boolean>();
+        var responseResult = new AtomicInteger(0);
+        var context = mock(TransformContext.class);
+
+        var listener = new TransformRetryableStartUpListener<>(
+            "transformId",
+            failOnceThen(immediatelyReturn(), new NotMasterException("not master")),
+            responseListener(responseResult),
+            retryListener(retryResult),
+            e -> e instanceof NotMasterException,
+            context
+        );
+
+        callThreeTimes("transformId", listener);
+
+        // assert only 1 retry and 1 success
+        assertEquals("Response Listener should only be called once.", 1, responseResult.get());
+        assertNotNull("Retry Listener should be called.", retryResult.get());
+        assertTrue("Retries should be scheduled.", retryResult.get());
+        verify(context, times(1)).incrementAndGetStartUpFailureCount(any(NotMasterException.class));
+        verify(context, times(1)).resetStartUpFailureCount();
     }
 
     /**
@@ -265,7 +331,7 @@ public class TransformRetryableStartUpListenerTests extends ESTestCase {
             action,
             responseListener(responseResult),
             retryListener(retryResult),
-            () -> true,
+            e -> true,
             context
         );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Transform] Tighten retry startup logic (#152803)](https://github.com/elastic/elasticsearch/pull/152803)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)