### PR TITLE
[9.3] Fix snapshot creation on CIFS shares in case of access denied exception (#153219)

### DIFF
--- a/docs/changelog/153219.yaml
+++ b/docs/changelog/153219.yaml
@@ -1,0 +1,6 @@
+area: Snapshot/Restore
+issues:
+ - 152053
+pr: 153219
+summary: Fix snapshot creation on CIFS shares in case of access denied exception
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -434,9 +434,10 @@ public class FsBlobContainer extends AbstractBlobContainer {
             return;
         } catch (FileSystemException e) {
             // In some filesystems (e.g., CIFS) the Files.createLink() does not throw UnsupportedOperationException (as Javadoc says) but
-            // FileSystemException instead. To handle this, we fall back to the no-hard-link operation. This is an indirect check
-            // that assumes that direct FileSystemExceptions instance creation is rare, and it indicates a lack of support for hard links.
-            if (e.getClass() != FileSystemException.class) {
+            // FileSystemException or AccessDeniedException instead. To handle this, we fall back to the no-hard-link operation. This is an
+            // indirect check that assumes that direct FileSystemExceptions or AccessDeniedException instances are rare, and they indicate
+            // a lack of support for hard links or insufficient permissions for creating them.
+            if (e.getClass() != FileSystemException.class && e instanceof AccessDeniedException == false) {
                 throw e;
             }
             fallbackMoveAtomically.accept(targetBlobPath, sourceBlobPath);

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.CopyOption;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
@@ -351,6 +352,21 @@ public class FsBlobContainerTests extends ESTestCase {
             }
         }.getFileSystem(null);
         PathUtilsForTesting.installMock(noHardLinkFs);
+        try {
+            checkAtomicWrite();
+        } finally {
+            PathUtilsForTesting.installMock(fileSystem);
+        }
+    }
+
+    public void testAtomicWriteHardLinkThrowsAccessDeniedException() throws IOException {
+        final var noPermissionsForHardLinksFs = new FilterFileSystemProvider("nohardlinkfs://", fileSystem) {
+            @Override
+            public void createLink(Path link, Path existing) throws IOException {
+                throw new AccessDeniedException(link.toString(), existing.toString(), "no permissions for hard links");
+            }
+        }.getFileSystem(null);
+        PathUtilsForTesting.installMock(noPermissionsForHardLinksFs);
         try {
             checkAtomicWrite();
         } finally {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix snapshot creation on CIFS shares in case of access denied exception (#153219)