### PR TITLE
[9.5] Unmute RcsCcsCommonYamlTestSuiteIT (#153327)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -655,9 +655,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.groupByMultipleRenamedColumns_AndTwoExpressions}
   issue: https://github.com/elastic/elasticsearch/issues/152801
-- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-  method: initializationError
-  issue: https://github.com/elastic/elasticsearch/issues/152849
 - class: org.elasticsearch.index.codec.tsdb.es95.ES95TSDBDocValuesFormatTests
   method: testConjunctionOfRangeFiltersMatchesBruteForce
   issue: https://github.com/elastic/elasticsearch/issues/152886


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Unmute RcsCcsCommonYamlTestSuiteIT (#153327)