### PR TITLE
[9.5] Fix realtime-refresh YAML tests (#153240)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -125,9 +125,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecStatsIT
   method: test {csv-spec:stats.sumAsSurrogateWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/146376
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
-  issue: https://github.com/elastic/elasticsearch/issues/146410
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
@@ -673,9 +670,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
   issue: https://github.com/elastic/elasticsearch/issues/152904
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=get/60_realtime_refresh/Realtime Refresh}
-  issue: https://github.com/elastic/elasticsearch/issues/152906
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testRotationCycleWithNoHandlers
   issue: https://github.com/elastic/elasticsearch/issues/152913

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
@@ -5,6 +5,7 @@
  - do:
      indices.create:
        index:    test_1
+       wait_for_active_shards: all
        body:
          settings:
            index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
@@ -6,6 +6,7 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
@@ -6,6 +6,7 @@
  - do:
       indices.create:
           index: test_1
+          wait_for_active_shards: all
           body:
               settings:
                   refresh_interval: -1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
@@ -5,6 +5,7 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix realtime-refresh YAML tests (#153240)