### PR TITLE
[8.19] [Gradle] Set tmp dir for build integ tests explicitly (#152833)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -9,6 +9,7 @@
 
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo
+import org.gradle.process.CommandLineArgumentProvider
 
 plugins {
   id 'java-gradle-plugin'
@@ -377,6 +378,12 @@ tasks.register("integTest", Test) {
   testClassesDirs = sourceSets.integTest.output.classesDirs
   classpath = sourceSets.integTest.runtimeClasspath
   useJUnitPlatform()
+  // ElasticsearchTestBasePlugin cannot apply itself, so java.io.tmpdir must be set manually here.
+  // Without it, JUnit/Spock create temp dirs under /tmp (root fs) instead of the build dir (/dev/shm in CI).
+  // The nested Gradle TestKit runners require an absolute path, so a relative value is not an option here.
+  // A CommandLineArgumentProvider keeps that absolute path out of the task inputs so it stays cache relocatable.
+  def tempDir = temporaryDir
+  jvmArgumentProviders.add({ ["-Djava.io.tmpdir=${tempDir}"] as List<String> } as CommandLineArgumentProvider)
 }
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -184,6 +184,10 @@ tasks.named('test').configure {
 tasks.register("integTest", Test) {
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
+    // The nested Gradle TestKit runners require an absolute path, so a relative value is not an option here.
+    // A CommandLineArgumentProvider keeps that absolute path out of the task inputs so it stays cache relocatable.
+    def tempDir = temporaryDir
+    jvmArgumentProviders.add({ ["-Djava.io.tmpdir=${tempDir}"] as List<String> } as CommandLineArgumentProvider)
     useJUnitPlatform()
 }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Gradle] Set tmp dir for build integ tests explicitly (#152833)