### PR TITLE
[9.5] [Inference API] Prevent overriding secret_parameters (#153309)

### DIFF
--- a/docs/changelog/153309.yaml
+++ b/docs/changelog/153309.yaml
@@ -1,0 +1,17 @@
+area: Inference
+breaking:
+  area: REST API
+  details: >-
+    The Inference API incorrectly allowed users to override values within `secret_parameters` with the contents of
+    `task_settings.parameters` during a POST request. This change prevents that behavior, ensuring that
+    `secret_parameters` cannot be overridden."
+  impact: >-
+    Users who relied on the previous behavior to override `secret_parameters` will need to create a new inference
+    endpoint with the `secret_parameters` moved to `task_settings` or no longer rely on the ability to override the
+    `secret_parameters` within a POST request."
+  notable: false
+  title: "[Inference API] Prevent overriding `secret_parameters`"
+issues: []
+pr: 153309
+summary: "[Inference API] Prevent overriding `secret_parameters`"
+type: breaking

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeSet;
 
 import static org.elasticsearch.xpack.inference.common.JsonUtils.toJson;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
@@ -44,19 +45,39 @@ public class CustomRequest implements OutboundRequest {
     public CustomRequest(RequestParameters requestParams, CustomModel model) {
         this.model = Objects.requireNonNull(model);
 
+        var secretParameters = model.getSecretSettings().getSecretParameters();
+        var taskSettingsParameters = model.getTaskSettings().getParameters();
+        validateTaskSettingsDoNotOverrideSecrets(secretParameters, taskSettingsParameters);
+
         var stringOnlyParams = new HashMap<String, String>();
-        addStringParams(stringOnlyParams, model.getSecretSettings().getSecretParameters());
-        addStringParams(stringOnlyParams, model.getTaskSettings().getParameters());
+        addStringParams(stringOnlyParams, secretParameters);
+        addStringParams(stringOnlyParams, taskSettingsParameters);
 
         var jsonParams = new HashMap<String, String>();
-        addJsonStringParams(jsonParams, model.getSecretSettings().getSecretParameters());
-        addJsonStringParams(jsonParams, model.getTaskSettings().getParameters());
+        addJsonStringParams(jsonParams, secretParameters);
+        addJsonStringParams(jsonParams, taskSettingsParameters);
 
         jsonParams.putAll(requestParams.jsonParameters());
 
         jsonPlaceholderReplacer = new ValidatingSubstitutor(jsonParams, "${", "}");
         stringPlaceholderReplacer = new ValidatingSubstitutor(stringOnlyParams, "${", "}");
         uri = buildUri();
+    }
+
+    private static void validateTaskSettingsDoNotOverrideSecrets(
+        Map<String, SecureString> secretParameters,
+        Map<String, Object> taskSettingsParameters
+    ) {
+        var overlappingKeys = new TreeSet<>(secretParameters.keySet());
+        overlappingKeys.retainAll(taskSettingsParameters.keySet());
+        if (overlappingKeys.isEmpty() == false) {
+            throw new IllegalArgumentException(
+                Strings.format(
+                    "Task settings parameters %s are not allowed to override secret parameters with the same name",
+                    overlappingKeys
+                )
+            );
+        }
     }
 
     private static void addStringParams(Map<String, String> stringParams, Map<String, ?> paramsToAdd) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequestTests.java
@@ -368,6 +368,121 @@ public class CustomRequestTests extends ESTestCase {
         );
     }
 
+    public void testCreateRequest_ThrowsException_WhenTaskSettingsOverrideSecretParameter() {
+        var inferenceId = "inference_id";
+        var targetHostKey = "target_host";
+        var authTokenKey = "auth_token";
+        var trustedHost = "trusted_host";
+        var adminSecretToken = "VERY_SECRET_FROM_ADMIN";
+        var attackerHost = "host.docker.internal";
+        Map<String, String> headers = Map.of(HttpHeaders.AUTHORIZATION, Strings.format("Bearer ${%s}", authTokenKey));
+        var requestContentString = """
+            {
+                "input": ${input}
+            }
+            """;
+
+        var serviceSettings = new CustomServiceSettings(
+            CustomServiceSettings.TextEmbeddingSettings.NON_TEXT_EMBEDDING_TASK_TYPE_SETTINGS,
+            Strings.format("http://${%s}:12345/fixed-path", targetHostKey),
+            headers,
+            null,
+            requestContentString,
+            new RerankResponseParser("$.result.score"),
+            new RateLimitSettings(10_000)
+        );
+
+        var model = CustomModelTests.createModel(
+            inferenceId,
+            TaskType.RERANK,
+            serviceSettings,
+            new CustomTaskSettings(Map.of(targetHostKey, attackerHost)),
+            new CustomSecretSettings(
+                Map.of(
+                    targetHostKey,
+                    new SecureString(trustedHost.toCharArray()),
+                    authTokenKey,
+                    new SecureString(adminSecretToken.toCharArray())
+                )
+            )
+        );
+
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new CustomRequest(
+                RerankParameters.of(
+                    new QueryAndDocsInputs(InferenceString.ofText("query string"), InferenceString.fromStringList(List.of("abc", "123")))
+                ),
+                model
+            )
+        );
+        assertThat(
+            exception.getMessage(),
+            is(
+                Strings.format(
+                    "Task settings parameters [%s] are not allowed to override secret parameters with the same name",
+                    targetHostKey
+                )
+            )
+        );
+    }
+
+    public void testCreateRequest_ThrowsException_WhenTaskSettingsOverrideMultipleSecretParameters() {
+        var inferenceId = "inference_id";
+        var targetHostKey = "target_host";
+        var authTokenKey = "auth_token";
+        var requestContentString = """
+            {
+                "input": ${input}
+            }
+            """;
+
+        var serviceSettings = new CustomServiceSettings(
+            CustomServiceSettings.TextEmbeddingSettings.NON_TEXT_EMBEDDING_TASK_TYPE_SETTINGS,
+            Strings.format("http://${%s}:18080/fixed-path", targetHostKey),
+            Map.of(HttpHeaders.AUTHORIZATION, Strings.format("Bearer ${%s}", authTokenKey)),
+            null,
+            requestContentString,
+            new RerankResponseParser("$.result.score"),
+            new RateLimitSettings(10_000)
+        );
+
+        var model = CustomModelTests.createModel(
+            inferenceId,
+            TaskType.RERANK,
+            serviceSettings,
+            new CustomTaskSettings(Map.of(targetHostKey, "host.docker.internal", authTokenKey, "attacker-supplied-value")),
+            new CustomSecretSettings(
+                Map.of(
+                    targetHostKey,
+                    new SecureString("trusted_host".toCharArray()),
+                    authTokenKey,
+                    new SecureString("VERY_SECRET_FROM_ADMIN".toCharArray())
+                )
+            )
+        );
+
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new CustomRequest(
+                RerankParameters.of(
+                    new QueryAndDocsInputs(InferenceString.ofText("query string"), InferenceString.fromStringList(List.of("abc", "123")))
+                ),
+                model
+            )
+        );
+        assertThat(
+            exception.getMessage(),
+            is(
+                Strings.format(
+                    "Task settings parameters [%s, %s] are not allowed to override secret parameters with the same name",
+                    authTokenKey,
+                    targetHostKey
+                )
+            )
+        );
+    }
+
     public void testCreateRequest_ThrowsException_ForInvalidUrl() {
         var inferenceId = "inference_id";
         var requestContentString = """


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Inference API] Prevent overriding secret_parameters (#153309)