### PR TITLE
[ESQLDS] Avoid warnings lost/flooded on parallel-parse paths

### DIFF
--- a/docs/changelog/153267.yaml
+++ b/docs/changelog/153267.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153267
+summary: "[ESQLDS] Avoid warnings lost/floode on parallel-parse paths"
+type: bug

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -37,6 +37,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -110,6 +111,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Consumer;
 
 /**
  * CSV/TSV format reader for external datasources.
@@ -1670,7 +1672,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             context.splitStartByte(),
             chunkMode ? context.statsStripeSize() : -1L,
             context.statsFileFinal(),
-            context.statsColumnScope()
+            context.statsColumnScope(),
+            context.warningSink()
         );
     }
 
@@ -2950,7 +2953,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             long splitStartByte,
             long statsStripeSize,
             boolean statsFileFinal,
-            StripeColumnScope statsColumnScope
+            StripeColumnScope statsColumnScope,
+            @Nullable Consumer<String> warningSink
         ) {
             this.reader = reader;
             this.recordReader = recordReader;
@@ -2980,14 +2984,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
             this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
             this.statsFileFinal = statsFileFinal;
             this.stripeHarvester = statsStripeSize > 0 ? new StripeStatsHarvester(statsStripeSize, statsFileFinal) : null;
-            this.skipWarnings = SkipWarnings.of(
-                errorPolicy,
-                "CSV read from ["
-                    + sourceLocation
-                    + "] encountered parse errors handled per policy (policy: "
-                    + errorPolicy.modeName()
-                    + "); affected rows/fields are listed below"
-            );
+            String skipWarningsSummary = "CSV read from ["
+                + sourceLocation
+                + "] encountered parse errors handled per policy (policy: "
+                + errorPolicy.modeName()
+                + "); affected rows/fields are listed below";
+            this.skipWarnings = warningSink != null
+                ? SkipWarnings.of(errorPolicy, skipWarningsSummary, warningSink)
+                : SkipWarnings.of(errorPolicy, skipWarningsSummary);
         }
 
         @Override

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -554,7 +554,8 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             context.statsBaseOffset(),
             context.statsStripeSize(),
             context.statsFileFinal(),
-            context.statsColumnScope()
+            context.statsColumnScope(),
+            context.warningSink()
         );
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -59,6 +59,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Parses NDJSON into {@link Page}s for a single input stream.
@@ -317,7 +318,8 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of()
+            Set.of(),
+            null
         );
     }
 
@@ -332,7 +334,8 @@ public class NdJsonPageDecoder implements Closeable {
         String sourceLocation,
         NdJsonReaderCounters counters,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         this(
             input,
@@ -349,7 +352,8 @@ public class NdJsonPageDecoder implements Closeable {
             counters,
             NdJsonUtils.JSON_FACTORY,
             declaredDateFormats,
-            declaredTypeColumns
+            declaredTypeColumns,
+            warningSink
         );
     }
 
@@ -380,7 +384,8 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of()
+            Set.of(),
+            null
         );
     }
 
@@ -403,7 +408,8 @@ public class NdJsonPageDecoder implements Closeable {
         String sourceLocation,
         NdJsonReaderCounters counters,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         this(
             null,
@@ -420,7 +426,8 @@ public class NdJsonPageDecoder implements Closeable {
             counters,
             NdJsonUtils.JSON_FACTORY,
             declaredDateFormats,
-            declaredTypeColumns
+            declaredTypeColumns,
+            warningSink
         );
     }
 
@@ -454,7 +461,8 @@ public class NdJsonPageDecoder implements Closeable {
             new NdJsonReaderCounters(),
             factory,
             Map.of(),
-            Set.of()
+            Set.of(),
+            null
         );
     }
 
@@ -473,7 +481,8 @@ public class NdJsonPageDecoder implements Closeable {
         NdJsonReaderCounters counters,
         JsonFactory factory,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         this.jsonFactory = factory;
         this.input = input;
@@ -502,14 +511,14 @@ public class NdJsonPageDecoder implements Closeable {
         this.datetimeFormatter = datetimeFormatter != null ? datetimeFormatter : NdJsonSchemaInferrer.STRICT_DATE_OPTIONAL_TIME;
         this.declaredDateFormats = declaredDateFormats != null ? Map.copyOf(declaredDateFormats) : Map.of();
         this.declaredTypeColumns = declaredTypeColumns != null ? Set.copyOf(declaredTypeColumns) : Set.of();
-        this.skipWarnings = SkipWarnings.of(
-            errorPolicy,
-            "NDJSON read from ["
-                + sourceLocation
-                + "] encountered parse errors handled per policy (policy: "
-                + errorPolicy.modeName()
-                + "); affected rows are listed below"
-        );
+        String skipWarningsSummary = "NDJSON read from ["
+            + sourceLocation
+            + "] encountered parse errors handled per policy (policy: "
+            + errorPolicy.modeName()
+            + "); affected rows are listed below";
+        this.skipWarnings = warningSink != null
+            ? SkipWarnings.of(errorPolicy, skipWarningsSummary, warningSink)
+            : SkipWarnings.of(errorPolicy, skipWarningsSummary);
 
         List<Attribute> fullSchema = attributes;
         // Three projection cases:

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -45,6 +46,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -215,7 +217,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         long statsBaseOffset,
         long statsStripeSize,
         boolean statsFileFinal,
-        StripeColumnScope statsColumnScope
+        StripeColumnScope statsColumnScope,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         Check.isTrue(counters != null, "counters must not be null");
@@ -251,7 +254,7 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         // mutually exclusive. The fold-in is kept as a correctness invariant for any future overlap.
         this.statsStripeBaseOffset = statsBaseOffset + skipped;
         if (trimLastPartialLine) {
-            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation, recordSplitter);
+            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation, recordSplitter, warningSink);
         }
         this.rowLimit = rowLimit;
         // ALL scope harvests min/max/null for EVERY file column, not just the projected ones. The output
@@ -306,7 +309,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 this.sourceLocation,
                 counters,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                warningSink
             );
         } else {
             // Streaming/fallback path (object too large for the fast path, unknown length, or a
@@ -328,7 +332,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 this.sourceLocation,
                 counters,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                warningSink
             );
         }
         // _rowPosition / _file.record_ref substrate: file-global per-record start offset.
@@ -795,6 +800,16 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         String sourceLocation,
         NdJsonRecordSplitter recordSplitter
     ) {
-        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation, recordSplitter);
+        return trimLastPartialLine(in, errorPolicy, sourceLocation, recordSplitter, null);
+    }
+
+    static InputStream trimLastPartialLine(
+        InputStream in,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter,
+        Consumer<String> warningSink
+    ) {
+        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation, recordSplitter, warningSink);
     }
 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.ndjson;
 
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.Level;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -22,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 /**
  * Wraps an NDJSON byte stream and exposes only bytes through the last {@code '\n'} in the stream,
@@ -62,21 +64,30 @@ final class TrimLastPartialLineInputStream extends InputStream {
             DEFAULT_TRIM_CHUNK_SIZE,
             errorPolicy,
             sourceLocation,
-            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES)
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES),
+            null
         );
     }
 
     TrimLastPartialLineInputStream(InputStream delegate, int chunkSize, ErrorPolicy errorPolicy, String sourceLocation) {
-        this(delegate, chunkSize, errorPolicy, sourceLocation, new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES));
+        this(
+            delegate,
+            chunkSize,
+            errorPolicy,
+            sourceLocation,
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES),
+            null
+        );
     }
 
     TrimLastPartialLineInputStream(
         InputStream delegate,
         ErrorPolicy errorPolicy,
         String sourceLocation,
-        NdJsonRecordSplitter recordSplitter
+        NdJsonRecordSplitter recordSplitter,
+        @Nullable Consumer<String> warningSink
     ) {
-        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation, recordSplitter);
+        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation, recordSplitter, warningSink);
     }
 
     TrimLastPartialLineInputStream(
@@ -84,7 +95,8 @@ final class TrimLastPartialLineInputStream extends InputStream {
         int chunkSize,
         ErrorPolicy errorPolicy,
         String sourceLocation,
-        NdJsonRecordSplitter recordSplitter
+        NdJsonRecordSplitter recordSplitter,
+        @Nullable Consumer<String> warningSink
     ) {
         this.delegate = delegate;
         Check.isTrue(chunkSize > 0, "chunkSize must strictly positive");
@@ -93,10 +105,14 @@ final class TrimLastPartialLineInputStream extends InputStream {
         this.errorPolicy = errorPolicy;
         Check.isTrue(recordSplitter != null, "recordSplitter must not be null");
         this.recordSplitter = recordSplitter;
-        this.skipWarnings = SkipWarnings.of(
-            errorPolicy,
-            "NDJSON read from [" + sourceLocation + "] discarded an oversized partial line (policy: " + errorPolicy.modeName() + ")"
-        );
+        String skipWarningsSummary = "NDJSON read from ["
+            + sourceLocation
+            + "] discarded an oversized partial line (policy: "
+            + errorPolicy.modeName()
+            + ")";
+        this.skipWarnings = warningSink != null
+            ? SkipWarnings.of(errorPolicy, skipWarningsSummary, warningSink)
+            : SkipWarnings.of(errorPolicy, skipWarningsSummary);
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -504,7 +504,8 @@ public class NdJsonPageDecoderTests extends ESTestCase {
                 "test://declared-date",
                 new NdJsonReaderCounters(),
                 Map.of("ts", "dd/MMM/yyyy:HH:mm:ss Z"),
-                Set.of()
+                Set.of(),
+                null
             )
         ) {
             try (Page page = decoder.decodePage()) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -478,7 +478,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 chunk,
                 ErrorPolicy.STRICT,
                 "test://input",
-                new NdJsonRecordSplitter(maxRecordBytes)
+                new NdJsonRecordSplitter(maxRecordBytes),
+                null
             )
         ) {
             IOException ex = expectThrows(IOException.class, trimmed::readAllBytes);
@@ -500,7 +501,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 chunk,
                 ErrorPolicy.LENIENT,
                 "test://input",
-                new NdJsonRecordSplitter(maxRecordBytes)
+                new NdJsonRecordSplitter(maxRecordBytes),
+                null
             )
         ) {
             assertEquals(0, trimmed.readAllBytes().length);
@@ -515,7 +517,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 4,
                 ErrorPolicy.LENIENT,
                 "test://input",
-                new NdJsonRecordSplitter(8)
+                new NdJsonRecordSplitter(8),
+                null
             )
         ) {
             assertEquals("ok\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
@@ -530,7 +533,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 5,
                 ErrorPolicy.LENIENT,
                 "test://input",
-                new NdJsonRecordSplitter(8)
+                new NdJsonRecordSplitter(8),
+                null
             )
         ) {
             assertEquals("ok\r\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
@@ -545,7 +549,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 12,
                 ErrorPolicy.LENIENT,
                 "test://input",
-                new NdJsonRecordSplitter(8)
+                new NdJsonRecordSplitter(8),
+                null
             )
         ) {
             assertEquals("ok\nnext\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -12,7 +12,9 @@ import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.IsBlockedResult;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderStatus;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,6 +87,24 @@ public final class AsyncExternalSourceBuffer {
     private final Queue<String> pendingWarnings = new ConcurrentLinkedQueue<>();
 
     /**
+     * Cap on reader-parse-warning lines a single query may emit, applied ONCE across every segment/chunk
+     * instead of per {@link SkipWarnings} instance — otherwise each segment/chunk's own cap would multiply
+     * the response header size by the segment/chunk count. The {@code +2} mirrors the 1 summary + 1
+     * overflow line a single {@link SkipWarnings} instance adds around its {@code MAX_ADDED_WARNINGS} details.
+     */
+    private static final int MAX_READER_WARNINGS = SkipWarnings.MAX_ADDED_WARNINGS + 2;
+
+    /**
+     * Client-visible reader parse warnings (null-fill/skip-row events). Distinct from {@link #pendingWarnings}:
+     * these never flip {@link #partial}, since that's exactly what a non-strict policy asked for. Drained
+     * and re-emitted the same way as {@link #pendingWarnings} — see its javadoc.
+     */
+    private final Queue<String> pendingReaderWarnings = new ConcurrentLinkedQueue<>();
+    // Each caller gets a unique count, so exactly one caller ever sees count == MAX_READER_WARNINGS and
+    // adds the overflow line — no separate overflow flag needed.
+    private final AtomicInteger readerWarningsAdded = new AtomicInteger();
+
+    /**
      * Set when the background reader path drops data under a lenient policy — currently a streaming
      * {@code max_record_size} truncation under a non-strict {@code error_mode}. Surfaced through the
      * operator's {@code Status} into {@link org.elasticsearch.compute.operator.DriverCompletionInfo} so the
@@ -134,6 +154,25 @@ public final class AsyncExternalSourceBuffer {
     /** Removes and returns the next recorded warning, or {@code null} if none remain. */
     public String pollWarning() {
         return pendingWarnings.poll();
+    }
+
+    /**
+     * Records a client-visible reader parse warning (see {@link #pendingReaderWarnings}), applying
+     * {@link #MAX_READER_WARNINGS} as a single cap across every caller. Thread-safe: called from
+     * concurrent parse-worker threads, potentially many per query.
+     */
+    public void recordReaderWarning(String warning) {
+        int count = readerWarningsAdded.incrementAndGet();
+        if (count < MAX_READER_WARNINGS) {
+            pendingReaderWarnings.add(warning);
+        } else if (count == MAX_READER_WARNINGS) {
+            pendingReaderWarnings.add("... further reader warnings suppressed (more than " + (MAX_READER_WARNINGS - 1) + " recorded)");
+        }
+    }
+
+    /** Removes and returns the next recorded reader parse warning, or {@code null} if none remain. */
+    public String pollReaderWarning() {
+        return pendingReaderWarnings.poll();
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperator.java
@@ -159,17 +159,23 @@ public class AsyncExternalSourceOperator extends SourceOperator {
     }
 
     /**
-     * Drains the buffer's recorded partial-results warnings and re-emits them via {@link HeaderWarning}.
-     * The driver invokes {@link #close()} on its own thread during teardown — the same thread whose
-     * response headers {@code DriverRunner} collects into the client response. The producer records these
-     * off a forked reader / parse-worker thread whose own response headers are never merged back, so the
-     * re-emission must happen here, on the driver thread, for the warning to reach the client (see #835).
+     * Drains the buffer's recorded partial-results warnings AND reader parse warnings, re-emitting both
+     * via {@link HeaderWarning}. The driver invokes {@link #close()} on its own thread during teardown —
+     * the same thread whose response headers {@code DriverRunner} collects into the client response. The
+     * producer records these off a forked reader / parse-worker thread whose own response headers are
+     * never merged back, so the re-emission must happen here, on the driver thread, for the warning to
+     * reach the client (see #835 for partial-results warnings; the reader-warning channel extends the
+     * same mechanism to {@link org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings}-shaped
+     * null-fill/skip-row events, which are lost or flooded on the parallel-parsing paths otherwise).
      * This mirrors how {@link org.elasticsearch.compute.operator.AsyncOperator} flushes a
      * {@code ResponseHeadersCollector} from its {@code close()}.
      */
     private void emitPendingWarnings() {
         String warning;
         while ((warning = buffer.pollWarning()) != null) {
+            HeaderWarning.addWarning(warning);
+        }
+        while ((warning = buffer.pollReaderWarning()) != null) {
             HeaderWarning.addWarning(warning);
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1914,7 +1914,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     PhysicalNames.translateSchema(perFileReadSchema, renames),
                     fileSplit.offset(),
                     state.buffer.capturedSourceMetadataSink(),
-                    state.buffer::recordWarning
+                    state.buffer::recordWarning,
+                    state.buffer::recordReaderWarning
                 );
                 if (pages == null) {
                     boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
@@ -2110,7 +2111,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 PhysicalNames.translateSchema(perFileReadSchema, renames),
                 0L,
                 state.buffer.capturedSourceMetadataSink(),
-                state.buffer::recordWarning
+                state.buffer::recordWarning,
+                state.buffer::recordReaderWarning
             );
             if (pages == null) {
                 int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining;
@@ -2242,7 +2244,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 null,
                 0L,
                 buffer.capturedSourceMetadataSink(),
-                buffer::recordWarning
+                buffer::recordWarning,
+                buffer::recordReaderWarning
             );
             if (pages == null) {
                 FormatReadContext ctx = FormatReadContext.builder()
@@ -2491,7 +2494,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         @Nullable List<Attribute> perFileReadSchema,
         long baseFileOffset,
         @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
-        @Nullable Consumer<String> partialResultsWarningSink
+        @Nullable Consumer<String> partialResultsWarningSink,
+        @Nullable Consumer<String> readerWarningSink
     ) throws IOException {
         if (rowLimit != FormatReader.NO_LIMIT || parsingParallelism <= 1) {
             return null;
@@ -2521,7 +2525,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     statsStripeSize,
                     statsColumnScope,
                     splitIsFileFinal,
-                    externalSourceMetrics
+                    externalSourceMetrics,
+                    readerWarningSink
                 );
             }
             case STREAM_ONLY_COMPRESSED -> {
@@ -2563,7 +2568,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         captureSink,
                         statsStripeSize,
                         statsColumnScope,
-                        partialResultsWarningSink
+                        partialResultsWarningSink,
+                        readerWarningSink
                     );
                 } catch (Exception e) {
                     try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
@@ -41,6 +42,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Coordinates parallel parsing of a single file by splitting it into byte-range
@@ -402,6 +404,58 @@ public final class ParallelParsingCoordinator {
         boolean splitIsFileFinal,
         ExternalSourceMetrics metrics
     ) throws IOException {
+        return parallelRead(
+            reader,
+            storageObject,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            errorPolicy,
+            splitStartsAtRecordBoundary,
+            splitIncludesFileLeader,
+            readSchema,
+            baseFileOffset,
+            maxConcurrentOpenSegments,
+            captureSink,
+            maxRecordBytes,
+            statsStripeSize,
+            statsColumnScope,
+            splitIsFileFinal,
+            metrics,
+            null
+        );
+    }
+
+    /**
+     * As the {@code metrics} overload, plus an explicit sink for {@link SkipWarnings}-shaped reader parse
+     * warnings raised by segment workers. Each segment parses on a forked executor thread whose response
+     * headers never reach the client directly (see the class-level {@code Warning} routing note in
+     * {@code AsyncExternalSourceOperatorFactory#openWithParallelism}), so warnings are routed to this sink
+     * for consumer-thread re-emission instead of the default {@code HeaderWarning}-direct behavior. Pass
+     * {@code null} to leave {@link SkipWarnings} on its default (which is a no-op on a forked thread).
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        StorageObject storageObject,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy,
+        boolean splitStartsAtRecordBoundary,
+        boolean splitIncludesFileLeader,
+        List<Attribute> readSchema,
+        long baseFileOffset,
+        int maxConcurrentOpenSegments,
+        @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
+        int maxRecordBytes,
+        long statsStripeSize,
+        StripeColumnScope statsColumnScope,
+        boolean splitIsFileFinal,
+        ExternalSourceMetrics metrics,
+        @Nullable Consumer<String> warningSink
+    ) throws IOException {
         long fileLength = storageObject.length();
         long minSegment = reader.minimumSegmentSize();
 
@@ -433,6 +487,7 @@ public final class ParallelParsingCoordinator {
             // macro-split is never file-final — a later split supplies the terminal stripe.
             .stats(baseFileOffset, statsStripeSize, splitIsFileFinal)
             .statsColumnScope(statsColumnScope)
+            .warningSink(warningSink)
             .build();
         if (parallelism <= 1 || fileLength < minSegment * 2) {
             return parallelReader.read(storageObject, baseCtx);
@@ -462,7 +517,8 @@ public final class ParallelParsingCoordinator {
             statsStripeSize,
             statsColumnScope,
             splitIsFileFinal,
-            metrics
+            metrics,
+            warningSink
         );
         // Fully constructed and published before any worker is dispatched — see AsReadyParallelIterator#start.
         iterator.start();
@@ -603,6 +659,13 @@ public final class ParallelParsingCoordinator {
         private final boolean splitIsFileFinal;
         /** Node telemetry sink for the {@code reader.pool.rejected} event; {@link ExternalSourceMetrics#NOOP} when unwired. */
         private final ExternalSourceMetrics metrics;
+        /**
+         * Where each segment worker routes {@link SkipWarnings}-shaped reader parse warnings, or {@code null}
+         * for the default ({@code HeaderWarning}-direct) behavior. See the class-level dispatch method's
+         * javadoc for why segment workers cannot rely on {@code HeaderWarning} reaching the client directly.
+         */
+        @Nullable
+        private final Consumer<String> warningSink;
 
         private final List<long[]> segments;
         private final Executor executor;
@@ -643,7 +706,8 @@ public final class ParallelParsingCoordinator {
             long statsStripeSize,
             StripeColumnScope statsColumnScope,
             boolean splitIsFileFinal,
-            ExternalSourceMetrics metrics
+            ExternalSourceMetrics metrics,
+            @Nullable Consumer<String> warningSink
         ) {
             this.reader = reader;
             this.storageObject = storageObject;
@@ -659,6 +723,7 @@ public final class ParallelParsingCoordinator {
             this.statsStripeSize = statsStripeSize;
             this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
             this.metrics = metrics == null ? ExternalSourceMetrics.NOOP : metrics;
+            this.warningSink = warningSink;
             this.segments = segments;
             this.executor = executor;
             // Single clamp site for the effective window: the configured cap, never more than the parser
@@ -785,6 +850,7 @@ public final class ParallelParsingCoordinator {
                 .maxRecordBytes(maxRecordBytes)
                 .stats(segmentFileOffset, statsStripeSize, statsFileFinal)
                 .statsColumnScope(statsColumnScope)
+                .warningSink(warningSink)
                 .build();
 
             // Bind the consumer-owned sink on this worker so the reader's close hook (which publishes its

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -117,6 +118,7 @@ public final class StreamingParallelParsingCoordinator {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
+            null,
             null
         );
     }
@@ -148,6 +150,14 @@ public final class StreamingParallelParsingCoordinator {
      * thread (the segmentator runs on a forked worker whose response headers never reach the client —
      * see #835). Pass {@code null} to fall back to a direct {@link HeaderWarning} on the current thread
      * (tests, benchmarks).
+     * <p>
+     * {@code readerWarningSink} is distinct from {@code partialResultsWarningSink}: it receives the
+     * per-chunk {@link SkipWarnings}-shaped null-fill/skip-row warnings each chunk's {@link FormatReader}
+     * raises, not the one-shot truncation notice. Production passes
+     * {@link AsyncExternalSourceBuffer#recordReaderWarning} — never {@code recordWarning}, since a
+     * null-fill/skip event is exactly what the non-strict policy asked for, not a truncated result.
+     * Pass {@code null} to fall back to the default ({@code HeaderWarning}-direct, a no-op on a forked
+     * chunk-parser thread).
      */
     public static CloseableIterator<Page> parallelRead(
         SegmentableFormatReader reader,
@@ -164,7 +174,8 @@ public final class StreamingParallelParsingCoordinator {
         @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
         long statsStripeSize,
         StripeColumnScope statsColumnScope,
-        @Nullable Consumer<String> partialResultsWarningSink
+        @Nullable Consumer<String> partialResultsWarningSink,
+        @Nullable Consumer<String> readerWarningSink
     ) throws IOException {
         if (logger.isDebugEnabled()) {
             logger.debug(
@@ -191,6 +202,7 @@ public final class StreamingParallelParsingCoordinator {
                 .maxRecordBytes(maxRecordBytes)
                 .stats(baseFileOffset, statsStripeSize, true)
                 .statsColumnScope(statsColumnScope)
+                .warningSink(readerWarningSink)
                 .build();
             return reader.read(new InputStreamStorageObject(decompressedStream), ctx);
         }
@@ -210,7 +222,8 @@ public final class StreamingParallelParsingCoordinator {
             captureSink,
             statsStripeSize,
             statsColumnScope,
-            partialResultsWarningSink
+            partialResultsWarningSink,
+            readerWarningSink
         );
     }
 
@@ -252,6 +265,16 @@ public final class StreamingParallelParsingCoordinator {
          */
         @Nullable
         private final Consumer<String> partialResultsWarningSink;
+        /**
+         * Where each chunk's parser worker routes {@link SkipWarnings}-shaped reader parse warnings (distinct
+         * from {@link #partialResultsWarningSink}, which is truncation-only). Threaded into each chunk's
+         * {@link FormatReadContext} in {@link #runParserOnce}. Production wires
+         * {@link AsyncExternalSourceBuffer#recordReaderWarning}, which applies one global cap across every
+         * chunk instead of letting each chunk's independent {@link SkipWarnings} instance emit its own
+         * capped batch — the fix for the per-chunk warning flood.
+         */
+        @Nullable
+        private final Consumer<String> readerWarningSink;
         /** Compressed file being decompressed; {@code null} in tests that only supply a stream. */
         @Nullable
         private final StorageObject storageObject;
@@ -344,7 +367,8 @@ public final class StreamingParallelParsingCoordinator {
             @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
             long statsStripeSize,
             StripeColumnScope statsColumnScope,
-            @Nullable Consumer<String> partialResultsWarningSink
+            @Nullable Consumer<String> partialResultsWarningSink,
+            @Nullable Consumer<String> readerWarningSink
         ) {
             this.reader = reader;
             this.storageObject = storageObject;
@@ -358,6 +382,7 @@ public final class StreamingParallelParsingCoordinator {
             this.statsStripeSize = statsStripeSize;
             this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
             this.partialResultsWarningSink = partialResultsWarningSink;
+            this.readerWarningSink = readerWarningSink;
             this.bufferPoolSize = parallelism + 1;
             this.pageQueueRingSize = parallelism + 1;
 
@@ -759,6 +784,7 @@ public final class StreamingParallelParsingCoordinator {
                     .maxRecordBytes(maxRecordBytes)
                     .stats(chunkFileGlobalStart, statsStripeSize, chunk.last())
                     .statsColumnScope(statsColumnScope)
+                    .warningSink(readerWarningSink)
                     .build();
                 // Bind the consumer-owned sink on this worker so the reader's close hook reaches the
                 // same map the consumer-thread StatsCapturingIterator binds. The pages iterator is

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -11,6 +11,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Immutable context for a single {@link FormatReader#read} or {@link FormatReader#readAsync} call.
@@ -79,6 +80,12 @@ import java.util.List;
  *                         {@link StripeColumnScope#PROJECTED} (back-compat for call sites that predate the
  *                         setting); the compact constructor collapses {@code null} to that default so
  *                         readers do one check.
+ * @param warningSink      where readers should route {@link SkipWarnings}-shaped skip/null-fill warnings,
+ *                         or {@code null} to use the default ({@link SkipWarnings}'s own
+ *                         {@code HeaderWarning}-direct behavior). Non-{@code null} on reads dispatched to a
+ *                         forked worker thread whose response headers never reach the client directly
+ *                         (the parallel-parsing coordinators), so warnings can be routed to a consumer-thread
+ *                         re-emission mechanism instead.
  */
 public record FormatReadContext(
     List<String> projectedColumns,
@@ -94,7 +101,8 @@ public record FormatReadContext(
     long statsBaseOffset,
     long statsStripeSize,
     boolean statsFileFinal,
-    StripeColumnScope statsColumnScope
+    StripeColumnScope statsColumnScope,
+    @Nullable Consumer<String> warningSink
 ) {
 
     public FormatReadContext {
@@ -138,7 +146,8 @@ public record FormatReadContext(
             statsBaseOffset,
             statsStripeSize,
             statsFileFinal,
-            statsColumnScope
+            statsColumnScope,
+            warningSink
         );
     }
 
@@ -160,7 +169,8 @@ public record FormatReadContext(
             statsBaseOffset,
             statsStripeSize,
             statsFileFinal,
-            statsColumnScope
+            statsColumnScope,
+            warningSink
         );
     }
 
@@ -182,7 +192,31 @@ public record FormatReadContext(
             statsBaseOffset,
             statsStripeSize,
             statsFileFinal,
-            statsColumnScope
+            statsColumnScope,
+            warningSink
+        );
+    }
+
+    /**
+     * Returns a copy with a different warning sink; see {@link #warningSink()}.
+     */
+    public FormatReadContext withWarningSink(@Nullable Consumer<String> warningSink) {
+        return new FormatReadContext(
+            projectedColumns,
+            batchSize,
+            rowLimit,
+            errorPolicy,
+            firstSplit,
+            lastSplit,
+            recordAligned,
+            readSchema,
+            splitStartByte,
+            maxRecordBytes,
+            statsBaseOffset,
+            statsStripeSize,
+            statsFileFinal,
+            statsColumnScope,
+            warningSink
         );
     }
 
@@ -209,6 +243,8 @@ public record FormatReadContext(
         private long statsStripeSize = -1L;
         private boolean statsFileFinal = false;
         private StripeColumnScope statsColumnScope = StripeColumnScope.PROJECTED;
+        @Nullable
+        private Consumer<String> warningSink = null;
 
         private Builder() {}
 
@@ -291,6 +327,12 @@ public record FormatReadContext(
             return this;
         }
 
+        /** See {@link FormatReadContext#warningSink()}; pass {@code null} for the default HeaderWarning-direct behavior. */
+        public Builder warningSink(@Nullable Consumer<String> warningSink) {
+            this.warningSink = warningSink;
+            return this;
+        }
+
         public FormatReadContext build() {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive, got: " + batchSize);
@@ -309,7 +351,8 @@ public record FormatReadContext(
                 statsBaseOffset,
                 statsStripeSize,
                 statsFileFinal,
-                statsColumnScope
+                statsColumnScope,
+                warningSink
             );
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.elasticsearch.common.logging.HeaderWarning;
 
+import java.util.function.Consumer;
+
 /**
  * Collects response {@code Warning} headers for datasource read paths that skip a malformed input
  * and resume processing (non-strict {@link ErrorPolicy}, or similar best-effort fallbacks).
@@ -18,10 +20,18 @@ import org.elasticsearch.common.logging.HeaderWarning;
  * details. Per-event details are capped at {@link #MAX_ADDED_WARNINGS}; on overflow a single
  * "further warnings suppressed" entry is emitted so clients know more were dropped.
  * <p>
- * Writes go through {@link HeaderWarning#addWarning(String, Object...)} which attaches them to the
- * current thread's response headers; if no thread context is bound (e.g. in unit tests that don't
- * care), the call is a no-op. Instances are stateful and not thread-safe: create one per reader
- * iterator or decoder.
+ * By default, lines go through {@link HeaderWarning#addWarning(String, Object...)} which attaches
+ * them to the current thread's response headers; if no thread context is bound (e.g. in unit tests
+ * that don't care), the call is a no-op. Callers that parse on a forked worker thread whose response
+ * headers never reach the client (e.g. the parallel-parsing coordinators) instead pass an explicit
+ * sink via {@link #of(ErrorPolicy, String, Consumer)} so lines can be routed to a consumer-thread
+ * re-emission mechanism; that sink typically applies its own cross-chunk/segment cap on top (see
+ * {@code AsyncExternalSourceBuffer#recordReaderWarning}). Because that shared cap is a small, fixed
+ * budget split across however many segments/chunks are parsing concurrently, a sink-routed instance
+ * caps its own per-event detail count far below {@link #MAX_ADDED_WARNINGS} (see
+ * {@link #MAX_ADDED_WARNINGS_PER_SHARED_SINK}) so a single busy segment/chunk cannot exhaust the whole
+ * shared budget before any other segment/chunk gets a chance to contribute.
+ * Instances are stateful and not thread-safe: create one per reader iterator or decoder.
  * <p>
  * Callers working against an {@link ErrorPolicy} should use {@link #of(ErrorPolicy, String)} to
  * obtain either a live collector or the shared {@link #NOOP} sink, so that call sites never have
@@ -37,22 +47,53 @@ public class SkipWarnings {
     public static final int MAX_ADDED_WARNINGS = 20;
 
     /**
+     * Per-event detail cap used when this instance's lines are routed to an external sink (see
+     * {@link #of(ErrorPolicy, String, Consumer)}), rather than the {@link #MAX_ADDED_WARNINGS} default.
+     * That sink is typically shared by many concurrent {@link SkipWarnings} instances — one per
+     * parallel-parsing segment or streaming chunk — feeding a single small, central, cross-instance
+     * budget (see {@code AsyncExternalSourceBuffer#recordReaderWarning}). Capping each instance's own
+     * contribution far below that shared budget means a single segment/chunk with many errors cannot
+     * exhaust the whole budget by itself, leaving room for other concurrently-parsed segments/chunks to
+     * also be represented.
+     */
+    public static final int MAX_ADDED_WARNINGS_PER_SHARED_SINK = 4;
+
+    /**
      * Shared sink used when the current {@link ErrorPolicy} never triggers skip/null-fill behavior
      * (e.g. {@link ErrorPolicy#isStrict()}). All {@link #add(String)} calls are silently dropped.
      */
-    public static final SkipWarnings NOOP = new SkipWarnings("") {
+    public static final SkipWarnings NOOP = new SkipWarnings("", HeaderWarning::addWarning, MAX_ADDED_WARNINGS) {
         @Override
         public void add(String detail) {}
     };
 
     private final String summary;
+    private final Consumer<String> sink;
+    private final int maxAddedWarnings;
     // Mutable state: not thread-safe, one instance per reader iterator/decoder.
     private int added;
     private boolean summaryEmitted;
     private boolean overflowEmitted;
 
     public SkipWarnings(String summary) {
+        this(summary, HeaderWarning::addWarning, MAX_ADDED_WARNINGS);
+    }
+
+    /**
+     * @param sink where summary/detail/overflow lines are sent, in place of the default
+     *             {@link HeaderWarning#addWarning(String, Object...)}. Used by callers that parse on a
+     *             thread whose response headers do not reach the client. Caps this instance's own detail
+     *             count at {@link #MAX_ADDED_WARNINGS_PER_SHARED_SINK} rather than
+     *             {@link #MAX_ADDED_WARNINGS} — see that constant's javadoc for why.
+     */
+    public SkipWarnings(String summary, Consumer<String> sink) {
+        this(summary, sink, MAX_ADDED_WARNINGS_PER_SHARED_SINK);
+    }
+
+    private SkipWarnings(String summary, Consumer<String> sink, int maxAddedWarnings) {
         this.summary = summary;
+        this.sink = sink;
+        this.maxAddedWarnings = maxAddedWarnings;
     }
 
     /**
@@ -64,23 +105,32 @@ public class SkipWarnings {
     }
 
     /**
+     * As {@link #of(ErrorPolicy, String)}, routing lines through {@code sink} instead of
+     * {@link HeaderWarning} directly when the policy is non-strict.
+     */
+    public static SkipWarnings of(ErrorPolicy policy, String summary, Consumer<String> sink) {
+        return policy.isStrict() ? NOOP : new SkipWarnings(summary, sink);
+    }
+
+    /**
      * Record a single skip/null-fill event. Emits the summary header on the first call, the detail
-     * on this and the next up to {@link #MAX_ADDED_WARNINGS} calls, and a single
-     * "further warnings suppressed" header when the cap is exceeded.
+     * on this and the next up to this instance's detail cap ({@link #MAX_ADDED_WARNINGS} by default, or
+     * {@link #MAX_ADDED_WARNINGS_PER_SHARED_SINK} when constructed with an explicit sink) calls, and a
+     * single "further warnings suppressed" header when the cap is exceeded.
      */
     public void add(String detail) {
         if (summaryEmitted == false) {
-            // Use the no-varargs overload so HeaderWarning treats both summary and detail as plain
-            // strings (LoggerMessageFormat#format early-returns when argArray is empty); this keeps
-            // user data containing '{' or '}' from being reinterpreted as a placeholder pattern.
-            HeaderWarning.addWarning(summary);
+            // The default sink (HeaderWarning::addWarning) binds via its varargs overload with a zero-length
+            // params array, so LoggerMessageFormat#format early-returns and treats the string as plain text;
+            // this keeps user data containing '{' or '}' from being reinterpreted as a placeholder pattern.
+            sink.accept(summary);
             summaryEmitted = true;
         }
-        if (added < MAX_ADDED_WARNINGS) {
-            HeaderWarning.addWarning(detail);
+        if (added < maxAddedWarnings) {
+            sink.accept(detail);
             added++;
         } else if (overflowEmitted == false) {
-            HeaderWarning.addWarning("... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)");
+            sink.accept("... further warnings suppressed (more than " + maxAddedWarnings + " recorded)");
             overflowEmitted = true;
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -18,7 +18,10 @@ import org.elasticsearch.compute.operator.IsBlockedResult;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonReaderStatus;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -266,5 +269,52 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         buffer.incSplitsProcessed();
         assertEquals(2, buffer.currentSplit());
         assertEquals(2, buffer.splitsProcessed());
+    }
+
+    public void testRecordReaderWarningDoesNotFlipPartial() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        buffer.recordReaderWarning("null-filled row 3");
+        assertFalse("a reader parse warning is not a partial-result signal", buffer.isPartial());
+        assertEquals("null-filled row 3", buffer.pollReaderWarning());
+        assertNull(buffer.pollReaderWarning());
+    }
+
+    public void testRecordReaderWarningIsIndependentOfPartialResultsWarnings() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        buffer.recordWarning("truncated at max_record_size");
+        buffer.recordReaderWarning("null-filled row 3");
+        assertTrue(buffer.isPartial());
+        assertEquals("truncated at max_record_size", buffer.pollWarning());
+        assertEquals("null-filled row 3", buffer.pollReaderWarning());
+        assertNull(buffer.pollWarning());
+        assertNull(buffer.pollReaderWarning());
+    }
+
+    /**
+     * The whole point of the central cap: many independent per-segment/per-chunk {@link
+     * org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings} instances feeding the same buffer must
+     * not multiply the header count by the segment/chunk count. Regression coverage for the streaming
+     * per-chunk flood.
+     */
+    public void testRecordReaderWarningAppliesOneGlobalCapAcrossManyCallers() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        // Simulate 50 chunks each independently emitting a summary + a detail, as 50 independent
+        // SkipWarnings instances would on the streaming-parallel path pre-fix.
+        int chunks = 50;
+        for (int c = 0; c < chunks; c++) {
+            buffer.recordReaderWarning("chunk " + c + " summary");
+            buffer.recordReaderWarning("chunk " + c + " detail");
+        }
+
+        List<String> drained = new ArrayList<>();
+        String w;
+        while ((w = buffer.pollReaderWarning()) != null) {
+            drained.add(w);
+        }
+
+        int maxReaderWarnings = SkipWarnings.MAX_ADDED_WARNINGS + 2;
+        assertEquals("total lines must be bounded regardless of how many chunks contributed", maxReaderWarnings, drained.size());
+        assertTrue("the last line must note suppression", drained.get(drained.size() - 1).contains("further reader warnings suppressed"));
+        assertFalse(buffer.isPartial());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -2519,6 +2519,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 null,
                 0L,
                 null,
+                null,
                 null
             )
         );
@@ -2546,6 +2547,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 true,
                 null,
                 0L,
+                null,
                 null,
                 null
             );
@@ -2576,7 +2578,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
 
         IOException thrown = expectThrows(
             IOException.class,
-            () -> factory.openWithParallelism(cdr, object, List.of("a"), ErrorPolicy.STRICT, false, true, true, null, 0L, null, null)
+            () -> factory.openWithParallelism(cdr, object, List.of("a"), ErrorPolicy.STRICT, false, true, true, null, 0L, null, null, null)
         );
         assertEquals("decompress failed", thrown.getMessage());
         assertTrue("raw stream must be aborted when decompression fails", tracking.aborted.get());
@@ -2603,6 +2605,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 true,
                 null,
                 0L,
+                null,
                 null,
                 null
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -67,6 +67,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 public class ParallelParsingCoordinatorTests extends ESTestCase {
 
@@ -386,6 +387,73 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
                 + contributions,
             partialCount,
             Matchers.greaterThanOrEqualTo(2L)
+        );
+    }
+
+    /**
+     * Regression test for the "lost warnings" half of the parallel-parse warning bug: prior to routing
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings}-shaped reader parse warnings
+     * through an explicit sink, segment workers had no way to get a warning back to the client at all
+     * (their {@code HeaderWarning} writes landed on a forked worker's thread context, never merged back).
+     * This asserts the sink threaded through the widest {@code parallelRead} overload actually reaches
+     * every segment worker — one call per segment, none dropped.
+     */
+    public void testParallelReadRoutesReaderWarningsThroughSink() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        int lineCount = 200;
+        for (int i = 0; i < lineCount; i++) {
+            sb.append("line-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append("\n");
+        }
+        byte[] contentBytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        StorageObject obj = new InMemoryStorageObject(contentBytes);
+        WarningEmittingLineReader reader = new WarningEmittingLineReader(blockFactory());
+
+        List<long[]> segments = ParallelParsingCoordinator.computeSegments(
+            reader,
+            obj,
+            contentBytes.length,
+            4,
+            reader.minimumSegmentSize()
+        );
+        assertThat("test must drive the multi-segment worker path", segments.size(), Matchers.greaterThanOrEqualTo(2));
+
+        List<String> collected = new CopyOnWriteArrayList<>();
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(
+                reader,
+                obj,
+                List.of("line"),
+                50,
+                4,
+                exec,
+                null,
+                false,
+                true,
+                null,
+                0L,
+                ParallelParsingCoordinator.DEFAULT_MAX_CONCURRENT_OPEN_SEGMENTS,
+                null,
+                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                -1L,
+                StripeColumnScope.PROJECTED,
+                false,
+                ExternalSourceMetrics.NOOP,
+                collected::add
+            );
+            try (iter) {
+                while (iter.hasNext()) {
+                    iter.next().releaseBlocks();
+                }
+            }
+        } finally {
+            exec.shutdown();
+        }
+
+        assertEquals(
+            "every segment worker must route its warning through the sink, none lost: saw " + collected,
+            segments.size(),
+            collected.size()
         );
     }
 
@@ -1491,6 +1559,28 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public void close() {}
+    }
+
+    /**
+     * Wraps {@link LineFormatReader} so each segment's {@code read} call emits one warning through
+     * {@link FormatReadContext#warningSink()} when present — mirroring how a real reader's
+     * {@code SkipWarnings} instance would route a null-fill/skip-row event. Used by
+     * {@link #testParallelReadRoutesReaderWarningsThroughSink} to verify the sink threaded through the
+     * coordinator actually reaches every segment worker.
+     */
+    private static class WarningEmittingLineReader extends LineFormatReader {
+        WarningEmittingLineReader(BlockFactory blockFactory) {
+            super(blockFactory);
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            Consumer<String> sink = context.warningSink();
+            if (sink != null) {
+                sink.accept("simulated reader parse warning for segment starting at byte " + context.splitStartByte());
+            }
+            return super.read(object, context);
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
@@ -186,6 +187,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 sink,
                 -1L,
                 StripeColumnScope.PROJECTED,
+                null,
                 null
             );
             try (CloseableIterator<Page> iter = StatsCapturingIterator.wrap(outer, sink)) {
@@ -246,6 +248,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 sink,
                 -1L,
                 StripeColumnScope.PROJECTED,
+                null,
                 null
             );
             CloseableIterator<Page> iter = StatsCapturingIterator.wrap(outer, sink);
@@ -446,6 +449,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     sink,
                     64L, // stripe addressing active
                     StripeColumnScope.PROJECTED,
+                    null,
                     null
                 )
             );
@@ -473,6 +477,65 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     ctx.statsBaseOffset() >= baseFileOffset
                 );
             }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Regression test for the per-chunk warning flood: prior to routing
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings}-shaped reader parse warnings
+     * through a shared sink, each chunk parsed with its own independent {@code SkipWarnings} instance,
+     * so N chunks could each emit up to {@code MAX_ADDED_WARNINGS + 2} lines — unbounded in N. This
+     * asserts every chunk's {@link FormatReadContext} carries the SAME sink instance passed to
+     * {@code parallelRead}, and that invoking each chunk's sink (as a real reader's {@code SkipWarnings}
+     * would on a null-fill/skip event) delivers exactly one message per chunk to that single shared sink
+     * — the substrate the central cap in {@code AsyncExternalSourceBuffer#recordReaderWarning} relies on.
+     */
+    public void testStreamingParallelReadThreadsSameReaderWarningSinkToEveryChunk() throws Exception {
+        int lineCount = 1000;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        List<String> collected = new CopyOnWriteArrayList<>();
+        Consumer<String> readerWarningSink = collected::add;
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            LineFormatReader reader = new LineFormatReader(1024);
+            collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    stream,
+                    null,
+                    List.of("line"),
+                    100,
+                    4,
+                    executor,
+                    ErrorPolicy.STRICT,
+                    null,
+                    0L,
+                    SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                    null,
+                    -1L,
+                    StripeColumnScope.PROJECTED,
+                    null,
+                    readerWarningSink
+                )
+            );
+
+            List<FormatReadContext> seen;
+            synchronized (reader.seenContexts) {
+                seen = new ArrayList<>(reader.seenContexts);
+            }
+            assertTrue("test needs at least 2 chunks to be meaningful, saw " + seen.size(), seen.size() >= 2);
+            for (FormatReadContext ctx : seen) {
+                assertSame("every chunk must be threaded the SAME reader-warning sink instance", readerWarningSink, ctx.warningSink());
+            }
+
+            for (int i = 0; i < seen.size(); i++) {
+                seen.get(i).warningSink().accept("chunk " + i + " simulated null-fill warning");
+            }
+            assertEquals("one message per chunk must reach the single shared sink, none lost", seen.size(), collected.size());
         } finally {
             executor.shutdownNow();
         }
@@ -1186,6 +1249,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
+                null,
                 null
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(iterator));
@@ -1235,6 +1299,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
+                null,
                 null
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(strictIterator));
@@ -1266,6 +1331,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
+                null,
                 null
             );
             List<String> got = collectLines(lenientIterator);
@@ -1314,7 +1380,8 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                sink::add
+                sink::add,
+                null
             );
             List<String> got = collectLines(iterator);
             assertEquals("an undelimitable first record yields no rows under truncation", 0, got.size());
@@ -1363,6 +1430,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
+            null,
             null
         );
         List<String> got = collectLines(iterator);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SkipWarningsTests extends ESTestCase {
@@ -91,6 +92,63 @@ public class SkipWarningsTests extends ESTestCase {
             20,
             SkipWarnings.MAX_ADDED_WARNINGS
         );
+    }
+
+    public void testCustomSinkReceivesSummaryDetailAndOverflowInsteadOfHeaderWarning() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = new SkipWarnings("summary", sunk::add);
+        int total = SkipWarnings.MAX_ADDED_WARNINGS_PER_SHARED_SINK + 5;
+        for (int i = 0; i < total; i++) {
+            warnings.add("detail " + i);
+        }
+
+        // Nothing should have gone through HeaderWarning/the thread context on the sink-routed path.
+        assertNull(threadContext.getResponseHeaders().get("Warning"));
+
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS_PER_SHARED_SINK + 2, sunk.size());
+        assertEquals("summary", sunk.get(0));
+        assertEquals("detail 0", sunk.get(1));
+        assertTrue(sunk.get(sunk.size() - 1).contains("further warnings suppressed"));
+    }
+
+    /**
+     * A sink-routed instance must cap itself far below {@link SkipWarnings#MAX_ADDED_WARNINGS}: that sink
+     * is shared by many concurrent per-segment/per-chunk instances feeding one small central budget (see
+     * {@code AsyncExternalSourceBuffer#recordReaderWarning}), so a single instance hitting the full
+     * MAX_ADDED_WARNINGS cap could exhaust the whole shared budget by itself.
+     */
+    public void testSinkRoutedInstanceUsesSmallerCapThanDefault() {
+        assertTrue(
+            "sink-routed cap must be strictly smaller than the default so one instance can't hog a shared budget",
+            SkipWarnings.MAX_ADDED_WARNINGS_PER_SHARED_SINK < SkipWarnings.MAX_ADDED_WARNINGS
+        );
+
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = SkipWarnings.of(ErrorPolicy.LENIENT, "summary", sunk::add);
+        for (int i = 0; i < SkipWarnings.MAX_ADDED_WARNINGS_PER_SHARED_SINK; i++) {
+            warnings.add("detail " + i);
+        }
+        // Exactly at the cap: no overflow line yet.
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS_PER_SHARED_SINK + 1, sunk.size());
+        assertFalse(sunk.get(sunk.size() - 1).contains("further warnings suppressed"));
+
+        warnings.add("one more");
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS_PER_SHARED_SINK + 2, sunk.size());
+        assertTrue(sunk.get(sunk.size() - 1).contains("further warnings suppressed"));
+    }
+
+    public void testOfWithSinkStrictPolicyReturnsNoop() {
+        List<String> sunk = new ArrayList<>();
+        assertSame(SkipWarnings.NOOP, SkipWarnings.of(ErrorPolicy.STRICT, "ignored", sunk::add));
+    }
+
+    public void testOfWithSinkLenientPolicyRoutesToSink() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = SkipWarnings.of(ErrorPolicy.LENIENT, "live summary", sunk::add);
+        assertNotSame(SkipWarnings.NOOP, warnings);
+        warnings.add("a detail");
+        assertEquals(List.of("live summary", "a detail"), sunk);
+        assertNull(threadContext.getResponseHeaders().get("Warning"));
     }
 
     private List<String> drain() {


### PR DESCRIPTION
Fixes elastic/esql-planning#1109

## Problem

Reader parse warnings (`SkipWarnings`-shaped, e.g. `null_field` skip/null-fill events) were:

- **Lost** on the uncompressed parallel-parse path (`ParallelParsingCoordinator`) — zero warnings ever reached the client.
- **Flooded** on the gzip/zstd streaming path (`StreamingParallelParsingCoordinator`) — each chunk emitted its own independently-capped batch of warnings, multiplying header count by chunk count and eventually making the response undeliverable (`curl: (56) Too large response headers`).

Root cause: both coordinators dispatch parsing to forked worker threads whose `HeaderWarning` writes never reach the client's response headers — only the driver thread's headers are collected into the response.

## Fix

Routed all reader parse warnings through the same driver-thread re-emission mechanism `#835` built for truncation warnings, but via a new **non-partial** entry point, with a single cap applied **centrally** instead of per-chunk.

- **`SkipWarnings`** — new pluggable `Consumer<String>` sink (default stays `HeaderWarning::addWarning`, byte-identical on the serial path).
- **`FormatReadContext`** — new `warningSink` component.
- **`ParallelParsingCoordinator`** / **`StreamingParallelParsingCoordinator`** — thread the sink into every segment/chunk context (and the single-segment fallback).
- **`AsyncExternalSourceBuffer`** — new `recordReaderWarning` / `pollReaderWarning`. Does **not** flip `is_partial` (a null-fill/skip event is exactly what the non-strict policy asked for, not a truncated result). Applies one global cap (`SkipWarnings.MAX_ADDED_WARNINGS + 2` = 22 lines total) regardless of segment/chunk count.
- **`AsyncExternalSourceOperator.close()`** drains and re-emits both warning queues on the driver thread.
- **`AsyncExternalSourceOperatorFactory`** wires `buffer::recordReaderWarning` through all three producer call sites to both coordinators.


## Deliberately deferred

- **File-global byte offsets in warning messages.** The issue's plan calls for `CsvFormatReader`/`NdJsonPageDecoder` warning text to reference file-global byte offsets instead of chunk-local row numbers (`totalRowCount`). This is cosmetic — it doesn't affect whether warnings are lost or flooded — but touches ~10 `onRowError`/`onFieldError`/`checkBudget` call sites across dense, performance-sensitive hot paths (bulk Jackson path, direct-block plain/quoted paths) in two readers. Given the risk/value tradeoff, this was left as-is.
- **Backstop emission.** The issue proposes: if `formatReaderStatus` shows `parseErrors > 0` but zero reader warnings were recorded, emit a one-line summary from the counter as a defensive fallback. `FormatReaderStatus` is a format-agnostic interface (shared by CSV/NDJSON/Parquet/ORC) that doesn't expose `parseErrors()` generically, so this would require extending that interface. Deferred as an optional defense-in-depth item, not the core bug.
- **`CsvReaderCounters` survival through the `withSchema` clone.** A separate, narrower issue where the empty-projection clone inside `ParallelParsingCoordinator.parallelRead` could detach from the status snapshot. Unrelated to warning routing; deferred.
