### PR TITLE
Fix realtime-refresh YAML tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -337,9 +337,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.integration.TransformIT
   method: testStopWaitForCheckpoint
   issue: https://github.com/elastic/elasticsearch/issues/149663
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=exists/60_realtime_refresh/Realtime Refresh}
-  issue: https://github.com/elastic/elasticsearch/issues/151706
 - class: org.elasticsearch.search.basic.SearchDuringRollingRestartIT
   method: testSearchesSurviveRollingRestart
   issue: https://github.com/elastic/elasticsearch/issues/151828

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
@@ -5,6 +5,7 @@
  - do:
      indices.create:
        index:    test_1
+       wait_for_active_shards: all
        body:
          settings:
            index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
@@ -6,6 +6,7 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
@@ -6,6 +6,7 @@
  - do:
       indices.create:
           index: test_1
+          wait_for_active_shards: all
           body:
               settings:
                   refresh_interval: -1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/60_realtime_refresh.yml
@@ -5,6 +5,7 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:


### PR DESCRIPTION
These tests do not wait for replicas to start before indexing a
document, and if that indexing lands before all shards have started then
some shards may expose the new document to non-realtime operations like
gets and searches. This commit adjusts the `index.create` invocation to
wait for all shards to start before proceeding.

Closes #146410
Closes #151706
Closes #152906

Backport of #153240 to 9.3.
