### PR TITLE
[9.5] ES|QL: drop copy_to and _source.enabled from dataset declared mappings (#153379)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.put_dataset.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.put_dataset.json
@@ -31,7 +31,7 @@
       ]
     },
     "body": {
-      "description": "Dataset definition: parent data_source name, resource path, optional description, type-specific settings, and an optional mappings block (column types, path renames, copy_to, _source, _id).",
+      "description": "Dataset definition: parent data_source name, resource path, optional description, type-specific settings, and an optional mappings block (column types, path renames, format, _id).",
       "required": true
     }
   }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Dataset.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Dataset.java
@@ -79,7 +79,7 @@ public final class Dataset implements Writeable, ToXContentObject, IndexAbstract
         PARSER.declareString(ConstructingObjectParser.constructorArg(), RESOURCE);
         PARSER.declareStringOrNull(ConstructingObjectParser.optionalConstructorArg(), DESCRIPTION);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(), SETTINGS);
-        // Declared mapping: an optional `mappings` block (columns + the `_source`/`_id` meta-fields).
+        // Declared mapping: an optional `mappings` block (columns + the `_id` meta-field).
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> DatasetMapping.parseMappings(p), MAPPINGS);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetFieldMapping.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetFieldMapping.java
@@ -14,15 +14,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -32,17 +29,10 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * One declared column inside a dataset's {@link DatasetMapping} {@code properties} block — the value
  * of a {@code "logical_name": { ... }} entry.
  *
- * <p>Both name-remapping keys mirror the index mapping so the dataset mapping is a subset of it: {@code path} is a
- * <em>move</em> (rename) — the physical column name the value is read from, as the index {@code alias} field's
- * {@code path} names its underlying field; {@code copy_to} is a <em>copy</em> — further logical columns that also
- * receive this column's value, exactly like the index {@code copy_to}.
- *
- * <p><b>Move vs copy.</b> {@code path} is a <em>move</em>: the physical column becomes this one logical column
- * (the physical name is consumed, 1:1) — a read-path rename. {@code copy_to} keeps this column's own value
- * <em>and</em> gives the named target(s) that value — e.g. {@code "@timestamp": {"type":"date","path":"ts"}}
- * renames {@code ts}, while {@code "user_id": {"type":"keyword","copy_to":"actor"}} keeps {@code user_id} and adds
- * {@code actor}. A copy is not a second read: it is materialized as an {@code EVAL target = <this column>} above the
- * external relation (in the ES|QL analyzer), so it works for every format and never touches the read path.
+ * <p>{@code path} mirrors the index mapping so the dataset mapping is a subset of it: it is a <em>move</em>
+ * (rename) — the physical column name the value is read from, as the index {@code alias} field's {@code path}
+ * names its underlying field. The physical column becomes this one logical column (the physical name is consumed,
+ * 1:1) — a read-path rename. E.g. {@code "@timestamp": {"type":"date","path":"ts"}} renames {@code ts}.
  *
  * <p><b>Binding contract per format family.</b> Non-strict resolution binds a declared column to the file column of
  * the same physical name (from the header/keys). Strict resolution ({@code dynamic: false}) reads no file at
@@ -63,42 +53,25 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
 
     private static final ParseField TYPE = new ParseField("type");
     private static final ParseField PATH = new ParseField("path");
-    private static final ParseField COPY_TO = new ParseField("copy_to");
     private static final ParseField FORMAT = new ParseField("format");
 
-    @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DatasetFieldMapping, Void> PARSER = new ConstructingObjectParser<>(
         "dataset_field_mapping",
         false,
-        args -> new DatasetFieldMapping((String) args[0], (String) args[1], (List<String>) args[2], (String) args[3])
+        args -> DatasetFieldMapping.withFormat((String) args[0], (String) args[1], (String) args[2])
     );
 
     static {
         PARSER.declareString(constructorArg(), TYPE);
         PARSER.declareString(optionalConstructorArg(), PATH);
-        // copy_to accepts a single string or an array of strings (mirrors core ES copy_to).
-        PARSER.declareField(optionalConstructorArg(), (p, c) -> parseStringOrStringArray(p), COPY_TO, ObjectParser.ValueType.STRING_ARRAY);
         // date-parse pattern for a declared `date` column (the index date-field `format` shape); type/pattern validity
         // is checked in the ES|QL layer at dataset-put, not here.
         PARSER.declareString(optionalConstructorArg(), FORMAT);
     }
 
-    private static List<String> parseStringOrStringArray(XContentParser parser) throws IOException {
-        if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
-            List<String> targets = new ArrayList<>();
-            while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                targets.add(parser.text());
-            }
-            return targets;
-        }
-        return List.of(parser.text());
-    }
-
     private final String type;
     @Nullable
     private final String path;
-    /** Logical columns that receive a copy of this column's value ({@code copy_to}); empty when none, never null. */
-    private final List<String> copyTo;
     /**
      * Date-parse pattern for a declared {@code date} column (the index date-field {@code format} shape), or {@code null}.
      * Only valid on a column whose type resolves to {@code datetime}; the type/pattern check happens in the ES|QL layer
@@ -107,34 +80,35 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
     @Nullable
     private final String format;
 
-    /** Convenience: a column with no {@code copy_to}. */
+    /** Convenience: a column with no declared date {@code format}. */
     public DatasetFieldMapping(String type, @Nullable String path) {
-        this(type, path, List.of());
+        this(type, path, (String) null);
     }
 
-    /** Convenience: a single {@code copy_to} target. */
-    public DatasetFieldMapping(String type, @Nullable String path, @Nullable String copyTo) {
-        this(type, path, copyTo == null ? List.of() : List.of(copyTo));
+    /**
+     * A column with a declared date {@code format}.
+     *
+     * <p>This is a named factory, not a public 3-arg constructor, on purpose. The erased signature
+     * {@code (String, String, String)} previously meant {@code (type, path, copyTo)}; {@code copy_to} has since been
+     * dropped and the third String now means {@code format}. Exposing it only as {@code withFormat} keeps the
+     * argument's meaning in the call site and prevents a future third-String field from silently inheriting the old
+     * positional contract.
+     */
+    public static DatasetFieldMapping withFormat(String type, @Nullable String path, @Nullable String format) {
+        return new DatasetFieldMapping(type, path, format);
     }
 
-    /** Convenience: {@code copy_to} targets with no declared date {@code format}. */
-    public DatasetFieldMapping(String type, @Nullable String path, @Nullable List<String> copyTo) {
-        this(type, path, copyTo, null);
-    }
-
-    public DatasetFieldMapping(String type, @Nullable String path, @Nullable List<String> copyTo, @Nullable String format) {
+    private DatasetFieldMapping(String type, @Nullable String path, @Nullable String format) {
         this.type = Objects.requireNonNull(type, "field mapping type must not be null");
         this.path = path;
-        this.copyTo = copyTo == null ? List.of() : List.copyOf(copyTo);
         this.format = format;
     }
 
     public DatasetFieldMapping(StreamInput in) throws IOException {
         // Reached only under the dataset_declared_schema transport version (the whole DatasetMapping is gated),
-        // which is unreleased — so copy_to and format ship in that one version with no separate gate.
+        // which is unreleased — so format ships in that one version with no separate gate.
         this.type = in.readString();
         this.path = in.readOptionalString();
-        this.copyTo = in.readStringCollectionAsList();
         this.format = in.readOptionalString();
     }
 
@@ -142,7 +116,6 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(type);
         out.writeOptionalString(path);
-        out.writeStringCollection(copyTo);
         out.writeOptionalString(format);
     }
 
@@ -156,9 +129,6 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
         builder.field(TYPE.getPreferredName(), type);
         if (path != null) {
             builder.field(PATH.getPreferredName(), path);
-        }
-        if (copyTo.isEmpty() == false) {
-            builder.field(COPY_TO.getPreferredName(), copyTo);
         }
         if (format != null) {
             builder.field(FORMAT.getPreferredName(), format);
@@ -178,11 +148,6 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
         return path;
     }
 
-    /** Logical columns that receive a copy of this column's value ({@code copy_to}); empty when none, never null. */
-    public List<String> copyTo() {
-        return copyTo;
-    }
-
     /** Date-parse pattern for a declared {@code date} column, or {@code null} when none is declared. */
     @Nullable
     public String format() {
@@ -194,15 +159,12 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DatasetFieldMapping that = (DatasetFieldMapping) o;
-        return type.equals(that.type)
-            && Objects.equals(path, that.path)
-            && copyTo.equals(that.copyTo)
-            && Objects.equals(format, that.format);
+        return type.equals(that.type) && Objects.equals(path, that.path) && Objects.equals(format, that.format);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, path, copyTo, format);
+        return Objects.hash(type, path, format);
     }
 
     @Override
@@ -210,7 +172,6 @@ public final class DatasetFieldMapping implements Writeable, ToXContentObject {
         return "DatasetFieldMapping[type="
             + type
             + (path != null ? ", path=" + path : "")
-            + (copyTo.isEmpty() ? "" : ", copyTo=" + copyTo)
             + (format != null ? ", format=" + format : "")
             + "]";
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetMapping.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DatasetMapping.java
@@ -30,17 +30,15 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
  * {@code DatasetMapping} resolves its schema by inference, exactly as before.
  *
  * <p>Currently this wraps a single {@code mappings} block ({@link Mappings}): a {@code dynamic} mode, per-column
- * {@code properties}, and the meta-fields {@code _source} ({@code enabled}) and {@code _id} ({@code path}). The
- * wrapper is retained (rather than inlining {@code mappings} onto {@link Dataset}) so future top-level declaration
- * keys have a home.
+ * {@code properties}, and the meta-field {@code _id} ({@code path}). The wrapper is retained (rather than inlining
+ * {@code mappings} onto {@link Dataset}) so future top-level declaration keys have a home.
  *
  * <p>There are <b>no role designations</b>. A time axis is just a column named {@code @timestamp}, declared as an
  * ordinary rename ({@code "@timestamp": {"type":"date","path":"ts"}}) and recognized by the stack by name — a
  * "move", not a designation. Setting {@code _id} from a column is likewise a meta-field
- * ({@code "_id": {"path": "col"}}), sibling of {@code _source} inside {@code mappings} — the ES meta-field shape,
- * not a separate top-level role — so it always rides a {@code mappings} wrapper (exactly as {@code _source.enabled}
- * does). Whether the named column exists is validated in the ES|QL layer: at put time when it is declared, otherwise
- * at first query.
+ * ({@code "_id": {"path": "col"}}) inside {@code mappings} — the ES meta-field shape, not a separate top-level role
+ * — so it always rides a {@code mappings} wrapper. Whether the named column exists is validated in the ES|QL layer:
+ * at put time when it is declared, otherwise at first query.
  *
  * <p>Like {@link DataSourceReference}, this has no standalone XContent: {@link Dataset#toXContent} emits the
  * {@code mappings} key and {@link Dataset#PARSER} reads it back, assembling this object via {@link #assemble}.
@@ -72,65 +70,40 @@ public final class DatasetMapping implements Writeable {
     /**
      * The {@code mappings} block: an undeclared-column policy and the per-column declarations keyed by logical name.
      *
-     * @param dynamic       undeclared-column policy ({@code true} = infer + overlay, {@code false} = declaration is the
-     *                      whole schema).
-     * @param properties    per-column declarations keyed by logical name; order-preserving, may be empty (e.g.
-     *                      {@code "mappings": { "dynamic": "false" }}).
-     * @param sourceEnabled {@code _source.enabled}: whether a synthetic {@code _source} is produced for the dataset's
-     *                      rows. {@code null} means unset — the default ({@code true}, source available). Mirrors the
-     *                      core {@code _source} mapping's {@code enabled}, restricted to the read-applicable knob.
+     * @param dynamic    undeclared-column policy ({@code true} = infer + overlay, {@code false} = declaration is the
+     *                   whole schema).
+     * @param properties per-column declarations keyed by logical name; order-preserving, may be empty (e.g.
+     *                   {@code "mappings": { "dynamic": "false" }}).
+     * @param idPath     {@code _id.path}: the column the reader stamps {@code _id} from, or {@code null} when unset.
      */
-    public record Mappings(
-        Dynamic dynamic,
-        Map<String, DatasetFieldMapping> properties,
-        @Nullable Boolean sourceEnabled,
-        @Nullable String idPath
-    ) implements Writeable {
+    public record Mappings(Dynamic dynamic, Map<String, DatasetFieldMapping> properties, @Nullable String idPath) implements Writeable {
 
         public Mappings {
             Objects.requireNonNull(dynamic, "dynamic must not be null");
             properties = properties == null ? Map.of() : Collections.unmodifiableMap(properties);
         }
 
-        /** Convenience: a mappings block with no meta-field knobs ({@code _source}, {@code _id}). */
+        /** Convenience: a mappings block with no {@code _id.path}. */
         public Mappings(Dynamic dynamic, Map<String, DatasetFieldMapping> properties) {
-            this(dynamic, properties, null, null);
-        }
-
-        /** Convenience: a mappings block with a {@code _source} knob but no {@code _id.path}. */
-        public Mappings(Dynamic dynamic, Map<String, DatasetFieldMapping> properties, @Nullable Boolean sourceEnabled) {
-            this(dynamic, properties, sourceEnabled, null);
+            this(dynamic, properties, null);
         }
 
         Mappings(StreamInput in) throws IOException {
             // The whole DatasetMapping is gated by the dataset_declared_schema transport version (see Dataset), which is
-            // unreleased — so every field (incl. _source.enabled and _id.path) ships in that one version; no separate gate.
-            this(
-                in.readEnum(Dynamic.class),
-                in.readOrderedMap(StreamInput::readString, DatasetFieldMapping::new),
-                in.readOptionalBoolean(),
-                in.readOptionalString()
-            );
+            // unreleased — so every field (incl. _id.path) ships in that one version; no separate gate.
+            this(in.readEnum(Dynamic.class), in.readOrderedMap(StreamInput::readString, DatasetFieldMapping::new), in.readOptionalString());
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeEnum(dynamic);
             out.writeMap(properties, (o, v) -> v.writeTo(o));
-            out.writeOptionalBoolean(sourceEnabled);
             out.writeOptionalString(idPath);
-        }
-
-        /** {@code _source.enabled} resolved to its effective value: {@code true} (available) unless explicitly disabled. */
-        public boolean sourceAvailable() {
-            return sourceEnabled == null || sourceEnabled;
         }
     }
 
     private static final String DYNAMIC = "dynamic";
     private static final String PROPERTIES = "properties";
-    private static final String SOURCE = "_source";
-    private static final String ENABLED = "enabled";
     private static final String ID = "_id";
     private static final String PATH = "path";
 
@@ -153,21 +126,19 @@ public final class DatasetMapping implements Writeable {
     /**
      * Builds a {@link DatasetMapping} from the parsed {@code mappings} block, or {@code null} when it is absent (a
      * dataset with no declared schema). Used by {@link Dataset#PARSER}. All declaration surfaces — column
-     * {@code properties}, and the meta-fields {@code _source} and {@code _id} — live inside {@code mappings}, so a
-     * dataset that only sets, say, {@code _id.path} still needs a {@code mappings} wrapper (exactly as an index does
-     * for {@code _source.enabled}).
+     * {@code properties} and the meta-field {@code _id} — live inside {@code mappings}, so a dataset that only sets,
+     * say, {@code _id.path} still needs a {@code mappings} wrapper.
      */
     @Nullable
     public static DatasetMapping assemble(@Nullable Mappings mappings) {
         return mappings == null ? null : new DatasetMapping(mappings);
     }
 
-    /** Parses the {@code mappings} object ({@code dynamic}, {@code properties}, {@code _source}, {@code _id}). */
+    /** Parses the {@code mappings} object ({@code dynamic}, {@code properties}, {@code _id}). */
     public static Mappings parseMappings(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         Dynamic dynamic = Dynamic.TRUE;
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        Boolean sourceEnabled = null;
         String idPath = null;
         String field = null;
         XContentParser.Token token;
@@ -185,20 +156,6 @@ public final class DatasetMapping implements Writeable {
                         name = parser.currentName();
                     } else {
                         properties.put(name, DatasetFieldMapping.fromXContent(parser));
-                    }
-                }
-            } else if (SOURCE.equals(field)) {
-                // _source: { enabled: <bool> } — the only supported knob (mirrors the core _source mapping, read-side).
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
-                XContentParser.Token t;
-                while ((t = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (t == XContentParser.Token.FIELD_NAME) {
-                        String key = parser.currentName();
-                        if (ENABLED.equals(key) == false) {
-                            throw new IllegalArgumentException("unknown [_source] field [" + key + "]; only [enabled] is supported");
-                        }
-                    } else {
-                        sourceEnabled = parser.booleanValue();
                     }
                 }
             } else if (ID.equals(field)) {
@@ -220,10 +177,10 @@ public final class DatasetMapping implements Writeable {
                 throw new IllegalArgumentException("unknown mappings field [" + field + "]");
             }
         }
-        return new Mappings(dynamic, properties, sourceEnabled, idPath);
+        return new Mappings(dynamic, properties, idPath);
     }
 
-    /** Emits the {@code mappings} block (incl. the {@code _source} and {@code _id} meta-fields) into an open dataset object. */
+    /** Emits the {@code mappings} block (incl. the {@code _id} meta-field) into an open dataset object. */
     public void toXContentFragment(XContentBuilder builder) throws IOException {
         if (mappings != null) {
             builder.startObject("mappings");
@@ -235,9 +192,6 @@ public final class DatasetMapping implements Writeable {
                     e.getValue().toXContent(builder, null);
                 }
                 builder.endObject();
-            }
-            if (mappings.sourceEnabled() != null) {
-                builder.startObject(SOURCE).field(ENABLED, mappings.sourceEnabled()).endObject();
             }
             if (mappings.idPath() != null) {
                 builder.startObject(ID).field(PATH, mappings.idPath()).endObject();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DatasetFieldMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DatasetFieldMappingTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -35,21 +34,11 @@ public class DatasetFieldMappingTests extends AbstractXContentSerializingTestCas
 
     @Override
     protected DatasetFieldMapping createTestInstance() {
-        return new DatasetFieldMapping(
+        return DatasetFieldMapping.withFormat(
             randomFrom("keyword", "long", "integer", "double", "boolean", "date"),
             randomBoolean() ? null : randomAlphaOfLength(6).toLowerCase(Locale.ROOT),
-            randomCopyTo(),
             randomFormat()
         );
-    }
-
-    private static List<String> randomCopyTo() {
-        int n = randomIntBetween(0, 2);
-        List<String> targets = new ArrayList<>(n);
-        for (int i = 0; i < n; i++) {
-            targets.add(randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
-        }
-        return targets;
     }
 
     // This is the shape-only model layer, so it round-trips `format` as an opaque optional string regardless of type;
@@ -60,29 +49,20 @@ public class DatasetFieldMappingTests extends AbstractXContentSerializingTestCas
 
     @Override
     protected DatasetFieldMapping mutateInstance(DatasetFieldMapping instance) {
-        return switch (randomIntBetween(0, 3)) {
-            case 0 -> new DatasetFieldMapping(
+        return switch (randomIntBetween(0, 2)) {
+            case 0 -> DatasetFieldMapping.withFormat(
                 randomValueOtherThan(instance.type(), () -> randomFrom("keyword", "long", "integer", "double", "boolean", "date")),
                 instance.path(),
-                instance.copyTo(),
                 instance.format()
             );
-            case 1 -> new DatasetFieldMapping(
+            case 1 -> DatasetFieldMapping.withFormat(
                 instance.type(),
                 randomValueOtherThan(instance.path(), () -> randomBoolean() ? null : randomAlphaOfLength(7).toLowerCase(Locale.ROOT)),
-                instance.copyTo(),
                 instance.format()
             );
-            case 2 -> new DatasetFieldMapping(
+            default -> DatasetFieldMapping.withFormat(
                 instance.type(),
                 instance.path(),
-                randomValueOtherThan(instance.copyTo(), DatasetFieldMappingTests::randomCopyTo),
-                instance.format()
-            );
-            default -> new DatasetFieldMapping(
-                instance.type(),
-                instance.path(),
-                instance.copyTo(),
                 randomValueOtherThan(instance.format(), DatasetFieldMappingTests::randomFormat)
             );
         };
@@ -105,8 +85,8 @@ public class DatasetFieldMappingTests extends AbstractXContentSerializingTestCas
 
     /**
      * A declared field deliberately supports only {@code type}, {@code path} (the index {@code alias}-style rename),
-     * {@code copy_to} (the index copy), and {@code format} (the date parse-pattern, on {@code date} columns). Every
-     * other core field-mapper parameter must be rejected at parse time. This guards against silently diverging from the
+     * and {@code format} (the date parse-pattern, on {@code date} columns). Every other core field-mapper parameter
+     * must be rejected at parse time. This guards against silently diverging from the
      * core mapping: a parameter we don't model can't creep in or be quietly dropped — adding support for one has to be
      * a deliberate change that breaks this test.
      */

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DatasetMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DatasetMappingTests.java
@@ -88,27 +88,6 @@ public class DatasetMappingTests extends AbstractWireSerializingTestCase<Dataset
         }
     }
 
-    public void testSourceEnabledParsesAndDefaults() throws IOException {
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"dynamic\":\"true\",\"_source\":{\"enabled\":false}}")) {
-            parser.nextToken();
-            DatasetMapping.Mappings m = DatasetMapping.parseMappings(parser);
-            assertEquals(Boolean.FALSE, m.sourceEnabled());
-            assertFalse(m.sourceAvailable());
-        }
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"dynamic\":\"true\"}")) {
-            parser.nextToken();
-            DatasetMapping.Mappings m = DatasetMapping.parseMappings(parser);
-            assertNull("absent _source leaves the knob unset", m.sourceEnabled());
-            assertTrue("unset means available by default", m.sourceAvailable());
-        }
-        // Only [enabled] is supported under _source; other core _source knobs (mode, includes, ...) are rejected.
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"_source\":{\"mode\":\"synthetic\"}}")) {
-            parser.nextToken();
-            Exception e = expectThrows(Exception.class, () -> DatasetMapping.parseMappings(parser));
-            assertThat(e.getMessage(), containsString("_source"));
-        }
-    }
-
     public void testAssembleReturnsNullWhenMappingsAbsent() {
         assertNull(DatasetMapping.assemble(null));
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DatasetTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DatasetTests.java
@@ -124,9 +124,8 @@ public class DatasetTests extends AbstractXContentSerializingTestCase<Dataset> {
             String path = randomBoolean() ? null : randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
             properties.put("col_" + i, new DatasetFieldMapping(type, path));
         }
-        Boolean sourceEnabled = randomBoolean() ? null : randomBoolean();
         String idPath = randomBoolean() ? null : randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
-        return new DatasetMapping.Mappings(dynamic, properties, sourceEnabled, idPath);
+        return new DatasetMapping.Mappings(dynamic, properties, idPath);
     }
 
     private static Map<String, Object> randomSettings() {
@@ -279,7 +278,7 @@ public class DatasetTests extends AbstractXContentSerializingTestCase<Dataset> {
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
         properties.put("when", new DatasetFieldMapping("date", "ts"));
         properties.put("status", new DatasetFieldMapping("integer", null));
-        var mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties, null, "request_id"));
+        var mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties, "request_id"));
         var dataset = new Dataset(
             "access_logs",
             new DataSourceReference("my-s3"),
@@ -302,7 +301,7 @@ public class DatasetTests extends AbstractXContentSerializingTestCase<Dataset> {
 
     public void testXContentRoundTripIdPathOnlyNoProperties() throws IOException {
         // _id.path with an otherwise-empty mappings block — the id-source is a meta-field, so it rides a mappings wrapper.
-        var mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, Map.of(), null, "request_id"));
+        var mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, Map.of(), "request_id"));
         var dataset = new Dataset("events", new DataSourceReference("s3"), "s3://b/*.ndjson", null, Map.of(), mapping);
         assertExplicitXContentRoundTrip(dataset);
         assertEquals("request_id", dataset.mapping().mappings().idPath());

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -161,12 +161,6 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         "employees_ndjson_rename_nonstrict",
         "employees_parquet_rename",
         "employees_rename_multi",
-        "employees_source_disabled",
-        "employees_source_enabled",
-        "employees_copy_nonstrict",
-        "employees_parquet_copy",
-        "employees_copy_collide",
-        "employees_copy_multi",
         "employees_swap",
         "employees_id_from_col",
         "employees_id_bad_path",
@@ -471,50 +465,6 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         }
     }
 
-    public void testCopyToDuplicatesColumnNonStrict() throws Exception {
-        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
-
-        // Non-strict copy: emp_no is kept AND copied to emp_copy. The copy materializes as EVAL emp_copy = emp_no above
-        // the base relation, so both columns carry the same value and the read path is untouched.
-        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("emp_no", new DatasetFieldMapping("long", null, "emp_copy"));
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
-
-        assertAcked(
-            client().execute(
-                PutDatasetAction.INSTANCE,
-                new PutDatasetAction.Request(
-                    TIMEOUT,
-                    TIMEOUT,
-                    "employees_copy_nonstrict",
-                    "local_ds",
-                    csvFixture.toUri().toString(),
-                    null,
-                    new HashMap<>(Map.of("format", "csv")),
-                    mapping
-                )
-            )
-        );
-
-        try (
-            var response = run(
-                syncEsqlQueryRequest("FROM employees_copy_nonstrict | KEEP emp_no, emp_copy | SORT emp_no | LIMIT 10"),
-                TIMEOUT
-            )
-        ) {
-            List<? extends ColumnInfo> columns = response.columns();
-            assertThat(columns, hasSize(2));
-            assertThat(columns.get(0).name(), equalTo("emp_no"));
-            assertThat(columns.get(1).name(), equalTo("emp_copy")); // the copy target
-            List<List<Object>> rows = getValuesList(response);
-            assertThat(rows, hasSize(3));
-            for (List<Object> row : rows) {
-                assertThat("copy carries the source value", row.get(1), equalTo(row.get(0)));
-            }
-            assertThat(rows.get(0).get(0), equalTo(1L));
-        }
-    }
-
     public void testRenameWithKeepSubsetProjectsRenamedColumn() throws Exception {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
 
@@ -558,7 +508,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
 
         // Strict declaration: `ts` is a date parsed with the access-log pattern (which carries an explicit zone).
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         properties.put("note", new DatasetFieldMapping("keyword", null));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
 
@@ -593,7 +543,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // Non-strict overlay retypes the inferred keyword `ts` to a date with the declared format; date comparison then
         // works on the parsed instants. Only the 11/Oct row (2000-10-11T16:00:00Z) is >= the 2000-10-11T00:00:00Z bound.
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
 
         assertAcked(
@@ -629,7 +579,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // File-level datetime_format is a pattern that CANNOT parse the access-log text; the column's own declared
         // format must win for that column, so the value still parses to the exact zone-aware epoch.
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         properties.put("note", new DatasetFieldMapping("keyword", null));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
 
@@ -696,7 +646,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // rejected loudly at query resolution rather than silently ignored.
         Path parquet = writeParquetRenameFixture();
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", "emp_no", List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", "emp_no", ACCESS_LOG_FORMAT));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
 
         assertAcked(
@@ -726,7 +676,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // NDJSON already parses dates via the ES DateFormatter; a per-column declared format reparses that column with
         // its own pattern (same zone-aware semantics).
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
 
         assertAcked(
@@ -759,7 +709,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // the key back to `ts` for the reader). If the logical->physical re-keying were inverted, the reader would look
         // up the formatter under the wrong name and the value would fall to the undeclared path.
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("event_time", new DatasetFieldMapping("date", "ts", List.of(), ACCESS_LOG_FORMAT));
+        properties.put("event_time", DatasetFieldMapping.withFormat("date", "ts", ACCESS_LOG_FORMAT));
         properties.put("note", new DatasetFieldMapping("keyword", null));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
 
@@ -806,7 +756,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // `.csv.gz` is covered separately by testStrictOverGzipCsvReads (and its tsv/ndjson twins). The overlay retypes
         // the inferred `ts` to a date with the format.
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
 
         assertAcked(
@@ -936,7 +886,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // resolution path bypasses the non-strict overlay's reject, so it must guard the columnar case itself.
         Path parquet = writeParquetRenameFixture();
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", "emp_no", List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", "emp_no", ACCESS_LOG_FORMAT));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
 
         assertAcked(
@@ -1072,59 +1022,6 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
             assertThat(rows, hasSize(3));
             assertThat(rows.get(0).get(0), equalTo(1L));
             assertThat(rows.get(0).get(1).toString(), equalTo("Alice"));
-        }
-    }
-
-    public void testSourceDisabledReturnsEmptySource() throws Exception {
-        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
-        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("emp_no", new DatasetFieldMapping("integer", null));
-        // _source.enabled: false -> METADATA _source must succeed with a null _source column, matching a real
-        // index whose _source is disabled (SourceFieldMapper's ConstantNull block loader) rather than erroring.
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties, false));
-        assertAcked(
-            client().execute(
-                PutDatasetAction.INSTANCE,
-                new PutDatasetAction.Request(
-                    TIMEOUT,
-                    TIMEOUT,
-                    "employees_source_disabled",
-                    "local_ds",
-                    csvFixture.toUri().toString(),
-                    null,
-                    new HashMap<>(Map.of("format", "csv")),
-                    mapping
-                )
-            )
-        );
-
-        // _source is not sortable (true for a real index too), so sort on emp_no and KEEP _source alongside it.
-        try (
-            var response = run(
-                syncEsqlQueryRequest("FROM employees_source_disabled METADATA _source | KEEP emp_no, _source | SORT emp_no | LIMIT 10"),
-                TIMEOUT
-            )
-        ) {
-            assertThat(response.columns().get(1).name(), equalTo("_source"));
-            List<List<Object>> rows = getValuesList(response);
-            assertThat(rows, hasSize(3));
-            for (List<Object> row : rows) {
-                assertThat("_source is null when _source.enabled: false", row.get(1), org.hamcrest.Matchers.nullValue());
-            }
-        }
-    }
-
-    public void testSourceEnabledByDefaultAllowsMetadataSource() throws Exception {
-        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
-        // No _source knob -> available by default; METADATA _source resolves to a column (not rejected).
-        assertAcked(
-            client().execute(
-                PutDatasetAction.INSTANCE,
-                putDatasetRequest("employees_source_enabled", "local_ds", csvFixture.toUri().toString(), Map.of("format", "csv"))
-            )
-        );
-        try (var response = run(syncEsqlQueryRequest("FROM employees_source_enabled METADATA _source | KEEP _source | LIMIT 1"), TIMEOUT)) {
-            assertThat(response.columns().get(0).name(), equalTo("_source"));
         }
     }
 
@@ -1307,76 +1204,6 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         }
     }
 
-    public void testCopyToMultipleTargets() throws Exception {
-        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
-        // copy_to a LIST of targets: emp_no is copied to both emp_a and emp_b (one EVAL alias per target).
-        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("emp_no", new DatasetFieldMapping("long", null, java.util.List.of("emp_a", "emp_b")));
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
-        assertAcked(
-            client().execute(
-                PutDatasetAction.INSTANCE,
-                new PutDatasetAction.Request(
-                    TIMEOUT,
-                    TIMEOUT,
-                    "employees_copy_multi",
-                    "local_ds",
-                    csvFixture.toUri().toString(),
-                    null,
-                    new HashMap<>(Map.of("format", "csv")),
-                    mapping
-                )
-            )
-        );
-        try (
-            var response = run(
-                syncEsqlQueryRequest("FROM employees_copy_multi | SORT emp_no | KEEP emp_no, emp_a, emp_b | LIMIT 10"),
-                TIMEOUT
-            )
-        ) {
-            List<? extends ColumnInfo> columns = response.columns();
-            assertThat(columns, hasSize(3));
-            assertThat(columns.get(1).name(), equalTo("emp_a"));
-            assertThat(columns.get(2).name(), equalTo("emp_b"));
-            List<List<Object>> rows = getValuesList(response);
-            assertThat(rows, hasSize(3));
-            for (List<Object> row : rows) {
-                assertThat(row.get(1), equalTo(row.get(0))); // emp_a == emp_no
-                assertThat(row.get(2), equalTo(row.get(0))); // emp_b == emp_no
-            }
-        }
-    }
-
-    public void testCopyToTargetCollidingWithInferredColumnRejected() throws Exception {
-        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
-        // Non-strict copy whose target collides with a REAL (inferred) file column. PUT can't see inferred columns, so
-        // it passes; the query must reject rather than let the EVAL silently overwrite first_name with a copy of emp_no.
-        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("emp_no", new DatasetFieldMapping("long", null, "first_name")); // target == an inferred column
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
-        assertAcked(
-            client().execute(
-                PutDatasetAction.INSTANCE,
-                new PutDatasetAction.Request(
-                    TIMEOUT,
-                    TIMEOUT,
-                    "employees_copy_collide",
-                    "local_ds",
-                    csvFixture.toUri().toString(),
-                    null,
-                    new HashMap<>(Map.of("format", "csv")),
-                    mapping
-                )
-            )
-        );
-        Exception e = expectThrows(Exception.class, () -> {
-            try (var ignored = run(syncEsqlQueryRequest("FROM employees_copy_collide | KEEP emp_no, first_name"), TIMEOUT)) {
-                // must not reach here — the copy target collides with the inferred first_name
-            }
-        });
-        assertThat(e.getMessage(), containsString("collides with an existing column"));
-    }
-
     public void testStrictColumnarLongToDatetimeCoerces() throws Exception {
         // Strict + columnar: declaring the physical int64 `emp_no` as DATETIME COERCES at read time (Hive/Trino style) —
         // the reader reinterprets the epoch-millis long as a datetime, no reject and no silent null. emp_no 1,2,3 read
@@ -1421,7 +1248,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
         Path parquet = writeParquetDeferredCoerceFixture();
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", "event_ts", List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", "event_ts", ACCESS_LOG_FORMAT));
         properties.put("id_str", new DatasetFieldMapping("keyword", "id")); // physical int64 -> stringify
         properties.put("msg", new DatasetFieldMapping("keyword", null));
         properties.put("pri", new DatasetFieldMapping("integer", null));
@@ -1532,7 +1359,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
         Path parquet = writeParquetBadDateTokenFixture();
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("ts", new DatasetFieldMapping("date", "event_ts", List.of(), ACCESS_LOG_FORMAT));
+        properties.put("ts", DatasetFieldMapping.withFormat("date", "event_ts", ACCESS_LOG_FORMAT));
         properties.put("id_str", new DatasetFieldMapping("keyword", "id"));
         properties.put("msg", new DatasetFieldMapping("keyword", null));
         properties.put("pri", new DatasetFieldMapping("integer", null));
@@ -1620,7 +1447,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         Path csv = createTempFile("dataset-bad-date-", ".csv");
         Files.writeString(csv, "ts:keyword,note:keyword\ndefinitely-not-a-date,alpha\n");
         Map<String, DatasetFieldMapping> csvProps = new LinkedHashMap<>();
-        csvProps.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        csvProps.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         csvProps.put("note", new DatasetFieldMapping("keyword", null));
         assertAcked(
             client().execute(
@@ -1657,7 +1484,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
             {"ts":"definitely-not-a-date","note":"beta"}
             """;
         Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
-        props.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        props.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         props.put("note", new DatasetFieldMapping("keyword", null));
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, props));
 
@@ -1744,7 +1571,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
 
         Map<String, DatasetFieldMapping> csvProps = new LinkedHashMap<>();
-        csvProps.put("ts", new DatasetFieldMapping("date", null, List.of(), ACCESS_LOG_FORMAT));
+        csvProps.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
         csvProps.put("note", new DatasetFieldMapping("keyword", null));
         assertAcked(
             client().execute(
@@ -1765,7 +1592,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         Path parquet = writeParquetStringDateFixture();
         Map<String, DatasetFieldMapping> pqProps = new LinkedHashMap<>();
         pqProps.put("id", new DatasetFieldMapping("long", null));
-        pqProps.put("ts", new DatasetFieldMapping("date", "event_ts", List.of(), ACCESS_LOG_FORMAT));
+        pqProps.put("ts", DatasetFieldMapping.withFormat("date", "event_ts", ACCESS_LOG_FORMAT));
         assertAcked(
             client().execute(
                 PutDatasetAction.INSTANCE,
@@ -2109,49 +1936,6 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         }
     }
 
-    public void testParquetStrictCopyToAndFilterPushdown() throws Exception {
-        // Strict + columnar + copy: comp (physical salary) is moved AND copied to comp2. The copy is an EVAL above the
-        // relation, so it works for parquet exactly as for CSV, and a WHERE on the copy target substitutes back to the
-        // source and pushes down — the trickiest combination (strict, columnar pushdown, copy alias-substitution).
-        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
-        Path parquet = writeParquetRenameFixture();
-        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
-        properties.put("id", new DatasetFieldMapping("long", "emp_no"));
-        properties.put("comp", new DatasetFieldMapping("integer", "salary", "comp2")); // move salary->comp, copy to comp2
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
-        assertAcked(
-            client().execute(
-                PutDatasetAction.INSTANCE,
-                new PutDatasetAction.Request(
-                    TIMEOUT,
-                    TIMEOUT,
-                    "employees_parquet_copy",
-                    "local_ds",
-                    parquet.toUri().toString(),
-                    null,
-                    new HashMap<>(Map.of("format", "parquet")),
-                    mapping
-                )
-            )
-        );
-
-        // 1) the copy carries the source value
-        try (var response = run(syncEsqlQueryRequest("FROM employees_parquet_copy | SORT id | KEEP comp, comp2 | LIMIT 10"), TIMEOUT)) {
-            List<List<Object>> rows = getValuesList(response);
-            assertThat(rows, hasSize(3));
-            for (List<Object> row : rows) {
-                assertThat("copy carries the source value", row.get(1), equalTo(row.get(0)));
-            }
-        }
-        // 2) WHERE on the copy target pushes down (substituted to salary): Bob (200), Carol (300)
-        try (var response = run(syncEsqlQueryRequest("FROM employees_parquet_copy | WHERE comp2 > 150 | SORT id | LIMIT 10"), TIMEOUT)) {
-            List<List<Object>> rows = getValuesList(response);
-            assertThat(rows, hasSize(2));
-            assertThat(rows.get(0).get(0), equalTo(2L));
-            assertThat(rows.get(1).get(0), equalTo(3L));
-        }
-    }
-
     private void putParquetRenameDataset(String name, Path parquet) {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
@@ -2284,7 +2068,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         Path parquet = writeParquetStringDateFixture();
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
         properties.put("id", new DatasetFieldMapping("long", null));
-        properties.put("ts", new DatasetFieldMapping("date", "event_ts", List.of(), ACCESS_LOG_FORMAT)); // string -> date
+        properties.put("ts", DatasetFieldMapping.withFormat("date", "event_ts", ACCESS_LOG_FORMAT)); // string -> date
         DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
         assertAcked(
             client().execute(
@@ -3089,7 +2873,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // Non-strict declaration whose only knob is _id.path = first_name (a keyword column). The columns keep their
         // inferred names/types; _id is stamped from first_name's value.
         DatasetMapping mapping = new DatasetMapping(
-            new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, new LinkedHashMap<>(), null, "first_name")
+            new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, new LinkedHashMap<>(), "first_name")
         );
 
         assertAcked(
@@ -3165,7 +2949,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // logical space — _id equals the renamed column's values.
         Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
         properties.put("uid", new DatasetFieldMapping("keyword", "first_name"));
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties, null, "uid"));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties, "uid"));
         assertAcked(
             client().execute(
                 PutDatasetAction.INSTANCE,
@@ -3213,7 +2997,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         props.put("first_name", new DatasetFieldMapping("keyword", null));
         // Non-strict, _id.path = region (the partition key). PUT accepts (non-strict defers the id-column existence
         // check); the reject fires at query time when _id is actually requested.
-        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, props, null, "region"));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, props, "region"));
         assertAcked(
             client().execute(
                 PutDatasetAction.INSTANCE,
@@ -3381,7 +3165,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // Non-strict declaration whose _id.path names a column that exists in NO file — a typo, or the files lost it.
         // PUT accepts it (non-strict defers the existence check to query time; the files may not exist yet at PUT).
         DatasetMapping mapping = new DatasetMapping(
-            new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, new LinkedHashMap<>(), null, "no_such_column")
+            new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, new LinkedHashMap<>(), "no_such_column")
         );
         assertAcked(
             client().execute(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.xpack.esql.analysis;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
-import org.elasticsearch.cluster.metadata.DatasetMapping;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -707,79 +705,18 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 bindResult.unresolvedMetadata(),
                 resolvedSource.declaredReadSpec()
             );
-            // A declared `copy_to` materializes as an EVAL `target = <source column>` above the base relation. Copies
-            // stay out of the read/reconciliation schema — every format reader gets them for free, the read path is
-            // untouched, and the copy reuses the plan's projection, pushdown alias-substitution, and cast machinery.
-            List<Alias> copyAliases = copyToAliases(plan.mapping(), relation.output(), plan.source());
-            // A requested _source on a _source.enabled: false dataset binds to a null constant here instead of a
-            // relation column — see bindMetadataFields's nullConstantMetadata. Combined with copy_to into one Eval.
-            List<Alias> evalAliases = bindResult.nullConstantMetadata();
-            if (copyAliases.isEmpty() == false) {
-                evalAliases = new ArrayList<>(evalAliases);
-                evalAliases.addAll(copyAliases);
-            }
-            return evalAliases.isEmpty() ? relation : new Eval(plan.source(), relation, evalAliases);
-        }
-
-        /**
-         * One {@link Alias} per declared {@code copy_to} target: {@code target = <the property's own column>}. The
-         * source column is a base-relation output attribute (a move renames it there; an as-is column keeps its name),
-         * so the copy is a plain reference — the optimizer substitutes it on pushdown. Empty when nothing copies, so
-         * the common path adds no {@code Eval}.
-         */
-        private static List<Alias> copyToAliases(DatasetMapping mapping, List<Attribute> baseOutput, Source source) {
-            DatasetMapping.Mappings mappings = mapping == null ? null : mapping.mappings();
-            if (mappings == null) {
-                return List.of();
-            }
-            Map<String, Attribute> byName = new HashMap<>(baseOutput.size());
-            for (Attribute a : baseOutput) {
-                byName.putIfAbsent(a.name(), a);
-            }
-            List<Alias> aliases = new ArrayList<>();
-            for (Map.Entry<String, DatasetFieldMapping> e : mappings.properties().entrySet()) {
-                List<String> targets = e.getValue().copyTo();
-                if (targets.isEmpty()) {
-                    continue;
-                }
-                Attribute src = byName.get(e.getKey());
-                if (src == null) {
-                    // The source is always a declared/overlaid base output attribute; if it isn't, fail loud rather
-                    // than silently drop the copy.
-                    throw new IllegalArgumentException("copy_to source column [" + e.getKey() + "] is not present in the dataset schema");
-                }
-                for (String copyTo : targets) {
-                    if (byName.containsKey(copyTo)) {
-                        // The target collides with an existing (declared, inferred, or another copy) output column. An
-                        // EVAL would silently SHADOW/overwrite it — reject. PUT validation can't catch a collision with
-                        // an INFERRED column (no file I/O at PUT), so this is where the base output is finally known.
-                        throw new IllegalArgumentException(
-                            "copy_to target [" + copyTo + "] on column [" + e.getKey() + "] collides with an existing column"
-                        );
-                    }
-                    aliases.add(new Alias(source, copyTo, src));
-                    byName.put(copyTo, src); // reserve the target name so a later copy onto it is caught as a collision
-                }
-            }
-            return aliases;
+            return relation;
         }
 
         /**
          * Result of {@link #bindMetadataFields}: the enriched schema (resolved standard /
-         * {@code _file.*} names appended to the base schema), the list of metadata expressions the
-         * bind could not resolve, and any metadata columns bound to a null constant instead of a
-         * schema column (currently only a requested {@code _source} on a {@code _source.enabled:
-         * false} dataset — see the {@code _source} branch below). The unresolved list is threaded
+         * {@code _file.*} names appended to the base schema) and the list of metadata expressions the
+         * bind could not resolve. The unresolved list is threaded
          * through to {@link ExternalRelation#metadataFields()} so the verifier's
          * {@code checkUnresolvedAttributes} walk fires the indexed-equivalent
-         * {@code "Unresolved metadata pattern [...]"} error. The null-constant list rides an
-         * {@link Eval} above the relation, alongside {@link #copyToAliases}.
+         * {@code "Unresolved metadata pattern [...]"} error.
          */
-        private record MetadataBindResult(
-            List<Attribute> schema,
-            List<? extends NamedExpression> unresolvedMetadata,
-            List<Alias> nullConstantMetadata
-        ) {}
+        private record MetadataBindResult(List<Attribute> schema, List<? extends NamedExpression> unresolvedMetadata) {}
 
         /**
          * Walks the user's METADATA clause. Names registered in
@@ -799,7 +736,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             Set<String> partitionColumnNames
         ) {
             if (plan.metadataFields().isEmpty()) {
-                return new MetadataBindResult(baseSchema, List.of(), List.of());
+                return new MetadataBindResult(baseSchema, List.of());
             }
             Set<String> existing = new LinkedHashSet<>();
             for (Attribute a : baseSchema) {
@@ -807,26 +744,12 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             }
             List<Attribute> enriched = null;
             List<NamedExpression> unresolved = null;
-            List<Alias> nullConstants = null;
             for (NamedExpression requested : plan.metadataFields()) {
                 // FROM's parser threads non-standard names through UnresolvedMetadataAttributeExpression
                 // (whose name() throws); EXTERNAL's parser threads plain UnresolvedAttribute. Resolve
                 // the textual name from either shape without invoking the throwing accessor.
                 String name = requested instanceof UnresolvedMetadataAttributeExpression unr ? unr.pattern() : requested.name();
                 if (existing.contains(name)) {
-                    continue;
-                }
-                // _source.enabled: false — mirrors a real index's disabled-_source behavior (SourceFieldMapper's
-                // ConstantNull block loader, see EsPhysicalOperationProviders): the query succeeds and _source reads
-                // as null. Bind _source to a null literal instead of adding it to the schema, so the relation's
-                // output never carries it and the producer-side SynthesizeExternalSource is never asked to build it
-                // (VirtualColumnIterator only synthesizes _source when it finds the column in the relation's output).
-                if (ExternalMetadataColumns.SOURCE.equals(name) && sourceDisabled(plan)) {
-                    if (nullConstants == null) {
-                        nullConstants = new ArrayList<>();
-                    }
-                    nullConstants.add(new Alias(plan.source(), name, new Literal(plan.source(), null, DataType.SOURCE)));
-                    existing.add(name);
                     continue;
                 }
                 // _id.path names the column the reader stamps _id from. If the dataset declares one but the resolved
@@ -887,13 +810,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             }
             List<Attribute> resolvedSchema = enriched == null ? baseSchema : List.copyOf(enriched);
             List<? extends NamedExpression> unresolvedList = unresolved == null ? List.of() : List.copyOf(unresolved);
-            List<Alias> nullConstantList = nullConstants == null ? List.of() : List.copyOf(nullConstants);
-            return new MetadataBindResult(resolvedSchema, unresolvedList, nullConstantList);
-        }
-
-        private static boolean sourceDisabled(UnresolvedExternalRelation plan) {
-            var mapping = plan.mapping();
-            return mapping != null && mapping.mappings() != null && mapping.mappings().sourceAvailable() == false;
+            return new MetadataBindResult(resolvedSchema, unresolvedList);
         }
 
         /** The declared {@code mappings._id.path}, or {@code null} when the dataset does not set {@code _id} from a column. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaResolver.java
@@ -44,11 +44,6 @@ public final class DeclaredSchemaResolver {
      * Expand a {@code mappings} block into its declared <b>base</b> logical columns, keyed by logical name in
      * declaration order. A property contributes exactly one column ({@code path} is a <em>move</em>: physical =
      * path, or the logical name when unset), so this is a 1:1 physical↔logical mapping.
-     *
-     * <p>A {@code copy_to} target is deliberately NOT expanded here: a copy is materialized as an {@code EVAL
-     * target = <this column>} projected above the external relation (see {@code Analyzer.ResolveExternalRelations}), reusing
-     * the plan's projection/pushdown/cast machinery. Keeping copies out of the read/reconciliation schema is what lets
-     * every format get copy for free and leaves the read path untouched.
      */
     private static LinkedHashMap<String, ColSpec> declaredLogicalColumns(DatasetMapping.Mappings mappings) {
         LinkedHashMap<String, ColSpec> cols = new LinkedHashMap<>();
@@ -63,8 +58,7 @@ public final class DeclaredSchemaResolver {
 
     /**
      * The declared columns as ES|QL attributes, keyed by <b>logical</b> name and in declaration order. Returns an empty
-     * list when there is no {@code mappings} block (an _id/_source-only mappings block contributes no columns). A {@code copy_to} does
-     * not appear here — it is materialized as an {@code EVAL} above the relation, not a base column.
+     * list when there is no {@code mappings} block (an _id-only mappings block contributes no columns).
      */
     public static List<Attribute> declaredAttributes(DatasetMapping mapping) {
         DatasetMapping.Mappings mappings = mapping == null ? null : mapping.mappings();
@@ -82,9 +76,8 @@ public final class DeclaredSchemaResolver {
     /**
      * Logical&rarr;physical name map for the columns that declare a {@code path} move (logical name &ne; physical
      * name). Empty when nothing renames. The map is 1:1 (a physical is claimed by at most one logical — validation
-     * enforces it), so its {@link PhysicalNames#inverse} is well-defined. A {@code copy_to} is NOT in this map — it is
-     * an {@code EVAL} above the relation, never a read-path rename. {@link PhysicalNames} uses this at the last-mile
-     * reader-facing boundaries; the reader and {@code ColumnMapping} stay rename-agnostic.
+     * enforces it), so its {@link PhysicalNames#inverse} is well-defined. {@link PhysicalNames} uses this at the
+     * last-mile reader-facing boundaries; the reader and {@code ColumnMapping} stay rename-agnostic.
      */
     public static Map<String, String> renameMap(DatasetMapping mapping) {
         DatasetMapping.Mappings mappings = mapping == null ? null : mapping.mappings();
@@ -133,7 +126,7 @@ public final class DeclaredSchemaResolver {
         }
         LinkedHashMap<String, ColSpec> declaredLogicals = declaredLogicalColumns(mappings);
         // physical (file) name -> the declared logical name + type that overrides it. Exactly 1:1: validation rejects
-        // two columns sharing a physical, and a copy_to is an EVAL above the relation, so it never reaches the resolver.
+        // two columns sharing a physical.
         Map<String, String> logicalByPhysical = new LinkedHashMap<>();
         Map<String, DataType> typeByPhysical = new LinkedHashMap<>();
         for (Map.Entry<String, ColSpec> e : declaredLogicals.entrySet()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -73,17 +72,13 @@ public final class DeclaredSchemaValidator {
                 throw new IllegalArgumentException("[dynamic: false] requires at least one declared column under [properties]");
             }
             // Physical-name uniqueness for the read (move) columns: a column's physical name is its `path`, or its
-            // logical name. Two columns resolving to one physical break the 1:1 read-path rename, so reject. (A COPY is
-            // NOT a shared physical: `copy_to` is materialized as an EVAL above the relation, so it never touches the
-            // read path — only the OUTPUT name must be unique, checked below.)
-            Set<String> outputNames = new HashSet<>();
+            // logical name. Two columns resolving to one physical break the 1:1 read-path rename, so reject.
             Map<String, String> physicalToLogical = new HashMap<>();
             for (Map.Entry<String, DatasetFieldMapping> e : mappings.properties().entrySet()) {
                 requireNonBlank(e.getKey(), "column name");
                 requireNonBlank(e.getValue().path(), "path of column [" + e.getKey() + "]");
                 validateType(e.getKey(), e.getValue().type());
                 validateFormat(e.getKey(), e.getValue().type(), e.getValue().format());
-                outputNames.add(e.getKey()); // property keys are unique by JSON-object semantics
                 String logical = e.getKey();
                 String physical = e.getValue().path() != null ? e.getValue().path() : logical;
                 String clash = physicalToLogical.putIfAbsent(physical, logical);
@@ -93,30 +88,7 @@ public final class DeclaredSchemaValidator {
                     );
                 }
             }
-            // Every copy_to target is a NEW output column — it must not collide with a declared column or another target.
-            Set<String> copyToTargets = new HashSet<>();
-            for (Map.Entry<String, DatasetFieldMapping> e : mappings.properties().entrySet()) {
-                for (String copyTo : e.getValue().copyTo()) {
-                    requireNonBlank(copyTo, "copy_to target of column [" + e.getKey() + "]");
-                    if (outputNames.add(copyTo) == false) {
-                        throw new IllegalArgumentException(
-                            "copy_to target [" + copyTo + "] on column [" + e.getKey() + "] collides with another declared column"
-                        );
-                    }
-                    copyToTargets.add(copyTo);
-                }
-            }
             requireNonBlank(mappings.idPath(), "[_id] path");
-            // _id must be stamped from a column that is actually read from the file. A copy_to target is a projection
-            // computed above the read (it has no per-row storage the reader can see), so pointing _id at one would
-            // silently produce null ids — reject it at PUT instead.
-            if (mappings.idPath() != null && copyToTargets.contains(mappings.idPath())) {
-                throw new IllegalArgumentException(
-                    "[_id] path ["
-                        + mappings.idPath()
-                        + "] references a copy_to target; _id must be read from a column of the file, not a copy"
-                );
-            }
             boolean strict = mappings.dynamic() == DatasetMapping.Dynamic.FALSE;
             validateIdPath(mappings, strict);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/EsqlDataSourcesCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/EsqlDataSourcesCapabilities.java
@@ -12,7 +12,7 @@ public final class EsqlDataSourcesCapabilities {
     /** Advertises that this node exposes the data_sources + datasets CRUD endpoints. */
     public static final String DATA_SOURCES = "data_sources";
 
-    /** The dataset PUT body accepts a declared `mappings` block (types, path renames, copy_to, _source, _id). */
+    /** The dataset PUT body accepts a declared `mappings` block (types, path renames, format, _id). */
     public static final String DATASET_DECLARED_SCHEMA = "dataset_declared_schema";
 
     private EsqlDataSourcesCapabilities() {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
@@ -119,7 +119,7 @@ public class DatasetService {
                 throw ex;
             }
         }
-        // Shape-only validation of the declared mapping (no file I/O): declarable types, rename/copy_to name collisions,
+        // Shape-only validation of the declared mapping (no file I/O): declarable types, rename name collisions,
         // and the _id.path reference. A `path` column rename is honored by all formats (translation is centralized at
         // the reader boundary).
         DeclaredSchemaValidator.validate(request.mapping());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -192,14 +192,13 @@ public class Eval extends UnaryPlan
     }
 
     /**
-     * True for a {@code _source} column bound to a constant {@code null} — the shape
-     * {@code Analyzer.ResolveExternalRelations} produces for a requested {@code _source} on an
-     * external dataset declaring {@code _source.enabled: false}, mirroring a real index's
-     * disabled-source behavior (the {@code ConstantNull} block loader wired in
-     * {@code SourceFieldMapper} / {@code EsPhysicalOperationProviders}). {@code DataType.SOURCE} is
-     * otherwise excluded from {@link DataType#isRepresentable} because no scalar function computes a
-     * {@code _source} value; a constant null is the one legitimate exception, so it is carved out
-     * here rather than widening {@code isRepresentable} itself.
+     * True for a {@code _source} column bound to a constant {@code null}. When a FORK/UnionAll branch is missing a column
+     * present in a sibling branch, {@code Analyzer.resolveFork} null-fills it with {@code new Literal(source, null, attrType)}
+     * where {@code attrType} is the missing attribute's own {@code dataType}, and wraps the fill in a synthesized {@link Eval}.
+     * The null-fill only rewrites {@code UNSUPPORTED} to {@code KEYWORD}, so a missing {@code _source} column (requested via
+     * {@code METADATA _source}) yields a null literal of {@link DataType#SOURCE}. {@code DataType.SOURCE} is excluded from
+     * {@link DataType#isRepresentable} because no scalar function computes a {@code _source} value; a constant null is the one
+     * legitimate exception, so it is carved out here rather than widening {@code isRepresentable} itself.
      */
     private static boolean isNullSourceLiteral(Alias field) {
         return field.dataType() == DataType.SOURCE && Alias.unwrap(field) instanceof Literal literal && literal.value() == null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -450,6 +450,14 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testForkWithSourceInOneBranch() {
+        // A FORK/UnionAll branch that lacks a _source column present in a sibling branch gets that column null-filled by
+        // Analyzer.resolveFork with a Literal(null, DataType.SOURCE). That null SOURCE literal lands in a synthesized Eval.
+        // SOURCE is excluded from DataType.isRepresentable, so Eval.postAnalysisVerification must carve out a null SOURCE
+        // literal or it wrongly fails the query with "EVAL does not support type [_source]".
+        defaultAnalyzer().query("FROM test METADATA _source | FORK (WHERE emp_no > 0) (WHERE emp_no > 0 | DROP _source)");
+    }
+
     public void testRoundFunctionInvalidInputs() {
         defaultAnalyzer().error(
             "row a = 1, b = \"c\" | eval x = round(b, 3)",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaResolverTests.java
@@ -83,7 +83,7 @@ public class DeclaredSchemaResolverTests extends ESTestCase {
         List<Attribute> inferred = List.of(attr("a", DataType.KEYWORD));
         DeclaredSchemaResolver.Overlaid o = DeclaredSchemaResolver.overlayNonStrict(
             inferred,
-            new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), null, "row_id"))
+            new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), "row_id"))
         );
         assertSame(inferred, o.output());
         assertSame(inferred, o.fileSchema());
@@ -122,7 +122,7 @@ public class DeclaredSchemaResolverTests extends ESTestCase {
     }
 
     public void testNoMappingsYieldsEmpty() {
-        DatasetMapping roleOnly = new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), null, "row_id"));
+        DatasetMapping roleOnly = new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), "row_id"));
         assertTrue(DeclaredSchemaResolver.declaredAttributes(roleOnly).isEmpty());
         assertTrue(DeclaredSchemaResolver.renameMap(roleOnly).isEmpty());
         assertTrue(DeclaredSchemaResolver.declaredAttributes(null).isEmpty());
@@ -148,18 +148,5 @@ public class DeclaredSchemaResolverTests extends ESTestCase {
         List<String> names = DeclaredSchemaResolver.overlayNonStrict(inferred, m).output().stream().map(Attribute::name).toList();
         assertEquals(List.of("@timestamp", "other"), names);
         assertEquals(Map.of("@timestamp", "ts"), DeclaredSchemaResolver.renameMap(m));
-    }
-
-    public void testCopyToLeavesTheResolverSchema() {
-        // A copy_to is NOT expanded in the resolver — it becomes an EVAL above the relation. The resolver schema stays
-        // base (just the source column), and the rename map carries only the move.
-        List<Attribute> inferred = List.of(attr("ts", DataType.DATETIME), attr("other", DataType.KEYWORD));
-        Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
-        props.put("ts", new DatasetFieldMapping("date", null, "@timestamp"));
-        DatasetMapping m = mapping(props);
-        List<String> names = DeclaredSchemaResolver.overlayNonStrict(inferred, m).output().stream().map(Attribute::name).toList();
-        assertEquals(List.of("ts", "other"), names); // no @timestamp here — it's an Eval target
-        assertTrue(DeclaredSchemaResolver.renameMap(m).isEmpty()); // ts == physical ts, no rename; copy is not a rename
-        assertEquals(List.of("ts"), DeclaredSchemaResolver.declaredAttributes(m).stream().map(Attribute::name).toList());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidatorTests.java
@@ -15,13 +15,12 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 public class DeclaredSchemaValidatorTests extends ESTestCase {
 
     private static DatasetMapping mapping(Dynamic dynamic, Map<String, DatasetFieldMapping> props, String idPath) {
-        return new DatasetMapping(new Mappings(dynamic, props, null, idPath));
+        return new DatasetMapping(new Mappings(dynamic, props, idPath));
     }
 
     private static Map<String, DatasetFieldMapping> props(Object... pairs) {
@@ -36,26 +35,18 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
         DeclaredSchemaValidator.validate(null); // no throw
     }
 
-    public void testCopyToAcceptedAtPut() {
-        // A copy_to is shape-valid at PUT — it materializes as an EVAL above the relation, so the source column stays a
-        // normal 1:1 move/read and the target is a new output column.
-        Map<String, DatasetFieldMapping> copyTo = new LinkedHashMap<>();
-        copyTo.put("ts", new DatasetFieldMapping("date", null, "@timestamp"));
-        DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, copyTo))); // no throw
-    }
-
     public void testFormatOnDateColumnAcceptedAtPut() {
         // A date-parse pattern on a `date` column is shape-valid at PUT; the pattern is validated with the same ES
         // DateFormatter the readers use.
         Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
-        props.put("ts", new DatasetFieldMapping("date", null, List.of(), "dd/MMM/yyyy:HH:mm:ss Z"));
+        props.put("ts", DatasetFieldMapping.withFormat("date", null, "dd/MMM/yyyy:HH:mm:ss Z"));
         DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props))); // no throw
     }
 
     public void testFormatOnNonDateColumnRejected() {
         // `format` is a date-parse pattern, so it is only meaningful on a date column.
         Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
-        props.put("name", new DatasetFieldMapping("keyword", null, List.of(), "yyyy-MM-dd"));
+        props.put("name", DatasetFieldMapping.withFormat("keyword", null, "yyyy-MM-dd"));
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props)))
@@ -66,7 +57,7 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
     public void testInvalidFormatPatternRejectedAtPut() {
         // A bad pattern must fail the PUT, not the first query.
         Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
-        props.put("ts", new DatasetFieldMapping("date", null, List.of(), "not-a-valid-pattern-{{{"));
+        props.put("ts", DatasetFieldMapping.withFormat("date", null, "not-a-valid-pattern-{{{"));
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props)))
@@ -75,7 +66,7 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
     }
 
     public void testTwoSourcesOntoOnePhysicalRejected() {
-        // Two columns reading one physical break the 1:1 read-path rename (a copy must use copy_to, not a shared source).
+        // Two columns reading one physical break the 1:1 read-path rename, so the shared source is rejected.
         Map<String, DatasetFieldMapping> sameSource = new LinkedHashMap<>();
         sameSource.put("a", new DatasetFieldMapping("keyword", "x"));
         sameSource.put("b", new DatasetFieldMapping("keyword", "x"));
@@ -84,18 +75,6 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
             () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.FALSE, sameSource)))
         );
         assertTrue(e.getMessage(), e.getMessage().contains("physical column [x]"));
-    }
-
-    public void testCopyToTargetCollisionRejected() {
-        // A copy_to target must not collide with another declared output column (two columns with the same name).
-        Map<String, DatasetFieldMapping> clash = new LinkedHashMap<>();
-        clash.put("ts", new DatasetFieldMapping("date", null, "status"));
-        clash.put("status", new DatasetFieldMapping("integer", null));
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, clash)))
-        );
-        assertTrue(e.getMessage(), e.getMessage().contains("copy_to target [status]"));
     }
 
     public void testSourceRenameAcceptedAtPut() {
@@ -177,7 +156,7 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
     public void testIdPathWithNoPropertiesIsValid() {
         // _id.path with an otherwise-empty mappings block (no properties) — non-strict, so the id column is deferred to
         // query-time resolution. (The id-source is a meta-field inside mappings, so it always rides a mappings wrapper.)
-        DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), null, "row_id")));
+        DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), "row_id")));
     }
 
     public void testStrictWithNoPropertiesRejected() {
@@ -191,7 +170,7 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
     }
 
     public void testBlankNamesRejected() {
-        // Index-mapping precedent: field names must be non-empty. Blank property key / path / copy_to / _id.path all reject.
+        // Index-mapping precedent: field names must be non-empty. Blank property key / path / _id.path all reject.
         Map<String, DatasetFieldMapping> blankKey = new LinkedHashMap<>();
         blankKey.put(" ", new DatasetFieldMapping("keyword", null));
         expectThrows(
@@ -206,29 +185,9 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
             () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, blankPath)))
         );
 
-        Map<String, DatasetFieldMapping> blankCopyTo = new LinkedHashMap<>();
-        blankCopyTo.put("a", new DatasetFieldMapping("keyword", null, ""));
         expectThrows(
             IllegalArgumentException.class,
-            () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, blankCopyTo)))
+            () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), " ")))
         );
-
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, Map.of(), null, " ")))
-        );
-    }
-
-    public void testIdPathReferencingCopyToTargetRejected() {
-        // A copy_to target is a projection above the read, not a stored column — the reader has nothing to stamp _id
-        // from, so pointing _id.path at one would silently produce null ids. Rejected at PUT.
-        Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
-        props.put("user_id", new DatasetFieldMapping("keyword", null, "actor"));
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props, null, "actor")))
-        );
-        assertTrue(e.getMessage(), e.getMessage().contains("copy_to target"));
-        assertTrue(e.getMessage(), e.getMessage().contains("actor"));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/dataset/PutDatasetActionRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/dataset/PutDatasetActionRequestTests.java
@@ -193,10 +193,7 @@ public class PutDatasetActionRequestTests extends AbstractWireSerializingTestCas
             );
         }
         String idPath = randomBoolean() ? null : randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
-        Boolean sourceEnabled = randomBoolean() ? null : randomBoolean();
-        return DatasetMapping.assemble(
-            new DatasetMapping.Mappings(randomFrom(DatasetMapping.Dynamic.values()), props, sourceEnabled, idPath)
-        );
+        return DatasetMapping.assemble(new DatasetMapping.Mappings(randomFrom(DatasetMapping.Dynamic.values()), props, idPath));
     }
 
     private static Map<String, Object> randomSettings() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -634,7 +634,6 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
                             randomBoolean() ? null : randomAlphaOfLength(4)
                         )
                     ),
-                    randomBoolean() ? null : randomBoolean(),
                     randomBoolean() ? null : randomAlphaOfLength(5)
                 )
             );

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_dataset.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_dataset.yml
@@ -122,18 +122,7 @@ setup:
           mappings:
             _id: { type: keyword }
 
-  # _source supports only [enabled].
-  - do:
-      catch: /unknown \[_source\] field \[mode\]; only \[enabled\] is supported/
-      esql.put_dataset:
-        name: ds
-        body:
-          data_source: parent
-          resource: "s3://x/*.csv"
-          mappings:
-            _source: { mode: synthetic }
-
-  # Field parameters outside {type, path, copy_to} are rejected (index-mapping params we don't model).
+  # Field parameters outside {type, path, format} are rejected (index-mapping params we don't model).
   - do:
       catch: /\[analyzer\]/
       esql.put_dataset:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL: drop copy_to and _source.enabled from dataset declared mappings (#153379)](https://github.com/elastic/elasticsearch/pull/153379)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)