### PR TITLE
[Test] ignore AlreadyClosedException on failing a shard

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -184,9 +184,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.cache.StatelessOnlinePrewarmingIT
   method: testShardPrewarming
   issue: https://github.com/elastic/elasticsearch/issues/147838
-- class: org.elasticsearch.xpack.stateless.commits.StatelessClusterIntegrityStressIT
-  method: testRandomActivities
-  issue: https://github.com/elastic/elasticsearch/issues/147841
 - class: org.elasticsearch.xpack.stateless.autoscaling.search.AutoscalingReplicaIT
   method: testSearchSizeAffectsReplicasSPBetween100And250
   issue: https://github.com/elastic/elasticsearch-serverless/issues/5731

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessClusterIntegrityStressIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessClusterIntegrityStressIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.stateless.commits;
 
 import org.apache.logging.log4j.Level;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushRequestBuilder;
@@ -722,7 +723,11 @@ public class StatelessClusterIntegrityStressIT extends AbstractStatelessPluginIn
                             }
                         };
                         masterClusterService.addListener(clusterStateListener);
-                        indexShard.failShard("broken", new Exception("boom local " + (searchShard ? "search" : "indexing") + " shard"));
+                        try {
+                            indexShard.failShard("broken", new Exception("boom local " + (searchShard ? "search" : "indexing") + " shard"));
+                        } catch (AlreadyClosedException e) {
+                            logger.info("--> shard is already closed due to concurrent node restart/replace/isolation");
+                        }
                         safeAwait(unassignedLatch);
                         masterClusterService.removeListener(clusterStateListener);
                         ensureGreenIgnoreNodeDisconnection(0, trackedIndex.index.getName());


### PR DESCRIPTION
A shard can be concurrently closed due to other node activities such as replacing, restart or isolation. It is OK to ignore the exception when attempt to fail it. The shard is gone regardless and the test can simply proceed further.

Resolves #147841
