### PR TITLE
ES|QL: Remove query pragma for runtime search

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/MatchAtRuntimeBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/MatchAtRuntimeBenchmark.java
@@ -12,14 +12,12 @@ package org.elasticsearch.benchmark.esql;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.benchmark.Utils;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -29,10 +27,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.Match;
-import org.elasticsearch.xpack.esql.plan.ResolvedSettings;
 import org.elasticsearch.xpack.esql.planner.Layout;
-import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
-import org.elasticsearch.xpack.esql.session.Configuration;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -46,10 +41,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import java.time.Instant;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -89,26 +81,7 @@ public class MatchAtRuntimeBenchmark {
 
         Attribute field = new ReferenceAttribute(Source.EMPTY, "field", DataType.TEXT);
 
-        Configuration config = new Configuration(
-            Instant.now(),
-            Locale.US,
-            null,
-            null,
-            new QueryPragmas(Settings.builder().put("runtime_lexical_search", "true").build()),
-            AnalyzerSettings.QUERY_RESULT_TRUNCATION_MAX_SIZE.getDefault(Settings.EMPTY),
-            AnalyzerSettings.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
-            "",
-            false,
-            Map.of(),
-            System.nanoTime(),
-            false,
-            AnalyzerSettings.QUERY_TIMESERIES_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
-            AnalyzerSettings.QUERY_TIMESERIES_RESULT_TRUNCATION_DEFAULT_SIZE.get(Settings.EMPTY),
-            ResolvedSettings.EMPTY,
-            Map.of()
-        );
-
-        Expression expr = new Match(Source.EMPTY, field, Literal.text(Source.EMPTY, "abc"), null, config);
+        Expression expr = new Match(Source.EMPTY, field, Literal.text(Source.EMPTY, "abc"), null);
 
         // Build evaluator through the standard eval pipeline
         Layout.Builder layoutBuilder = new Layout.Builder();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.junit.AfterClass;
 import org.junit.AssumptionViolatedException;
 import org.junit.BeforeClass;
@@ -847,20 +846,6 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                     }
                 }
             }
-            // A MATCH(...) whose keyword field argument was wrapped in field_extract(...) is pushed
-            // to Lucene as a synthetic field attribute, which only the runtime lexical search path
-            // can score. That path is gated on the MATCH_RUNTIME_SEARCH capability, which is
-            // snapshot-only (see EsqlCapabilities). In a release build the RUNTIME_LEXICAL_SEARCH
-            // pragma has no effect, so the analyzer rejects the wrapped field with "cannot operate
-            // on [field_extract(...)]". Skip the variant there rather than launch a query that is
-            // guaranteed to fail for a build-flavor reason unrelated to field_extract coverage.
-            if (result.wrappedMatchFunctionArg() && org.elasticsearch.Build.current().isSnapshot() == false) {
-                SILENCED_COUNTS_BY_REASON.computeIfAbsent("match_runtime_search_snapshot_only", k -> new AtomicInteger()).incrementAndGet();
-                logger.info("keyword→flattened: skipping; MATCH runtime search is snapshot-only [{}]", testId);
-                throw new StacklessAssumptionViolatedException(
-                    "skipping: MATCH(field_extract(...)) requires the snapshot-only MATCH_RUNTIME_SEARCH capability"
-                );
-            }
             // The short "launched" marker is emitted unconditionally so that every launched test has a single,
             // grep-able log line tying the test method (from the JUnit thread context) to the set of fields
             // the rewriter actually wrapped. The multi-line rewritten query itself is gated on
@@ -879,9 +864,6 @@ public class CsvFlattenedKeywordIT extends CsvIT {
             }
 
             Settings extraPragmas = Settings.EMPTY;
-            if (result.wrappedMatchFunctionArg()) {
-                extraPragmas = Settings.builder().put(QueryPragmas.RUNTIME_LEXICAL_SEARCH.getKey(), true).build();
-            }
             return new IndexLoadStrategy.TransformedQuery(result.rewrittenQuery(), extraPragmas);
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -42,7 +42,6 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.expression.Foldables;
-import org.elasticsearch.xpack.esql.expression.function.ConfigurationFunction;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
@@ -66,7 +65,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Map.entry;
@@ -101,11 +99,11 @@ import static org.elasticsearch.xpack.esql.expression.predicate.operator.compari
 /**
  * Full text function that performs a {@link org.elasticsearch.xpack.esql.querydsl.query.MatchQuery} .
  */
-public class Match extends SingleFieldFullTextFunction implements OptionalArgument, ConfigurationFunction {
+public class Match extends SingleFieldFullTextFunction implements OptionalArgument {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Match", Match::readFrom);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Match.class)
-        .ternaryConfig(Match::new)
+        .ternary(Match::new)
         .capabilities("runtime_filter")
         .name("match");
     public static final Set<DataType> FIELD_DATA_TYPES = Set.of(
@@ -150,8 +148,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
         entry(ZERO_TERMS_QUERY_FIELD.getPreferredName(), KEYWORD)
     );
     private static final String CONTENT_FIELD = "content_field";
-
-    private final Configuration configuration;
 
     @FunctionInfo(
         returnType = "boolean",
@@ -294,20 +290,12 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
                         + "when using a stop filter. Defaults to none."
                 ) },
             optional = true
-        ) Expression options,
-        Configuration configuration
+        ) Expression options
     ) {
-        this(source, field, matchQuery, options, null, configuration);
+        this(source, field, matchQuery, options, null);
     }
 
-    public Match(
-        Source source,
-        Expression field,
-        Expression matchQuery,
-        Expression options,
-        QueryBuilder queryBuilder,
-        Configuration configuration
-    ) {
+    public Match(Source source, Expression field, Expression matchQuery, Expression options, QueryBuilder queryBuilder) {
         super(
             source,
             field,
@@ -316,7 +304,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
             options == null ? List.of(field, matchQuery) : List.of(field, matchQuery, options),
             queryBuilder
         );
-        this.configuration = configuration;
     }
 
     @Override
@@ -330,7 +317,7 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
         Expression query = in.readNamedWriteable(Expression.class);
         QueryBuilder queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
         Configuration configuration = ((PlanStreamInput) in).configuration();
-        return new Match(source, field, query, null, queryBuilder, configuration);
+        return new Match(source, field, query, null, queryBuilder);
     }
 
     // This is not meant to be overriden by MatchOperator - MatchOperator should be serialized to Match
@@ -382,10 +369,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
         return ALLOWED_OPTIONS;
     }
 
-    protected Configuration configuration() {
-        return configuration;
-    }
-
     private Map<String, Object> matchQueryOptions() throws InvalidArgumentException {
         if (options() == null) {
             return Map.of(LENIENT_FIELD.getPreferredName(), true);
@@ -401,7 +384,7 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, Match::new, field(), query(), options(), queryBuilder(), configuration);
+        return NodeInfo.create(this, Match::new, field(), query(), options(), queryBuilder());
     }
 
     @Override
@@ -411,14 +394,13 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
             newChildren.get(0),
             newChildren.get(1),
             newChildren.size() > 2 ? newChildren.get(2) : null,
-            queryBuilder(),
-            configuration
+            queryBuilder()
         );
     }
 
     @Override
     public Expression replaceQueryBuilder(QueryBuilder queryBuilder) {
-        return new Match(source(), field, query(), options(), queryBuilder, configuration);
+        return new Match(source(), field, query(), options(), queryBuilder);
     }
 
     @Override
@@ -432,10 +414,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
 
     @Override
     protected boolean isRuntimeSearch() {
-        if (false == configuration.pragmas().runtimeLexicalSearch()) {
-            // Runtime search is disabled.
-            return false;
-        }
         if (fieldAsFieldAttribute() == null) {
             // This *isn't* a field in the index OR a pushed block loader
             return true;
@@ -698,21 +676,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
             return false;
         }
         return fieldBlock.hasValue(position, query);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (super.equals(o) == false) {
-            return false;
-        }
-
-        Match other = (Match) o;
-        return configuration.equals(other.configuration);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), configuration);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchOperator.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.xpack.esql.capabilities.ConfigurationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -17,7 +16,6 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
-import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.util.List;
 
@@ -27,7 +25,7 @@ import java.util.List;
  * the match operator in the function syntax.
  * Serialization is provided as a way to pass the corresponding tests - serialization must be done to a Match class.
  */
-public class MatchOperator extends Match implements ConfigurationAware {
+public class MatchOperator extends Match {
 
     @FunctionInfo(
         returnType = "boolean",
@@ -78,14 +76,13 @@ public class MatchOperator extends Match implements ConfigurationAware {
             name = "query",
             type = { "keyword", "boolean", "date", "date_nanos", "double", "integer", "ip", "long", "unsigned_long", "version" },
             description = "Value to find in the provided field or expression."
-        ) Expression matchQuery,
-        Configuration configuration
+        ) Expression matchQuery
     ) {
-        super(source, field, matchQuery, null, null, configuration);
+        super(source, field, matchQuery, null, null);
     }
 
-    private MatchOperator(Source source, Expression field, Expression matchQuery, QueryBuilder queryBuilder, Configuration configuration) {
-        super(source, field, matchQuery, null, queryBuilder, configuration);
+    private MatchOperator(Source source, Expression field, Expression matchQuery, QueryBuilder queryBuilder) {
+        super(source, field, matchQuery, null, queryBuilder);
     }
 
     @Override
@@ -100,26 +97,16 @@ public class MatchOperator extends Match implements ConfigurationAware {
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, MatchOperator::new, field(), query(), configuration());
+        return NodeInfo.create(this, MatchOperator::new, field(), query());
     }
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new MatchOperator(source(), newChildren.get(0), newChildren.get(1), queryBuilder(), configuration());
+        return new MatchOperator(source(), newChildren.get(0), newChildren.get(1), queryBuilder());
     }
 
     @Override
     public Expression replaceQueryBuilder(QueryBuilder queryBuilder) {
-        return new MatchOperator(source(), field, query(), queryBuilder, configuration());
-    }
-
-    @Override
-    public Configuration configuration() {
-        return super.configuration();
-    }
-
-    @Override
-    public Expression withConfiguration(Configuration configuration) {
-        return new MatchOperator(source(), field, query(), queryBuilder(), configuration);
+        return new MatchOperator(source(), field, query(), queryBuilder);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -1381,6 +1381,6 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
             matchFieldExpression = expression(ctx.fieldExp);
         }
 
-        return new MatchOperator(source(ctx), matchFieldExpression, expression(ctx.matchQuery), ConfigurationAware.CONFIGURATION_MARKER);
+        return new MatchOperator(source(ctx), matchFieldExpression, expression(ctx.matchQuery));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -190,11 +190,6 @@ public final class QueryPragmas implements Writeable {
      */
     public static final Setting<Integer> MIN_DOCS_PER_SLICE = Setting.intSetting("min_docs_per_slice", -1, -1);
 
-    /**
-     *  When {@code true}, allows full-text functions to be used with expressions that are not indexed fields.
-     */
-    public static final Setting<Boolean> RUNTIME_LEXICAL_SEARCH = Setting.boolSetting("runtime_lexical_search", true);
-
     public static final QueryPragmas EMPTY = new QueryPragmas(Settings.EMPTY);
 
     public static final List<String> VALID_PRAGMA_NAMES = Stream.of(
@@ -219,8 +214,7 @@ public final class QueryPragmas implements Writeable {
         MAX_CONCURRENT_OPEN_SEGMENTS,
         MAX_RECORD_SIZE,
         FORCE_DOC_SEQUENCE,
-        PlannerSettings.TIME_SERIES_TARGET_CHUNK_ROWS,
-        RUNTIME_LEXICAL_SEARCH
+        PlannerSettings.TIME_SERIES_TARGET_CHUNK_ROWS
     ).map(Setting::getKey).toList();
 
     private final Settings settings;
@@ -420,10 +414,6 @@ public final class QueryPragmas implements Writeable {
     public int minDocsPerSlice(int defaultMinDocsPerSlice) {
         int override = MIN_DOCS_PER_SLICE.get(settings);
         return override > 0 ? override : defaultMinDocsPerSlice;
-    }
-
-    public boolean runtimeLexicalSearch() {
-        return RUNTIME_LEXICAL_SEARCH.get(settings);
     }
 
     public boolean isEmpty() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchErrorTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
@@ -38,7 +37,7 @@ public class MatchErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        Match match = new Match(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null, EsqlTestUtils.TEST_CFG);
+        Match match = new Match(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null);
         // We need to add the QueryBuilder to the match expression, as it is used to implement equals() and hashCode() and
         // thus test the serialization methods. But we can only do this if the parameters make sense .
         if (args.get(0) instanceof FieldAttribute && args.get(1).foldable()) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchOperatorErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchOperatorErrorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -34,7 +33,7 @@ public class MatchOperatorErrorTests extends ErrorsForCasesWithoutExamplesTestCa
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new MatchOperator(source, args.get(0), args.get(1), EsqlTestUtils.TEST_CFG);
+        return new MatchOperator(source, args.get(0), args.get(1));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchOperatorTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
@@ -38,7 +37,7 @@ public class MatchOperatorTests extends SingleFieldFullTextFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new MatchOperator(source, args.get(0), args.get(1), EsqlTestUtils.TEST_CFG);
+        return new MatchOperator(source, args.get(0), args.get(1));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchRuntimeSearchEvaluatorTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -108,7 +107,7 @@ public class MatchRuntimeSearchEvaluatorTests extends ESTestCase {
     private static Match runtimeMatch(DataType fieldType, Object queryValue, DataType queryType) {
         ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "field", fieldType);
         Literal query = new Literal(Source.EMPTY, queryValue, queryType);
-        Match match = new Match(Source.EMPTY, field, query, null, EsqlTestUtils.TEST_CFG);
+        Match match = new Match(Source.EMPTY, field, query, null);
         assertTrue("expected a runtime search, not a pushed-down query", match.isRuntimeSearch());
         return match;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchSerializationTests.java
@@ -19,7 +19,7 @@ public class MatchSerializationTests extends AbstractExpressionSerializationTest
         Source source = randomSource();
         Expression field = randomChild();
         Expression query = randomChild();
-        return new Match(source, field, query, null, configuration());
+        return new Match(source, field, query, null);
     }
 
     @Override
@@ -32,6 +32,6 @@ public class MatchSerializationTests extends AbstractExpressionSerializationTest
         } else {
             query = randomValueOtherThan(query, AbstractExpressionSerializationTests::randomChild);
         }
-        return new Match(source, field, query, null, configuration());
+        return new Match(source, field, query, null);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchTests.java
@@ -45,7 +45,7 @@ public class MatchTests extends SingleFieldFullTextFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Match(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null, testCase.getConfiguration());
+        return new Match(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null);
     }
 
     protected static List<TestCaseSupplier> testCaseSuppliers() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
@@ -77,7 +77,6 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.FIVE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.FOUR;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.ONE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.SIX;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TWO;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
@@ -319,8 +318,7 @@ public class PushDownAndCombineFiltersTests extends AbstractLogicalPlanOptimizer
             completion.targetField(),
             randomLiteral(DataType.TEXT),
             mock(Expression.class),
-            mock(QueryBuilder.class),
-            TEST_CFG
+            mock(QueryBuilder.class)
         );
         Filter filterB = new Filter(EMPTY, completion, new And(EMPTY, conditionB, conditionCompletion));
 


### PR DESCRIPTION
Since the feature is now released, we no longer need the `runtime_lexical_search` query pragma which now has a default value of `true` (e.g. always enabled).

We also needed to refactor `Match` since it no longer requires the `configuration` object.