### PR TITLE
[9.5] ESQL:DS: Fix Parquet tests failing on test files download (#153372)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -694,12 +694,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
-  method: testParquetFile {datapage_v2_empty_datapage.snappy}
-  issue: https://github.com/elastic/elasticsearch/issues/153047
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
-  method: testParquetFile {alltypes_plain.snappy}
-  issue: https://github.com/elastic/elasticsearch/issues/153048
 - class: org.elasticsearch.xpack.esql.action.NdJsonCrossFileScalarObjectConflictIT
   method: testDefaultSettingsFailsOnCrossFileScalarObjectConflict
   issue: https://github.com/elastic/elasticsearch/issues/153054

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ClickBenchFixture.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ClickBenchFixture.java
@@ -21,6 +21,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
+import org.elasticsearch.xpack.esql.datasources.HttpDownloadRetry;
 import org.junit.rules.ExternalResource;
 
 import java.io.ByteArrayOutputStream;
@@ -71,6 +72,12 @@ public class ClickBenchFixture extends ExternalResource {
     private static final int DOWNLOAD_TIMEOUT_MS = 120_000;
     private static final byte[] PARQUET_MAGIC = { 'P', 'A', 'R', '1' };
     private static final int SPLIT_COUNT = 5;
+
+    // Same retry policy as ParquetTestingIT#downloadFile, so the two fixtures behave consistently
+    // against occasional rate-limiting/transient errors from their respective third-party hosts.
+    private static final int DOWNLOAD_MAX_ATTEMPTS = 4;
+    private static final long DOWNLOAD_INITIAL_BACKOFF_MILLIS = 1000L;
+    private static final long DOWNLOAD_MAX_BACKOFF_MILLIS = 8000L;
 
     /**
      * The 18 file indices with the smallest RG0, sorted by RG0 compressed size ascending.
@@ -153,7 +160,24 @@ public class ClickBenchFixture extends ExternalResource {
             String url = BASE_URL + idx + SUFFIX;
             logger.info("Downloading RG0 from hits_{}", idx);
             Path tmpFile = rawDir.resolve("rg0_" + idx + ".parquet.tmp");
-            boolean ok = downloadRG0ToFile(url, tmpFile);
+            boolean ok;
+            try {
+                ok = HttpDownloadRetry.withRetries(
+                    logger,
+                    "download RG0 from hits_" + idx,
+                    DOWNLOAD_MAX_ATTEMPTS,
+                    DOWNLOAD_INITIAL_BACKOFF_MILLIS,
+                    DOWNLOAD_MAX_BACKOFF_MILLIS,
+                    () -> downloadRG0ToFile(url, tmpFile)
+                );
+            } catch (IOException e) {
+                // A single source file's download failure that persists across retries (e.g. a permanent
+                // 404, or transient errors that outlasted the retry budget) should not abort the whole
+                // fixture and fail every test in the suite -- skip this file like the ok == false path.
+                logger.warn("Failed to download RG0 from hits_{}, skipping: {}", idx, e.getMessage());
+                Files.deleteIfExists(tmpFile);
+                continue;
+            }
             if (ok == false) {
                 logger.warn("Failed to download RG0 from hits_{}, skipping", idx);
                 Files.deleteIfExists(tmpFile);
@@ -334,6 +358,10 @@ public class ClickBenchFixture extends ExternalResource {
         conn.setConnectTimeout(DOWNLOAD_TIMEOUT_MS);
         conn.setReadTimeout(DOWNLOAD_TIMEOUT_MS);
         try {
+            int code = conn.getResponseCode();
+            if (code != 200) {
+                throw new HttpDownloadRetry.HttpStatusException("HTTP HEAD to [" + url + "] failed with status " + code, code);
+            }
             return conn.getContentLengthLong();
         } finally {
             conn.disconnect();
@@ -349,7 +377,7 @@ public class ClickBenchFixture extends ExternalResource {
         try {
             int code = conn.getResponseCode();
             if (code != 206 && code != 200) {
-                throw new IOException("HTTP range request to [" + url + "] failed with status " + code);
+                throw new HttpDownloadRetry.HttpStatusException("HTTP range request to [" + url + "] failed with status " + code, code);
             }
             try (InputStream in = conn.getInputStream()) {
                 return in.readAllBytes();

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTestingIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTestingIT.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.AssertWarnings;
 import org.elasticsearch.xpack.esql.datasource.parquet.PlainCompressionCodecFactory;
 import org.elasticsearch.xpack.esql.datasource.parquet.PlainParquetReadOptions;
 import org.elasticsearch.xpack.esql.datasources.DatasetRegistry;
+import org.elasticsearch.xpack.esql.datasources.HttpDownloadRetry;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -265,7 +266,15 @@ public class ParquetTestingIT extends ESRestTestCase {
     private void testGoodData(String url, String dataset) throws Exception {
         logger.info("Testing good data: {}", parquetFile);
 
-        byte[] parquetBytes = downloadFile(url);
+        byte[] parquetBytes;
+        try {
+            parquetBytes = downloadFile(url);
+        } catch (IOException e) {
+            // raw.githubusercontent.com occasionally rate-limits (HTTP 429) the pinned-commit fixture under
+            // CI load; that is an environmental condition, not a reader regression.
+            assumeNoException("Unable to download parquet-testing fixture [" + url + "]", e);
+            return;
+        }
         GroundTruth groundTruth;
         try {
             groundTruth = readGroundTruth(parquetBytes);
@@ -741,12 +750,33 @@ public class ParquetTestingIT extends ESRestTestCase {
         return "FROM " + dataset + " | LIMIT " + limit;
     }
 
+    private static final int DOWNLOAD_MAX_ATTEMPTS = 4;
+    private static final long DOWNLOAD_INITIAL_BACKOFF_MILLIS = 1000L;
+    private static final long DOWNLOAD_MAX_BACKOFF_MILLIS = 8000L;
+
+    /**
+     * Downloads {@code url}, retrying transient failures (HTTP 429/5xx, or connection-level errors below
+     * the HTTP layer) via {@link HttpDownloadRetry#withRetries}. A permanent HTTP error (e.g. 404) is
+     * thrown immediately without retrying. Throws the last failure once attempts are exhausted; the
+     * caller treats that as an environmental skip rather than a test failure.
+     */
     private static byte[] downloadFile(String url) throws IOException {
+        return HttpDownloadRetry.withRetries(
+            logger,
+            "download [" + url + "]",
+            DOWNLOAD_MAX_ATTEMPTS,
+            DOWNLOAD_INITIAL_BACKOFF_MILLIS,
+            DOWNLOAD_MAX_BACKOFF_MILLIS,
+            () -> downloadFileOnce(url)
+        );
+    }
+
+    private static byte[] downloadFileOnce(String url) throws IOException {
         HttpGet request = new HttpGet(url);
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             int status = response.getStatusLine().getStatusCode();
             if (status != 200) {
-                throw new IOException("Failed to download " + url + ": HTTP " + status);
+                throw new HttpDownloadRetry.HttpStatusException("Failed to download " + url + ": HTTP " + status, status);
             }
             return EntityUtils.toByteArray(response.getEntity());
         }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/HttpDownloadRetry.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/HttpDownloadRetry.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+/**
+ * Shared retry-with-backoff helper for test fixtures that download data over HTTP from third-party
+ * hosts (e.g. {@code raw.githubusercontent.com}, ClickHouse's ClickBench dataset host). These hosts
+ * occasionally rate-limit (HTTP 429) or return transient 5xx errors under CI load; {@link #withRetries}
+ * retries such failures with capped exponential backoff and jitter. Any other failure (e.g. a permanent
+ * 4xx like 404, or exhausted retries) is rethrown so the caller can decide how to handle it -- typically
+ * skipping the affected file or test via {@code assumeNoException} rather than failing outright.
+ */
+public final class HttpDownloadRetry {
+
+    private HttpDownloadRetry() {}
+
+    /** HTTP status codes considered transient, and therefore worth retrying. */
+    public static boolean isRetryableStatus(int status) {
+        return status == 429 || (status >= 500 && status < 600);
+    }
+
+    /**
+     * An {@link IOException} carrying the HTTP status code of a failed download attempt, so
+     * {@link #withRetries} can distinguish transient failures (429/5xx) from permanent ones (e.g. 404)
+     * without wasting time retrying the latter.
+     */
+    public static class HttpStatusException extends IOException {
+        private final int status;
+
+        public HttpStatusException(String message, int status) {
+            super(message);
+            this.status = status;
+        }
+
+        public int status() {
+            return status;
+        }
+    }
+
+    /**
+     * Runs {@code attempt}, retrying on transient failures with capped exponential backoff and jitter.
+     * A failure is transient -- and therefore retried -- if it is either an {@link HttpStatusException}
+     * with a {@linkplain #isRetryableStatus(int) retryable status}, or any other {@link IOException}
+     * (e.g. a connection reset or timeout below the HTTP layer, which are inherently transient). A
+     * non-retryable {@link HttpStatusException} (e.g. 404) is rethrown immediately without retrying.
+     *
+     * @param description short, human-readable description of the operation, used in log messages
+     * @param maxAttempts total number of attempts, including the first (non-retry) one
+     * @param initialBackoffMillis backoff before the first retry; doubles on each subsequent retry
+     * @param maxBackoffMillis cap applied to the (pre-jitter) backoff
+     */
+    public static <T> T withRetries(
+        Logger logger,
+        String description,
+        int maxAttempts,
+        long initialBackoffMillis,
+        long maxBackoffMillis,
+        CheckedSupplier<T, IOException> attempt
+    ) throws IOException {
+        IOException lastFailure = null;
+        for (int attemptNum = 1; attemptNum <= maxAttempts; attemptNum++) {
+            try {
+                return attempt.get();
+            } catch (IOException e) {
+                lastFailure = e;
+                if (e instanceof HttpStatusException statusException && isRetryableStatus(statusException.status()) == false) {
+                    throw e;
+                }
+                if (attemptNum == maxAttempts) {
+                    break;
+                }
+                long backoff = Math.min(initialBackoffMillis << (attemptNum - 1), maxBackoffMillis);
+                long jitter = ESTestCase.randomLongBetween(0, backoff / 2);
+                logger.warn(
+                    "Attempt {}/{} to {} failed ({}), retrying in {}ms",
+                    attemptNum,
+                    maxAttempts,
+                    description,
+                    e.getMessage(),
+                    backoff + jitter
+                );
+                try {
+                    Thread.sleep(backoff + jitter);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while retrying " + description, interrupted);
+                }
+            }
+        }
+        throw lastFailure;
+    }
+}


### PR DESCRIPTION
This fixes two tests that fail on downloading test data. Part of them were resilient to this failure, so that's now extended to all test data.

(cherry picked from commit 039a38023078983eaef92feb0eef19910d95a96f)
