### PR TITLE
Fix combined_fields/mlt on annotated_text fields

### DIFF
--- a/docs/changelog/153355.yaml
+++ b/docs/changelog/153355.yaml
@@ -1,0 +1,6 @@
+pr: 153355
+summary: Fix `combined_fields` and `more_like_this` queries on `annotated_text` fields
+area: Relevance
+type: bug
+issues:
+ - 153045

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -524,6 +524,11 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         public String typeName() {
             return CONTENT_TYPE;
         }
+
+        @Override
+        public String familyTypeName() {
+            return TextFieldMapper.CONTENT_TYPE;
+        }
     }
 
     private final IndexVersion indexCreatedVersion;

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -30,6 +30,14 @@ public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
         assertEquals(Intervals.term("donald"), source);
     }
 
+    public void testFamilyTypeName() {
+        MappedFieldType ft = new AnnotatedTextFieldMapper.AnnotatedTextFieldType("field", Collections.emptyMap());
+        assertEquals("annotated_text", ft.typeName());
+        // family type name must stay "text" so text-family query validation (e.g. combined_fields,
+        // more_like_this) treats annotated_text like any other text-family field
+        assertEquals("text", ft.familyTypeName());
+    }
+
     public void testFetchSourceValue() throws IOException {
         MappedFieldType fieldType = new AnnotatedTextFieldMapper.Builder(
             "field",

--- a/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/10_basic.yml
+++ b/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/10_basic.yml
@@ -75,6 +75,44 @@
 
 
 ---
+"combined_fields and more_like_this support annotated_text fields":
+  - do:
+      indices.create:
+        index: annotated
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+          mappings:
+            properties:
+              title:
+                type: annotated_text
+              body:
+                type: annotated_text
+
+  - do:
+      index:
+        index: annotated
+        body:
+          "title" : "The [quick brown fox](entity_3789) is brown."
+          "body" : "the lazy dog"
+        refresh: true
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "query" : {"combined_fields" : { "query" : "quick", "fields" : ["title", "body"] } } }
+
+  - match: { hits.total: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "query" : {"more_like_this" : { "fields" : ["title"], "like" : "quick brown fox", "min_term_freq" : 1, "min_doc_freq" : 1 } } }
+
+  - match: { hits.total: 1 }
+
+---
 "issue 39395 thread safety issue -requires multiple calls to reveal":
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -57,7 +57,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
@@ -80,9 +79,9 @@ public class MoreLikeThisQueryBuilder extends LeafQueryBuilder<MoreLikeThisQuery
     public static final boolean DEFAULT_INCLUDE = false;
     public static final boolean DEFAULT_FAIL_ON_UNSUPPORTED_FIELDS = true;
 
-    private static final Set<Class<? extends MappedFieldType>> SUPPORTED_FIELD_TYPES = new HashSet<>(
-        Arrays.asList(TextFieldType.class, KeywordFieldType.class)
-    );
+    private static boolean isSupportedFieldType(MappedFieldType fieldType) {
+        return fieldType instanceof TextFieldType || fieldType instanceof KeywordFieldType;
+    }
 
     private static final ParseField FIELDS = new ParseField("fields");
     private static final ParseField LIKE = new ParseField("like");
@@ -919,7 +918,7 @@ public class MoreLikeThisQueryBuilder extends LeafQueryBuilder<MoreLikeThisQuery
         } else {
             for (String field : fields) {
                 MappedFieldType fieldType = context.getFieldType(field);
-                if (fieldType != null && SUPPORTED_FIELD_TYPES.contains(fieldType.getClass()) == false) {
+                if (fieldType != null && isSupportedFieldType(fieldType) == false) {
                     if (failOnUnsupportedField) {
                         throw new IllegalArgumentException("more_like_this only supports text/keyword fields: [" + field + "]");
                     } else {


### PR DESCRIPTION
Both queries gated eligible fields on field-type identity instead of the type hierarchy, so annotated_text (a subclass of TextFieldType) was rejected even though it behaves like any other text-family field:

- combined_fields checked familyTypeName().equals("text"), but AnnotatedTextFieldType did not override familyTypeName() and inherited the default (which returns typeName(), "annotated_text"). Fixed by overriding familyTypeName() to return "text", following the same pattern already used by MatchOnlyTextFieldType.

- more_like_this checked fieldType.getClass() against an exact-class set {TextFieldType, KeywordFieldType}, rejecting any subclass. Replaced with an instanceof check.

Fixes #153045

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
