### PR TITLE
Fix KnnSearchSingleNodeTests.testKnnWithQuery flake

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -811,9 +811,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/153282
-- class: org.elasticsearch.action.search.KnnSearchSingleNodeTests
-  method: testKnnWithQuery
-  issue: https://github.com/elastic/elasticsearch/issues/153319
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
   method: testParquetFile {datapage_v2.snappy}
   issue: https://github.com/elastic/elasticsearch/issues/153325

--- a/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
@@ -101,13 +101,13 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
         createIndex("index", indexSettings, builder);
 
         for (int doc = 0; doc < 10; doc++) {
-            prepareIndex("index").setSource("vector", randomVector(), "text", "hello world").get();
+            prepareIndex("index").setSource("vector", randomVector(0f, 1f), "text", "hello world").get();
             prepareIndex("index").setSource("text", "goodnight world").get();
         }
 
         indicesAdmin().prepareRefresh("index").get();
 
-        float[] queryVector = randomVector();
+        float[] queryVector = randomVector(0f, 1f);
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 5, 50, 10f, null, null).boost(5.0f).queryName("knn");
         assertResponse(
             client().prepareSearch("index")


### PR DESCRIPTION
## Summary

- Uses bounded vector range `randomVector(0f, 1f)` in `testKnnWithQuery` to restore the original scoring behavior
- PR #153235 changed `randomVector()` to produce values in `[-1, 1)` (via `VectorTestUtils.randomFloatVector()`), which doubles expected L2 distances and reduces knn scores below BM25 text match scores on some seeds
- Removes mute entry from `muted-tests.yml`

Verified: passes with the original failing seed and 50 random iterations.

Closes #153319