### PR TITLE
Replace node restarts with network isolation in resharding disruption tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -566,9 +566,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:highlight.highlightFieldWithNoMatch}
   issue: https://github.com/elastic/elasticsearch/issues/152240
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
-  method: testReshardWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/152259
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecDateRangeIT
   method: test {csv-spec:date_range.rangeWithinPointMultiValueSomeMatch}
   issue: https://github.com/elastic/elasticsearch/issues/152267

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardDisruptionBaseIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardDisruptionBaseIT.java
@@ -8,22 +8,31 @@
 package org.elasticsearch.xpack.stateless.reshard;
 
 import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.elasticsearch.action.admin.cluster.reroute.TransportClusterRerouteAction;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.disruption.NetworkDisruption;
+import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
 
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
 
 // Inspired by StatelessTranslogIT.
 // TODO consider generalizing this and sharing with StatelessTranslogIT.
@@ -38,27 +47,43 @@ public class StatelessReshardDisruptionBaseIT extends AbstractStatelessPluginInt
         var indexMetadata = project.index(index);
 
         switch (failure) {
-            // TODO restart masters
-            case RESTART -> {
-                String nodeToRestart = randomOtherDataNode(coordinator);
-                logger.info("--> restarting node [{}]", nodeToRestart);
-                internalCluster().restartNode(nodeToRestart);
-                ensureStableCluster(clusterSize);
-            }
-            case REPLACE_FAILED_NODE -> {
-                boolean searchNode = randomBoolean();
-                if (searchNode) {
-                    String nodeToReplace = randomOtherSearchNode(clusterState, coordinator).get();
-                    logger.info("--> replacing search node [{}]", nodeToReplace);
-                    internalCluster().stopNode(nodeToReplace);
-                    startSearchNode();
-                } else {
-                    String nodeToReplace = randomOtherIndexingNode(clusterState, coordinator).get();
-                    logger.info("--> replacing index node [{}]", nodeToReplace);
-                    internalCluster().stopNode(nodeToReplace);
-                    startIndexNode();
+            // TODO restart master node
+            case ISOLATE_NODE -> {
+                String isolatedNode = randomOtherDataNode(coordinator);
+                logger.info("--> isolating node [{}]", isolatedNode);
+
+                Set<String> isolatedSide = Set.of(isolatedNode);
+                Set<String> otherSide = Arrays.stream(internalCluster().getNodeNames())
+                    .filter(name -> name.equals(isolatedNode) == false)
+                    .collect(Collectors.toSet());
+                var disruption = new NetworkDisruption(new TwoPartitions(isolatedSide, otherSide), NetworkDisruption.DISCONNECT);
+                disruption.applyToCluster(internalCluster());
+                disruption.startDisrupting();
+                try {
+                    // waitForRelocation may succeed before the cluster state reflects the isolated node
+                    awaitClusterState(
+                        masterNode,
+                        cs -> cs.nodes().getNodes().values().stream().noneMatch(n -> n.getName().equals(isolatedNode))
+                    );
+                    // We can't use `ensureGreen` here since it requires all nodes to be available and we just isolated a node.
+                    // So we craft the health request manually.
+                    ClusterHealthRequest healthRequest = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, index.getName())
+                        // We have custom logic to keep the index green during resharding to this should work.
+                        .waitForStatus(ClusterHealthStatus.GREEN)
+                        .waitForEvents(Priority.LANGUID)
+                        .waitForNoRelocatingShards(true)
+                        // Target shards may be uninitialized.
+                        .waitForNoInitializingShards(false);
+                    ClusterHealthResponse actionGet = client(coordinator).admin().cluster().health(healthRequest).actionGet();
+                    if (actionGet.isTimedOut()) {
+                        assertThat("timed out waiting for green state during network disruption", actionGet.isTimedOut(), equalTo(false));
+                    }
+                } finally {
+                    disruption.stopDisrupting();
+                    NetworkDisruption.ensureFullyConnectedCluster(internalCluster());
+                    ensureStableCluster(clusterSize);
                 }
-                ensureStableCluster(clusterSize);
+                ensureGreen(index.getName());
             }
             case LOCAL_FAIL_SHARD -> {
                 try {
@@ -146,8 +171,7 @@ public class StatelessReshardDisruptionBaseIT extends AbstractStatelessPluginInt
     }
 
     enum Failure {
-        RESTART,
-        REPLACE_FAILED_NODE,
+        ISOLATE_NODE,
         LOCAL_FAIL_SHARD,
         RELOCATE_SHARD,
     }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardDisruptionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardDisruptionIT.java
@@ -29,14 +29,23 @@ public class StatelessReshardDisruptionIT extends StatelessReshardDisruptionBase
     public void testReshardWithDisruption() throws InterruptedException, ExecutionException {
         var masterNode = startMasterOnlyNode();
 
+        String dedicatedCoordinatorNode = startSearchNode();
+        // Exclude coordinator from allocation.
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .setPersistentSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", dedicatedCoordinatorNode))
+            .get();
+
         int shards = randomIntBetween(1, 5);
 
-        int indexNodes = randomIntBetween(1, shards * 2);
+        // At least two of each role so we still have usable nodes when `ISOLATE_NODE` disruption is applied.
+        int indexNodes = randomIntBetween(2, shards * 2);
         startIndexNodes(indexNodes);
-        int searchNodes = randomIntBetween(1, shards * 2);
+        int searchNodes = randomIntBetween(2, shards * 2);
         startSearchNodes(searchNodes);
 
-        int clusterSize = indexNodes + searchNodes + 1;
+        int clusterSize = 1 + 1 + indexNodes + searchNodes;
         ensureStableCluster(clusterSize);
 
         final String indexName = randomIndexName();
@@ -61,7 +70,7 @@ public class StatelessReshardDisruptionIT extends StatelessReshardDisruptionBase
                 do {
                     Failure randomFailure = randomFrom(Failure.values());
                     try {
-                        induceFailure(randomFailure, index, null);
+                        induceFailure(randomFailure, index, dedicatedCoordinatorNode);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardMixedOperationsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardMixedOperationsIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchService;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -62,8 +63,7 @@ public class StatelessReshardMixedOperationsIT extends StatelessReshardDisruptio
             public void start(Index index, int clusterSize, int shardCount, String coordinator) {
                 var thread = new Thread(() -> {
                     do {
-                        // We don't stop/restart nodes due to #147842.
-                        Failure randomFailure = randomFrom(Failure.LOCAL_FAIL_SHARD, Failure.RELOCATE_SHARD);
+                        Failure randomFailure = randomFrom(Failure.values());
                         try {
                             induceFailure(randomFailure, index, coordinator);
                         } catch (Exception e) {
@@ -97,7 +97,13 @@ public class StatelessReshardMixedOperationsIT extends StatelessReshardDisruptio
             .put(RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD.getKey(), TimeValue.timeValueMillis(100))
             // Reduce the delay between retries to speed up the test.
             .put(SplitSourceService.STATE_MACHINE_RETRY_DELAY.getKey(), TimeValue.timeValueMillis(10))
-            .put(SplitTargetService.START_SPLIT_RETRY_TIMEOUT.getKey(), TimeValue.timeValueSeconds(5));
+            .put(SplitTargetService.START_SPLIT_RETRY_TIMEOUT.getKey(), TimeValue.timeValueSeconds(5))
+            // Reader contexts are only cleaned up (outside of search execution) if a shard is reassigned to a node
+            // or when keepalive expires.
+            // With `ISOLATE_NODE` disruption it is possible that a reader context is opened
+            // to execute a search but not closed since the node is isolated and search failed on this shard.
+            // To prevent asserts for leaked reader contexts we shorten the keepalive.
+            .put(SearchService.DEFAULT_KEEPALIVE_SETTING.getKey(), TimeValue.timeValueSeconds(1));
     }
 
     @Override
@@ -606,9 +612,10 @@ public class StatelessReshardMixedOperationsIT extends StatelessReshardDisruptio
 
         int shards = randomIntBetween(2, 5);
 
-        int indexNodes = randomIntBetween(1, shards * 2);
+        // At least two of each role so we still have usable nodes when `ISOLATE_NODE` disruption is applied.
+        int indexNodes = randomIntBetween(2, shards * 2);
         startIndexNodes(indexNodes);
-        int searchNodes = randomIntBetween(1, shards * 2);
+        int searchNodes = randomIntBetween(2, shards * 2);
         startSearchNodes(searchNodes);
 
         int clusterSize = 1 + 1 + indexNodes + searchNodes;


### PR DESCRIPTION
The current usage of `restartNode`/`stopNode` as a way to add disruption is problematic. In production we never stop nodes with live shards on them, we first relocate all shards and then stop the node. This is not what is done here - we just stop the node while it has active shards and ongoing operations. This exposes issues with the shutdown order of different services like #152157, #152259, and others. 

While these are (arguably?) real issues, the effort required to work through them in my opinion starts to become way too big considering again that this is not something that can happen in a real system. See #151648, #151753, #152278.

This PR replaces this disruption mode with network-level isolation of a random non-master node. This _avoids_ the shutdown order problems since we don't call `Node#stop` anymore. It is also actually much closer to what we want to use in disruption tests as it is something that can happen in reality and we take the real failure handling code paths.