### PR TITLE
ES|QL|DS: NDJSON bad-row error names the dataset setting, not a WITH clause

### DIFF
--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -1906,7 +1906,7 @@ public class NdJsonPageDecoder implements Closeable {
             if (errorPolicy.isStrict()) {
                 // Mirror CsvFormatReader.onRowErrorImpl's field-error hint so the fail-fast message is actionable.
                 throw new EsqlIllegalArgumentException(
-                    message + "; set error_mode to null_field (or skip_row) in WITH options to null-fill/skip and warn instead of failing"
+                    message + "; set error_mode=null_field (or skip_row) to null-fill/skip and warn instead of failing"
                 );
             }
             if (inArray == false) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1149,6 +1149,13 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 }
             });
             assertThat(e.getMessage(), Matchers.containsString("could not be coerced to type [long]"));
+            // The recovery hint must name the dataset setting, not a query clause: FROM <dataset> has no
+            // WITH options clause, so a user who followed a "in WITH options" hint would get a parse error.
+            assertThat(
+                e.getMessage(),
+                Matchers.containsString("set error_mode=null_field (or skip_row) to null-fill/skip and warn instead of failing")
+            );
+            assertThat(e.getMessage(), Matchers.not(Matchers.containsString("WITH options")));
         }
     }
 


### PR DESCRIPTION
# ES|QL|DS: NDJSON bad-row error names the dataset setting, not a WITH clause

Closes https://github.com/elastic/esql-planning/issues/1123

## What

A bad NDJSON row that fails a strict query told the user to recover with a
clause that does not exist:

> `...; set error_mode to null_field (or skip_row) in WITH options ...`

`FROM <dataset>` has no `WITH options` clause. `error_mode` is dataset
configuration (set at dataset creation), not query syntax, so a user who
followed the hint got a parse error. A format-reader error should not
prescribe query syntax.

## Fix

In `NdJsonPageDecoder`, name the setting instead of a query clause:

> `; set error_mode=null_field (or skip_row) to null-fill/skip and warn instead of failing`

This mirrors the sweep `CsvFormatReader` already received. One user-visible
string, no behavior change.
