### PR TITLE
Unmutes `VirtualBatchedCompoundCommitsIT.testGetVirtualBatchedCompoundCommitChunkFailureWhenIndexCloses`.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -244,9 +244,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:stats.sumWithOverflowRow}
   issue: https://github.com/elastic/elasticsearch/issues/149574
-- class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
-  method: testGetVirtualBatchedCompoundCommitChunkFailureWhenIndexCloses
-  issue: https://github.com/elastic/elasticsearch/issues/149586
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/147383


### PR DESCRIPTION
This was already fixed by #148517, merged the day after the original CI
failure. Confirmed by reproducing the original failure deterministically
against the pre-#148517 tree using the exact reported seed; the same seed no
longer reproduces on current main. This pr just unmutes the test.

- [x] Reproduced the original failure on the pre #148517 commit with the exact CI seed
- [x] Confirmed the same seed passes on current main
- [x] Ran 50 additional randomized-seed iterations on current main with no failures

closes: https://github.com/elastic/elasticsearch/issues/149586