### PR TITLE
[9.4] Disable flaky testSnapshotWithLargeSegmentFiles

### DIFF
--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
@@ -180,6 +180,15 @@ public class S3BlobStoreRepositoryTimeoutTests extends ESMockAPIBasedRepositoryI
         // Skip testing request stats since the S3StallingHttpHandler does not track request stats
     }
 
+    @Override
+    public void testSnapshotWithLargeSegmentFiles() {
+        // See #146156
+        // The aggressive settings + zero retries can make this test flaky (since we are using an actual HTTP stack
+        // and can be subject to transport errors during heavy loads).
+        // This test is already exercised under representative settings in S3BlobStoreRepositoryTests, there is
+        // no real differentiating coverage from duplicating it here.
+    }
+
     @SuppressForbidden(reason = "this test uses a HttpHandler to emulate an S3 endpoint")
     protected class S3StallingHttpHandler extends S3HttpHandler implements BlobStoreHttpHandler {
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -251,9 +251,6 @@ tests:
 - class: org.elasticsearch.test.apmintegration.TracesApmIT
   method: testTraces
   issue: https://github.com/elastic/elasticsearch/issues/153062
-- class: org.elasticsearch.repositories.s3.S3BlobStoreRepositoryTimeoutTests
-  method: testSnapshotWithLargeSegmentFiles
-  issue: https://github.com/elastic/elasticsearch/issues/153106
 - class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectIT
   method: testUpdateTransformWithProjectRouting
   issue: https://github.com/elastic/elasticsearch/issues/147534

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -157,7 +157,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
     /**
      * Test the snapshot and restore of an index which has large segments files.
      */
-    public final void testSnapshotWithLargeSegmentFiles() throws Exception {
+    public void testSnapshotWithLargeSegmentFiles() throws Exception {
         final String repository = createRepository(randomRepositoryName());
         final String index = "index-no-merges";
         createIndex(index, 1, 0);


### PR DESCRIPTION
Backport of #146388 to `9.4`.

`S3BlobStoreRepositoryTimeoutTests.testSnapshotWithLargeSegmentFiles` uses deliberately aggressive S3 client settings (`read_timeout=1s`, `max_retries=0`) against a real HTTP stack. Under load the snapshot can fail on every shard, tripping `assertThat(successfulShards(), greaterThan(0))`. The same scenario is already covered under representative settings in `S3BlobStoreRepositoryTests`, so #146388 disabled it on `main`. That fix was never backported to `9.4`, where the test remained active, flaked, and was auto-muted.

This backport:
- Cherry-picks #146388 (drops `final` from the base method, adds the empty override).
- Removes the now-dead mute entry from `muted-tests.yml`.

Closes #153106