### PR TITLE
Guard kNN bfloat16 BWC tests behind lucene_10_4_upgrade

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -619,12 +619,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessCommitServiceTests
   method: testUnreferencedCommitsAreReleasedAfterRecovery
   issue: https://github.com/elastic/elasticsearch/issues/152730
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/kNN search only}
-  issue: https://github.com/elastic/elasticsearch/issues/152784
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/kNN search plus query}
-  issue: https://github.com/elastic/elasticsearch/issues/152786
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testCloseWhileShardsAreHollowed
   issue: https://github.com/elastic/elasticsearch/issues/151861

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized_bfloat16.yml
@@ -78,6 +78,9 @@ setup:
       indices.refresh: { }
 ---
 "kNN search only":
+  - requires:
+      cluster_features: [ "lucene_10_4_upgrade" ]
+      reason: "Approximate int8_hnsw scoring differs between Lucene 10.3 and 10.4+ quantizers"
   - do:
       search:
         index: hnsw_byte_quantized
@@ -112,6 +115,9 @@ setup:
   - match: {hits.hits.1.fields.name.0: "moose.jpg"}
 ---
 "kNN search plus query":
+  - requires:
+      cluster_features: [ "lucene_10_4_upgrade" ]
+      reason: "Approximate int8_hnsw scoring differs between Lucene 10.3 and 10.4+ quantizers"
   - do:
       search:
         index: hnsw_byte_quantized


### PR DESCRIPTION
The `kNN search only` and `kNN search plus query` tests in
`41_knn_search_byte_quantized_bfloat16.yml` assert strict hit ordering that is
sensitive to quantization differences between Lucene 10.3 (`ScalarQuantizer`)
and 10.4+ (`OptimizedScalarQuantizer`). In mixed-cluster BWC tests against
9.3.8, the approximate `int8_hnsw` scoring can produce different orderings
depending on which node version handles the search (~2.1% fail rate in CI).

**Root cause:** The moose and rabbit vectors have near-equal L2 distances to the
query vector after int8 quantization. The old quantizer (Lucene 10.3.2) and new
quantizer (Lucene 10.5.0) compute slightly different approximate distances,
causing an ordering swap.

**Fix:** Add `cluster_features: ["lucene_10_4_upgrade"]` guards to the two
affected test methods, consistent with the existing guard in the companion file
`42_knn_search_int8_flat_bfloat16.yml`. This skips the test on clusters
containing pre-Lucene-10.4 nodes where the scoring divergence occurs. Also
removes the corresponding mute entries from `muted-tests.yml`.

Prior fix attempts (PR #151778, PR #152023) adjusted the rabbit vector but were
only validated against 9.3.6, not 9.3.8 where the failure persists.

Closes #152784
Closes #152786