### PR TITLE
[9.5] ESQL: Render `flattened` to `arrow` in the same way as `_source` - json

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/arrow/ArrowResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/arrow/ArrowResponse.java
@@ -439,7 +439,7 @@ public class ArrowResponse implements ChunkedRestResponseBodyPart, Releasable {
 
             case AGGREGATE_METRIC_DOUBLE -> TO_BE_IMPLEMENTED_MARKER;
             case EXPONENTIAL_HISTOGRAM -> TO_BE_IMPLEMENTED_MARKER;
-            case FLATTENED -> TO_BE_IMPLEMENTED_MARKER;
+            case FLATTENED -> new BlockArrowFormatter.TransformedBytesRef(type, MinorType.VARCHAR, ValueConversions::sourceToJson);
             case GEOHASH -> TO_BE_IMPLEMENTED_MARKER;
             case GEOHEX -> TO_BE_IMPLEMENTED_MARKER;
             case GEOTILE -> TO_BE_IMPLEMENTED_MARKER;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/arrow/ArrowResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/arrow/ArrowResponseTests.java
@@ -158,6 +158,14 @@ public class ArrowResponseTests extends ESTestCase {
         (v, i) -> new String(v.get(i), StandardCharsets.UTF_8)
     );
 
+    static final ValueType FLATTENED_VALUES = new ValueTypeImpl<BytesRefBlock.Builder, BytesRefBlock, VarCharVector>(
+        "flattened",
+        factory -> factory.newBytesRefBlockBuilder(0),
+        block -> block.appendBytesRef(new BytesRef("{\"foo\": " + randomIntBetween(-42, 42) + "}")),
+        (b, i, s) -> b.getBytesRef(i, s).utf8ToString(),
+        (v, i) -> new String(v.get(i), StandardCharsets.UTF_8)
+    );
+
     static final ValueType IP_VALUES = new ValueTypeImpl<BytesRefBlock.Builder, BytesRefBlock, VarBinaryVector>(
         "ip",
         factory -> factory.newBytesRefBlockBuilder(0),
@@ -226,6 +234,7 @@ public class ArrowResponseTests extends ESTestCase {
         Map.entry(DataType.IP, IP_VALUES),
         Map.entry(DataType.VERSION, VERSION_VALUES),
         Map.entry(DataType.SOURCE, SOURCE_VALUES),
+        Map.entry(DataType.FLATTENED, FLATTENED_VALUES),
 
         Map.entry(DataType.NULL, NULL_VALUES),
         Map.entry(DataType.UNSUPPORTED, NULL_VALUES),


### PR DESCRIPTION
Backports the following commits to `9.5`:
- #153130
