### PR TITLE
[9.3] [ML] Automatically repair ML anomaly results aliases pointing at a .reindexed-v7 index (#147688)

### DIFF
--- a/docs/changelog/147688.yaml
+++ b/docs/changelog/147688.yaml
@@ -1,0 +1,7 @@
+area: Machine Learning
+issues:
+ - 147686
+pr: 147688
+summary: Automatically repair ML anomaly results aliases pointing at a .reindexed-v7
+  index
+type: bug

--- a/docs/reference/elasticsearch/configuration-reference/machine-learning-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/machine-learning-settings.md
@@ -89,6 +89,9 @@ $$$xpack.ml.max_open_jobs$$$
 `xpack.ml.results_index_rollover_max_size`
 :   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) The maximum size the anomaly detection results indices can reach before being rolled over by the nightly maintenance task. When the {{operator-feature}} is enabled, this setting can be updated only by operator users. Valid values must be greater than or equal to `-1B`. A value of `-1B` means the indices will never be rolled over. A value of `0B` means the indices will always be rolled over, regardless of size. Defaults to `50GB`.
 
+`xpack.ml.anomalies.heal_reindexed_v7.enabled` {applies_to}`stack: ga 9.3`
+:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) Controls if {{es}} automatically fixes anomaly detection result aliases that point to `.reindexed-v7-ml-anomalies-*` indices with incorrect mappings after an upgrade. See [#147686](https://github.com/elastic/elasticsearch/issues/147686) for details. When `true`, startup maintenance repairs affected aliases; historic data remains in old indices, with ML Notifications providing manual reindexing steps. Set to `false` to disable. Defaults to `true`.
+
 `xpack.ml.node_concurrent_job_allocations`
 :   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) The maximum number of jobs that can concurrently be in the `opening` state on each node. Typically, jobs spend a small amount of time in this state before they move to `open` state. Jobs that must restore large models when they are opening spend more time in the `opening` state. When the {{operator-feature}} is enabled, this setting can be updated only by operator users. Defaults to `2`.
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -29,6 +29,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -576,6 +577,92 @@ public final class MlIndexAndAlias {
     }
 
     /**
+     * Filters {@code candidates} to only those exactly matching {@code baseIndexName-NNNNNN}.
+     * Complements {@link #indicesMatchingBasename} by excluding indices that just share the prefix.
+     * Use when dealing with rollover generations to avoid matching unrelated indices.
+
+     *
+     * @param baseIndexName The base part of an index name, without the 6 digit suffix.
+     * @param candidates    The candidate index names to filter (typically the result of
+     *                      {@link #indicesMatchingBasename}).
+     * @return              The subset of {@code candidates} that belong to exactly this family.
+     */
+    public static String[] strictFamily(String baseIndexName, String[] candidates) {
+        int expectedLength = baseIndexName.length() + FIRST_INDEX_SIX_DIGIT_SUFFIX.length();
+        return Arrays.stream(candidates).filter(i -> has6DigitSuffix(i) && i.length() == expectedLength).toArray(String[]::new);
+    }
+
+    /**
+     * Convenience method combining {@link #indicesMatchingBasename} and {@link #strictFamily}:
+     * resolves all cluster indices that match {@code baseIndexName + "*"} and then filters
+     * to the exact family (i.e. exactly {@code baseIndexName-NNNNNN} names).
+     *
+     * @param baseIndexName      The base part of an index name, without the 6 digit suffix.
+     * @param expressionResolver The expression resolver.
+     * @param state              The cluster state.
+     * @return                   The exact rollover family for {@code baseIndexName}.
+     */
+    public static String[] strictFamilyOf(String baseIndexName, IndexNameExpressionResolver expressionResolver, ClusterState state) {
+        return strictFamily(baseIndexName, indicesMatchingBasename(baseIndexName, expressionResolver, state));
+    }
+
+    /**
+     * Returns the lowest suffix integer (≥ 1) not yet occupied by any member of
+     * {@code exactFamily}.  If {@code exactFamily} is empty, returns {@code 1},
+     * which will produce the first {@code base-000001} index.
+     * <p>
+     * Only family members with a parseable numeric 6-digit suffix are considered;
+     * anything else is silently skipped.
+     *
+     * @param exactFamily The strict (length-exact) rollover family array, as returned by
+     *                    {@link #strictFamily} or {@link #strictFamilyOf}.
+     * @return            The next free suffix integer.
+     */
+    public static int nextSuffix(String[] exactFamily) {
+        int highest = 0;
+        for (String idx : exactFamily) {
+            if (has6DigitSuffix(idx)) {
+                String suffixStr = idx.substring(idx.length() - 6);
+                try {
+                    highest = Math.max(highest, Integer.parseInt(suffixStr));
+                } catch (NumberFormatException ignored) {
+                    // non-numeric suffix; skip
+                }
+            }
+        }
+        return highest + 1;
+    }
+
+    /**
+     * Returns {@code true} if the top-level mapping of {@code indexMetadata} contains a field
+     * named {@code fieldName} whose {@code "type"} attribute equals {@code expectedType}.
+     * <p>
+     * Returns {@code false} for absent metadata, missing mappings, missing {@code properties}
+     * block, missing field, or non-matching type — i.e. all failure modes are collapsed to
+     * {@code false} so callers do not need defensive null-checks.
+     *
+     * @param indexMetadata The index metadata to inspect. May be {@code null}.
+     * @param fieldName     The field to look up inside the top-level {@code properties} block.
+     * @param expectedType  The expected Elasticsearch field type string (e.g. {@code "keyword"}).
+     * @return              {@code true} iff the field exists and has the expected type.
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean hasFieldTypedAs(IndexMetadata indexMetadata, String fieldName, String expectedType) {
+        if (indexMetadata == null || indexMetadata.mapping() == null) {
+            return false;
+        }
+        var rawProperties = indexMetadata.mapping().sourceAsMap().get("properties");
+        if (rawProperties instanceof Map<?, ?> == false) {
+            return false;
+        }
+        var rawField = ((Map<String, Object>) rawProperties).get(fieldName);
+        if (rawField instanceof Map<?, ?> == false) {
+            return false;
+        }
+        return expectedType.equals(((Map<String, Object>) rawField).get("type"));
+    }
+
+    /**
      * Strip any suffix from the index name and find any other indices
      * that match the base name. Then return the latest index from the
      * matching ones.
@@ -596,17 +683,9 @@ public final class MlIndexAndAlias {
         var matching = indicesMatchingBasename(baseIndexName, expressionResolver, latestState);
 
         // We used to assert here if no matching indices could be found. However, when called _before_ a job is created it may be the case
-        // that no .ml-anomalies-shared* indices yet exist
-        if (matching.length == 0) {
-            return index;
-        }
-
-        // Exclude indices that start with the same base name but are a different index
-        // e.g. .ml-anomalies-foobar should not be included when the index name is
-        // .ml-anomalies-foo
-        String[] filtered = Arrays.stream(matching).filter(i -> {
-            return i.equals(index) || (has6DigitSuffix(i) && i.length() == baseIndexName.length() + FIRST_INDEX_SIX_DIGIT_SUFFIX.length());
-        }).toArray(String[]::new);
+        // that no .ml-anomalies-shared* indices yet exist.
+        // strictFamily also excludes prefix-siblings (e.g. .ml-anomalies-foobar when the base is .ml-anomalies-foo).
+        String[] filtered = strictFamily(baseIndexName, matching);
 
         if (filtered.length == 0) {
             return index;

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAnomaliesIndexUpdateIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlAnomaliesIndexUpdateIT.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.indices.TestIndexNameExpressionResolver;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.ml.MlAnomaliesIndexUpdate;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.notifications.SystemAuditor;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Integration tests for the reindexed-anomalies heal logic in {@link MlAnomaliesIndexUpdate}.
+ *
+ * Each test sets up the broken post-upgrade state (a {@code .reindexed-*-ml-anomalies-*}
+ * index with {@code job_id} mapped as {@code text} and live {@code .ml-anomalies-*} aliases)
+ * then drives the heal and asserts the actual cluster-state outcome: aliases moved, target
+ * index exists with the correct keyword mapping, bad index is left alias-free.
+ */
+public class MlAnomaliesIndexUpdateIT extends MlSingleNodeTestCase {
+
+    /**
+     * job_id mapped as text — the broken dynamic-mapping shape produced by the buggy upgrade.
+     * The outer {@code _doc} wrapper is required by {@link CreateIndexRequest#mapping(String)}.
+     */
+    private static final String BROKEN_MAPPING = """
+        {"_doc":{"properties":{"job_id":{"type":"text","fields":{"keyword":{"type":"keyword"}}}}}}""";
+
+    /**
+     * job_id mapped as text for a pre-existing target index that the heal should consider
+     * non-reusable, forcing it to create the next suffix instead.
+     */
+    private static final String TEXT_MAPPING = """
+        {"_doc":{"properties":{"job_id":{"type":"text"}}}}""";
+
+    @Before
+    public void waitForTemplates() throws Exception {
+        waitForMlTemplates();
+    }
+
+    public void testHeals_GivenSharedIndexWithBadMapping_HealsToNewIndex() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String targetIndex = ".ml-anomalies-shared-000001";
+        List<String> jobs = List.of("jobA", "jobB");
+
+        createBadIndex(badIndex, BROKEN_MAPPING, jobs);
+        runHeal();
+
+        ClusterState state = clusterService().state();
+
+        // Bad index still exists but has no ml-anomalies aliases
+        assertBadIndexHasNoMlAliases(badIndex, state);
+
+        // Target index was created and aliases were moved to it
+        assertAliasesOnIndex(targetIndex, jobs, state);
+
+        // The heal created the target via the ML template → job_id must be keyword
+        assertJobIdIsKeyword(targetIndex, state);
+    }
+
+    public void testHeals_GivenCustomResultsIndexWithBadMapping_HealsToNewIndex() {
+        String badIndex = ".reindexed-v7-ml-anomalies-custom-foo-000001";
+        String expectedTarget = ".ml-anomalies-custom-foo-000001";
+        List<String> jobs = List.of("fooJob");
+
+        createBadIndex(badIndex, BROKEN_MAPPING, jobs);
+        runHeal();
+
+        ClusterState state = clusterService().state();
+
+        assertBadIndexHasNoMlAliases(badIndex, state);
+        assertAliasesOnIndex(expectedTarget, jobs, state);
+    }
+
+    public void testHeals_GivenSharedIndexWithGoodMapping_ReusesExistingIndex() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String targetIndex = ".ml-anomalies-shared-000001";
+        List<String> jobs = List.of("jobA");
+
+        // Pre-create the target through the normal template — it will get keyword mapping
+        client().admin().indices().create(new CreateIndexRequest(targetIndex)).actionGet();
+        createBadIndex(badIndex, BROKEN_MAPPING, jobs);
+
+        runHeal();
+
+        ClusterState state = clusterService().state();
+
+        // Aliases moved to the pre-existing target
+        assertAliasesOnIndex(targetIndex, jobs, state);
+        assertBadIndexHasNoMlAliases(badIndex, state);
+
+        // No -000002 index was created
+        assertNull(
+            "heal should reuse existing target, not create a new one",
+            state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(".ml-anomalies-shared-000002")
+        );
+    }
+
+    /**
+     * Regression guard for the cross-customer index-resolution bug: when two custom results
+     * groups share a name prefix (e.g. {@code foo} and {@code foobar}), the unfiltered
+     * {@code .ml-anomalies-custom-foo*} glob resolves both families, and a suffix tie in
+     * {@link org.elasticsearch.xpack.core.ml.utils.MlIndexAndAlias#latestIndex} can pick the
+     * wrong winner. Without strict family filtering the heal would move {@code foo}'s aliases
+     * onto the unrelated {@code foobar-000001} index, corrupting both customers' results.
+     */
+    public void testHeals_GivenCustomPrefixSibling_DoesNotReuseUnrelatedIndex() {
+        String badIndex = ".reindexed-v7-ml-anomalies-custom-foo-000001";
+        String unrelatedSibling = ".ml-anomalies-custom-foobar-000001";
+        String expectedTarget = ".ml-anomalies-custom-foo-000001";
+        List<String> fooJobs = List.of("fooJob");
+
+        // Pre-create the unrelated sibling via the ML template so it gets the correct
+        // keyword job_id mapping — the only conditions under which the buggy resolver
+        // would have happily reused it as the foo family's heal target.
+        client().admin().indices().create(new CreateIndexRequest(unrelatedSibling)).actionGet();
+
+        createBadIndex(badIndex, BROKEN_MAPPING, fooJobs);
+        runHeal();
+
+        ClusterState state = clusterService().state();
+
+        // Heal picked the correct foo target, not the prefix-matching foobar sibling.
+        assertThat(
+            "foo target should have been created, not reused from unrelated sibling",
+            state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(expectedTarget),
+            is(notNullValue())
+        );
+        assertAliasesOnIndex(expectedTarget, fooJobs, state);
+        assertJobIdIsKeyword(expectedTarget, state);
+        assertBadIndexHasNoMlAliases(badIndex, state);
+
+        // Unrelated sibling must be untouched — no foo-job aliases leaked onto it.
+        assertNoMlAliasesOnIndex(unrelatedSibling, state);
+    }
+
+    public void testHeals_GivenV7AndV8ReindexedSharedResults_DifferentJobs_HealsBothToSingleTarget() {
+        String v7 = ".reindexed-v7-ml-anomalies-shared-000001";
+        String v8 = ".reindexed-v8-ml-anomalies-shared";
+        String targetIndex = ".ml-anomalies-shared-000001";
+
+        createBadIndex(v7, BROKEN_MAPPING, List.of("jobA"));
+        createBadIndex(v8, BROKEN_MAPPING, List.of("jobB"));
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        new MlAnomaliesIndexUpdate(
+            clusterService(),
+            TestIndexNameExpressionResolver.newInstance(),
+            client(),
+            auditor,
+            systemAuditor,
+            () -> true
+        ).runUpdate(clusterService().state());
+
+        ClusterState state = clusterService().state();
+        assertBadIndexHasNoMlAliases(v7, state);
+        assertBadIndexHasNoMlAliases(v8, state);
+        assertAliasesOnIndex(targetIndex, List.of("jobA", "jobB"), state);
+        assertJobIdIsKeyword(targetIndex, state);
+        verify(systemAuditor, times(2)).warning(anyString());
+        verify(auditor).warning(eq("jobA"), anyString());
+        verify(auditor).warning(eq("jobB"), anyString());
+    }
+
+    public void testHeals_GivenReindexedV8SharedIndexWithBadMapping_HealsToNewIndex() {
+        String badIndex = ".reindexed-v8-ml-anomalies-shared";
+        String targetIndex = ".ml-anomalies-shared-000001";
+        List<String> jobs = List.of("v8OnlyJob");
+
+        createBadIndex(badIndex, BROKEN_MAPPING, jobs);
+        runHeal();
+
+        ClusterState state = clusterService().state();
+        assertBadIndexHasNoMlAliases(badIndex, state);
+        assertAliasesOnIndex(targetIndex, jobs, state);
+        assertJobIdIsKeyword(targetIndex, state);
+    }
+
+    /**
+     * Regression for the rollover conflict observed on ECH deployment
+     * {@code 922f01fd42834c778dc547a221c83622}:
+     *
+     * <ul>
+     *   <li>{@code .reindexed-v7-ml-anomalies-shared-000001} has the broken {@code job_id:text}
+     *       mapping and is the write claimant for the {@code .ml-anomalies-.write-shared} alias.</li>
+     *   <li>{@code .reindexed-v8-ml-anomalies-shared} has a healthy keyword mapping (UA's
+     *       8&rarr;9 reindex applied the template correctly) but also holds the same job's
+     *       read + write aliases as non-write claims (UA copies aliases during reindex).</li>
+     * </ul>
+     *
+     * Before this fix, heal moved v7's aliases to a fresh target while leaving v8's claims
+     * intact. The rollover loop then discovered v8 (matches {@code .ml-anomalies-*} via its
+     * alias), created {@code .reindexed-v8-ml-anomalies-shared-000001}, and the atomic
+     * alias-update tripped {@code "alias [.ml-anomalies-.write-shared] has more than one
+     * write index"} because both the heal target and the new rollover destination claimed
+     * the write alias.
+     *
+     * Post-fix, heal strips the aliases from every {@code .reindexed-*-ml-anomalies-*} index
+     * (cluster-wide, scoped), so v8 is alias-free by the time the rollover loop runs and is
+     * no longer a rollover candidate.
+     */
+    public void testHeals_GivenV7BrokenAndV8HealthyShareJobAliases_RolloverDoesNotConflict() {
+        String v7 = ".reindexed-v7-ml-anomalies-shared-000001";
+        String v8 = ".reindexed-v8-ml-anomalies-shared";
+        String targetIndex = ".ml-anomalies-shared-000001";
+        String jobId = "shared";
+
+        // v7-000001 broken; helper sets writeIndex=true on .write-shared.
+        createBadIndex(v7, BROKEN_MAPPING, List.of(jobId));
+
+        // v8 has the template-applied (healthy keyword) mapping — no explicit mapping arg.
+        client().admin().indices().create(new CreateIndexRequest(v8)).actionGet();
+
+        // Add the same job's aliases to v8 as non-write so ES accepts the dual setup alongside
+        // v7's writeIndex=true claim.
+        var addV8Aliases = client().admin().indices().prepareAliases(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
+        addV8Aliases.addAliasAction(
+            IndicesAliasesRequest.AliasActions.add().index(v8).alias(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).isHidden(true)
+        );
+        addV8Aliases.addAliasAction(
+            IndicesAliasesRequest.AliasActions.add()
+                .index(v8)
+                .alias(AnomalyDetectorsIndex.resultsWriteAlias(jobId))
+                .writeIndex(false)
+                .isHidden(true)
+        );
+        addV8Aliases.get();
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        // runUpdate must complete without throwing — the rollover loop must not see v8 as a
+        // candidate because heal evacuated its aliases cluster-wide.
+        new MlAnomaliesIndexUpdate(
+            clusterService(),
+            TestIndexNameExpressionResolver.newInstance(),
+            client(),
+            auditor,
+            systemAuditor,
+            () -> true
+        ).runUpdate(clusterService().state());
+
+        ClusterState state = clusterService().state();
+        assertBadIndexHasNoMlAliases(v7, state);
+        assertBadIndexHasNoMlAliases(v8, state);
+        assertAliasesOnIndex(targetIndex, List.of(jobId), state);
+        assertJobIdIsKeyword(targetIndex, state);
+
+        // Specifically: the rollover loop must NOT have created .reindexed-v8-ml-anomalies-shared-000001.
+        assertNull(
+            "rollover must not fire on v8 once heal has cleared its aliases",
+            state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(".reindexed-v8-ml-anomalies-shared-000001")
+        );
+    }
+
+    public void testHeals_RunsHealBeforeRolloverLegacyIndex_NoException() {
+        // Legacy-shaped name (no 6-digit suffix) on the current index version still triggers the
+        // rollover path, while a broken reindexed-v7 index triggers heal — runUpdate must complete
+        // without alias conflicts (heal runs first, then rollover reads fresh cluster state).
+        String legacy = ".ml-anomalies-healrollover";
+        client().admin().indices().create(new CreateIndexRequest(legacy)).actionGet();
+
+        var aliasReq = client().admin().indices().prepareAliases(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
+        aliasReq.addAliasAction(
+            IndicesAliasesRequest.AliasActions.add()
+                .index(legacy)
+                .alias(AnomalyDetectorsIndex.jobResultsAliasedName("legacyRolloverJob"))
+                .isHidden(true)
+        );
+        aliasReq.addAliasAction(
+            IndicesAliasesRequest.AliasActions.add()
+                .index(legacy)
+                .alias(AnomalyDetectorsIndex.resultsWriteAlias("legacyRolloverJob"))
+                .writeIndex(true)
+                .isHidden(true)
+        );
+        aliasReq.get();
+
+        createBadIndex(".reindexed-v7-ml-anomalies-shared-000001", BROKEN_MAPPING, List.of("healRolloverJob"));
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        new MlAnomaliesIndexUpdate(
+            clusterService(),
+            TestIndexNameExpressionResolver.newInstance(),
+            client(),
+            auditor,
+            systemAuditor,
+            () -> true
+        ).runUpdate(clusterService().state());
+    }
+
+    public void testHeals_GivenSharedIndexWithSuffixCollision_PicksNextIndex() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String existingBlocker = ".ml-anomalies-shared-000001";
+        String expectedTarget = ".ml-anomalies-shared-000002";
+        List<String> jobs = List.of("jobA");
+
+        // Pre-create -000001 with text mapping (not keyword) so the heal considers it non-reusable.
+        // The explicit request mapping for job_id takes precedence over the template mapping.
+        client().admin().indices().create(new CreateIndexRequest(existingBlocker).mapping(TEXT_MAPPING)).actionGet();
+        createBadIndex(badIndex, BROKEN_MAPPING, jobs);
+
+        runHeal();
+
+        ClusterState state = clusterService().state();
+
+        // Heal must have picked the next suffix
+        assertAliasesOnIndex(expectedTarget, jobs, state);
+        assertBadIndexHasNoMlAliases(existingBlocker, state);
+        assertBadIndexHasNoMlAliases(badIndex, state);
+    }
+
+    /**
+     * Builds the heal updater against the real single-node cluster and runs it.
+     * Uses mock auditors to avoid async writes to the notifications index.
+     */
+    private void runHeal() {
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        MlAnomaliesIndexUpdate updater = new MlAnomaliesIndexUpdate(
+            clusterService(),
+            TestIndexNameExpressionResolver.newInstance(),
+            client(),
+            auditor,
+            systemAuditor,
+            () -> true
+        );
+        updater.runUpdate(clusterService().state());
+        verify(systemAuditor).warning(anyString());
+        verify(auditor, atLeastOnce()).warning(any(), anyString());
+    }
+
+    /** Creates an index with the broken mapping and the canonical ML read+write aliases. */
+    private void createBadIndex(String name, String mappingSource, List<String> jobIds) {
+        createResultsIndexWithAliases(name, mappingSource, jobIds);
+    }
+
+    /** Asserts that no {@code .ml-anomalies-*} alias lives on the given bad index. */
+    private static void assertBadIndexHasNoMlAliases(String badIndex, ClusterState state) {
+        assertNoMlAliasesOnIndex(badIndex, state);
+    }
+
+    /** Asserts that no {@code .ml-anomalies-*} alias lives on the given index. */
+    private static void assertNoMlAliasesOnIndex(String index, ClusterState state) {
+        Map<String, List<AliasMetadata>> aliasesMap = state.metadata()
+            .getProject(Metadata.DEFAULT_PROJECT_ID)
+            .findAllAliases(new String[] { index });
+        List<AliasMetadata> mlAliases = aliasesMap.getOrDefault(index, List.of())
+            .stream()
+            .filter(a -> a.alias().startsWith(".ml-anomalies-"))
+            .toList();
+        assertThat("index [" + index + "] should have no ml-anomalies aliases", mlAliases, is(empty()));
+    }
+
+    /**
+     * Asserts that both the read alias and write alias for each job in {@code jobs}
+     * are present on {@code targetIndex}.
+     */
+    private static void assertAliasesOnIndex(String targetIndex, List<String> jobs, ClusterState state) {
+        Map<String, List<AliasMetadata>> aliasesMap = state.metadata()
+            .getProject(Metadata.DEFAULT_PROJECT_ID)
+            .findAllAliases(new String[] { targetIndex });
+        List<AliasMetadata> targetAliases = aliasesMap.getOrDefault(targetIndex, List.of());
+        for (String jobId : jobs) {
+            String readAlias = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);
+            String writeAlias = AnomalyDetectorsIndex.resultsWriteAlias(jobId);
+            boolean hasRead = targetAliases.stream().anyMatch(a -> a.alias().equals(readAlias));
+            boolean hasWrite = targetAliases.stream().anyMatch(a -> a.alias().equals(writeAlias));
+            assertTrue("read alias [" + readAlias + "] should be on [" + targetIndex + "]", hasRead);
+            assertTrue("write alias [" + writeAlias + "] should be on [" + targetIndex + "]", hasWrite);
+        }
+    }
+
+    /**
+     * Asserts that the {@code job_id} field in the given index's mapping is type {@code keyword},
+     * confirming the ML template was applied correctly when the target was created.
+     */
+    @SuppressWarnings("unchecked")
+    private static void assertJobIdIsKeyword(String indexName, ClusterState state) {
+        IndexMetadata meta = state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(indexName);
+        assertThat("index [" + indexName + "] should exist in cluster state", meta, is(notNullValue()));
+        assertNotNull("index [" + indexName + "] should have mappings", meta.mapping());
+
+        Map<String, Object> properties = (Map<String, Object>) meta.mapping().sourceAsMap().get("properties");
+        assertThat("mapping should have properties", properties, is(notNullValue()));
+        assertThat("properties should contain job_id", properties, hasKey("job_id"));
+
+        Map<String, Object> jobIdField = (Map<String, Object>) properties.get("job_id");
+        assertEquals("job_id should be mapped as keyword after heal", "keyword", jobIdField.get("type"));
+    }
+
+    private ClusterService clusterService() {
+        return getInstanceFromNode(ClusterService.class);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -860,7 +860,8 @@ public class MachineLearning extends Plugin
             DUMMY_ENTITY_MEMORY,
             DUMMY_ENTITY_PROCESSORS,
             SCALE_UP_COOLDOWN_TIME,
-            SCALE_TO_ZERO_AFTER_NO_REQUESTS_TIME
+            SCALE_TO_ZERO_AFTER_NO_REQUESTS_TIME,
+            MlAnomaliesIndexUpdate.HEAL_REINDEXED_V7_ENABLED
         );
     }
 
@@ -1306,7 +1307,14 @@ public class MachineLearning extends Plugin
                     indexNameExpressionResolver,
                     client
                 ),
-                new MlAnomaliesIndexUpdate(indexNameExpressionResolver, client)
+                new MlAnomaliesIndexUpdate(
+                    clusterService,
+                    indexNameExpressionResolver,
+                    client,
+                    anomalyDetectionAuditor,
+                    systemAuditor,
+                    () -> clusterService.getClusterSettings().get(MlAnomaliesIndexUpdate.HEAL_REINDEXED_V7_ENABLED)
+                )
             )
         );
         clusterService.addListener(mlAutoUpdateService);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdate.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdate.java
@@ -9,11 +9,20 @@ package org.elasticsearch.xpack.ml;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -21,37 +30,107 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.MlIndexAndAlias;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.notifications.SystemAuditor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 /**
- * Rollover the various .ml-anomalies result indices
- * updating the read and write aliases
+ * Rollover the various .ml-anomalies result indices updating the read and write aliases.
+ * Also detects and heals indices that were rolled over with an incorrect dynamic job_id
+ * mapping (the reindexed-ml-anomalies bug introduced in ES 8.18/8.19, including
+ * {@code .reindexed-v7-ml-anomalies-*} and {@code .reindexed-v8-ml-anomalies-*} lineages).
  */
 public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction {
 
     private static final Logger logger = LogManager.getLogger(MlAnomaliesIndexUpdate.class);
 
+    /**
+     * Kill-switch: set to {@code false} to disable the reindexed-anomalies heal step without affecting
+     * the normal rollover loop. Dynamically updatable.
+     * <p>
+     * Setting key retains {@code reindexed_v7} for backwards compatibility; the heal applies to
+     * all {@code .reindexed-*-ml-anomalies-*} indices with broken {@code job_id} mappings.
+     */
+    public static final Setting<Boolean> HEAL_REINDEXED_V7_ENABLED = Setting.boolSetting(
+        "xpack.ml.anomalies.heal_reindexed_v7.enabled",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Index pattern used to resolve all reindexed ML anomalies candidates (e.g.
+     * {@code .reindexed-v7-ml-anomalies-*}, {@code .reindexed-v8-ml-anomalies-*}).
+     */
+    static final String REINDEXED_ANOMALIES_PATTERN = ".reindexed-*-ml-anomalies-*";
+
+    /**
+     * Strips {@code .reindexed-<version>-} from a concrete index name, leaving {@code ml-anomalies-...}
+     * so {@link MlIndexAndAlias#baseIndexName} can derive the canonical results base (e.g. {@code .ml-anomalies-shared}).
+     */
+    private static final Pattern REINDEXED_ANOMALIES_STRIP = Pattern.compile("^\\.reindexed-[^-]+-(ml-anomalies-.*)$");
+
+    /**
+     * Timeout for each synchronous alias-update call during the heal step.
+     */
+    private static final TimeValue HEAL_TIMEOUT = TimeValue.timeValueMinutes(5);
+
+    /** Max collision retries when the derived target index name already exists. */
+    private static final int MAX_SUFFIX_RETRIES = 5;
+
+    private final ClusterService clusterService;
     private final IndexNameExpressionResolver expressionResolver;
     private final OriginSettingClient client;
+    private final AnomalyDetectionAuditor auditor;
+    private final SystemAuditor systemAuditor;
+    private final BooleanSupplier healEnabled;
 
-    public MlAnomaliesIndexUpdate(IndexNameExpressionResolver expressionResolver, Client client) {
+    public MlAnomaliesIndexUpdate(
+        ClusterService clusterService,
+        IndexNameExpressionResolver expressionResolver,
+        Client client,
+        AnomalyDetectionAuditor auditor,
+        SystemAuditor systemAuditor,
+        BooleanSupplier healEnabled
+    ) {
+        this.clusterService = clusterService;
         this.expressionResolver = expressionResolver;
         this.client = new OriginSettingClient(client, ML_ORIGIN);
+        this.auditor = auditor;
+        this.systemAuditor = systemAuditor;
+        this.healEnabled = healEnabled;
     }
 
     @Override
@@ -84,8 +163,48 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
         return "ml_anomalies_index_update";
     }
 
+    /**
+     * Executes updates related to ML anomaly indices.
+     * - Heals any <code>.reindexed-*-ml-anomalies-*</code> indices with broken {@code job_id} mappings if necessary.
+     * - Runs the rollover process for ML anomaly indices against a fresh {@link ClusterState} so rollovers see
+     *   aliases already moved off reindexed lineages by the heal step.
+     * If either task fails, an aggregated {@link ElasticsearchStatusException} is thrown
+     * containing all suppressed failures.
+     *
+     * @param latestState The latest {@link ClusterState} to operate against.
+     * @throws ElasticsearchStatusException if one or more update steps fail.
+     */
     @Override
     public void runUpdate(ClusterState latestState) {
+        Exception healFailure = null;
+        try {
+            healReindexedAnomalies(latestState);
+        } catch (Exception e) {
+            healFailure = e;
+        }
+
+        Exception rolloverFailure = null;
+        try {
+            runRolloverLoop(clusterService.state());
+        } catch (Exception e) {
+            rolloverFailure = e;
+        }
+
+        if (rolloverFailure != null || healFailure != null) {
+            var combined = new ElasticsearchStatusException("One or more ml anomalies index update steps failed.", RestStatus.CONFLICT);
+            if (healFailure != null) combined.addSuppressed(healFailure);
+            if (rolloverFailure != null) combined.addSuppressed(rolloverFailure);
+            throw combined;
+        }
+    }
+
+    /**
+     * Rolls over each outdated or legacy ML anomaly index to ensure all indices are up-to-date and compatible.
+     * Only acts on the latest index in each group. Records any failures.
+     *
+     * @param latestState Cluster state used for resolving anomaly indices.
+     */
+    private void runRolloverLoop(ClusterState latestState) {
         List<Exception> failures = new ArrayList<>();
 
         // list all indices starting .ml-anomalies-
@@ -104,7 +223,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
 
         for (String index : indices) {
             boolean isCompatibleIndexVersion = MlIndexAndAlias.indexIsReadWriteCompatibleInV9(
-                latestState.metadata().getProject().index(index).getCreationVersion()
+                latestState.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(index).getCreationVersion()
             );
 
             // Ensure the index name is of a format amenable to simplifying maintenance
@@ -174,5 +293,328 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
 
     private void createAliasForRollover(String indexName, String aliasName, ActionListener<IndicesAliasesResponse> listener) {
         MlIndexAndAlias.createAliasForRollover(client, indexName, aliasName, listener);
+    }
+
+    /**
+     * Detects any {@code .reindexed-*-ml-anomalies-*} indices that still carry live
+     * {@code .ml-anomalies-*} read/write aliases (i.e., that were created in the buggy
+     * template-mismatch window), and moves those aliases to a correctly-mapped target index.
+     *
+     * The method is a no-op when the kill-switch setting is {@code false} or when no
+     * affected indices are found. Failures on individual candidates are collected and
+     * re-thrown as a combined {@link ElasticsearchStatusException}.
+     *
+     * @param state Cluster state used for resolving anomaly indices.
+     */
+    void healReindexedAnomalies(ClusterState state) {
+        if (healEnabled.getAsBoolean() == false) {
+            logger.debug("Setting [{}] is disabled; heal step skipped", HEAL_REINDEXED_V7_ENABLED.getKey());
+            return;
+        }
+
+        String[] candidates = expressionResolver.concreteIndexNames(
+            state,
+            IndicesOptions.lenientExpandOpenHidden(),
+            REINDEXED_ANOMALIES_PATTERN
+        );
+
+        List<Exception> failures = new ArrayList<>();
+
+        // Memoize the target index per base, so related bad indices share one new target index.
+
+        Map<String, String> targetByBase = new HashMap<>();
+
+        for (String badIndex : candidates) {
+            try {
+                healOneBadIndex(badIndex, state, targetByBase);
+            } catch (Exception e) {
+                logger.warn("failed to heal reindexed ml anomalies index [{}]", badIndex, e);
+                String msg = Strings.format("failed to heal reindexed ml anomalies index [%s]", badIndex);
+                if (e instanceof ElasticsearchException ee) {
+                    failures.add(new ElasticsearchStatusException(msg, ee.status(), ee));
+                } else {
+                    failures.add(new ElasticsearchStatusException(msg, RestStatus.INTERNAL_SERVER_ERROR, e));
+                }
+            }
+        }
+
+        if (failures.isEmpty() == false) {
+            var combined = new ElasticsearchStatusException("one or more reindexed ml anomalies heal steps failed", RestStatus.CONFLICT);
+            failures.forEach(combined::addSuppressed);
+            throw combined;
+        }
+    }
+
+    /**
+     * If necessary, create a new index with the name that does not clash with any existing index and move
+     * the aliases from the bad index to the new index.
+     *
+     * @param badIndex     The index to heal.
+     * @param state        The cluster state snapshot for this heal run.
+     * @param targetByBase Maps target base name to created target index for this heal run, so related indices use the
+     *                     same new target index.
+     */
+    private void healOneBadIndex(String badIndex, ClusterState state, Map<String, String> targetByBase) {
+        // Determine if the mapping is broken (absent or non-keyword job_id)
+        if (hasCorrectJobIdMapping(badIndex, state)) {
+            return;
+        }
+
+        // Skip if there are no live ml-anomalies aliases still on this bad index
+        Map<String, List<AliasMetadata>> aliasesMap = state.metadata()
+            .getProject(Metadata.DEFAULT_PROJECT_ID)
+            .findAllAliases(new String[] { badIndex });
+        List<AliasMetadata> liveAliases = aliasesMap.getOrDefault(badIndex, List.of())
+            .stream()
+            .filter(am -> MlIndexAndAlias.isAnomaliesReadAlias(am.alias()) || MlIndexAndAlias.isAnomaliesWriteAlias(am.alias()))
+            .toList();
+        if (liveAliases.isEmpty()) {
+            return;
+        }
+
+        // Extract the distinct job ids from the aliases
+        Set<String> jobIds = new LinkedHashSet<>();
+        for (AliasMetadata am : liveAliases) {
+            AnomalyDetectorsIndex.jobIdFromAlias(am.alias()).ifPresent(jobIds::add);
+        }
+
+        Matcher stripMatch = REINDEXED_ANOMALIES_STRIP.matcher(badIndex);
+        if (stripMatch.matches() == false) {
+            throw new IllegalStateException("unexpected reindexed ml anomalies index name [" + badIndex + "]");
+        }
+        // e.g. ".ml-anomalies-shared-000001" or ".ml-anomalies-shared" (no 6-digit suffix)
+        String strippedName = "." + stripMatch.group(1);
+        String targetBase = MlIndexAndAlias.baseIndexName(strippedName); // e.g. ".ml-anomalies-shared"
+
+        String targetIndex = targetByBase.computeIfAbsent(targetBase, base -> resolveOrCreateTargetIndex(base, state));
+        moveAliasesToTarget(badIndex, targetIndex, jobIds);
+        emitAdvisoryNotifications(badIndex, targetIndex, jobIds);
+
+        logger.warn(
+            "The ML anomalies index [{}] was missing required keyword mapping for [job_id]. "
+                + "Aliases for jobs [{}] have been moved to a compatible anomalies index [{}].",
+            badIndex,
+            jobIds,
+            targetIndex
+        );
+
+    }
+
+    /**
+     * Returns {@code true} iff the {@code job_id} field in {@code indexName}'s mapping
+     * is typed as {@code keyword} (i.e. the ML index template was applied correctly).
+     */
+    private boolean hasCorrectJobIdMapping(String indexName, ClusterState state) {
+        var indexMetadata = state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(indexName);
+        return MlIndexAndAlias.hasFieldTypedAs(indexMetadata, Job.ID.getPreferredName(), "keyword");
+    }
+
+    /**
+     * Finds the most-recent existing target index that is v9-compatible and has
+     * a keyword job_id mapping (i.e., the template was applied). Falls back to
+     * creating a new index with the next free 6-digit suffix.
+     */
+    private String resolveOrCreateTargetIndex(String targetBase, ClusterState state) {
+        String[] existingFamily = MlIndexAndAlias.strictFamilyOf(targetBase, expressionResolver, state);
+        if (existingFamily.length > 0) {
+            String latest = MlIndexAndAlias.latestIndex(existingFamily);
+            var latestMeta = state.metadata().getProject(Metadata.DEFAULT_PROJECT_ID).index(latest);
+            if (latestMeta != null
+                && MlIndexAndAlias.indexIsReadWriteCompatibleInV9(latestMeta.getCreationVersion())
+                && hasCorrectJobIdMapping(latest, state)) {
+                logger.debug("[ml_anomalies_reindexed_v7_heal] reusing existing target index [{}] for base [{}]", latest, targetBase);
+                return latest;
+            }
+        }
+
+        // Need to create a new index; find the next free suffix
+        return createNewTargetIndex(targetBase, existingFamily);
+    }
+
+    /**
+     * Creates a new target index under {@code targetBase} with the next free 6-digit suffix.
+     * Retries up to {@link #MAX_SUFFIX_RETRIES} times on {@link ResourceAlreadyExistsException}.
+     * <p>
+     * {@code existingFamily} comes from the cluster-state at the start of {@link #runUpdate}.
+     * If another node creates a conflicting index before this method runs, we increment
+     * the suffix and retry. {@code MAX_SUFFIX_RETRIES = 5} covers all likely cases,
+     * since (a) {@code targetByBase} allows just one create per base per run, and
+     * (b) outside creation of {@code .ml-anomalies-*} indices is extremely rare.
+     * If all retries fail, the heal is skipped for this candidate; no data is lost,
+     * and the next {@link #runUpdate} will work once state is up to date.
+
+     */
+    private String createNewTargetIndex(String targetBase, String[] existingFamily) {
+        int firstSuffix = MlIndexAndAlias.nextSuffix(existingFamily);
+
+        for (int attempt = 0; attempt < MAX_SUFFIX_RETRIES; attempt++) {
+            String targetName = targetBase + "-" + Strings.format("%06d", firstSuffix + attempt);
+
+            PlainActionFuture<CreateIndexResponse> createFuture = new PlainActionFuture<>();
+            CreateIndexRequest request = new CreateIndexRequest(targetName);
+            request.waitForActiveShards(ActiveShardCount.DEFAULT);
+
+            executeAsyncWithOrigin(client, ML_ORIGIN, TransportCreateIndexAction.TYPE, request, createFuture);
+
+            try {
+                createFuture.actionGet(HEAL_TIMEOUT);
+            } catch (ResourceAlreadyExistsException e) {
+                logger.debug("[ml_anomalies_reindexed_v7_heal] target [{}] already exists; trying next suffix", targetName);
+                continue;
+            }
+
+            // Wait for yellow before returning
+            waitForYellow(targetName);
+            logger.info("[ml_anomalies_reindexed_v7_heal] created target index [{}]", targetName);
+            return targetName;
+        }
+
+        throw new ElasticsearchStatusException(
+            "unable to create target index for base [" + targetBase + "] after " + MAX_SUFFIX_RETRIES + " attempts",
+            RestStatus.CONFLICT
+        );
+    }
+
+    private void waitForYellow(String indexName) {
+        PlainActionFuture<ClusterHealthResponse> healthFuture = new PlainActionFuture<>();
+        ClusterHealthRequest healthRequest = new ClusterHealthRequest(HEAL_TIMEOUT, indexName).waitForYellowStatus()
+            .waitForNoRelocatingShards(true)
+            .waitForNoInitializingShards(true);
+
+        executeAsyncWithOrigin(client, ML_ORIGIN, TransportClusterHealthAction.TYPE, healthRequest, healthFuture);
+        try {
+            healthFuture.actionGet(HEAL_TIMEOUT);
+        } catch (Exception e) {
+            // A timed-out health request is not fatal; the alias update will still work.
+            logger.debug(
+                "[ml_anomalies_reindexed_v7_heal] cluster health wait for [{}] failed or timed out: {}",
+                indexName,
+                e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Builds a single atomic {@link IndicesAliasesRequest} that strips the job's read+write
+     * aliases from every {@code .reindexed-*-ml-anomalies-*} index that currently claims them
+     * (not just {@code badIndex}) and adds them to {@code targetIndex}.
+     * <p>
+     * Cluster-wide strip is required because UA's 8&rarr;9 reindex copies a v7 source's aliases
+     * onto the v8 destination (e.g. {@code .reindexed-v8-ml-anomalies-*}). If we only stripped
+     * {@code badIndex}, the surviving sibling reindexed lineage would still hold the read+write
+     * alias and the next rollover pass would fail validation with
+     * {@code "alias [...] has more than one write index"} as soon as it tries to move the write
+     * alias onto a newly created rollover index — the heal target already claims it.
+     * <p>
+     * Scoping the cluster-wide strip to {@code .reindexed-*-ml-anomalies-*} (i.e.
+     * {@link #REINDEXED_ANOMALIES_STRIP}) is deliberate: canonical {@code .ml-anomalies-*-NNNNNN}
+     * family members keep their read aliases so historical results in older generations remain
+     * queryable. Only the post-migration stale reindexed lineages are evacuated.
+     * <p>
+     * {@code mustExist(false)} keeps every remove idempotent under racing cluster-state updates.
+     */
+    private void moveAliasesToTarget(String badIndex, String targetIndex, Set<String> jobIds) {
+        IndicesAliasesRequestBuilder req = MlIndexAndAlias.createIndicesAliasesRequestBuilder(client);
+
+        // Freshest available state — heal may have already created the target index after the
+        // start-of-runUpdate snapshot, and a prior heal iteration may have moved aliases for
+        // other jobs onto the same target.
+        var project = clusterService.state().metadata().getProject(Metadata.DEFAULT_PROJECT_ID);
+
+        for (String jobId : jobIds) {
+            String writeAlias = AnomalyDetectorsIndex.resultsWriteAlias(jobId);
+            String readAlias = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);
+
+            for (String aliasName : List.of(writeAlias, readAlias)) {
+                for (Index claimant : project.aliasedIndices(aliasName)) {
+                    String claimantName = claimant.getName();
+                    if (claimantName.equals(targetIndex)) {
+                        // Never strip from the target; we are about to (re-)add the alias here.
+                        continue;
+                    }
+                    if (REINDEXED_ANOMALIES_STRIP.matcher(claimantName).matches() == false) {
+                        // Leave canonical family members alone — older .ml-anomalies-*-NNNNNN
+                        // generations legitimately hold the read alias for historical results.
+                        continue;
+                    }
+                    req.addAliasAction(IndicesAliasesRequest.AliasActions.remove().index(claimantName).alias(aliasName).mustExist(false));
+                }
+            }
+
+            req.addAliasAction(
+                IndicesAliasesRequest.AliasActions.add().index(targetIndex).alias(writeAlias).isHidden(true).writeIndex(true)
+            );
+            req.addAliasAction(
+                IndicesAliasesRequest.AliasActions.add()
+                    .index(targetIndex)
+                    .alias(readAlias)
+                    .isHidden(true)
+                    .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
+            );
+        }
+
+        PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        MlIndexAndAlias.updateAliases(req, future);
+        try {
+            future.actionGet(HEAL_TIMEOUT);
+        } catch (Exception e) {
+            throw new ElasticsearchStatusException(
+                "failed to move aliases from [" + badIndex + "] to [" + targetIndex + "]",
+                e instanceof ElasticsearchException ee ? ee.status() : RestStatus.REQUEST_TIMEOUT,
+                e
+            );
+        }
+    }
+
+    /**
+     * Emits one actionable warning notification per healed bad index (cluster-wide, via {@link SystemAuditor},
+     * so Kibana ML notifications can surface it under job type "system"), plus a per-job warning for each
+     * affected job (via {@link AnomalyDetectionAuditor}).
+     */
+    private void emitAdvisoryNotifications(String badIndex, String targetIndex, Set<String> jobIds) {
+        String affectedJobs = String.join(", ", jobIds);
+        String clusterMessage = Strings.format(
+            "Anomaly detection historical results are stranded in index [%s] because an Elasticsearch upgrade "
+                + "on one of the affected versions (pre-8.18.8, pre-8.19.5, pre-9.0.8, pre-9.1.5, pre-9.2.0) "
+                + "produced a broken dynamic job_id mapping. "
+                + "New results are now written to [%s] with the correct mappings and will appear in the UI again. "
+                + "Affected jobs: [%s]. "
+                + "To recover the historical results, ensure your user has read and write on .ml-anomalies-* "
+                + "(or manage_ml / superuser) and run: "
+                + "POST _reindex?wait_for_completion=false "
+                + "{\"source\":{\"index\":\"%s\"},\"dest\":{\"index\":\"%s\",\"op_type\":\"create\"}}. "
+                + "Using op_type:create avoids overwriting documents that were already renormalized in the destination. "
+                + "After verifying documents arrived, [%s] may be deleted. "
+                + "Details: https://github.com/elastic/elasticsearch/issues/147686",
+            badIndex,
+            targetIndex,
+            affectedJobs,
+            badIndex,
+            targetIndex,
+            badIndex
+        );
+
+        String perJobMessage = Strings.format(
+            "Historical anomaly results for this job are stranded in index [%s] due to a broken job_id mapping from "
+                + "an earlier upgrade. New results are now being written to [%s]. "
+                + "See the cluster-wide ML notification (job type: System) for the recovery procedure. "
+                + "Details: https://github.com/elastic/elasticsearch/issues/147686",
+            badIndex,
+            targetIndex
+        );
+
+        try {
+            systemAuditor.warning(clusterMessage);
+        } catch (Exception e) {
+            logger.warn("Failed to emit cluster-wide audit notification for [{}]", badIndex, e);
+        }
+
+        for (String jobId : jobIds) {
+            try {
+                auditor.warning(jobId, perJobMessage);
+            } catch (Exception e) {
+                logger.warn("Failed to emit per-job audit notification for job [{}]", jobId, e);
+            }
+        }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdateTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdateTests.java
@@ -7,10 +7,15 @@
 
 package org.elasticsearch.xpack.ml;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.action.admin.indices.alias.TransportIndicesAliasesAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
@@ -21,23 +26,34 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.notifications.SystemAuditor;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -45,13 +61,52 @@ import static org.mockito.Mockito.when;
 
 public class MlAnomaliesIndexUpdateTests extends ESTestCase {
 
+    private static final BooleanSupplier HEAL_ENABLED = () -> true;
+    private static final BooleanSupplier HEAL_DISABLED = () -> false;
+
+    private static ClusterService mockClusterService(ClusterState state) {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(state);
+        return clusterService;
+    }
+
+    private static MlAnomaliesIndexUpdate updater(Client client, ClusterState rolloverState) {
+        return updater(client, rolloverState, mock(AnomalyDetectionAuditor.class), mock(SystemAuditor.class), HEAL_ENABLED);
+    }
+
+    private static MlAnomaliesIndexUpdate updater(
+        Client client,
+        ClusterState rolloverState,
+        AnomalyDetectionAuditor auditor,
+        BooleanSupplier healEnabled
+    ) {
+        return updater(client, rolloverState, auditor, mock(SystemAuditor.class), healEnabled);
+    }
+
+    private static MlAnomaliesIndexUpdate updater(
+        Client client,
+        ClusterState rolloverState,
+        AnomalyDetectionAuditor auditor,
+        SystemAuditor systemAuditor,
+        BooleanSupplier healEnabled
+    ) {
+        return new MlAnomaliesIndexUpdate(
+            mockClusterService(rolloverState),
+            TestIndexNameExpressionResolver.newInstance(),
+            client,
+            auditor,
+            systemAuditor,
+            healEnabled
+        );
+    }
+
     public void testIsAbleToRun_IndicesDoNotExist() {
         RoutingTable.Builder routingTable = RoutingTable.builder();
-        var updater = new MlAnomaliesIndexUpdate(TestIndexNameExpressionResolver.newInstance(), mock(Client.class));
-
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
         csBuilder.routingTable(routingTable.build());
-        assertTrue(updater.isAbleToRun(csBuilder.build()));
+        ClusterState state = csBuilder.build();
+        var u = updater(mock(Client.class), state);
+        assertTrue(u.isAbleToRun(state));
     }
 
     public void testIsAbleToRun_IndicesHaveNoRouting() {
@@ -67,28 +122,27 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
         Metadata.Builder metadata = Metadata.builder();
         metadata.put(indexMetadata);
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
-        csBuilder.routingTable(RoutingTable.builder().build()); // no routing to index
+        csBuilder.routingTable(RoutingTable.builder().build()); // no routing table
         csBuilder.metadata(metadata);
 
-        var updater = new MlAnomaliesIndexUpdate(TestIndexNameExpressionResolver.newInstance(), mock(Client.class));
-
-        assertFalse(updater.isAbleToRun(csBuilder.build()));
+        ClusterState cs = csBuilder.build();
+        assertFalse(updater(mock(Client.class), cs).isAbleToRun(cs));
     }
 
     public void testRunUpdate_UpToDateIndices() {
         String indexName = ".ml-anomalies-sharedindex-000001";
         var jobs = List.of("job1", "job2");
-        IndexMetadata.Builder indexMetadata = createSharedResultsIndex(indexName, IndexVersion.current(), jobs);
+        IndexMetadata.Builder indexMetadata = createResultsIndex(indexName, IndexVersion.current(), jobs, null);
 
         Metadata.Builder metadata = Metadata.builder();
         metadata.put(indexMetadata);
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
         csBuilder.metadata(metadata);
 
+        ClusterState cs = csBuilder.build();
         var client = mock(Client.class);
-        var updater = new MlAnomaliesIndexUpdate(TestIndexNameExpressionResolver.newInstance(), client);
-        updater.runUpdate(csBuilder.build());
-        // everything up to date so no action for the client
+        updater(client, cs).runUpdate(cs);
+        // everything up to date so no network calls expected
         verify(client).settings();
         verify(client).threadPool();
         verify(client).projectResolver();
@@ -98,23 +152,252 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
     public void testRunUpdate_LegacyIndex() {
         String indexName = ".ml-anomalies-sharedindex";
         var jobs = List.of("job1", "job2");
-        IndexMetadata.Builder indexMetadata = createSharedResultsIndex(indexName, IndexVersions.V_7_17_0, jobs);
+        IndexMetadata.Builder indexMetadata = createResultsIndex(indexName, IndexVersions.V_7_17_0, jobs, null);
 
         Metadata.Builder metadata = Metadata.builder();
         metadata.put(indexMetadata);
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
         csBuilder.metadata(metadata);
 
+        ClusterState cs = csBuilder.build();
         var client = mockClientWithRolloverAndAlias(indexName);
-        var updater = new MlAnomaliesIndexUpdate(TestIndexNameExpressionResolver.newInstance(), client);
-
-        updater.runUpdate(csBuilder.build());
+        updater(client, cs).runUpdate(cs);
         verify(client).settings();
         verify(client, times(7)).threadPool();
         verify(client).projectResolver();
-        verify(client, times(2)).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());  // create rollover alias and update
-        verify(client).execute(same(RolloverAction.INSTANCE), any(), any());  // index rolled over
+        verify(client, times(2)).execute(same(TransportIndicesAliasesAction.TYPE), any(), any()); // create rollover alias and update
+        verify(client).execute(same(RolloverAction.INSTANCE), any(), any());
         verifyNoMoreInteractions(client);
+    }
+
+    public void testHealReindexedV7_NoOp_WhenMappingAlreadyKeyword() {
+        // job_id is already keyword — do NOT touch this index (operator has fixed it manually)
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        ClusterState cs = clusterStateWithBadIndex(badIndex, IndexVersion.current(), List.of("jobA"), keywordJobIdMapping());
+        var client = mock(Client.class);
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        mockThreadPool(client);
+
+        updater(client, cs, auditor, systemAuditor, HEAL_ENABLED).runUpdate(cs);
+
+        verify(client, never()).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+        verify(client, never()).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
+        verify(auditor, never()).warning(any(), any());
+        verify(systemAuditor, never()).warning(anyString());
+    }
+
+    public void testHealReindexedV7_NoOp_WhenAliasesAlreadyMoved() {
+        // Bad index exists with broken mapping but has NO .ml-anomalies-* aliases left → skip
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        // Build cluster state WITHOUT any alias on the bad index
+        IndexMetadata.Builder idxMeta = IndexMetadata.builder(badIndex)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_bad")
+            )
+            .putMapping(textJobIdMapping());
+        ClusterState cs = ClusterState.builder(new ClusterName("_name")).metadata(Metadata.builder().put(idxMeta)).build();
+
+        var client = mock(Client.class);
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        mockThreadPool(client);
+
+        updater(client, cs, auditor, systemAuditor, HEAL_ENABLED).runUpdate(cs);
+
+        verify(client, never()).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+        verify(auditor, never()).warning(any(), any());
+        verify(systemAuditor, never()).warning(anyString());
+    }
+
+    public void testRunUpdate_RolloverFailureDoesNotBlockHeal() {
+        // The legacy index triggers a rollover failure; the heal should still run.
+        String legacyIndex = ".ml-anomalies-sharedindex";
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String targetIndex = ".ml-anomalies-shared-000001";
+
+        IndexMetadata.Builder legacyMeta = IndexMetadata.builder(legacyIndex)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.V_7_17_0)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_legacy")
+            )
+            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.jobResultsAliasedName("legacyJob")).isHidden(true).build())
+            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.resultsWriteAlias("legacyJob")).writeIndex(true).isHidden(true).build());
+
+        IndexMetadata.Builder badMeta = IndexMetadata.builder(badIndex)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_bad")
+            )
+            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.resultsWriteAlias("healJob")).writeIndex(true).isHidden(true).build())
+            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.jobResultsAliasedName("healJob")).isHidden(true).build())
+            .putMapping(textJobIdMapping());
+
+        ClusterState cs = ClusterState.builder(new ClusterName("_name")).metadata(Metadata.builder().put(legacyMeta).put(badMeta)).build();
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        var client = mockClientWithRolloverFailureAndHeal(targetIndex);
+
+        var updater = updater(client, cs, auditor, systemAuditor, HEAL_ENABLED);
+        var ex = expectThrows(ElasticsearchStatusException.class, () -> updater.runUpdate(cs));
+        assertEquals(RestStatus.CONFLICT, ex.status());
+        // The combined exception should include the rollover failure as a suppressed cause.
+        assertTrue(ex.getSuppressed().length > 0);
+
+        // Heal ran despite rollover failure: create + aliases + audit
+        verify(client).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+        verify(systemAuditor).warning(anyString());
+        verify(auditor).warning(eq("healJob"), anyString());
+    }
+
+    public void testHealReindexedV7_AuditorFailureDoesNotFailHeal() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        String targetIndex = ".ml-anomalies-shared-000001";
+        ClusterState cs = clusterStateWithBadIndex(badIndex, IndexVersion.current(), List.of("jobA"), textJobIdMapping());
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        doThrow(new RuntimeException("notifications index unavailable")).when(auditor).warning(any(), any());
+        doThrow(new RuntimeException("notifications index unavailable")).when(systemAuditor).warning(anyString());
+
+        var client = mockClientForHeal(targetIndex);
+        var updater = updater(client, cs, auditor, systemAuditor, HEAL_ENABLED);
+
+        // Should NOT throw even though the auditor threw
+        updater.runUpdate(cs);
+
+        // Aliases still moved
+        verify(client).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
+    }
+
+    public void testHealReindexedV7_HealDisabled() {
+        String badIndex = ".reindexed-v7-ml-anomalies-shared-000001";
+        ClusterState cs = clusterStateWithBadIndex(badIndex, IndexVersion.current(), List.of("jobA"), textJobIdMapping());
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        var client = mock(Client.class);
+        mockThreadPool(client);
+
+        updater(client, cs, auditor, systemAuditor, HEAL_DISABLED).runUpdate(cs);
+
+        verify(client, never()).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+        verify(client, never()).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
+        verify(auditor, never()).warning(any(), any());
+        verify(systemAuditor, never()).warning(anyString());
+    }
+
+    /**
+     * Scoping guard for the cluster-wide alias strip in
+     * {@code MlAnomaliesIndexUpdate.moveAliasesToTarget}.
+     * <p>
+     * The cluster-wide strip evacuates ML aliases from every {@code .reindexed-*-ml-anomalies-*}
+     * claimant so a subsequent rollover does not collide with the heal target. It must NOT strip
+     * the read alias from canonical {@code .ml-anomalies-*-NNNNNN} family members — older
+     * generations legitimately keep that alias for historical results.
+     * <p>
+     * Setup: a v9-version {@code .reindexed-v7-ml-anomalies-custom-foo-000001} with broken
+     * {@code job_id:text} mapping plus a non-write claim on the write alias, the heal-reuse
+     * target {@code .ml-anomalies-custom-foo-000002} (v9-version, keyword, current write index),
+     * and an older canonical {@code .ml-anomalies-custom-foo-000001} holding the read alias only.
+     * <p>
+     * Expectation: the captured alias-update request removes the read alias from the
+     * {@code .reindexed-v7-*} claimant but NOT from {@code .ml-anomalies-custom-foo-000001}.
+     */
+    public void testHealReindexedV7_DoesNotStripReadAliasFromOlderCanonicalGeneration() {
+        String reindexedBad = ".reindexed-v7-ml-anomalies-custom-foo-000001";
+        String oldCanonical = ".ml-anomalies-custom-foo-000001";
+        String newCanonical = ".ml-anomalies-custom-foo-000002";
+        String jobId = "fooJob";
+        String readAlias = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);
+        String writeAlias = AnomalyDetectorsIndex.resultsWriteAlias(jobId);
+
+        IndexMetadata.Builder oldMeta = IndexMetadata.builder(oldCanonical)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_old")
+            )
+            .putMapping(keywordJobIdMapping())
+            .putAlias(AliasMetadata.builder(readAlias).isHidden(true).build());
+
+        IndexMetadata.Builder newMeta = IndexMetadata.builder(newCanonical)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_new")
+            )
+            .putMapping(keywordJobIdMapping())
+            .putAlias(AliasMetadata.builder(readAlias).isHidden(true).build())
+            .putAlias(AliasMetadata.builder(writeAlias).writeIndex(true).isHidden(true).build());
+
+        IndexMetadata.Builder badMeta = IndexMetadata.builder(reindexedBad)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_INDEX_UUID, "_uuid_bad")
+            )
+            .putMapping(textJobIdMapping())
+            .putAlias(AliasMetadata.builder(readAlias).isHidden(true).build())
+            .putAlias(AliasMetadata.builder(writeAlias).writeIndex(false).isHidden(true).build());
+
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().put(oldMeta).put(newMeta).put(badMeta))
+            .build();
+
+        AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
+        SystemAuditor systemAuditor = mock(SystemAuditor.class);
+        var client = mockClientForHeal(newCanonical);
+
+        updater(client, cs, auditor, systemAuditor, HEAL_ENABLED).runUpdate(cs);
+
+        // Heal must have fired.
+        verify(systemAuditor).warning(anyString());
+
+        // Inspect every alias-update request issued by heal.
+        ArgumentCaptor<IndicesAliasesRequest> captor = ArgumentCaptor.forClass(IndicesAliasesRequest.class);
+        verify(client, atLeastOnce()).execute(same(TransportIndicesAliasesAction.TYPE), captor.capture(), any());
+
+        boolean strippedFromOldCanonical = captor.getAllValues()
+            .stream()
+            .flatMap(r -> r.getAliasActions().stream())
+            .anyMatch(
+                a -> a.actionType() == IndicesAliasesRequest.AliasActions.Type.REMOVE
+                    && a.indices().length > 0
+                    && a.indices()[0].equals(oldCanonical)
+                    && a.aliases().length > 0
+                    && a.aliases()[0].equals(readAlias)
+            );
+        assertFalse("read alias must NOT be removed from older canonical generation", strippedFromOldCanonical);
+
+        boolean strippedFromReindexed = captor.getAllValues()
+            .stream()
+            .flatMap(r -> r.getAliasActions().stream())
+            .anyMatch(
+                a -> a.actionType() == IndicesAliasesRequest.AliasActions.Type.REMOVE
+                    && a.indices().length > 0
+                    && a.indices()[0].equals(reindexedBad)
+                    && a.aliases().length > 0
+                    && a.aliases()[0].equals(readAlias)
+            );
+        assertTrue("read alias must be removed from .reindexed-v7-* claimant", strippedFromReindexed);
     }
 
     private record AliasActionMatcher(String aliasName, String index, IndicesAliasesRequest.AliasActions.Type actionType) {
@@ -125,7 +408,17 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
         }
     }
 
-    private IndexMetadata.Builder createSharedResultsIndex(String indexName, IndexVersion indexVersion, List<String> jobs) {
+    /**
+     * Creates a cluster-state containing a single ML results index (shared or bad) with
+     * the given jobs' aliases and optional mappingSource.
+     */
+    private ClusterState clusterStateWithBadIndex(String indexName, IndexVersion version, List<String> jobs, String mappingSource) {
+        IndexMetadata.Builder indexMetadata = createResultsIndex(indexName, version, jobs, mappingSource);
+        return ClusterState.builder(new ClusterName("_name")).metadata(Metadata.builder().put(indexMetadata)).build();
+    }
+
+    /** Builds an IndexMetadata.Builder with job aliases and optional mapping. */
+    private IndexMetadata.Builder createResultsIndex(String indexName, IndexVersion indexVersion, List<String> jobs, String mappingSource) {
         IndexMetadata.Builder indexMetadata = IndexMetadata.builder(indexName);
         indexMetadata.settings(
             Settings.builder()
@@ -142,7 +435,107 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
             );
         }
 
+        if (mappingSource != null) {
+            indexMetadata.putMapping(mappingSource);
+        }
+
         return indexMetadata;
+    }
+
+    /** Mapping JSON where job_id is text (the broken dynamic-mapping case). */
+    private static String textJobIdMapping() {
+        return "{\"properties\":{\"job_id\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\"}}}}}";
+    }
+
+    /** Mapping JSON where job_id is keyword (healthy). */
+    private static String keywordJobIdMapping() {
+        return "{\"properties\":{\"job_id\":{\"type\":\"keyword\"}}}";
+    }
+
+    /** Mocks threadPool() on a client (needed for OriginSettingClient internals). */
+    private static void mockThreadPool(Client client) {
+        var threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(threadPool);
+    }
+
+    /**
+     * Returns a client mock that succeeds for all heal operations:
+     * create-index, cluster-health, and alias update.
+     */
+    @SuppressWarnings("unchecked")
+    static Client mockClientForHeal(String targetIndexName) {
+        var client = mock(Client.class);
+        mockThreadPool(client);
+
+        // create-index
+        doAnswer(inv -> {
+            ActionListener<CreateIndexResponse> l = inv.getArgument(2);
+            l.onResponse(new CreateIndexResponse(true, true, targetIndexName));
+            return null;
+        }).when(client).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+
+        // cluster health
+        doAnswer(inv -> {
+            ActionListener<ClusterHealthResponse> l = inv.getArgument(2);
+            l.onResponse(mock(ClusterHealthResponse.class));
+            return null;
+        }).when(client).execute(same(TransportClusterHealthAction.TYPE), any(), any());
+
+        // alias update
+        mockAliasResponse(client);
+
+        return client;
+    }
+
+    /** Stubs the alias execute call to respond with success. */
+    @SuppressWarnings("unchecked")
+    private static void mockAliasResponse(Client client) {
+        doAnswer(inv -> {
+            ActionListener<IndicesAliasesResponse> l = inv.getArgument(2);
+            l.onResponse(IndicesAliasesResponse.ACKNOWLEDGED_NO_ERRORS);
+            return null;
+        }).when(client).execute(same(TransportIndicesAliasesAction.TYPE), any(), any());
+    }
+
+    /**
+     * A client mock where the rollover action FAILS (simulates a transient rollover error) but
+     * heal actions (create + health + alias) succeed.
+     */
+    @SuppressWarnings("unchecked")
+    private static Client mockClientWithRolloverFailureAndHeal(String targetIndexName) {
+        var client = mock(Client.class);
+        mockThreadPool(client);
+
+        // Rollover fails
+        doAnswer(inv -> {
+            ActionListener<?> l = inv.getArgument(2);
+            l.onFailure(new RuntimeException("rollover failed intentionally"));
+            return null;
+        }).when(client).execute(same(RolloverAction.INSTANCE), any(RolloverRequest.class), any());
+
+        // Alias for rollover setup also needed
+        doAnswer(inv -> {
+            ActionListener<IndicesAliasesResponse> l = inv.getArgument(2);
+            l.onResponse(IndicesAliasesResponse.ACKNOWLEDGED_NO_ERRORS);
+            return null;
+        }).when(client).execute(same(TransportIndicesAliasesAction.TYPE), any(IndicesAliasesRequest.class), any());
+
+        // Heal: create-index
+        doAnswer(inv -> {
+            ActionListener<CreateIndexResponse> l = inv.getArgument(2);
+            l.onResponse(new CreateIndexResponse(true, true, targetIndexName));
+            return null;
+        }).when(client).execute(same(TransportCreateIndexAction.TYPE), any(), any());
+
+        // Heal: cluster-health
+        doAnswer(inv -> {
+            ActionListener<ClusterHealthResponse> l = inv.getArgument(2);
+            l.onResponse(mock(ClusterHealthResponse.class));
+            return null;
+        }).when(client).execute(same(TransportClusterHealthAction.TYPE), any(), any());
+
+        return client;
     }
 
     @SuppressWarnings("unchecked")
@@ -161,7 +554,7 @@ public class MlAnomaliesIndexUpdateTests extends ESTestCase {
             ActionListener<IndicesAliasesResponse> actionListener = (ActionListener<IndicesAliasesResponse>) invocationOnMock
                 .getArguments()[2];
             var request = (IndicesAliasesRequest) invocationOnMock.getArguments()[1];
-            // Check the rollover alias is create and deleted
+            // Check the rollover alias is created and deleted
             if (aliasRequestCount.getAndIncrement() == 0) {
                 var addAliasAction = new AliasActionMatcher(
                     indexName + ".rollover_alias",

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.ml;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.features.TransportResetFeatureStateAction;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -37,6 +39,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.MlDataFrameAnalysisNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.ml.aggs.correlation.CorrelationNamedContentProvider;
 import org.elasticsearch.xpack.ml.inference.modelsize.MlModelSizeNamedXContentProvider;
@@ -175,6 +178,41 @@ public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
             return;
         }
         throw error.get();
+    }
+
+    /**
+     * Creates an index with the given name and mapping source, then attaches the canonical
+     * ML read and write aliases for each supplied job id — mirroring the alias shape that
+     * anomaly detection produces in production.
+     * <p>
+     * Intended for tests that need to pre-seed a results index in the state that a broken
+     * upgrade would leave behind (e.g. a {@code .reindexed-v7-ml-anomalies-*} index with
+     * aliases still pointing at it).
+     *
+     * @param indexName     The concrete index name to create.
+     * @param mappingSource The mapping JSON, in {@link CreateIndexRequest#mapping(String)} form
+     *                      (i.e. with an outer {@code _doc} wrapper if the server expects it).
+     * @param jobIds        Job ids whose read + write aliases will be added to the index.
+     */
+    protected void createResultsIndexWithAliases(String indexName, String mappingSource, List<String> jobIds) {
+        client().admin().indices().create(new CreateIndexRequest(indexName).mapping(mappingSource)).actionGet();
+        var aliasReq = client().admin().indices().prepareAliases(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
+        for (String jobId : jobIds) {
+            aliasReq.addAliasAction(
+                IndicesAliasesRequest.AliasActions.add()
+                    .index(indexName)
+                    .alias(AnomalyDetectorsIndex.jobResultsAliasedName(jobId))
+                    .isHidden(true)
+            );
+            aliasReq.addAliasAction(
+                IndicesAliasesRequest.AliasActions.add()
+                    .index(indexName)
+                    .alias(AnomalyDetectorsIndex.resultsWriteAlias(jobId))
+                    .writeIndex(true)
+                    .isHidden(true)
+            );
+        }
+        aliasReq.get();
     }
 
     public static class MockPainlessScriptEngine extends MockScriptEngine {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ML] Automatically repair ML anomaly results aliases pointing at a .reindexed-v7 index (#147688)](https://github.com/elastic/elasticsearch/pull/147688)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)