### PR TITLE
Fix columnar_stored nested stored fields

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -764,9 +764,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:exponential_histogram.allAggsInlineGrouped}
   issue: https://github.com/elastic/elasticsearch/issues/153123
-- class: org.elasticsearch.index.mapper.SyntheticVersusColumnarStoredSourceIT
-  method: testStoredIgnoredSource
-  issue: https://github.com/elastic/elasticsearch/issues/153124
 - class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
   method: testPointInTimeRelocationPitPositionsInBcc
   issue: https://github.com/elastic/elasticsearch/issues/153149

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/SyntheticVersusColumnarStoredSourceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/SyntheticVersusColumnarStoredSourceIT.java
@@ -132,6 +132,35 @@ public class SyntheticVersusColumnarStoredSourceIT extends ESIntegTestCase {
         assertEqualSource(mappingXContent, document, randomBoolean());
     }
 
+    /**
+     * With the time-series doc-values format disabled, a keyword sub-field of a nested field whose values exceed
+     * {@code ignore_above} keeps a copy of the ignored values in a per-document stored field so synthetic source can reconstruct
+     * them. Each nested array entry is a separate Lucene document, but columnar_stored reconstructs them all through one reused
+     * single-document reader that always reports the same doc id, and a reused stored-field loader skips re-reading on an unchanged
+     * doc id - so it used to return the first entry's stored values for every sibling. Verify every entry keeps its own values.
+     */
+    public void testNestedWithIgnoredKeywordPerEntry() throws Exception {
+        var mappingXContent = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("n")
+            .field("type", "nested")
+            .startObject("properties")
+            .startObject("kw")
+            .field("type", "keyword")
+            .field("ignore_above", 4)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        // Every value exceeds ignore_above (length 4), so all are stored in the ignored-value fallback. The first entry is
+        // multi-valued to make first-entry-duplication observable if the reused stored-field loader is not read per entry.
+        var document = Map.of("n", List.of(Map.of("kw", List.of("aaaaa", "bbbbb")), Map.of("kw", "ccccc"), Map.of("kw", "ddddd")));
+        // The stored-field fallback (and thus this bug) only occurs with the time-series doc-values format disabled.
+        assertEqualSource(mappingXContent, document, false);
+    }
+
     private void runTest(boolean useTimeSeriesDocValuesFormat) throws Exception {
         var spec = buildSpec();
         var template = new TemplateGenerator(spec).generate();

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -476,7 +476,6 @@ public class NestedObjectMapper extends ObjectMapper {
         private boolean columnar;
         private ColumnarSourceWriter.ReusableColumnarStoredLeafReader columnarChildReader;
         private SourceLoader.Leaf columnarChildLeaf;
-        private LeafStoredFieldLoader columnarChildStoredLoader;
         private final List<LuceneDocument> columnarChildren = new ArrayList<>();
 
         private NestedSyntheticFieldLoader(
@@ -502,10 +501,6 @@ public class NestedObjectMapper extends ObjectMapper {
                 this.columnarChildren.clear();
                 this.columnarChildReader = new ColumnarSourceWriter.ReusableColumnarStoredLeafReader();
                 this.columnarChildLeaf = sourceLoader.leaf(columnarChildReader, ColumnarSourceWriter.DOC_IDS);
-                this.columnarChildStoredLoader = storedFieldLoader.getLoader(
-                    columnarChildReader.getContext(),
-                    ColumnarSourceWriter.DOC_IDS
-                );
                 return parentDoc -> {
                     columnarChildren.clear();
                     LuceneDocument parent = parentReader.currentDoc();
@@ -590,8 +585,10 @@ public class NestedObjectMapper extends ObjectMapper {
 
         private void writeColumnarChild(LuceneDocument child, XContentBuilder b) throws IOException {
             columnarChildReader.repopulate(child);
-            columnarChildStoredLoader.advanceTo(ColumnarSourceWriter.DOC_ID);
-            columnarChildLeaf.write(columnarChildStoredLoader, ColumnarSourceWriter.DOC_ID, b);
+            // A fresh loader per child: every child reuses DOC_ID (0), and a reused loader would skip re-reading stored fields.
+            var childStoredLoader = storedFieldLoader.getLoader(columnarChildReader.getContext(), ColumnarSourceWriter.DOC_IDS);
+            childStoredLoader.advanceTo(ColumnarSourceWriter.DOC_ID);
+            columnarChildLeaf.write(childStoredLoader, ColumnarSourceWriter.DOC_ID, b);
         }
 
         /**


### PR DESCRIPTION
In `columnar_stored` source mode, every child of a nested field is reconstructed through a single reused single-document reader that always reports `DOC_ID` (0). The stored-field loader was created once and reused across children, but `ReaderStoredFieldLoader#advanceTo` caches its fields by doc id and skips re-reading when the id is unchanged — so after the first child, every sibling kept the first child's stored fields.

This surfaced as a keyword's `ignore_above` fallback (kept in a stored field when the time-series doc-values format is disabled) duplicating the first entry's values across all nested entries:

```
expected: {n=[{kw=[aaaaa, bbbbb]}, {kw=ccccc}, {kw=ddddd}]}
but was:  {n=[{kw=[aaaaa, bbbbb]}, {kw=[aaaaa, bbbbb]}, {kw=[aaaaa, bbbbb]}]}
```

Doc-values-backed subfields were unaffected because the reader's slots are refilled per child by `repopulate`. The fix creates a fresh stored-field loader per child, mirroring how `ColumnarSourceWriter#write` builds one per document. It covers any stored-field-backed subfield inside a columnar nested array, not just the keyword `ignore_above` fallback.

Also adds a deterministic regression test and unmutes `SyntheticVersusColumnarStoredSourceIT#testStoredIgnoredSource`.

Fixes #153124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
