### PR TITLE
[ES|QL] Queries with delay function cannot be cancelled properly

### DIFF
--- a/docs/changelog/153346.yaml
+++ b/docs/changelog/153346.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 153297
+pr: 153346
+summary: Queries with delay function cannot be cancelled properly
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/DelayCancellationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/DelayCancellationIT.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.TransportCancelTasksAction;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.compute.operator.DriverStatus;
+import org.elasticsearch.compute.operator.DriverTaskRunner;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.xpack.core.async.AsyncExecutionId;
+import org.elasticsearch.xpack.core.async.AsyncStopRequest;
+import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
+import org.elasticsearch.xpack.core.async.TransportDeleteAsyncResultAction;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.core.TimeValue.timeValueMillis;
+import static org.elasticsearch.core.TimeValue.timeValueMinutes;
+import static org.elasticsearch.core.TimeValue.timeValueSeconds;
+import static org.elasticsearch.xpack.esql.action.EsqlAsyncTestUtils.getAsyncResponse;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.asyncEsqlQueryRequest;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Locks the cancellation contract for a query whose {@code delay()} blocks the <em>coordinator's</em> final
+ * driver (an {@code EVAL delay(...)} after {@code LIMIT} runs on the coordinator, downstream of the exchange
+ * source and terminating in an {@code OutputOperator}). Every cancellation entry point must wind that driver
+ * down promptly instead of waiting out the whole sleep:
+ * <ul>
+ *   <li><b>DELETE</b> (async hard cancel) rides {@code waitForCompletion=true}, so it genuinely blocks until the
+ *       coordinator driver finishes. Cancellation is cooperative — {@code Driver.cancel} only sets a flag and
+ *       never interrupts {@link Thread#sleep} — so {@code delay()} must poll
+ *       {@code DriverContext.checkForEarlyTermination()} between sleep slices for DELETE to return quickly.</li>
+ *   <li><b>STOP</b> (graceful) closes the exchange source and fires the per-task stop hooks, but neither sets
+ *       the coordinator driver's cancel/early-finished flag; {@code delay()} registers a stop hook so a sleeping
+ *       delay aborts and STOP returns partial results.</li>
+ *   <li><b>{@code _tasks/{id}/_cancel}</b> (hard cancel, the path a client disconnect also takes) on the sync
+ *       query task, on the async task, or directly on the coordinator {@code delay()} driver — all must fail the
+ *       query with {@link TaskCancelledException} promptly and tear the tasks down.</li>
+ * </ul>
+ * These mirror the cancellation patterns in {@code EsqlActionTaskIT} (task/driver cancel) and
+ * {@code AsyncEsqlQueryActionIT} (async cancel), but the block is a coordinator-side {@code delay()} rather than a
+ * paused script. Without the {@code delay()} fix every entry point blocks for the full remaining delay; the
+ * {@link #PROMPT} bound (well below {@link #DELAY}) is what turns a regression into a fast, clear failure.
+ */
+public class DelayCancellationIT extends AbstractEsqlIntegTestCase {
+
+    /** Delay long enough that "waited the whole sleep" (a regression) is unmistakably distinct from a prompt cancel. */
+    private static final TimeValue DELAY = timeValueSeconds(30);
+    /** Upper bound a correctly-wired cancel must beat. Generous vs. the observed ~0.5s so CI slowness never flakes it,
+     *  yet far below {@link #DELAY} so a regressed cancel (which blocks ~{@link #DELAY}) trips it. */
+    private static final TimeValue PROMPT = timeValueSeconds(15);
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        // Wires up the async ES|QL actions (submit/get/stop/delete) used below.
+        plugins.add(EsqlAsyncActionIT.LocalStateEsqlAsync.class);
+        plugins.add(InternalExchangePlugin.class);
+        return Collections.unmodifiableList(plugins);
+    }
+
+    @Before
+    public void setupIndex() {
+        assumeTrue("delay() is only available in snapshot builds", Build.current().isSnapshot());
+        client().admin().indices().prepareCreate("test").setSettings(indexSettings(1, 0)).setMapping("foo", "type=long").get();
+        BulkRequestBuilder bulk = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        for (int i = 0; i < 5; i++) {
+            bulk.add(prepareIndex("test").setId(Integer.toString(i)).setSource("foo", i));
+        }
+        bulk.get();
+    }
+
+    /**
+     * DELETE on a query blocked in a coordinator-side {@code delay()} must return well within {@link #PROMPT}
+     * (not after the full {@link #DELAY}), tear the task down, and leave nothing retrievable.
+     */
+    public void testDeleteCancelsBlockingDelayPromptly() throws Exception {
+        final String asyncId = submitBlockingDelayQuery();
+        awaitDelayDriverSleeping();
+
+        long start = System.nanoTime();
+        ActionFuture<AcknowledgedResponse> deleteFuture = client().execute(
+            TransportDeleteAsyncResultAction.TYPE,
+            new DeleteAsyncResultRequest(asyncId)
+        );
+        AcknowledgedResponse deleteResponse;
+        try {
+            deleteResponse = deleteFuture.actionGet(PROMPT);
+        } catch (ElasticsearchTimeoutException e) {
+            throw new AssertionError(
+                "DELETE did not return within "
+                    + PROMPT
+                    + " for a delay("
+                    + DELAY
+                    + ") query — the coordinator delay driver "
+                    + "blocked cancellation instead of observing it between sleep slices (fix regressed)",
+                e
+            );
+        }
+        long elapsedMillis = TimeValue.nsecToMSec(System.nanoTime() - start);
+        assertTrue(deleteResponse.isAcknowledged());
+        logger.info("DELETE returned in {} ms for delay({})", elapsedMillis, DELAY);
+
+        // The async task must be gone after DELETE torn it down.
+        TaskId asyncTaskId = AsyncExecutionId.decode(asyncId).getTaskId();
+        assertBusy(() -> assertFalse("async task should be gone after DELETE", isTaskRunning(asyncTaskId)));
+        // And nothing should remain retrievable.
+        Exception thrown = expectThrows(Exception.class, () -> { getAsyncResponse(client(), asyncId).close(); });
+        assertThat(
+            "GET after DELETE must surface ResourceNotFoundException, got: " + thrown,
+            ExceptionsHelper.unwrap(thrown, ResourceNotFoundException.class),
+            notNullValue()
+        );
+    }
+
+    /**
+     * STOP on a query blocked in a coordinator-side {@code delay()} must return well within {@link #PROMPT} with a
+     * finished, partial response — the stop hook stops the sleep so the in-flight row drains through and the pipeline
+     * completes naturally, rather than the whole {@link #DELAY} being slept out.
+     */
+    public void testStopCancelsBlockingDelayPromptly() throws Exception {
+        final String asyncId = submitBlockingDelayQuery();
+        awaitDelayDriverSleeping();
+
+        long start = System.nanoTime();
+        ActionFuture<EsqlQueryResponse> stopFuture = client().execute(EsqlAsyncStopAction.INSTANCE, new AsyncStopRequest(asyncId));
+        EsqlQueryResponse response;
+        try {
+            response = stopFuture.actionGet(PROMPT);
+        } catch (ElasticsearchTimeoutException e) {
+            throw new AssertionError(
+                "STOP did not return within "
+                    + PROMPT
+                    + " for a delay("
+                    + DELAY
+                    + ") query — the coordinator delay driver "
+                    + "did not observe the stop hook and slept out the full delay (fix regressed)",
+                e
+            );
+        }
+        try {
+            long elapsedMillis = TimeValue.nsecToMSec(System.nanoTime() - start);
+            logger.info("STOP returned in {} ms for delay({})", elapsedMillis, DELAY);
+            assertThat("STOP response must be finished", response.isRunning(), is(false));
+            assertThat(
+                "STOP must flag is_partial — the delay stop hook reported it cut a still-running unit of work, which "
+                    + "TransportEsqlAsyncStopAction reports as partial",
+                response.isPartial(),
+                is(true)
+            );
+            assertThat(
+                "STOP stops the delay sleeping and lets the in-flight LIMIT 1 row drain through to the output",
+                countRows(response),
+                equalTo(1)
+            );
+        } finally {
+            response.close();
+            EsqlAsyncTestUtils.deleteAsyncId(client(), asyncId);
+        }
+    }
+
+    /**
+     * Sync hard cancel via the generic {@code _tasks/{id}/_cancel} API (the same path a client disconnect takes) must
+     * fail the query with {@link TaskCancelledException} well within {@link #PROMPT} and leave no tasks behind. Mirrors
+     * {@code EsqlActionTaskIT#testCancelEsqlTask}, but the block is a coordinator-side {@code delay()} rather than a
+     * paused script.
+     */
+    public void testSyncTaskCancelCancelsBlockingDelayPromptly() throws Exception {
+        String marker = "delay_sync_cancel_" + System.nanoTime();
+        ActionFuture<EsqlQueryResponse> queryFuture = submitSyncBlockingDelayQuery(marker);
+        TaskId taskId = findEsqlQueryTask(marker);
+        assertThat("the EsqlQueryAction task must be present while delay() is sleeping", taskId, notNullValue());
+        awaitDelayDriverSleeping();
+
+        long elapsedMillis = cancelAndWait(taskId, "sync task");
+        logger.info("sync task cancel returned in {} ms for delay({})", elapsedMillis, DELAY);
+
+        Exception thrown = expectThrows(Exception.class, () -> {
+            try (var ignored = queryFuture.actionGet(PROMPT)) {
+                fail("cancel must hard-fail the delay() query, not return a response body");
+            }
+        });
+        assertThat(
+            "sync cancel must surface as TaskCancelledException, got: " + thrown,
+            ExceptionsHelper.unwrap(thrown, TaskCancelledException.class),
+            notNullValue()
+        );
+        assertNoEsqlTasksRunning();
+    }
+
+    /**
+     * Cancelling the specific coordinator driver that runs {@code delay()} (its {@link DriverStatus} description is
+     * {@code "final"}) must chain up to fail the whole query with {@link TaskCancelledException} within {@link #PROMPT}.
+     * Mirrors {@code EsqlActionTaskIT#testCancelMerge}, which cancels the coordinator "final" driver directly.
+     */
+    public void testCancelCoordinatorDelayDriverPromptly() throws Exception {
+        String marker = "delay_driver_cancel_" + System.nanoTime();
+        ActionFuture<EsqlQueryResponse> queryFuture = submitSyncBlockingDelayQuery(marker);
+        assertThat("the EsqlQueryAction task must be present", findEsqlQueryTask(marker), notNullValue());
+        TaskId driverTaskId = awaitCoordinatorDelayDriver();
+
+        long elapsedMillis = cancelAndWait(driverTaskId, "coordinator driver");
+        logger.info("coordinator driver cancel returned in {} ms for delay({})", elapsedMillis, DELAY);
+
+        Exception thrown = expectThrows(Exception.class, () -> {
+            try (var ignored = queryFuture.actionGet(PROMPT)) {
+                fail("cancelling the delay() driver must hard-fail the query");
+            }
+        });
+        assertThat(
+            "cancelling the coordinator delay driver must surface as TaskCancelledException, got: " + thrown,
+            ExceptionsHelper.unwrap(thrown, TaskCancelledException.class),
+            notNullValue()
+        );
+        assertNoEsqlTasksRunning();
+    }
+
+    /**
+     * Async hard cancel via {@code _tasks/{id}/_cancel} on the async task (not DELETE) must wind the blocked delay
+     * driver down within {@link #PROMPT}, after which the stored result surfaces a cancel-side failure. Mirrors
+     * {@code AsyncEsqlQueryActionIT#testGetAsyncWhileQueryTaskIsBeingCancelled} and
+     * {@code ExternalAsyncStopAndCancelIT#testAsyncTaskCancelHardFailsWithNoRows}.
+     */
+    public void testAsyncTaskCancelCancelsBlockingDelayPromptly() throws Exception {
+        final String asyncId = submitBlockingDelayQuery();
+        awaitDelayDriverSleeping();
+        TaskId asyncTaskId = AsyncExecutionId.decode(asyncId).getTaskId();
+        assertTrue("the async task must be alive before cancel", isTaskRunning(asyncTaskId));
+
+        long elapsedMillis = cancelAndWait(asyncTaskId, "async task");
+        logger.info("async task cancel returned in {} ms for delay({})", elapsedMillis, DELAY);
+
+        try {
+            // After cancel (waitForCompletion=true), the stored async result surfaces a cancel-side failure: either
+            // TaskCancelledException reached the stored response, or the cancel cascade wiped the entry before the GET.
+            Exception thrown = expectThrows(Exception.class, () -> { getAsyncResponse(client(), asyncId).close(); });
+            boolean cancelled = ExceptionsHelper.unwrap(thrown, TaskCancelledException.class) != null;
+            boolean notFound = ExceptionsHelper.unwrap(thrown, ResourceNotFoundException.class) != null;
+            assertTrue(
+                "async cancel must surface as TaskCancelledException or ResourceNotFoundException, got: " + thrown,
+                cancelled || notFound
+            );
+        } finally {
+            // best-effort cleanup if the cancel cascade did not already wipe the stored entry
+            try {
+                EsqlAsyncTestUtils.deleteAsyncId(client(), asyncId);
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private String submitBlockingDelayQuery() {
+        EsqlQueryRequest request = asyncEsqlQueryRequest("FROM test | LIMIT 1 | EVAL d = delay(" + DELAY.seconds() + "s)")
+            .waitForCompletionTimeout(timeValueMillis(100))
+            .keepOnCompletion(true)
+            .keepAlive(timeValueMinutes(10));
+        try (EsqlQueryResponse resp = client().execute(EsqlQueryAction.INSTANCE, request).actionGet(30, TimeUnit.SECONDS)) {
+            assertTrue("query should still be running", resp.isRunning());
+            assertTrue(resp.asyncExecutionId().isPresent());
+            return resp.asyncExecutionId().get();
+        }
+    }
+
+    private ActionFuture<EsqlQueryResponse> submitSyncBlockingDelayQuery(String marker) {
+        // The marker rides in a line comment so it shows up in the task description, letting findEsqlQueryTask latch
+        // onto this exact task even if other ES|QL traffic is present (same trick as ExternalAsyncStopAndCancelIT).
+        String query = "// " + marker + "\nFROM test | LIMIT 1 | EVAL d = delay(" + DELAY.seconds() + "s)";
+        return client().execute(EsqlQueryAction.INSTANCE, syncEsqlQueryRequest(query));
+    }
+
+    /**
+     * Waits until a compute driver is running, then gives {@code delay()} a moment to enter {@link Thread#sleep}, so the
+     * cancel below lands while the coordinator driver is actually blocked (the case the fix targets).
+     */
+    private void awaitDelayDriverSleeping() throws Exception {
+        assertBusy(() -> assertThat(listDriverTasks().size(), greaterThanOrEqualTo(1)));
+        safeSleep(1000);
+    }
+
+    /**
+     * Resolves the coordinator driver that runs {@code delay()} — its {@link DriverStatus} description is
+     * {@code "final"} — then gives {@code delay()} a moment to enter {@link Thread#sleep} so the cancel lands mid-sleep.
+     */
+    private TaskId awaitCoordinatorDelayDriver() throws Exception {
+        List<TaskId> found = new ArrayList<>();
+        assertBusy(() -> {
+            List<TaskInfo> finalDrivers = listDriverTasks().stream()
+                .filter(t -> t.status() instanceof DriverStatus ds && ds.description().equals("final"))
+                .toList();
+            assertThat("the coordinator 'final' driver running delay() must be present", finalDrivers, not(empty()));
+            found.clear();
+            found.add(finalDrivers.get(0).taskId());
+        });
+        safeSleep(1000);
+        return found.get(0);
+    }
+
+    /**
+     * Resolves the {@link EsqlQueryAction} task carrying {@code marker} in its description (the query text). Retries
+     * via {@code assertBusy} because the task appears a beat after the request is dispatched.
+     */
+    private TaskId findEsqlQueryTask(String marker) throws Exception {
+        List<TaskId> found = new ArrayList<>();
+        assertBusy(() -> {
+            List<TaskInfo> matched = client().admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(EsqlQueryAction.NAME)
+                .setDetailed(true)
+                .get()
+                .getTasks()
+                .stream()
+                .filter(t -> t.description() != null && t.description().contains(marker))
+                .toList();
+            assertThat(matched, not(empty()));
+            found.clear();
+            found.add(matched.get(0).taskId());
+        });
+        return found.get(0);
+    }
+
+    /**
+     * Cancels {@code taskId} with {@code waitForCompletion=true} (so the call genuinely blocks until the driver winds
+     * down) and returns how long that took. Converts the {@link #PROMPT} timeout into a clear regression failure.
+     */
+    private long cancelAndWait(TaskId taskId, String what) {
+        long start = System.nanoTime();
+        CancelTasksRequest cancel = new CancelTasksRequest().setTargetTaskId(taskId).setReason("test cancel");
+        cancel.setWaitForCompletion(true);
+        try {
+            client().admin().cluster().execute(TransportCancelTasksAction.TYPE, cancel).actionGet(PROMPT);
+        } catch (ElasticsearchTimeoutException e) {
+            throw new AssertionError(
+                what
+                    + " cancel did not return within "
+                    + PROMPT
+                    + " for a delay("
+                    + DELAY
+                    + ") query — the coordinator delay driver blocked cancellation instead of observing it between "
+                    + "sleep slices (fix regressed)",
+                e
+            );
+        }
+        return TimeValue.nsecToMSec(System.nanoTime() - start);
+    }
+
+    private List<TaskInfo> listDriverTasks() {
+        return client().admin().cluster().prepareListTasks().setActions(DriverTaskRunner.ACTION_NAME).setDetailed(true).get().getTasks();
+    }
+
+    private void assertNoEsqlTasksRunning() throws Exception {
+        assertBusy(
+            () -> assertThat(
+                client().admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .setActions(EsqlQueryAction.NAME, DriverTaskRunner.ACTION_NAME)
+                    .setDetailed(true)
+                    .get()
+                    .getTasks(),
+                emptyIterable()
+            )
+        );
+    }
+
+    private boolean isTaskRunning(TaskId taskId) {
+        return client().admin().cluster().prepareListTasks().setTargetTaskId(taskId).get().getTasks().isEmpty() == false;
+    }
+
+    private static int countRows(EsqlQueryResponse response) {
+        int rows = 0;
+        Iterator<Iterator<Object>> values = response.values();
+        while (values.hasNext()) {
+            Iterator<Object> row = values.next();
+            while (row.hasNext()) {
+                row.next();
+            }
+            rows++;
+        }
+        return rows;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/Delay.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/Delay.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFuncti
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
@@ -118,8 +119,27 @@ public class Delay extends UnaryScalarFunction {
     static final class DelayEvaluator implements ExpressionEvaluator {
         private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DelayEvaluator.class);
 
+        /**
+         * Upper bound on how long the sleep can ignore a cancelled/stopped query. The requested delay is
+         * slept in slices no longer than this so that {@link DriverContext#checkForEarlyTermination()} is
+         * polled at least this often; without it a single long {@link Thread#sleep} would pin the driver's
+         * worker thread for the whole duration and cancellation could only be observed once it returned.
+         */
+        static final long CANCELLATION_CHECK_INTERVAL_MS = 100;
+
         private final DriverContext driverContext;
         private final long ms;
+
+        /**
+         * Flipped by the {@link DriverContext#addStopHook stop hook} below when the user requests async STOP.
+         * Hard cancel and the exchange-sink-close early-finish are observed through
+         * {@link DriverContext#checkForEarlyTermination()}, but async STOP winds a query down by firing stop hooks
+         * (and closing the exchange source) without setting the driver's cancel/early-finished flag on a coordinator
+         * pipeline driver — its last operator is an {@code OutputOperator}, not an exchange sink, so {@code finishEarly}
+         * cannot be used to wind it down cleanly. Instead the sleep stops early (see {@link #delay(long)}), letting the
+         * in-flight row flow through and the pipeline drain to natural completion, matching how EXTERNAL STOP behaves.
+         */
+        private final AtomicBoolean stopRequested = new AtomicBoolean();
 
         DelayEvaluator(DriverContext driverContext, long ms) {
             if (Build.current().isSnapshot() == false) {
@@ -127,6 +147,8 @@ public class Delay extends UnaryScalarFunction {
             }
             this.driverContext = driverContext;
             this.ms = ms;
+            // Returning true the first time reports that STOP cut a running unit of work, which marks the response partial.
+            driverContext.addStopHook(() -> stopRequested.compareAndSet(false, true));
         }
 
         @Override
@@ -139,11 +161,22 @@ public class Delay extends UnaryScalarFunction {
         }
 
         private void delay(long ms) {
-            try {
-                driverContext.checkForEarlyTermination();
-                Thread.sleep(ms);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+            long remaining = ms;
+            while (remaining > 0) {
+                // Cancellation is cooperative and the sleep is not interruptible, so poll between slices.
+                driverContext.checkForEarlyTermination(); // hard cancel + exchange-sink-close early finish
+                if (stopRequested.get()) {
+                    // Async STOP: stop waiting and let the in-flight row flow through so the pipeline drains normally.
+                    return;
+                }
+                long slice = Math.min(remaining, CANCELLATION_CHECK_INTERVAL_MS);
+                try {
+                    Thread.sleep(slice);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                remaining -= slice;
             }
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/DelayTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/DelayTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.util;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.DriverEarlyTerminationException;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+
+public class DelayTests extends ESTestCase {
+
+    private final List<CircuitBreaker> breakers = Collections.synchronizedList(new ArrayList<>());
+
+    /**
+     * Regression test for slow query cancellation: {@code delay()} must observe cancellation while it is
+     * sleeping, not only once before it starts. The driver's cancellation is cooperative and the sleep is
+     * not interruptible, so the evaluator has to poll {@link DriverContext#checkForEarlyTermination()}
+     * periodically. Here the checker lets the first poll through (query still running) and trips on the next
+     * one (query cancelled mid-sleep); with the previous single-check implementation the evaluator would
+     * sleep for the whole {@code delayMs} and never see the cancellation.
+     */
+    public void testDelayObservesCancellationWhileSleeping() {
+        assumeTrue("delay() is only available in snapshot builds", Build.current().isSnapshot());
+        DriverContext driverContext = driverContext();
+        AtomicInteger checks = new AtomicInteger();
+        driverContext.initializeEarlyTerminationChecker(() -> {
+            if (checks.incrementAndGet() >= 2) {
+                throw new DriverEarlyTerminationException("simulated cancellation");
+            }
+        });
+
+        // Long enough to span many cancellation-check slices; the fix must abort well before it elapses.
+        long delayMs = 5000;
+        try (Delay.DelayEvaluator evaluator = new Delay.DelayEvaluator(driverContext, delayMs); Page page = new Page(1)) {
+            long start = System.nanoTime();
+            expectThrows(DriverEarlyTerminationException.class, () -> {
+                Block block = evaluator.eval(page);
+                block.close();
+            });
+            long elapsedMs = TimeValue.nsecToMSec(System.nanoTime() - start);
+            assertThat("delay() should abort mid-sleep, not sleep the whole duration", elapsedMs, lessThan(delayMs));
+            assertThat(checks.get(), greaterThanOrEqualTo(2));
+        }
+    }
+
+    /**
+     * Companion to {@link #testDelayObservesCancellationWhileSleeping}, but for graceful async STOP. Unlike a
+     * hard cancel, STOP winds a query down by firing the driver's {@link DriverContext#runStopHooks() stop
+     * hooks} (and closing the exchange source) rather than setting the driver's cancel/early-finished flags, so
+     * on a coordinator pipeline driver ending in an {@code OutputOperator} the sleep would otherwise run to
+     * completion. The evaluator registers a stop hook so a sleeping delay aborts with a
+     * {@link DriverEarlyTerminationException} (clean wind-down, partial results). Here a background thread fires
+     * the stop hooks mid-sleep, mimicking the STOP transport thread.
+     */
+    public void testDelayObservesStopWhileSleeping() throws Exception {
+        assumeTrue("delay() is only available in snapshot builds", Build.current().isSnapshot());
+        DriverContext driverContext = driverContext();
+
+        // Long enough to span many cancellation-check slices; STOP must cut the sleep short well before it elapses.
+        long delayMs = 5000;
+        try (Delay.DelayEvaluator evaluator = new Delay.DelayEvaluator(driverContext, delayMs); Page page = new Page(1)) {
+            // The evaluator's constructor registered the stop hook; fire it from another thread as STOP does.
+            Thread stopper = new Thread(() -> {
+                safeSleep(50);
+                assertThat("stop hook should report it cut running work", driverContext.runStopHooks(), equalTo(true));
+            }, "delay-stopper");
+            stopper.start();
+            long start = System.nanoTime();
+            // Unlike hard cancel, STOP does not throw: the sleep returns early so the in-flight row can flow through
+            // and the pipeline drains to natural completion.
+            try (Block block = evaluator.eval(page)) {
+                assertThat(block.getPositionCount(), equalTo(1));
+                assertThat(((BooleanBlock) block).getBoolean(0), equalTo(true));
+            }
+            long elapsedMs = TimeValue.nsecToMSec(System.nanoTime() - start);
+            stopper.join();
+            assertThat("delay() should stop sleeping on STOP, not sleep the whole duration", elapsedMs, lessThan(delayMs));
+        }
+    }
+
+    /**
+     * Sanity check that a delay which is never cancelled still produces a boolean {@code true} for every row.
+     */
+    public void testDelayReturnsResultWhenNotCancelled() {
+        assumeTrue("delay() is only available in snapshot builds", Build.current().isSnapshot());
+        DriverContext driverContext = driverContext();
+        int positions = between(1, 10);
+        try (Delay.DelayEvaluator evaluator = new Delay.DelayEvaluator(driverContext, 1); Page page = new Page(positions)) {
+            try (Block block = evaluator.eval(page)) {
+                assertThat(block.getPositionCount(), equalTo(positions));
+                BooleanBlock booleanBlock = (BooleanBlock) block;
+                for (int p = 0; p < positions; p++) {
+                    assertThat(booleanBlock.getBoolean(p), equalTo(true));
+                }
+            }
+        }
+    }
+
+    private DriverContext driverContext() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        breakers.add(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST));
+        return new DriverContext(bigArrays, BlockFactory.builder(bigArrays).build(), null);
+    }
+
+    @After
+    public void allMemoryReleased() {
+        for (CircuitBreaker breaker : breakers) {
+            assertThat(breaker.getUsed(), equalTo(0L));
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/153297