### PR TITLE
[9.5] ESQL:DS: Drop ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG (#153139)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -72,7 +72,6 @@ import org.elasticsearch.cluster.metadata.DataStreamAction;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadataStats;
 import org.elasticsearch.cluster.metadata.IndexWriteLoad;
@@ -1856,9 +1855,8 @@ public class DataStreamIT extends ESIntegTestCase {
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
             aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("logs-es").aliases("logs"));
             var e = expectThrows(InvalidAliasNameException.class, indicesAdmin().aliases(aliasesAddRequest));
-            String expectedLogs = DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-                ? "Invalid alias name [logs]: an index, data stream, ESQL view, or ESQL dataset exists with the same name as the alias"
-                : "Invalid alias name [logs]: an index, data stream, or ESQL view exists with the same name as the alias";
+            String expectedLogs = "Invalid alias name [logs]: an index, data stream, ESQL view, or ESQL dataset exists "
+                + "with the same name as the alias";
             assertThat(e.getMessage(), equalTo(expectedLogs));
         }
         {
@@ -1878,9 +1876,8 @@ public class DataStreamIT extends ESIntegTestCase {
                     false
                 )
             );
-            String expectedLogs = DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-                ? "Invalid alias name [logs]: an index, data stream, ESQL view, or ESQL dataset exists with the same name as the alias"
-                : "Invalid alias name [logs]: an index, data stream, or ESQL view exists with the same name as the alias";
+            String expectedLogs = "Invalid alias name [logs]: an index, data stream, ESQL view, or ESQL dataset exists "
+                + "with the same name as the alias";
             assertThat(e.getCause().getMessage(), equalTo(expectedLogs));
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
@@ -653,11 +652,8 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         indicesAdmin().preparePutTemplate("template_1").setPatterns(Collections.singletonList("te*")).addAlias(new Alias("index")).get();
 
         InvalidAliasNameException e = expectThrows(InvalidAliasNameException.class, () -> createIndex("test"));
-        // The AliasValidator message enumeration is gated by the ES|QL external data sources feature flag (snapshot-on,
-        // release-off), so the assertion must branch on the flag to pass in both states.
-        String expected = DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            ? "Invalid alias name [index]: an index, data stream, ESQL view, or ESQL dataset exists with the same name as the alias"
-            : "Invalid alias name [index]: an index, data stream, or ESQL view exists with the same name as the alias";
+        String expected = "Invalid alias name [index]: an index, data stream, ESQL view, or ESQL dataset exists "
+            + "with the same name as the alias";
         assertThat(e.getMessage(), equalTo(expected));
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -88,14 +88,10 @@ public class AliasValidator {
 
         String sameNameAsAlias = lookup.apply(alias);
         if (sameNameAsAlias != null) {
-            // The enumeration in this error message is gated by the ES|QL external data sources feature flag. When the
-            // flag is off, datasets are not user-visible (no CRUD API) and must not appear in messages users hit during
-            // ordinary index/alias/data-stream/view operations. Collision detection runs unconditionally because it
-            // depends on cluster-state contents, not on the flag; only the description string switches.
-            String message = DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-                ? "an index, data stream, ESQL view, or ESQL dataset exists with the same name as the alias"
-                : "an index, data stream, or ESQL view exists with the same name as the alias";
-            throw new InvalidAliasNameException(alias, message);
+            throw new InvalidAliasNameException(
+                alias,
+                "an index, data stream, ESQL view, or ESQL dataset exists with the same name as the alias"
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetMetadata.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -37,13 +36,6 @@ import java.util.Objects;
  * Datasets participate in the index namespace (via {@link IndexAbstraction.Type#DATASET}).
  */
 public final class DatasetMetadata extends AbstractNamedDiffable<Metadata.ProjectCustom> implements Metadata.ProjectCustom {
-
-    /**
-     * Gates the ES|QL external data sources + datasets feature end-to-end. Lives on this server-resident
-     * custom so {@code server} and {@code x-pack} consumers share one source of truth (the data-source
-     * types live in x-pack). System property: {@code es.esql_external_datasources_feature_flag_enabled}.
-     */
-    public static final FeatureFlag ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG = new FeatureFlag("esql_external_datasources");
 
     /** Shared transport version for {@code DataSourceMetadata} and {@link DatasetMetadata} — introduced and evolved together. */
     public static final TransportVersion ESQL_DATASOURCES = TransportVersion.fromName("esql_datasources");

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
@@ -1858,14 +1858,8 @@ public class ProjectMetadata implements Iterable<IndexMetadata>, Diffable<Projec
                 collectAliasDuplicates(indicesMap, dataStreamMetadata, aliasDuplicatesWithDataStreams, duplicates);
             }
             if (duplicates.isEmpty() == false) {
-                // The preamble enumeration is gated by the ES|QL external data sources feature flag. When the flag is
-                // off, datasets are not user-visible (no CRUD API) and must not appear in messages users can hit during
-                // ordinary index/alias/data-stream/view operations. The specific duplicate strings above already mention
-                // "dataset" when a dataset is actually involved in a collision, but that can only happen after datasets
-                // exist in cluster state, which requires the feature flag to be on.
-                String preamble = DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-                    ? "index, alias, data stream, view, and dataset names need to be unique, but the following duplicates were found ["
-                    : "index, alias, data stream, and view names need to be unique, but the following duplicates were found [";
+                String preamble = "index, alias, data stream, view, and dataset names need to be unique, "
+                    + "but the following duplicates were found [";
                 throw new IllegalStateException(preamble + Strings.collectionToCommaDelimitedString(duplicates) + "]");
             }
         }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ProjectMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ProjectMetadataTests.java
@@ -90,14 +90,9 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class ProjectMetadataTests extends ESTestCase {
 
-    /**
-     * Preamble for {@code ensureNoNameCollisions}. The enumeration is gated by the ES|QL external data sources
-     * feature flag (snapshot-on, release-off), so assertions must branch on the flag to pass in both states.
-     */
+    /** Preamble for {@code ensureNoNameCollisions}. */
     private static String collisionPreamble() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            ? "index, alias, data stream, view, and dataset names need to be unique"
-            : "index, alias, data stream, and view names need to be unique";
+        return "index, alias, data stream, view, and dataset names need to be unique";
     }
 
     /** {@link #collisionPreamble()} followed by " but the following duplicates were found " — trailing space, no open bracket. */

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ExternalClusters.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ExternalClusters.java
@@ -8,18 +8,16 @@
 package org.elasticsearch.xpack.esql.heap_attack;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils;
 
 import java.util.function.Supplier;
 
 /**
  * Cluster factory for {@link HeapAttackExternalIT}: builds on top of the base cluster spec from
- * {@link Clusters#buildClusterSpec()} and wires in the ESQL external-datasources feature flag
- * plus the S3 client configuration for the in-memory test fixture. Kept separate from
- * {@link Clusters} so that environment-specific overrides of {@code Clusters} (e.g. serverless)
- * only need to expose the cluster shape via {@code buildClusterSpec()} without duplicating the
- * S3 or feature-flag wiring.
+ * {@link Clusters#buildClusterSpec()} and wires in the S3 client configuration for the in-memory
+ * test fixture. Kept separate from {@link Clusters} so that environment-specific overrides of
+ * {@code Clusters} (e.g. serverless) only need to expose the cluster shape via
+ * {@code buildClusterSpec()} without duplicating the S3 wiring.
  */
 class ExternalClusters {
 
@@ -36,7 +34,6 @@ class ExternalClusters {
      */
     static ElasticsearchCluster buildExternalCluster(Supplier<String> s3EndpointSupplier) {
         return Clusters.buildClusterSpec()
-            .feature(FeatureFlag.ESQL_EXTERNAL_DATASOURCES)
             // Pin the request-breaker limit so the suite reliably trips it regardless of the
             // base cluster's heap size (which varies between the standard and serverless configs).
             // Kept low to leave headroom for untracked S3/Netty allocations.

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -26,7 +26,6 @@ public enum FeatureFlag {
     ),
 
     RANDOM_SAMPLING("es.random_sampling_feature_flag_enabled=true", Version.fromString("9.2.0"), null),
-    ESQL_EXTERNAL_DATASOURCES("es.esql_external_datasources_feature_flag_enabled=true", Version.fromString("9.4.0"), null),
     TSDB_NO_SEQNO("es.tsdb_no_tsbd_feature_flag_enabled=true", Version.fromString("9.4.0"), null),
     PROMETHEUS_FEATURE_FLAG("es.prometheus_feature_flag_enabled=true", Version.fromString("9.4.0"), null),
     SLICE_INDEXING("es.slice_indexing_feature_flag_enabled=true", Version.fromString("9.5.0"), null),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -33,7 +33,6 @@ import org.elasticsearch.action.datastreams.PromoteDataStreamAction;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
 import org.elasticsearch.action.search.TransportSearchShardsAction;
 import org.elasticsearch.action.support.IndexComponentSelector;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
@@ -288,43 +287,37 @@ public final class IndexPrivilege extends Privilege {
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue))
         ),
         sortByAccessLevel(
-            Stream.concat(
-                Stream.of(
-                    entry("none", NONE),
-                    entry("all", ALL),
-                    entry("manage", MANAGE),
-                    entry("create_index", CREATE_INDEX),
-                    entry("monitor", MONITOR),
-                    entry("read", READ),
-                    entry("index", INDEX),
-                    entry("delete", DELETE),
-                    entry("write", WRITE),
-                    entry("create", CREATE),
-                    entry("create_doc", CREATE_DOC),
-                    entry("delete_index", DELETE_INDEX),
-                    entry("view_index_metadata", VIEW_METADATA),
-                    entry("read_cross_cluster", DEPRECATED_READ_CROSS_CLUSTER),
-                    entry("manage_follow_index", MANAGE_FOLLOW_INDEX),
-                    entry("manage_leader_index", MANAGE_LEADER_INDEX),
-                    entry("manage_ilm", MANAGE_ILM),
-                    entry("manage_data_stream_lifecycle", MANAGE_DATA_STREAM_LIFECYCLE),
-                    entry("maintenance", MAINTENANCE),
-                    entry("auto_configure", AUTO_CONFIGURE),
-                    entry("cross_cluster_replication", CROSS_CLUSTER_REPLICATION),
-                    entry("cross_cluster_replication_internal", CROSS_CLUSTER_REPLICATION_INTERNAL),
-                    entry("manage_view", MANAGE_VIEW),
-                    entry("create_view", CREATE_VIEW),
-                    entry("delete_view", DELETE_VIEW),
-                    entry("read_view_metadata", READ_VIEW_METADATA)
-                ),
-                DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-                    ? Stream.of(
-                        entry("manage_dataset", MANAGE_DATASET),
-                        entry("create_dataset", CREATE_DATASET),
-                        entry("delete_dataset", DELETE_DATASET),
-                        entry("read_dataset_metadata", READ_DATASET_METADATA)
-                    )
-                    : Stream.of()
+            Stream.of(
+                entry("none", NONE),
+                entry("all", ALL),
+                entry("manage", MANAGE),
+                entry("create_index", CREATE_INDEX),
+                entry("monitor", MONITOR),
+                entry("read", READ),
+                entry("index", INDEX),
+                entry("delete", DELETE),
+                entry("write", WRITE),
+                entry("create", CREATE),
+                entry("create_doc", CREATE_DOC),
+                entry("delete_index", DELETE_INDEX),
+                entry("view_index_metadata", VIEW_METADATA),
+                entry("read_cross_cluster", DEPRECATED_READ_CROSS_CLUSTER),
+                entry("manage_follow_index", MANAGE_FOLLOW_INDEX),
+                entry("manage_leader_index", MANAGE_LEADER_INDEX),
+                entry("manage_ilm", MANAGE_ILM),
+                entry("manage_data_stream_lifecycle", MANAGE_DATA_STREAM_LIFECYCLE),
+                entry("maintenance", MAINTENANCE),
+                entry("auto_configure", AUTO_CONFIGURE),
+                entry("cross_cluster_replication", CROSS_CLUSTER_REPLICATION),
+                entry("cross_cluster_replication_internal", CROSS_CLUSTER_REPLICATION_INTERNAL),
+                entry("manage_view", MANAGE_VIEW),
+                entry("create_view", CREATE_VIEW),
+                entry("delete_view", DELETE_VIEW),
+                entry("read_view_metadata", READ_VIEW_METADATA),
+                entry("manage_dataset", MANAGE_DATASET),
+                entry("create_dataset", CREATE_DATASET),
+                entry("delete_dataset", DELETE_DATASET),
+                entry("read_dataset_metadata", READ_DATASET_METADATA)
             ).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue))
         )
     );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilegeTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.update.TransportUpdateAction;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.test.ESTestCase;
@@ -86,20 +85,18 @@ public class IndexPrivilegeTests extends ESTestCase {
             findPrivilegesThatGrant(EsqlViewActionNames.ESQL_DELETE_VIEW_ACTION_NAME),
             equalTo(List.of("delete_view", "manage_view", "manage", "all"))
         );
-        if (DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()) {
-            assertThat(
-                findPrivilegesThatGrant(EsqlDatasetActionNames.ESQL_PUT_DATASET_ACTION_NAME),
-                equalTo(List.of("create_dataset", "manage_dataset", "manage", "all"))
-            );
-            assertThat(
-                findPrivilegesThatGrant(EsqlDatasetActionNames.ESQL_GET_DATASET_ACTION_NAME),
-                equalTo(List.of("read_dataset_metadata", "manage_dataset", "manage", "all"))
-            );
-            assertThat(
-                findPrivilegesThatGrant(EsqlDatasetActionNames.ESQL_DELETE_DATASET_ACTION_NAME),
-                equalTo(List.of("delete_dataset", "manage_dataset", "manage", "all"))
-            );
-        }
+        assertThat(
+            findPrivilegesThatGrant(EsqlDatasetActionNames.ESQL_PUT_DATASET_ACTION_NAME),
+            equalTo(List.of("create_dataset", "manage_dataset", "manage", "all"))
+        );
+        assertThat(
+            findPrivilegesThatGrant(EsqlDatasetActionNames.ESQL_GET_DATASET_ACTION_NAME),
+            equalTo(List.of("read_dataset_metadata", "manage_dataset", "manage", "all"))
+        );
+        assertThat(
+            findPrivilegesThatGrant(EsqlDatasetActionNames.ESQL_DELETE_DATASET_ACTION_NAME),
+            equalTo(List.of("delete_dataset", "manage_dataset", "manage", "all"))
+        );
 
         Predicate<IndexPrivilege> failuresOnly = p -> p.getSelectorPredicate() == IndexComponentSelectorPredicate.FAILURES;
         assertThat(findPrivilegesThatGrant(TransportSearchAction.TYPE.name(), failuresOnly), equalTo(List.of("read_failure_store")));
@@ -163,27 +160,25 @@ public class IndexPrivilegeTests extends ESTestCase {
             assertThat(actual, equalTo(IndexPrivilege.MANAGE_VIEW));
             assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
         }
-        if (DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()) {
-            {
-                IndexPrivilege actual = IndexPrivilege.get("create_dataset");
-                assertThat(actual, equalTo(IndexPrivilege.CREATE_DATASET));
-                assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
-            }
-            {
-                IndexPrivilege actual = IndexPrivilege.get("delete_dataset");
-                assertThat(actual, equalTo(IndexPrivilege.DELETE_DATASET));
-                assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
-            }
-            {
-                IndexPrivilege actual = IndexPrivilege.get("read_dataset_metadata");
-                assertThat(actual, equalTo(IndexPrivilege.READ_DATASET_METADATA));
-                assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
-            }
-            {
-                IndexPrivilege actual = IndexPrivilege.get("manage_dataset");
-                assertThat(actual, equalTo(IndexPrivilege.MANAGE_DATASET));
-                assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
-            }
+        {
+            IndexPrivilege actual = IndexPrivilege.get("create_dataset");
+            assertThat(actual, equalTo(IndexPrivilege.CREATE_DATASET));
+            assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
+        }
+        {
+            IndexPrivilege actual = IndexPrivilege.get("delete_dataset");
+            assertThat(actual, equalTo(IndexPrivilege.DELETE_DATASET));
+            assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
+        }
+        {
+            IndexPrivilege actual = IndexPrivilege.get("read_dataset_metadata");
+            assertThat(actual, equalTo(IndexPrivilege.READ_DATASET_METADATA));
+            assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
+        }
+        {
+            IndexPrivilege actual = IndexPrivilege.get("manage_dataset");
+            assertThat(actual, equalTo(IndexPrivilege.MANAGE_DATASET));
+            assertThat(actual.getSelectorPredicate(), equalTo(IndexComponentSelectorPredicate.DATA));
         }
     }
 
@@ -504,10 +499,6 @@ public class IndexPrivilegeTests extends ESTestCase {
     }
 
     public void testDatasetPrivileges() {
-        assumeTrue(
-            "ESQL external datasources feature flag is disabled",
-            DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-        );
         final IndexPrivilege createDataset = resolvePrivilegeAndAssertSingleton(Set.of("create_dataset"));
         assertThat(createDataset.predicate.test(EsqlDatasetActionNames.ESQL_PUT_DATASET_ACTION_NAME), is(true));
         assertThat(

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureDataSourcePlugin.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.azure;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.env.Environment;
@@ -40,8 +39,7 @@ import java.util.concurrent.ExecutorService;
  * Without it the workload-identity chain is {@code ManagedIdentity}-only.
  * <p>
  * Azure is not in the released ship set yet (S3 is the released cloud provider), so registration is
- * gated on the umbrella {@link DatasetMetadata#ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG} and the
- * component {@link #ESQL_EXTERNAL_AZURE_FEATURE_FLAG}: available in snapshot/development builds, disabled
+ * gated on {@link #ESQL_EXTERNAL_AZURE_FEATURE_FLAG}: available in snapshot/development builds, disabled
  * in release. When the gate is off the {@code wasbs}/{@code wasb} schemes are not registered, so an
  * Azure source resolves to the generic "Unsupported storage scheme" rejection.
  */
@@ -54,7 +52,7 @@ public class AzureDataSourcePlugin extends Plugin implements DataSourcePlugin {
     public static final FeatureFlag ESQL_EXTERNAL_AZURE_FEATURE_FLAG = new FeatureFlag("esql_external_azure");
 
     private static boolean enabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() && ESQL_EXTERNAL_AZURE_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_AZURE_FEATURE_FLAG.isEnabled();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureDataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureDataSourcePluginTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.azure;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
@@ -21,16 +20,15 @@ import java.util.Map;
  * Unit tests for AzureDataSourcePlugin.
  * Tests that the plugin correctly registers storage provider factories for wasbs:// and wasb:// schemes.
  * <p>
- * Azure registration is gated on the external-datasources umbrella and the {@code esql_external_azure}
- * sub-flag (snapshot-on, release-off). The provider-shape tests below assume the gate is on; a
- * dedicated test asserts nothing is registered when it is off. Across the snapshot and
- * {@code elasticsearch.esql-release} build variants both branches get exercised.
+ * Azure registration is gated on the {@code esql_external_azure} sub-flag (snapshot-on, release-off).
+ * The provider-shape tests below assume the gate is on; a dedicated test asserts nothing is
+ * registered when it is off. Across the snapshot and {@code elasticsearch.esql-release} build
+ * variants both branches get exercised.
  */
 public class AzureDataSourcePluginTests extends ESTestCase {
 
     private static boolean azureEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && AzureDataSourcePlugin.ESQL_EXTERNAL_AZURE_FEATURE_FLAG.isEnabled();
+        return AzureDataSourcePlugin.ESQL_EXTERNAL_AZURE_FEATURE_FLAG.isEnabled();
     }
 
     public void testStorageProvidersRegistersWasbsAndWasbSchemes() {

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePlugin.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.gcs;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.plugins.Plugin;
@@ -31,8 +30,7 @@ import java.util.concurrent.ExecutorService;
  * </pre>
  * <p>
  * GCS is not in the released ship set yet (S3 is the released cloud provider), so registration is
- * gated on the umbrella {@link DatasetMetadata#ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG} and the
- * component {@link #ESQL_EXTERNAL_GCS_FEATURE_FLAG}: available in snapshot/development builds, disabled
+ * gated on {@link #ESQL_EXTERNAL_GCS_FEATURE_FLAG}: available in snapshot/development builds, disabled
  * in release. When the gate is off the {@code gs} scheme is not registered, so a {@code gs://} source
  * resolves to the generic "Unsupported storage scheme" rejection.
  */
@@ -45,7 +43,7 @@ public class GcsDataSourcePlugin extends Plugin implements DataSourcePlugin {
     public static final FeatureFlag ESQL_EXTERNAL_GCS_FEATURE_FLAG = new FeatureFlag("esql_external_gcs");
 
     private static boolean enabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() && ESQL_EXTERNAL_GCS_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_GCS_FEATURE_FLAG.isEnabled();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsDataSourcePluginTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.gcs;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
@@ -20,16 +19,15 @@ import java.util.Map;
  * Unit tests for GcsDataSourcePlugin.
  * Tests that the plugin correctly registers storage provider factories for the gs:// scheme.
  * <p>
- * GCS registration is gated on the external-datasources umbrella and the {@code esql_external_gcs}
- * sub-flag (snapshot-on, release-off). The provider-shape tests below assume the gate is on; a
- * dedicated test asserts nothing is registered when it is off. Across the snapshot and
- * {@code elasticsearch.esql-release} build variants both branches get exercised.
+ * GCS registration is gated on the {@code esql_external_gcs} sub-flag (snapshot-on, release-off).
+ * The provider-shape tests below assume the gate is on; a dedicated test asserts nothing is
+ * registered when it is off. Across the snapshot and {@code elasticsearch.esql-release} build
+ * variants both branches get exercised.
  */
 public class GcsDataSourcePluginTests extends ESTestCase {
 
     private static boolean gcsEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && GcsDataSourcePlugin.ESQL_EXTERNAL_GCS_FEATURE_FLAG.isEnabled();
+        return GcsDataSourcePlugin.ESQL_EXTERNAL_GCS_FEATURE_FLAG.isEnabled();
     }
 
     public void testStorageProvidersRegistersGsScheme() {

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePlugin.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.http;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.plugins.Plugin;
@@ -40,39 +39,33 @@ import java.util.concurrent.ExecutorService;
  * {@link DataSourcePlugin#storageProviders(Settings, ExecutorService)} SPI method,
  * backed by the ES GENERIC thread pool.
  *
- * <p>Registration of both providers is gated on the umbrella
- * {@link DatasetMetadata#ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG}. HTTP/HTTPS additionally requires
+ * <p>Registration of both providers is gated per scheme. HTTP/HTTPS requires
  * {@link #ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG} (snapshot-on, release-off). Local file access
- * is on by default under the umbrella — the security gate is the
- * {@code esql.datasource.local_allowed_paths} node setting, not a feature flag. When a gate is off the
- * relevant schemes are not registered, so any query targeting them resolves to the generic "unsupported
- * storage scheme" rejection.
+ * is on by default — the security gate is the {@code esql.datasource.local_allowed_paths} node setting,
+ * not a feature flag. When a gate is off the relevant schemes are not registered, so any query targeting
+ * them resolves to the generic "unsupported storage scheme" rejection.
  */
 public class HttpDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
     /**
      * Gates provisioning HTTP/HTTPS ({@code http://}, {@code https://}) data sources/datasets. Snapshot-on,
      * release-off; override in release with {@code -Des.esql_external_datasources_http_feature_flag_enabled=true}.
-     * Also requires the umbrella {@link DatasetMetadata#ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG}.
      */
     public static final FeatureFlag ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG = new FeatureFlag("esql_external_datasources_http");
 
     /**
      * Gates local-file ({@code file://}) data sources/datasets. Snapshot-on, release-off; override in release
      * with {@code -Des.esql_external_datasources_local_feature_flag_enabled=true}.
-     * Also requires the umbrella {@link DatasetMetadata#ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG}.
      * Access is further controlled at runtime by the {@code esql.datasource.local_allowed_paths} node setting.
      */
     public static final FeatureFlag ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG = new FeatureFlag("esql_external_datasources_local");
 
     private static boolean httpEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled();
     }
 
     private static boolean localEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpDataSourcePluginTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.http;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
@@ -23,13 +22,11 @@ public class HttpDataSourcePluginTests extends ESTestCase {
     private final HttpDataSourcePlugin plugin = new HttpDataSourcePlugin();
 
     private static boolean httpEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled();
     }
 
     private static boolean localEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled();
     }
 
     public void testHttpValidatorRegisteredWhenFlagEnabled() {
@@ -91,16 +88,9 @@ public class HttpDataSourcePluginTests extends ESTestCase {
         expectThrows(ValidationException.class, () -> http.validateDatasource(Map.of("region", "us-east-1")));
     }
 
-    public void testDisabledWhenUmbrellaFlagOff() {
-        assumeFalse("only when umbrella flag is off", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
-        assertTrue("no schemes when disabled", plugin.supportedSchemes().isEmpty());
-        assertTrue("no datasource validators when disabled", plugin.datasourceValidators(Settings.EMPTY).isEmpty());
-    }
-
     public void testLocalEnabledWhenOnlyHttpFlagOff() {
         // Local does not require ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG — the two flags are independent.
-        // This test verifies local is available even when the http sub-flag is off (umbrella + local flag on).
-        assumeTrue("requires umbrella flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        // This test verifies local is available even when the http sub-flag is off (local flag on).
         assumeTrue("requires local flag", ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
         assumeFalse("only when http flag is off", ESQL_EXTERNAL_DATASOURCES_HTTP_FEATURE_FLAG.isEnabled());
         assertNotNull("local validator should be present", plugin.datasourceValidators(Settings.EMPTY).get("local"));

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcDataSourcePlugin.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.orc;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.FeatureFlag;
@@ -30,8 +29,7 @@ import java.util.Set;
  * <p>Heavy dependencies (ORC, Hadoop) are isolated in this module to avoid jar hell issues
  * in the core ESQL plugin.
  *
- * <p>ORC is not in the released ship set yet, so format registration is gated on the umbrella
- * {@link DatasetMetadata#ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG} and the component
+ * <p>ORC is not in the released ship set yet, so format registration is gated on
  * {@link #ESQL_EXTERNAL_ORC_FEATURE_FLAG}: the reader is available in snapshot/development builds and
  * disabled in release. When the gate is off the {@code orc} format and {@code .orc} extension are not
  * registered, so an ORC dataset resolves to the generic "No format reader registered" rejection.
@@ -45,7 +43,7 @@ public class OrcDataSourcePlugin extends Plugin implements DataSourcePlugin {
     public static final FeatureFlag ESQL_EXTERNAL_ORC_FEATURE_FLAG = new FeatureFlag("esql_external_orc");
 
     private static boolean enabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() && ESQL_EXTERNAL_ORC_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_ORC_FEATURE_FLAG.isEnabled();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcDataSourcePluginTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcDataSourcePluginTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.orc;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
@@ -15,15 +14,14 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 /**
  * Unit tests for {@link OrcDataSourcePlugin}'s feature-flag gating.
  * <p>
- * ORC registration is gated on the external-datasources umbrella and the {@code esql_external_orc}
- * sub-flag (snapshot-on, release-off). Across the snapshot and {@code elasticsearch.esql-release}
- * build variants both the enabled and disabled branches get exercised.
+ * ORC registration is gated on the {@code esql_external_orc} sub-flag (snapshot-on, release-off).
+ * Across the snapshot and {@code elasticsearch.esql-release} build variants both the enabled and
+ * disabled branches get exercised.
  */
 public class OrcDataSourcePluginTests extends ESTestCase {
 
     private static boolean orcEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()
-            && OrcDataSourcePlugin.ESQL_EXTERNAL_ORC_FEATURE_FLAG.isEnabled();
+        return OrcDataSourcePlugin.ESQL_EXTERNAL_ORC_FEATURE_FLAG.isEnabled();
     }
 
     public void testRegistersOrcFormatWhenEnabled() {

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -190,10 +190,8 @@ tasks.named("internalClusterTest").configure {
    * task and generates a types table for the LOOKUP JOIN command. It is possible
    * in future we might have move tests that do this.
    */
-  systemProperty 'es.esql_external_datasources_feature_flag_enabled', 'true'
   // Local file:// access is on by default in snapshot builds; in release builds the local flag is off unless
-  // explicitly enabled here. Since the umbrella flag is force-enabled above we must also enable the local
-  // sub-flag so that External*IT and FromDatasetIT actually run (not just skip) in release testing.
+  // explicitly enabled here, so External*IT and FromDatasetIT actually run (not just skip) in release testing.
   systemProperty 'es.esql_external_datasources_local_feature_flag_enabled', 'true'
   // Data sources require the project encryption key feature (EsqlPlugin fails fast otherwise); pair the flags.
   systemProperty 'es.project_encryption_key_feature_flag_enabled', 'true'

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedClusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedClusters.java
@@ -28,12 +28,10 @@ public class ExternalDistributedClusters {
 
     static ElasticsearchCluster testCluster(Supplier<String> s3EndpointSupplier) {
         return Clusters.testCluster(spec -> {
-            spec.feature(FeatureFlag.ESQL_EXTERNAL_DATASOURCES);
-            // This suite force-enables the umbrella feature so its external tests run even in release builds. Each
-            // storage backend / format is individually gated (snapshot-on, release-off) under the umbrella, so force
-            // them all on: file:// and http(s):// scheme registration depends on their sub-flags (otherwise those
-            // reads hit "No storage provider registered for scheme: …"), and GCS/Azure/ORC/parquet-rs must be on to
-            // exercise every backend in release builds too.
+            // This suite force-enables every storage backend / format flag so its external tests run even in
+            // release builds: file:// and http(s):// scheme registration depends on their sub-flags (otherwise
+            // those reads hit "No storage provider registered for scheme: …"), and GCS/Azure/ORC/parquet-rs must
+            // be on to exercise every backend in release builds too.
             spec.feature(FeatureFlag.ESQL_EXTERNAL_DATASOURCES_LOCAL);
             spec.feature(FeatureFlag.ESQL_EXTERNAL_DATASOURCES_HTTP);
             spec.feature(FeatureFlag.ESQL_EXTERNAL_GCS);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
@@ -20,7 +20,6 @@ import org.apache.parquet.schema.MessageTypeParser;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
 import org.elasticsearch.cluster.metadata.DatasetMapping;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ExtensiblePlugin;
@@ -85,10 +84,10 @@ import static org.hamcrest.Matchers.notNullValue;
  * supplied as a node plugin (a single discovery path), so {@code EsqlPlugin}'s duplicate-validator guard
  * never trips.
  *
- * <p>A single {@link #requireFeatureFlag()} {@code @Before} gates every subclass on the external-datasources
- * feature flag (which also gates {@code FROM <dataset>} resolution) and the local-filesystem feature flag,
- * and {@link #nodeSettings} allowlists the shared temp-dir root for {@code file://} access, so subclasses do
- * not repeat either the assume or the settings override.
+ * <p>A single {@link #requireFeatureFlag()} {@code @Before} gates every subclass on the
+ * {@code dataset-in-from-command} capability (which also gates {@code FROM <dataset>} resolution) and the
+ * local-filesystem feature flag, and {@link #nodeSettings} allowlists the shared temp-dir root for
+ * {@code file://} access, so subclasses do not repeat either the assume or the settings override.
  *
  * <p>Deliberately imposes no {@code @ClusterScope} and does not override {@code getPragmas()} — both
  * vary per concrete test, so subclasses keep their own.
@@ -177,13 +176,14 @@ public abstract class AbstractExternalDataSourceIT extends AbstractEsqlIntegTest
     }
 
     /**
-     * Gates every subclass on the external-datasources feature flag, which also gates {@code FROM <dataset>}
-     * resolution, plus the local-filesystem feature flag every subclass relies on for its {@code file://}
-     * fixtures. Mirrors {@code FromDatasetIT.requireFeatureFlag}, so subclasses no longer repeat the assume.
+     * Gates every subclass on the {@code dataset-in-from-command} capability, which also gates
+     * {@code FROM <dataset>} resolution, plus the local-filesystem feature flag every subclass relies on for
+     * its {@code file://} fixtures. Mirrors {@code FromDatasetIT.requireFeatureFlag}, so subclasses no longer
+     * repeat the assume.
      */
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
         assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterDatasetIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.fieldcaps.RemoteDatasetNotSupportedException;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
@@ -99,7 +98,7 @@ public class CrossClusterDatasetIT extends AbstractCrossClusterTestCase {
 
     @Before
     public void setupClustersAndDataset() throws IOException {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
         setupClusters(3);
 
         // A plain index on the remote that the successful query reads from.

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceTelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalSourceTelemetryIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
@@ -134,7 +133,7 @@ public class ExternalSourceTelemetryIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
         assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FileSourceSecretDecryptionAcrossNodesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FileSourceSecretDecryptionAcrossNodesIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ExtensiblePlugin;
@@ -136,7 +135,7 @@ public class FileSourceSecretDecryptionAcrossNodesIT extends AbstractEsqlIntegTe
 
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
     }
 
     @Before

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FileSourceSecretDecryptionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FileSourceSecretDecryptionIT.java
@@ -17,7 +17,6 @@ import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ExtensiblePlugin;
@@ -189,7 +188,7 @@ public class FileSourceSecretDecryptionIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
     }
 
     @Before

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.action;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -118,7 +117,7 @@ public class NdJsonCrossFileScalarObjectConflictIT extends AbstractEsqlIntegTest
 
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
         assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonScalarObjectConflictIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.action;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -120,7 +119,7 @@ public class NdJsonScalarObjectConflictIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
         assumeTrue("requires local filesystem feature flag", HttpDataSourcePlugin.ESQL_EXTERNAL_DATASOURCES_LOCAL_FEATURE_FLAG.isEnabled());
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/S3ManagedIdentityAuthIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/S3ManagedIdentityAuthIT.java
@@ -16,7 +16,6 @@ import com.carrotsearch.randomizedtesting.ThreadFilter;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.sun.net.httpserver.HttpServer;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
@@ -199,7 +198,7 @@ public class S3ManagedIdentityAuthIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void requireFeatureFlag() {
-        assumeTrue("requires external data sources feature flag", DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        assumeTrue("requires dataset-in-from-command capability", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
     }
 
     @After

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.compute.lucene.query.LuceneQueryEvaluator;
 import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
@@ -2667,25 +2666,25 @@ public class EsqlCapabilities {
         /**
          * Support for the EXTERNAL command (datasource access).
          */
-        EXTERNAL_COMMAND(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_COMMAND,
 
         /**
          * Support for the EXTERNAL command (datasource access).
          */
-        EXTERNAL_CSV_IP_SUPPORT(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_CSV_IP_SUPPORT,
 
         /**
          * Support for the {@code header_row} (and the related {@code column_prefix}) CSV options
          * on the {@code EXTERNAL} command, used to read headerless CSV files.
          */
-        EXTERNAL_CSV_HEADER_ROW_OPTION(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_CSV_HEADER_ROW_OPTION,
 
         /**
          * Per-file planner-resolved read schema is threaded down to runtime readers via
          * {@code FileSplit.readSchema()}. Pins each file's column layout to the planner's view,
          * preventing reader self-inference that drifts across files in a multi-file glob.
          */
-        EXTERNAL_SOURCE_READ_SCHEMA(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_SOURCE_READ_SCHEMA,
 
         /**
          * Always-on {@code _file.*} virtual columns ({@code _file.path}, {@code _file.name}, {@code _file.directory},
@@ -2694,7 +2693,7 @@ public class EsqlCapabilities {
          * against a remote cluster on a pre-feature build, so {@code fileMetadata*} csv-spec tests must be gated on
          * this capability rather than on {@link #EXTERNAL_COMMAND}.
          */
-        EXTERNAL_SOURCE_FILE_METADATA_COLUMNS(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_SOURCE_FILE_METADATA_COLUMNS,
 
         /**
          * Standard ES metadata columns ({@code _id}, {@code _index}, {@code _version}, {@code _source}, ...)
@@ -2702,7 +2701,7 @@ public class EsqlCapabilities {
          * coordinators reject the names with {@code Unknown column}; tests exercising these columns
          * gate on this capability.
          */
-        EXTERNAL_SOURCE_STANDARD_METADATA_COLUMNS(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_SOURCE_STANDARD_METADATA_COLUMNS,
 
         /**
          * Support for projecting nested STRUCT subfields (e.g. {@code event.action}) from
@@ -2713,7 +2712,7 @@ public class EsqlCapabilities {
          * <p>Tracks: elastic/esql-planning#435 (this PR) and elastic/esql-planning#320
          * (correctness gap for Parquet-Java MAP/STRUCT/nested LIST).
          */
-        EXTERNAL_SOURCE_NESTED_STRUCT_PROJECTION(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_SOURCE_NESTED_STRUCT_PROJECTION,
 
         /**
          * Correct decoding of a {@code LIST} leaf reached through a {@code STRUCT}
@@ -2725,7 +2724,7 @@ public class EsqlCapabilities {
          *
          * <p>Tracks: elastic/esql-planning#1055 (correctness gap for Parquet-Java list-under-struct).
          */
-        EXTERNAL_SOURCE_LIST_UNDER_STRUCT(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_SOURCE_LIST_UNDER_STRUCT,
 
         /**
          * Multi-file external UNION_BY_NAME widens cross-file type disagreements to KEYWORD
@@ -2734,13 +2733,12 @@ public class EsqlCapabilities {
          * reader's output is adapted via SchemaAdaptingIterator. STRICT mode still throws.
          * See esql-planning#794.
          */
-        EXTERNAL_UNION_BY_NAME_KEYWORD_FALLBACK(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_UNION_BY_NAME_KEYWORD_FALLBACK,
 
         /**
          * {@code FROM <dataset>} resolved through the same pipeline as {@code FROM <index>} (Phase 1: dataset-only patterns).
-         * Gated on the same flag as {@link #EXTERNAL_COMMAND}.
          */
-        DATASET_IN_FROM_COMMAND(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        DATASET_IN_FROM_COMMAND,
 
         /**
          * {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantAggregateGroupings} rebuilds a pruned
@@ -2748,7 +2746,7 @@ public class EsqlCapabilities {
          * pre-aggregate attribute it no longer surfaces, fixing the {@code optimized incorrectly due to missing references}
          * verification failure that old coordinators in a mixed cluster still hit.
          */
-        FIX_PRUNE_RENAMED_DERIVED_EXTERNAL_GROUPING(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        FIX_PRUNE_RENAMED_DERIVED_EXTERNAL_GROUPING,
 
         /**
          * A present-but-empty field on a string (KEYWORD/TEXT) column in an external CSV/TSV datasource reads as the empty
@@ -2756,7 +2754,7 @@ public class EsqlCapabilities {
          * fields on non-string columns still read as {@code null}. Used to gate the affected external csv-spec tests so they
          * are skipped on mixed clusters where a pre-change node still maps empty string cells to {@code null}.
          */
-        EXTERNAL_CSV_EMPTY_STRING_NOT_NULL(DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
+        EXTERNAL_CSV_EMPTY_STRING_NOT_NULL,
 
         /**
          * Datasource file plugins (CSV, ORC, Parquet) no longer return {@code TEXT} types, only {@code KEYWORD}.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolver.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -65,9 +64,9 @@ public final class FormatNameResolver {
         ? Map.of(READER_PARQUET_RS, FORMAT_PARQUET_RS, READER_JAVA, FORMAT_PARQUET)
         : Map.of(READER_JAVA, FORMAT_PARQUET);
 
-    /** The parquet-rs reader is live iff the external-datasources umbrella and the parquet-rs sub-flag are both on. */
+    /** The parquet-rs reader is live iff the parquet-rs sub-flag is on. */
     public static boolean parquetRsEnabled() {
-        return DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() && ESQL_EXTERNAL_PARQUET_RS_FEATURE_FLAG.isEnabled();
+        return ESQL_EXTERNAL_PARQUET_RS_FEATURE_FLAG.isEnabled();
     }
 
     private FormatNameResolver() {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestDeleteDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestDeleteDatasetAction.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestDeleteDatasetAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestGetDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestGetDatasetAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestGetDatasetAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestPutDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestPutDatasetAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestPutDatasetAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestDeleteDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestDeleteDataSourceAction.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestDeleteDataSourceAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestGetDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestGetDataSourceAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestGetDataSourceAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestPutDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestPutDataSourceAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestPutDataSourceAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlConfig.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlConfig.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.parser;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 
 public class EsqlConfig {
@@ -31,16 +30,12 @@ public class EsqlConfig {
     }
 
     /**
-     * Whether the EXTERNAL command and external data source grammar are enabled. This respects the
-     * {@code esql_external_datasources} feature flag (on by default in snapshot builds). Snapshot test runs may also use
+     * Whether the EXTERNAL command and external data source grammar are enabled. Snapshot test runs may also use
      * {@link #EsqlConfig(boolean, EsqlFunctionRegistry) EsqlConfig(false, ...)} to simulate production parsing; in that case
-     * EXTERNAL is disabled even when the feature flag is on. Non-snapshot (release) builds ignore that simulation and rely on
-     * the feature flag alone.
+     * EXTERNAL is disabled even in a snapshot build. Non-snapshot (release) builds ignore that simulation and are always
+     * enabled.
      */
     public boolean isExternalDataSourcesEnabled() {
-        if (DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() == false) {
-            return false;
-        }
         return isDevVersion || Build.current().isSnapshot() == false;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -624,36 +624,29 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
 
     @Override
     public List<ActionHandler> getActions() {
-        List<ActionHandler> actions = new ArrayList<>(
-            List.of(
-                new ActionHandler(EsqlQueryAction.INSTANCE, TransportEsqlQueryAction.class),
-                new ActionHandler(EsqlAsyncGetResultAction.INSTANCE, TransportEsqlAsyncGetResultsAction.class),
-                new ActionHandler(EsqlStatsAction.INSTANCE, TransportEsqlStatsAction.class),
-                new ActionHandler(XPackUsageFeatureAction.ESQL, EsqlUsageTransportAction.class),
-                new ActionHandler(XPackInfoFeatureAction.ESQL, EsqlInfoTransportAction.class),
-                new ActionHandler(EsqlResolveFieldsAction.TYPE, EsqlResolveFieldsAction.class),
-                new ActionHandler(EsqlSearchShardsAction.TYPE, EsqlSearchShardsAction.class),
-                new ActionHandler(EsqlAsyncStopAction.INSTANCE, TransportEsqlAsyncStopAction.class),
-                new ActionHandler(EsqlListQueriesAction.INSTANCE, TransportEsqlListQueriesAction.class),
-                new ActionHandler(EsqlGetQueryAction.INSTANCE, TransportEsqlGetQueryAction.class),
-                new ActionHandler(PutViewAction.INSTANCE, TransportPutViewAction.class),
-                new ActionHandler(DeleteViewAction.INSTANCE, TransportDeleteViewAction.class),
-                new ActionHandler(EsqlResolveViewAction.TYPE, EsqlResolveViewAction.class),
-                // Unconditional like resolve_views: the FROM <dataset> rewrite is gated on datasets being present
-                // in cluster state, not on the feature flag, so its authorization gate must always be resolvable.
-                new ActionHandler(EsqlResolveDatasetAction.TYPE, EsqlResolveDatasetAction.class),
-                new ActionHandler(GetViewAction.INSTANCE, TransportGetViewAction.class)
-            )
+        return List.of(
+            new ActionHandler(EsqlQueryAction.INSTANCE, TransportEsqlQueryAction.class),
+            new ActionHandler(EsqlAsyncGetResultAction.INSTANCE, TransportEsqlAsyncGetResultsAction.class),
+            new ActionHandler(EsqlStatsAction.INSTANCE, TransportEsqlStatsAction.class),
+            new ActionHandler(XPackUsageFeatureAction.ESQL, EsqlUsageTransportAction.class),
+            new ActionHandler(XPackInfoFeatureAction.ESQL, EsqlInfoTransportAction.class),
+            new ActionHandler(EsqlResolveFieldsAction.TYPE, EsqlResolveFieldsAction.class),
+            new ActionHandler(EsqlSearchShardsAction.TYPE, EsqlSearchShardsAction.class),
+            new ActionHandler(EsqlAsyncStopAction.INSTANCE, TransportEsqlAsyncStopAction.class),
+            new ActionHandler(EsqlListQueriesAction.INSTANCE, TransportEsqlListQueriesAction.class),
+            new ActionHandler(EsqlGetQueryAction.INSTANCE, TransportEsqlGetQueryAction.class),
+            new ActionHandler(PutViewAction.INSTANCE, TransportPutViewAction.class),
+            new ActionHandler(DeleteViewAction.INSTANCE, TransportDeleteViewAction.class),
+            new ActionHandler(EsqlResolveViewAction.TYPE, EsqlResolveViewAction.class),
+            new ActionHandler(EsqlResolveDatasetAction.TYPE, EsqlResolveDatasetAction.class),
+            new ActionHandler(GetViewAction.INSTANCE, TransportGetViewAction.class),
+            new ActionHandler(PutDataSourceAction.INSTANCE, TransportPutDataSourceAction.class),
+            new ActionHandler(GetDataSourceAction.INSTANCE, TransportGetDataSourceAction.class),
+            new ActionHandler(DeleteDataSourceAction.INSTANCE, TransportDeleteDataSourceAction.class),
+            new ActionHandler(PutDatasetAction.INSTANCE, TransportPutDatasetAction.class),
+            new ActionHandler(GetDatasetAction.INSTANCE, TransportGetDatasetAction.class),
+            new ActionHandler(DeleteDatasetAction.INSTANCE, TransportDeleteDatasetAction.class)
         );
-        if (DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()) {
-            actions.add(new ActionHandler(PutDataSourceAction.INSTANCE, TransportPutDataSourceAction.class));
-            actions.add(new ActionHandler(GetDataSourceAction.INSTANCE, TransportGetDataSourceAction.class));
-            actions.add(new ActionHandler(DeleteDataSourceAction.INSTANCE, TransportDeleteDataSourceAction.class));
-            actions.add(new ActionHandler(PutDatasetAction.INSTANCE, TransportPutDatasetAction.class));
-            actions.add(new ActionHandler(GetDatasetAction.INSTANCE, TransportGetDatasetAction.class));
-            actions.add(new ActionHandler(DeleteDatasetAction.INSTANCE, TransportDeleteDatasetAction.class));
-        }
-        return List.copyOf(actions);
     }
 
     @Override
@@ -663,28 +656,23 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         EsqlCapabilities capabilities = this.capabilities.get();
-        List<RestHandler> handlers = new ArrayList<>(
-            List.of(
-                new RestEsqlQueryAction(capabilities),
-                new RestEsqlAsyncQueryAction(capabilities),
-                new RestEsqlGetAsyncResultAction(),
-                new RestEsqlStopAsyncAction(),
-                new RestEsqlDeleteAsyncResultAction(),
-                new RestEsqlListQueriesAction(),
-                new RestPutViewAction(),
-                new RestDeleteViewAction(),
-                new RestGetViewAction()
-            )
+        return List.of(
+            new RestEsqlQueryAction(capabilities),
+            new RestEsqlAsyncQueryAction(capabilities),
+            new RestEsqlGetAsyncResultAction(),
+            new RestEsqlStopAsyncAction(),
+            new RestEsqlDeleteAsyncResultAction(),
+            new RestEsqlListQueriesAction(),
+            new RestPutViewAction(),
+            new RestDeleteViewAction(),
+            new RestGetViewAction(),
+            new RestPutDataSourceAction(),
+            new RestGetDataSourceAction(),
+            new RestDeleteDataSourceAction(),
+            new RestPutDatasetAction(),
+            new RestGetDatasetAction(),
+            new RestDeleteDatasetAction()
         );
-        if (DatasetMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()) {
-            handlers.add(new RestPutDataSourceAction());
-            handlers.add(new RestGetDataSourceAction());
-            handlers.add(new RestDeleteDataSourceAction());
-            handlers.add(new RestPutDatasetAction());
-            handlers.add(new RestGetDatasetAction());
-            handlers.add(new RestDeleteDatasetAction());
-        }
-        return List.copyOf(handlers);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerExternalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerExternalTests.java
@@ -362,8 +362,9 @@ public class AnalyzerExternalTests extends ESTestCase {
     /**
      * {@code _tier} (canonical name {@code DataTierFieldMapper.NAME}) is snapshot-only in the
      * standard metadata registry. The binding rule must mirror that: in non-snapshot builds, the
-     * name is unknown and skipped (the verifier later surfaces "Unknown column" if the user
-     * references it downstream).
+     * name is unknown, so requesting it via {@link #analyzeExternalWithMetadata} (which models it
+     * as a plain {@link UnresolvedAttribute}, not a METADATA-clause pattern) fails verification
+     * with the usual "Unknown column" diagnostic; in snapshot builds it binds normally.
      */
     public void testStandardMetadataTierSnapshotOnly() {
         assumeTrue("requires EXTERNAL command capability", EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled());
@@ -371,12 +372,15 @@ public class AnalyzerExternalTests extends ESTestCase {
         DataType registered = MetadataAttribute.dataType("_tier");
         boolean snapshotOnly = registered == null;
 
-        var leafOutput = externalLeafOutput(analyzeExternalWithMetadata(S3_PATH, employeesSchema(), List.of("_tier"), "my_dataset"));
-
-        boolean bound = leafOutput.stream().anyMatch(a -> a.name().equals("_tier"));
         if (snapshotOnly) {
-            assertFalse("_tier must not bind outside snapshot builds", bound);
+            org.elasticsearch.xpack.esql.VerificationException e = expectThrows(
+                org.elasticsearch.xpack.esql.VerificationException.class,
+                () -> analyzeExternalWithMetadata(S3_PATH, employeesSchema(), List.of("_tier"), "my_dataset")
+            );
+            assertThat(e.getMessage(), containsString("Unknown column [_tier]"));
         } else {
+            var leafOutput = externalLeafOutput(analyzeExternalWithMetadata(S3_PATH, employeesSchema(), List.of("_tier"), "my_dataset"));
+            boolean bound = leafOutput.stream().anyMatch(a -> a.name().equals("_tier"));
             assertTrue("_tier must bind in snapshot builds", bound);
         }
     }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL:DS: Drop ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG (#153139)