### PR TITLE
[ESQL] Add tryAdvance() to prevent drain deadlock

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -769,9 +769,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.fileMetadataFilterPathLike [ndjson.bz2/S3]}
   issue: https://github.com/elastic/elasticsearch/issues/153182
-- class: org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinatorTests
-  method: testConcurrentProducerLoopsOnSharedPoolDoNotDeadlock
-  issue: https://github.com/elastic/elasticsearch/issues/153183
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:stats_sparkline.sparklineInInlineStatsByMvField}
   issue: https://github.com/elastic/elasticsearch/issues/153184
@@ -826,9 +823,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.AllSupportedFieldsIT
   method: testFetchDenseVector {pref=STORED mode=logsdb}
   issue: https://github.com/elastic/elasticsearch/issues/153207
-- class: org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinatorTests
-  method: testConcurrentProducerLoopsThroughStatsCapturingWrapperDoNotDeadlock
-  issue: https://github.com/elastic/elasticsearch/issues/153210
 - class: org.elasticsearch.xpack.stateless.commits.StatelessClusterIntegrityStressIT
   method: testRandomActivities
   issue: https://github.com/elastic/elasticsearch/issues/147841

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/CloseableIterator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/CloseableIterator.java
@@ -30,4 +30,20 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
     default SubscribableListener<Void> waitForReady() {
         return SubscribableListener.newSucceeded(null);
     }
+
+    /**
+     * Non-blocking single-step advance: returns the next element, or {@code null} if none is
+     * immediately available (either because upstream is still producing or because the iterator
+     * is exhausted). Callers distinguish "not yet" from "EOF" via {@link #waitForReady()}: a
+     * {@code null} return paired with an immediately-done {@code waitForReady()} means EOF;
+     * a {@code null} paired with a non-done listener means more data may arrive.
+     *
+     * <p>The default delegates to {@link #hasNext()}/{@link #next()} and is therefore blocking
+     * for iterators whose {@code hasNext()} blocks. Async iterators should override this to
+     * guarantee a non-blocking return so the caller (typically an executor-bound producer loop)
+     * can yield its thread instead of pinning it.
+     */
+    default T tryAdvance() {
+        return hasNext() ? next() : null;
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1692,34 +1692,33 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             if (ready.isDone() == false) {
                 return parkUntilReady(ready, state, completionListener);
             }
-            if (pages.hasNext() == false) {
-                // Race: waitForReady reported done (page available or EOF), but by the time we
-                // called hasNext the state advanced (e.g. another consumer drained, or POISON
-                // got handled inside hasNext and the next slot is not yet populated). For
-                // synchronous iterators where the default waitForReady returns immediately-done,
-                // hasNext=false truly means EOF and the recheck remains done. For async iterators
-                // like {@code StreamingParallelIterator}, a non-done recheck means the iterator
-                // is still producing — yield and let the parser-side {@code signalReady()} wake us.
+            Page page = pages.tryAdvance();
+            if (page == null) {
+                // tryAdvance returned null: either EOF or the iterator is between chunks.
+                // Recheck waitForReady: not-done = more data coming, yield. Done = hasNext
+                // gives the definitive answer (won't block since isReadyNow was just true).
                 SubscribableListener<Void> recheck = pages.waitForReady();
                 if (recheck.isDone()) {
-                    return DrainResult.EOF;
+                    if (pages.hasNext() == false) {
+                        return DrainResult.EOF;
+                    }
+                    page = pages.next();
+                } else {
+                    return parkUntilReady(recheck, state, completionListener);
                 }
-                return parkUntilReady(recheck, state, completionListener);
             }
+            // Check downstream space BEFORE committing the page to the buffer. The page is
+            // already consumed from the iterator (tryAdvance/next popped it), so if we must
+            // park on space we hold it in the listener closure and deliver it on resume.
             SubscribableListener<Void> space = buffer.waitForSpace();
             if (space.isDone() == false) {
-                return parkUntilReady(space, state, completionListener);
+                return parkUntilReadyWithPage(space, page, state, completionListener);
             }
             if (buffer.noMoreInputs()) {
+                page.releaseBlocks();
                 return DrainResult.DONE;
             }
-            Page page = pages.next();
-            int rows = page.getPositionCount();
-            page.allowPassingToDifferentDriver();
-            buffer.addPage(page);
-            if (rowLimit != FormatReader.NO_LIMIT) {
-                state.rowsRemaining -= rows;
-            }
+            deliverPage(page, state);
         }
     }
 
@@ -1761,6 +1760,47 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             completionListener.onFailure(e);
         }));
         return DrainResult.BLOCKED;
+    }
+
+    /**
+     * Like {@link #parkUntilReady} but holds an already-consumed page across the park. On resume
+     * the page is delivered to the buffer (or released if the buffer was finished); then the
+     * producer loop continues.
+     */
+    private DrainResult parkUntilReadyWithPage(
+        SubscribableListener<Void> signal,
+        Page page,
+        ProducerState state,
+        ActionListener<Void> completionListener
+    ) {
+        signal.addListener(ActionListener.wrap(v -> {
+            try {
+                if (state.buffer.noMoreInputs()) {
+                    page.releaseBlocks();
+                } else {
+                    deliverPage(page, state);
+                }
+                producerExecutor.execute(() -> runProducerLoop(state, completionListener));
+            } catch (Exception e) {
+                page.releaseBlocks();
+                clearCurrentIterator(state);
+                completionListener.onFailure(e);
+            }
+        }, e -> {
+            page.releaseBlocks();
+            clearCurrentIterator(state);
+            completionListener.onFailure(e);
+        }));
+        return DrainResult.BLOCKED;
+    }
+
+    private void deliverPage(Page page, ProducerState state) {
+        int rows = page.getPositionCount();
+        page.allowPassingToDifferentDriver();
+        state.buffer.addPage(page);
+        if (rowLimit != FormatReader.NO_LIMIT) {
+            state.rowsRemaining -= rows;
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -936,6 +936,20 @@ public final class ParallelParsingCoordinator {
             return result;
         }
 
+        @Override
+        public Page tryAdvance() {
+            if (closed) {
+                return null;
+            }
+            if (buffered != null) {
+                Page result = buffered;
+                buffered = null;
+                return result;
+            }
+            checkError();
+            return sharedQueue.poll();
+        }
+
         /**
          * Drains the shared queue in as-ready order. Returns the next data page, or {@code null} once every
          * segment has finished and the queue is empty. Polls with a timeout (rather than blocking forever) so

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -156,17 +156,25 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page>, ColumnExt
     }
 
     @Override
+    public Page tryAdvance() {
+        Page filePage = delegate.tryAdvance();
+        return filePage != null ? adaptPage(filePage) : null;
+    }
+
+    @Override
     public Page next() {
         if (delegate.hasNext() == false) {
             throw new NoSuchElementException();
         }
-        Page filePage = delegate.next();
+        return adaptPage(delegate.next());
+    }
+
+    private Page adaptPage(Page filePage) {
         try {
             Page schemaAdapted = mapping.mapPage(filePage, blockFactory, perFileColumnTypes, outputColumnNames, castWarnings());
             if (rowPositionInputIndex < 0) {
                 return schemaAdapted;
             }
-            // Extend the schema-adapted page with the row-position block in the trailing slot.
             int width = schemaAdapted.getBlockCount();
             Block[] withRowPos = new Block[width + 1];
             try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -1104,6 +1104,31 @@ public final class StreamingParallelParsingCoordinator {
             return result;
         }
 
+        @Override
+        public Page tryAdvance() {
+            if (closed) {
+                return null;
+            }
+            if (buffered != null) {
+                Page result = buffered;
+                buffered = null;
+                return result;
+            }
+            checkError();
+            skipDrainedPoison();
+            if (currentChunk >= chunksDispatched.get()) {
+                return null;
+            }
+            int slot = currentChunk % pageQueueRingSize;
+            Page page = pageQueues[slot].poll();
+            if (page == POISON) {
+                currentChunk++;
+                dispatchPermits.release();
+                return null;
+            }
+            return page;
+        }
+
         /**
          * Returns {@code true} when {@link #hasNext()} can run without blocking on upstream
          * production: a real page is available at the head of the current slot, EOF has been reached,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/VirtualColumnIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/VirtualColumnIterator.java
@@ -247,6 +247,12 @@ final class VirtualColumnIterator implements CloseableIterator<Page> {
     }
 
     @Override
+    public Page tryAdvance() {
+        Page raw = delegate.tryAdvance();
+        return raw != null ? inject(raw) : null;
+    }
+
+    @Override
     public SubscribableListener<Void> waitForReady() {
         return delegate.waitForReady();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
@@ -80,6 +80,11 @@ public final class StatsCapturingIterator implements CloseableIterator<Page>, Co
     }
 
     @Override
+    public Page tryAdvance() {
+        return delegate.tryAdvance();
+    }
+
+    @Override
     public void close() throws IOException {
         try (ExternalStatsCapture.Handle handle = ExternalStatsCapture.bind(sink)) {
             delegate.close();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/NullSpliceRowPositionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/NullSpliceRowPositionStrategy.java
@@ -96,16 +96,22 @@ public final class NullSpliceRowPositionStrategy implements RowPositionStrategy 
         }
 
         @Override
+        public Page tryAdvance() {
+            Page innerPage = inner.tryAdvance();
+            return innerPage != null ? splicePage(innerPage) : null;
+        }
+
+        @Override
         public Page next() {
             if (inner.hasNext() == false) {
                 throw new NoSuchElementException();
             }
-            Page innerPage = inner.next();
+            return splicePage(inner.next());
+        }
+
+        private Page splicePage(Page innerPage) {
             int positions = innerPage.getPositionCount();
             int innerBlockCount = innerPage.getBlockCount();
-            // The splice loops below only cover slots in [0, innerBlockCount]; today the optimizer
-            // appends _rowPosition at the end (slot == innerBlockCount), so lock the bound against
-            // a future rule emitting a slot past the inner page's width.
             assert rowPosSlot <= innerBlockCount : "rowPosSlot " + rowPosSlot + " past inner block count " + innerBlockCount;
             Block[] blocks = new Block[innerBlockCount + 1];
             boolean success = false;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -1521,21 +1521,25 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
                     );
                     return;
                 }
-                if (it.hasNext() == false) { // pre-fix: BLOCKS here for the whole read (default waitForReady is immediately done)
+                Page p = it.tryAdvance();
+                if (p == null) {
                     SubscribableListener<Void> recheck = it.waitForReady();
                     if (recheck.isDone()) {
-                        done.onResponse(collected);
+                        if (it.hasNext() == false) {
+                            done.onResponse(collected);
+                            return;
+                        }
+                        p = it.next();
+                    } else {
+                        recheck.addListener(
+                            ActionListener.wrap(
+                                v -> pool.execute(() -> drainAsReadyViaProducerLoop(it, pool, started, startedLatch, collected, done)),
+                                done::onFailure
+                            )
+                        );
                         return;
                     }
-                    recheck.addListener(
-                        ActionListener.wrap(
-                            v -> pool.execute(() -> drainAsReadyViaProducerLoop(it, pool, started, startedLatch, collected, done)),
-                            done::onFailure
-                        )
-                    );
-                    return;
                 }
-                Page p = it.next();
                 BytesRefBlock block = (BytesRefBlock) p.getBlock(0);
                 for (int i = 0; i < block.getPositionCount(); i++) {
                     collected.add(block.getBytesRef(block.getFirstValueIndex(i), scratch).utf8ToString());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -952,18 +952,22 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     );
                     return;
                 }
-                if (it.hasNext() == false) { // pre-fix: BLOCKS here on a POISON gap (isReadyNow reports ready on POISON)
+                Page p = it.tryAdvance();
+                if (p == null) {
                     SubscribableListener<Void> recheck = it.waitForReady();
                     if (recheck.isDone()) {
-                        done.onResponse(rows.get());
+                        if (it.hasNext() == false) {
+                            done.onResponse(rows.get());
+                            return;
+                        }
+                        p = it.next();
+                    } else {
+                        recheck.addListener(
+                            ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoop(it, pool, rows, done)), done::onFailure)
+                        );
                         return;
                     }
-                    recheck.addListener(
-                        ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoop(it, pool, rows, done)), done::onFailure)
-                    );
-                    return;
                 }
-                Page p = it.next();
                 rows.addAndGet(p.getPositionCount());
                 p.releaseBlocks();
             }
@@ -989,18 +993,25 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     );
                     return;
                 }
-                if (it.hasNext() == false) {
+                Page p = it.tryAdvance();
+                if (p == null) {
                     SubscribableListener<Void> recheck = it.waitForReady();
                     if (recheck.isDone()) {
-                        done.onResponse(sink.lines.size());
+                        if (it.hasNext() == false) {
+                            done.onResponse(sink.lines.size());
+                            return;
+                        }
+                        p = it.next();
+                    } else {
+                        recheck.addListener(
+                            ActionListener.wrap(
+                                v -> pool.execute(() -> drainViaProducerLoopCollecting(it, pool, sink, done)),
+                                done::onFailure
+                            )
+                        );
                         return;
                     }
-                    recheck.addListener(
-                        ActionListener.wrap(v -> pool.execute(() -> drainViaProducerLoopCollecting(it, pool, sink, done)), done::onFailure)
-                    );
-                    return;
                 }
-                Page p = it.next();
                 BytesRefBlock block = p.getBlock(0);
                 for (int i = 0; i < block.getPositionCount(); i++) {
                     sink.lines.add(block.getBytesRef(i, scratch).utf8ToString());


### PR DESCRIPTION
Add non-blocking `tryAdvance()` to `CloseableIterator`. The async drain (`drainHotPath`) uses it instead of `hasNext()`, which can block in `latch.await()` and deadlock a shared pool. The hot path calls `tryAdvance()` (guaranteed non-blocking); the recheck falls back to `hasNext()` only after `waitForReady()` confirms readiness. Fixes esql-planning#1119.