### PR TITLE
[9.5] ES|QL: Use analyzed tokens stream instead of MemoryIndex (#151050)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -2017,3 +2017,19 @@ ROW a = [100, 200, 300]::unsigned_long
 a:unsigned_long
 200
 ;
+
+matchMultipleTermsOnRuntimeText
+required_capability: match_operator_colon
+required_capability: fn_match_runtime_filter
+
+ROW content = to_text(["This is a brown fox", "This is a brown dog", "This dog is really brown"])
+| MV_EXPAND content
+| WHERE content:"fox dog"
+| SORT content
+;
+
+content:text
+This dog is really brown
+This is a brown dog
+This is a brown fox
+;

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchTextEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchTextEvaluator.java
@@ -7,7 +7,10 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 import java.io.IOException;
 import java.lang.Override;
 import java.lang.String;
+import java.util.Set;
+import java.util.function.Function;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -30,20 +33,23 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
 
   private final ExpressionEvaluator fieldBlock;
 
-  private final String queryString;
+  private final Set<BytesRef> queryTerms;
 
   private final Analyzer analyzer;
+
+  private final BytesRef scratch;
 
   private final DriverContext driverContext;
 
   private Warnings warnings;
 
-  public MatchTextEvaluator(Source source, ExpressionEvaluator fieldBlock, String queryString,
-      Analyzer analyzer, DriverContext driverContext) {
+  public MatchTextEvaluator(Source source, ExpressionEvaluator fieldBlock, Set<BytesRef> queryTerms,
+      Analyzer analyzer, BytesRef scratch, DriverContext driverContext) {
     this.source = source;
     this.fieldBlock = fieldBlock;
-    this.queryString = queryString;
+    this.queryTerms = queryTerms;
     this.analyzer = analyzer;
+    this.scratch = scratch;
     this.driverContext = driverContext;
   }
 
@@ -65,7 +71,7 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
     try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
         try {
-          result.appendBoolean(Match.processText(p, fieldBlockBlock, this.queryString, this.analyzer));
+          result.appendBoolean(Match.processText(p, fieldBlockBlock, this.queryTerms, this.analyzer, this.scratch));
         } catch (IOException e) {
           warnings().registerException(e);
           result.appendNull();
@@ -77,7 +83,7 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "MatchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", queryString=" + queryString + ", analyzer=" + analyzer + "]";
+    return "MatchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", queryTerms=" + queryTerms + ", analyzer=" + analyzer + "]";
   }
 
   @Override
@@ -97,26 +103,29 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
 
     private final ExpressionEvaluator.Factory fieldBlock;
 
-    private final String queryString;
+    private final Set<BytesRef> queryTerms;
 
     private final Analyzer analyzer;
 
-    public Factory(Source source, ExpressionEvaluator.Factory fieldBlock, String queryString,
-        Analyzer analyzer) {
+    private final Function<DriverContext, BytesRef> scratch;
+
+    public Factory(Source source, ExpressionEvaluator.Factory fieldBlock, Set<BytesRef> queryTerms,
+        Analyzer analyzer, Function<DriverContext, BytesRef> scratch) {
       this.source = source;
       this.fieldBlock = fieldBlock;
-      this.queryString = queryString;
+      this.queryTerms = queryTerms;
       this.analyzer = analyzer;
+      this.scratch = scratch;
     }
 
     @Override
     public MatchTextEvaluator get(DriverContext context) {
-      return new MatchTextEvaluator(source, fieldBlock.get(context), queryString, analyzer, context);
+      return new MatchTextEvaluator(source, fieldBlock.get(context), queryTerms, analyzer, scratch.apply(context), context);
     }
 
     @Override
     public String toString() {
-      return "MatchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", queryString=" + queryString + ", analyzer=" + analyzer + "]";
+      return "MatchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", queryTerms=" + queryTerms + ", analyzer=" + analyzer + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -8,11 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.index.memory.MemoryIndex;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -26,6 +24,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -64,6 +63,7 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -511,7 +511,20 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
 
         // Text fields keep analyzer-based matching; every other type compares the query value against the field block directly.
         if (field.dataType() == TEXT) {
-            return new MatchTextEvaluator.Factory(source(), toEvaluator.apply(field()), queryAsObject().toString(), new StandardAnalyzer());
+            // TODO: use the analyzer specified in the options, for now we use the standard analyzer.
+            Analyzer analyzer = new StandardAnalyzer();
+            Set<BytesRef> queryTerms;
+            try {
+                queryTerms = queryTerms(analyzer);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Failed to tokenize query string: " + e.getMessage(), e);
+            }
+            // TODO: use the `zero_terms_query` option, for now we use `none`.
+            if (queryTerms.isEmpty()) {
+                return ConstantEvaluators.CONSTANT_FALSE_FACTORY;
+            }
+
+            return new MatchTextEvaluator.Factory(source(), toEvaluator.apply(field()), queryTerms, analyzer, context -> new BytesRef());
         }
 
         Object queryValue = queryAsRuntimeSearchValue(field.dataType(), query().dataType(), Foldables.queryAsObject(query(), sourceText()));
@@ -587,30 +600,53 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
         };
     }
 
+    private Set<BytesRef> queryTerms(Analyzer analyzer) throws IOException {
+        Set<BytesRef> queryTerms = new HashSet<>();
+
+        try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, queryAsObject().toString())) {
+            stream.reset();
+            TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+            while (stream.incrementToken()) {
+                queryTerms.add(BytesRef.deepCopyOf(term.getBytesRef()));
+            }
+            stream.end();
+        }
+        return queryTerms;
+    }
+
     @Evaluator(extraName = "Text", warnExceptions = { IOException.class }, allNullsIsNull = false)
-    static boolean processText(@Position int position, BytesRefBlock fieldBlock, @Fixed String queryString, @Fixed Analyzer analyzer)
-        throws IOException {
+    static boolean processText(
+        @Position int position,
+        BytesRefBlock fieldBlock,
+        @Fixed Set<BytesRef> queryTerms,
+        @Fixed Analyzer analyzer,
+        @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRef scratch
+    ) throws IOException {
         if (fieldBlock == null) {
             return false;
         }
 
         final var valueCount = fieldBlock.getValueCount(position);
         final var startIndex = fieldBlock.getFirstValueIndex(position);
-        var value = new BytesRef();
 
         for (int valueIndex = startIndex; valueIndex < startIndex + valueCount; valueIndex++) {
-            // TODO: See if we really need a memory index, we could match the terms directly from the analyzer token stream.
-            MemoryIndex index = new MemoryIndex();
-            value = fieldBlock.getBytesRef(valueIndex, value);
-            index.addField(CONTENT_FIELD, value.utf8ToString(), analyzer);
-            IndexSearcher searcher = index.createSearcher();
-
-            org.apache.lucene.util.QueryBuilder queryBuilder = new org.apache.lucene.util.QueryBuilder(analyzer);
-            // TODO: Use the operator specified in the query options instead of `BooleanClause.Occur.SHOULD`.
-            org.apache.lucene.search.Query query = queryBuilder.createBooleanQuery(CONTENT_FIELD, queryString, BooleanClause.Occur.SHOULD);
-
-            TopDocs topDocs = searcher.search(query, 1);
-            if (topDocs.scoreDocs.length > 0) {
+            boolean foundMatch = false;
+            scratch = fieldBlock.getBytesRef(valueIndex, scratch);
+            // Because we use the standard analyzer and options cannot be specified, we can look for matches in the analyzed token stream.
+            // Once we accept options, we might need to take a different execution path and use a Lucene MemoryIndex.
+            try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, scratch.utf8ToString())) {
+                stream.reset();
+                TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+                // TODO: Use the operator specified in the query options. For now, we use OR, meaning we stop as soon as we find a match.
+                while (stream.incrementToken()) {
+                    if (queryTerms.contains(term.getBytesRef())) {
+                        foundMatch = true;
+                        break;
+                    }
+                }
+                stream.end();
+            }
+            if (foundMatch) {
                 return true;
             }
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchRuntimeSearchEvaluatorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.test.ESTestCase;
@@ -44,6 +45,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 /**
  * End-to-end execution tests for runtime {@code match}, where the field is
@@ -176,6 +178,40 @@ public class MatchRuntimeSearchEvaluatorTests extends ESTestCase {
         assertArrayEquals(new Boolean[] { true, false }, result);
     }
 
+    public void testTextWithZeroQueryTerms() {
+        Boolean[] result = evaluate(runtimeMatch(TEXT, new BytesRef("! ! !"), TEXT), factory -> bytesRefBlock(factory, builder -> {
+            builder.appendBytesRef(new BytesRef("This is a Brown fox"));
+            builder.appendBytesRef(new BytesRef("The cat sat on the mat"));
+        }));
+        assertArrayEquals(new Boolean[] { false, false }, result);
+    }
+
+    public void testTextAndTermNormalization() {
+        Boolean[] result = evaluate(runtimeMatch(TEXT, new BytesRef("cat dog"), TEXT), factory -> bytesRefBlock(factory, builder -> {
+            builder.appendBytesRef(new BytesRef("The CAT sat on the mat"));
+            builder.appendBytesRef(new BytesRef("LAZY DOG"));
+        }));
+        assertArrayEquals(new Boolean[] { true, true }, result);
+    }
+
+    public void testTextAndMultiTermQuery() {
+        Boolean[] result = evaluate(runtimeMatch(TEXT, new BytesRef("fox dog"), TEXT), factory -> bytesRefBlock(factory, builder -> {
+            builder.appendBytesRef(new BytesRef("This is a brown fox"));
+            builder.appendBytesRef(new BytesRef("This is a brown dog"));
+            builder.appendBytesRef(new BytesRef("Just a turtle"));
+            builder.appendBytesRef(new BytesRef("This dog is really brown"));
+        }));
+        assertArrayEquals(new Boolean[] { true, true, false, true }, result);
+    }
+
+    public void testTextWithZeroTermsValues() {
+        Boolean[] result = evaluate(runtimeMatch(TEXT, new BytesRef("fox"), TEXT), factory -> bytesRefBlock(factory, builder -> {
+            builder.appendBytesRef(new BytesRef("! !"));
+            builder.appendBytesRef(new BytesRef(""));
+        }));
+        assertArrayEquals(new Boolean[] { false, false }, result);
+    }
+
     // ---- keyword: exact (unanalyzed) matching ----
 
     public void testKeywordIsExactAndCaseSensitive() {
@@ -248,6 +284,11 @@ public class MatchRuntimeSearchEvaluatorTests extends ESTestCase {
             }
         });
         assertArrayEquals(new Boolean[] { true, false, false }, result);
+    }
+
+    public void testTextWithZeroTermsQueryUsesConstantBlock() {
+        Match match = runtimeMatch(TEXT, new BytesRef("! ! !"), TEXT);
+        assertThat(match.toEvaluator(toEvaluator()), instanceOf(ConstantEvaluators.CONSTANT_FALSE_FACTORY.getClass()));
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ES|QL: Use analyzed tokens stream instead of MemoryIndex (#151050)