### PR TITLE
[9.4] Include ingest metadata in self reference checks (#152932)

### DIFF
--- a/docs/changelog/152932.yaml
+++ b/docs/changelog/152932.yaml
@@ -1,0 +1,5 @@
+area: Ingest Node
+issues: []
+pr: 152932
+summary: Include ingest metadata in self reference checks
+type: bug

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -122,8 +122,11 @@ public final class IngestDocument {
      */
     public IngestDocument(IngestDocument other) {
         this(
-            new IngestCtxMap(deepCopyMap(ensureNoSelfReferences(other.ctxMap.getSource())), other.ctxMap.getMetadata().clone()),
-            deepCopyMap(other.ingestMetadata)
+            new IngestCtxMap(
+                deepCopyMap(ensureNoSelfReferences(other.ctxMap.getSource(), "source document")),
+                other.ctxMap.getMetadata().clone()
+            ),
+            deepCopyMap(ensureNoSelfReferences(other.ingestMetadata, "ingest metadata"))
         );
         /*
          * The executedPipelines and accessPatternStack fields are clearly execution-centric rather than data centric.
@@ -140,9 +143,9 @@ public final class IngestDocument {
      * in a constructor. This is only for use in the {@link IngestDocument#IngestDocument(IngestDocument)} copy constructor, it's not a
      * general purpose method.
      */
-    private static Map<String, Object> ensureNoSelfReferences(Map<String, Object> source) {
-        CollectionUtils.ensureNoSelfReferences(source, null);
-        return source;
+    private static Map<String, Object> ensureNoSelfReferences(Map<String, Object> map, String hint) {
+        CollectionUtils.ensureNoSelfReferences(map, hint);
+        return map;
     }
 
     /**
@@ -1058,6 +1061,11 @@ public final class IngestDocument {
      */
     public Map<String, Object> getIngestMetadata() {
         return this.ingestMetadata;
+    }
+
+    void ensureNoSelfReferences() {
+        CollectionUtils.ensureNoSelfReferences(ctxMap.getSource(), "source document");
+        CollectionUtils.ensureNoSelfReferences(ingestMetadata, "ingest metadata");
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -58,7 +58,6 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.streams.StreamType;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -1241,11 +1240,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 try {
                     // check for self-references if necessary, (i.e. if a script processor has run), and clear the bit
                     if (ingestDocument.doNoSelfReferencesCheck()) {
-                        CollectionUtils.ensureNoSelfReferences(ingestDocument.getSource(), null);
+                        ingestDocument.ensureNoSelfReferences();
                         ingestDocument.doNoSelfReferencesCheck(false);
                     }
                 } catch (IllegalArgumentException ex) {
-                    // An IllegalArgumentException can be thrown when an ingest processor creates a source map that is self-referencing.
+                    // An IllegalArgumentException can be thrown when an ingest processor creates self-referencing data.
                     // In that case, we catch and wrap the exception, so we can include more details
                     exceptionHandler.accept(
                         new IngestPipelineException(

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -1915,7 +1915,17 @@ public class IngestDocumentTests extends ESTestCase {
             someList.add(someList); // the list contains itself
             ingestDocument.setFieldValue("someList", someList);
             Exception e = expectThrows(IllegalArgumentException.class, () -> new IngestDocument(ingestDocument));
-            assertThat(e.getMessage(), equalTo("Iterable object is self-referencing itself"));
+            assertThat(e.getMessage(), equalTo("Iterable object is self-referencing itself (source document)"));
+        }
+
+        {
+            // the copy constructor rejects self-references in ingest metadata too
+            IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+            Map<String, Object> selfReference = new HashMap<>();
+            selfReference.put("self", selfReference);
+            ingestDocument.getIngestMetadata().put("self", selfReference);
+            Exception e = expectThrows(IllegalArgumentException.class, () -> new IngestDocument(ingestDocument));
+            assertThat(e.getMessage(), equalTo("Iterable object is self-referencing itself (ingest metadata)"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1403,6 +1403,73 @@ public class IngestServiceTests extends ESTestCase {
         verify(listener, times(1)).onResponse(null);
     }
 
+    public void testExecuteSelfReferenceFailures() {
+        Processor.Factory selfRefProcessor = (factories, tag, description, config, projectId) -> {
+            boolean ingestMetadata = Boolean.TRUE.equals(config.remove("ingest_metadata"));
+            return new FakeProcessor("self_ref", tag, description, ingestDocument -> {
+                Map<String, Object> selfReference = new HashMap<>();
+                selfReference.put("self", selfReference);
+                if (ingestMetadata) {
+                    ingestDocument.getIngestMetadata().put("self", selfReference);
+                } else {
+                    ingestDocument.setFieldValue("self", selfReference);
+                }
+                ingestDocument.doNoSelfReferencesCheck(true);
+            });
+        };
+        IngestService ingestService = createWithProcessors(Map.of("self_ref", selfRefProcessor));
+        var projectId = randomProjectIdOrDefault();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .putProjectMetadata(ProjectMetadata.builder(projectId).build())
+            .build();
+        ClusterState previousClusterState = clusterState;
+        clusterState = executePut(
+            projectId,
+            putJsonPipelineRequest("source_self_ref", "{\"processors\": [{\"self_ref\" : {}}]}"),
+            clusterState
+        );
+        clusterState = executePut(
+            projectId,
+            putJsonPipelineRequest("ingest_metadata_self_ref", "{\"processors\": [{\"self_ref\" : {\"ingest_metadata\": true}}]}"),
+            clusterState
+        );
+        ingestService.applyClusterState(new ClusterChangedEvent("", clusterState, previousClusterState));
+
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.add(new IndexRequest("_index").id("_id1").source(Map.of()).setPipeline("source_self_ref").setFinalPipeline("_none"));
+        bulkRequest.add(
+            new IndexRequest("_index").id("_id2").source(Map.of()).setPipeline("ingest_metadata_self_ref").setFinalPipeline("_none")
+        );
+        boolean[] failures = new boolean[2];
+        List<String> expectedMessages = List.of(
+            "Iterable object is self-referencing itself (source document)",
+            "Iterable object is self-referencing itself (ingest metadata)"
+        );
+        final TriConsumer<Integer, Exception, IndexDocFailureStoreStatus> failureHandler = (slot, e, status) -> {
+            failures[slot] = true;
+            assertThat(e, instanceOf(IngestPipelineException.class));
+            assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
+            assertThat(e.getCause().getCause().getMessage(), equalTo(expectedMessages.get(slot)));
+            assertThat(status, equalTo(IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN));
+        };
+        @SuppressWarnings("unchecked")
+        final ActionListener<Void> listener = mock(ActionListener.class);
+        ingestService.executeBulkRequest(
+            projectId,
+            bulkRequest.numberOfActions(),
+            bulkRequest.requests(),
+            indexReq -> {},
+            (s) -> null,
+            (slot, targetIndex, e) -> fail("Should not be redirecting failures"),
+            failureHandler,
+            listener
+        );
+        assertTrue(failures[0]);
+        assertTrue(failures[1]);
+        verify(listener, times(1)).onResponse(null);
+    }
+
     public void testDynamicTemplates() throws Exception {
         IngestService ingestService = createWithProcessors(
             Map.of(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Include ingest metadata in self reference checks (#152932)](https://github.com/elastic/elasticsearch/pull/152932)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)