### PR TITLE
Update search context metrics counter description

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/BulkByPaginatedSearchSearchContextMetrics.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/BulkByPaginatedSearchSearchContextMetrics.java
@@ -40,7 +40,7 @@ public class BulkByPaginatedSearchSearchContextMetrics {
     public BulkByPaginatedSearchSearchContextMetrics(MeterRegistry meterRegistry) {
         this.searchContextKeepaliveExpiredCounter = meterRegistry.registerLongCounter(
             SEARCH_CONTEXT_KEEPALIVE_EXPIRED_COUNTER,
-            "Bulk-by-scroll tasks whose missing scroll/PIT contexts expired before the next refresh (heuristic)",
+            "Bulk-by-paginated-search tasks whose missing scroll/PIT contexts expired before the next refresh (heuristic)",
             "unit"
         );
     }


### PR DESCRIPTION
Use `bulk-by-paginated-search` wording in the human-readable metric description.

Relates: elastic/elasticsearch-team#2406