### PR TITLE
Painless: allocation annotations for Elasticsearch field-access allocators

### DIFF
--- a/docs/changelog/153435.yaml
+++ b/docs/changelog/153435.yaml
@@ -1,0 +1,5 @@
+area: Infra/Scripting
+issues: []
+pr: 153435
+summary: Add Painless allocation annotations for Elasticsearch field-access allocators
+type: enhancement

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/AllocationEstimators.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/AllocationEstimators.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.painless;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+
 import java.util.Collection;
 import java.util.Locale;
 
@@ -100,6 +103,22 @@ public final class AllocationEstimators {
     public static long linkedListCopyBytes(Collection<?> source) {
         long size = source == null ? 0 : source.size();
         return 32 + AllocSizes.mulSat(size, 40);
+    }
+
+    /**
+     * Cost of {@code BytesRef.utf8ToString()}: a new {@link String}. Its UTF-16 character count is at most the ref's UTF-8
+     * byte length, so charging by the byte length is a safe upper bound.
+     */
+    public static long utf8ToStringBytes(BytesRef receiver) {
+        return newStringBytes(receiver == null ? 0 : receiver.length);
+    }
+
+    /**
+     * Cost of {@code ScriptDocValues.GeoPoints.getLats()}/{@code getLons()}: a new {@code double[]} sized to the number of
+     * points in the field value.
+     */
+    public static long geoPointsDoublesBytes(ScriptDocValues.GeoPoints receiver) {
+        return AllocSizes.arrayBytes(receiver == null ? 0 : receiver.size(), 8);
     }
 
     /** Cost of {@code Collection.toArray()}: a new {@code Object[]} sized to the collection. */

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.net.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.net.txt
@@ -8,12 +8,12 @@
 #
 
 class org.elasticsearch.script.field.IPAddress {
-    (String)
+    (String) @allocates_constant[bytes="64b"]
     boolean isV4()
     boolean isV6()
 }
 
 class org.elasticsearch.painless.api.CIDR {
-    (String)
+    (String) @allocates_constant[bytes="48b"]
     boolean contains(String)
 }

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.ingest.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.ingest.txt
@@ -10,9 +10,9 @@
 # This file contains a whitelist for the ingest scripts
 
 class java.lang.String {
-  String org.elasticsearch.painless.api.Augmentation sha1()
-  String org.elasticsearch.painless.api.Augmentation sha256()
-  String org.elasticsearch.painless.api.Augmentation sha512()
+  String org.elasticsearch.painless.api.Augmentation sha1() @allocates_constant[bytes="112b"]
+  String org.elasticsearch.painless.api.Augmentation sha256() @allocates_constant[bytes="160b"]
+  String org.elasticsearch.painless.api.Augmentation sha512() @allocates_constant[bytes="288b"]
 }
 
 class org.elasticsearch.painless.api.Json {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.reindex.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.reindex.txt
@@ -10,9 +10,9 @@
 # This file contains a whitelist for reindex scripts
 
 class java.lang.String {
-  String org.elasticsearch.painless.api.Augmentation sha1()
-  String org.elasticsearch.painless.api.Augmentation sha256()
-  String org.elasticsearch.painless.api.Augmentation sha512()
+  String org.elasticsearch.painless.api.Augmentation sha1() @allocates_constant[bytes="112b"]
+  String org.elasticsearch.painless.api.Augmentation sha256() @allocates_constant[bytes="160b"]
+  String org.elasticsearch.painless.api.Augmentation sha512() @allocates_constant[bytes="288b"]
 }
 
 class org.elasticsearch.painless.api.Json {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.score.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.score.txt
@@ -25,10 +25,10 @@ class org.elasticsearch.script.StatsSummary {
 class org.elasticsearch.script.ScriptTermStats {
     int uniqueTermsCount()
     int matchedTermsCount()
-    StatsSummary docFreq()
-    StatsSummary totalTermFreq()
-    StatsSummary termFreq()
-    StatsSummary termPositions()
+    StatsSummary docFreq() @allocates_constant[bytes="48b"]
+    StatsSummary totalTermFreq() @allocates_constant[bytes="48b"]
+    StatsSummary termFreq() @allocates_constant[bytes="48b"]
+    StatsSummary termPositions() @allocates_constant[bytes="48b"]
 }
 
 static_import {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
@@ -10,9 +10,9 @@
 # This file contains a whitelist for update scripts
 
 class java.lang.String {
-  String org.elasticsearch.painless.api.Augmentation sha1()
-  String org.elasticsearch.painless.api.Augmentation sha256()
-  String org.elasticsearch.painless.api.Augmentation sha512()
+  String org.elasticsearch.painless.api.Augmentation sha1() @allocates_constant[bytes="112b"]
+  String org.elasticsearch.painless.api.Augmentation sha256() @allocates_constant[bytes="160b"]
+  String org.elasticsearch.painless.api.Augmentation sha512() @allocates_constant[bytes="288b"]
 }
 
 class org.elasticsearch.painless.api.Json {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update_by_query.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update_by_query.txt
@@ -10,9 +10,9 @@
 # This file contains a whitelist for update_by_query scripts
 
 class java.lang.String {
-  String org.elasticsearch.painless.api.Augmentation sha1()
-  String org.elasticsearch.painless.api.Augmentation sha256()
-  String org.elasticsearch.painless.api.Augmentation sha512()
+  String org.elasticsearch.painless.api.Augmentation sha1() @allocates_constant[bytes="112b"]
+  String org.elasticsearch.painless.api.Augmentation sha256() @allocates_constant[bytes="160b"]
+  String org.elasticsearch.painless.api.Augmentation sha512() @allocates_constant[bytes="288b"]
 }
 
 class org.elasticsearch.painless.api.Json {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
@@ -50,8 +50,8 @@ class org.elasticsearch.painless.api.Debug {
 #### ES Scripting API
 
 class org.elasticsearch.common.geo.GeoPoint {
-  ()
-  (double, double)
+  () @allocates_constant[bytes="32b"]
+  (double, double) @allocates_constant[bytes="32b"]
   double getLat()
   double getLon()
 }
@@ -96,8 +96,8 @@ class org.elasticsearch.index.fielddata.ScriptDocValues$GeoPoints {
   org.elasticsearch.common.geo.GeoPoint getValue()
   double getLat()
   double getLon()
-  double[] getLats()
-  double[] getLons()
+  double[] getLats() @allocates_dynamic[class="org.elasticsearch.painless.AllocationEstimators", method="geoPointsDoublesBytes"]
+  double[] getLons() @allocates_dynamic[class="org.elasticsearch.painless.AllocationEstimators", method="geoPointsDoublesBytes"]
 
   # geo distance functions
   double arcDistance(double,double)
@@ -133,7 +133,7 @@ class org.apache.lucene.util.BytesRef {
   int offset
   int length
   boolean bytesEquals(BytesRef)
-  String utf8ToString()
+  String utf8ToString() @allocates_dynamic[class="org.elasticsearch.painless.AllocationEstimators", method="utf8ToStringBytes"]
 }
 
 class org.elasticsearch.search.lookup.FieldLookup {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AllocationEsFieldTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AllocationEsFieldTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.painless;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.painless.spi.WhitelistLoader;
+
+/**
+ * Tests for the Elasticsearch field-access allocation annotations in {@code org.elasticsearch.txt}: the constant
+ * {@code GeoPoint} constructors (exercised end to end) and the estimators for {@code BytesRef.utf8ToString} and
+ * {@code GeoPoints.getLats/getLons} (whose receivers come from doc values and so are exercised directly — the whitelist
+ * loading in the end-to-end tests confirms their annotations resolve).
+ */
+public class AllocationEsFieldTests extends AllocationTestCase {
+
+    public void testGeoPointConstructorCharged() {
+        assertEquals(32L, allocatedBytes("new GeoPoint(1.0, 2.0); return \"x\";"));
+    }
+
+    public void testGeoPointConstructorTripsLimit() {
+        assertTripsLimit("new GeoPoint(1.0, 2.0); return \"x\";");
+    }
+
+    public void testUtf8ToStringEstimator() {
+        // A BytesRef of N UTF-8 bytes yields a String of at most N chars: overhead (32) + 2 bytes per char.
+        assertEquals(32L + 2L * 5, AllocationEstimators.utf8ToStringBytes(new BytesRef("hello")));
+        assertEquals(32L, AllocationEstimators.utf8ToStringBytes(new BytesRef("")));
+        assertEquals(32L, AllocationEstimators.utf8ToStringBytes(null));
+    }
+
+    public void testContextWhitelistsWithConstantAnnotationsParse() {
+        // StatsSummary (score) and sha1/256/512 (ingest/reindex/update/update_by_query) live in context whitelists that the
+        // base test context does not load, so parse them directly to validate their new @allocates_constant annotations.
+        WhitelistLoader.loadFromResourceFiles(
+            PainlessPlugin.class,
+            "org.elasticsearch.script.score.txt",
+            "org.elasticsearch.script.ingest.txt",
+            "org.elasticsearch.script.reindex.txt",
+            "org.elasticsearch.script.update.txt",
+            "org.elasticsearch.script.update_by_query.txt"
+        );
+    }
+}


### PR DESCRIPTION
Annotates the common Elasticsearch field-access allocators in the base and context allowlists with the allocation-cost annotations from #153155. Follow-up to #153299 (java.lang/java.util); the x-pack and java.math areas come in later PRs.

Estimators live in `AllocationEstimators` and reference `BytesRef` and `ScriptDocValues`, both already on the `lang-painless` module path.

### Dynamic (`@allocates_dynamic` — estimator, sized at runtime)

| Method | Estimator | Sizing |
|---|---|---|
| `BytesRef.utf8ToString()` | `utf8ToStringBytes` | new String; ≤ ref's UTF-8 byte length (overhead + 2 bytes/char) |
| `ScriptDocValues.GeoPoints.getLats()` / `getLons()` | `geoPointsDoublesBytes` | `double[]` sized to the point count |

### Constant (`@allocates_constant` — fixed size)

| Constructor / method | Bytes | Basis |
|---|---|---|
| `new GeoPoint()` / `new GeoPoint(double, double)` | 32 | object + two `double` fields |
| `new IPAddress(String)` | 64 | wrapper + parsed `InetAddress` |
| `new CIDR(String)` | 48 | wrapper + `InetAddress` + prefix |
| `ScriptTermStats.StatsSummary` accessors (`docFreq`/`totalTermFreq`/`termFreq`/`termPositions`) | 48 | new `StatsSummary` (count + min/max/sum) |
| `String.sha1()` (augmentation) | 112 | fixed 40-char hex String |
| `String.sha256()` (augmentation) | 160 | fixed 64-char hex String |
| `String.sha512()` (augmentation) | 288 | fixed 128-char hex String |

### Deferred (follow-up)

Doc-value list materializers (`asStrings`/`asDoubles`/`getValues` — need per-field-class size accessors), `Json.load`/`dump` (parsed/serialized size not cheaply knowable before the call), and keyword-field `get(...)` (materializes a term whose length is unknown before the call, so it cannot be pre-checked).

Tracking off (the default) emits bit-identical bytecode. Covered by end-to-end (`GeoPoint`), direct-estimator (`utf8ToString`), and whitelist-parse tests.
