### PR TITLE
[9.4] ESQL: fix METRICS_INFO duplicate data streams (#153128)

### DIFF
--- a/docs/changelog/153128.yaml
+++ b/docs/changelog/153128.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues: []
+pr: 153128
+summary: Resolve prefixed searchable-snapshot backing indices to their data stream
+  in `METRICS_INFO`/`TS_INFO`
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MetricsInfoOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MetricsInfoOperator.java
@@ -416,16 +416,26 @@ public class MetricsInfoOperator implements Operator {
      * {@code DataStream#getDefaultIndexName}: {@code .ds-{name}-{yyyy.MM.dd}-{000001}}
      * (or the {@code .fs-} variant).
      * <p>
+     * Index management can prepend dash-terminated prefixes to a backing index when it is
+     * mounted or rewritten in place, for example {@code partial-} and {@code restored-}
+     * (searchable snapshots), {@code shrink-{uuid}-}, and {@code downsample-{interval}-}.
+     * These prefixes can also be chained, e.g. {@code partial-restored-shrink-{uuid}-.ds-...}.
+     * The optional {@code (?:.*-)?} group ignores any such prefix while still requiring the
+     * {@code .ds-}/{@code .fs-} marker, so the captured data-stream name is unaffected.
+     * <p>
      * Group 1 captures the data-stream name.
      */
-    private static final Pattern BACKING_INDEX_PATTERN = Pattern.compile("^\\.(?:ds|fs)-(.+)-\\d{4}\\.\\d{2}\\.\\d{2}-\\d{6}$");
+    private static final Pattern BACKING_INDEX_PATTERN = Pattern.compile("^(?:.*-)?\\.(?:ds|fs)-(.+)-\\d{4}\\.\\d{2}\\.\\d{2}-\\d{6}$");
 
     /**
      * Resolves the data-stream name from a concrete backing-index name.
      * <p>
      * If the name matches the standard format produced by
      * {@code DataStream#getDefaultIndexName} ({@code .ds-{name}-{yyyy.MM.dd}-{000001}}),
-     * the data-stream name is extracted. Otherwise the raw index name is returned unchanged.
+     * including any dash-terminated prefixes added when a backing index is mounted or
+     * rewritten (e.g. {@code partial-}, {@code restored-}, {@code shrink-{uuid}-},
+     * {@code downsample-{interval}-}), the data-stream name is extracted. Otherwise the
+     * raw index name is returned unchanged.
      * <p>
      * Handles cluster-alias prefixed names (e.g. {@code remote:.ds-k8s-2024.01.15-000001})
      * so that the output preserves the cluster qualifier (e.g. {@code remote:k8s}).

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MetricsInfoOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MetricsInfoOperatorTests.java
@@ -583,6 +583,66 @@ public class MetricsInfoOperatorTests extends OperatorTestCase {
     }
 
     /**
+     * Backing indices mounted or rewritten by index management carry dash-terminated prefixes
+     * (searchable snapshots: partial-/restored-, shrink, downsample). These must resolve to the
+     * same data-stream name as the un-prefixed backing index so the two are not reported as
+     * separate data streams.
+     */
+    public void testResolveDataStreamNameWithBackingIndexPrefixes() {
+        // Searchable-snapshot mounts
+        assertThat(
+            MetricsInfoOperator.resolveDataStreamName("partial-.ds-metrics-system.cpu-2024.01.15-000001"),
+            equalTo("metrics-system.cpu")
+        );
+        assertThat(
+            MetricsInfoOperator.resolveDataStreamName("restored-.ds-metrics-system.cpu-2024.01.15-000001"),
+            equalTo("metrics-system.cpu")
+        );
+        // Shrink and downsample rewrites
+        assertThat(MetricsInfoOperator.resolveDataStreamName("shrink-abc123-.ds-k8s-2024.01.15-000001"), equalTo("k8s"));
+        assertThat(MetricsInfoOperator.resolveDataStreamName("downsample-1h-.ds-k8s-2024.01.15-000001"), equalTo("k8s"));
+        // Chained prefixes
+        assertThat(
+            MetricsInfoOperator.resolveDataStreamName("partial-restored-shrink-abc123-downsample-1h-.ds-k8s-2024.01.15-000001"),
+            equalTo("k8s")
+        );
+        // Failure store with a prefix
+        assertThat(MetricsInfoOperator.resolveDataStreamName("restored-.fs-my-stream-2024.01.15-000001"), equalTo("my-stream"));
+        // Cluster-prefixed, mounted backing index → cluster prefix preserved, data-stream name resolved
+        assertThat(MetricsInfoOperator.resolveDataStreamName("remote:partial-.ds-k8s-2024.01.15-000001"), equalTo("remote:k8s"));
+        // A plain index whose name embeds ".ds" without the dash boundary is not a backing index
+        assertThat(MetricsInfoOperator.resolveDataStreamName("my.ds-index-2024.01.15-000001"), equalTo("my.ds-index-2024.01.15-000001"));
+    }
+
+    /**
+     * A data stream whose frozen tier holds a partially-mounted searchable snapshot must produce a
+     * single entry: the prefixed backing index resolves to the same data-stream name as the plain
+     * backing index, so both merge instead of emitting a spurious duplicate row.
+     */
+    public void testPartiallyMountedBackingIndexMergesWithPlainBackingIndex() {
+        BlockFactory blockFactory = driverContext().blockFactory();
+        try (Operator op = createInitialOperator()) {
+            Page hot = buildPage(blockFactory, "{\"cpu_usage\": 0.5, \"host\": \"a\"}", ".ds-metrics-system.cpu-2024.01.15-000002");
+            Page frozen = buildPage(
+                blockFactory,
+                "{\"cpu_usage\": 0.9, \"host\": \"b\"}",
+                "partial-.ds-metrics-system.cpu-2024.01.15-000001"
+            );
+            op.addInput(hot);
+            op.addInput(frozen);
+            op.finish();
+
+            Page output = op.getOutput();
+            assertNotNull(output);
+            assertThat(output.getPositionCount(), equalTo(1));
+            assertColumnValue(output, 0, 0, "cpu_usage");
+            assertThat(collectMultiValues(output, 1, 0), equalTo(Set.of("metrics-system.cpu")));
+
+            output.releaseBlocks();
+        }
+    }
+
+    /**
      * Different metrics in the same tsid can have different dimension sets.
      * Metric A appears only with dim "host", metric B appears only with dim "mount".
      * After processing, A should have {host} and B should have {mount}, not the union.


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: fix METRICS_INFO duplicate data streams (#153128)