### PR TITLE
ESQL: PoC dictionary-encoded BlockHash for wide keys

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -246,6 +246,27 @@ public abstract class BlockHash implements Releasable, SeenGroupIds {
                 }
             }
         }
+        // POC, NOT PRODUCTION READY - routes the (LONG/INT prefix + N>=2 BYTES_REF tail) shape to
+        // PrefixBlockHash instead of the generic fallback below.
+        // TODO: this blind structural dispatch is unsafe for general use - PrefixBlockHash throws on
+        // multi-valued tail columns instead of doing PackedValuesBlockHash's combinatorial expansion,
+        // so this would incorrectly break any other query matching this shape with genuinely
+        // multi-valued group-by columns. Before shipping, either (a) add combinatorial multi-valued
+        // support to PrefixBlockHash, or (b) remove this generic dispatch entirely and instead have
+        // TranslateTimeSeriesAggregate explicitly request PrefixBlockHash for its coordinator-side
+        // aggregate, since it has static, certain knowledge that PackDimension's output is
+        // single-valued - that's the real fix, this generic hook only exists to make end-to-end
+        // verification of the approach possible without a full planner-wiring pass.
+        if (groups.size() >= 2
+            && (groups.get(0).elementType() == ElementType.LONG || groups.get(0).elementType() == ElementType.INT)
+            && groups.subList(1, groups.size()).stream().allMatch(g -> g.elementType() == ElementType.BYTES_REF)) {
+            return new PrefixBlockHash(
+                groups.get(0).channel(),
+                groups.get(0).elementType(),
+                groups.subList(1, groups.size()),
+                blockFactory
+            );
+        }
         return new PackedValuesBlockHash(groups, blockFactory, emitBatchSize);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PrefixBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PrefixBlockHash.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.BytesRefHashTable;
+import org.elasticsearch.common.util.LongLongHashTable;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.SeenGroupIds;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.compute.operator.topn.TopNEncoder;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+
+/**
+ * A {@link BlockHash} for groupings shaped like {@code (prefix, tail1, tail2, ..., tailN)} where
+ * the {@code tail} columns, taken together as one tuple, recur unchanged across many different
+ * {@code prefix} values - the classic shape of a time-bucketed aggregate
+ * ({@code STATS ... BY bucket(...), dim1, dim2, ..., dimN}, the shape produced for the
+ * coordinator-side aggregate by {@code TranslateTimeSeriesAggregate}), but not limited to it: any
+ * grouping where one column varies often while the rest of the tuple repeats fits this shape.
+ * <p>
+ * The generic fallback for wide/mixed-type groupings, {@link PackedValuesBlockHash}, flattens
+ * {@code (prefix, tail1, ..., tailN)} into one composite byte string per row and hashes that
+ * directly. When the tail repeats, this is wasteful: the same tail bytes get physically re-copied
+ * once per distinct prefix value the tail is paired with, instead of once per distinct tail.
+ * <p>
+ * This class avoids that by hashing the tail tuple through its own dictionary first, reducing it
+ * to a small integer ordinal, and storing the raw tail bytes only once per distinct tail. The
+ * outer hash that actually assigns group ids is then a cheap two-{@code long} hash keyed on
+ * {@code (tailOrdinal, prefix)} - the same dictionary pattern {@link TimeSeriesBlockHash} already
+ * uses for {@code (tsid, timestamp)}.
+ * <p>
+ * This is a proof-of-concept, not production ready. Known gaps, tracked as TODOs below and in
+ * {@link BlockHash#build}:
+ * <ul>
+ *   <li>TODO: tail columns must currently be single-valued - a multi-valued tail column throws
+ *       {@link UnsupportedOperationException} instead of doing {@link PackedValuesBlockHash}'s
+ *       correct combinatorial expansion. Needed before this can replace the generic fallback for
+ *       real, unscoped traffic.</li>
+ *   <li>TODO: {@link #lookup} is unimplemented (mirrors the same gap in {@link TimeSeriesBlockHash}
+ *       for the same reason - only {@code add} is exercised by the aggregate use case this targets).
+ *       Needs a real implementation if this is ever used somewhere lookups matter (e.g. a join).</li>
+ *   <li>TODO: no cardinality/size-based fallback - if the tail turns out to have little or no
+ *       repetition in practice, this pays a small extra indirection (the dictionary lookup) for no
+ *       benefit over {@link PackedValuesBlockHash}. Not currently a problem for the query this was
+ *       built for, but worth measuring before using this shape more broadly.</li>
+ *   <li>TODO: not wired into the planner. Currently only reachable via a temporary, unsafe dispatch
+ *       hook in {@link BlockHash#build} - see the TODO there for what real wiring should look like.</li>
+ * </ul>
+ */
+public final class PrefixBlockHash extends BlockHash {
+
+    private static final TopNEncoder ENCODER = TopNEncoder.DEFAULT_UNSORTABLE;
+
+    private final int prefixChannel;
+    private final ElementType prefixType;
+    private final List<GroupSpec> tailSpecs;
+    private final int nullTrackingBytes;
+
+    // Package-private (not private) so tests can inspect ramBytesUsed() directly, matching the same
+    // precedent as PackedValuesBlockHash#bytesRefHash.
+    final BytesRefHashTable tailDictionary;
+    final LongLongHashTable outerHash;
+    private final BreakingBytesRefBuilder packBuffer;
+    private final BytesRef scratch = new BytesRef();
+
+    public PrefixBlockHash(int prefixChannel, ElementType prefixType, List<GroupSpec> tailSpecs, BlockFactory blockFactory) {
+        super(blockFactory);
+        if (prefixType != ElementType.LONG && prefixType != ElementType.INT) {
+            throw new IllegalArgumentException("prefix column must be LONG or INT, got [" + prefixType + "]");
+        }
+        this.prefixChannel = prefixChannel;
+        this.prefixType = prefixType;
+        this.tailSpecs = tailSpecs;
+        this.nullTrackingBytes = (tailSpecs.size() + 7) / 8;
+        boolean success = false;
+        try {
+            this.tailDictionary = HashImplFactory.newBytesRefHash(blockFactory);
+            this.outerHash = HashImplFactory.newLongLongHash(blockFactory);
+            this.packBuffer = new BreakingBytesRefBuilder(blockFactory.breaker(), "PrefixBlockHash", 128);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(tailDictionary, outerHash, packBuffer);
+    }
+
+    @Override
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+        final int positionCount = page.getPositionCount();
+        final Block prefixBlock = page.getBlock(prefixChannel);
+        final Block[] tailBlocks = new Block[tailSpecs.size()];
+        for (int g = 0; g < tailSpecs.size(); g++) {
+            tailBlocks[g] = page.getBlock(tailSpecs.get(g).channel());
+        }
+        try (var groupIdsBuilder = blockFactory.newIntVectorFixedBuilder(positionCount)) {
+            for (int p = 0; p < positionCount; p++) {
+                if (prefixBlock.isNull(p)) {
+                    throw new UnsupportedOperationException("null prefix values are not supported by PrefixBlockHash");
+                }
+                long prefixValue = readPrefixValue(prefixBlock, prefixBlock.getFirstValueIndex(p));
+                long ordinal = hashOrdToGroup(tailDictionary.add(packTail(tailBlocks, p)));
+                long groupId = hashOrdToGroup(outerHash.add(ordinal, prefixValue));
+                groupIdsBuilder.appendInt(p, Math.toIntExact(groupId));
+            }
+            try (var groupIds = groupIdsBuilder.build()) {
+                addInput.add(0, groupIds);
+            }
+        }
+    }
+
+    private long readPrefixValue(Block block, int valueIndex) {
+        return switch (prefixType) {
+            case LONG -> ((LongBlock) block).getLong(valueIndex);
+            case INT -> ((IntBlock) block).getInt(valueIndex);
+            default -> throw new IllegalStateException("unreachable: prefix type checked in constructor");
+        };
+    }
+
+    /** Packs one row's tail values into {@link #packBuffer}, returning a view of it. */
+    private BytesRef packTail(Block[] tailBlocks, int position) {
+        packBuffer.clear();
+        byte[] nullBitmap = new byte[nullTrackingBytes];
+        for (int g = 0; g < tailBlocks.length; g++) {
+            if (tailBlocks[g].isNull(position)) {
+                nullBitmap[g >> 3] |= (byte) (1 << (g & 7));
+            }
+        }
+        packBuffer.append(nullBitmap, 0, nullTrackingBytes);
+        for (int g = 0; g < tailBlocks.length; g++) {
+            Block block = tailBlocks[g];
+            if (block.isNull(position)) {
+                continue;
+            }
+            if (block.getValueCount(position) != 1) {
+                throw new UnsupportedOperationException("PrefixBlockHash does not support multi-valued tail columns yet");
+            }
+            int valueIndex = block.getFirstValueIndex(position);
+            switch (block.elementType()) {
+                case BYTES_REF -> ENCODER.encodeBytesRef(((BytesRefBlock) block).getBytesRef(valueIndex, scratch), packBuffer);
+                case LONG -> ENCODER.encodeLong(((LongBlock) block).getLong(valueIndex), packBuffer);
+                case INT -> ENCODER.encodeInt(((IntBlock) block).getInt(valueIndex), packBuffer);
+                case DOUBLE -> ENCODER.encodeDouble(((DoubleBlock) block).getDouble(valueIndex), packBuffer);
+                case BOOLEAN -> ENCODER.encodeBoolean(((BooleanBlock) block).getBoolean(valueIndex), packBuffer);
+                default -> throw new IllegalStateException("unsupported tail element type [" + block.elementType() + "]");
+            }
+        }
+        return packBuffer.bytesRefView();
+    }
+
+    @Override
+    public ReleasableIterator<IntBlock> lookup(Page page, ByteSizeValue targetBlockSize) {
+        // Not needed for the STATS/aggregate use case this class targets (mirrors TimeSeriesBlockHash,
+        // which has the same gap for the same reason: only GroupingAggregatorFunction#add is used here).
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    @Override
+    public Block[] getKeys(IntVector selected) {
+        final int positionCount = selected.getPositionCount();
+        final Block[] result = new Block[1 + tailSpecs.size()];
+
+        if (prefixType == ElementType.LONG) {
+            try (var b = blockFactory.newLongVectorFixedBuilder(positionCount)) {
+                for (int p = 0; p < positionCount; p++) {
+                    b.appendLong(p, outerHash.getKey2(selected.getInt(p)));
+                }
+                result[0] = b.build().asBlock();
+            }
+        } else {
+            try (var b = blockFactory.newIntVectorFixedBuilder(positionCount)) {
+                for (int p = 0; p < positionCount; p++) {
+                    b.appendInt(p, Math.toIntExact(outerHash.getKey2(selected.getInt(p))));
+                }
+                result[0] = b.build().asBlock();
+            }
+        }
+
+        final Block.Builder[] builders = new Block.Builder[tailSpecs.size()];
+        for (int g = 0; g < tailSpecs.size(); g++) {
+            builders[g] = newBuilderFor(tailSpecs.get(g).elementType(), positionCount);
+        }
+        boolean success = false;
+        try {
+            BytesRef dictScratch = new BytesRef();
+            for (int p = 0; p < positionCount; p++) {
+                long ordinal = outerHash.getKey1(selected.getInt(p));
+                BytesRef packed = tailDictionary.get(ordinal, dictScratch);
+                unpackTail(packed, builders);
+            }
+            for (int g = 0; g < tailSpecs.size(); g++) {
+                result[1 + g] = builders[g].build();
+            }
+            success = true;
+        } finally {
+            // Builders must be closed whether or not build() was called on them - ownership of their
+            // backing arrays transfers to the built Block on success, this is just releasing the
+            // (now-empty) builder itself, matching the try-with-resources pattern used everywhere else
+            // in this codebase (e.g. InternalPacks/PackedValuesBlockHash).
+            Releasables.close(builders);
+            if (success == false) {
+                Releasables.close(result[0]);
+            }
+        }
+        return result;
+    }
+
+    private Block.Builder newBuilderFor(ElementType type, int positionCount) {
+        return switch (type) {
+            case BYTES_REF -> blockFactory.newBytesRefBlockBuilder(positionCount);
+            case LONG -> blockFactory.newLongBlockBuilder(positionCount);
+            case INT -> blockFactory.newIntBlockBuilder(positionCount);
+            case DOUBLE -> blockFactory.newDoubleBlockBuilder(positionCount);
+            case BOOLEAN -> blockFactory.newBooleanBlockBuilder(positionCount);
+            default -> throw new IllegalStateException("unsupported tail element type [" + type + "]");
+        };
+    }
+
+    /** Reverses {@link #packTail}: decodes one tail tuple's packed bytes back into typed columns. */
+    private void unpackTail(BytesRef packed, Block.Builder[] builders) {
+        BytesRef cursor = new BytesRef(packed.bytes, packed.offset, packed.length);
+        byte[] nullBitmap = new byte[nullTrackingBytes];
+        System.arraycopy(cursor.bytes, cursor.offset, nullBitmap, 0, nullTrackingBytes);
+        cursor.offset += nullTrackingBytes;
+        cursor.length -= nullTrackingBytes;
+
+        BytesRef decodeScratch = new BytesRef();
+        for (int g = 0; g < tailSpecs.size(); g++) {
+            boolean isNull = (nullBitmap[g >> 3] & (1 << (g & 7))) != 0;
+            if (isNull) {
+                builders[g].appendNull();
+                continue;
+            }
+            switch (tailSpecs.get(g).elementType()) {
+                case BYTES_REF -> ((BytesRefBlock.Builder) builders[g]).appendBytesRef(ENCODER.decodeBytesRef(cursor, decodeScratch));
+                case LONG -> ((LongBlock.Builder) builders[g]).appendLong(ENCODER.decodeLong(cursor));
+                case INT -> ((IntBlock.Builder) builders[g]).appendInt(ENCODER.decodeInt(cursor));
+                case DOUBLE -> ((DoubleBlock.Builder) builders[g]).appendDouble(ENCODER.decodeDouble(cursor));
+                case BOOLEAN -> ((BooleanBlock.Builder) builders[g]).appendBoolean(ENCODER.decodeBoolean(cursor));
+                default -> throw new IllegalStateException("unsupported tail element type [" + tailSpecs.get(g).elementType() + "]");
+            }
+        }
+    }
+
+    @Override
+    public IntVector nonEmpty() {
+        return blockFactory.newIntRangeVector(0, Math.toIntExact(outerHash.size()));
+    }
+
+    @Override
+    public int numKeys() {
+        return Math.toIntExact(outerHash.size());
+    }
+
+    @Override
+    public BitArray seenGroupIds(BigArrays bigArrays) {
+        return new SeenGroupIds.Range(0, Math.toIntExact(outerHash.size())).seenGroupIds(bigArrays);
+    }
+
+    @Override
+    public String toString() {
+        return "PrefixBlockHash{prefix=["
+            + prefixChannel
+            + "], tail="
+            + tailSpecs.size()
+            + ", entries="
+            + outerHash.size()
+            + ", dictionarySize="
+            + tailDictionary.ramBytesUsed()
+            + "b, outerHashSize="
+            + outerHash.ramBytesUsed()
+            + "b, totalSize="
+            + (tailDictionary.ramBytesUsed() + outerHash.ramBytesUsed())
+            + "b}";
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/PrefixBlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/PrefixBlockHashTests.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.Releasables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+
+public class PrefixBlockHashTests extends BlockHashTestCase {
+
+    private int[] addAndCaptureGroupIds(BlockHash blockHash, Block... values) {
+        int[][] captured = new int[1][];
+        blockHash.add(new Page(values), new GroupingAggregatorFunction.AddInput() {
+            private void addBlock(int positionOffset, IntBlock groupIds) {
+                int[] ids = new int[groupIds.getPositionCount()];
+                for (int p = 0; p < ids.length; p++) {
+                    ids[p] = groupIds.getInt(p);
+                }
+                captured[0] = ids;
+            }
+
+            @Override
+            public void add(int positionOffset, IntArrayBlock groupIds) {
+                addBlock(positionOffset, groupIds);
+            }
+
+            @Override
+            public void add(int positionOffset, IntBigArrayBlock groupIds) {
+                addBlock(positionOffset, groupIds);
+            }
+
+            @Override
+            public void add(int positionOffset, IntVector groupIds) {
+                addBlock(positionOffset, groupIds.asBlock());
+            }
+
+            @Override
+            public void close() {
+                fail("hashes should not close AddInput");
+            }
+        });
+        return captured[0];
+    }
+
+    public void testGroupsSamePrefixAndTailTogether() {
+        try (
+            LongBlock prefix = blockFactory.newLongArrayVector(new long[] { 1, 1, 2, 2, 1 }, 5).asBlock();
+            BytesRefBlock tail = bytesRefBlock("a", "b", "a", "b", "a");
+            BlockHash hash = new PrefixBlockHash(
+                0,
+                ElementType.LONG,
+                List.of(new BlockHash.GroupSpec(1, ElementType.BYTES_REF)),
+                blockFactory
+            )
+        ) {
+            int[] ids = addAndCaptureGroupIds(hash, prefix, tail);
+            // (prefix=1, tail="a") occurs at positions 0 and 4 - must get the same group id.
+            assertThat(ids[0], equalTo(ids[4]));
+            // Every other combination must be distinct from each other and from group 0.
+            assertThat(ids[1], not(equalTo(ids[0])));
+            assertThat(ids[2], not(equalTo(ids[0])));
+            assertThat(ids[3], not(equalTo(ids[0])));
+            assertThat(ids[1], not(equalTo(ids[2])));
+            assertThat(ids[1], not(equalTo(ids[3])));
+            assertThat(ids[2], not(equalTo(ids[3])));
+            assertThat(hash.numKeys(), equalTo(4));
+
+            assertRoundTrip(hash, ids, new Object[][] { { 1L, "a" }, { 1L, "b" }, { 2L, "a" }, { 2L, "b" }, { 1L, "a" } });
+        }
+    }
+
+    public void testMultipleTailColumns() {
+        try (
+            LongBlock prefix = blockFactory.newLongArrayVector(new long[] { 10, 10, 20 }, 3).asBlock();
+            BytesRefBlock tail1 = bytesRefBlock("host-1", "host-1", "host-1");
+            BytesRefBlock tail2 = bytesRefBlock("cpu0", "cpu1", "cpu0");
+            BlockHash hash = new PrefixBlockHash(
+                0,
+                ElementType.LONG,
+                List.of(new BlockHash.GroupSpec(1, ElementType.BYTES_REF), new BlockHash.GroupSpec(2, ElementType.BYTES_REF)),
+                blockFactory
+            )
+        ) {
+            int[] ids = addAndCaptureGroupIds(hash, prefix, tail1, tail2);
+            assertThat(ids[0], not(equalTo(ids[1]))); // same prefix, different tail2
+            assertThat(ids[0], not(equalTo(ids[2]))); // same tail, different prefix
+            assertThat(hash.numKeys(), equalTo(3));
+
+            assertRoundTrip(hash, ids, new Object[][] { { 10L, "host-1", "cpu0" }, { 10L, "host-1", "cpu1" }, { 20L, "host-1", "cpu0" } });
+        }
+    }
+
+    public void testNullTailValue() {
+        try (BytesRefBlock.Builder tailBuilder = blockFactory.newBytesRefBlockBuilder(2)) {
+            tailBuilder.appendBytesRef(new BytesRef("x"));
+            tailBuilder.appendNull();
+            try (
+                LongBlock prefix = blockFactory.newLongArrayVector(new long[] { 1, 1 }, 2).asBlock();
+                BytesRefBlock tail = tailBuilder.build();
+                BlockHash hash = new PrefixBlockHash(
+                    0,
+                    ElementType.LONG,
+                    List.of(new BlockHash.GroupSpec(1, ElementType.BYTES_REF)),
+                    blockFactory
+                )
+            ) {
+                int[] ids = addAndCaptureGroupIds(hash, prefix, tail);
+                assertThat(ids[0], not(equalTo(ids[1])));
+                assertThat(hash.numKeys(), equalTo(2));
+                assertRoundTrip(hash, ids, new Object[][] { { 1L, "x" }, { 1L, null } });
+            }
+        }
+    }
+
+    public void testMultiValuedTailThrows() {
+        LongBlock prefix = blockFactory.newLongArrayVector(new long[] { 1 }, 1).asBlock();
+        try (BytesRefBlock.Builder tailBuilder = blockFactory.newBytesRefBlockBuilder(1)) {
+            tailBuilder.beginPositionEntry();
+            tailBuilder.appendBytesRef(new BytesRef("a"));
+            tailBuilder.appendBytesRef(new BytesRef("b"));
+            tailBuilder.endPositionEntry();
+            try (
+                BytesRefBlock tail = tailBuilder.build();
+                BlockHash hash = new PrefixBlockHash(
+                    0,
+                    ElementType.LONG,
+                    List.of(new BlockHash.GroupSpec(1, ElementType.BYTES_REF)),
+                    blockFactory
+                )
+            ) {
+                expectThrows(UnsupportedOperationException.class, () -> addAndCaptureGroupIds(hash, prefix, tail));
+            } finally {
+                Releasables.closeExpectNoException(prefix);
+            }
+        }
+    }
+
+    /**
+     * Reproduces the actual measured shape from the PromQL wide-clause investigation: a series
+     * (10-label tail tuple) recurring across several time buckets (the prefix), unchanged.
+     * Verifies the dictionary design gives a real, measured memory win over the generic
+     * flat-composite-key approach ({@link PackedValuesBlockHash}) - not just a theoretical one.
+     */
+    public void testMemoryUsageVsPackedValuesBlockHash() {
+        final int distinctTails = 500;
+        final int prefixesPerTail = 6;
+        final int tailColumnCount = 10;
+        final int labelPaddingLength = 30; // realistic label length, similar to the real hostmetrics dimensions measured
+
+        final int rowCount = distinctTails * prefixesPerTail;
+        long[] prefixValues = new long[rowCount];
+        String[][] tailValues = new String[tailColumnCount][rowCount];
+        int row = 0;
+        for (int t = 0; t < distinctTails; t++) {
+            for (int b = 0; b < prefixesPerTail; b++) {
+                prefixValues[row] = b;
+                for (int d = 0; d < tailColumnCount; d++) {
+                    tailValues[d][row] = String.format(Locale.ROOT, "tuple-%05d-dim-%02d-%s", t, d, "x".repeat(labelPaddingLength));
+                }
+                row++;
+            }
+        }
+
+        List<BlockHash.GroupSpec> tailSpecs = new ArrayList<>();
+        for (int d = 0; d < tailColumnCount; d++) {
+            tailSpecs.add(new BlockHash.GroupSpec(1 + d, ElementType.BYTES_REF));
+        }
+        List<BlockHash.GroupSpec> packedSpecs = new ArrayList<>();
+        packedSpecs.add(new BlockHash.GroupSpec(0, ElementType.LONG));
+        packedSpecs.addAll(tailSpecs);
+
+        Block[] blocks = new Block[1 + tailColumnCount];
+        blocks[0] = blockFactory.newLongArrayVector(prefixValues, rowCount).asBlock();
+        for (int d = 0; d < tailColumnCount; d++) {
+            blocks[1 + d] = bytesRefBlock(tailValues[d]);
+        }
+
+        long packedBytes;
+        try (PackedValuesBlockHash packed = new PackedValuesBlockHash(packedSpecs, blockFactory, 1024)) {
+            addAndCaptureGroupIds(packed, blocks);
+            packedBytes = packed.bytesRefHash.ramBytesUsed();
+        }
+
+        long dictionaryBytes;
+        try (PrefixBlockHash dict = new PrefixBlockHash(0, ElementType.LONG, tailSpecs, blockFactory)) {
+            addAndCaptureGroupIds(dict, blocks);
+            dictionaryBytes = dict.tailDictionary.ramBytesUsed() + dict.outerHash.ramBytesUsed();
+        }
+
+        Releasables.closeExpectNoException(blocks);
+
+        logger.info(
+            "PackedValuesBlockHash={} bytes, PrefixBlockHash={} bytes, ratio={}",
+            packedBytes,
+            dictionaryBytes,
+            (double) packedBytes / dictionaryBytes
+        );
+        // Expect roughly a prefixesPerTail-fold reduction (6x here); assert a conservative 3x
+        // floor so this doesn't flake on hash-table load-factor/rounding differences.
+        assertThat((double) packedBytes / dictionaryBytes, greaterThan(3.0));
+    }
+
+    /**
+     * Feeds each row's group id back into {@link BlockHash#getKeys} and checks the recovered
+     * (prefix, tail1, tail2, ...) tuple matches the original row exactly - i.e. the dictionary
+     * ordinal/outer-hash round trip is lossless.
+     */
+    private void assertRoundTrip(BlockHash hash, int[] groupIdsPerRow, Object[][] expectedPerRow) {
+        try (IntVector selected = blockFactory.newIntRangeVector(0, hash.numKeys())) {
+            Block[] keys = hash.getKeys(selected);
+            try {
+                for (int row = 0; row < groupIdsPerRow.length; row++) {
+                    int groupId = groupIdsPerRow[row];
+                    Object[] expected = expectedPerRow[row];
+                    assertThat("prefix for row " + row, ((LongBlock) keys[0]).getLong(groupId), equalTo(expected[0]));
+                    for (int d = 0; d < expected.length - 1; d++) {
+                        Object expectedTail = expected[d + 1];
+                        BytesRefBlock tailBlock = (BytesRefBlock) keys[1 + d];
+                        if (expectedTail == null) {
+                            assertThat("tail " + d + " for row " + row, tailBlock.isNull(groupId), equalTo(true));
+                        } else {
+                            assertThat(
+                                "tail " + d + " for row " + row,
+                                tailBlock.getBytesRef(groupId, new BytesRef()),
+                                equalTo(new BytesRef((String) expectedTail))
+                            );
+                        }
+                    }
+                }
+            } finally {
+                Releasables.closeExpectNoException(keys);
+            }
+        }
+    }
+
+    private BytesRefBlock bytesRefBlock(String... values) {
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(values.length)) {
+            for (String v : values) {
+                builder.appendBytesRef(new BytesRef(v));
+            }
+            return builder.build();
+        }
+    }
+}


### PR DESCRIPTION
## What

While digging into #152770, profiling traced the dominant cost to the coordinator's `HashAggregationOperator`:

[Data shard ×2]
TimeSeriesSourceOperator
-> ValuesSourceReaderOperator (@timestamp -> _tsid + metric + temporality) # 716k samples
-> TimeSeriesAggregationOperator (PARTIAL, [tsid, step]) # 716k samples -> 24k / shard
-> ValuesSourceReaderOperator (10 label fields)
-> 10× EvalOperator (pass-through)
-> ExchangeSink

[Coordinator]
ExchangeSource (24k × 2 -> 48k rows)
-> TimeSeriesAggregationOperator (FINAL, [tsid, step]) # small, fixed-size BytesRefLongBlockHash ~250KB
-> 10× EvalOperator (PackDimension) # build composite label key
-> HashAggregationOperator (SINGLE) # 48k -> 13k groups, ~19MB has table ~18.6MB in keys (bytesRefs + BigCore) & ~800KB in values (GroupingSumState).
-> 10× EvalOperator (UnpackDimension)
-> Filter/Limit # 13k -> 10k


`PackedValuesBlockHash` flattens `(step, dim1 ... dim10)` into one composite byte string per row, hashes it and use for group membership condition. The same tuple can be represented as `[head := step], [tail = dim1, ... dim10]`; for any constant `tail` there will be `step`'s copies of `tail`. E.g. in our case `tail` occupies ~400 bytes and tens of thousand steps. Not good. 

## Fix (proof of concept)

Idea - do not copy tail. `PrefixBlockHash` hashes the repeating `tail` to int ordinal, then keys the actual grouping hash on `(ordinal, prefix)`. That reduces storage by distinct `ordinal`'s times. 

Measured on the real query end-to-end (real 200-host local repro, not synthetic):

```diff
@@                       | Coordinator hash size | @@
- PackedValuesBlockHash  | ~18.6mb                |
+ PrefixBlockHash        | ~3.44mb  # -81.6%
```


We can likely generalize this beyond step/bucket use-case and sort grouping tuple by cardinality so that low cardinality columns come first, then use prefix index structure or multi-level hash table.

## Scope / what this is not

This is a proof of concept demonstrating the approach works and the win is real, not a mergeable change. TODOs are left inline for what's missing:
- `PrefixBlockHash` doesn't yet support multi-valued tail columns (throws instead of doing `PackedValuesBlockHash`'s correct combinatorial expansion).
- It's wired in via a blind structural dispatch check in `BlockHash#build` (any `LONG/INT` + `BYTES_REF...` grouping routes here), not real planner-level selection. That's unsafe for general traffic as-is - see the TODO comment at the call site for what the real fix should look like (`TranslateTimeSeriesAggregate` explicitly requesting this hash, since it has certain knowledge its `PackDimension` output is single-valued).
- `lookup()` is unimplemented (mirrors the same pre-existing gap in `TimeSeriesBlockHash`, for the same reason).

Doesn't address `rate()`'s own raw-sample buffering (measured separately, a modest ~4-8% surcharge, not the dominant cost) or Lucene read-path cost - this is scoped to the one confirmed dominant, differentiating cost center.


