### PR TITLE
Fix flaky mtermvectors BWC test relocation race

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -725,9 +725,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testMultiTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/150101
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/153084
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.doubleShadowingWithEval}
   issue: https://github.com/elastic/elasticsearch/issues/153096

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -101,6 +101,14 @@ setup:
         index: testidx2
         name: test_alias
 
+  # Creating testidx2 can trigger shard rebalancing in mixed-cluster BWC tests.
+  # Wait for relocations to finish so the mtermvectors request hits a fully
+  # recovered shard copy of testidx.
+  - do:
+      cluster.health:
+        index: testidx
+        wait_for_no_relocating_shards: true
+
   - do:
         mtermvectors:
           "term_statistics" : true


### PR DESCRIPTION
Closes #153084

The `Tests catching other exceptions per item` section in `mtermvectors/10_basic.yml` creates a second index (`testidx2`) and aliases, which can trigger shard rebalancing in mixed-cluster BWC tests. If the `_mtermvectors` request hits a shard copy that is still recovering after relocation, `term_freq` and `ttf` come back null.

The existing `wait_for_no_relocating_shards` in the `setup:` block only covers relocations at test start time — it doesn't account for rebalancing triggered by the second index creation within this specific test section.

This adds a second `wait_for_no_relocating_shards` call after the alias setup and before the `_mtermvectors` call to close the race window.

This is a long-standing intermittent flake (~0.2% failure rate) that has recurred since 2020: #65385, #113325, #122414, #148096.