### PR TITLE
[9.4] [ML] Retry audit on failures (#146399) | [Transform] Retry audit index creation (#147754)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -101,9 +101,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
   issue: https://github.com/elastic/elasticsearch/issues/145904
-- class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectIT
-  method: testUpdateTransformWithProjectRouting
-  issue: https://github.com/elastic/elasticsearch/issues/147534
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/delete_expired_data/Test delete expired data with body parameters}
   issue: https://github.com/elastic/elasticsearch/issues/147656

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.template.put.TransportPutComposabl
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.RetryableAction;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -31,6 +32,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
@@ -41,6 +43,9 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
 
     private static final Logger logger = LogManager.getLogger(AbstractAuditor.class);
     static final int MAX_BUFFER_SIZE = 1000;
+    static final int MAX_WRITE_RETRIES = 2;
+    static final TimeValue RETRY_INITIAL_DELAY = TimeValue.timeValueMillis(200);
+    static final TimeValue RETRY_TIMEOUT = TimeValue.timeValueSeconds(10);
     protected static final TimeValue MASTER_TIMEOUT = TimeValue.timeValueMinutes(1);
 
     private final OriginSettingClient client;
@@ -154,14 +159,46 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
     private void writeDoc(ToXContent toXContent) {
         client.index(indexRequest(toXContent), ActionListener.wrap(AbstractAuditor::onIndexResponse, e -> {
             if (e instanceof IndexNotFoundException) {
-                executorService.execute(() -> {
-                    reset();
-                    indexDoc(toXContent);
-                });
+                handleIndexNotFound(toXContent);
             } else {
-                onIndexFailure(e);
+                retryWriteDoc(toXContent);
             }
         }));
+    }
+
+    private void retryWriteDoc(ToXContent toXContent) {
+        var attempts = new AtomicInteger(0);
+        new RetryableAction<DocWriteResponse>(
+            logger,
+            clusterService.threadPool(),
+            RETRY_INITIAL_DELAY,
+            RETRY_TIMEOUT,
+            ActionListener.wrap(AbstractAuditor::onIndexResponse, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    handleIndexNotFound(toXContent);
+                } else {
+                    onIndexFailure(e);
+                }
+            }),
+            executorService
+        ) {
+            @Override
+            public void tryAction(ActionListener<DocWriteResponse> listener) {
+                client.index(indexRequest(toXContent), listener);
+            }
+
+            @Override
+            public boolean shouldRetry(Exception e) {
+                return (e instanceof IndexNotFoundException) == false && attempts.getAndIncrement() < MAX_WRITE_RETRIES;
+            }
+        }.run();
+    }
+
+    private void handleIndexNotFound(ToXContent toXContent) {
+        executorService.execute(() -> {
+            reset();
+            indexDoc(toXContent);
+        });
     }
 
     private IndexRequest indexRequest(ToXContent toXContent) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
@@ -32,7 +32,6 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
@@ -43,6 +42,7 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
 
     private static final Logger logger = LogManager.getLogger(AbstractAuditor.class);
     static final int MAX_BUFFER_SIZE = 1000;
+    static final int MAX_INDEX_CREATION_RETRIES = 2;
     static final int MAX_WRITE_RETRIES = 2;
     static final TimeValue RETRY_INITIAL_DELAY = TimeValue.timeValueMillis(200);
     static final TimeValue RETRY_TIMEOUT = TimeValue.timeValueSeconds(10);
@@ -131,7 +131,12 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
                 writeBacklog();
             }
 
-        }, e -> { indexAndAliasCreationInProgress.set(false); });
+        }, e -> {
+            logger.atWarn()
+                .withThrowable(e)
+                .log("Failed to create audit index [{}] after retries, will retry on next audit message", auditIndexWriteAlias);
+            indexAndAliasCreationInProgress.set(false);
+        });
 
         synchronized (this) {
             if (indexAndAliasCreated.get() == false) {
@@ -167,7 +172,7 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
     }
 
     private void retryWriteDoc(ToXContent toXContent) {
-        var attempts = new AtomicInteger(0);
+        int[] attempts = { 0 };
         new RetryableAction<DocWriteResponse>(
             logger,
             clusterService.threadPool(),
@@ -189,11 +194,18 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
 
             @Override
             public boolean shouldRetry(Exception e) {
-                return (e instanceof IndexNotFoundException) == false && attempts.getAndIncrement() < MAX_WRITE_RETRIES;
+                if (e instanceof IndexNotFoundException) {
+                    return false;
+                }
+                return attempts[0]++ < MAX_WRITE_RETRIES;
             }
         }.run();
     }
 
+    // No backoff needed: IndexNotFoundException means the index was deleted externally
+    // (e.g., feature state reset). Re-entering indexDoc buffers this message in the
+    // backlog and triggers installTemplateAndCreateIndex, which has its own
+    // RetryableAction with exponential backoff.
     private void handleIndexNotFound(ToXContent toXContent) {
         executorService.execute(() -> {
             reset();
@@ -250,23 +262,39 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
     }
 
     private void installTemplateAndCreateIndex(ActionListener<Boolean> listener) {
-        SubscribableListener.<Boolean>newForked(l -> {
-            MlIndexAndAlias.installIndexTemplateIfRequired(clusterService.state(), client, templateVersion(), putTemplateRequest(), l);
-        }).<Boolean>andThen((l, success) -> {
-            var indexDetails = indexDetails();
-            MlIndexAndAlias.createIndexAndAliasIfNecessary(
-                client,
-                clusterService.state(),
-                indexNameExpressionResolver,
-                indexDetails.indexPrefix(),
-                indexDetails.indexVersion(),
-                auditIndexWriteAlias,
-                MASTER_TIMEOUT,
-                ActiveShardCount.DEFAULT,
-                l
-            );
+        int[] attempts = { 0 };
+        new RetryableAction<Boolean>(logger, clusterService.threadPool(), RETRY_INITIAL_DELAY, RETRY_TIMEOUT, listener, executorService) {
+            @Override
+            public void tryAction(ActionListener<Boolean> retryListener) {
+                SubscribableListener.<Boolean>newForked(l -> {
+                    MlIndexAndAlias.installIndexTemplateIfRequired(
+                        clusterService.state(),
+                        client,
+                        templateVersion(),
+                        putTemplateRequest(),
+                        l
+                    );
+                }).<Boolean>andThen((l, success) -> {
+                    var indexDetails = indexDetails();
+                    MlIndexAndAlias.createIndexAndAliasIfNecessary(
+                        client,
+                        clusterService.state(),
+                        indexNameExpressionResolver,
+                        indexDetails.indexPrefix(),
+                        indexDetails.indexVersion(),
+                        auditIndexWriteAlias,
+                        MASTER_TIMEOUT,
+                        ActiveShardCount.DEFAULT,
+                        l
+                    );
+                }).addListener(retryListener);
+            }
 
-        }).addListener(listener);
+            @Override
+            public boolean shouldRetry(Exception e) {
+                return attempts[0]++ < MAX_INDEX_CREATION_RETRIES;
+            }
+        }.run();
     }
 
     protected abstract TransportPutComposableIndexTemplateAction.Request putTemplateRequest();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -277,6 +278,47 @@ public class AbstractAuditorTests extends ESTestCase {
         assertBusy(() -> verify(client, times(2)).execute(eq(TransportBulkAction.TYPE), any(), any()));
     }
 
+    @SuppressWarnings("unchecked")
+    public void testWriteDocRetriesOnTransientFailure() throws Exception {
+        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled();
+        auditor.info("foo", "First message via backlog");
+        verify(client, times(1)).execute(eq(TransportBulkAction.TYPE), any(), any());
+
+        AtomicInteger indexAttempts = new AtomicInteger(0);
+        doAnswer(ans -> {
+            ActionListener<Object> listener = (ActionListener<Object>) ans.getArgument(2);
+            if (indexAttempts.incrementAndGet() < 3) {
+                listener.onFailure(new RuntimeException("transient error"));
+            } else {
+                listener.onResponse(null);
+            }
+            return null;
+        }).when(client).execute(eq(TransportIndexAction.TYPE), any(), any());
+
+        auditor.info("foo", "Message with retry");
+        // RetryableAction schedules retries asynchronously with backoff
+        assertBusy(() -> assertThat(indexAttempts.get(), equalTo(3)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testWriteDocGivesUpAfterMaxRetries() throws Exception {
+        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled();
+        auditor.info("foo", "First message via backlog");
+        verify(client, times(1)).execute(eq(TransportBulkAction.TYPE), any(), any());
+
+        AtomicInteger indexAttempts = new AtomicInteger(0);
+        doAnswer(ans -> {
+            ActionListener<Object> listener = (ActionListener<Object>) ans.getArgument(2);
+            indexAttempts.incrementAndGet();
+            listener.onFailure(new RuntimeException("persistent error"));
+            return null;
+        }).when(client).execute(eq(TransportIndexAction.TYPE), any(), any());
+
+        auditor.info("foo", "Message that always fails");
+        // 1 initial attempt in writeDoc + MAX_WRITE_RETRIES attempts in retryWriteDoc
+        assertBusy(() -> assertThat(indexAttempts.get(), equalTo(1 + AbstractAuditor.MAX_WRITE_RETRIES)));
+    }
+
     public void testMaxBufferSize() throws Exception {
         CountDownLatch writeSomeDocsBeforeTemplateLatch = new CountDownLatch(1);
         AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithoutTemplate(
@@ -333,6 +375,7 @@ public class AbstractAuditorTests extends ESTestCase {
 
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(state);
+        when(clusterService.threadPool()).thenReturn(threadPool);
         return clusterService;
     }
 
@@ -389,6 +432,7 @@ public class AbstractAuditorTests extends ESTestCase {
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(state);
+        when(clusterService.threadPool()).thenReturn(threadPool);
 
         return new TestAuditor(client, TEST_NODE_NAME, clusterService);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditorTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.common.notifications;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
@@ -279,25 +280,42 @@ public class AbstractAuditorTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    public void testWriteDocRecoversFromIndexNotFound() throws Exception {
+        AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled();
+        auditor.info("foo", "First message via backlog");
+        verify(client, times(1)).execute(eq(TransportBulkAction.TYPE), any(), any());
+
+        doAnswer(ans -> {
+            ActionListener<Object> listener = (ActionListener<Object>) ans.getArgument(2);
+            listener.onFailure(new IndexNotFoundException("test_index"));
+            return null;
+        }).when(client).execute(eq(TransportIndexAction.TYPE), any(), any());
+
+        auditor.info("foo", "Message that hits IndexNotFoundException");
+        // writeDoc gets INFE → handleIndexNotFound → reset → indexDoc → backlog → writeBacklog (bulk)
+        assertBusy(() -> verify(client, times(2)).execute(eq(TransportBulkAction.TYPE), any(), any()));
+    }
+
+    @SuppressWarnings("unchecked")
     public void testWriteDocRetriesOnTransientFailure() throws Exception {
         AbstractAuditor<AbstractAuditMessageTests.TestAuditMessage> auditor = createTestAuditorWithTemplateInstalled();
         auditor.info("foo", "First message via backlog");
         verify(client, times(1)).execute(eq(TransportBulkAction.TYPE), any(), any());
 
-        AtomicInteger indexAttempts = new AtomicInteger(0);
+        AtomicInteger writeAttempts = new AtomicInteger(0);
         doAnswer(ans -> {
             ActionListener<Object> listener = (ActionListener<Object>) ans.getArgument(2);
-            if (indexAttempts.incrementAndGet() < 3) {
-                listener.onFailure(new RuntimeException("transient error"));
+            if (writeAttempts.incrementAndGet() < 3) {
+                listener.onFailure(new RuntimeException("transient write error"));
             } else {
-                listener.onResponse(null);
+                listener.onResponse(mock(DocWriteResponse.class));
             }
             return null;
         }).when(client).execute(eq(TransportIndexAction.TYPE), any(), any());
 
-        auditor.info("foo", "Message with retry");
-        // RetryableAction schedules retries asynchronously with backoff
-        assertBusy(() -> assertThat(indexAttempts.get(), equalTo(3)));
+        auditor.info("foo", "Message that fails then succeeds on retry");
+
+        assertBusy(() -> assertThat(writeAttempts.get(), equalTo(3)));
     }
 
     @SuppressWarnings("unchecked")
@@ -306,17 +324,62 @@ public class AbstractAuditorTests extends ESTestCase {
         auditor.info("foo", "First message via backlog");
         verify(client, times(1)).execute(eq(TransportBulkAction.TYPE), any(), any());
 
-        AtomicInteger indexAttempts = new AtomicInteger(0);
+        AtomicInteger writeAttempts = new AtomicInteger(0);
         doAnswer(ans -> {
             ActionListener<Object> listener = (ActionListener<Object>) ans.getArgument(2);
-            indexAttempts.incrementAndGet();
-            listener.onFailure(new RuntimeException("persistent error"));
+            writeAttempts.incrementAndGet();
+            listener.onFailure(new RuntimeException("persistent write error"));
             return null;
         }).when(client).execute(eq(TransportIndexAction.TYPE), any(), any());
 
         auditor.info("foo", "Message that always fails");
-        // 1 initial attempt in writeDoc + MAX_WRITE_RETRIES attempts in retryWriteDoc
-        assertBusy(() -> assertThat(indexAttempts.get(), equalTo(1 + AbstractAuditor.MAX_WRITE_RETRIES)));
+
+        // 1 optimistic attempt + 1 initial RetryableAction attempt + MAX_WRITE_RETRIES retries = 4 total
+        assertBusy(() -> assertThat(writeAttempts.get(), equalTo(1 + 1 + AbstractAuditor.MAX_WRITE_RETRIES)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testInstallTemplateRetriesOnTransientFailure() throws Exception {
+        AtomicInteger createIndexAttempts = new AtomicInteger(0);
+
+        doAnswer(ans -> {
+            ActionListener<AcknowledgedResponse> listener = ans.getArgument(2);
+            listener.onResponse(AcknowledgedResponse.TRUE);
+            return null;
+        }).when(client).execute(eq(TransportPutComposableIndexTemplateAction.TYPE), any(), any());
+
+        doAnswer(ans -> {
+            ActionListener<CreateIndexResponse> listener = ans.getArgument(2);
+            if (createIndexAttempts.incrementAndGet() < 3) {
+                listener.onFailure(new RuntimeException("transient create index error"));
+            } else {
+                listener.onResponse(new CreateIndexResponse(true, true, "foo"));
+            }
+            return null;
+        }).when(client).execute(eq(TransportCreateIndexAction.TYPE), any(), any());
+
+        doAnswer(ans -> {
+            ActionListener<ClusterHealthResponse> listener = ans.getArgument(2);
+            listener.onResponse(new ClusterHealthResponse());
+            return null;
+        }).when(client).execute(eq(TransportClusterHealthAction.TYPE), any(), any());
+
+        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
+        AdminClient adminClient = mock(AdminClient.class);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+        when(client.admin()).thenReturn(adminClient);
+
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(state);
+        when(clusterService.threadPool()).thenReturn(threadPool);
+
+        TestAuditor auditor = new TestAuditor(client, TEST_NODE_NAME, clusterService);
+
+        auditor.info("foobar", "Message queued during index creation");
+
+        assertBusy(() -> assertThat(createIndexAttempts.get(), equalTo(3)));
+        assertBusy(() -> verify(client, times(1)).execute(eq(TransportBulkAction.TYPE), any(), any()));
     }
 
     public void testMaxBufferSize() throws Exception {

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/TransformSingleNodeTestCase.java
@@ -14,11 +14,13 @@ import org.elasticsearch.action.admin.cluster.snapshots.features.TransportResetF
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
@@ -158,17 +160,22 @@ public abstract class TransformSingleNodeTestCase extends ESSingleNodeTestCase {
     }
 
     protected Set<String> getAuditMessages(String transformId) {
-        var searchRequest = new SearchRequest(TransformInternalIndexConstants.AUDIT_INDEX_PATTERN);
-        var searchResponse = client().search(searchRequest).actionGet(TimeValue.THIRTY_SECONDS);
         try {
-            return Arrays.stream(searchResponse.getHits().getHits())
-                .map(SearchHit::getSourceAsMap)
-                .filter(source -> Objects.equals(source.get("transform_id"), transformId))
-                .map(source -> source.get("message"))
-                .map(Object::toString)
-                .collect(Collectors.toSet());
-        } finally {
-            searchResponse.decRef();
+            var searchRequest = new SearchRequest(TransformInternalIndexConstants.AUDIT_INDEX_PATTERN);
+            var searchResponse = client().search(searchRequest).actionGet(TimeValue.THIRTY_SECONDS);
+            try {
+                return Arrays.stream(searchResponse.getHits().getHits())
+                    .map(SearchHit::getSourceAsMap)
+                    .filter(source -> Objects.equals(source.get("transform_id"), transformId))
+                    .map(source -> source.get("message"))
+                    .map(Object::toString)
+                    .collect(Collectors.toSet());
+            } finally {
+                searchResponse.decRef();
+            }
+        } catch (SearchPhaseExecutionException | IndexNotFoundException e) {
+            logger.debug("Failed to search audit messages, returning empty set for retry", e);
+            return Set.of();
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ML] Retry audit on failures (#146399)](https://github.com/elastic/elasticsearch/pull/146399)
 - [[Transform] Retry audit index creation (#147754)](https://github.com/elastic/elasticsearch/pull/147754)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)