### PR TITLE
Fix MergedOverspillAssignments size and out-of-range ordinals

### DIFF
--- a/docs/changelog/153344.yaml
+++ b/docs/changelog/153344.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+ - 153324
+pr: 153344
+summary: Fix `MergedOverspillAssignments` size and out-of-range ordinals
+type: bug

--- a/docs/changelog/153344.yaml
+++ b/docs/changelog/153344.yaml
@@ -1,6 +1,0 @@
-area: Vector Search
-issues:
- - 153324
-pr: 153344
-summary: Fix `MergedOverspillAssignments` size and out-of-range ordinals
-type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansWithOverspill.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansWithOverspill.java
@@ -71,6 +71,7 @@ public record KMeansWithOverspill<V>(KMeansResult<V> result, OverspillAssignment
         OverspillAssignments overspill = spillAssignmentIdx == 0
             ? OverspillAssignments.NONE
             : new MergedOverspillAssignments(
+                numAssignments,
                 Arrays.copyOf(spillAssignmentOffsets, spillAssignmentIdx),
                 Arrays.copyOf(spillCentroidOffsets, spillAssignmentIdx),
                 Arrays.copyOf(overspills, spillAssignmentIdx)
@@ -86,14 +87,19 @@ public record KMeansWithOverspill<V>(KMeansResult<V> result, OverspillAssignment
         private final OverspillAssignments[] assignments;
         private final int size;
 
-        private MergedOverspillAssignments(int[] assignmentOffsets, int[] centroidOffsets, OverspillAssignments[] assignments) {
+        private MergedOverspillAssignments(
+            int totalSize,
+            int[] assignmentOffsets,
+            int[] centroidOffsets,
+            OverspillAssignments[] assignments
+        ) {
             assert assignmentOffsets.length == assignments.length;
             assert centroidOffsets.length == assignmentOffsets.length;
 
             this.assignmentOffsets = assignmentOffsets;
             this.centroidOffsets = centroidOffsets;
             this.assignments = assignments;
-            size = assignmentOffsets[assignmentOffsets.length - 1] + assignments[assignmentOffsets.length - 1].size();
+            this.size = totalSize;
         }
 
         @Override
@@ -104,6 +110,10 @@ public record KMeansWithOverspill<V>(KMeansResult<V> result, OverspillAssignment
         @Override
         public PrimitiveIterator.OfInt getAssignmentsFor(int ordinal) {
             int index = Arrays.binarySearch(assignmentOffsets, ordinal);
+            if (index == -1) {
+                // ordinal is before the first tracked offset — no overspill for this position
+                return EMPTY_ITERATOR;
+            }
             if (index < 0) {
                 index = -index - 2; // go back one to the offset < ordinal, as that's the assignment containing this ordinal
             }


### PR DESCRIPTION
When merging sliced IVF clustering results, `MergedOverspillAssignments.size()` was computed from the last tracked offset plus its component size. This gives incorrect results when trailing slices have empty overspill (e.g. slices with a single centroid), causing the assertion in `CentroidAssignments` to fail:

```
AssertionError: assignments and overspillAssignments must have the same length
```

Additionally, `getAssignmentsFor(ordinal)` crashes with `ArrayIndexOutOfBoundsException: Index -1` when the ordinal precedes the first tracked offset (i.e. when the first slice has empty overspill).

**Fixes:**
1. Pass the total assignment count into `MergedOverspillAssignments` and use it directly as `size()`, instead of deriving it from offset arrays that skip empty slices.
2. Handle the `binarySearch` returning `-1` (ordinal before first offset) by returning an empty iterator.

Reproduces deterministically with:
```
gradlew :server:test --tests DiversifyingChildrenIVFKnnFloatSlicedVectorQueryTests.testSlicesDenseWithFilter \
  -Dtests.seed=6C9FCC6DB7DC91A2 -Dtests.locale=mi -Dtests.timezone=Asia/Kamchatka \
  -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

Verified with 50 iterations of the failing test plus 20 iterations of all `testSlices*` methods.

Note: This overlaps with #153294 which addresses the `getAssignmentsFor` crash for issue #153272. Both fixes are needed here since both bugs trigger with the same seed on this test.

Closes #153324