### PR TITLE
[9.5] ESQL:DS: Fix emission of Warnings (#153029)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -661,9 +661,6 @@ tests:
 - class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
   method: testConjunctionOfRangeFiltersMatchesBruteForce
   issue: https://github.com/elastic/elasticsearch/issues/152887
-- class: org.elasticsearch.xpack.esql.action.NdJsonScalarObjectConflictIT
-  method: testSkipRowPolicyNullFillsAndWarnsClient
-  issue: https://github.com/elastic/elasticsearch/issues/152891
 - class: org.elasticsearch.xpack.transform.integration.TransformIT
   method: testStopWaitForCheckpoint
   issue: https://github.com/elastic/elasticsearch/issues/149663

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -37,6 +37,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -110,6 +111,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.Consumer;
 
 /**
  * CSV/TSV format reader for external datasources.
@@ -1670,7 +1672,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             context.splitStartByte(),
             chunkMode ? context.statsStripeSize() : -1L,
             context.statsFileFinal(),
-            context.statsColumnScope()
+            context.statsColumnScope(),
+            context.informationalWarningSink()
         );
     }
 
@@ -2950,7 +2953,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             long splitStartByte,
             long statsStripeSize,
             boolean statsFileFinal,
-            StripeColumnScope statsColumnScope
+            StripeColumnScope statsColumnScope,
+            @Nullable Consumer<String> warningSink
         ) {
             this.reader = reader;
             this.recordReader = recordReader;
@@ -2986,7 +2990,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     + sourceLocation
                     + "] encountered parse errors handled per policy (policy: "
                     + errorPolicy.modeName()
-                    + "); affected rows/fields are listed below"
+                    + "); affected rows/fields are listed below",
+                warningSink
             );
         }
 

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -4519,6 +4519,43 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
+     * Same shape as {@link #testWarningsIncludeRowNumber}, but with {@link FormatReadContext#informationalWarningSink()}
+     * supplied: every emitted message must route through the sink instead of {@link HeaderWarning}, since
+     * {@link CsvFormatReader#read} can be invoked from a background reader thread whose thread-local response
+     * headers never reach the client (see {@code SkipWarnings}).
+     */
+    public void testWarningsRouteThroughWarningSinkWhenSupplied() throws IOException {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            bad_id,Bob
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(100, true);
+        List<String> sunk = new ArrayList<>();
+
+        try (
+            CloseableIterator<Page> iterator = reader.read(
+                object,
+                FormatReadContext.builder().batchSize(10).errorPolicy(lenient).informationalWarningSink(sunk::add).build()
+            )
+        ) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        }
+
+        // 1 summary + 1 detail
+        assertEquals(2, sunk.size());
+        assertTrue("Summary should mention skip_row, got: " + sunk.get(0), sunk.get(0).contains("policy: skip_row"));
+        assertTrue("Detail should include row number, got: " + sunk.get(1), sunk.get(1).contains("Row [2]"));
+        assertTrue("no message should reach the thread-local response headers", drainWarnings().isEmpty());
+    }
+
+    /**
      * Reads the response-header warnings emitted on the test thread and clears them so the
      * {@link ESTestCase#after()} no-warnings post-check passes. Returns the unwrapped warning
      * messages (without the "299 Elasticsearch-... " prefix and surrounding quotes).

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -554,7 +554,8 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             context.statsBaseOffset(),
             context.statsStripeSize(),
             context.statsFileFinal(),
-            context.statsColumnScope()
+            context.statsColumnScope(),
+            context.informationalWarningSink()
         );
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -59,6 +59,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Parses NDJSON into {@link Page}s for a single input stream.
@@ -294,7 +295,7 @@ public class NdJsonPageDecoder implements Closeable {
      */
     private final BytesRef keywordScratch = new BytesRef(BytesRef.EMPTY_BYTES);
 
-    /** No-declared-date-formats convenience (tests and callers that declare no per-column {@code format}). */
+    /** No-declared-date-formats, no-sink convenience (tests and callers that need neither feature). */
     NdJsonPageDecoder(
         InputStream input,
         DateFormatter datetimeFormatter,
@@ -317,7 +318,67 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of()
+            Set.of(),
+            null
+        );
+    }
+
+    /** Test-only: back-compat overload for callers that don't need sink-routed warnings. */
+    NdJsonPageDecoder(
+        InputStream input,
+        DateFormatter datetimeFormatter,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonReaderCounters counters,
+        Map<String, String> declaredDateFormats,
+        Set<String> declaredTypeColumns
+    ) throws IOException {
+        this(
+            input,
+            datetimeFormatter,
+            attributes,
+            projectedColumns,
+            batchSize,
+            blockFactory,
+            errorPolicy,
+            sourceLocation,
+            counters,
+            declaredDateFormats,
+            declaredTypeColumns,
+            null
+        );
+    }
+
+    /** Test-only: back-compat overload for callers that don't need declared-date/type info. */
+    NdJsonPageDecoder(
+        InputStream input,
+        DateFormatter datetimeFormatter,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonReaderCounters counters,
+        @Nullable Consumer<String> warningSink
+    ) throws IOException {
+        this(
+            input,
+            datetimeFormatter,
+            attributes,
+            projectedColumns,
+            batchSize,
+            blockFactory,
+            errorPolicy,
+            sourceLocation,
+            counters,
+            Map.of(),
+            Set.of(),
+            warningSink
         );
     }
 
@@ -332,7 +393,8 @@ public class NdJsonPageDecoder implements Closeable {
         String sourceLocation,
         NdJsonReaderCounters counters,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         this(
             input,
@@ -349,11 +411,12 @@ public class NdJsonPageDecoder implements Closeable {
             counters,
             NdJsonUtils.JSON_FACTORY,
             declaredDateFormats,
-            declaredTypeColumns
+            declaredTypeColumns,
+            warningSink
         );
     }
 
-    /** No-declared-date-formats convenience for the byte[] path (see the {@code declaredDateFormats}-carrying ctor below). */
+    /** No-declared-date-formats, no-sink convenience for the byte[] path (see the fully-loaded ctor below). */
     NdJsonPageDecoder(
         byte[] data,
         int offset,
@@ -380,7 +443,8 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of()
+            Set.of(),
+            null
         );
     }
 
@@ -390,6 +454,7 @@ public class NdJsonPageDecoder implements Closeable {
      * (no buffered-bytes shuttling through {@link NdJsonUtils#moveToNextLine}) by scanning for the
      * next {@code '\n'} from the parser's current byte offset.
      */
+    /** Test-only: back-compat overload for callers that don't need sink-routed warnings. */
     NdJsonPageDecoder(
         byte[] data,
         int offset,
@@ -406,6 +471,73 @@ public class NdJsonPageDecoder implements Closeable {
         Set<String> declaredTypeColumns
     ) throws IOException {
         this(
+            data,
+            offset,
+            length,
+            datetimeFormatter,
+            attributes,
+            projectedColumns,
+            batchSize,
+            blockFactory,
+            errorPolicy,
+            sourceLocation,
+            counters,
+            declaredDateFormats,
+            declaredTypeColumns,
+            null
+        );
+    }
+
+    /** Test-only: back-compat overload for callers that don't need declared-date/type info. */
+    NdJsonPageDecoder(
+        byte[] data,
+        int offset,
+        int length,
+        DateFormatter datetimeFormatter,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonReaderCounters counters,
+        @Nullable Consumer<String> warningSink
+    ) throws IOException {
+        this(
+            data,
+            offset,
+            length,
+            datetimeFormatter,
+            attributes,
+            projectedColumns,
+            batchSize,
+            blockFactory,
+            errorPolicy,
+            sourceLocation,
+            counters,
+            Map.of(),
+            Set.of(),
+            warningSink
+        );
+    }
+
+    NdJsonPageDecoder(
+        byte[] data,
+        int offset,
+        int length,
+        DateFormatter datetimeFormatter,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonReaderCounters counters,
+        Map<String, String> declaredDateFormats,
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
+    ) throws IOException {
+        this(
             null,
             data,
             offset,
@@ -420,7 +552,8 @@ public class NdJsonPageDecoder implements Closeable {
             counters,
             NdJsonUtils.JSON_FACTORY,
             declaredDateFormats,
-            declaredTypeColumns
+            declaredTypeColumns,
+            warningSink
         );
     }
 
@@ -439,6 +572,21 @@ public class NdJsonPageDecoder implements Closeable {
         String sourceLocation,
         JsonFactory factory
     ) throws IOException {
+        this(input, attributes, projectedColumns, batchSize, blockFactory, errorPolicy, sourceLocation, factory, null);
+    }
+
+    /** Test-only: like the above, but also allows asserting on the {@link SkipWarnings} sink. */
+    NdJsonPageDecoder(
+        InputStream input,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        JsonFactory factory,
+        @Nullable Consumer<String> warningSink
+    ) throws IOException {
         this(
             input,
             null,
@@ -454,7 +602,8 @@ public class NdJsonPageDecoder implements Closeable {
             new NdJsonReaderCounters(),
             factory,
             Map.of(),
-            Set.of()
+            Set.of(),
+            warningSink
         );
     }
 
@@ -473,7 +622,8 @@ public class NdJsonPageDecoder implements Closeable {
         NdJsonReaderCounters counters,
         JsonFactory factory,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         this.jsonFactory = factory;
         this.input = input;
@@ -508,7 +658,8 @@ public class NdJsonPageDecoder implements Closeable {
                 + sourceLocation
                 + "] encountered parse errors handled per policy (policy: "
                 + errorPolicy.modeName()
-                + "); affected rows are listed below"
+                + "); affected rows are listed below",
+            warningSink
         );
 
         List<Attribute> fullSchema = attributes;

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -45,6 +46,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -215,7 +217,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         long statsBaseOffset,
         long statsStripeSize,
         boolean statsFileFinal,
-        StripeColumnScope statsColumnScope
+        StripeColumnScope statsColumnScope,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         Check.isTrue(counters != null, "counters must not be null");
@@ -251,7 +254,7 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         // mutually exclusive. The fold-in is kept as a correctness invariant for any future overlap.
         this.statsStripeBaseOffset = statsBaseOffset + skipped;
         if (trimLastPartialLine) {
-            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation, recordSplitter);
+            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation, recordSplitter, warningSink);
         }
         this.rowLimit = rowLimit;
         // ALL scope harvests min/max/null for EVERY file column, not just the projected ones. The output
@@ -306,7 +309,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 this.sourceLocation,
                 counters,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                warningSink
             );
         } else {
             // Streaming/fallback path (object too large for the fast path, unknown length, or a
@@ -328,7 +332,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 this.sourceLocation,
                 counters,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                warningSink
             );
         }
         // _rowPosition / _file.record_ref substrate: file-global per-record start offset.
@@ -785,7 +790,8 @@ final class NdJsonPageIterator extends BufferingPageIterator {
             in,
             errorPolicy,
             sourceLocation,
-            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES)
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES),
+            null
         );
     }
 
@@ -795,6 +801,16 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         String sourceLocation,
         NdJsonRecordSplitter recordSplitter
     ) {
-        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation, recordSplitter);
+        return trimLastPartialLine(in, errorPolicy, sourceLocation, recordSplitter, null);
+    }
+
+    static InputStream trimLastPartialLine(
+        InputStream in,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter,
+        @Nullable Consumer<String> warningSink
+    ) {
+        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation, recordSplitter, warningSink);
     }
 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.ndjson;
 
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.Level;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -22,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 /**
  * Wraps an NDJSON byte stream and exposes only bytes through the last {@code '\n'} in the stream,
@@ -62,12 +64,20 @@ final class TrimLastPartialLineInputStream extends InputStream {
             DEFAULT_TRIM_CHUNK_SIZE,
             errorPolicy,
             sourceLocation,
-            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES)
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES),
+            null
         );
     }
 
     TrimLastPartialLineInputStream(InputStream delegate, int chunkSize, ErrorPolicy errorPolicy, String sourceLocation) {
-        this(delegate, chunkSize, errorPolicy, sourceLocation, new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES));
+        this(
+            delegate,
+            chunkSize,
+            errorPolicy,
+            sourceLocation,
+            new NdJsonRecordSplitter(SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES),
+            null
+        );
     }
 
     TrimLastPartialLineInputStream(
@@ -76,7 +86,7 @@ final class TrimLastPartialLineInputStream extends InputStream {
         String sourceLocation,
         NdJsonRecordSplitter recordSplitter
     ) {
-        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation, recordSplitter);
+        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation, recordSplitter, null);
     }
 
     TrimLastPartialLineInputStream(
@@ -85,6 +95,27 @@ final class TrimLastPartialLineInputStream extends InputStream {
         ErrorPolicy errorPolicy,
         String sourceLocation,
         NdJsonRecordSplitter recordSplitter
+    ) {
+        this(delegate, chunkSize, errorPolicy, sourceLocation, recordSplitter, null);
+    }
+
+    TrimLastPartialLineInputStream(
+        InputStream delegate,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter,
+        @Nullable Consumer<String> warningSink
+    ) {
+        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation, recordSplitter, warningSink);
+    }
+
+    TrimLastPartialLineInputStream(
+        InputStream delegate,
+        int chunkSize,
+        ErrorPolicy errorPolicy,
+        String sourceLocation,
+        NdJsonRecordSplitter recordSplitter,
+        @Nullable Consumer<String> warningSink
     ) {
         this.delegate = delegate;
         Check.isTrue(chunkSize > 0, "chunkSize must strictly positive");
@@ -95,7 +126,8 @@ final class TrimLastPartialLineInputStream extends InputStream {
         this.recordSplitter = recordSplitter;
         this.skipWarnings = SkipWarnings.of(
             errorPolicy,
-            "NDJSON read from [" + sourceLocation + "] discarded an oversized partial line (policy: " + errorPolicy.modeName() + ")"
+            "NDJSON read from [" + sourceLocation + "] discarded an oversized partial line (policy: " + errorPolicy.modeName() + ")",
+            warningSink
         );
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.hamcrest.Matchers;
 import org.junit.After;
 
@@ -350,6 +351,38 @@ public class NdJsonPageDecoderTests extends ESTestCase {
         List<String> warnings = drainWarnings();
         assertFalse("expected a client warning for the shape conflict", warnings.isEmpty());
         assertTrue("warning should name the conflicting field, got: " + warnings, warnings.stream().anyMatch(w -> w.contains("address")));
+    }
+
+    /**
+     * Same shape conflict as {@link #testScalarWhereNestedObjectExpectedLenientWarnsAndNullFills}, but with a
+     * {@code warningSink} supplied: the decoder must route every emitted message through the sink instead of
+     * {@link HeaderWarning}, since {@link NdJsonPageDecoder}'s decode loop can run on a background reader thread
+     * whose thread-local response headers never reach the client (see {@link SkipWarnings}).
+     */
+    public void testScalarWhereNestedObjectExpectedLenientRoutesThroughWarningSink() throws IOException {
+        String ndjson = "{\"address\": {\"city\": \"NYC\"}, \"id\": 1}\n" + "{\"address\": \"unstructured\", \"id\": 2}\n";
+        List<String> sunk = new ArrayList<>();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                List.of(attribute("address.city", DataType.KEYWORD), attribute("id", DataType.INTEGER)),
+                null,
+                1024,
+                blockFactory,
+                ErrorPolicy.LENIENT,
+                "test://decode",
+                NdJsonUtils.JSON_FACTORY,
+                sunk::add
+            )
+        ) {
+            try (Page page = decoder.decodePage()) {
+                assertNotNull(page);
+            }
+        }
+
+        assertFalse("expected a client warning routed through the sink", sunk.isEmpty());
+        assertTrue("warning should name the conflicting field, got: " + sunk, sunk.stream().anyMatch(w -> w.contains("address")));
+        assertTrue("no message should reach the thread-local response headers when a sink is supplied", drainWarnings().isEmpty());
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1629,6 +1629,32 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         assertTrue("warning should name the conflicting field, got: " + warnings, warnings.stream().anyMatch(w -> w.contains("user")));
     }
 
+    /**
+     * Same fixture as {@link #testScalarThenObjectConflictLenientNullFillsAndWarns}, but with
+     * {@link FormatReadContext#informationalWarningSink()} supplied: the shape-conflict warning must route
+     * through the sink instead of {@link org.elasticsearch.common.logging.HeaderWarning}, since
+     * {@code read} can be invoked from a background reader thread whose thread-local response
+     * headers never reach the client (see {@code SkipWarnings}).
+     */
+    public void testScalarThenObjectConflictLenientRoutesThroughWarningSinkWhenSupplied() throws IOException {
+        String ndjson = """
+            {"event":1,"user":"alice"}
+            {"event":2,"user":{"id":"bob","tier":"gold"}}
+            {"event":3,"user":"carol"}
+            """;
+        var object = new BytesStorageObject("memory://scalar-then-object-sink.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        List<String> sunk = new ArrayList<>();
+        var ctx = FormatReadContext.builder().batchSize(100).errorPolicy(ErrorPolicy.LENIENT).informationalWarningSink(sunk::add).build();
+        try (var iterator = reader.read(object, ctx)) {
+            assertTrue(iterator.hasNext());
+            iterator.next();
+        }
+        assertFalse("expected a warning for the shape conflict routed through the sink", sunk.isEmpty());
+        assertTrue("warning should name the conflicting field, got: " + sunk, sunk.stream().anyMatch(w -> w.contains("user")));
+        assertTrue("no message should reach the thread-local response headers", drainWarnings().isEmpty());
+    }
+
     private static int indexOf(List<Attribute> schema, String name) {
         for (int i = 0; i < schema.size(); i++) {
             if (schema.get(i).name().equals(name)) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -101,6 +101,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 
 /**
  * FormatReader implementation for Parquet files.
@@ -1265,7 +1266,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 // own row-group ordering already matches the file footer.
                 null,
                 filter -> openParquetFileCached(object, parquetInputFile, readOptionsBuilder().withRecordFilter(filter).build()),
-                resolveErrorPolicy(context.errorPolicy())
+                resolveErrorPolicy(context.errorPolicy()),
+                context.informationalWarningSink()
             );
         } finally {
             // read_nanos covers the synchronous setup phase only; per-page decode/decompress time
@@ -1601,7 +1603,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     readOptionsBuilder().withRange(rangeStart, rangeEnd).withRecordFilter(filter).build(),
                     filterBlocksByRange(fullFooter, rangeStart, rangeEnd)
                 ),
-                resolveErrorPolicy(context.errorPolicy())
+                resolveErrorPolicy(context.errorPolicy()),
+                context.informationalWarningSink()
             );
         } finally {
             counters.addTotalReadNanos(System.nanoTime() - startNanos);
@@ -1661,7 +1664,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         ParquetMetadata fullFooter,
         long[] rangeBlockGlobalOffsets,
         FilteredReopener reopener,
-        ErrorPolicy errorPolicy
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         counters.setLateMaterializationEnabled(lateMaterializationEnabled);
         try {
@@ -1727,7 +1731,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     recordFilter,
                     rangeBlockGlobalOffsets,
                     fullFooter,
-                    errorPolicy
+                    errorPolicy,
+                    warningSink
                 );
             }
             return new ParquetColumnIterator(
@@ -1744,7 +1749,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 counters,
                 declaredDateFormats,
                 declaredTypeColumns,
-                errorPolicy
+                errorPolicy,
+                warningSink
             );
         } catch (Throwable t) {
             reader.close();
@@ -1765,7 +1771,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         FilterCompat.Filter recordFilter,
         long[] rowGroupFirstRowGlobalOverride,
         ParquetMetadata fullFooter,
-        ErrorPolicy errorPolicy
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> warningSink
     ) {
         if (inputFile instanceof ParquetStorageObjectAdapter == false) {
             throw new ElasticsearchException(
@@ -1780,7 +1787,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             reader,
             projectedAttributes,
             columnInfos,
-            declaredTypeColumns
+            declaredTypeColumns,
+            warningSink
         );
 
         // Pass the predicate column names so the metadata preload also batch-fetches dictionary
@@ -2533,7 +2541,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         ParquetFileReader reader,
         List<Attribute> attributes,
         ColumnInfo[] columnInfos,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        @Nullable Consumer<String> warningSink
     ) {
         MessageType fullSchema = reader.getFileMetaData().getSchema();
         SkipWarnings skipWarnings = null;
@@ -2559,7 +2568,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                         "Parquet file ["
                             + fileLocation
                             + "] has columns whose on-disk type is incompatible with the planner type; "
-                            + "they are returned as null"
+                            + "they are returned as null",
+                        warningSink
                     );
                 }
                 skipWarnings.add(
@@ -2682,7 +2692,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             ParquetReaderCounters counters,
             Map<String, String> declaredDateFormats,
             Set<String> declaredTypeColumns,
-            ErrorPolicy errorPolicy
+            ErrorPolicy errorPolicy,
+            @Nullable Consumer<String> warningSink
         ) {
             this.errorPolicy = errorPolicy;
             this.reader = reader;
@@ -2745,7 +2756,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             } else {
                 this.rowGroupFirstRowGlobal = null;
             }
-            validatePlannerTypesAgainstFile(logger, fileLocation, reader, attributes, columnInfos, declaredTypeColumns);
+            validatePlannerTypesAgainstFile(logger, fileLocation, reader, attributes, columnInfos, declaredTypeColumns, warningSink);
         }
 
         @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -3760,6 +3760,44 @@ public class ParquetFormatReaderTests extends ESTestCase {
         return messages;
     }
 
+    /**
+     * Same schema-mismatch scenario as {@link #testSchemaMismatchEmitsResponseWarningHeader}, but
+     * through {@link ParquetFormatReader#read(StorageObject, FormatReadContext)} with a
+     * {@link FormatReadContext#informationalWarningSink()} supplied: the mismatch warning must route through the
+     * sink instead of {@link HeaderWarning}, since {@code read} can be invoked from a background
+     * reader thread whose thread-local response headers never reach the client (see
+     * {@code SkipWarnings}).
+     */
+    public void testSchemaMismatchRoutesThroughWarningSinkWhenSupplied() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT32).named("x").named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("x", 42);
+            return List.of(g);
+        });
+        StorageObject storageObject = createStorageObject(parquetData, "s3://bucket/warn.parquet");
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        List<Attribute> plannerTypes = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.KEYWORD));
+        List<String> sunk = new ArrayList<>();
+
+        try (
+            CloseableIterator<Page> iterator = reader.read(
+                storageObject,
+                FormatReadContext.builder().batchSize(100).readSchema(plannerTypes).informationalWarningSink(sunk::add).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertTrue(page.getBlock(0).isNull(0));
+        }
+
+        // 1 summary + 1 detail
+        assertEquals("Expected summary + 1 detail, got: " + sunk, 2, sunk.size());
+        assertTrue("Summary should mention the file path, got: " + sunk.get(0), sunk.get(0).contains("s3://bucket/warn.parquet"));
+        assertTrue("Detail should mention column [x], got: " + sunk.get(1), sunk.get(1).contains("Column [x]"));
+        assertTrue("no message should reach the thread-local response headers", drainWarnings().isEmpty());
+    }
+
     public void testReadRangeSelectsCorrectRowGroups() throws Exception {
         byte[] parquetData = createWideMultiRowGroupFile(500);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -73,14 +73,18 @@ public final class AsyncExternalSourceBuffer {
     private volatile int cachedMetadataPathCount = 0;
 
     /**
-     * Client-visible partial-results warnings recorded by the background reader path — currently a
-     * streaming {@code max_record_size} truncation under a non-strict {@code error_mode} (see
-     * {@code StreamingParallelParsingCoordinator}). Producer / parse-worker threads append here off
-     * the driver thread; {@link AsyncExternalSourceOperator#close()} drains and re-emits them via
-     * {@link org.elasticsearch.common.logging.HeaderWarning} on the driver thread, whose response
-     * headers {@code DriverRunner} collects into the client response. Emitting from the forked worker
-     * thread directly would land the header on that worker's {@code ThreadContext}, which is never
-     * merged back into the response — so the warning would be invisible to the client.
+     * Client-visible warnings recorded by the background reader path — both genuine partial-results
+     * signals (currently a streaming {@code max_record_size} truncation under a non-strict
+     * {@code error_mode}, see {@code StreamingParallelParsingCoordinator}) and per-record
+     * skip/null-fill warnings relayed from format-reader {@code SkipWarnings} sinks (see
+     * {@code FormatReadContext#informationalWarningSink()} / {@code RangeReadContext#informationalWarningSink()}),
+     * which do not necessarily imply a dropped record. See {@link #recordWarning} vs {@link
+     * #recordInformationalWarning}. Producer / parse-worker threads append here off the driver thread;
+     * {@link AsyncExternalSourceOperator#close()} drains and re-emits them via {@link
+     * org.elasticsearch.common.logging.HeaderWarning} on the driver thread, whose response headers
+     * {@code DriverRunner} collects into the client response. Emitting from the forked worker thread
+     * directly would land the header on that worker's {@code ThreadContext}, which is never merged
+     * back into the response — so the warning would be invisible to the client.
      */
     private final Queue<String> pendingWarnings = new ConcurrentLinkedQueue<>();
 
@@ -118,17 +122,47 @@ public final class AsyncExternalSourceBuffer {
 
     /**
      * Records a client-visible partial-results warning to be re-emitted on the driver thread when the
-     * operator closes. Thread-safe: called from the background reader / parse-worker thread.
+     * operator closes, and flips {@link #partial}. Thread-safe: called from the background reader /
+     * parse-worker thread.
      * <p>
-     * This sink is currently wired exclusively to the lenient {@code max_record_size} truncation path
-     * (see {@code StreamingParallelParsingCoordinator#emitTruncationWarning}), so it also flips
-     * {@link #partial}: a recorded warning here always means the read returned fewer records than the
-     * source held. If a future caller routes a non-partial warning through this method, split the
-     * partial signal out into its own entry point.
+     * This sink is wired exclusively to the lenient {@code max_record_size} truncation path (see
+     * {@code StreamingParallelParsingCoordinator#emitTruncationWarning}): a recorded warning here
+     * always means the read returned fewer records than the source held. Per-record {@code SkipWarnings}
+     * warnings (row skipped or field null-filled under a lenient {@code ErrorPolicy}) must use
+     * {@link #recordInformationalWarning} instead — not because a skipped row is never a "real" partial
+     * result, but because {@link #partial} has never tracked that case (this predates warning-sink
+     * relaying entirely: on the driver thread such warnings always emitted straight to
+     * {@link org.elasticsearch.common.logging.HeaderWarning} without touching this flag). Overloading
+     * {@link #partial}'s meaning to also cover {@code SKIP_ROW} drops is a separate, pre-existing
+     * question and out of scope here.
      */
     public void recordWarning(String warning) {
         pendingWarnings.add(warning);
         partial = true;
+    }
+
+    /**
+     * Records a client-visible warning to be re-emitted on the driver thread when the operator closes,
+     * without affecting {@link #partial}. Thread-safe: called from the background reader / parse-worker
+     * thread.
+     * <p>
+     * Use this for warnings relayed from format-reader {@code SkipWarnings} sinks (see {@code
+     * FormatReadContext#informationalWarningSink()} / {@code RangeReadContext#informationalWarningSink()})
+     * — e.g. CSV/NDJSON per-record skip/null-fill handling or Parquet on-disk/planner type mismatches.
+     * This preserves these warnings' pre-existing behavior of never flipping {@link #partial} (previously
+     * they only ever reached {@link org.elasticsearch.common.logging.HeaderWarning} directly, which has
+     * no notion of {@link #partial} either); this method only fixes their delivery when the read runs
+     * off the driver thread, without changing what they signal. See {@link #recordWarning} for the one
+     * warning that has always mapped to {@link #partial}.
+     * <p>
+     * Each {@code SkipWarnings} instance caps its own per-event details at
+     * {@code SkipWarnings.MAX_ADDED_WARNINGS} (20), but that cap is per reader instance, not per query:
+     * a parallel or macro-split read constructs one {@code SkipWarnings} per chunk/segment, so a single
+     * read can add well more than 20 entries to {@link #pendingWarnings} here — this queue itself is
+     * unbounded.
+     */
+    public void recordInformationalWarning(String warning) {
+        pendingWarnings.add(warning);
     }
 
     /** Removes and returns the next recorded warning, or {@code null} if none remain. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1874,7 +1874,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     fileSplit.offset(),
                     rangeEnd,
                     PhysicalNames.translateSchema(perFileResolvedAttributes, renames),
-                    errorPolicy
+                    errorPolicy,
+                    state.buffer::recordInformationalWarning
                 );
                 if (fileContext != null) {
                     rangeCtx.setFileContext(fileContext);
@@ -1939,7 +1940,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     PhysicalNames.translateSchema(perFileReadSchema, renames),
                     fileSplit.offset(),
                     state.buffer.capturedSourceMetadataSink(),
-                    state.buffer::recordWarning
+                    state.buffer::recordWarning,
+                    state.buffer::recordInformationalWarning
                 );
                 if (pages == null) {
                     boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
@@ -1964,6 +1966,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         // its trailing stripe to EOF).
                         .stats(fileSplit.offset(), statsStripeSize, splitIsFileFinal)
                         .statsColumnScope(statsColumnScope)
+                        .informationalWarningSink(state.buffer::recordInformationalWarning)
                         .build();
                     pages = fileReader.read(obj, ctx);
                 }
@@ -2135,7 +2138,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 PhysicalNames.translateSchema(perFileReadSchema, renames),
                 0L,
                 state.buffer.capturedSourceMetadataSink(),
-                state.buffer::recordWarning
+                state.buffer::recordWarning,
+                state.buffer::recordInformationalWarning
             );
             if (pages == null) {
                 int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining;
@@ -2147,6 +2151,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .readSchema(PhysicalNames.translateSchema(perFileReadSchema, renames))
                     .maxRecordBytes(maxRecordBytes)
                     .statsColumnScope(statsColumnScope)
+                    .informationalWarningSink(state.buffer::recordInformationalWarning)
                     .build();
                 pages = fileReader.read(obj, ctx);
             }
@@ -2226,6 +2231,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             .errorPolicy(errorPolicy)
             .maxRecordBytes(maxRecordBytes)
             .statsColumnScope(statsColumnScope)
+            .informationalWarningSink(buffer::recordInformationalWarning)
             .build();
         FormatReader reader = readerWithDynamicThreshold(formatReader);
         reader.readAsync(storageObject, ctx, executor, ActionListener.wrap(iterator -> {
@@ -2267,7 +2273,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 null,
                 0L,
                 buffer.capturedSourceMetadataSink(),
-                buffer::recordWarning
+                buffer::recordWarning,
+                buffer::recordInformationalWarning
             );
             if (pages == null) {
                 FormatReadContext ctx = FormatReadContext.builder()
@@ -2277,6 +2284,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .errorPolicy(errorPolicy)
                     .maxRecordBytes(maxRecordBytes)
                     .statsColumnScope(statsColumnScope)
+                    .informationalWarningSink(buffer::recordInformationalWarning)
                     .build();
                 pages = reader.read(storageObject, ctx);
             }
@@ -2516,7 +2524,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         @Nullable List<Attribute> perFileReadSchema,
         long baseFileOffset,
         @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
-        @Nullable Consumer<String> partialResultsWarningSink
+        @Nullable Consumer<String> partialResultsWarningSink,
+        @Nullable Consumer<String> warningSink
     ) throws IOException {
         if (rowLimit != FormatReader.NO_LIMIT || parsingParallelism <= 1) {
             return null;
@@ -2546,7 +2555,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     statsStripeSize,
                     statsColumnScope,
                     splitIsFileFinal,
-                    externalSourceMetrics
+                    externalSourceMetrics,
+                    warningSink
                 );
             }
             case STREAM_ONLY_COMPRESSED -> {
@@ -2588,7 +2598,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         captureSink,
                         statsStripeSize,
                         statsColumnScope,
-                        partialResultsWarningSink,
+                        new StreamingParallelParsingCoordinator.WarningSinks(partialResultsWarningSink, warningSink),
                         streamingSegmentatorAdmission
                     );
                 } catch (Exception e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
@@ -42,6 +43,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Coordinates parallel parsing of a single file by splitting it into byte-range
@@ -403,6 +405,61 @@ public final class ParallelParsingCoordinator {
         boolean splitIsFileFinal,
         ExternalSourceMetrics metrics
     ) throws IOException {
+        return parallelRead(
+            reader,
+            storageObject,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            errorPolicy,
+            splitStartsAtRecordBoundary,
+            splitIncludesFileLeader,
+            readSchema,
+            baseFileOffset,
+            maxConcurrentOpenSegments,
+            captureSink,
+            maxRecordBytes,
+            statsStripeSize,
+            statsColumnScope,
+            splitIsFileFinal,
+            metrics,
+            null
+        );
+    }
+
+    /**
+     * As the {@code metrics} overload, plus a relay for client-visible lenient-policy warnings raised
+     * while parsing a segment (see {@link SkipWarnings}). Segment parsing runs on {@code executor}
+     * worker threads, so a direct {@link org.elasticsearch.common.logging.HeaderWarning} call there
+     * would attach to the wrong thread's response headers and be dropped; production passes
+     * {@code AsyncExternalSourceBuffer::recordInformationalWarning} so the operator can re-emit it on
+     * the driver thread without flipping the response's {@code is_partial} flag (these are per-record
+     * skip/null-fill warnings, not a truncation of the whole read — see
+     * {@code AsyncExternalSourceBuffer#recordWarning} for that case). Pass {@code null} to fall back to
+     * a direct {@code HeaderWarning} call on the parsing thread (tests, benchmarks).
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        StorageObject storageObject,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy,
+        boolean splitStartsAtRecordBoundary,
+        boolean splitIncludesFileLeader,
+        List<Attribute> readSchema,
+        long baseFileOffset,
+        int maxConcurrentOpenSegments,
+        @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
+        int maxRecordBytes,
+        long statsStripeSize,
+        StripeColumnScope statsColumnScope,
+        boolean splitIsFileFinal,
+        ExternalSourceMetrics metrics,
+        @Nullable Consumer<String> warningSink
+    ) throws IOException {
         long fileLength = storageObject.length();
         long minSegment = reader.minimumSegmentSize();
 
@@ -434,6 +491,7 @@ public final class ParallelParsingCoordinator {
             // macro-split is never file-final — a later split supplies the terminal stripe.
             .stats(baseFileOffset, statsStripeSize, splitIsFileFinal)
             .statsColumnScope(statsColumnScope)
+            .informationalWarningSink(warningSink)
             .build();
         if (parallelism <= 1 || fileLength < minSegment * 2) {
             return parallelReader.read(storageObject, baseCtx);
@@ -463,7 +521,8 @@ public final class ParallelParsingCoordinator {
             statsStripeSize,
             statsColumnScope,
             splitIsFileFinal,
-            metrics
+            metrics,
+            warningSink
         );
         // Fully constructed and published before any worker is dispatched — see AsReadyParallelIterator#start.
         iterator.start();
@@ -604,6 +663,13 @@ public final class ParallelParsingCoordinator {
         private final boolean splitIsFileFinal;
         /** Node telemetry sink for the {@code reader.pool.rejected} event; {@link ExternalSourceMetrics#NOOP} when unwired. */
         private final ExternalSourceMetrics metrics;
+        /**
+         * Relay for client-visible {@link SkipWarnings} messages raised while parsing a segment; see
+         * {@link #parallelRead}'s {@code warningSink} parameter. {@code null} falls back to a direct
+         * {@link org.elasticsearch.common.logging.HeaderWarning} call on the segment worker thread.
+         */
+        @Nullable
+        private final Consumer<String> warningSink;
 
         private final List<long[]> segments;
         private final Executor executor;
@@ -655,7 +721,8 @@ public final class ParallelParsingCoordinator {
             long statsStripeSize,
             StripeColumnScope statsColumnScope,
             boolean splitIsFileFinal,
-            ExternalSourceMetrics metrics
+            ExternalSourceMetrics metrics,
+            @Nullable Consumer<String> warningSink
         ) {
             this.reader = reader;
             this.storageObject = storageObject;
@@ -671,6 +738,7 @@ public final class ParallelParsingCoordinator {
             this.statsStripeSize = statsStripeSize;
             this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
             this.metrics = metrics == null ? ExternalSourceMetrics.NOOP : metrics;
+            this.warningSink = warningSink;
             this.segments = segments;
             this.executor = executor;
             // Single clamp site for the effective window: the configured cap, never more than the parser
@@ -797,6 +865,7 @@ public final class ParallelParsingCoordinator {
                 .maxRecordBytes(maxRecordBytes)
                 .stats(segmentFileOffset, statsStripeSize, statsFileFinal)
                 .statsColumnScope(statsColumnScope)
+                .informationalWarningSink(warningSink)
                 .build();
 
             // Bind the consumer-owned sink on this worker so the reader's close hook (which publishes its

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -82,6 +82,29 @@ public final class StreamingParallelParsingCoordinator {
     private StreamingParallelParsingCoordinator() {}
 
     /**
+     * Bundles the two independent, easily-confused warning relays a streaming parallel read may need
+     * to thread onto worker threads, as a single typed parameter — two bare adjacent
+     * {@code Consumer<String>} parameters/fields invite silent transposition at a call site.
+     *
+     * @param partialResultsWarningSink receives a single client-visible message if a non-strict
+     *                                  {@link ErrorPolicy} truncates the read at a {@code max_record_size}
+     *                                  cap-hit — a genuine partial-results signal. Production passes
+     *                                  {@link AsyncExternalSourceBuffer#recordWarning} so the operator can
+     *                                  re-emit it on the driver thread (the segmentator runs on a forked
+     *                                  worker whose response headers never reach the client — see #835).
+     * @param informationalWarningSink  the unrelated, generic per-format relay (see
+     *                                  {@link FormatReadContext#informationalWarningSink()}) for warnings a
+     *                                  chunk's own reader raises while decoding (e.g. a malformed row skipped
+     *                                  or a field null-filled) — these do not carry the same "fewer records
+     *                                  than the source held" guarantee, so they must not be conflated with
+     *                                  {@code partialResultsWarningSink}. Production passes
+     *                                  {@link AsyncExternalSourceBuffer#recordInformationalWarning}.
+     */
+    public record WarningSinks(@Nullable Consumer<String> partialResultsWarningSink, @Nullable Consumer<String> informationalWarningSink) {
+        public static final WarningSinks NONE = new WarningSinks(null, null);
+    }
+
+    /**
      * Creates a parallel-parsing iterator over a sequential decompressed stream.
      *
      * @param reader              the segmentable format reader (provides record boundary semantics)
@@ -117,8 +140,7 @@ public final class StreamingParallelParsingCoordinator {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
-            null,
-            StreamingSegmentatorAdmission.unbounded()
+            WarningSinks.NONE
         );
     }
 
@@ -144,11 +166,11 @@ public final class StreamingParallelParsingCoordinator {
      * {@link ParallelParsingCoordinator}).
      * <p>
      * {@code partialResultsWarningSink} receives a single client-visible message if a non-strict
-     * {@link ErrorPolicy} truncates the read at a {@code max_record_size} cap-hit. Production passes
-     * {@link AsyncExternalSourceBuffer#recordWarning} so the operator can re-emit it on the driver
-     * thread (the segmentator runs on a forked worker whose response headers never reach the client —
-     * see #835). Pass {@code null} to fall back to a direct {@link HeaderWarning} on the current thread
-     * (tests, benchmarks).
+     * {@link ErrorPolicy} truncates the read at a {@code max_record_size} cap-hit — a genuine partial-
+     * results signal. Production passes {@link AsyncExternalSourceBuffer#recordWarning} so the operator
+     * can re-emit it on the driver thread (the segmentator runs on a forked worker whose response
+     * headers never reach the client — see #835). Pass {@code null} to fall back to a direct
+     * {@link HeaderWarning} on the current thread (tests, benchmarks).
      */
     public static CloseableIterator<Page> parallelRead(
         SegmentableFormatReader reader,
@@ -166,6 +188,97 @@ public final class StreamingParallelParsingCoordinator {
         long statsStripeSize,
         StripeColumnScope statsColumnScope,
         @Nullable Consumer<String> partialResultsWarningSink,
+        StreamingSegmentatorAdmission admission
+    ) throws IOException {
+        return parallelRead(
+            reader,
+            decompressedStream,
+            storageObject,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            errorPolicy,
+            readSchema,
+            baseFileOffset,
+            maxRecordBytes,
+            captureSink,
+            statsStripeSize,
+            statsColumnScope,
+            new WarningSinks(partialResultsWarningSink, null)
+        );
+    }
+
+    /**
+     * As the above, plus {@code warningSinks.informationalWarningSink()} — see {@link WarningSinks}'
+     * Javadoc. Kept as a separate overload so the many existing truncation-focused callers (tests,
+     * benchmarks) that don't care about generic per-format warnings are unaffected.
+     * <p>
+     * Supplies an {@link StreamingSegmentatorAdmission#unbounded()} controller: the segmentator is
+     * dispatched immediately, matching the pre-admission behavior. Retained for tests and benchmarks
+     * running on an isolated, generously-sized pool where segmentator saturation cannot arise;
+     * production always threads the per-node admission gate via the overload below.
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        InputStream decompressedStream,
+        @Nullable StorageObject storageObject,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy,
+        @Nullable List<Attribute> readSchema,
+        long baseFileOffset,
+        int maxRecordBytes,
+        @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
+        long statsStripeSize,
+        StripeColumnScope statsColumnScope,
+        WarningSinks warningSinks
+    ) throws IOException {
+        return parallelRead(
+            reader,
+            decompressedStream,
+            storageObject,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            errorPolicy,
+            readSchema,
+            baseFileOffset,
+            maxRecordBytes,
+            captureSink,
+            statsStripeSize,
+            statsColumnScope,
+            warningSinks,
+            StreamingSegmentatorAdmission.unbounded()
+        );
+    }
+
+    /**
+     * Full-control overload that also accepts an explicit {@link StreamingSegmentatorAdmission}
+     * controller, bounding how many segmentators occupy the shared executor at once (see
+     * {@link StreamingSegmentatorAdmission}). Production always threads the per-node admission gate;
+     * the overload above supplies {@link StreamingSegmentatorAdmission#unbounded()} for tests and
+     * benchmarks running on an isolated, generously-sized pool where segmentator saturation cannot arise.
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        InputStream decompressedStream,
+        @Nullable StorageObject storageObject,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy,
+        @Nullable List<Attribute> readSchema,
+        long baseFileOffset,
+        int maxRecordBytes,
+        @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
+        long statsStripeSize,
+        StripeColumnScope statsColumnScope,
+        WarningSinks warningSinks,
         StreamingSegmentatorAdmission admission
     ) throws IOException {
         if (logger.isDebugEnabled()) {
@@ -193,6 +306,7 @@ public final class StreamingParallelParsingCoordinator {
                 .maxRecordBytes(maxRecordBytes)
                 .stats(baseFileOffset, statsStripeSize, true)
                 .statsColumnScope(statsColumnScope)
+                .informationalWarningSink(warningSinks.informationalWarningSink())
                 .build();
             return reader.read(new InputStreamStorageObject(decompressedStream), ctx);
         }
@@ -212,51 +326,8 @@ public final class StreamingParallelParsingCoordinator {
             captureSink,
             statsStripeSize,
             statsColumnScope,
-            partialResultsWarningSink,
+            warningSinks,
             admission
-        );
-    }
-
-    /**
-     * Convenience overload that supplies an {@link StreamingSegmentatorAdmission#unbounded()} controller: the
-     * segmentator is dispatched immediately, matching the pre-admission behavior. Retained for tests and benchmarks
-     * running on an isolated, generously-sized pool where segmentator saturation cannot arise; production always
-     * threads the per-node admission gate.
-     */
-    public static CloseableIterator<Page> parallelRead(
-        SegmentableFormatReader reader,
-        InputStream decompressedStream,
-        @Nullable StorageObject storageObject,
-        List<String> projectedColumns,
-        int batchSize,
-        int parallelism,
-        Executor executor,
-        ErrorPolicy errorPolicy,
-        @Nullable List<Attribute> readSchema,
-        long baseFileOffset,
-        int maxRecordBytes,
-        @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
-        long statsStripeSize,
-        StripeColumnScope statsColumnScope,
-        @Nullable Consumer<String> partialResultsWarningSink
-    ) throws IOException {
-        return parallelRead(
-            reader,
-            decompressedStream,
-            storageObject,
-            projectedColumns,
-            batchSize,
-            parallelism,
-            executor,
-            errorPolicy,
-            readSchema,
-            baseFileOffset,
-            maxRecordBytes,
-            captureSink,
-            statsStripeSize,
-            statsColumnScope,
-            partialResultsWarningSink,
-            StreamingSegmentatorAdmission.unbounded()
         );
     }
 
@@ -291,13 +362,18 @@ public final class StreamingParallelParsingCoordinator {
         @Nullable
         private final ConcurrentMap<String, List<Map<String, Object>>> captureSink;
         /**
-         * Receives the truncation warning when a non-strict policy converts a {@code max_record_size}
-         * cap-hit into a graceful stop. Production wires {@link AsyncExternalSourceBuffer#recordWarning}
-         * so the operator re-emits it on the driver thread; {@code null} falls back to a direct
-         * {@link HeaderWarning} on the segmentator thread (tests / benchmarks). See {@link #emitTruncationWarning}.
+         * The two independent warning relays this iterator's workers may need — see {@link WarningSinks}.
+         * {@link WarningSinks#partialResultsWarningSink()} receives the truncation warning when a
+         * non-strict policy converts a {@code max_record_size} cap-hit into a graceful stop (production
+         * wires {@link AsyncExternalSourceBuffer#recordWarning}; {@code null} falls back to a direct
+         * {@link HeaderWarning} on the segmentator thread — tests / benchmarks. See
+         * {@link #emitTruncationWarning}). {@link WarningSinks#informationalWarningSink()} is the
+         * unrelated, generic per-format relay (see {@link FormatReadContext#informationalWarningSink()})
+         * for warnings a chunk's own reader raises while decoding (e.g. a malformed row skipped or a
+         * field null-filled) — these do not necessarily mean the read returned fewer records than the
+         * source held, so they must not be conflated with the truncation sink.
          */
-        @Nullable
-        private final Consumer<String> partialResultsWarningSink;
+        private final WarningSinks warningSinks;
         /** Compressed file being decompressed; {@code null} in tests that only supply a stream. */
         @Nullable
         private final StorageObject storageObject;
@@ -402,7 +478,7 @@ public final class StreamingParallelParsingCoordinator {
             @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
             long statsStripeSize,
             StripeColumnScope statsColumnScope,
-            @Nullable Consumer<String> partialResultsWarningSink
+            WarningSinks warningSinks
         ) {
             this(
                 reader,
@@ -419,7 +495,7 @@ public final class StreamingParallelParsingCoordinator {
                 captureSink,
                 statsStripeSize,
                 statsColumnScope,
-                partialResultsWarningSink,
+                warningSinks,
                 StreamingSegmentatorAdmission.unbounded()
             );
         }
@@ -439,7 +515,7 @@ public final class StreamingParallelParsingCoordinator {
             @Nullable ConcurrentMap<String, List<Map<String, Object>>> captureSink,
             long statsStripeSize,
             StripeColumnScope statsColumnScope,
-            @Nullable Consumer<String> partialResultsWarningSink,
+            WarningSinks warningSinks,
             StreamingSegmentatorAdmission admission
         ) {
             this.admission = admission;
@@ -454,7 +530,7 @@ public final class StreamingParallelParsingCoordinator {
             this.captureSink = captureSink;
             this.statsStripeSize = statsStripeSize;
             this.statsColumnScope = statsColumnScope != null ? statsColumnScope : StripeColumnScope.PROJECTED;
-            this.partialResultsWarningSink = partialResultsWarningSink;
+            this.warningSinks = warningSinks;
             this.bufferPoolSize = parallelism + 1;
             this.pageQueueRingSize = parallelism + 1;
 
@@ -555,7 +631,7 @@ public final class StreamingParallelParsingCoordinator {
          * i.e. the point at which good data ended — not where scanning gave up; it advances only after
          * a successful dispatch, so it is a stable "results truncated here" marker.
          * <p>
-         * The message is routed through {@link #partialResultsWarningSink} when present so the operator
+         * The message is routed through {@link WarningSinks#partialResultsWarningSink()} when present so the operator
          * can re-emit it on the driver thread and the header actually reaches the client (the segmentator
          * runs on a forked worker whose response headers are never merged back — see #835). Callers
          * without a sink (tests, benchmarks) fall back to a direct {@link HeaderWarning} on the current
@@ -570,6 +646,7 @@ public final class StreamingParallelParsingCoordinator {
                 + errorPolicy.modeName()
                 + "): "
                 + causeMessage;
+            Consumer<String> partialResultsWarningSink = warningSinks.partialResultsWarningSink();
             if (partialResultsWarningSink != null) {
                 partialResultsWarningSink.accept(warning);
             } else {
@@ -866,6 +943,7 @@ public final class StreamingParallelParsingCoordinator {
                     .maxRecordBytes(maxRecordBytes)
                     .stats(chunkFileGlobalStart, statsStripeSize, chunk.last())
                     .statsColumnScope(statsColumnScope)
+                    .informationalWarningSink(warningSinks.informationalWarningSink())
                     .build();
                 // Bind the consumer-owned sink on this worker so the reader's close hook reaches the
                 // same map the consumer-thread StatsCapturingIterator binds. The pages iterator is

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -11,6 +11,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Immutable context for a single {@link FormatReader#read} or {@link FormatReader#readAsync} call.
@@ -79,6 +80,17 @@ import java.util.List;
  *                         {@link StripeColumnScope#PROJECTED} (back-compat for call sites that predate the
  *                         setting); the compact constructor collapses {@code null} to that default so
  *                         readers do one check.
+ * @param informationalWarningSink optional relay for client-visible lenient-policy warnings (see
+ *                         {@link SkipWarnings}) raised while reading. {@code null} means the reader
+ *                         should fall back to emitting warnings directly via {@link
+ *                         org.elasticsearch.common.logging.HeaderWarning}, which is only correct when
+ *                         the read runs on the request/driver thread. Callers that dispatch reads to a
+ *                         background thread (e.g. {@code AsyncExternalSourceOperatorFactory}) must set
+ *                         this to a sink — typically {@code AsyncExternalSourceBuffer::recordInformationalWarning},
+ *                         preserving these warnings' pre-existing behavior of never flipping the response's
+ *                         {@code is_partial} flag (see {@code AsyncExternalSourceBuffer#recordWarning} for
+ *                         the one warning that does) — so the warning is relayed back and re-emitted on
+ *                         the correct thread instead of being silently dropped.
  */
 public record FormatReadContext(
     List<String> projectedColumns,
@@ -94,7 +106,8 @@ public record FormatReadContext(
     long statsBaseOffset,
     long statsStripeSize,
     boolean statsFileFinal,
-    StripeColumnScope statsColumnScope
+    StripeColumnScope statsColumnScope,
+    @Nullable Consumer<String> informationalWarningSink
 ) {
 
     public FormatReadContext {
@@ -138,7 +151,8 @@ public record FormatReadContext(
             statsBaseOffset,
             statsStripeSize,
             statsFileFinal,
-            statsColumnScope
+            statsColumnScope,
+            informationalWarningSink
         );
     }
 
@@ -160,7 +174,8 @@ public record FormatReadContext(
             statsBaseOffset,
             statsStripeSize,
             statsFileFinal,
-            statsColumnScope
+            statsColumnScope,
+            informationalWarningSink
         );
     }
 
@@ -182,7 +197,8 @@ public record FormatReadContext(
             statsBaseOffset,
             statsStripeSize,
             statsFileFinal,
-            statsColumnScope
+            statsColumnScope,
+            informationalWarningSink
         );
     }
 
@@ -209,6 +225,8 @@ public record FormatReadContext(
         private long statsStripeSize = -1L;
         private boolean statsFileFinal = false;
         private StripeColumnScope statsColumnScope = StripeColumnScope.PROJECTED;
+        @Nullable
+        private Consumer<String> informationalWarningSink = null;
 
         private Builder() {}
 
@@ -291,6 +309,15 @@ public record FormatReadContext(
             return this;
         }
 
+        /**
+         * See {@link FormatReadContext#informationalWarningSink()}; pass {@code null} for
+         * direct-to-HeaderWarning emission.
+         */
+        public Builder informationalWarningSink(@Nullable Consumer<String> informationalWarningSink) {
+            this.informationalWarningSink = informationalWarningSink;
+            return this;
+        }
+
         public FormatReadContext build() {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive, got: " + batchSize);
@@ -309,7 +336,8 @@ public record FormatReadContext(
                 statsBaseOffset,
                 statsStripeSize,
                 statsFileFinal,
-                statsColumnScope
+                statsColumnScope,
+                informationalWarningSink
             );
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
@@ -11,6 +11,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Context for a single {@link RangeAwareFormatReader#readRange} call. Bundles the per-split
@@ -24,6 +25,9 @@ public final class RangeReadContext {
     private final long rangeEnd;
     private final List<Attribute> resolvedAttributes;
     private final ErrorPolicy errorPolicy;
+    /** See {@link #informationalWarningSink()}. */
+    @Nullable
+    private final Consumer<String> informationalWarningSink;
     /**
      * Opaque file-level context, single-writer/single-reader, carried by the owning producer across successive readRange calls.
      */
@@ -38,12 +42,30 @@ public final class RangeReadContext {
         List<Attribute> resolvedAttributes,
         ErrorPolicy errorPolicy
     ) {
+        this(projectedColumns, batchSize, rangeStart, rangeEnd, resolvedAttributes, errorPolicy, null);
+    }
+
+    /**
+     * As the above, plus {@code informationalWarningSink} — see {@link #informationalWarningSink()}.
+     * Kept as a separate constructor so the many existing callers (tests, benchmarks) that don't
+     * care about relaying warnings off this thread are unaffected.
+     */
+    public RangeReadContext(
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> informationalWarningSink
+    ) {
         this.projectedColumns = projectedColumns;
         this.batchSize = batchSize;
         this.rangeStart = rangeStart;
         this.rangeEnd = rangeEnd;
         this.resolvedAttributes = resolvedAttributes;
         this.errorPolicy = errorPolicy;
+        this.informationalWarningSink = informationalWarningSink;
     }
 
     public List<String> projectedColumns() {
@@ -68,6 +90,20 @@ public final class RangeReadContext {
 
     public ErrorPolicy errorPolicy() {
         return errorPolicy;
+    }
+
+    /**
+     * Optional relay for client-visible lenient-policy warnings (see {@code SkipWarnings}) raised
+     * while reading this range. {@code null} means the reader should fall back to emitting warnings
+     * directly via {@link org.elasticsearch.common.logging.HeaderWarning}, which is only correct when
+     * the read runs on the request/driver thread. Callers that dispatch {@code readRange} to a
+     * background thread (e.g. {@code AsyncExternalSourceOperatorFactory}) must set this to a sink so
+     * the warning is relayed back and re-emitted on the correct thread instead of being silently
+     * dropped. See {@link FormatReadContext#informationalWarningSink()} for the non-range-read counterpart.
+     */
+    @Nullable
+    public Consumer<String> informationalWarningSink() {
+        return informationalWarningSink;
     }
 
     @Nullable

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.core.Nullable;
+
+import java.util.function.Consumer;
 
 /**
  * Collects response {@code Warning} headers for datasource read paths that skip a malformed input
@@ -18,14 +21,21 @@ import org.elasticsearch.common.logging.HeaderWarning;
  * details. Per-event details are capped at {@link #MAX_ADDED_WARNINGS}; on overflow a single
  * "further warnings suppressed" entry is emitted so clients know more were dropped.
  * <p>
- * Writes go through {@link HeaderWarning#addWarning(String, Object...)} which attaches them to the
- * current thread's response headers; if no thread context is bound (e.g. in unit tests that don't
- * care), the call is a no-op. Instances are stateful and not thread-safe: create one per reader
- * iterator or decoder.
+ * By default, writes go through {@link HeaderWarning#addWarning(String, Object...)} which attaches
+ * them to the current thread's response headers; if no thread context is bound (e.g. in unit tests
+ * that don't care), the call is a no-op. This is only correct when {@link #add(String)} is called on
+ * a thread whose {@code ThreadContext} response headers actually feed the client response (e.g. the
+ * originating request thread). Readers whose decode loop can run on a different thread (e.g. a
+ * background reader thread wrapped by {@code AsyncExternalSourceOperatorFactory}) must instead supply
+ * a {@code sink} — typically {@code AsyncExternalSourceBuffer::recordInformationalWarning} — via
+ * {@link #SkipWarnings(String, Consumer)} / {@link #of(ErrorPolicy, String, Consumer)} so the message
+ * is relayed and re-emitted on the correct thread instead of being silently dropped. Instances are
+ * stateful and not thread-safe: create one per reader iterator or decoder.
  * <p>
- * Callers working against an {@link ErrorPolicy} should use {@link #of(ErrorPolicy, String)} to
- * obtain either a live collector or the shared {@link #NOOP} sink, so that call sites never have
- * to null-guard subsequent {@link #add(String)} invocations.
+ * Callers working against an {@link ErrorPolicy} should use {@link #of(ErrorPolicy, String)} (or the
+ * sink-aware {@link #of(ErrorPolicy, String, Consumer)}) to obtain either a live collector or the
+ * shared {@link #NOOP} sink, so that call sites never have to null-guard subsequent {@link #add(String)}
+ * invocations.
  * <p>
  * This utility lives alongside {@link ErrorPolicy} in the {@code spi} package because datasource
  * plugins may need to emit the same shape of warnings from outside this module; it is a concrete
@@ -46,13 +56,30 @@ public class SkipWarnings {
     };
 
     private final String summary;
+    /**
+     * Where emitted messages go. {@code null} (the default) preserves the original direct-to-
+     * {@link HeaderWarning} behavior, which is only safe on a thread whose response headers are
+     * actually collected into the client response.
+     */
+    @Nullable
+    private final Consumer<String> sink;
     // Mutable state: not thread-safe, one instance per reader iterator/decoder.
     private int added;
     private boolean summaryEmitted;
     private boolean overflowEmitted;
 
     public SkipWarnings(String summary) {
+        this(summary, null);
+    }
+
+    /**
+     * @param sink when non-{@code null}, every emitted message is handed to this consumer instead of
+     *             {@link HeaderWarning#addWarning(String, Object...)}. Use this on any code path whose
+     *             {@link #add(String)} calls may run off the request/driver thread.
+     */
+    public SkipWarnings(String summary, @Nullable Consumer<String> sink) {
         this.summary = summary;
+        this.sink = sink;
     }
 
     /**
@@ -60,7 +87,15 @@ public class SkipWarnings {
      * to emit a warning), or a fresh live collector seeded with {@code summary} otherwise.
      */
     public static SkipWarnings of(ErrorPolicy policy, String summary) {
-        return policy.isStrict() ? NOOP : new SkipWarnings(summary);
+        return of(policy, summary, null);
+    }
+
+    /**
+     * Like {@link #of(ErrorPolicy, String)}, but routes emitted messages through {@code sink} instead
+     * of directly through {@link HeaderWarning}. See {@link #SkipWarnings(String, Consumer)}.
+     */
+    public static SkipWarnings of(ErrorPolicy policy, String summary, @Nullable Consumer<String> sink) {
+        return policy.isStrict() ? NOOP : new SkipWarnings(summary, sink);
     }
 
     /**
@@ -73,15 +108,23 @@ public class SkipWarnings {
             // Use the no-varargs overload so HeaderWarning treats both summary and detail as plain
             // strings (LoggerMessageFormat#format early-returns when argArray is empty); this keeps
             // user data containing '{' or '}' from being reinterpreted as a placeholder pattern.
-            HeaderWarning.addWarning(summary);
+            emit(summary);
             summaryEmitted = true;
         }
         if (added < MAX_ADDED_WARNINGS) {
-            HeaderWarning.addWarning(detail);
+            emit(detail);
             added++;
         } else if (overflowEmitted == false) {
-            HeaderWarning.addWarning("... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)");
+            emit("... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)");
             overflowEmitted = true;
+        }
+    }
+
+    private void emit(String message) {
+        if (sink != null) {
+            sink.accept(message);
+        } else {
+            HeaderWarning.addWarning(message);
         }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -2519,6 +2519,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 null,
                 0L,
                 null,
+                null,
                 null
             )
         );
@@ -2546,6 +2547,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 true,
                 null,
                 0L,
+                null,
                 null,
                 null
             );
@@ -2576,7 +2578,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
 
         IOException thrown = expectThrows(
             IOException.class,
-            () -> factory.openWithParallelism(cdr, object, List.of("a"), ErrorPolicy.STRICT, false, true, true, null, 0L, null, null)
+            () -> factory.openWithParallelism(cdr, object, List.of("a"), ErrorPolicy.STRICT, false, true, true, null, 0L, null, null, null)
         );
         assertEquals("decompress failed", thrown.getMessage());
         assertTrue("raw stream must be aborted when decompression fails", tracking.aborted.get());
@@ -2603,6 +2605,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 true,
                 null,
                 0L,
+                null,
                 null,
                 null
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -186,7 +186,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 sink,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
             );
             try (CloseableIterator<Page> iter = StatsCapturingIterator.wrap(outer, sink)) {
                 while (iter.hasNext()) {
@@ -246,7 +246,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 sink,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
             );
             CloseableIterator<Page> iter = StatsCapturingIterator.wrap(outer, sink);
             // Consume one page, then close without draining — an early termination.
@@ -446,7 +446,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     sink,
                     64L, // stripe addressing active
                     StripeColumnScope.PROJECTED,
-                    null
+                    StreamingParallelParsingCoordinator.WarningSinks.NONE
                 )
             );
 
@@ -1074,7 +1074,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                         null,
                         -1L,
                         StripeColumnScope.PROJECTED,
-                        null,
+                        StreamingParallelParsingCoordinator.WarningSinks.NONE,
                         admission
                     )
                 );
@@ -1295,7 +1295,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(iterator));
             String chain = ex.toString() + (ex.getCause() != null ? " | cause: " + ex.getCause() : "");
@@ -1344,7 +1344,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
             );
             RuntimeException ex = expectThrows(RuntimeException.class, () -> collectLines(strictIterator));
             String chain = ex.toString() + (ex.getCause() != null ? " | cause: " + ex.getCause() : "");
@@ -1375,7 +1375,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                null
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
             );
             List<String> got = collectLines(lenientIterator);
             assertEquals("non-strict policy must return the records parsed before the cap-hit", leadingRecords, got.size());
@@ -1423,7 +1423,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 null,
                 -1L,
                 StripeColumnScope.PROJECTED,
-                sink::add
+                new StreamingParallelParsingCoordinator.WarningSinks(sink::add, null)
             );
             List<String> got = collectLines(iterator);
             assertEquals("an undelimitable first record yields no rows under truncation", 0, got.size());
@@ -1472,7 +1472,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             null,
             -1L,
             StripeColumnScope.PROJECTED,
-            null
+            StreamingParallelParsingCoordinator.WarningSinks.NONE
         );
         List<String> got = collectLines(iterator);
         assertEquals("an undelimitable first record yields no rows under truncation", 0, got.size());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SkipWarningsTests extends ESTestCase {
@@ -78,6 +79,51 @@ public class SkipWarningsTests extends ESTestCase {
         assertEquals(2, emitted.size());
         assertEquals("live summary", emitted.get(0));
         assertEquals("a detail", emitted.get(1));
+    }
+
+    /**
+     * A supplied sink must receive every emitted message instead of {@link HeaderWarning}, so
+     * warnings raised on a background reader thread (whose {@code ThreadContext} response headers
+     * never reach the client) can be relayed back to the driver thread by the caller.
+     */
+    public void testSinkReceivesMessagesInsteadOfHeaderWarning() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = new SkipWarnings("the summary", sunk::add);
+        warnings.add("first detail");
+        warnings.add("second detail");
+
+        assertEquals(List.of("the summary", "first detail", "second detail"), sunk);
+        assertNull("no message should reach the thread-local response headers", threadContext.getResponseHeaders().get("Warning"));
+    }
+
+    public void testOfWithSinkRoutesThroughSinkForLenientPolicy() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = SkipWarnings.of(ErrorPolicy.LENIENT, "live summary", sunk::add);
+        assertNotSame(SkipWarnings.NOOP, warnings);
+        warnings.add("a detail");
+
+        assertEquals(List.of("live summary", "a detail"), sunk);
+        assertNull(threadContext.getResponseHeaders().get("Warning"));
+    }
+
+    public void testOfWithSinkStrictPolicyReturnsNoopAndIgnoresSink() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = SkipWarnings.of(ErrorPolicy.STRICT, "summary ignored", sunk::add);
+        assertSame(SkipWarnings.NOOP, warnings);
+        warnings.add("dropped");
+        assertTrue(sunk.isEmpty());
+    }
+
+    public void testSinkAlsoReceivesOverflowMessage() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = new SkipWarnings("summary", sunk::add);
+        int total = SkipWarnings.MAX_ADDED_WARNINGS + 5;
+        for (int i = 0; i < total; i++) {
+            warnings.add("detail " + i);
+        }
+        // 1 summary + MAX_ADDED_WARNINGS details + 1 overflow notice
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS + 2, sunk.size());
+        assertTrue(sunk.get(sunk.size() - 1).contains("further warnings suppressed"));
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL:DS: Fix emission of Warnings (#153029)