### PR TITLE
fix shardsClosedListenerChainLength counting

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -307,12 +307,9 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     // execute them all (because the last thread that decreases the ref count to 0 of a {@link RefCountingListener}
                     // also executes its listeners, which in turn might decrease the ref count to 0 of another
                     // {@link RefCountingListerner}, again executing its listeners, etc...).
-                    ++shardsClosedListenerChainLength < 8 ? EsExecutors.DIRECT_EXECUTOR_SERVICE : threadPool.generic(),
+                    shardsClosedListenerChainLength < 8 ? EsExecutors.DIRECT_EXECUTOR_SERVICE : threadPool.generic(),
                     null
                 );
-                if (shardsClosedListenerChainLength >= 8) {
-                    shardsClosedListenerChainLength = 0;
-                }
                 // reset the variable before applying the cluster state
                 closingMoreShards = false;
             }
@@ -324,8 +321,12 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             if (closingMoreShards == false) {
                 // avoids chaining when no shard has been closed after applying this cluster state
                 lastClusterStateShardsClosedListener = previousShardsClosedListener;
-                if (shardsClosedListenerChainLength > 0) {
-                    shardsClosedListenerChainLength--;
+            } else {
+                // only update the chain length when closing more shards
+                if (shardsClosedListenerChainLength < 8) {
+                    shardsClosedListenerChainLength++;
+                } else {
+                    shardsClosedListenerChainLength = 0;
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -307,7 +307,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     // execute them all (because the last thread that decreases the ref count to 0 of a {@link RefCountingListener}
                     // also executes its listeners, which in turn might decrease the ref count to 0 of another
                     // {@link RefCountingListerner}, again executing its listeners, etc...).
-                    shardsClosedListenerChainLength++ < 8 ? EsExecutors.DIRECT_EXECUTOR_SERVICE : threadPool.generic(),
+                    ++shardsClosedListenerChainLength < 8 ? EsExecutors.DIRECT_EXECUTOR_SERVICE : threadPool.generic(),
                     null
                 );
                 if (shardsClosedListenerChainLength >= 8) {


### PR DESCRIPTION
In [#132536](https://github.com/elastic/elasticsearch/pull/132536),  there are two bugs: 

1. shardsClosedListenerChainLength is counted Incorrectly, so that threadPool.generic() is never called.

> shardsClosedListenerChainLength++ < 8 ? EsExecutors.DIRECT_EXECUTOR_SERVICE : threadPool.generic()
> ... 
> if (shardsClosedListenerChainLength >= 8) {
>            shardsClosedListenerChainLength = 0;
> }

More specifically, when shardsClosedListenerChainLength is 7, `shardsClosedListenerChainLength++` returns 7 and `EsExecutors.DIRECT_EXECUTOR_SERVICE` is called. Then shardsClosedListenerChainLength increases to 8, and is reset to 0.

2. If we fix the first bug by `++shardsClosedListenerChainLength` instead of `shardsClosedListenerChainLength++`, then when shardsClosedListenerChainLength reaches limit and is reset to zero, and no more shards are being closed, lastClusterStateShardsClosedListener is assigned previousShardsClosedListener, which means the actual length of the chain is still 7 but the chainLength variable is reset to 0. 
   So in the pr, the chainLength variable is only updated when there are actually more shards being closed.