### PR TITLE
Fix AbstractResumeBulkByPaginatedSearchAction javadoc

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByPaginatedSearchAction.java
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.util.concurrent.Executor;
 
-/// Abstract transport action for resuming BulkByScrollAction operations asynchronously. Delegates to the corresponding action on the local
+/// Abstract transport action for resuming BulkByPaginatedSearchAction operations asynchronously. Delegates to the corresponding action on the local
 /// node, then returns a [ResumeBulkByPaginatedSearchResponse] containing the task id of the delegate action.
 public abstract class AbstractResumeBulkByPaginatedSearchAction<Request extends AbstractBulkByPaginatedSearchRequest<Request>> extends
     HandledTransportAction<ResumeBulkByPaginatedSearchRequest, ResumeBulkByPaginatedSearchResponse> {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractResumeBulkByPaginatedSearchAction.java
@@ -30,8 +30,8 @@ import org.elasticsearch.transport.TransportService;
 
 import java.util.concurrent.Executor;
 
-/// Abstract transport action for resuming BulkByPaginatedSearchAction operations asynchronously. Delegates to the corresponding action on the local
-/// node, then returns a [ResumeBulkByPaginatedSearchResponse] containing the task id of the delegate action.
+/// Abstract transport action for resuming BulkByPaginatedSearchAction operations asynchronously. Delegates to the corresponding action on
+/// the local node, then returns a [ResumeBulkByPaginatedSearchResponse] containing the task id of the delegate action.
 public abstract class AbstractResumeBulkByPaginatedSearchAction<Request extends AbstractBulkByPaginatedSearchRequest<Request>> extends
     HandledTransportAction<ResumeBulkByPaginatedSearchRequest, ResumeBulkByPaginatedSearchResponse> {
 


### PR DESCRIPTION
Use BulkByPaginatedSearchAction in the class javadoc.

Relates: elastic/elasticsearch-team#2406

