### PR TITLE
[9.5] ESQL: external multi-file warm COUNT survives schema-TTL expiry and many-stripe cache pressure (#153085)

### DIFF
--- a/docs/changelog/153085.yaml
+++ b/docs/changelog/153085.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153085
+summary: "[ESQLDS] Fix external multi-file warm COUNT/MIN/MAX re-scanning under schema-cache eviction"
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalMultiChunkPerStripeWarmFoldIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalMultiChunkPerStripeWarmFoldIT.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.operator.exchange.ExchangeService;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.gzip.GzipDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceOperator;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalStats;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Warm short-circuit regression coverage for the <b>parallel multiple-chunks-per-stripe</b> read geometry, for
+ * EVERY row format. The sibling fold ITs leave a hole this test closes:
+ * <ul>
+ *   <li>{@link ExternalMultiFileWarmAggregateFoldIT} writes files below the segment-size chunking threshold, so
+ *       each file is read whole (one authoritative summary) and never parallel-chunked.</li>
+ *   <li>{@link ExternalNdJsonMultiStripeFoldIT} pins parallelism to 1 (again a whole-file read), and uses a 64kb
+ *       stripe far smaller than a read chunk, so a chunk spans MANY stripes.</li>
+ * </ul>
+ * Neither exercises the bench shape: a file large enough to split into several real read chunks, with a stripe
+ * grid LARGER than a chunk so each stripe is stitched together from MULTIPLE parallel chunks via the coordinator's
+ * per-stripe byte-range interval-cover fold. That is exactly the geometry where NDJSON's retired page-capped
+ * striping used to leave the fold incomplete and warm {@code COUNT(*)}/{@code MIN}/{@code MAX} re-scanned the file
+ * while CSV/TSV short-circuited. Any reader that stops committing per-stripe stats for this realistic shape (or
+ * regresses the whole-file EOF marker so the {@code 0..K} fold never closes) must fail this test. The geometry
+ * itself is asserted from the cold profile's captured contributions ({@link #assertMultiChunkPerStripeGeometry}),
+ * so a silent degradation to a whole-file or single-chunk read fails loudly instead of passing vacuously (a
+ * whole-file summary is authoritative and would still short-circuit warm).
+ * <p>
+ * Each file is ~12 MB (well over the default 4 MB segment size, so the parallel-parse path yields ~3 chunks per file), the
+ * stripe grid is pinned to 6 MB (larger than a 4 MB chunk, so every stripe spans a chunk boundary), and the
+ * dataset spans multiple files. Columns cover a LONG stats column and a temporal (DATETIME) stats column — the
+ * bench {@code EventDate} shape — so both {@code MIN}/{@code MAX} over a plain integer and over a date short-circuit.
+ * Runs for CSV, NDJSON, and gzip-compressed NDJSON (which drives the sibling {@code StreamingParallelParsingCoordinator}
+ * over the decompressed stream); TSV shares the CSV reader's stripe path.
+ */
+public class ExternalMultiChunkPerStripeWarmFoldIT extends AbstractExternalDataSourceIT {
+
+    private static final int FILE_COUNT = 2;
+    private static final int ROWS_PER_FILE = 120_000; // ~12 MB/file once padded -> 3 chunks at the 4 MB segment size
+    private static final long TOTAL = (long) FILE_COUNT * ROWS_PER_FILE;
+    private static final long TS_BASE_MILLIS = 1_577_836_800_000L; // 2020-01-01T00:00:00Z
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class, NdJsonDataSourcePlugin.class, GzipDataSourcePlugin.class);
+    }
+
+    /**
+     * Registers {@link InternalExchangePlugin} so the short inactive-sink reap interval below is a known
+     * node setting. Without it the reaper runs at its 5-minute default and a data-node exchange sink whose
+     * async post-query cleanup lags the test's teardown window is not removed in time — the CI-only
+     * "Leftover exchanges" / "Request breaker not reset" teardown failure the sibling multi-file fold IT hit.
+     */
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), InternalExchangePlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            // Stripe (6 MB) LARGER than the default 4 MB read segment: every stripe spans a chunk boundary, so
+            // the per-stripe interval-cover must stitch fragments from more than one parallel chunk. This is the
+            // "multiple chunks per stripe" geometry the sibling fold ITs (64kb stripe, or parallelism 1) never hit.
+            .put("esql.source.cache.stripe.size", "6mb")
+            // Reap inactive exchange sinks within a few seconds (default is 5 minutes) so a data-node sink whose
+            // async cleanup trails the query response is released well inside the exchange/breaker teardown checks.
+            .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueMillis(between(3000, 4000)))
+            .build();
+    }
+
+    /**
+     * Pins every query to one coordinator: the reconciled schema cache is per-coordinator, so the cold scan and
+     * the warm short-circuit must hit the same node (mirrors {@link ExternalMultiFileWarmAggregateFoldIT}).
+     */
+    @Override
+    public EsqlQueryResponse run(EsqlQueryRequest request, TimeValue timeout) {
+        try {
+            return client(internalCluster().getMasterName()).execute(EsqlQueryAction.INSTANCE, request).actionGet(timeout);
+        } catch (ElasticsearchTimeoutException e) {
+            throw new AssertionError("timeout", e);
+        }
+    }
+
+    public void testCsvMultiChunkPerStripeWarmShortCircuit() throws Exception {
+        assertWarmAggregatesShortCircuit(writeAndRegister("csv"));
+    }
+
+    public void testNdjsonMultiChunkPerStripeWarmShortCircuit() throws Exception {
+        assertWarmAggregatesShortCircuit(writeAndRegister("ndjson"));
+    }
+
+    /**
+     * gzip-compressed NDJSON drives {@code StreamingParallelParsingCoordinator} (the decompressed-stream parallel
+     * path) instead of {@code ParallelParsingCoordinator}. It is a stream-only source, so it is read as a single
+     * serial decompressing stream cut into record-aligned chunks; the per-stripe fold must still reach whole-file
+     * completeness over the decompressed byte grid for the warm aggregate to short-circuit.
+     */
+    public void testGzipNdjsonMultiChunkPerStripeWarmShortCircuit() throws Exception {
+        assertWarmAggregatesShortCircuit(writeAndRegister("ndjson.gz"));
+    }
+
+    /**
+     * Cold-then-warm for COUNT(*), MIN/MAX over a LONG column, and MIN/MAX over a DATETIME column. Each warm pass
+     * must short-circuit ({@code documentsFound == 0}), proving the per-stripe fold reached whole-file completeness
+     * across chunks and files. COUNT(*) runs first so its row-count-only per-file entries are in place before
+     * MIN/MAX, reproducing the production ordering.
+     */
+    private void assertWarmAggregatesShortCircuit(String dataset) {
+        // The multi-chunk-per-stripe geometry requires the parallel-parse path (parsing_parallelism > 1). That
+        // pragma is snapshot-only (rejected in release builds), so this test relies on its node default —
+        // EsExecutors.allocatedProcessors(EMPTY), i.e. the machine's cores — and skips on a single-processor
+        // runner, where the read would be a whole-file sequential scan and the geometry would not be exercised.
+        assumeTrue(
+            "multi-chunk-per-stripe geometry needs parsing_parallelism > 1 (allocated processors)",
+            EsExecutors.allocatedProcessors(Settings.EMPTY) > 1
+        );
+        String countQuery = "FROM " + dataset + " | STATS c = COUNT(*)";
+        Map<String, List<Map<String, Object>>> coldContributions;
+        try (var response = runProfiled(countQuery)) {
+            assertSingleLong(response, TOTAL);
+            assertThat("cold COUNT(*) reads every row", response.documentsFound(), equalTo(TOTAL));
+            coldContributions = capturedContributionsByPath(response);
+        }
+        try (var response = runProfiled(countQuery)) {
+            assertSingleLong(response, TOTAL);
+            assertThat("warm COUNT(*) must short-circuit across multi-chunk-per-stripe files", response.documentsFound(), equalTo(0L));
+        }
+        // Only meaningful AFTER the warm assertion: the warm serve firing proves the cold profile's
+        // contribution snapshot was the complete reconcile input (see capturedContributionsByPath),
+        // so the geometry read below cannot race the producer-completion async hop.
+        assertMultiChunkPerStripeGeometry(coldContributions);
+
+        String longQuery = "FROM " + dataset + " | STATS lo = MIN(value), hi = MAX(value)";
+        try (var response = runProfiled(longQuery)) {
+            assertMinMax(response, 0L, TOTAL - 1);
+            assertThat("cold MIN/MAX(long) reads every row", response.documentsFound(), equalTo(TOTAL));
+        }
+        try (var response = runProfiled(longQuery)) {
+            assertMinMax(response, 0L, TOTAL - 1);
+            assertThat("warm MIN/MAX(long) must short-circuit across multi-chunk-per-stripe files", response.documentsFound(), equalTo(0L));
+        }
+
+        // Temporal (DATETIME) stats column — the bench EventDate shape. MIN/MAX over a date must short-circuit AND
+        // serve the true extrema. The cold full scan is authoritative; the warm serve must return the identical row
+        // (representation-agnostic — the DATETIME rendering is whatever the cold scan produced), not just fire.
+        String dateQuery = "FROM " + dataset + " | STATS lo = MIN(ts), hi = MAX(ts)";
+        List<Object> coldDateExtrema;
+        try (var response = runProfiled(dateQuery)) {
+            coldDateExtrema = getValuesList(response).get(0);
+            assertThat("cold MIN/MAX(date) reads every row", response.documentsFound(), equalTo(TOTAL));
+        }
+        try (var response = runProfiled(dateQuery)) {
+            assertThat("warm MIN/MAX(date) must serve the cold extrema", getValuesList(response).get(0), equalTo(coldDateExtrema));
+            assertThat("warm MIN/MAX(date) must short-circuit across multi-chunk-per-stripe files", response.documentsFound(), equalTo(0L));
+        }
+    }
+
+    /**
+     * Runs {@code query} with profiling on. {@code parsing_parallelism} is NOT pinned here: it is a
+     * snapshot-only pragma (a request carrying it is rejected in release builds), so the parallel-parse path
+     * relies on the node default (allocated processors), which the {@code assumeTrue} in
+     * {@link #assertWarmAggregatesShortCircuit} requires to be &gt; 1.
+     */
+    private EsqlQueryResponse runProfiled(String query) {
+        return run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5));
+    }
+
+    private static void assertSingleLong(EsqlQueryResponse response, long expected) {
+        List<List<Object>> rows = getValuesList(response);
+        assertThat(rows.size(), equalTo(1));
+        assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo(expected));
+    }
+
+    private static void assertMinMax(EsqlQueryResponse response, long expectedMin, long expectedMax) {
+        List<List<Object>> rows = getValuesList(response);
+        assertThat(rows.size(), equalTo(1));
+        assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo(expectedMin));
+        assertThat(((Number) rows.get(0).get(1)).longValue(), equalTo(expectedMax));
+    }
+
+    /**
+     * The scan's per-file stats contributions, read off the query profile's
+     * {@link AsyncExternalSourceOperator.Status#capturedSourceMetadata()}. This is the exact payload the
+     * coordinator reconciled into the schema cache: the driver captures each operator's status ONCE at
+     * close, and both the response profile and {@code DriverCompletionInfo} (the reconcile input) read
+     * that same snapshot. The snapshot is only guaranteed complete once the producer has drained — the
+     * async hop {@link ExternalSourceProfileIT} documents — which the caller proves by asserting the warm
+     * short-circuit BEFORE interrogating this map: the warm serve can only fire if the reconcile saw the
+     * complete stripe cover, and the reconcile input IS this snapshot.
+     */
+    private static Map<String, List<Map<String, Object>>> capturedContributionsByPath(EsqlQueryResponse response) {
+        assertThat("query must run with profile(true) to read the scan's contributions", response.profile(), notNullValue());
+        Map<String, List<Map<String, Object>>> byPath = new HashMap<>();
+        for (var driver : response.profile().drivers()) {
+            for (var op : driver.operators()) {
+                if (op.status() instanceof AsyncExternalSourceOperator.Status status) {
+                    for (var e : status.capturedSourceMetadata().entrySet()) {
+                        byPath.computeIfAbsent(e.getKey(), k -> new ArrayList<>()).addAll(e.getValue());
+                    }
+                }
+            }
+        }
+        return byPath;
+    }
+
+    /**
+     * Asserts the cold read actually exercised the multiple-chunks-per-stripe geometry this test exists
+     * for. The warm assertions alone cannot see it: a read that silently degrades to a whole-file pass
+     * (or to one chunk per file) still short-circuits warm — a whole-file summary is authoritative — so
+     * the coverage this suite adds over the sibling fold ITs would evaporate invisibly on a config or
+     * reader change. Per file: every contribution must be a partial-chunk stripe fragment (no whole-file
+     * reads), and at least one stripe ordinal must be covered by fragments from more than one chunk
+     * (distinct coverage starts) — the per-stripe interval-cover had to stitch. With the pinned 6 MB
+     * stripe over 4 MB chunks every interior stripe splits, so one stitched stripe per file is the
+     * loosest assertion that still pins the geometry.
+     */
+    private static void assertMultiChunkPerStripeGeometry(Map<String, List<Map<String, Object>>> contributionsByPath) {
+        assertThat("every file must contribute captured stats", contributionsByPath.keySet(), hasSize(FILE_COUNT));
+        for (Map.Entry<String, List<Map<String, Object>>> file : contributionsByPath.entrySet()) {
+            Map<Long, Set<Long>> fragmentStartsByStripe = new HashMap<>();
+            for (Map<String, Object> contribution : file.getValue()) {
+                assertTrue(
+                    "file [" + file.getKey() + "] must be read as parallel chunks, not a whole-file pass",
+                    Boolean.TRUE.equals(contribution.get(ExternalStats.PARTIAL_CHUNK_KEY))
+                );
+                long ordinal = ((Number) contribution.get(ExternalStats.STRIPE_ORDINAL_KEY)).longValue();
+                long start = ((Number) contribution.get(ExternalStats.COVERAGE_START_KEY)).longValue();
+                fragmentStartsByStripe.computeIfAbsent(ordinal, o -> new HashSet<>()).add(start);
+            }
+            assertTrue(
+                "file ["
+                    + file.getKey()
+                    + "] must have at least one stripe stitched from several chunks; per-stripe fragment starts: "
+                    + fragmentStartsByStripe,
+                fragmentStartsByStripe.values().stream().anyMatch(starts -> starts.size() > 1)
+            );
+        }
+    }
+
+    /** Writes {@code FILE_COUNT} files of the given format into a directory and registers the glob as a dataset. */
+    private String writeAndRegister(String format) throws IOException {
+        Path dir = createTempDir();
+        long v = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            Path file = dir.resolve("part-" + f + "." + format);
+            v = switch (format) {
+                case "csv" -> writeCsvFile(file, v);
+                case "ndjson" -> writeNdjsonFile(file, v, false);
+                case "ndjson.gz" -> writeNdjsonFile(file, v, true);
+                default -> throw new IllegalArgumentException("unknown format: " + format);
+            };
+        }
+        String dirUri = StoragePath.fileUri(dir);
+        if (dirUri.endsWith("/") == false) {
+            dirUri += "/";
+        }
+        return registerDataset("multichunk_" + format, dirUri + "*." + format, Map.of());
+    }
+
+    // ~50 bytes of padding per row so a 120k-row file clears the 4 MB segment*2 chunking threshold with margin.
+    private static final String PAD = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+    /** Writes a CSV file; {@code value} runs from {@code base}. Returns the next global value. */
+    private static long writeCsvFile(Path file, long base) throws IOException {
+        StringBuilder sb = new StringBuilder("id,value,ts,pad\n");
+        long v = base;
+        for (int i = 0; i < ROWS_PER_FILE; i++, v++) {
+            sb.append(v)
+                .append(',')
+                .append(v)
+                .append(',')
+                .append(Instant.ofEpochMilli(TS_BASE_MILLIS + v * 1000L))
+                .append(',')
+                .append(PAD)
+                .append('\n');
+        }
+        Files.writeString(file, sb.toString(), StandardCharsets.UTF_8);
+        return v;
+    }
+
+    /**
+     * Writes an NDJSON file (optionally gzip-compressed); {@code value} runs from {@code base}. Returns the next
+     * global value. When {@code gzip} the file exceeds the chunk size in DECOMPRESSED bytes, so the streaming
+     * coordinator still cuts several chunks over the inflated stream.
+     */
+    private static long writeNdjsonFile(Path file, long base, boolean gzip) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        long v = base;
+        for (int i = 0; i < ROWS_PER_FILE; i++, v++) {
+            sb.append("{\"id\":")
+                .append(v)
+                .append(",\"value\":")
+                .append(v)
+                .append(",\"ts\":\"")
+                .append(Instant.ofEpochMilli(TS_BASE_MILLIS + v * 1000L))
+                .append("\",\"pad\":\"")
+                .append(PAD)
+                .append("\"}\n");
+        }
+        if (gzip) {
+            writeGzipped(file, sb.toString());
+        } else {
+            Files.writeString(file, sb.toString(), StandardCharsets.UTF_8);
+        }
+        return v;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -938,13 +938,6 @@ public class ExternalSourceResolver {
         return dot >= 0 ? name.substring(dot) : "";
     }
 
-    /** True for the coordinator-cache stripe bookkeeping keys that have no plan-side consumer. */
-    private static boolean isStripeBookkeeping(String key) {
-        return key.startsWith(ExternalStats.STRIPE_ENTRY_PREFIX)
-            || key.equals(ExternalStats.STRIPE_LAST_INDEX_KEY)
-            || key.equals(ExternalStats.STRIPE_GRID_KEY);
-    }
-
     /**
      * Returns {@code safeMetadata} without the coordinator-cache stripe bookkeeping ({@code _stats.stripe.<k>},
      * {@code _stats.stripe_last_index}, {@code _stats.stripe_grid}) — those feed the cache-side 0..K fold and are
@@ -952,7 +945,7 @@ public class ExternalSourceResolver {
      * when it carries no stripe keys (no copy on the common already-folded warm-serve path).
      */
     private static Map<String, Object> stripStripeBookkeeping(Map<String, Object> safeMetadata) {
-        return withoutKeys(safeMetadata, ExternalSourceResolver::isStripeBookkeeping);
+        return withoutKeys(safeMetadata, ExternalStats::isStripeBookkeeping);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.cache.CacheLoader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.KeyedLock;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.logging.LogManager;
@@ -26,10 +27,12 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Coordinator-only, in-memory cache service for external source metadata.
@@ -147,7 +150,16 @@ public class ExternalSourceCacheService implements Closeable {
         if (enabled == false || contributionsPerFile == null || contributionsPerFile.isEmpty()) {
             return;
         }
-        Map<String, Map<String, Object>> merged = new HashMap<>(contributionsPerFile.size());
+        // Snapshot the glob's entries BEFORE any commit writes: the first put() sweeps TTL-expired
+        // entries, evicting files #2..N's entries before their deltas apply. See snapshotEntriesByPath.
+        Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> preCommitSnapshot = snapshotEntriesByPath(
+            contributionsPerFile.keySet()
+        );
+        // LinkedHashMap, not HashMap: commit whole-file entries in the caller's contribution order so the
+        // reconcile (and which sibling a capacity/TTL sweep hits during a commit) is deterministic rather
+        // than dependent on path hashCode. Final per-entry state is order-independent (each path keys a
+        // distinct entry; a swept sibling is recovered per key), so this only pins reproducibility.
+        Map<String, Map<String, Object>> merged = new LinkedHashMap<>(contributionsPerFile.size());
         for (Map.Entry<String, List<Map<String, Object>>> e : contributionsPerFile.entrySet()) {
             List<Map<String, Object>> contributions = e.getValue();
             if (contributions == null || contributions.isEmpty()) {
@@ -194,9 +206,111 @@ public class ExternalSourceCacheService implements Closeable {
                 logger.debug("dropping captured stats for [{}]: no complete stripe among fragments", e.getKey());
                 continue;
             }
-            commitStripeDelta(e.getKey(), delta);
+            commitStripeDelta(e.getKey(), delta, preCommitSnapshot.get(e.getKey()));
         }
-        reconcileSourceStats(merged);
+        reconcileSourceStats(merged, preCommitSnapshot);
+    }
+
+    /**
+     * Snapshots, per contribution path, every schema-cache entry whose canonical path matches — taken
+     * BEFORE a reconcile's first commit write. A cold scan longer than the schema TTL reconciles into a
+     * cache whose entries for the scanned glob have ALL expired: expired entries are still forEach-visible
+     * (expiry evicts lazily), but the first {@code schemaCache.put()} prunes them from the LRU tail, so
+     * file #1's commit would evict files #2..N's entries before their deltas apply — the deltas match
+     * nothing, the all-or-nothing multi-file fold goes incomplete, and the warm aggregate re-scans the
+     * whole source.
+     * <p>
+     * Only ever consulted (via {@link #collectMatchingEntries}'s {@code fallback}) to recover a SIBLING's
+     * swept entry, so it is worth building only for a multi-path reconcile. A single-path reconcile has no
+     * sibling to evict, and its lone path's live sweep runs before any {@code put()} — seeing the same
+     * pre-write state the snapshot would — so it never consults the snapshot; we skip the sweep entirely
+     * there (the common single-file reconcile, where a second full-cache forEach would just double the
+     * hot-path scan cost). Freshness (mtime) and config-fingerprint discrimination are NOT applied here —
+     * {@link #collectMatchingEntries} re-checks both, exactly as it does for live matches.
+     */
+    private Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> snapshotEntriesByPath(Set<String> paths) {
+        if (paths.size() < 2) {
+            return Map.of(); // no sibling to evict — the fallback is never consulted; skip the whole-cache sweep
+        }
+        // One whole-cache forEach, filtered to the contribution paths. This cannot be a set of per-path
+        // get()s: SchemaCacheKey is a 6-tuple (path, mtime, formatType, formatConfig, endpoint, region), so
+        // a contribution path alone does not reconstruct a key, and forEach is the only path-agnostic
+        // enumeration the Cache exposes that is safe against concurrent LRU mutation (keys()/values() walk
+        // the lock-free LRU list). The sweep is O(cache) for a multi-path reconcile, but that is the price of
+        // capturing each sibling's pre-eviction entry before the first commit's put() prunes the expired ones.
+        Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> byPath = new HashMap<>();
+        schemaCache.forEach((key, entry) -> {
+            if (paths.contains(key.canonicalPath())) {
+                byPath.computeIfAbsent(key.canonicalPath(), p -> new ArrayList<>()).add(Map.entry(key, entry));
+            }
+        });
+        return byPath;
+    }
+
+    /**
+     * Collects every schema-cache entry a contribution for {@code (path, mtimeMillis, fingerprint)}
+     * applies to: every live match, plus — per KEY, for keys the live sweep no longer has — the
+     * pre-reconcile {@code fallback} snapshot (see {@link #snapshotEntriesByPath}), the case where a
+     * sibling path's earlier commit swept this path's expired entry out of the cache before its stats
+     * could be applied. The recovery is per key, not all-or-nothing on the live sweep: the same
+     * {@code (path, mtime, fingerprint)} can live under several keys (endpoint/region are key
+     * components but not fingerprint inputs), and a partial sweep evicting one twin must not forfeit
+     * its delta just because another twin survived. A live entry always wins over its snapshot
+     * version (it may carry a concurrent commit's enrichment). A fallback entry passes the same
+     * mtime + fingerprint predicate as a live one, and re-putting it re-inserts the entry with a
+     * fresh write time — the same revive a live expired match already gets. Must run holding the
+     * per-path {@link #stripeCommitLocks} lock; callers mutate and re-put the returned entries after
+     * this method returns.
+     */
+    private List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> collectMatchingEntries(
+        String path,
+        long mtimeMillis,
+        Object fingerprint,
+        @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback
+    ) {
+        List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> matches = new ArrayList<>();
+        // Cache.forEach iterates each segment's HashMap under the segment's readLock, making it safe
+        // against concurrent LRU mutations: promote() (called by get(), computeIfAbsent, etc. on any
+        // thread) acquires only lruLock, not the segment readLock, so it cannot corrupt the forEach
+        // traversal. Cache.keys() and Cache.values() walk the LRU doubly-linked list with no locks and
+        // are therefore unsafe here. Do NOT call get() or put() inside the forEach consumer — the
+        // segment readLock is not reentrant and put() acquires the segment writeLock.
+        schemaCache.forEach((key, existing) -> {
+            if (matchesContribution(key, existing, path, mtimeMillis, fingerprint)) {
+                matches.add(Map.entry(key, existing));
+            }
+        });
+        if (fallback != null) {
+            Set<SchemaCacheKey> liveKeys = new HashSet<>(matches.size());
+            for (Map.Entry<SchemaCacheKey, SchemaCacheEntry> match : matches) {
+                liveKeys.add(match.getKey());
+            }
+            int recovered = 0;
+            for (Map.Entry<SchemaCacheKey, SchemaCacheEntry> candidate : fallback) {
+                if (liveKeys.contains(candidate.getKey()) == false
+                    && matchesContribution(candidate.getKey(), candidate.getValue(), path, mtimeMillis, fingerprint)) {
+                    matches.add(candidate);
+                    recovered++;
+                }
+            }
+            if (recovered > 0) {
+                logger.debug("recovering [{}] cache entries for [{}] swept by a sibling commit", recovered, path);
+            }
+        }
+        return matches;
+    }
+
+    /** True when the entry is for {@code path}, observed at the contribution's mtime, under the same format config. */
+    private static boolean matchesContribution(
+        SchemaCacheKey key,
+        SchemaCacheEntry entry,
+        String path,
+        long mtimeMillis,
+        Object fingerprint
+    ) {
+        return path.equals(key.canonicalPath())
+            && key.lastModifiedEpochMillis() == mtimeMillis
+            && Objects.equals(entry.safeMetadata().get(ExternalStats.CONFIG_FINGERPRINT_KEY), fingerprint);
     }
 
     /**
@@ -400,7 +514,7 @@ public class ExternalSourceCacheService implements Closeable {
      * making the short-circuit deterministic: complete knowledge implies enrichment, possibly
      * assembled across queries.
      */
-    private void commitStripeDelta(String path, StripeDelta delta) {
+    private void commitStripeDelta(String path, StripeDelta delta, @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback) {
         if (enabled == false || path == null) {
             return;
         }
@@ -411,29 +525,22 @@ public class ExternalSourceCacheService implements Closeable {
         // same file would otherwise each copy the same entry snapshot and the later put would drop the
         // earlier stripe (lost update). Commits are coordinator-side and infrequent.
         try (Releasable ignored = stripeCommitLocks.acquire(path)) {
-            applyStripeDelta(path, delta);
+            applyStripeDelta(path, delta, fallback);
         }
     }
 
     /**
-     * The locked read-modify-write of {@link #commitStripeDelta}: collect matching entries under the
-     * {@code Cache.forEach} segment readLock (see {@code reconcileSourceStats} for that contract), then
-     * enrich and re-put each. Must run holding the per-path {@link #stripeCommitLocks} lock.
+     * The locked read-modify-write of {@link #commitStripeDelta}: collect matching entries via
+     * {@link #collectMatchingEntries} (live cache, snapshot fallback), then enrich and re-put each.
+     * Must run holding the per-path {@link #stripeCommitLocks} lock.
      */
-    private void applyStripeDelta(String path, StripeDelta delta) {
-        // Same matching + concurrency discipline as reconcileSourceStats: collect under forEach
-        // (segment readLock), mutate after (see that method's javadoc for the Cache.forEach contract).
-        List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> matchingEntries = new ArrayList<>();
-        schemaCache.forEach((key, existing) -> {
-            if (path.equals(key.canonicalPath()) == false || key.lastModifiedEpochMillis() != delta.mtimeMillis()) {
-                return;
-            }
-            Object existingFingerprint = existing.safeMetadata().get(ExternalStats.CONFIG_FINGERPRINT_KEY);
-            if (Objects.equals(existingFingerprint, delta.fingerprint()) == false) {
-                return;
-            }
-            matchingEntries.add(Map.entry(key, existing));
-        });
+    private void applyStripeDelta(String path, StripeDelta delta, @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback) {
+        List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> matchingEntries = collectMatchingEntries(
+            path,
+            delta.mtimeMillis(),
+            delta.fingerprint(),
+            fallback
+        );
         for (Map.Entry<SchemaCacheKey, SchemaCacheEntry> match : matchingEntries) {
             SchemaCacheKey key = match.getKey();
             SchemaCacheEntry existing = match.getValue();
@@ -447,8 +554,7 @@ public class ExternalSourceCacheService implements Closeable {
             Object entryGrid = enriched.get(ExternalStats.STRIPE_GRID_KEY);
             boolean gridMatches = entryGrid instanceof Number n && n.longValue() == delta.stripeSize();
             if (gridMatches == false) {
-                enriched.keySet().removeIf(k -> k.startsWith(ExternalStats.STRIPE_ENTRY_PREFIX));
-                enriched.remove(ExternalStats.STRIPE_LAST_INDEX_KEY);
+                clearStripeState(enriched);
             }
             enriched.put(ExternalStats.STRIPE_GRID_KEY, delta.stripeSize());
             for (Map.Entry<Long, Map<String, Object>> stripe : delta.stripes().entrySet()) {
@@ -469,22 +575,10 @@ public class ExternalSourceCacheService implements Closeable {
             }
             Map<String, Object> wholeFile = foldCommittedStripes(enriched, delta);
             if (wholeFile != null) {
+                clearStripeState(enriched); // compaction: the fold subsumes the stripes; entry weight back to O(1)
                 enriched.putAll(wholeFile);
             }
-            schemaCache.put(
-                key,
-                new SchemaCacheEntry(
-                    existing.columnNames(),
-                    existing.columnTypes(),
-                    existing.columnNullabilities(),
-                    existing.columnSynthetics(),
-                    existing.sourceType(),
-                    existing.location(),
-                    enriched,
-                    existing.connectorConfig(),
-                    existing.cachedAtMillis()
-                )
-            );
+            schemaCache.put(key, existing.withSafeMetadata(enriched));
         }
     }
 
@@ -672,6 +766,26 @@ public class ExternalSourceCacheService implements Closeable {
     }
 
     /**
+     * Drops the per-stripe accumulation state ({@code _stats.stripe.<k>} sub-entries, EOF marker, grid
+     * stamp) from an entry's metadata, once the stripes can no longer contribute. Two call sites:
+     * <ul>
+     *   <li>After {@link #foldCommittedStripes} materializes the whole-file {@code _stats.*}, as weight
+     *   compaction — the stripes' only purpose was composing partial knowledge until the file was fully
+     *   covered. Retaining them makes the entry's cache weight O(stripe count), and a multi-file glob of
+     *   many-stripe entries overflows the schema-cache budget; the LRU then evicts already-committed
+     *   sibling entries and the all-or-nothing multi-file fold forces a full warm re-scan. Compacting is
+     *   safe because the file is fully known: a later scan of the same (path, mtime, fingerprint)
+     *   re-emits identical stripes idempotently, and a partial re-scan folds to null but leaves the
+     *   committed whole-file stats in place.</li>
+     *   <li>On the grid-mismatch reset in {@link #applyStripeDelta} — stale-grid ordinals are
+     *   incomparable with the delta's, so accumulation restarts on the delta's grid.</li>
+     * </ul>
+     */
+    private static void clearStripeState(Map<String, Object> enriched) {
+        enriched.keySet().removeIf(ExternalStats::isStripeBookkeeping);
+    }
+
+    /**
      * Folds duplicate whole-file contributions for the same file into one map. Row count, mtime,
      * and config fingerprint must agree across entries (asserted) since each contribution already
      * covers the entire file under the same pinned config. Column-stats keys, however, may differ
@@ -745,6 +859,22 @@ public class ExternalSourceCacheService implements Closeable {
         if (enabled == false || mergedStatsPerFile == null || mergedStatsPerFile.isEmpty()) {
             return;
         }
+        reconcileSourceStats(mergedStatsPerFile, snapshotEntriesByPath(mergedStatsPerFile.keySet()));
+    }
+
+    /**
+     * Snapshot-aware body of {@link #reconcileSourceStats}. {@code preCommitSnapshot} is the pre-reconcile
+     * per-path entry snapshot (see {@link #snapshotEntriesByPath}), consulted only when the live cache
+     * has no match — the sibling-commit expiry-sweep case described there. Same discipline as
+     * {@link #applyStripeDelta}.
+     */
+    private void reconcileSourceStats(
+        Map<String, Map<String, Object>> mergedStatsPerFile,
+        Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> preCommitSnapshot
+    ) {
+        if (enabled == false || mergedStatsPerFile == null || mergedStatsPerFile.isEmpty()) {
+            return;
+        }
         for (Map.Entry<String, Map<String, Object>> entry : mergedStatsPerFile.entrySet()) {
             String path = entry.getKey();
             Map<String, Object> mergedStats = entry.getValue();
@@ -771,24 +901,12 @@ public class ExternalSourceCacheService implements Closeable {
             // earlier's enrichment (lost update). The lock keyspace (canonical path) is shared, so the
             // two writers serialize against each other.
             try (Releasable ignored = stripeCommitLocks.acquire(path)) {
-                // Cache.forEach iterates each segment's HashMap under the segment's readLock,
-                // making it safe against concurrent LRU mutations: promote() (called by get(),
-                // computeIfAbsent, etc. on any thread) acquires only lruLock, not the segment
-                // readLock, so it cannot corrupt the forEach traversal. Cache.keys() and
-                // Cache.values() walk the LRU doubly-linked list with no locks and are therefore
-                // unsafe here. Do NOT call get() or put() inside the forEach consumer — the
-                // segment readLock is not reentrant and put() acquires the segment writeLock.
-                List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> matchingEntries = new ArrayList<>();
-                schemaCache.forEach((key, existing) -> {
-                    if (path.equals(key.canonicalPath()) == false || key.lastModifiedEpochMillis() != mtimeMillis) {
-                        return;
-                    }
-                    Object existingFingerprint = existing.safeMetadata().get(ExternalStats.CONFIG_FINGERPRINT_KEY);
-                    if (Objects.equals(existingFingerprint, contributionFingerprint) == false) {
-                        return;
-                    }
-                    matchingEntries.add(Map.entry(key, existing));
-                });
+                List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> matchingEntries = collectMatchingEntries(
+                    path,
+                    mtimeMillis,
+                    contributionFingerprint,
+                    preCommitSnapshot.get(path)
+                );
                 for (Map.Entry<SchemaCacheKey, SchemaCacheEntry> match : matchingEntries) {
                     SchemaCacheKey key = match.getKey();
                     SchemaCacheEntry existing = match.getValue();
@@ -798,20 +916,7 @@ public class ExternalSourceCacheService implements Closeable {
                     // Long.MAX for a LONG-resolved column) is DROPPED rather than stored — otherwise the
                     // serve would coerce it to the resolved type and produce a wrong value.
                     enriched.putAll(coerceColumnStatsToResolvedTypes(mergedStats, existing.columnNames(), existing.columnTypes(), true));
-                    schemaCache.put(
-                        key,
-                        new SchemaCacheEntry(
-                            existing.columnNames(),
-                            existing.columnTypes(),
-                            existing.columnNullabilities(),
-                            existing.columnSynthetics(),
-                            existing.sourceType(),
-                            existing.location(),
-                            enriched,
-                            existing.connectorConfig(),
-                            existing.cachedAtMillis()
-                        )
-                    );
+                    schemaCache.put(key, existing.withSafeMetadata(enriched));
                 }
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalStats.java
@@ -133,6 +133,17 @@ public final class ExternalStats {
      */
     public static final String STRIPE_GRID_KEY = "_stats.stripe_grid";
 
+    /**
+     * True for the coordinator-cache per-stripe bookkeeping keys ({@link #STRIPE_ENTRY_PREFIX} sub-entries,
+     * {@link #STRIPE_LAST_INDEX_KEY}, {@link #STRIPE_GRID_KEY}) — the accumulation state behind the
+     * {@code 0..K} whole-file fold. They have no consumer outside {@code ExternalSourceCacheService}: the
+     * resolver strips them off the plan wire and the cache clears them once they can no longer contribute
+     * (complete fold, stale grid). This predicate is the single definition of that key set.
+     */
+    public static boolean isStripeBookkeeping(String key) {
+        return key.startsWith(STRIPE_ENTRY_PREFIX) || key.equals(STRIPE_LAST_INDEX_KEY) || key.equals(STRIPE_GRID_KEY);
+    }
+
     private ExternalStats() {}
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntry.java
@@ -46,6 +46,25 @@ public record SchemaCacheEntry(
         connectorConfig = connectorConfig != null ? Map.copyOf(connectorConfig) : Map.of();
     }
 
+    /**
+     * An identical entry whose {@code safeMetadata} is replaced with {@code metadata} — the schema-cache
+     * enrichment helper: entries are immutable, so a stats commit copies the metadata, mutates the copy,
+     * and swaps the whole entry.
+     */
+    public SchemaCacheEntry withSafeMetadata(Map<String, Object> metadata) {
+        return new SchemaCacheEntry(
+            columnNames,
+            columnTypes,
+            columnNullabilities,
+            columnSynthetics,
+            sourceType,
+            location,
+            metadata,
+            connectorConfig,
+            cachedAtMillis
+        );
+    }
+
     public static SchemaCacheEntry from(
         List<Attribute> schema,
         String sourceType,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -35,13 +35,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.lessThan;
+
 public class ExternalSourceCacheServiceTests extends ESTestCase {
 
     private static Settings defaultSettings() {
+        return schemaTtlSettings("5m");
+    }
+
+    /** {@link #defaultSettings()} with a chosen schema TTL — shrunk by the expiry-sweep tests. */
+    private static Settings schemaTtlSettings(String schemaTtl) {
         return Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.schema.ttl", schemaTtl)
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
     }
@@ -567,6 +574,157 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         }
     }
 
+    /**
+     * Regression test for the scale mechanism behind the ndjson warm-COUNT loss seen at ClickBench-100M scale:
+     * a cold multi-file scan LONGER than the schema TTL (multi-minute external scans vs the 5m default)
+     * reconciles into a cache whose entries for the scanned glob have ALL expired. Expired entries are
+     * still forEach-visible, but the first commit's {@code put()} prunes every expired entry from the
+     * LRU tail; pre-fix, files #2..N's deltas then matched nothing and were silently dropped — the
+     * multi-file whole-source fold is all-or-nothing, so the warm {@code COUNT(*)} re-scanned the
+     * entire source. Single-file sources self-healed (no sibling entry to sweep), which is exactly the
+     * bench signature: every 1file cell short-circuited even at cold ≫ TTL while multi-file cells with
+     * cold > TTL full-re-scanned. The TTL here is shrunk so the seeded entries are expired by reconcile
+     * time, standing in for "the scan outlived the TTL".
+     */
+    public void testMultiFileStripeCommitSurvivesSchemaTtlExpiry() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("500ms"))) {
+            long mtime = 1000L;
+            String pathA = "s3://bucket/data/hits_00.ndjson";
+            String pathB = "s3://bucket/data/hits_01.ndjson";
+            SchemaCacheKey keyA = SchemaCacheKey.build(pathA, mtime, ".ndjson", Map.of("format", "ndjson"));
+            SchemaCacheKey keyB = SchemaCacheKey.build(pathB, mtime, ".ndjson", Map.of("format", "ndjson"));
+            seedSchemaCache(service, keyA, pathA, "fp");
+            seedSchemaCache(service, keyB, pathB, "fp");
+
+            // Let both entries expire (but remain physically cached — expiry evicts lazily), exactly
+            // the state a scan longer than the TTL leaves behind at reconcile time.
+            Thread.sleep(1200);
+
+            Map<String, List<Map<String, Object>>> contributions = new LinkedHashMap<>();
+            contributions.put(pathA, List.of(stripeFragment(mtime, "fp", 100L, 1024L, 0, 0, 100, true, true, true)));
+            contributions.put(pathB, List.of(stripeFragment(mtime, "fp", 200L, 1024L, 0, 0, 100, true, true, true)));
+            service.reconcileSourceStatsFromContributions(contributions);
+
+            // BOTH files must retain their committed row counts: losing either forfeits the whole
+            // source's warm COUNT(*) (aggregateFileStatistics is all-or-nothing across the glob).
+            assertEquals("first-committed file must keep its stats", 100L, schemaRowCount(service, pathA));
+            assertEquals("sibling file's delta must survive the expiry sweep", 200L, schemaRowCount(service, pathB));
+        }
+    }
+
+    /** Whole-file-contribution twin of {@link #testMultiFileStripeCommitSurvivesSchemaTtlExpiry}. */
+    public void testMultiFileWholeFileCommitSurvivesSchemaTtlExpiry() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("500ms"))) {
+            long mtime = 1000L;
+            String pathA = "s3://bucket/data/hits_00.csv";
+            String pathB = "s3://bucket/data/hits_01.csv";
+            SchemaCacheKey keyA = SchemaCacheKey.build(pathA, mtime, ".csv", Map.of("format", "csv"));
+            SchemaCacheKey keyB = SchemaCacheKey.build(pathB, mtime, ".csv", Map.of("format", "csv"));
+            seedSchemaCache(service, keyA, pathA, "fp");
+            seedSchemaCache(service, keyB, pathB, "fp");
+
+            Thread.sleep(1200);
+
+            Map<String, List<Map<String, Object>>> contributions = new LinkedHashMap<>();
+            contributions.put(pathA, List.of(wholeFileStats(mtime, "fp", 100L)));
+            contributions.put(pathB, List.of(wholeFileStats(mtime, "fp", 200L)));
+            service.reconcileSourceStatsFromContributions(contributions);
+
+            assertEquals("first-committed file must keep its stats", 100L, schemaRowCount(service, pathA));
+            assertEquals("sibling file's whole-file stats must survive the expiry sweep", 200L, schemaRowCount(service, pathB));
+        }
+    }
+
+    /**
+     * A single-file reconcile whose sole entry has expired must still commit its stats. There is no sibling
+     * to sweep, so the pre-write snapshot is never consulted — the lone path's live sweep finds the
+     * expired-but-still-visible entry and revives it — and {@link ExternalSourceCacheService#snapshotEntriesByPath}
+     * skips the whole-cache forEach entirely. This guards that the skip is behavior-preserving for the common
+     * single-file case (the one that would otherwise pay a doubled full-cache scan).
+     */
+    public void testSingleFileStripeCommitSurvivesSchemaTtlExpiry() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("500ms"))) {
+            long mtime = 1000L;
+            String path = "s3://bucket/data/hits_00.ndjson";
+            SchemaCacheKey key = SchemaCacheKey.build(path, mtime, ".ndjson", Map.of("format", "ndjson"));
+            seedSchemaCache(service, key, path, "fp");
+
+            // Let the entry expire (but remain physically cached — expiry evicts lazily).
+            Thread.sleep(1200);
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(path, List.of(stripeFragment(mtime, "fp", 100L, 1024L, 0, 0, 100, true, true, true)))
+            );
+
+            assertEquals("single-file stats must survive the expiry, snapshot-skip notwithstanding", 100L, schemaRowCount(service, path));
+        }
+    }
+
+    /**
+     * The same {@code (path, mtime, fingerprint)} can live under SEVERAL cache keys — endpoint/region are
+     * {@link SchemaCacheKey} components but not config-fingerprint inputs — and a commit applies its delta to
+     * every one of them. A sibling path's earlier commit can sweep ONE twin (the older, expired one) while the
+     * other is still live; the snapshot recovery must be per key, not all-or-nothing on the live sweep, or the
+     * swept twin's delta is silently lost. Staggered seeding makes the sweep partial deterministically: the
+     * first twin outlives the TTL by reconcile time, the second does not. (If a CI stall expires the second
+     * twin too, both are recovered from the snapshot and the test still passes — it degrades to the
+     * all-swept case rather than false-failing. The one stall that WOULD false-fail is between the two
+     * seeds: a second seed landing past the first twin's TTL sweeps the first twin at seed time, before
+     * any snapshot exists to recover it from. The 3s TTL keeps that window a &gt;2.3s stall inside a
+     * two-statement gap.)
+     */
+    public void testPartialTwinSweepRecoversSweptTwinEntry() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("3s"))) {
+            long mtime = 1000L;
+            String pathA = "s3://bucket/data/hits_00.csv";
+            String pathB = "s3://bucket/data/hits_01.csv";
+            SchemaCacheKey keyA = SchemaCacheKey.build(pathA, mtime, ".csv", Map.of("format", "csv"));
+            SchemaCacheKey twinB1 = SchemaCacheKey.build(pathB, mtime, ".csv", Map.of("format", "csv", "endpoint", "https://e1"));
+            SchemaCacheKey twinB2 = SchemaCacheKey.build(pathB, mtime, ".csv", Map.of("format", "csv", "endpoint", "https://e2"));
+            seedSchemaCache(service, keyA, pathA, "fp");
+            seedSchemaCache(service, twinB1, pathB, "fp");
+            Thread.sleep(700);
+            seedSchemaCache(service, twinB2, pathB, "fp"); // still inside the TTL: seeding must not sweep the first twin
+            Thread.sleep(2500); // now twinB1 and keyA have expired; twinB2 has not
+
+            // Order matters and is honored: pathA must commit before pathB so pathA's put sweeps the expired
+            // twinB1 from the LRU tail BEFORE pathB is collected (that is the partial sweep under test). The
+            // reconcile commits whole-file entries in this LinkedHashMap's insertion order (see the
+            // LinkedHashMap in reconcileSourceStatsFromContributions), so pathA-before-pathB is deterministic
+            // here, not a filename-hashCode accident.
+            Map<String, List<Map<String, Object>>> contributions = new LinkedHashMap<>();
+            contributions.put(pathA, List.of(wholeFileStats(mtime, "fp", 100L)));
+            contributions.put(pathB, List.of(wholeFileStats(mtime, "fp", 200L)));
+            service.reconcileSourceStatsFromContributions(contributions);
+
+            assertEquals("first-committed file must keep its stats", 100L, schemaRowCount(service, keyA));
+            assertEquals("live twin must receive the delta", 200L, schemaRowCount(service, twinB2));
+            assertEquals("twin swept by the sibling commit must be recovered per key", 200L, schemaRowCount(service, twinB1));
+        }
+    }
+
+    /** The committed row count of {@code path}'s entry, read expiry-blind via forEach (get() would hide expired entries). */
+    private static Object schemaRowCount(ExternalSourceCacheService service, String path) {
+        AtomicReference<Object> found = new AtomicReference<>();
+        service.schemaCache().forEach((k, e) -> {
+            if (path.equals(k.canonicalPath())) {
+                found.set(e.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+            }
+        });
+        return found.get();
+    }
+
+    /** Key-precise variant of {@link #schemaRowCount(ExternalSourceCacheService, String)} for paths cached under twin keys. */
+    private static Object schemaRowCount(ExternalSourceCacheService service, SchemaCacheKey key) {
+        AtomicReference<Object> found = new AtomicReference<>();
+        service.schemaCache().forEach((k, e) -> {
+            if (key.equals(k)) {
+                found.set(e.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+            }
+        });
+        return found.get();
+    }
+
     public void testReconcileSingleCompleteStripe() throws Exception {
         // One chunk fully covers stripe 0 to EOF: complete, marker = 0, whole-file fold = 100.
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
@@ -581,7 +739,12 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
 
             SchemaCacheEntry enriched = service.getOrComputeSchema(key, k -> { throw new AssertionError("should be cached"); });
             assertEquals(100L, enriched.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
-            assertEquals(0L, enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY));
+            // Once the 0..K fold is complete the per-stripe bookkeeping is compacted away (it has served its
+            // purpose) so the entry weight stays O(1) — see ExternalSourceCacheService#clearStripeState.
+            assertNull(
+                "stripe bookkeeping compacted after a complete fold",
+                enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY)
+            );
         }
     }
 
@@ -724,7 +887,10 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
                 100L,
                 enriched.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT)
             );
-            assertEquals(1L, enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY));
+            assertNull(
+                "stripe bookkeeping compacted after a complete fold",
+                enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY)
+            );
         }
     }
 
@@ -1078,6 +1244,50 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         }
     }
 
+    /**
+     * Regression test for the second, TTL-independent mechanism of the ndjson warm-COUNT loss: a many-stripe file's
+     * entry must NOT keep its per-stripe sub-entries once the whole-file 0..K fold is complete. Retaining them
+     * makes the entry weight O(stripe count); a multi-file glob of such entries overflows the schema-cache weight
+     * budget, the LRU evicts already-committed sibling entries, and the all-or-nothing multi-file warm serve
+     * re-scans. After a complete fold the entry must hold ONLY the whole-file _stats.* (no _stats.stripe.*),
+     * keeping its weight O(1) and its estimatedBytes small regardless of stripe count.
+     */
+    public void testManyStripeEntryCompactedToConstantWeightAfterCompleteFold() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String path = "file:///data/big.ndjson";
+            long mtime = 1000L;
+            SchemaCacheKey key = SchemaCacheKey.build(path, mtime, ".ndjson", Map.of("format", "ndjson"));
+            seedSchemaCache(service, key, path, "fp");
+
+            int stripes = 500;
+            long grid = 100L;
+            List<Map<String, Object>> fragments = new ArrayList<>(stripes);
+            for (int k = 0; k < stripes; k++) {
+                boolean last = k == stripes - 1;
+                fragments.add(stripeFragment(mtime, "fp", 3L, grid, k, k * grid, (k + 1) * grid, true, true, last));
+            }
+            service.reconcileSourceStatsFromContributions(Map.of(path, fragments));
+
+            SchemaCacheEntry enriched = service.getOrComputeSchema(key, k -> { throw new AssertionError("should be cached"); });
+            assertEquals(
+                "whole-file fold sums every stripe",
+                (long) stripes * 3L,
+                enriched.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT)
+            );
+            long stripeSubEntries = enriched.safeMetadata()
+                .keySet()
+                .stream()
+                .filter(kk -> kk.startsWith(ExternalStats.STRIPE_ENTRY_PREFIX))
+                .count();
+            assertEquals("no per-stripe sub-entries retained after a complete fold", 0L, stripeSubEntries);
+            assertNull("stripe EOF marker compacted", enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY));
+            assertNull("stripe grid stamp compacted", enriched.safeMetadata().get(ExternalStats.STRIPE_GRID_KEY));
+            // The entry weight must not scale with stripe count: 500 stripes must weigh no more than a small
+            // constant over a fold-only entry (a retained-stripe entry would be tens of KB heavier).
+            assertThat("compacted entry weight must be O(1), not O(stripe count)", enriched.estimatedBytes(), lessThan(2_000L));
+        }
+    }
+
     public void testReconcileEmptyStripeFromOversizedRecord() throws Exception {
         // A record larger than the grid skips an ordinal entirely — the reader emits an explicit
         // zero-length empty fragment for it (atStripeStart & atStripeEnd). The whole-file fold counts
@@ -1103,7 +1313,10 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
                 10L,
                 enriched.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT)
             );
-            assertEquals(2L, enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY));
+            assertNull(
+                "stripe bookkeeping compacted after a complete fold",
+                enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY)
+            );
         }
     }
 
@@ -1160,7 +1373,10 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
                 stripes * rowsPerStripe,
                 enriched.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT)
             );
-            assertEquals((long) (stripes - 1), enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY));
+            assertNull(
+                "stripe bookkeeping compacted after a complete fold",
+                enriched.safeMetadata().get(ExternalStats.STRIPE_LAST_INDEX_KEY)
+            );
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ESQL: external multi-file warm COUNT survives schema-TTL expiry and many-stripe cache pressure (#153085)](https://github.com/elastic/elasticsearch/pull/153085)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)