### PR TITLE
Grant implicit privileges for workflow executions

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -72,7 +72,8 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         "kibana.workflows.execution.logs.managed.index.version";
 
     /**
-     * Matches workflows-related system <strong>indices</strong> under {@code .workflows-}, but not the log
+     * Matches workflows-related system <strong>indices</strong> under {@code .workflows-}, but not the execution
+     * analytics index or log
      * {@linkplain SystemDataStreamDescriptor system data streams} registered in {@link #getSystemDataStreamDescriptors()}
      * ({@value #WORKFLOWS_EVENTS_DATA_STREAM_NAME} and {@value #WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME}).
      * <p>
@@ -81,7 +82,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
      * a {@link SystemDataStreamDescriptor} (see {@code checkForOverlappingPatterns}). Uses the same complement style as Fleet's
      * {@code .fleet-actions~(-results*)}; see {@link SystemIndexDescriptor} for pattern syntax.
      */
-    public static final String WORKFLOWS_SYSTEM_INDEX_PATTERN = ".workflows~(-events*|-execution-data-stream-logs*)";
+    public static final String WORKFLOWS_SYSTEM_INDEX_PATTERN = ".workflows~(-executions|-events*|-execution-data-stream-logs*)";
 
     public static final SystemIndexDescriptor KIBANA_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
         .setIndexPattern(".kibana_*")

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -44,6 +44,7 @@ public class KibanaPluginTests extends ESTestCase {
 
     public void testNoSystemIndexPatternCoversWorkflowsDataStreams() {
         var indexDescriptors = new KibanaPlugin().getSystemIndexDescriptors(Settings.EMPTY);
+        assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".workflows-executions")));
         assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".workflows-events")));
         assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".workflows-execution-data-stream-logs")));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -343,6 +343,7 @@ import org.elasticsearch.xpack.security.authz.interceptor.ShardSearchRequestInte
 import org.elasticsearch.xpack.security.authz.interceptor.UpdateRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.interceptor.ValidateRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.interceptor.ViewAndDatasetDlsFlsRequestInterceptor;
+import org.elasticsearch.xpack.security.authz.privilege.KibanaWorkflowsImplicitPrivilegesProvider;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 import org.elasticsearch.xpack.security.authz.store.DeprecationRoleDescriptorConsumer;
 import org.elasticsearch.xpack.security.authz.store.FileRolesStore;
@@ -1042,9 +1043,10 @@ public class Security extends Plugin
             customRoleProviders,
             getLicenseState()
         );
-        final List<ImplicitPrivilegesProvider> implicitPrivilegesProviders = securityExtensions.stream()
-            .flatMap(extension -> extension.getImplicitPrivilegesProviders(extensionComponents).stream())
-            .toList();
+        final List<ImplicitPrivilegesProvider> implicitPrivilegesProviders = Stream.concat(
+            Stream.of(new KibanaWorkflowsImplicitPrivilegesProvider()),
+            securityExtensions.stream().flatMap(extension -> extension.getImplicitPrivilegesProviders(extensionComponents).stream())
+        ).toList();
         final CompositeRolesStore allRolesStore = new CompositeRolesStore(
             settings,
             clusterService,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/privilege/KibanaWorkflowsImplicitPrivilegesProvider.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/privilege/KibanaWorkflowsImplicitPrivilegesProvider.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.authz.privilege;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
+import org.elasticsearch.xpack.core.security.authz.privilege.ImplicitPrivilegesProvider;
+import org.elasticsearch.xpack.core.security.support.Automatons;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Grants read access to Kibana's workflow execution analytics index when a role
+ * grants the corresponding Kibana Workflows application privileges. The emitted
+ * index privilege remains scoped by DLS so users only see executions from the
+ * spaces where their Kibana role grants execution-read access.
+ */
+public class KibanaWorkflowsImplicitPrivilegesProvider implements ImplicitPrivilegesProvider {
+
+    public static final String WORKFLOWS_EXECUTIONS_INDEX = ".workflows-executions";
+    public static final String WORKFLOWS_READ_EXECUTION_ACTION = "api:workflowsManagement:readExecution";
+    public static final String WORKFLOWS_READ_MANAGED_EXECUTION_ACTION = "api:workflowsManagement:managed:readExecution";
+
+    private static final String KIBANA_APPLICATION_SAMPLE = "kibana-.kibana";
+    private static final String GLOBAL_RESOURCE = "*";
+    private static final String SPACE_RESOURCE_PREFIX = "space:";
+
+    @Override
+    public Collection<RoleDescriptor.IndicesPrivileges> getImplicitIndicesPrivileges(
+        RoleDescriptor roleDescriptor,
+        Collection<ApplicationPrivilegeDescriptor> storedApplicationPrivileges
+    ) {
+        final ResourceGrant readExecutions = collectResourcesForAction(
+            roleDescriptor,
+            storedApplicationPrivileges,
+            WORKFLOWS_READ_EXECUTION_ACTION
+        );
+        if (readExecutions.isEmpty()) {
+            return List.of();
+        }
+
+        final ResourceGrant readManagedExecutions = collectResourcesForAction(
+            roleDescriptor,
+            storedApplicationPrivileges,
+            WORKFLOWS_READ_MANAGED_EXECUTION_ACTION
+        );
+        final String dlsQuery = buildDlsQuery(readExecutions, readExecutions.intersection(readManagedExecutions));
+
+        final RoleDescriptor.IndicesPrivileges.Builder builder = RoleDescriptor.IndicesPrivileges.builder()
+            .indices(WORKFLOWS_EXECUTIONS_INDEX)
+            .privileges("read");
+        if (dlsQuery != null) {
+            builder.query(new BytesArray(dlsQuery));
+        }
+        return List.of(builder.build());
+    }
+
+    private static ResourceGrant collectResourcesForAction(
+        RoleDescriptor roleDescriptor,
+        Collection<ApplicationPrivilegeDescriptor> storedApplicationPrivileges,
+        String action
+    ) {
+        final ResourceGrant grant = new ResourceGrant();
+        for (RoleDescriptor.ApplicationResourcePrivileges applicationPrivileges : roleDescriptor.getApplicationPrivileges()) {
+            if (isKibanaApplication(applicationPrivileges.getApplication()) == false) {
+                continue;
+            }
+            if (grantsAction(applicationPrivileges, storedApplicationPrivileges, action) == false) {
+                continue;
+            }
+            for (String resource : applicationPrivileges.getResources()) {
+                if (GLOBAL_RESOURCE.equals(resource)) {
+                    grant.all = true;
+                } else if (resource.startsWith(SPACE_RESOURCE_PREFIX)) {
+                    grant.spaces.add(resource.substring(SPACE_RESOURCE_PREFIX.length()));
+                }
+            }
+        }
+        return grant;
+    }
+
+    private static boolean isKibanaApplication(String application) {
+        if (application.contains("*")) {
+            return Automatons.predicate(application).test(KIBANA_APPLICATION_SAMPLE);
+        }
+        return application.startsWith("kibana-");
+    }
+
+    private static boolean grantsAction(
+        RoleDescriptor.ApplicationResourcePrivileges applicationPrivileges,
+        Collection<ApplicationPrivilegeDescriptor> storedApplicationPrivileges,
+        String action
+    ) {
+        for (String privilege : applicationPrivileges.getPrivileges()) {
+            if (Automatons.predicate(List.of(privilege)).test(action)) {
+                return true;
+            }
+            for (ApplicationPrivilegeDescriptor descriptor : storedApplicationPrivileges) {
+                if (privilege.equals(descriptor.getName())
+                    && applicationMatches(applicationPrivileges.getApplication(), descriptor.getApplication())
+                    && Automatons.predicate(descriptor.getActions()).test(action)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean applicationMatches(String applicationPattern, String application) {
+        if (applicationPattern.contains("*")) {
+            return Automatons.predicate(applicationPattern).test(application);
+        }
+        return applicationPattern.equals(application);
+    }
+
+    private static String buildDlsQuery(ResourceGrant readExecutions, ResourceGrant readManagedExecutions) {
+        if (readExecutions.all && readManagedExecutions.all) {
+            return null;
+        }
+
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startObject();
+            builder.startObject("bool");
+            builder.startArray("should");
+
+            if (readExecutions.all) {
+                writeUnmanagedExecutionsClause(builder);
+            } else {
+                writeUnmanagedExecutionsClause(builder, readExecutions.spaces);
+            }
+
+            if (readManagedExecutions.all == false && readManagedExecutions.spaces.isEmpty() == false) {
+                writeSpacesClause(builder, readManagedExecutions.spaces);
+            }
+
+            builder.endArray();
+            builder.field("minimum_should_match", 1);
+            builder.endObject();
+            builder.endObject();
+            return Strings.toString(builder);
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to build workflow execution DLS query", e);
+        }
+    }
+
+    private static void writeUnmanagedExecutionsClause(XContentBuilder builder) throws IOException {
+        builder.startObject();
+        builder.startObject("bool");
+        writeManagedMustNotClause(builder);
+        builder.endObject();
+        builder.endObject();
+    }
+
+    private static void writeUnmanagedExecutionsClause(XContentBuilder builder, Set<String> spaces) throws IOException {
+        if (spaces.isEmpty()) {
+            return;
+        }
+        builder.startObject();
+        builder.startObject("bool");
+        builder.startArray("filter");
+        writeSpacesClause(builder, spaces);
+        builder.endArray();
+        writeManagedMustNotClause(builder);
+        builder.endObject();
+        builder.endObject();
+    }
+
+    private static void writeManagedMustNotClause(XContentBuilder builder) throws IOException {
+        builder.startArray("must_not");
+        builder.startObject();
+        builder.startObject("term");
+        builder.field("managed", true);
+        builder.endObject();
+        builder.endObject();
+        builder.endArray();
+    }
+
+    private static void writeSpacesClause(XContentBuilder builder, Set<String> spaces) throws IOException {
+        builder.startObject();
+        builder.startObject("terms");
+        builder.array("spaceId", spaces.toArray(Strings.EMPTY_ARRAY));
+        builder.endObject();
+        builder.endObject();
+    }
+
+    private static class ResourceGrant {
+        private boolean all;
+        private final TreeSet<String> spaces = new TreeSet<>();
+
+        private boolean isEmpty() {
+            return all == false && spaces.isEmpty();
+        }
+
+        private ResourceGrant intersection(ResourceGrant other) {
+            final ResourceGrant result = new ResourceGrant();
+            if (all) {
+                result.all = other.all;
+                result.spaces.addAll(other.spaces);
+            } else if (other.all) {
+                result.spaces.addAll(spaces);
+            } else {
+                result.spaces.addAll(spaces);
+                result.spaces.retainAll(other.spaces);
+            }
+            return result;
+        }
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/privilege/KibanaWorkflowsImplicitPrivilegesProviderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/privilege/KibanaWorkflowsImplicitPrivilegesProviderTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under
+ * one or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.authz.privilege;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.ApplicationResourcePrivileges;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.IndicesPrivileges;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+
+public class KibanaWorkflowsImplicitPrivilegesProviderTests extends ESTestCase {
+
+    private final KibanaWorkflowsImplicitPrivilegesProvider provider = new KibanaWorkflowsImplicitPrivilegesProvider();
+
+    public void testGrantsUnmanagedExecutionReadForAuthorizedSpace() {
+        final Collection<IndicesPrivileges> privileges = provider.getImplicitIndicesPrivileges(
+            roleWithPrivileges(
+                ApplicationResourcePrivileges.builder()
+                    .application("kibana-.kibana")
+                    .privileges("feature_workflowsManagement.workflow_execution_read")
+                    .resources("space:marketing")
+                    .build()
+            ),
+            Set.of(
+                new ApplicationPrivilegeDescriptor(
+                    "kibana-.kibana",
+                    "feature_workflowsManagement.workflow_execution_read",
+                    Set.of(KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_READ_EXECUTION_ACTION),
+                    Map.of()
+                )
+            )
+        );
+
+        assertThat(privileges, hasSize(1));
+        final IndicesPrivileges indexPrivilege = privileges.iterator().next();
+        assertArrayEquals(new String[] { KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_EXECUTIONS_INDEX }, indexPrivilege.getIndices());
+        assertArrayEquals(new String[] { "read" }, indexPrivilege.getPrivileges());
+        final String query = query(indexPrivilege);
+        assertThat(query, containsString("\"spaceId\":[\"marketing\"]"));
+        assertThat(query, containsString("\"must_not\":[{\"term\":{\"managed\":true}}]"));
+    }
+
+    public void testManagedExecutionReadOnlyBroadensSpacesWithBaseExecutionRead() {
+        final Collection<IndicesPrivileges> privileges = provider.getImplicitIndicesPrivileges(
+            roleWithPrivileges(
+                ApplicationResourcePrivileges.builder()
+                    .application("kibana-.kibana")
+                    .privileges("feature_workflowsManagement.workflow_execution_read")
+                    .resources("space:marketing", "space:sales")
+                    .build(),
+                ApplicationResourcePrivileges.builder()
+                    .application("kibana-.kibana")
+                    .privileges("feature_workflowsManagement.workflow_execution_read_managed")
+                    .resources("space:marketing")
+                    .build()
+            ),
+            Set.of(
+                new ApplicationPrivilegeDescriptor(
+                    "kibana-.kibana",
+                    "feature_workflowsManagement.workflow_execution_read",
+                    Set.of(KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_READ_EXECUTION_ACTION),
+                    Map.of()
+                ),
+                new ApplicationPrivilegeDescriptor(
+                    "kibana-.kibana",
+                    "feature_workflowsManagement.workflow_execution_read_managed",
+                    Set.of(KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_READ_MANAGED_EXECUTION_ACTION),
+                    Map.of()
+                )
+            )
+        );
+
+        assertThat(privileges, hasSize(1));
+        final String query = query(privileges.iterator().next());
+        assertThat(query, containsString("\"spaceId\":[\"marketing\",\"sales\"]"));
+        assertThat(query, containsString("\"must_not\":[{\"term\":{\"managed\":true}}]"));
+        assertThat(query, containsString("\"spaceId\":[\"marketing\"]"));
+    }
+
+    public void testGlobalExecutionAndManagedReadDoesNotNeedDls() {
+        final Collection<IndicesPrivileges> privileges = provider.getImplicitIndicesPrivileges(
+            roleWithPrivileges(
+                ApplicationResourcePrivileges.builder()
+                    .application("kibana-.kibana")
+                    .privileges(
+                        "feature_workflowsManagement.workflow_execution_read",
+                        "feature_workflowsManagement.workflow_execution_read_managed"
+                    )
+                    .resources("*")
+                    .build()
+            ),
+            Set.of(
+                new ApplicationPrivilegeDescriptor(
+                    "kibana-.kibana",
+                    "feature_workflowsManagement.workflow_execution_read",
+                    Set.of(KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_READ_EXECUTION_ACTION),
+                    Map.of()
+                ),
+                new ApplicationPrivilegeDescriptor(
+                    "kibana-.kibana",
+                    "feature_workflowsManagement.workflow_execution_read_managed",
+                    Set.of(KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_READ_MANAGED_EXECUTION_ACTION),
+                    Map.of()
+                )
+            )
+        );
+
+        assertThat(privileges, hasSize(1));
+        assertThat(privileges.iterator().next().getQuery(), nullValue());
+    }
+
+    private static RoleDescriptor roleWithPrivileges(ApplicationResourcePrivileges... privileges) {
+        return new RoleDescriptor("role", null, null, privileges);
+    }
+
+    private static String query(IndicesPrivileges privilege) {
+        return privilege.getQuery().utf8ToString();
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/privilege/KibanaWorkflowsImplicitPrivilegesProviderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/privilege/KibanaWorkflowsImplicitPrivilegesProviderTests.java
@@ -45,7 +45,10 @@ public class KibanaWorkflowsImplicitPrivilegesProviderTests extends ESTestCase {
 
         assertThat(privileges, hasSize(1));
         final IndicesPrivileges indexPrivilege = privileges.iterator().next();
-        assertArrayEquals(new String[] { KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_EXECUTIONS_INDEX }, indexPrivilege.getIndices());
+        assertArrayEquals(
+            new String[] { KibanaWorkflowsImplicitPrivilegesProvider.WORKFLOWS_EXECUTIONS_INDEX },
+            indexPrivilege.getIndices()
+        );
         assertArrayEquals(new String[] { "read" }, indexPrivilege.getPrivileges());
         final String query = query(indexPrivilege);
         assertThat(query, containsString("\"spaceId\":[\"marketing\"]"));


### PR DESCRIPTION
## Summary
- Removes `.workflows-executions` from the Kibana Workflows system-index descriptor so it can be exposed as a hidden, non-restricted analytics index.
- Adds a built-in implicit privileges provider that grants `.workflows-executions` read access from Kibana Workflows execution-read application privileges.
- Applies DLS on top-level `spaceId` and `managed` so users only see executions from authorized spaces, with managed executions included only when `readManagedExecution` is also granted.

## Test plan
- Not run locally: ES Gradle requires a Java runtime and this machine currently has no Java runtime configured (`/usr/libexec/java_home -V` fails).
- Intended checks: `./gradlew :x-pack:plugin:security:test --tests org.elasticsearch.xpack.security.authz.privilege.KibanaWorkflowsImplicitPrivilegesProviderTests`
- Intended checks: `./gradlew :modules:kibana:test --tests org.elasticsearch.kibana.KibanaPluginTests`

## Companion PR
- Kibana: elastic/kibana#276868