### PR TITLE
Fix hang on batched query response failure

### DIFF
--- a/docs/changelog/153401.yaml
+++ b/docs/changelog/153401.yaml
@@ -1,0 +1,5 @@
+area: EQL
+issues: []
+pr: 153401
+summary: Fix hang on batched query response failure
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -940,7 +940,11 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                     writeReductionFailureResponse(out, reductionFailure);
                 }
                 success = true;
-            } catch (IOException e) {
+            } catch (Exception e) {
+                // Any failure here (not just IOException) must still notify the channel: onShardDone only runs once the
+                // CountDown reaches zero, so a caller that catches an exception from this method and retries by calling
+                // onShardDone() again will find the count already at zero and silently no-op, leaving the coordinating
+                // node waiting forever for a response that will never arrive.
                 releaseAllResultsContexts();
                 channelListener.onFailure(e);
                 return;
@@ -1067,7 +1071,9 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                     }
                     NodeQueryResponse.writeMergeResult(out, mergeResult, queryPhaseResultConsumer.topDocsStats);
                     success = true;
-                } catch (IOException e) {
+                } catch (Exception e) {
+                    // See the comment in onShardDone(): any failure here (not just IOException) must still notify the
+                    // channel, since this is the last chance to do so before the CountDown has already reached zero.
                     releaseAllResultsContexts();
                     channelListener.onFailure(e);
                     return;

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -10,31 +10,44 @@
 package org.elasticsearch.action.search;
 
 import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.lucene.grouping.TopFieldGroups;
 import org.elasticsearch.rest.action.search.SearchResponseMetrics;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchPhaseResult;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -45,6 +58,9 @@ import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 
@@ -55,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
@@ -63,10 +80,194 @@ import java.util.function.LongSupplier;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
+
+    /**
+     * Regression test for a bug in the batched (multi-shard-per-node) query phase: if a data node throws anything
+     * other than an {@link IOException} while building the combined response for a {@code NodeQueryRequest}
+     * (inside {@code QueryPerNodeState#onShardDone}/{@code #bwcRespond}), the exception used to propagate up to
+     * {@code executeShardTasks}'s generic catch block, which "recovers" by calling {@code onShardDone()} again.
+     * But the internal {@link org.elasticsearch.common.util.concurrent.CountDown} had already reached zero on the
+     * first (failing) call, so the retry silently no-ops and the transport channel is never responded to -- the
+     * coordinating node then waits forever for a response that will never arrive.
+     * <p>
+     * This test drives the real, unmodified {@link SearchQueryThenFetchAsyncAction} end-to-end over a real (mock)
+     * transport connection between two nodes, and registers the real, unmodified server-side handler
+     * ({@link SearchQueryThenFetchAsyncAction#registerNodeSearchAction}) on the data node. The only test double is
+     * the data node's {@link NamedWriteableRegistry}, made to fail exactly the way a genuine PIT/alias-filter
+     * decode failure would -- this is what triggers the real (unguarded, prior to the fix) exception inside
+     * {@code maybeFreeContext -> isPartOfPIT} while the data node writes its response.
+     */
+    public void testUnguardedExceptionBuildingBatchedNodeResponseDoesNotHangCoordinator() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool(getTestName());
+        MockTransportService coordinatorTransport = MockTransportService.createNewService(
+            Settings.EMPTY,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
+        MockTransportService dataNodeTransport = MockTransportService.createNewService(
+            Settings.EMPTY,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
+        try {
+            coordinatorTransport.start();
+            coordinatorTransport.acceptIncomingRequests();
+            dataNodeTransport.start();
+            dataNodeTransport.acceptIncomingRequests();
+            DiscoveryNode coordinatorNode = coordinatorTransport.getLocalNode();
+            DiscoveryNode dataNode = dataNodeTransport.getLocalNode();
+            AbstractSimpleTransportTestCase.connectToNode(coordinatorTransport, dataNode);
+            AbstractSimpleTransportTestCase.connectToNode(dataNodeTransport, coordinatorNode);
+
+            // Data node: register the real batched-query handler. The registry fails to resolve the alias
+            // filter's query builder while decoding the PIT -- a realistic decode failure -- which is what makes
+            // QueryPerNodeState#maybeFreeContext (via #isPartOfPIT) throw while the response is being built.
+            NamedWriteableRegistry failingRegistry = mock(NamedWriteableRegistry.class);
+            when(failingRegistry.getReader(eq(QueryBuilder.class), any())).thenThrow(
+                new IllegalStateException("simulated failure resolving PIT alias filter query")
+            );
+            SearchService mockSearchService = mock(SearchService.class);
+            when(mockSearchService.getCircuitBreaker()).thenReturn(new NoopCircuitBreaker(CircuitBreaker.REQUEST));
+            // Collect the "birth ref" of each result created below, to release once the test is done -- mirroring
+            // the real InboundHandler's response.decRef() that normally runs once a result has been consumed.
+            List<QuerySearchResult> resultsToRelease = Collections.synchronizedList(new ArrayList<>());
+            doAnswer(invocation -> {
+                ShardSearchRequest request = invocation.getArgument(0);
+                @SuppressWarnings("unchecked")
+                ActionListener<SearchPhaseResult> listener = invocation.getArgument(2);
+                QuerySearchResult result = new QuerySearchResult(
+                    new ShardSearchContextId(UUIDs.randomBase64UUID(), request.shardId().id()),
+                    new SearchShardTarget(dataNode.getId(), request.shardId(), null),
+                    null
+                );
+                result.topDocs(
+                    new TopDocsAndMaxScore(new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]), Float.NaN),
+                    new DocValueFormat[0]
+                );
+                result.from(0);
+                result.size(0);
+                resultsToRelease.add(result);
+                listener.onResponse(result);
+                return null;
+            }).when(mockSearchService).executeQueryPhase(any(), any(), any());
+            SearchTransportService dataSearchTransportService = new SearchTransportService(dataNodeTransport, null, null);
+            SearchQueryThenFetchAsyncAction.registerNodeSearchAction(
+                dataSearchTransportService,
+                mockSearchService,
+                new SearchPhaseController((t, r) -> InternalAggregationTestCase.emptyReduceContextBuilder()),
+                failingRegistry
+            );
+
+            // Coordinator: a real search request with a PIT referencing a non-empty alias filter, and 2 shards
+            // that both live on the (only) data node -- so the coordinator batches them into a single
+            // NodeQueryRequest, exactly the scenario that exercises the vulnerable response-building code.
+            String indexUuid = "test-index-uuid";
+            ShardId shard0 = new ShardId("idx", indexUuid, 0);
+            ShardId shard1 = new ShardId("idx", indexUuid, 1);
+            Map<ShardId, SearchContextIdForNode> pitShards = Map.of(
+                shard0,
+                new SearchContextIdForNode(null, dataNode.getId(), new ShardSearchContextId(UUIDs.randomBase64UUID(), 0)),
+                shard1,
+                new SearchContextIdForNode(null, dataNode.getId(), new ShardSearchContextId(UUIDs.randomBase64UUID(), 1))
+            );
+            Map<String, AliasFilter> pitAliasFilters = Map.of(indexUuid, AliasFilter.of(new MatchAllQueryBuilder(), "alias1"));
+            BytesReference pitId = SearchContextId.encode(
+                pitShards,
+                pitAliasFilters,
+                TransportVersion.current(),
+                ShardSearchFailure.EMPTY_ARRAY
+            );
+
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.allowPartialSearchResults(true);
+            searchRequest.source(new SearchSourceBuilder().size(0).pointInTimeBuilder(new PointInTimeBuilder(pitId)));
+
+            List<SearchShardIterator> shardsIter = SearchAsyncActionTests.getShardsIter(
+                "idx",
+                new OriginalIndices(new String[] { "idx" }, SearchRequest.DEFAULT_INDICES_OPTIONS),
+                2,
+                false,
+                dataNode,
+                null
+            );
+            TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
+                0,
+                System.nanoTime(),
+                System::nanoTime
+            );
+            SearchTask task = new SearchTask(0, "n/a", "n/a", () -> "test", null, Collections.emptyMap());
+            SearchTransportService coordinatorSearchTransportService = new SearchTransportService(coordinatorTransport, null, null);
+            CountDownLatch latch = new CountDownLatch(1);
+            try (
+                QueryPhaseResultConsumer resultConsumer = new QueryPhaseResultConsumer(
+                    searchRequest,
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                    new NoopCircuitBreaker(CircuitBreaker.REQUEST),
+                    new SearchPhaseController((t, r) -> InternalAggregationTestCase.emptyReduceContextBuilder()),
+                    task::isCancelled,
+                    task.getProgressListener(),
+                    shardsIter.size(),
+                    exc -> {}
+                )
+            ) {
+                SearchQueryThenFetchAsyncAction action = new SearchQueryThenFetchAsyncAction(
+                    logger,
+                    null,
+                    coordinatorSearchTransportService,
+                    new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(Long.MAX_VALUE)),
+                    (clusterAlias, nodeId) -> coordinatorTransport.getConnection(dataNode),
+                    Collections.singletonMap("_na_", AliasFilter.EMPTY),
+                    Collections.emptyMap(),
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                    resultConsumer,
+                    searchRequest,
+                    ActionListener.running(latch::countDown),
+                    shardsIter,
+                    Collections.emptyMap(),
+                    timeProvider,
+                    new ClusterState.Builder(new ClusterName("test")).build(),
+                    task,
+                    SearchResponse.Clusters.EMPTY,
+                    null,
+                    true,  // batchQueryPhase
+                    false, // pitRelocationEnabled
+                    new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
+                    Map.of()
+                ) {
+                    @Override
+                    protected SearchPhase getNextPhase() {
+                        return new SearchPhase("test") {
+                            @Override
+                            protected void run() {
+                                latch.countDown();
+                            }
+                        };
+                    }
+                };
+                action.start();
+                boolean completed = latch.await(10, TimeUnit.SECONDS);
+                resultsToRelease.forEach(QuerySearchResult::decRef);
+                assertTrue(
+                    "search never completed: the data node's response to the batched query never reached the "
+                        + "coordinator. This is the bug: an exception in QueryPerNodeState#onShardDone/#bwcRespond "
+                        + "left the transport channel with no response at all, so the coordinator waits forever.",
+                    completed
+                );
+            }
+        } finally {
+            IOUtils.closeWhileHandlingException(coordinatorTransport, dataNodeTransport, threadPool);
+        }
+    }
+
     public void testBottomFieldSort() throws Exception {
         testCase(false, false);
     }


### PR DESCRIPTION
QueryPerNodeState#onShardDone/#bwcRespond only caught IOException while building the combined response for a batched NodeQueryRequest. Any other exception escaped uncaught into executeShardTasks's retry path, which silently no-ops because CountDown already reached zero, so the channel is never responded to and the coordinator waits forever. Broaden both catches to Exception so any failure reaches the channel.

Related to https://github.com/elastic/elasticsearch/issues/150762
(it won't fix the EQL test failure, but it will reveal the actual exception)