### PR TITLE
[Docs] Update connectors default max file download size from 10MiB to 8MiB

### DIFF
--- a/docs/reference/search-connectors/es-connectors-azure-blob.md
+++ b/docs/reference/search-connectors/es-connectors-azure-blob.md
@@ -211,7 +211,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 The connector will fetch all data available in the container.
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-azure-blob.md
+++ b/docs/reference/search-connectors/es-connectors-azure-blob.md
@@ -211,7 +211,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 The connector will fetch all data available in the container.
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-box.md
+++ b/docs/reference/search-connectors/es-connectors-box.md
@@ -267,7 +267,7 @@ The connector syncs the following objects and entities:
 * **Folders**
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-box.md
+++ b/docs/reference/search-connectors/es-connectors-box.md
@@ -267,7 +267,7 @@ The connector syncs the following objects and entities:
 * **Folders**
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-confluence.md
+++ b/docs/reference/search-connectors/es-connectors-confluence.md
@@ -274,7 +274,7 @@ The connector syncs the following Confluence object types:
 * Attachments
 
 ::::{note}
-* Content of files bigger than 8 MB won’t be extracted.
+* Content of files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-confluence.md
+++ b/docs/reference/search-connectors/es-connectors-confluence.md
@@ -274,7 +274,7 @@ The connector syncs the following Confluence object types:
 * Attachments
 
 ::::{note}
-* Content of files bigger than 10 MB won’t be extracted.
+* Content of files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-content-extraction.md
+++ b/docs/reference/search-connectors/es-connectors-content-extraction.md
@@ -13,7 +13,7 @@ Search uses an [Elasticsearch ingest pipeline^](docs-content://manage-data/inges
 
 You can [view^](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md#create-manage-ingest-pipelines) this pipeline in Kibana. Customizing your pipeline usage is also an option. See [Ingest pipelines for Search indices](docs-content://solutions/search/ingest-for-search.md).
 
-For advanced use cases, the [self-hosted extraction service](#es-connectors-content-extraction-local) can be used to extract content from files larger than 8MB.
+For advanced use cases, the [self-hosted extraction service](#es-connectors-content-extraction-local) can be used to extract content from files larger than 8MiB.
 
 
 ## Supported file types [es-connectors-content-extraction-supported-file-types]
@@ -57,7 +57,7 @@ Currently, content extraction from large files via the Extraction Service is ava
 ::::
 
 
-Standard content extraction is done via the Attachment Processor, through Elasticsearch Ingest Pipelines. The self-managed connector limits file sizes for pipeline extraction to 8MB per file (Elasticsearch also has a hard limit of 100MB per file).
+Standard content extraction is done via the Attachment Processor, through Elasticsearch Ingest Pipelines. The self-managed connector limits file sizes for pipeline extraction to 8MiB per file (Elasticsearch also has a hard limit of 100MB per file).
 
 For use cases that require extracting content from files larger than these limits, the **self-managed extraction service** can be used for self-managed connectors. Instead of sending the file as an `attachment` to Elasticsearch, the file’s content is extracted at the edge by the extraction service before ingestion. The extracted text is then included as the `body` field of a document when it is ingested.
 

--- a/docs/reference/search-connectors/es-connectors-content-extraction.md
+++ b/docs/reference/search-connectors/es-connectors-content-extraction.md
@@ -13,7 +13,7 @@ Search uses an [Elasticsearch ingest pipeline^](docs-content://manage-data/inges
 
 You can [view^](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md#create-manage-ingest-pipelines) this pipeline in Kibana. Customizing your pipeline usage is also an option. See [Ingest pipelines for Search indices](docs-content://solutions/search/ingest-for-search.md).
 
-For advanced use cases, the [self-hosted extraction service](#es-connectors-content-extraction-local) can be used to extract content from files larger than 10MB.
+For advanced use cases, the [self-hosted extraction service](#es-connectors-content-extraction-local) can be used to extract content from files larger than 8MB.
 
 
 ## Supported file types [es-connectors-content-extraction-supported-file-types]
@@ -57,7 +57,7 @@ Currently, content extraction from large files via the Extraction Service is ava
 ::::
 
 
-Standard content extraction is done via the Attachment Processor, through Elasticsearch Ingest Pipelines. The self-managed connector limits file sizes for pipeline extraction to 10MB per file (Elasticsearch also has a hard limit of 100MB per file).
+Standard content extraction is done via the Attachment Processor, through Elasticsearch Ingest Pipelines. The self-managed connector limits file sizes for pipeline extraction to 8MB per file (Elasticsearch also has a hard limit of 100MB per file).
 
 For use cases that require extracting content from files larger than these limits, the **self-managed extraction service** can be used for self-managed connectors. Instead of sending the file as an `attachment` to Elasticsearch, the file’s content is extracted at the edge by the extraction service before ingestion. The extracted text is then included as the `body` field of a document when it is ingested.
 

--- a/docs/reference/search-connectors/es-connectors-dropbox.md
+++ b/docs/reference/search-connectors/es-connectors-dropbox.md
@@ -293,7 +293,7 @@ Due to a Dropbox issue, metadata updates to Paper files from Dropbox Paper are n
 
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Currently, the connector doesn’t retrieve files from shared Team folders.
 * Permissions are not synced by default. If [document level security (DLS)](/reference/search-connectors/document-level-security.md) is not enabled **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 

--- a/docs/reference/search-connectors/es-connectors-dropbox.md
+++ b/docs/reference/search-connectors/es-connectors-dropbox.md
@@ -293,7 +293,7 @@ Due to a Dropbox issue, metadata updates to Paper files from Dropbox Paper are n
 
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Currently, the connector doesn’t retrieve files from shared Team folders.
 * Permissions are not synced by default. If [document level security (DLS)](/reference/search-connectors/document-level-security.md) is not enabled **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 

--- a/docs/reference/search-connectors/es-connectors-github.md
+++ b/docs/reference/search-connectors/es-connectors-github.md
@@ -314,7 +314,7 @@ Only the following file extensions are ingested:
 * `.rst`
 
 ::::{note}
-* Content of files bigger than 10 MB won’t be extracted.
+* Content of files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-github.md
+++ b/docs/reference/search-connectors/es-connectors-github.md
@@ -314,7 +314,7 @@ Only the following file extensions are ingested:
 * `.rst`
 
 ::::{note}
-* Content of files bigger than 8 MB won’t be extracted.
+* Content of files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-gitlab.md
+++ b/docs/reference/search-connectors/es-connectors-gitlab.md
@@ -250,7 +250,7 @@ Only the following file extensions are ingested for README files:
 * `.txt`
 
 ::::{note}
-* Content of files bigger than 8 MB won't be extracted.
+* Content of files bigger than 8 MiB won't be extracted.
 * Epics are only available for Premium/Ultimate GitLab tiers and are synced at the group level.
 * **Epic syncing behavior**: Epics are fetched only for groups that contain synced projects.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.

--- a/docs/reference/search-connectors/es-connectors-gitlab.md
+++ b/docs/reference/search-connectors/es-connectors-gitlab.md
@@ -250,7 +250,7 @@ Only the following file extensions are ingested for README files:
 * `.txt`
 
 ::::{note}
-* Content of files bigger than 10 MB won't be extracted.
+* Content of files bigger than 8 MB won't be extracted.
 * Epics are only available for Premium/Ultimate GitLab tiers and are synced at the group level.
 * **Epic syncing behavior**: Epics are fetched only for groups that contain synced projects.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.

--- a/docs/reference/search-connectors/es-connectors-google-cloud.md
+++ b/docs/reference/search-connectors/es-connectors-google-cloud.md
@@ -126,7 +126,7 @@ The connector will fetch all buckets and paths the service account has access to
 The `Owner` field is not fetched as `read_only` scope doesn’t allow the connector to fetch IAM information.
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permission are not synced. All documents indexed to an Elastic deployment will be visible to all users with access to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-google-cloud.md
+++ b/docs/reference/search-connectors/es-connectors-google-cloud.md
@@ -126,7 +126,7 @@ The connector will fetch all buckets and paths the service account has access to
 The `Owner` field is not fetched as `read_only` scope doesn’t allow the connector to fetch IAM information.
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permission are not synced. All documents indexed to an Elastic deployment will be visible to all users with access to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-google-drive.md
+++ b/docs/reference/search-connectors/es-connectors-google-drive.md
@@ -193,7 +193,7 @@ The connector will fetch all files and folders the service account has access to
 It will attempt to extract the content from Google Suite documents (Google Docs, Google Sheets and Google Slides) and regular files.
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted
+* Content from files bigger than 8 MiB won’t be extracted
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-google-drive-client-document-level-security). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-google-drive.md
+++ b/docs/reference/search-connectors/es-connectors-google-drive.md
@@ -193,7 +193,7 @@ The connector will fetch all files and folders the service account has access to
 It will attempt to extract the content from Google Suite documents (Google Docs, Google Sheets and Google Slides) and regular files.
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted
+* Content from files bigger than 8 MB won’t be extracted
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-google-drive-client-document-level-security). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-jira.md
+++ b/docs/reference/search-connectors/es-connectors-jira.md
@@ -282,7 +282,7 @@ The connector syncs the following objects and entities:
 **Note:** Archived projects and issues are not indexed.
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted
+* Content from files bigger than 8 MB won’t be extracted
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-jira-client-document-level-security). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-jira.md
+++ b/docs/reference/search-connectors/es-connectors-jira.md
@@ -282,7 +282,7 @@ The connector syncs the following objects and entities:
 **Note:** Archived projects and issues are not indexed.
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted
+* Content from files bigger than 8 MiB won’t be extracted
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-jira-client-document-level-security). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-mongodb.md
+++ b/docs/reference/search-connectors/es-connectors-mongodb.md
@@ -373,7 +373,7 @@ Each sync is a "full" sync. For each MongoDB document discovered:
 This is recursive, because embedded documents can themselves contain embedded documents.
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted
+* Files bigger than 8 MiB won’t be extracted
 * Permissions are not synced. All documents indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-mongodb.md
+++ b/docs/reference/search-connectors/es-connectors-mongodb.md
@@ -373,7 +373,7 @@ Each sync is a "full" sync. For each MongoDB document discovered:
 This is recursive, because embedded documents can themselves contain embedded documents.
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted
+* Files bigger than 8 MB won’t be extracted
 * Permissions are not synced. All documents indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-ms-sql.md
+++ b/docs/reference/search-connectors/es-connectors-ms-sql.md
@@ -266,7 +266,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 * If the `last_user_update` of `sys.dm_db_index_usage_stats` table is not available for a specific table and database then all data in that table will be synced.
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-ms-sql.md
+++ b/docs/reference/search-connectors/es-connectors-ms-sql.md
@@ -266,7 +266,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 * If the `last_user_update` of `sys.dm_db_index_usage_stats` table is not available for a specific table and database then all data in that table will be synced.
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-network-drive.md
+++ b/docs/reference/search-connectors/es-connectors-network-drive.md
@@ -178,7 +178,7 @@ The connector syncs folders as separate documents in Elasticsearch. The followin
 * `id`
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted
+* Content from files bigger than 8 MiB won’t be extracted
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-network-drive-client-dls). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-network-drive.md
+++ b/docs/reference/search-connectors/es-connectors-network-drive.md
@@ -178,7 +178,7 @@ The connector syncs folders as separate documents in Elasticsearch. The followin
 * `id`
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted
+* Content from files bigger than 8 MB won’t be extracted
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-network-drive-client-dls). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-notion.md
+++ b/docs/reference/search-connectors/es-connectors-notion.md
@@ -255,7 +255,7 @@ The connector syncs the following objects and entities:
 
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to the relevant Elasticsearch index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-notion.md
+++ b/docs/reference/search-connectors/es-connectors-notion.md
@@ -255,7 +255,7 @@ The connector syncs the following objects and entities:
 
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to the relevant Elasticsearch index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-onedrive.md
+++ b/docs/reference/search-connectors/es-connectors-onedrive.md
@@ -253,7 +253,7 @@ The connector syncs the following objects and entities:
 * **Folders**
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-onedrive-client-dls). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-onedrive.md
+++ b/docs/reference/search-connectors/es-connectors-onedrive.md
@@ -253,7 +253,7 @@ The connector syncs the following objects and entities:
 * **Folders**
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. You must first enable [DLS](#es-connectors-onedrive-client-dls). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-opentext.md
+++ b/docs/reference/search-connectors/es-connectors-opentext.md
@@ -97,7 +97,7 @@ The connector syncs the following objects and entities:
 * **Files & Folders**
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to the destination Elasticsearch index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-opentext.md
+++ b/docs/reference/search-connectors/es-connectors-opentext.md
@@ -97,7 +97,7 @@ The connector syncs the following objects and entities:
 * **Files & Folders**
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to the destination Elasticsearch index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-oracle.md
+++ b/docs/reference/search-connectors/es-connectors-oracle.md
@@ -266,7 +266,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 * The `sys` user is not supported, as it contains 1000+ system tables. If you need to work with the `sys` user, use either `sysdba` or `sysoper` and configure this as the username.
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-oracle.md
+++ b/docs/reference/search-connectors/es-connectors-oracle.md
@@ -266,7 +266,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 * The `sys` user is not supported, as it contains 1000+ system tables. If you need to work with the `sys` user, use either `sysdba` or `sysoper` and configure this as the username.
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-outlook.md
+++ b/docs/reference/search-connectors/es-connectors-outlook.md
@@ -285,7 +285,7 @@ The connector syncs the following objects and entities:
 
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 * For Outlook Cloud (Office 365), the connector only discovers mailboxes belonging to **enabled** directory users (`accountEnabled = true`) that have an email address. **Shared mailboxes are not synced by default**, because their backing Entra ID account has sign-in disabled. To sync a shared mailbox, enable sign-in for its account in Entra ID (this may require assigning a license).
 

--- a/docs/reference/search-connectors/es-connectors-outlook.md
+++ b/docs/reference/search-connectors/es-connectors-outlook.md
@@ -285,7 +285,7 @@ The connector syncs the following objects and entities:
 
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 * For Outlook Cloud (Office 365), the connector only discovers mailboxes belonging to **enabled** directory users (`accountEnabled = true`) that have an email address. **Shared mailboxes are not synced by default**, because their backing Entra ID account has sign-in disabled. To sync a shared mailbox, enable sign-in for its account in Entra ID (this may require assigning a license).
 

--- a/docs/reference/search-connectors/es-connectors-postgresql.md
+++ b/docs/reference/search-connectors/es-connectors-postgresql.md
@@ -281,7 +281,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 This connector does not currently support [incremental syncs](/reference/search-connectors/content-syncs.md#es-connectors-sync-types-incremental).
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-postgresql.md
+++ b/docs/reference/search-connectors/es-connectors-postgresql.md
@@ -281,7 +281,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 This connector does not currently support [incremental syncs](/reference/search-connectors/content-syncs.md#es-connectors-sync-types-incremental).
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-s3.md
+++ b/docs/reference/search-connectors/es-connectors-s3.md
@@ -231,7 +231,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 ### Documents and syncs [es-connectors-s3-client-documents-syncs]
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-s3.md
+++ b/docs/reference/search-connectors/es-connectors-s3.md
@@ -231,7 +231,7 @@ We also have a quickstart self-managed option using Docker Compose, so you can s
 ### Documents and syncs [es-connectors-s3-client-documents-syncs]
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-salesforce.md
+++ b/docs/reference/search-connectors/es-connectors-salesforce.md
@@ -465,7 +465,7 @@ The connector syncs the following Salesforce objects:
 The connector will not ingest any objects that it does not have permissions to query.
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. You must enable [document level security](/reference/search-connectors/document-level-security.md). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-salesforce.md
+++ b/docs/reference/search-connectors/es-connectors-salesforce.md
@@ -465,7 +465,7 @@ The connector syncs the following Salesforce objects:
 The connector will not ingest any objects that it does not have permissions to query.
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. You must enable [document level security](/reference/search-connectors/document-level-security.md). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-servicenow.md
+++ b/docs/reference/search-connectors/es-connectors-servicenow.md
@@ -169,7 +169,7 @@ All services and records the user has access to will be indexed according to the
 * Attachments
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. You must enable [document level security](/reference/search-connectors/document-level-security.md). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-servicenow.md
+++ b/docs/reference/search-connectors/es-connectors-servicenow.md
@@ -169,7 +169,7 @@ All services and records the user has access to will be indexed according to the
 * Attachments
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. You must enable [document level security](/reference/search-connectors/document-level-security.md). Otherwise, **all documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-sharepoint-online.md
+++ b/docs/reference/search-connectors/es-connectors-sharepoint-online.md
@@ -362,7 +362,7 @@ We recommend setting `isHtmlString` to **True** for all Web Parts that need to b
 
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. Enable [document-level security (DLS)](/reference/search-connectors/document-level-security.md) to sync permissions.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-sharepoint-online.md
+++ b/docs/reference/search-connectors/es-connectors-sharepoint-online.md
@@ -362,7 +362,7 @@ We recommend setting `isHtmlString` to **True** for all Web Parts that need to b
 
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced by default. Enable [document-level security (DLS)](/reference/search-connectors/document-level-security.md) to sync permissions.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-sharepoint.md
+++ b/docs/reference/search-connectors/es-connectors-sharepoint.md
@@ -264,7 +264,7 @@ The connector syncs the following SharePoint object types:
 * Document Libraries and its attachment content(include Web Pages)
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-sharepoint.md
+++ b/docs/reference/search-connectors/es-connectors-sharepoint.md
@@ -264,7 +264,7 @@ The connector syncs the following SharePoint object types:
 * Document Libraries and its attachment content(include Web Pages)
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. Use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-teams.md
+++ b/docs/reference/search-connectors/es-connectors-teams.md
@@ -268,7 +268,7 @@ The connector syncs the following objects and entities:
 * **CALENDAR_EVENTS**
 
 ::::{note}
-* Files bigger than 10 MB won’t be extracted.
+* Files bigger than 8 MB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-teams.md
+++ b/docs/reference/search-connectors/es-connectors-teams.md
@@ -268,7 +268,7 @@ The connector syncs the following objects and entities:
 * **CALENDAR_EVENTS**
 
 ::::{note}
-* Files bigger than 8 MB won’t be extracted.
+* Files bigger than 8 MiB won’t be extracted.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-zoom.md
+++ b/docs/reference/search-connectors/es-connectors-zoom.md
@@ -263,7 +263,7 @@ The connector syncs the following objects and entities:
 * **Chat Files**
 
 ::::{note}
-* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MiB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::

--- a/docs/reference/search-connectors/es-connectors-zoom.md
+++ b/docs/reference/search-connectors/es-connectors-zoom.md
@@ -263,7 +263,7 @@ The connector syncs the following objects and entities:
 * **Chat Files**
 
 ::::{note}
-* Content from files bigger than 10 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
+* Content from files bigger than 8 MB won’t be extracted by default. You can use the [self-managed local extraction service](/reference/search-connectors/es-connectors-content-extraction.md#es-connectors-content-extraction-local) to handle larger binary files.
 * Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elastic Deployment.
 
 ::::


### PR DESCRIPTION
Updates the search-connectors reference documentation to reflect the new default `service.max_file_download_size` introduced in [elastic/connectors#4137](https://github.com/elastic/connectors/pull/4137), which lowers it from 10MiB (`10485760`) to 8MiB (`8388608`) to align with the 8MiB `ingest.attachment.max_field_size` cap enforced by Elasticsearch Serverless on the Ingest Attachment Processor.

Changes:
- `es-connectors-content-extraction.md`: the self-hosted extraction service threshold and the per-file pipeline extraction limit now read 8MiB (the unrelated 100MB Elasticsearch hard limit is left unchanged).
- All per-connector docs: the "Content from files bigger than 10 MB won't be extracted" notes now read "bigger than 8 MiB".
- Units switched from `MB` to `MiB` since the underlying limit is binary and this matches the wording used in the connectors PR.

26 files changed. Docs-only change; no code or console snippets affected.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`? (N/A — docs-only change)
- [x] If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [ ] If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. (N/A)

Made with [Cursor](https://cursor.com)