### PR TITLE
ES|QL: Unmute MixedClusterEsqlSpecIT view-related tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -179,18 +179,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/150865
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:stats.commonFilterExtractionWithAliasAndOriginalNeedingNormalizationAndSimplification}
-  issue: https://github.com/elastic/elasticsearch/issues/150930
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:tdigest.Top level date group with no other groups (timeseries index)}
-  issue: https://github.com/elastic/elasticsearch/issues/150931
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:fork.forkBeforeCompletion}
-  issue: https://github.com/elastic/elasticsearch/issues/150932
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-rate.rate_of_long_no_grouping_promql_implicit_range}
-  issue: https://github.com/elastic/elasticsearch/issues/150933
 - class: org.elasticsearch.compute.operator.SparklineGenerateEmptyBucketsOperatorTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/150937


### PR DESCRIPTION
These failures were caused by test cleanup issuing view CRUD requests against 9.0.8 nodes that don't support views, crashing the old node's master and cascading into unrelated test failures. Fixed by #151055 (backported as #151539), which hardened the view-support capability check in CsvTestsDataLoader

Fixes: #150930
Fixes: #150931
Fixes: #150932
Fixes: #150933