### PR TITLE
Fix LIKE/RLIKE pattern lists on wildcard fields

### DIFF
--- a/docs/changelog/153391.yaml
+++ b/docs/changelog/153391.yaml
@@ -1,0 +1,6 @@
+pr: 153391
+summary: Fix `LIKE`/`RLIKE` with a list of patterns on `wildcard` fields
+area: ES|QL
+type: bug
+issues:
+ - 152512

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesStringIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesStringIT.java
@@ -387,7 +387,6 @@ public class PushQueriesStringIT extends ESRestTestCase {
     }
 
     public void testCaseInsensitiveLikeList() throws IOException {
-        assumeFalse("WILDCARD field type does not support automaton queries", type == Type.WILDCARD);
         String value = "v".repeat(between(1, 256));
         String differentValue = randomValueOtherThan(value, () -> randomAlphaOfLength(value.length()));
         String esqlQuery = """
@@ -398,12 +397,11 @@ public class PushQueriesStringIT extends ESRestTestCase {
             case AUTO, CONSTANT_KEYWORD, MATCH_ONLY_TEXT_WITH_KEYWORD, TEXT_WITH_KEYWORD -> "*:*";
             case SEMANTIC_TEXT_WITH_KEYWORD -> "FieldExistsQuery [field=_primary_term]";
             case KEYWORD -> "test:LIKE(\"%value*\", \"abc*\"), caseInsensitive=true";
-            case WILDCARD -> throw new AssertionError("unreachable");
+            case WILDCARD -> ":LIKE(\"%value*\", \"abc*\"), caseInsensitive=true";
         };
         ComputeSignature dataNodeSignature = switch (type) {
-            case CONSTANT_KEYWORD, KEYWORD -> ComputeSignature.FILTER_IN_QUERY;
+            case CONSTANT_KEYWORD, KEYWORD, WILDCARD -> ComputeSignature.FILTER_IN_QUERY;
             case AUTO, MATCH_ONLY_TEXT_WITH_KEYWORD, SEMANTIC_TEXT_WITH_KEYWORD, TEXT_WITH_KEYWORD -> ComputeSignature.FILTER_IN_COMPUTE;
-            case WILDCARD -> throw new AssertionError("unreachable");
         };
         testPushQuery(value, differentValue, esqlQuery, List.of(luceneQuery), dataNodeSignature, hasItem(List.of(value)));
     }
@@ -429,7 +427,6 @@ public class PushQueriesStringIT extends ESRestTestCase {
     }
 
     public void testLikeList() throws IOException {
-        assumeFalse("WILDCARD field type does not support automaton queries", type == Type.WILDCARD);
         String value = "v".repeat(between(1, 256));
         String differentValue = randomValueOtherThan(value, () -> randomAlphaOfLength(value.length()));
         String esqlQuery = """
@@ -440,12 +437,11 @@ public class PushQueriesStringIT extends ESRestTestCase {
             case CONSTANT_KEYWORD, MATCH_ONLY_TEXT_WITH_KEYWORD, AUTO, TEXT_WITH_KEYWORD -> "*:*";
             case SEMANTIC_TEXT_WITH_KEYWORD -> "FieldExistsQuery [field=_primary_term]";
             case KEYWORD -> "test:LIKE(\"%value*\", \"abc*\"), caseInsensitive=false";
-            case WILDCARD -> throw new AssertionError("unreachable");
+            case WILDCARD -> ":LIKE(\"%value*\", \"abc*\"), caseInsensitive=false";
         };
         ComputeSignature dataNodeSignature = switch (type) {
-            case CONSTANT_KEYWORD, KEYWORD -> ComputeSignature.FILTER_IN_QUERY;
+            case CONSTANT_KEYWORD, KEYWORD, WILDCARD -> ComputeSignature.FILTER_IN_QUERY;
             case AUTO, TEXT_WITH_KEYWORD, MATCH_ONLY_TEXT_WITH_KEYWORD, SEMANTIC_TEXT_WITH_KEYWORD -> ComputeSignature.FILTER_IN_COMPUTE;
-            case WILDCARD -> throw new AssertionError("unreachable");
         };
         testPushQuery(value, differentValue, esqlQuery, List.of(luceneQuery), dataNodeSignature, hasItem(List.of(value)));
     }
@@ -471,7 +467,6 @@ public class PushQueriesStringIT extends ESRestTestCase {
     }
 
     public void testRLikeList() throws IOException {
-        assumeFalse("WILDCARD field type does not support automaton queries", type == Type.WILDCARD);
         String value = "v".repeat(between(1, 256));
         String differentValue = randomValueOtherThan(value, () -> randomAlphaOfLength(value.length()));
         String esqlQuery = """
@@ -482,12 +477,11 @@ public class PushQueriesStringIT extends ESRestTestCase {
             case CONSTANT_KEYWORD, MATCH_ONLY_TEXT_WITH_KEYWORD, AUTO, TEXT_WITH_KEYWORD -> "*:*";
             case SEMANTIC_TEXT_WITH_KEYWORD -> "FieldExistsQuery [field=_primary_term]";
             case KEYWORD -> "test:RLIKE(\"%value.*\", \"abc.*\"), caseInsensitive=false";
-            case WILDCARD -> throw new AssertionError("unreachable");
+            case WILDCARD -> ":RLIKE(\"%value.*\", \"abc.*\"), caseInsensitive=false";
         };
         ComputeSignature dataNodeSignature = switch (type) {
-            case CONSTANT_KEYWORD, KEYWORD -> ComputeSignature.FILTER_IN_QUERY;
+            case CONSTANT_KEYWORD, KEYWORD, WILDCARD -> ComputeSignature.FILTER_IN_QUERY;
             case AUTO, TEXT_WITH_KEYWORD, MATCH_ONLY_TEXT_WITH_KEYWORD, SEMANTIC_TEXT_WITH_KEYWORD -> ComputeSignature.FILTER_IN_COMPUTE;
-            case WILDCARD -> throw new AssertionError("unreachable");
         };
         testPushQuery(value, differentValue, esqlQuery, List.of(luceneQuery), dataNodeSignature, hasItem(List.of(value)));
     }
@@ -515,7 +509,6 @@ public class PushQueriesStringIT extends ESRestTestCase {
     }
 
     public void testCaseInsensitiveRLikeList() throws IOException {
-        assumeFalse("WILDCARD field type does not support automaton queries", type == Type.WILDCARD);
         String value = "v".repeat(between(1, 256));
         String differentValue = randomValueOtherThan(value, () -> randomAlphaOfLength(value.length()));
         String esqlQuery = """

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -145,6 +145,24 @@ abstract class BinaryDvConfirmedQuery extends Query {
     }
 
     /**
+     * Returns a query that runs an already-built Automaton across all binary doc values (but only for docs
+     * that also match a provided approximation query which is key to getting good performance). Unlike the
+     * pattern-specific factories above, this accepts a pre-computed automaton, so it can serve callers that
+     * combine several patterns into one automaton (e.g. {@code LIKE ("a*", "b*")}). {@code description} is
+     * used only for {@link Query#toString()}. Reads the field's binary doc values using the in-order
+     * {@link org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ArrayOrderInlineNull ArrayOrderInlineNull} format when
+     * {@code arrayOrder} is {@code true} (high-cardinality columnar fields in strictly columnar index mode).
+     */
+    public static Query fromAutomaton(Query approximation, String field, Automaton automaton, String description, boolean arrayOrder) {
+        return new BinaryDvConfirmedAutomatonQuery(
+            approximation,
+            field,
+            new PrecomputedAutomatonProvider(automaton, description),
+            arrayOrder
+        );
+    }
+
+    /**
      * Returns a query that checks for equality of at least one of the provided terms across
      * all binary doc values (but only for docs that also match a provided approximation query which
      * is key to getting good performance). Reads the field's binary doc values using the in-order
@@ -415,6 +433,48 @@ abstract class BinaryDvConfirmedQuery extends Query {
         @Override
         public Automaton getAutomaton(String field) {
             return fuzzyQuery.getAutomata().automaton;
+        }
+    }
+
+    /**
+     * Wraps an already-built automaton. Equality is keyed on {@code description} rather than the automaton
+     * itself: the description is derived from the same patterns and case-sensitivity used to build the
+     * automaton, so it is a stable, unique identity that also lets the query cache reuse identical filters
+     * (Lucene's {@link Automaton} has only identity equality).
+     */
+    private static final class PrecomputedAutomatonProvider implements AutomatonProvider {
+        private final Automaton automaton;
+        private final String description;
+
+        PrecomputedAutomatonProvider(Automaton automaton, String description) {
+            this.automaton = automaton;
+            this.description = description;
+        }
+
+        @Override
+        public Automaton getAutomaton(String field) {
+            return automaton;
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return description.equals(((PrecomputedAutomatonProvider) o).description);
+        }
+
+        @Override
+        public int hashCode() {
+            return description.hashCode();
         }
     }
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.ElasticsearchParseException;
@@ -94,6 +95,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.index.IndexSettings.IGNORE_ABOVE_SETTING;
 import static org.elasticsearch.index.mapper.Mapper.IgnoreAbove.getIgnoreAboveDefaultValue;
@@ -372,6 +374,29 @@ public class WildcardFieldMapper extends FieldMapper {
                     arrayOrderBinaryDocValues
                 );
             }
+        }
+
+        /**
+         * Confirms an arbitrary automaton against the binary doc values. Unlike {@link #wildcardQuery} and
+         * {@link #regexpQuery} we can't derive an ngram approximation from a single pattern here, so the
+         * automaton (typically a union of several patterns, e.g. {@code LIKE ("a*", "b*")}) is checked against
+         * every document. This is the path ES|QL uses to push down multi-pattern {@code LIKE}/{@code RLIKE}.
+         */
+        @Override
+        public Query automatonQuery(
+            Supplier<Automaton> automatonSupplier,
+            Supplier<CharacterRunAutomaton> characterRunAutomatonSupplier,
+            @Nullable MultiTermQuery.RewriteMethod method,
+            SearchExecutionContext context,
+            String description
+        ) {
+            return BinaryDvConfirmedQuery.fromAutomaton(
+                Queries.ALL_DOCS_INSTANCE,
+                name(),
+                automatonSupplier.get(),
+                description,
+                arrayOrderBinaryDocValues
+            );
         }
 
         private Integer getApproxWildCardQuery(String wildcardPattern, BooleanQuery.Builder rewritten) {

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -42,12 +42,14 @@ import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -526,6 +528,74 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         indexDoc(parseDoc, doc, iw);
     }
 
+    // A pre-built automaton (a union of several patterns, as ES|QL's WildcardLikeList/RLikeList produce) must
+    // match the same docs on a wildcard field as on a keyword field. The corpus mixes ASCII and multi-byte
+    // values on purpose: a UTF-8 vs UTF-32 automaton-alphabet mistake is invisible on ASCII and would only
+    // show up on the accented/CJK docs. Without WildcardFieldType.automatonQuery this throws instead of matching.
+    public void testAutomatonQueryVersusKeywordField() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
+        iwc.setMergePolicy(newTieredMergePolicy(random()));
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, iwc);
+
+        List<String> values = List.of("value_a", "abc_thing", "other_z", "café", "naïve", "日本_a");
+        for (String value : values) {
+            indexDoc(iw, value);
+        }
+        iw.forceMerge(1);
+        DirectoryReader reader = iw.getReader();
+        IndexSearcher searcher = newSearcher(reader);
+        iw.close();
+
+        String[][] patternSets = {
+            { "value*", "abc*" },       // plain ASCII prefixes
+            { "*é", "日本*" }, // ends-with 'é' or starts-with '日本'
+            { "na?ve", "*_a" } };       // '?' spanning a 2-byte char, plus a suffix
+        for (boolean caseInsensitive : new boolean[] { false, true }) {
+            for (String[] patterns : patternSets) {
+                final Automaton automaton = unionOfWildcardPatterns(patterns, caseInsensitive);
+                Supplier<Automaton> automatonSupplier = () -> automaton;
+                Supplier<CharacterRunAutomaton> runAutomatonSupplier = () -> new CharacterRunAutomaton(automaton);
+                String description = "LIKE(" + String.join(", ", patterns) + "), caseInsensitive=" + caseInsensitive;
+
+                Query wildcardFieldQuery = wildcardFieldType.fieldType()
+                    .automatonQuery(automatonSupplier, runAutomatonSupplier, null, MOCK_CONTEXT, description);
+                Query keywordFieldQuery = keywordFieldType.fieldType()
+                    .automatonQuery(automatonSupplier, runAutomatonSupplier, null, MOCK_CONTEXT, description);
+
+                TopDocs keywordHits = searcher.search(keywordFieldQuery, values.size() + 1);
+                TopDocs wildcardHits = searcher.search(wildcardFieldQuery, values.size() + 1);
+                assertThat(
+                    description + "\n" + keywordFieldQuery + "\n" + wildcardFieldQuery,
+                    wildcardHits.totalHits.value(),
+                    equalTo(keywordHits.totalHits.value())
+                );
+                HashSet<Integer> expectedDocs = new HashSet<>();
+                for (ScoreDoc scoreDoc : keywordHits.scoreDocs) {
+                    expectedDocs.add(scoreDoc.doc);
+                }
+                for (ScoreDoc scoreDoc : wildcardHits.scoreDocs) {
+                    assertTrue(description, expectedDocs.remove(scoreDoc.doc));
+                }
+                assertThat(description, expectedDocs.size(), equalTo(0));
+            }
+        }
+        reader.close();
+        dir.close();
+    }
+
+    private static Automaton unionOfWildcardPatterns(String[] patterns, boolean caseInsensitive) {
+        List<Automaton> automata = new ArrayList<>(patterns.length);
+        for (String pattern : patterns) {
+            automata.add(
+                caseInsensitive
+                    ? AutomatonQueries.toCaseInsensitiveWildcardAutomaton(new Term("f", pattern))
+                    : WildcardQuery.toAutomaton(new Term("f", pattern), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+            );
+        }
+        return Operations.determinize(Operations.union(automata), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+    }
+
     public void testRangeQueryVersusKeywordField() throws IOException {
         Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
@@ -751,6 +821,32 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         Query arrayOrderQ = BinaryDvConfirmedQuery.fromWildcardQuery(Queries.ALL_DOCS_INSTANCE, "field", pattern, false, true);
         assertNotEquals(csQ, arrayOrderQ);
         assertNotEquals(csQ.hashCode(), arrayOrderQ.hashCode());
+    }
+
+    public void testQueryCachingEqualityFromAutomatonWithDescription() {
+        Automaton automaton = WildcardQuery.toAutomaton(new Term("field", "A*b*"), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+
+        // Equality is keyed on the description, so identical descriptions are equal regardless of the automaton instance
+        Query q1 = BinaryDvConfirmedQuery.fromAutomaton(Queries.ALL_DOCS_INSTANCE, "field", automaton, "LIKE(\"A*b*\")", false);
+        Query q2 = BinaryDvConfirmedQuery.fromAutomaton(Queries.ALL_DOCS_INSTANCE, "field", automaton, "LIKE(\"A*b*\")", false);
+        assertEquals(q1, q2);
+        assertEquals(q1.hashCode(), q2.hashCode());
+
+        // Different description should not be equal
+        Query differentDescription = BinaryDvConfirmedQuery.fromAutomaton(
+            Queries.ALL_DOCS_INSTANCE,
+            "field",
+            automaton,
+            "LIKE(\"A*b*\"), caseInsensitive=true",
+            false
+        );
+        assertNotEquals(q1, differentDescription);
+        assertNotEquals(q1.hashCode(), differentDescription.hashCode());
+
+        // Different arrayOrder should not be equal
+        Query arrayOrderQ = BinaryDvConfirmedQuery.fromAutomaton(Queries.ALL_DOCS_INSTANCE, "field", automaton, "LIKE(\"A*b*\")", true);
+        assertNotEquals(q1, arrayOrderQ);
+        assertNotEquals(q1.hashCode(), arrayOrderQ.hashCode());
     }
 
     public void testQueryCachingEqualityFromTerms() {


### PR DESCRIPTION
`LIKE ("*a", "b*")` (a pattern list) 400'd on `wildcard` fields: the field type never implemented `automatonQuery`, which the list pushdown uses. Added it to `WildcardFieldType`, reusing the binary-doc-values confirmation it already has.

It confirms against every doc instead of building an ngram approximation, since the API only hands over the unioned automaton, not the patterns. Happy to OR the per-pattern queries for acceleration if you'd prefer. Un-skipped the four list tests from #152514, added a mapper test.

Closes #152512
