### PR TITLE
ESQL:DS: Fix leaked pages on AsyncExternalSourceBuffer

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -667,12 +667,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
   method: testParquetFile {alltypes_plain.snappy}
   issue: https://github.com/elastic/elasticsearch/issues/153048
-- class: org.elasticsearch.xpack.esql.action.NdJsonCrossFileScalarObjectConflictIT
-  method: testDefaultSettingsFailsOnCrossFileScalarObjectConflict
-  issue: https://github.com/elastic/elasticsearch/issues/153054
-- class: org.elasticsearch.xpack.esql.action.NdJsonCrossFileScalarObjectConflictIT
-  method: testSkipRowPolicyNullFillsAndWarnsClient
-  issue: https://github.com/elastic/elasticsearch/issues/153055
 - class: org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTests
   method: testFetchRegion
   issue: https://github.com/elastic/elasticsearch/issues/153058

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -367,6 +367,16 @@ public final class AsyncExternalSourceBuffer {
 
     /**
      * Mark the buffer as finished. Called when reading is done or an error occurs.
+     * <p>
+     * {@code drainingPages} is honored regardless of whether this call wins the {@code noMoreInputs}
+     * transition: {@link AsyncExternalSourceOperator#close()} always calls {@code finish(true)}, and
+     * by the time a driver closes its operator {@code noMoreInputs} has very often already been set
+     * by the producer's own {@link #onFailure} or an earlier {@code finish(false)} — e.g. the producer
+     * reached natural EOF, or the read failed, before the driver got a chance to drain every page via
+     * {@code getOutput()}/{@link #pollPage()}. Gating {@link #discardPages()} behind the transition
+     * used to skip it entirely in that (common) case, leaking whatever the producer had already
+     * buffered when the driver's close is not preceded by a full drain (e.g. cross-driver task
+     * cancellation cutting this operator before its own poll loop ever ran).
      *
      * @return {@code true} if this call performed the running→finishing transition; {@code false} if the buffer had
      *         already been finished (e.g. producer reached natural EOF, or a concurrent {@code finish}/{@code onFailure}
@@ -375,9 +385,8 @@ public final class AsyncExternalSourceBuffer {
      *         (honestly complete result).
      */
     public boolean finish(boolean drainingPages) {
-        if (noMoreInputs.compareAndSet(false, true) == false) {
-            return false;
-        }
+        boolean transitioned = noMoreInputs.compareAndSet(false, true);
+        // See the javadoc above for why this must not be gated on `transitioned`.
         if (drainingPages) {
             discardPages();
         }
@@ -385,7 +394,7 @@ public final class AsyncExternalSourceBuffer {
         notifyNotFull(); // wake producers so they observe noMoreInputs and exit
         signalCompletionIfDrained();
         assert invariantsHold() : "buffer invariants violated after finish";
-        return true;
+        return transitioned;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -853,16 +853,21 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             // Implements async STOP semantics for coordinator-only EXTERNAL plans: when the user fires
             // {@code POST /_query/async/{id}/stop}, the task's stop-hook list fans out to each driver's
             // {@link DriverContext}, which calls this hook. {@code buffer.finish(false)} flips
-            // {@code noMoreInputs} on the buffer — pages already accepted into the queue stay reachable
-            // to the driver loop and flow through the pipeline, while producer threads observe the flag
-            // and exit instead of accepting more pages.
+            // {@code noMoreInputs} on the buffer — the {@code false} here (not draining) is what keeps
+            // pages already accepted into the queue reachable to the driver loop so they flow through
+            // the pipeline, while producer threads observe the flag and exit instead of accepting more
+            // pages. This is independent of the CAS outcome below: a losing {@code finish(false)} still
+            // leaves the queue untouched, exactly like a winning one.
             //
             // {@code finish} performs a CAS on {@code noMoreInputs} and returns {@code true} only when
             // it actually made the running→finishing transition; if the producer already EOF'd (natural
             // completion) or another thread finished the buffer first, it returns {@code false}. That
-            // eliminates the check-then-act race between {@code buffer.noMoreInputs()} and
-            // {@code buffer.finish(false)}: STOP marking the response {@code is_partial=true} now
-            // requires a genuine live cut, not merely observing "already finished".
+            // return value only reflects who won the transition — it does not indicate whether any pages
+            // were discarded (that is governed solely by the {@code drainingPages} argument, see
+            // {@link AsyncExternalSourceBuffer#finish}) — and eliminates the check-then-act race between
+            // {@code buffer.noMoreInputs()} and {@code buffer.finish(false)}: STOP marking the response
+            // {@code is_partial=true} now requires a genuine live cut, not merely observing "already
+            // finished".
             driverContext.addStopHook(() -> buffer.finish(false));
 
             if (sliceQueue != null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -218,6 +218,65 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         }
     }
 
+    /**
+     * Regression test for a leak where a page buffered before {@link AsyncExternalSourceBuffer#onFailure}
+     * is never released.
+     * <p>
+     * {@code onFailure} deliberately leaves already-queued pages in place so the driver can drain them
+     * via {@code getOutput()}/{@link AsyncExternalSourceBuffer#pollPage()} before the failure surfaces.
+     * But {@link AsyncExternalSourceOperator#close()} always calls {@code finish(true)}, and the prior
+     * implementation gated {@link AsyncExternalSourceBuffer#discardPages} behind the {@code noMoreInputs}
+     * CAS transition — which {@code onFailure} had already performed, so {@code finish(true)} always lost
+     * the race and skipped the discard. A close that arrives without the driver ever draining the queue
+     * (e.g. cross-driver task cancellation cutting this operator's poll loop before it runs) leaked the
+     * page's blocks forever.
+     */
+    public void testFinishAfterFailureStillDiscardsQueuedPages() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        Page page = createTestPage(2, 5);
+        IntBlock block = page.getBlock(0);
+        buffer.addPage(page);
+        assertEquals(1, buffer.size());
+
+        buffer.onFailure(new RuntimeException("simulated read failure"));
+        assertEquals("onFailure must not itself discard: the driver may still drain via pollPage()", 1, buffer.size());
+        assertFalse(block.isReleased());
+
+        // Simulates AsyncExternalSourceOperator#close() -> finish() arriving without the driver ever
+        // polling this page out (e.g. abrupt cancellation before the operator's own poll loop ran).
+        boolean transitioned = buffer.finish(true);
+        assertFalse("onFailure already performed the transition", transitioned);
+        assertEquals("finish(true) must discard the page onFailure left queued", 0, buffer.size());
+        assertEquals(0, buffer.bytesInBuffer());
+        assertTrue("the page's blocks must be released, not leaked", block.isReleased());
+    }
+
+    /**
+     * Companion to {@link #testFinishAfterFailureStillDiscardsQueuedPages} for the non-failure case: a
+     * prior {@code finish(false)} (natural producer EOF, called before the driver drained every page)
+     * must not prevent a later {@code finish(true)} — e.g. from {@code AsyncExternalSourceOperator#close()}
+     * — from discarding whatever is still queued.
+     */
+    public void testFinishTrueAfterFinishFalseStillDiscardsQueuedPages() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        Page page = createTestPage(2, 5);
+        IntBlock block = page.getBlock(0);
+        buffer.addPage(page);
+        assertEquals(1, buffer.size());
+
+        // Producer reached natural EOF before the driver polled this page out.
+        boolean firstTransitioned = buffer.finish(false);
+        assertTrue(firstTransitioned);
+        assertEquals(1, buffer.size());
+        assertFalse(block.isReleased());
+
+        boolean secondTransitioned = buffer.finish(true);
+        assertFalse("finish(false) already performed the transition", secondTransitioned);
+        assertEquals("finish(true) must discard the page finish(false) left queued", 0, buffer.size());
+        assertEquals(0, buffer.bytesInBuffer());
+        assertTrue("the page's blocks must be released, not leaked", block.isReleased());
+    }
+
     public void testFormatReaderStatusGetterMatchesLastRecorded() {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
         assertNull(buffer.formatReaderStatus());


### PR DESCRIPTION
Fixes a leak in `AsyncExternalSourceBuffer`: `discardPages()` was skipped whenever `finish(true)` lost the `noMoreInputs` CAS race (e.g. close() after a prior `onFailure`/`finish(false)`), leaving buffered pages - and their blocks - unreleased. `discardPages()` now runs unconditionally on `drainingPages=true`, independent of the CAS result, while the CAS result itself is still returned for the existing STOP/partial-result signaling.

Closes #153054
Closes #153055