### PR TITLE
Consolidate some of the many randomVector functions

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
@@ -85,6 +85,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -265,7 +266,7 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
 
             if (elementType == DenseVectorFieldMapper.ElementType.FLOAT) {
                 indexRandomly(dir, codec, numDocs, doc -> {
-                    float[] vector = randomVector(dimension);
+                    float[] vector = randomFloatVector(dimension);
                     doc.add(new KnnFloatVectorField("vector", vector, similarity));
                 });
             } else {
@@ -590,20 +591,12 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
     static void addRandomKnnVectors(Document doc) {
         int numFields = randomFrom(1, 3);
         for (int f = 0; f < numFields; f++) {
-            doc.add(new KnnFloatVectorField("knnvector-" + f, randomVector(DEFAULT_VECTOR_DIMENSION)));
+            doc.add(new KnnFloatVectorField("knnvector-" + f, randomFloatVector(DEFAULT_VECTOR_DIMENSION)));
         }
     }
 
     static void addRandomBloomFilterField(Document doc) {
         doc.add(new BloomFilterField(randomAlphaOfLength(5)));
-    }
-
-    private static float[] randomVector(int dimension) {
-        float[] vec = new float[dimension];
-        for (int i = 0; i < vec.length; i++) {
-            vec[i] = randomFloat();
-        }
-        return vec;
     }
 
     static void addRandomFields(Document doc) {

--- a/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -448,12 +449,12 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
         createIndex("index", indexSettings, builder);
 
         for (int doc = 0; doc < 10; doc++) {
-            prepareIndex("index").setSource("vector", randomVector(4096)).get();
+            prepareIndex("index").setSource("vector", randomFloatVector(4096)).get();
         }
 
         indicesAdmin().prepareRefresh("index").get();
 
-        float[] queryVector = randomVector(4096);
+        float[] queryVector = randomFloatVector(4096);
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 3, 50, 10f, null, null).boost(5.0f);
         assertResponse(client().prepareSearch("index").setKnnSearch(List.of(knnSearch)).addFetchField("*").setSize(10), response -> {
             assertHitCount(response, 3);
@@ -463,25 +464,13 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
     }
 
     private float[] randomVector() {
-        float[] vector = new float[VECTOR_DIMENSION];
-        for (int i = 0; i < vector.length; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
-    }
-
-    private float[] randomVector(int dims) {
-        float[] vector = new float[dims];
-        for (int i = 0; i < vector.length; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
+        return randomFloatVector(VECTOR_DIMENSION);
     }
 
     private float[] randomVector(float dimLower, float dimUpper) {
         float[] vector = new float[VECTOR_DIMENSION];
         for (int i = 0; i < vector.length; i++) {
-            vector[i] = (float) randomDoubleBetween(dimLower, dimUpper, true);
+            vector[i] = randomFloatBetween(dimLower, dimUpper, true);
         }
         return vector;
     }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/VectorTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/VectorTestUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+import java.util.Random;
+
+public class VectorTestUtils {
+
+    private VectorTestUtils() {}
+
+    public static float[] randomFloatVector(int dims) {
+        return randomFloatVector(ESTestCase.random(), dims);
+    }
+
+    public static float[] randomFloatVector(Random random, int dims) {
+        float[] vec = new float[dims];
+        generateRandomFloatVector(random, vec);
+        return vec;
+    }
+
+    public static float[] randomNormalizedFloatVector(int dims) {
+        return randomNormalizedFloatVector(ESTestCase.random(), dims);
+    }
+
+    public static float[] randomNormalizedFloatVector(Random random, int dims) {
+        float[] vec = new float[dims];
+        double squareSum = generateRandomFloatVector(random, vec);
+
+        double norm = Math.sqrt(squareSum);
+        for (int i = 0; i < vec.length; i++) {
+            vec[i] = (float) (vec[i] / norm);
+        }
+        return vec;
+    }
+
+    private static double generateRandomFloatVector(Random random, float[] vec) {
+        // we don't want a zero-length vector
+        double squareSum = 0f;
+        do {
+            for (int i = 0; i < vec.length; i++) {
+                // from -1 to +1
+                vec[i] = random.nextFloat() * 2f - 1f;
+                squareSum += vec[i] * vec[i];
+            }
+        } while (squareSum == 0d);
+
+        return squareSum;
+    }
+
+    public static byte[] randomByteVector(int dims) {
+        return randomByteVector(ESTestCase.random(), dims);
+    }
+
+    public static byte[] randomByteVector(Random random, int dims) {
+        // we don't want a zero-length vector
+        byte[] vec = new byte[dims];
+        do {
+            random.nextBytes(vec);
+        } while (Arrays.equals(vec, new byte[dims]));
+
+        return vec;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/VectorTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/VectorTestUtils.java
@@ -23,6 +23,7 @@ public class VectorTestUtils {
     }
 
     public static float[] randomFloatVector(Random random, int dims) {
+        assert dims > 0;
         float[] vec = new float[dims];
         generateRandomFloatVector(random, vec);
         return vec;
@@ -33,6 +34,7 @@ public class VectorTestUtils {
     }
 
     public static float[] randomNormalizedFloatVector(Random random, int dims) {
+        assert dims > 0;
         float[] vec = new float[dims];
         double squareSum = generateRandomFloatVector(random, vec);
 
@@ -45,8 +47,9 @@ public class VectorTestUtils {
 
     private static double generateRandomFloatVector(Random random, float[] vec) {
         // we don't want a zero-length vector
-        double squareSum = 0f;
+        double squareSum;
         do {
+            squareSum = 0;
             for (int i = 0; i < vec.length; i++) {
                 // from -1 to +1
                 vec[i] = random.nextFloat() * 2f - 1f;
@@ -62,6 +65,7 @@ public class VectorTestUtils {
     }
 
     public static byte[] randomByteVector(Random random, int dims) {
+        assert dims > 0;
         // we don't want a zero-length vector
         byte[] vec = new byte[dims];
         do {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es816/BinaryQuantizationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es816/BinaryQuantizationTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 
 import java.util.Random;
 
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
+
 public class BinaryQuantizationTests extends LuceneTestCase {
 
     public void testQuantizeForIndex() {
@@ -739,14 +741,6 @@ public class BinaryQuantizationTests extends LuceneTestCase {
         );
     }
 
-    private float[] generateRandomFloatArray(Random random, int dimensions, float lowerBoundInclusive, float upperBoundExclusive) {
-        float[] data = new float[dimensions];
-        for (int i = 0; i < dimensions; i++) {
-            data[i] = random.nextFloat(lowerBoundInclusive, upperBoundExclusive);
-        }
-        return data;
-    }
-
     public void testQuantizeForIndexMIP() {
         int dimensions = 768;
 
@@ -754,8 +748,8 @@ public class BinaryQuantizationTests extends LuceneTestCase {
         // quantization changes
         Random random = new Random(42);
 
-        float[] mipVectorToIndex = generateRandomFloatArray(random, dimensions, -1f, 1f);
-        float[] mipCentroid = generateRandomFloatArray(random, dimensions, -1f, 1f);
+        float[] mipVectorToIndex = randomFloatVector(random, dimensions);
+        float[] mipCentroid = randomFloatVector(random, dimensions);
 
         VectorSimilarityFunction[] similarityFunctionsActingLikeEucllidean = new VectorSimilarityFunction[] {
             VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
@@ -886,8 +880,8 @@ public class BinaryQuantizationTests extends LuceneTestCase {
         // quantization changes
         Random random = new Random(42);
 
-        float[] mipVectorToQuery = generateRandomFloatArray(random, dimensions, -1f, 1f);
-        float[] mipCentroid = generateRandomFloatArray(random, dimensions, -1f, 1f);
+        float[] mipVectorToQuery = randomFloatVector(random, dimensions);
+        float[] mipCentroid = randomFloatVector(random, dimensions);
 
         VectorSimilarityFunction[] similarityFunctionsActingLikeEucllidean = new VectorSimilarityFunction[] {
             VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
@@ -1311,8 +1305,8 @@ public class BinaryQuantizationTests extends LuceneTestCase {
         // quantization changes
         Random random = new Random(42);
 
-        float[] mipVectorToIndex = generateRandomFloatArray(random, dimensions, -1f, 1f);
-        float[] mipCentroid = generateRandomFloatArray(random, dimensions, -1f, 1f);
+        float[] mipVectorToIndex = randomFloatVector(random, dimensions);
+        float[] mipCentroid = randomFloatVector(random, dimensions);
 
         mipVectorToIndex = VectorUtil.l2normalize(mipVectorToIndex);
         mipCentroid = VectorUtil.l2normalize(mipCentroid);
@@ -1440,8 +1434,8 @@ public class BinaryQuantizationTests extends LuceneTestCase {
         // quantization changes
         Random random = new Random(42);
 
-        float[] mipVectorToQuery = generateRandomFloatArray(random, dimensions, -1f, 1f);
-        float[] mipCentroid = generateRandomFloatArray(random, dimensions, -1f, 1f);
+        float[] mipVectorToQuery = randomFloatVector(random, dimensions);
+        float[] mipCentroid = randomFloatVector(random, dimensions);
 
         mipVectorToQuery = VectorUtil.l2normalize(mipVectorToQuery);
         mipCentroid = VectorUtil.l2normalize(mipCentroid);

--- a/server/src/test/java/org/elasticsearch/search/retriever/RankDocsRetrieverBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/RankDocsRetrieverBuilderTests.java
@@ -67,7 +67,7 @@ public class RankDocsRetrieverBuilderTests extends ESTestCase {
             } else {
                 KnnRetrieverBuilder knnRetrieverBuilder = new KnnRetrieverBuilder(
                     randomAlphaOfLength(10),
-                    randomVector(randomInt(10)),
+                    randomVector(randomIntBetween(1, 10)),
                     null,
                     randomInt(10),
                     randomIntBetween(10, 100),

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomByteVector;
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DEFAULT_OVERSAMPLE;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.OVERSAMPLE_LIMIT;
 import static org.elasticsearch.search.SearchService.DEFAULT_SIZE;
@@ -331,7 +333,7 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
             }
         } else {
             // For float vectors, encode as floats
-            expectedVector = randomVector(vectorDimensions);
+            expectedVector = randomFloatVector(vectorDimensions);
             encoded = encodeToBase64(expectedVector);
         }
 
@@ -392,7 +394,7 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
             encoded = encodeToBase64(vector);
         } else {
             // For float vectors, encode as floats with wrong dimensions
-            float[] vector = randomVector(vectorDimensions + 1);
+            float[] vector = randomFloatVector(vectorDimensions + 1);
             encoded = encodeToBase64(vector);
         }
 
@@ -669,21 +671,5 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
 
     protected String encodeToBase64(byte[] vector) {
         return Base64.getEncoder().encodeToString(vector);
-    }
-
-    private float[] randomVector(int dims) {
-        float[] vector = new float[dims];
-        for (int i = 0; i < dims; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
-    }
-
-    private byte[] randomByteVector(int dims) {
-        byte[] vector = new byte[dims];
-        for (int i = 0; i < dims; i++) {
-            vector[i] = randomByte();
-        }
-        return vector;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/vectors/DenseVectorQueryBytesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DenseVectorQueryBytesTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 
 public class DenseVectorQueryBytesTests extends AbstractDenseVectorQueryTestCase {
     @Override
@@ -35,8 +36,7 @@ public class DenseVectorQueryBytesTests extends AbstractDenseVectorQueryTestCase
 
     @Override
     float[] randomVector(int dim) {
-        byte[] bytes = new byte[dim];
-        random().nextBytes(bytes);
+        byte[] bytes = VectorTestUtils.randomByteVector(dim);
         float[] floats = new float[dim];
         for (int i = 0; i < dim; i++) {
             floats[i] = bytes[i];

--- a/server/src/test/java/org/elasticsearch/search/vectors/DenseVectorQueryFloatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DenseVectorQueryFloatsTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 
 public class DenseVectorQueryFloatsTests extends AbstractDenseVectorQueryTestCase {
     @Override
@@ -27,11 +28,7 @@ public class DenseVectorQueryFloatsTests extends AbstractDenseVectorQueryTestCas
 
     @Override
     float[] randomVector(int dim) {
-        float[] vector = new float[dim];
-        for (int i = 0; i < vector.length; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
+        return VectorTestUtils.randomFloatVector(dim);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingParentBlockQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/DiversifyingParentBlockQueryTests.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -72,7 +73,7 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
         float[][] queries = new float[numQueries][];
         List<Map<String, Float>> expectedTopDocs = new ArrayList<>();
         for (int i = 0; i < numQueries; i++) {
-            queries[i] = randomVector(dims);
+            queries[i] = randomFloatVector(dims);
             expectedTopDocs.add(new HashMap<>());
         }
 
@@ -82,7 +83,7 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
                 int numVectors = randomIntBetween(0, 5);
                 float[][] vectors = new float[numVectors][];
                 for (int j = 0; j < numVectors; j++) {
-                    vectors[j] = randomVector(dims);
+                    vectors[j] = randomFloatVector(dims);
                 }
 
                 if (numVectors > 0) {
@@ -155,13 +156,5 @@ public class DiversifyingParentBlockQueryTests extends MapperServiceTestCase {
             builder.endObject();
             return new SourceToParse(id, BytesReference.bytes(builder), XContentType.JSON);
         }
-    }
-
-    private float[] randomVector(int dim) {
-        float[] vector = new float[dim];
-        for (int i = 0; i < vector.length; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatSlicedVectorQueryTests.java
@@ -29,8 +29,8 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
+import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormat;
 import org.junit.Before;
 
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFloat;
 import static org.hamcrest.Matchers.equalTo;
 
 public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQueryTestCase {
@@ -69,12 +68,7 @@ public class IVFKnnFloatSlicedVectorQueryTests extends AbstractIVFKnnVectorQuery
 
     @Override
     float[] randomVector(int dim) {
-        float[] vector = new float[dim];
-        for (int i = 0; i < dim; i++) {
-            vector[i] = randomFloat();
-        }
-        VectorUtil.l2normalize(vector);
-        return vector;
+        return VectorTestUtils.randomNormalizedFloatVector(dim);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/IVFKnnFloatVectorQueryTests.java
@@ -17,11 +17,9 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.util.VectorUtil;
+import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 
 import java.io.IOException;
-
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFloat;
 
 public class IVFKnnFloatVectorQueryTests extends AbstractIVFKnnVectorQueryTestCase {
 
@@ -32,12 +30,7 @@ public class IVFKnnFloatVectorQueryTests extends AbstractIVFKnnVectorQueryTestCa
 
     @Override
     float[] randomVector(int dim) {
-        float[] vector = new float[dim];
-        for (int i = 0; i < dim; i++) {
-            vector[i] = randomFloat();
-        }
-        VectorUtil.l2normalize(vector);
-        return vector;
+        return VectorTestUtils.randomNormalizedFloatVector(dim);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -337,11 +338,7 @@ public class KnnSearchBuilderTests extends AbstractXContentSerializingTestCase<K
     }
 
     public static float[] randomVector(int dim) {
-        float[] vector = new float[dim];
-        for (int i = 0; i < vector.length; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
+        return VectorTestUtils.randomFloatVector(dim);
     }
 
     private static class RewriteableQuery extends AbstractQueryBuilder<RewriteableQuery> {

--- a/server/src/test/java/org/elasticsearch/search/vectors/RescoreKnnVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/RescoreKnnVectorQueryTests.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormat.DEFAULT_CENTROIDS_PER_PARENT_CLUSTER;
 import static org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormat.DEFAULT_VECTORS_PER_CLUSTER;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -76,9 +77,11 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
         int numDims = randomIntBetween(5, 100);
         int k = randomIntBetween(1, numDocs - 1);
 
-        float[] queryVector = randomVector(numDims);
+        float[] queryVector = randomFloatVector(numDims);
         List<Query> innerQueries = new ArrayList<>();
-        innerQueries.add(new KnnFloatVectorQuery(FIELD_NAME, randomVector(numDims), (int) (k * randomFloatBetween(1.0f, 10.0f, true))));
+        innerQueries.add(
+            new KnnFloatVectorQuery(FIELD_NAME, randomFloatVector(numDims), (int) (k * randomFloatBetween(1.0f, 10.0f, true)))
+        );
         innerQueries.add(new DenseVectorQuery.Floats(queryVector, FIELD_NAME, new FieldExistsQuery(FIELD_NAME)));
         innerQueries.add(Queries.ALL_DOCS_INSTANCE);
 
@@ -127,7 +130,7 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
         int numDocs = randomIntBetween(10, 50);
         int numDims = randomIntBetween(5, 20);
         int k = randomIntBetween(1, numDocs - 1);
-        float[] queryVector = randomVector(numDims);
+        float[] queryVector = randomFloatVector(numDims);
 
         try (Directory d = newDirectory()) {
             addRandomDocuments(numDocs, d, numDims);
@@ -156,7 +159,7 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
         int k = randomIntBetween(1, 10);
         int rescoreK = randomIntBetween(k + 1, numDocs);
 
-        float[] queryVector = randomVector(numDims);
+        float[] queryVector = randomFloatVector(numDims);
 
         try (Directory d = newDirectory()) {
             addRandomDocuments(numDocs, d, numDims);
@@ -211,10 +214,12 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
         int numDims = randomIntBetween(5, 100);
         int k = randomIntBetween(1, numDocs - 1);
 
-        float[] queryVector = randomVector(numDims);
+        float[] queryVector = randomFloatVector(numDims);
 
         List<Query> innerQueries = new ArrayList<>();
-        innerQueries.add(new KnnFloatVectorQuery(FIELD_NAME, randomVector(numDims), (int) (k * randomFloatBetween(1.0f, 10.0f, true))));
+        innerQueries.add(
+            new KnnFloatVectorQuery(FIELD_NAME, randomFloatVector(numDims), (int) (k * randomFloatBetween(1.0f, 10.0f, true)))
+        );
         innerQueries.add(new DenseVectorQuery.Floats(queryVector, FIELD_NAME, new FieldExistsQuery(FIELD_NAME)));
         innerQueries.add(Queries.ALL_DOCS_INSTANCE);
 
@@ -261,7 +266,7 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
             addRandomDocuments(numDocs, d, numDims);
 
             try (IndexReader reader = DirectoryReader.open(d)) {
-                float[] queryVector = randomVector(numDims);
+                float[] queryVector = randomFloatVector(numDims);
 
                 checkProfiling(k, numDocs, queryVector, reader, Queries.ALL_DOCS_INSTANCE);
                 checkProfiling(k, numDocs, queryVector, reader, new MockQueryProfilerProvider(randomIntBetween(1, 100)));
@@ -286,14 +291,6 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
         }
 
         assertThat(queryProfiler.getVectorOpsCount(), equalTo(expectedVectorOpsCount));
-    }
-
-    private static float[] randomVector(int numDimensions) {
-        float[] vector = new float[numDimensions];
-        for (int j = 0; j < numDimensions; j++) {
-            vector[j] = randomFloatBetween(0, 1, true);
-        }
-        return vector;
     }
 
     /**
@@ -379,7 +376,7 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
         try (IndexWriter w = new IndexWriter(d, newIndexWriterConfig())) {
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
-                float[] vector = randomVector(numDims);
+                float[] vector = randomFloatVector(numDims);
                 KnnFloatVectorField vectorField = new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.COSINE);
                 document.add(vectorField);
                 w.addDocument(document);

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryVectorBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryVectorBuilderTestCase.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomVector;
 import static org.elasticsearch.search.SearchService.DEFAULT_SIZE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -174,14 +175,6 @@ public abstract class AbstractQueryVectorBuilderTestCase<T extends QueryVectorBu
      * @return An action response to be handled by the query vector builder
      */
     protected abstract ActionResponse createResponse(float[] array, T builder);
-
-    public static float[] randomVector(int dim) {
-        float[] vector = new float[dim];
-        for (int i = 0; i < vector.length; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
-    }
 
     private class AssertingClient extends NoOpClient {
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDenseVectorAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDenseVectorAggregatorFunctionTests.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import java.util.List;
 import java.util.stream.LongStream;
 
+import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomVector;
 import static org.hamcrest.Matchers.closeTo;
 
 public class SumDenseVectorAggregatorFunctionTests extends AggregatorFunctionTestCase {
@@ -36,14 +37,6 @@ public class SumDenseVectorAggregatorFunctionTests extends AggregatorFunctionTes
             blockFactory,
             LongStream.range(0, size).mapToObj(l -> randomVector(vectorDimensions))
         );
-    }
-
-    private static float[] randomVector(int dimensions) {
-        float[] vector = new float[dimensions];
-        for (int i = 0; i < dimensions; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDenseVectorGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDenseVectorGroupingAggregatorFunctionTests.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import java.util.List;
 import java.util.stream.LongStream;
 
+import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomVector;
 import static org.hamcrest.Matchers.closeTo;
 
 public class SumDenseVectorGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
@@ -38,14 +39,6 @@ public class SumDenseVectorGroupingAggregatorFunctionTests extends GroupingAggre
             blockFactory,
             LongStream.range(0, end).mapToObj(l -> Tuple.tuple(randomLongBetween(0, 4), randomVector(vectorDimensions)))
         );
-    }
-
-    private float[] randomVector(int dimensions) {
-        float[] vector = new float[dimensions];
-        for (int i = 0; i < dimensions; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -111,6 +111,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomVector;
 import static org.elasticsearch.compute.aggregation.AggregatorMode.FINAL;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
@@ -2792,17 +2793,8 @@ public class LocalPhysicalPlanOptimizerTests extends AbstractLocalPhysicalPlanOp
         final int k;
 
         KnnFunctionTestCase() {
-            super(Knn.class, "dense_vector", randomVector());
+            super(Knn.class, "dense_vector", randomVector(randomIntBetween(10, 20)));
             k = randomIntBetween(1, 10);
-        }
-
-        private static Object randomVector() {
-            int numDims = randomIntBetween(10, 20);
-            float[] vector = new float[numDims];
-            for (int i = 0; i < numDims; i++) {
-                vector[i] = randomFloat();
-            }
-            return vector;
         }
 
         @Override

--- a/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/BaseGPUIndexTestCase.java
+++ b/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/BaseGPUIndexTestCase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gpu.CuVSGPUSupport;
 import org.elasticsearch.gpu.GPUSupport;
+import org.elasticsearch.index.codec.vectors.VectorTestUtils;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
@@ -364,7 +365,7 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
         // Attempt to index a document and expect it to fail
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> client().prepareIndex(indexName).setId("1").setSource("my_vector", randomNonUnitFloatVector(dims)).get()
+            () -> client().prepareIndex(indexName).setId("1").setSource("my_vector", VectorTestUtils.randomFloatVector(dims)).get()
         );
         assertThat(
             ex.getMessage(),
@@ -429,33 +430,9 @@ public abstract class BaseGPUIndexTestCase extends ESIntegTestCase {
         );
     }
 
-    protected static float[] randomNonUnitFloatVector(int dims) {
-        float[] vector = new float[dims];
-        for (int i = 0; i < dims; i++) {
-            vector[i] = randomFloat();
-        }
-        return vector;
-    }
-
-    protected static float[] randomUnitVector(int dims) {
-        float[] vector = new float[dims];
-        double sumSquares = 0.0;
-        for (int i = 0; i < dims; i++) {
-            vector[i] = randomFloat() * 2 - 1; // Generate values between -1 and 1 for better distribution
-            sumSquares += vector[i] * vector[i];
-        }
-        float magnitude = (float) Math.sqrt(sumSquares);
-        if (magnitude > 0) {
-            for (int i = 0; i < dims; i++) {
-                vector[i] /= magnitude;
-            }
-        }
-        return vector;
-    }
-
     protected float[] randomFloatVector(int dims, String similarity) {
         boolean useUnitVectors = "dot_product".equals(similarity);
-        return useUnitVectors ? randomUnitVector(dims) : randomNonUnitFloatVector(dims);
+        return useUnitVectors ? VectorTestUtils.randomNormalizedFloatVector(dims) : VectorTestUtils.randomFloatVector(dims);
     }
 
     /**

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
@@ -56,6 +56,8 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomByteVector;
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_EMBEDDINGS_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.toSemanticTextFieldChunk;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.toSemanticTextFieldChunkLegacy;
@@ -304,7 +306,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
         assert elementType == DenseVectorFieldMapper.ElementType.FLOAT || elementType == DenseVectorFieldMapper.ElementType.BFLOAT16;
 
         int embeddingLength = DenseVectorFieldMapperTestUtils.getEmbeddingLength(elementType, model.getServiceSettings().dimensions());
-        return new GenericDenseEmbeddingFloatResults.Embedding(randomFloatVectorOfLength(embeddingLength));
+        return new GenericDenseEmbeddingFloatResults.Embedding(randomFloatVector(embeddingLength));
     }
 
     public static EmbeddingResults.Embedding<?> randomMultimodalEmbeddingByte(Model model) {
@@ -312,7 +314,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
         assert elementType == DenseVectorFieldMapper.ElementType.BYTE || elementType == DenseVectorFieldMapper.ElementType.BIT;
 
         int embeddingLength = DenseVectorFieldMapperTestUtils.getEmbeddingLength(elementType, model.getServiceSettings().dimensions());
-        return new GenericDenseEmbeddingByteResults.Embedding(randomByteVectorOfLength(embeddingLength));
+        return new GenericDenseEmbeddingByteResults.Embedding(randomByteVector(embeddingLength));
     }
 
     public static ChunkedInferenceEmbedding randomChunkedInferenceEmbedding(Model model, List<String> inputs) {
@@ -333,7 +335,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
 
         List<EmbeddingResults.Chunk> chunks = new ArrayList<>();
         for (String input : inputs) {
-            byte[] values = randomByteVectorOfLength(embeddingLength);
+            byte[] values = randomByteVector(embeddingLength);
             chunks.add(
                 new EmbeddingResults.Chunk(
                     new DenseEmbeddingByteResults.Embedding(values),
@@ -344,15 +346,6 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
         return new ChunkedInferenceEmbedding(chunks);
     }
 
-    public static byte[] randomByteVectorOfLength(int embeddingLength) {
-        byte[] values = new byte[embeddingLength];
-        for (int j = 0; j < values.length; j++) {
-            // to avoid vectors with zero magnitude
-            values[j] = (byte) Math.max(1, randomByte());
-        }
-        return values;
-    }
-
     public static ChunkedInferenceEmbedding randomChunkedInferenceEmbeddingFloat(Model model, List<String> inputs) {
         DenseVectorFieldMapper.ElementType elementType = model.getServiceSettings().elementType();
         int embeddingLength = DenseVectorFieldMapperTestUtils.getEmbeddingLength(elementType, model.getServiceSettings().dimensions());
@@ -360,7 +353,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
 
         List<EmbeddingResults.Chunk> chunks = new ArrayList<>();
         for (String input : inputs) {
-            float[] values = randomFloatVectorOfLength(embeddingLength);
+            float[] values = randomFloatVector(embeddingLength);
             chunks.add(
                 new EmbeddingResults.Chunk(
                     new DenseEmbeddingFloatResults.Embedding(values),
@@ -369,15 +362,6 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
             );
         }
         return new ChunkedInferenceEmbedding(chunks);
-    }
-
-    public static float[] randomFloatVectorOfLength(int embeddingLength) {
-        float[] values = new float[embeddingLength];
-        for (int j = 0; j < values.length; j++) {
-            // to avoid vectors with zero magnitude
-            values[j] = Math.max(1e-6f, randomFloat());
-        }
-        return values;
     }
 
     public static ChunkedInferenceEmbedding randomChunkedInferenceEmbeddingSparse(List<String> inputs) {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/HollowIndexEngineTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/HollowIndexEngineTests.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import static org.elasticsearch.common.bytes.BytesReference.bytes;
+import static org.elasticsearch.index.codec.vectors.VectorTestUtils.randomFloatVector;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.mock;
@@ -250,7 +251,7 @@ public class HollowIndexEngineTests extends EngineTestCase {
 
             try (IndexEngine engine = newIndexEngine(engineConfig)) {
                 for (int i = 0; i < numDocs; i++) {
-                    var denseVectorSource = JsonXContent.contentBuilder().startObject().array("dv", randomVector(3)).endObject();
+                    var denseVectorSource = JsonXContent.contentBuilder().startObject().array("dv", randomFloatVector(3)).endObject();
                     var denseVectorDoc = documentMapper.parse(new SourceToParse("dv_" + i, bytes(denseVectorSource), XContentType.JSON));
                     engine.index(indexForDoc(denseVectorDoc));
 
@@ -277,14 +278,6 @@ public class HollowIndexEngineTests extends EngineTestCase {
                 assertThat(e.sparseVectorStats(mappingLookup).getValueCount(), equalTo(0L)); // should be empty for hollow shards
             }
         }
-    }
-
-    private static float[] randomVector(int numDimensions) {
-        float[] vector = new float[numDimensions];
-        for (int j = 0; j < numDimensions; j++) {
-            vector[j] = randomPositiveFloat();
-        }
-        return vector;
     }
 
     private static float randomPositiveFloat() {


### PR DESCRIPTION
There are so, so, so, so, so many `randomVector` functions. Try to consolidate some of them, either into `VectorTestUtils`, or if that class isn't available, a `randomVector` function provided by Lucene.