### PR TITLE
Fix LeaderBulkByPaginatedSearchTaskState

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/LeaderBulkByPaginatedSearchTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/LeaderBulkByPaginatedSearchTaskState.java
@@ -70,7 +70,7 @@ public class LeaderBulkByPaginatedSearchTaskState {
     }
 
     /**
-     * Returns the number of slices this BulkByScrollRequest will use
+     * Returns the number of slices this BulkByPaginatedSearchRequest will use
      */
     public int getSlices() {
         return slices;


### PR DESCRIPTION
Use `BulkByPaginatedSearchRequest` in the `getSlices ()` method javadoc.

Relates: elastic/elasticsearch-team#2406
