### PR TITLE
[9.5][Inference Api] Unmute region policy tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -742,9 +742,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.FromDatasetIT
   method: testNdjsonBadDateTokenHonorsErrorPolicyMatchingColumnar
   issue: https://github.com/elastic/elasticsearch/issues/153158
-- class: org.elasticsearch.xpack.inference.RegionPolicyAuthorizationRefreshIT
-  method: testPutRegionPolicy_WhenDeniedEndpointReferencedByPipelineOnly_OmitsEmptyIndexesField
-  issue: https://github.com/elastic/elasticsearch/issues/153170
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testSourceRelocationAndTargetRestart
   issue: https://github.com/elastic/elasticsearch/issues/153173


### PR DESCRIPTION
Those were failing because the TransportPutRegionPolicyAction.findDeniedInUseEndpoints method executes code that asserts it should not be run on transport threads.

In #153140 this was fixed by executing the method on an inference utility thread.

This commit unmutes the relevant tests.

Backport of #153226
