### PR TITLE
Exclude flattened fields from columnar indices in mixed-version tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import static org.elasticsearch.index.mapper.ProvidedIdFieldMapper.ID_FIELD_MODE_MAPPING_ATTRIBUTE;
 import static org.elasticsearch.index.mapper.RoutingFieldMapper.ROUTING_AS_DOC_VALUES;
 import static org.elasticsearch.index.mapper.RoutingFieldMapper.ROUTING_AS_DOC_VALUES_BY_DEFAULT;
+import static org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.FLATTENED_COLUMNAR_DOCUMENT_ORDER;
 import static org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.FLATTENED_MAPPED_SUBFIELDS_FEATURE;
 import static org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.FLATTENED_PASSTHROUGH_FEATURE;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.RESCORE_VECTOR_QUANTIZED_VECTOR_MAPPING;
@@ -197,6 +198,7 @@ public class MapperFeatures implements FeatureSpecification {
             DOC_VALUES_MULTI_VALUE_RENAME,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
+            FLATTENED_COLUMNAR_DOCUMENT_ORDER,
             ARRAY_OBJECTS_LIMIT,
             ES940_DISK_BBQ,
             FLATTENED_PASSTHROUGH_FEATURE,

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -156,6 +156,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
 
     public static final NodeFeature FLATTENED_MAPPED_SUBFIELDS_FEATURE = new NodeFeature("mapper.flattened.mapped_subfields");
     public static final NodeFeature FLATTENED_PASSTHROUGH_FEATURE = new NodeFeature("mapper.flattened.passthrough");
+    public static final NodeFeature FLATTENED_COLUMNAR_DOCUMENT_ORDER = new NodeFeature("mapper.flattened.columnar_document_order");
 
     private static class Defaults {
         public static final int DEPTH_LIMIT = 20;

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -930,9 +930,9 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
             && clusterHasFeature("mapper.columnar.supports_shape_fields") == false) {
             return true;
         }
-        // flattened fields use the inline array-order binary doc values format in columnar mode; an older node without the
+        // flattened fields use the document-order binary doc values format in columnar mode; an older node without the
         // feature misreads the synthetic source doc values during a rolling upgrade.
-        if (type == DataType.FLATTENED && clusterHasFeature("mapper.columnar.inline_array_order_binary_doc_values") == false) {
+        if (type == DataType.FLATTENED && clusterHasFeature("mapper.flattened.columnar_document_order") == false) {
             return true;
         }
         return false;

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -921,11 +921,21 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
     }
 
     private static boolean excludedInColumnar(DataType type, IndexMode mode) {
+        if (mode.isStrictColumnar() == false) {
+            return false;
+        }
         // geo_shape/cartesian_shape are reconstructable in columnar only on nodes that have the feature, so exclude them
         // during a rolling upgrade where an older node would reject them in a columnar index.
-        return mode.isStrictColumnar()
-            && (type == DataType.GEO_SHAPE || type == DataType.CARTESIAN_SHAPE)
-            && clusterHasFeature("mapper.columnar.supports_shape_fields") == false;
+        if ((type == DataType.GEO_SHAPE || type == DataType.CARTESIAN_SHAPE)
+            && clusterHasFeature("mapper.columnar.supports_shape_fields") == false) {
+            return true;
+        }
+        // flattened fields use the inline array-order binary doc values format in columnar mode; an older node without the
+        // feature misreads the synthetic source doc values during a rolling upgrade.
+        if (type == DataType.FLATTENED && clusterHasFeature("mapper.columnar.inline_array_order_binary_doc_values") == false) {
+            return true;
+        }
+        return false;
     }
 
     private static String fieldName(DataType type) {


### PR DESCRIPTION
Closes #153285.

Flattened fields use the inline array-order binary doc-values format in strict-columnar mode (`mapper.columnar.inline_array_order_binary_doc_values`, added in #152809). During a rolling upgrade, a node predating that feature misreads the flattened synthetic-source doc values written in the new format, throwing `BytesRef length out of bounds`.

`AllSupportedFieldsTestCase` already excludes format-sensitive columnar fields (e.g. geo_shape/cartesian_shape) from columnar indices when the cluster lacks the corresponding feature. Flattened was missed. This adds it to `excludedInColumnar`, gated on the `inline_array_order_binary_doc_values` feature — so the flattened field is only exercised in columnar mode when every node supports the format. Columnar index mode is unreleased and its doc-values format is not a cross-version compatibility promise, so this is the intended handling rather than a mapper BWC gate.

Once merged, the temporary mute in #153287 can be reverted.
