### PR TITLE
Support HTTP QUERY method (RFC 10008) on _search (#153255)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -38,6 +38,8 @@ import java.util.stream.Collectors;
 
 public class Netty4HttpRequest implements HttpRequest {
 
+    private static final HttpMethod QUERY_METHOD = HttpMethod.valueOf("QUERY");
+
     private final int sequence;
     private final io.netty.handler.codec.http.HttpRequest nettyRequest;
     private boolean hasContent;
@@ -204,6 +206,10 @@ public class Netty4HttpRequest implements HttpRequest {
 
         if (httpMethod == HttpMethod.CONNECT) {
             return RestRequest.Method.CONNECT;
+        }
+
+        if (httpMethod == QUERY_METHOD) {
+            return RestRequest.Method.QUERY;
         }
 
         throw new IllegalArgumentException("Unexpected http method: " + httpMethod);

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -20,14 +20,16 @@
           "path": "/_search",
           "methods": [
             "GET",
-            "POST"
+            "POST",
+            "QUERY"
           ]
         },
         {
           "path": "/{index}/_search",
           "methods": [
             "GET",
-            "POST"
+            "POST",
+            "QUERY"
           ],
           "parts": {
             "index": {

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -246,7 +246,8 @@ public class RestRequest implements ToXContent.Params, Traceable {
         HEAD,
         PATCH,
         TRACE,
-        CONNECT
+        CONNECT,
+        QUERY
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -57,6 +57,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.core.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestRequest.Method.QUERY;
 import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
 
 @ServerlessScope(Scope.PUBLIC)
@@ -95,8 +96,10 @@ public class RestSearchAction extends BaseRestHandler {
         return List.of(
             new Route(GET, "/_search"),
             new Route(POST, "/_search"),
+            new Route(QUERY, "/_search"),
             new Route(GET, "/{index}/_search"),
-            new Route(POST, "/{index}/_search")
+            new Route(POST, "/{index}/_search"),
+            new Route(QUERY, "/{index}/_search")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -8,11 +8,13 @@
  */
 package org.elasticsearch.rest.action.search;
 
+import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.SliceIndexing;
+import org.elasticsearch.rest.RestHandler.Route;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -24,12 +26,15 @@ import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
 import org.elasticsearch.usage.UsageService;
+import org.elasticsearch.xcontent.XContentType;
 import org.junit.Before;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
 public final class RestSearchActionTests extends RestActionTestCase {
@@ -213,5 +218,105 @@ public final class RestSearchActionTests extends RestActionTestCase {
         assertEquals("s1", searchRequest.routing());
         assertTrue(searchRequest.isRoutingFromSlice());
         assertEquals("s1", searchRequest.searchSlice());
+    }
+
+    public void testQueryMethodRoutesAreRegistered() {
+        RestSearchAction action = new RestSearchAction(new UsageService().getSearchUsageHolder(), nf -> false, CrossProjectModeDecider.NOOP);
+        boolean hasQuerySearch = false;
+        boolean hasQueryIndexSearch = false;
+        for (Route route : action.routes()) {
+            if (route.getMethod() == RestRequest.Method.QUERY) {
+                if (route.getPath().equals("/_search")) {
+                    hasQuerySearch = true;
+                } else if (route.getPath().equals("/{index}/_search")) {
+                    hasQueryIndexSearch = true;
+                }
+            }
+        }
+        assertTrue("QUERY method not registered for /_search", hasQuerySearch);
+        assertTrue("QUERY method not registered for /{index}/_search", hasQueryIndexSearch);
+    }
+
+    /**
+     * QUERY method accepts requests with Content-Type header (RFC 10008 compliance).
+     * The handler should not reject QUERY requests based on method.
+     */
+    public void testQueryMethodAcceptsContentType() throws Exception {
+        AtomicReference<ActionType<?>> capturedActionType = new AtomicReference<>();
+        verifyingClient.setExecuteVerifier((actionType, request) -> {
+            capturedActionType.set(actionType);
+            return mock(SearchResponse.class);
+        });
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.QUERY)
+            .withPath("/_search")
+            .withContent(new BytesArray("{}"), XContentType.JSON)
+            .build();
+
+        action.handleRequest(request, new FakeRestChannel(request, randomBoolean()), verifyingClient);
+        assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+    }
+
+    /**
+     * QUERY method works with index-specific search endpoint
+     */
+    public void testQueryMethodWithIndexSpecificPath() throws Exception {
+        AtomicReference<ActionType<?>> capturedActionType = new AtomicReference<>();
+        verifyingClient.setExecuteVerifier((actionType, request) -> {
+            capturedActionType.set(actionType);
+            return mock(SearchResponse.class);
+        });
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.QUERY)
+            .withPath("/test_index/_search")
+            .build();
+
+        action.handleRequest(request, new FakeRestChannel(request, randomBoolean()), verifyingClient);
+        assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+    }
+
+    /**
+     * QUERY method supports standard query parameters (size, from, etc)
+     */
+    public void testQueryMethodWithStandardParams() throws Exception {
+        AtomicReference<ActionType<?>> capturedActionType = new AtomicReference<>();
+        verifyingClient.setExecuteVerifier((actionType, request) -> {
+            capturedActionType.set(actionType);
+            return mock(SearchResponse.class);
+        });
+
+        Map<String, String> params = new HashMap<>();
+        params.put("size", "20");
+        params.put("from", "10");
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.QUERY)
+            .withPath("/_search")
+            .withParams(params)
+            .build();
+
+        action.handleRequest(request, new FakeRestChannel(request, randomBoolean()), verifyingClient);
+        assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
+    }
+
+    /**
+     * QUERY method without body (empty/minimal request) should be accepted
+     */
+    public void testQueryMethodWithoutBody() throws Exception {
+        AtomicReference<ActionType<?>> capturedActionType = new AtomicReference<>();
+        verifyingClient.setExecuteVerifier((actionType, request) -> {
+            capturedActionType.set(actionType);
+            return mock(SearchResponse.class);
+        });
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.QUERY)
+            .withPath("/_search")
+            .build();
+
+        action.handleRequest(request, new FakeRestChannel(request, randomBoolean()), verifyingClient);
+        assertThat(capturedActionType.get(), equalTo(SearchAction.INSTANCE));
     }
 }


### PR DESCRIPTION
Add QUERY as a first-class HTTP method on _search and /{index}/_search. The method is safe, idempotent, and cacheable per RFC 10008, filling the gap between GET (URI-only) and POST (mutating).

Key changes:
* RestRequest.Method enum now includes QUERY
* RestSearchAction routes register QUERY on _search and /{index}/_search
* Netty4HttpRequest handles QUERY without changes (Netty already recognizes HttpMethod.QUERY)
* rest-api-spec schema documents QUERY as accepted method
* Unit tests added to RestSearchActionTests and RestControllerTests

Integration tests deferred: elasticsearch-java and opensearch-java client libraries must add QUERY to their HttpMethod enums first. Coordination tracked in opensearch-project/OpenSearch#22409 and elastic/elasticsearch#153255.

Backward compatible: GET and POST _search behavior unchanged. QUERY is purely opt-in for new clients that support RFC 10008.