### PR TITLE
[9.4] [Security] Fix clone API key dropping metadata after null expiration (#152874)

### DIFF
--- a/docs/changelog/152874.yaml
+++ b/docs/changelog/152874.yaml
@@ -1,0 +1,5 @@
+area: Authentication
+issues: []
+pr: 152874
+summary: Fix Clone API Key silently dropping fields that follow a null expiration
+type: bug

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCloneApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCloneApiKeyAction.java
@@ -55,7 +55,6 @@ public final class RestCloneApiKeyAction extends ApiKeyBaseRestHandler implement
         PARSER.declareString(CloneApiKeyRequest::setName, new ParseField("name"));
         PARSER.declareField(CloneApiKeyRequest::setExpiration, p -> {
             if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
-                p.nextToken();
                 return TimeValue.MINUS_ONE;
             }
             return TimeValue.parseTimeValue(p.text(), null, "expiration");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCloneApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCloneApiKeyActionTests.java
@@ -90,6 +90,30 @@ public class RestCloneApiKeyActionTests extends ESTestCase {
         }
     }
 
+    public void testParseXContentWithExpirationNullFollowedByMetadata() throws Exception {
+        // Regression test: a `null` expiration must not consume the field that follows it in the body.
+        final String encodedApiKey = randomBase64ApiKey();
+        final String name = randomAlphaOfLength(8);
+        try (
+            XContentParser parser = createParser(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field("api_key", encodedApiKey)
+                    .field("name", name)
+                    .nullField("expiration")
+                    .startObject("metadata")
+                    .field("foo", "bar")
+                    .endObject()
+                    .endObject()
+            )
+        ) {
+            CloneApiKeyRequest request = RestCloneApiKeyAction.PARSER.parse(parser, null);
+            assertThat(request.getExpiration(), equalTo(TimeValue.MINUS_ONE));
+            assertThat(request.getMetadata(), notNullValue());
+            assertThat(request.getMetadata(), is(Map.of("foo", "bar")));
+        }
+    }
+
     public void testParseXContentWithMetadata() throws Exception {
         final String encodedApiKey = randomBase64ApiKey();
         final String name = randomAlphaOfLength(8);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Security] Fix clone API key dropping metadata after null expiration (#152874)](https://github.com/elastic/elasticsearch/pull/152874)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)