### PR TITLE
Fix bulk-by-scroll javadoc in AsyncBulkByPaginatedSearchActionTests

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -1550,7 +1550,7 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
     }
 
     /**
-     * Sliced bulk-by-scroll must retain scroll when {@code max_docs} is at most the batch size. Otherwise, the search has
+     * Sliced bulk-by-paginated-search must retain scroll when {@code max_docs} is at most the batch size. Otherwise, the search has
      * {@code slice} with neither scroll nor point-in-time, which fails request validation.
      */
     public void testKeepScrollWhenMaxDocsAtMostScrollSizeButSliced() {


### PR DESCRIPTION
Replace `bulk-by-scroll` with `bulk-by-paginated-search` in the sliced `max_docs` test javadoc.

Relates: elastic/elasticsearch-team#2406