### PR TITLE
Fix realtime-refresh YAML tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -125,9 +125,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecStatsIT
   method: test {csv-spec:stats.sumAsSurrogateWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/146376
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
-  issue: https://github.com/elastic/elasticsearch/issues/146410
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
@@ -664,9 +661,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
   issue: https://github.com/elastic/elasticsearch/issues/152904
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=get/60_realtime_refresh/Realtime Refresh}
-  issue: https://github.com/elastic/elasticsearch/issues/152906
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testRotationCycleWithNoHandlers
   issue: https://github.com/elastic/elasticsearch/issues/152913

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
@@ -5,6 +5,7 @@
  - do:
      indices.create:
        index:    test_1
+       wait_for_active_shards: all
        body:
          settings:
            index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
@@ -6,6 +6,7 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
@@ -6,6 +6,7 @@
  - do:
       indices.create:
           index: test_1
+          wait_for_active_shards: all
           body:
               settings:
                   refresh_interval: -1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
@@ -5,6 +5,7 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:


### PR DESCRIPTION
These tests do not wait for replicas to start before indexing a
document, and if that indexing lands before all shards have started then
some shards may expose the new document to non-realtime operations like
gets and searches. This commit adjusts the `index.create` invocation to
wait for all shards to start before proceeding.

Closes #146410
Closes #151706
Closes #152906