### PR TITLE
[9.5] Eliminate network call for branches.json in Gradle func tests (#151851) (#153212)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -21,6 +21,23 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
     @TempDir
     File gradleUserHome
 
+    def setup() {
+        def branchesFile = file("branches.json")
+        branchesFile.text = """
+        {
+          "branches": [
+            { "branch": "main", "version": "9.0.0" },
+            { "branch": "8.x", "version": "8.4.0" },
+            { "branch": "8.3", "version": "8.3.0" },
+            { "branch": "8.2", "version": "8.2.1" },
+            { "branch": "8.1", "version": "8.1.3" },
+            { "branch": "7.16", "version": "7.16.10" }
+          ]
+        }
+        """
+        propertiesFile << "\norg.elasticsearch.build.branches-file-location=${branchesFile.absolutePath.replace('\\', '/')}\n"
+    }
+
     def "resolves current version from local build"() {
         given:
         internalBuild()

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -481,9 +481,6 @@ tests:
 - class: org.elasticsearch.cluster.ClusterInfoServiceIT
   method: testMaxQueueLatenciesInClusterInfo
   issue: https://github.com/elastic/elasticsearch/issues/151837
-- class: org.elasticsearch.gradle.internal.InternalDistributionDownloadPluginFuncTest
-  method: resolves current version from local build
-  issue: https://github.com/elastic/elasticsearch/issues/151851
 - class: org.elasticsearch.xpack.stateless.commits.StatelessFileDeletionIT
   method: testDeleteIndexAfterRecovery
   issue: https://github.com/elastic/elasticsearch/issues/151884


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Eliminate network call for branches.json in Gradle func tests (#151851) (#153212)