### PR TITLE
[9.3] Eliminate network call for branches.json in Gradle func tests (#151851) (#153212)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -21,6 +21,23 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
     @TempDir
     File gradleUserHome
 
+    def setup() {
+        def branchesFile = file("branches.json")
+        branchesFile.text = """
+        {
+          "branches": [
+            { "branch": "main", "version": "9.0.0" },
+            { "branch": "8.x", "version": "8.4.0" },
+            { "branch": "8.3", "version": "8.3.0" },
+            { "branch": "8.2", "version": "8.2.1" },
+            { "branch": "8.1", "version": "8.1.3" },
+            { "branch": "7.16", "version": "7.16.10" }
+          ]
+        }
+        """
+        propertiesFile << "\norg.elasticsearch.build.branches-file-location=${branchesFile.absolutePath.replace('\\', '/')}\n"
+    }
+
     def "resolves current version from local build"() {
         given:
         internalBuild()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Eliminate network call for branches.json in Gradle func tests (#151851) (#153212)](https://github.com/elastic/elasticsearch/pull/153212)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)