### PR TITLE
[9.5] Apply search timeout to the query rewrite step (#153082)

### DIFF
--- a/docs/changelog/153082.yaml
+++ b/docs/changelog/153082.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 104187
+pr: 153082
+summary: Apply search timeout to the query rewrite step
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
@@ -368,6 +368,31 @@ public class SearchTimeoutIT extends ESIntegTestCase {
         assertEquals(RestStatus.TOO_MANY_REQUESTS.getStatus(), ex.status().getStatus());
     }
 
+    public void testRewriteTimeoutWithPartialResults() {
+        SearchRequestBuilder searchRequestBuilder = prepareSearch("test").setTimeout(new TimeValue(10, TimeUnit.SECONDS))
+            .setQuery(new RewriteTimeoutQuery());
+        ElasticsearchAssertions.assertResponse(searchRequestBuilder, searchResponse -> {
+            assertThat(searchResponse.isTimedOut(), equalTo(true));
+            assertEquals(0, searchResponse.getShardFailures().length);
+            assertEquals(0, searchResponse.getFailedShards());
+            assertThat(searchResponse.getSuccessfulShards(), greaterThan(0));
+            assertEquals(searchResponse.getSuccessfulShards(), searchResponse.getTotalShards());
+            assertEquals(0, searchResponse.getHits().getTotalHits().value());
+            assertEquals(0, searchResponse.getHits().getHits().length);
+        });
+    }
+
+    public void testPartialResultsIntolerantRewriteTimeout() {
+        ElasticsearchException ex = expectThrows(
+            ElasticsearchException.class,
+            prepareSearch("test").setTimeout(new TimeValue(10, TimeUnit.SECONDS))
+                .setQuery(new RewriteTimeoutQuery())
+                .setAllowPartialSearchResults(false)
+        );
+        assertTrue(ex.toString().contains("Time exceeded"));
+        assertEquals(RestStatus.TOO_MANY_REQUESTS.getStatus(), ex.status().getStatus());
+    }
+
     public static final class SearchTimeoutPlugin extends Plugin implements SearchPlugin {
         @Override
         public List<QuerySpec<?>> getQueries() {
@@ -379,7 +404,12 @@ public class SearchTimeoutIT extends ESIntegTestCase {
                 ),
                 new QuerySpec<QueryBuilder>("dfs_knn_timeout", DfsKnnTimeoutQuery::new, parser -> {
                     throw new UnsupportedOperationException();
-                })
+                }),
+                new QuerySpec<QueryBuilder>(
+                    "rewrite_timeout",
+                    RewriteTimeoutQuery::new,
+                    parser -> { throw new UnsupportedOperationException(); }
+                )
             );
         }
 
@@ -619,6 +649,59 @@ public class SearchTimeoutIT extends ESIntegTestCase {
         @Override
         public TransportVersion getMinimalSupportedVersion() {
             return null;
+        }
+    }
+
+    /**
+     * Query builder which throws a TimeExceededException while the query is being rewritten, before any scoring happens.
+     */
+    public static final class RewriteTimeoutQuery extends DummyQueryBuilder {
+
+        RewriteTimeoutQuery() {}
+
+        RewriteTimeoutQuery(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "rewrite_timeout";
+        }
+
+        @Override
+        protected Query doToQuery(SearchExecutionContext context) {
+            return new Query() {
+                @Override
+                public Query rewrite(IndexSearcher searcher) {
+                    ((ContextIndexSearcher) searcher).throwTimeExceededException();
+                    throw new AssertionError("should have thrown TimeExceededException");
+                }
+
+                @Override
+                public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+                    throw new AssertionError("should have timed out during rewrite");
+                }
+
+                @Override
+                public String toString(String field) {
+                    return "rewrite timeout query";
+                }
+
+                @Override
+                public void visit(QueryVisitor visitor) {
+                    visitor.visitLeaf(this);
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                    return sameClassAs(obj);
+                }
+
+                @Override
+                public int hashCode() {
+                    return classHash();
+                }
+            };
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -163,6 +163,12 @@ public class QueryPhase {
         try {
             queryResult.from(searchContext.from());
             queryResult.size(searchContext.size());
+
+            final Runnable timeoutRunnable = getTimeoutCheck(searchContext);
+            if (timeoutRunnable != null) {
+                searcher.addQueryCancellation(timeoutRunnable);
+            }
+
             Query query = searchContext.rewrittenQuery();
             assert query == searcher.rewrite(query); // already rewritten
 
@@ -190,21 +196,16 @@ public class QueryPhase {
 
             final boolean hasFilterCollector = searchContext.parsedPostFilter() != null || searchContext.minimumScore() != null;
 
-            Weight postFilterWeight = null;
-            if (searchContext.parsedPostFilter() != null) {
-                postFilterWeight = searcher.createWeight(
-                    searcher.rewrite(searchContext.parsedPostFilter().query()),
-                    ScoreMode.COMPLETE_NO_SCORES,
-                    1f
-                );
-            }
-
-            final Runnable timeoutRunnable = getTimeoutCheck(searchContext);
-            if (timeoutRunnable != null) {
-                searcher.addQueryCancellation(timeoutRunnable);
-            }
-
             try {
+                Weight postFilterWeight = null;
+                if (searchContext.parsedPostFilter() != null) {
+                    postFilterWeight = searcher.createWeight(
+                        searcher.rewrite(searchContext.parsedPostFilter().query()),
+                        ScoreMode.COMPLETE_NO_SCORES,
+                        1f
+                    );
+                }
+
                 CollectorManager<Collector, QueryPhaseResult> collectorManager = QueryPhaseCollectorManager
                     .createQueryPhaseCollectorManager(
                         postFilterWeight,
@@ -249,9 +250,9 @@ public class QueryPhase {
 
     /**
      * Marks the current search as timed out and finalizes the {@link QuerySearchResult}
-     * with a well-formed empty response. This ensures that even when a timeout occurs
-     * (e.g., during collector setup or search execution), the shard still returns a
-     * valid result object with empty top docs and aggregations instead of throwing.
+     * with a well-formed empty response. This ensures that even when a timeout occurs,
+     * the shard returns a valid result object with empty top docs and aggregations rather
+     * than propagating a raw exception.
      */
     private static void finalizeAsTimedOutResult(SearchContext searchContext) {
         QuerySearchResult queryResult = searchContext.queryResult();

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
@@ -403,7 +403,145 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
         };
     }
 
+    public void testRewriteTimeout() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        {
+            TimeoutQuery query = newMatchAllRewriteTimeoutQuery(false);
+            try (SearchContext context = createSearchContext(query, size)) {
+                QueryPhase.executeQuery(context);
+                assertFalse(context.queryResult().searchTimedOut());
+                assertEquals(numDocs, context.queryResult().topDocs().topDocs.totalHits.value());
+                assertEquals(size, context.queryResult().topDocs().topDocs.scoreDocs.length);
+            }
+        }
+        {
+            TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
+            try (SearchContext context = createSearchContextWithTimeout(query, size)) {
+                QueryPhase.executeQuery(context);
+                assertTrue(context.queryResult().searchTimedOut());
+                assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value());
+                assertEquals(0, context.queryResult().topDocs().topDocs.scoreDocs.length);
+            }
+        }
+    }
+
+    public void testRewriteTimeoutDisallowPartialResults() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
+        try (SearchContext context = createSearchContextWithTimeout(query, size, false)) {
+            QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.executeQuery(context));
+            assertNotNull("expected a root cause", ex.getCause());
+            assertTrue("expected the cause to be a SearchTimeoutException", ex.getCause() instanceof SearchTimeoutException);
+        }
+    }
+
+    public void testPostFilterCreateWeightTimeout() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery mainQuery = new TimeoutQuery() {
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+                return new MatchAllWeight(this, boost, scoreMode) {};
+            }
+        };
+        try (SearchContext context = createSearchContextWithTimeout(mainQuery, size)) {
+            context.parsedPostFilter(new ParsedQuery(newThrowOnCreateWeightQuery()));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().searchTimedOut());
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value());
+            assertEquals(0, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        }
+    }
+
+    public void testPostFilterCreateWeightTimeoutDisallowPartialResults() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery mainQuery = new TimeoutQuery() {
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+                return new MatchAllWeight(this, boost, scoreMode) {};
+            }
+        };
+        try (SearchContext context = createSearchContextWithTimeout(mainQuery, size, false)) {
+            context.parsedPostFilter(new ParsedQuery(newThrowOnCreateWeightQuery()));
+            QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.executeQuery(context));
+            assertNotNull("expected a root cause", ex.getCause());
+            assertTrue("expected the cause to be a SearchTimeoutException", ex.getCause() instanceof SearchTimeoutException);
+        }
+    }
+
+    private static Query newThrowOnCreateWeightQuery() {
+        return new Query() {
+            @Override
+            public Query rewrite(IndexSearcher searcher) {
+                return this;
+            }
+
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+                ((ContextIndexSearcher) searcher).throwTimeExceededException();
+                throw new AssertionError("should have thrown TimeExceededException");
+            }
+
+            @Override
+            public String toString(String field) {
+                return "throw on create weight query";
+            }
+
+            @Override
+            public void visit(QueryVisitor visitor) {
+                visitor.visitLeaf(this);
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                return sameClassAs(obj);
+            }
+
+            @Override
+            public int hashCode() {
+                return classHash();
+            }
+        };
+    }
+
+    private static TimeoutQuery newMatchAllRewriteTimeoutQuery(boolean isTimeoutExpected) {
+        return new TimeoutQuery() {
+            @Override
+            public Query rewrite(IndexSearcher searcher) {
+                if (isTimeoutExpected) {
+                    shouldTimeout = true;
+                }
+
+                ((ContextIndexSearcher) searcher).checkCancelled();
+                assert shouldTimeout == false : "should have already timed out";
+                return this;
+            }
+
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+                return new MatchAllWeight(this, boost, scoreMode) {};
+            }
+        };
+    }
+
     private TestSearchContext createSearchContextWithTimeout(TimeoutQuery query, int size) throws IOException {
+        return createSearchContextWithTimeout(query, size, true);
+    }
+
+    private TestSearchContext createSearchContextWithTimeout(TimeoutQuery query, int size, boolean allowPartialSearchResults)
+        throws IOException {
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.allowPartialSearchResults(allowPartialSearchResults);
+        final ShardSearchRequest shardSearchRequest = new ShardSearchRequest(
+            OriginalIndices.NONE,
+            searchRequest,
+            indexShard.shardId(),
+            0,
+            1,
+            AliasFilter.EMPTY,
+            1F,
+            0,
+            null
+        );
         TestSearchContext context = new TestSearchContext(createSearchExecutionContext(), indexShard, newContextSearcher(reader)) {
             @Override
             public long getRelativeTimeInMillis() {
@@ -411,6 +549,11 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
                 // when a timeout is not expected. The tiniest increment to relative time in millis triggers a timeout.
                 // See QueryPhase#getTimeoutCheck
                 return query.shouldTimeout ? 1L : 0L;
+            }
+
+            @Override
+            public ShardSearchRequest request() {
+                return shardSearchRequest;
             }
         };
         context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Apply search timeout to the query rewrite step (#153082)