### PR TITLE
Updating RoutingNodes.noAssignedReplicaWithoutActivePrimary() to account for stateless

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -262,9 +262,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIntsIT
   method: test {csv-spec:ints.valuesLongGrouped}
   issue: https://github.com/elastic/elasticsearch/issues/149905
-- class: org.elasticsearch.xpack.stateless.allocation.StatelessDesiredBalanceReconcilerTests
-  method: testStatelessFallbackAllocation
-  issue: https://github.com/elastic/elasticsearch/issues/149947
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:UNMAPPED_FIELDS_LOAD}
   issue: https://github.com/elastic/elasticsearch/issues/148619

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -484,8 +484,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
     }
 
     /**
-     * Verifies that, if the unassigned shard is a replica, there is an active (started) primary shard. If the unassigned shard is a
-     * primary, there is no need to check and true is returned.
+     * Verifies that, if the unassigned shard is a promotable replica, there is an active (started) primary shard. If the unassigned shard
+     * is a primary, there is no need to check and true is returned. Unpromotable replicas (e.g. stateless search shards) are also exempt:
+     * they do not peer-recover from the primary and may be initialized without an active primary, recovering independently (e.g. from the
+     * object store).
      */
     private boolean noAssignedReplicaWithoutActivePrimary(ShardRouting unassignedShard) {
         assert unassignedShard.unassigned() : "expected an unassigned shard " + unassignedShard;
@@ -493,8 +495,12 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             // Assigning a primary, no need to check.
             return true;
         }
+        if (unassignedShard.isPromotableToPrimary() == false) {
+            // Unpromotable replicas recover independently of the primary, so an active primary is not required to initialize them.
+            return true;
+        }
 
-        // unassignedShard is a replica, since it is not a primary. Ensure that there's a started primary.
+        // unassignedShard is a promotable replica, since it is not a primary. Ensure that there's a started primary.
         var shards = assignedShards.get(unassignedShard.shardId());
         if (shards != null) {
             for (var shard : shards) {


### PR DESCRIPTION
StatelessDesiredBalanceReconcilerTests.testStatelessFallbackAllocation() began failing about half the time when #149645 was merged. This is because #149645 introduced an assertion that was too strict for serverless. It asserted that there were no assigned replica shards without an active primary. In stateless, we deliberately allow that because search shards are SEARCH_ONLY replicas that read from the object store. This PR updates the assertion to skip these shards that can't be promoted to primary anyway. This only impacts tests since assertions are disabled in production.
Closes #149947