### PR TITLE
ES|QL: add Configuration.setting(def) read delegate

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Kql.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Kql.java
@@ -193,7 +193,7 @@ public class Kql extends FullTextFunction implements OptionalArgument, Configura
     }
 
     private Map<String, Object> kqlQueryOptions() throws InvalidArgumentException {
-        if (options() == null && QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()).equals(ZoneOffset.UTC)) {
+        if (options() == null && configuration.setting(QuerySettings.TIME_ZONE).equals(ZoneOffset.UTC)) {
             return null;
         }
 
@@ -201,7 +201,7 @@ public class Kql extends FullTextFunction implements OptionalArgument, Configura
         if (options() != null) {
             Options.populateMap((MapExpression) options(), kqlOptions, source(), SECOND, ALLOWED_OPTIONS);
         }
-        kqlOptions.putIfAbsent(TIME_ZONE_FIELD.getPreferredName(), QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()).getId());
+        kqlOptions.putIfAbsent(TIME_ZONE_FIELD.getPreferredName(), configuration.setting(QuerySettings.TIME_ZONE).getId());
         return kqlOptions;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryString.java
@@ -340,7 +340,7 @@ public class QueryString extends FullTextFunction implements OptionalArgument, C
     }
 
     private Map<String, Object> queryStringOptions() throws InvalidArgumentException {
-        if (options() == null && QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()).equals(ZoneOffset.UTC)) {
+        if (options() == null && configuration.setting(QuerySettings.TIME_ZONE).equals(ZoneOffset.UTC)) {
             return null;
         }
 
@@ -348,10 +348,7 @@ public class QueryString extends FullTextFunction implements OptionalArgument, C
         if (options() != null) {
             Options.populateMap((MapExpression) options(), queryStringOptions, source(), SECOND, ALLOWED_OPTIONS);
         }
-        queryStringOptions.putIfAbsent(
-            TIME_ZONE_FIELD.getPreferredName(),
-            QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()).getId()
-        );
+        queryStringOptions.putIfAbsent(TIME_ZONE_FIELD.getPreferredName(), configuration.setting(QuerySettings.TIME_ZONE).getId());
         return queryStringOptions;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -438,7 +438,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
             int b = ((Number) buckets.fold(foldContext)).intValue();
             long f = foldToLong(foldContext, from);
             long t = foldToLong(foldContext, to);
-            var rounding = new DateRoundingPicker(b, f, t, QuerySettings.TIME_ZONE.get(configuration.resolvedSettings())).pickRounding();
+            var rounding = new DateRoundingPicker(b, f, t, configuration.setting(QuerySettings.TIME_ZONE)).pickRounding();
             if (UP.equals(roundingConvention)) {
                 rounding = Rounding.ToUpperRounding.createRounding(rounding);
             }
@@ -452,7 +452,7 @@ public class Bucket extends GroupingFunction.EvaluatableGroupingFunction
             assert DataType.isTemporalAmount(buckets.dataType()) : "Unexpected span data type [" + buckets.dataType() + "]";
             prepared = DateTrunc.createRounding(
                 buckets.fold(foldContext),
-                QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()),
+                configuration.setting(QuerySettings.TIME_ZONE),
                 min,
                 max,
                 offset,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java
@@ -121,7 +121,7 @@ public class ToDateNanos extends AbstractConvertFunction implements Configuratio
                         (source, fieldEval) -> new ToDateNanosFromStringEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_NANOS_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_NANOS_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     ),
                     Map.entry(
@@ -129,7 +129,7 @@ public class ToDateNanos extends AbstractConvertFunction implements Configuratio
                         (source, fieldEval) -> new ToDateNanosFromStringEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_NANOS_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_NANOS_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     )
                 )

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateRange.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateRange.java
@@ -91,7 +91,7 @@ public class ToDateRange extends AbstractConvertFunction implements Configuratio
     @Override
     protected Map<DataType, BuildFactory> factories() {
         if (lazyEvaluators == null) {
-            DateFormatter formatter = DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()));
+            DateFormatter formatter = DEFAULT_DATE_TIME_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE));
             BuildFactory fromString = (source, fieldEval) -> new ToDateRangeFromStringEvaluator.Factory(source, fieldEval, formatter);
             lazyEvaluators = Map.ofEntries(
                 Map.entry(DATE_RANGE, (source, fieldEval) -> fieldEval),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java
@@ -136,7 +136,7 @@ public class ToDatetime extends AbstractConvertFunction implements Configuration
                         (source, fieldEval) -> new ToDatetimeFromStringEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_TIME_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     ),
                     Map.entry(
@@ -144,7 +144,7 @@ public class ToDatetime extends AbstractConvertFunction implements Configuration
                         (source, fieldEval) -> new ToDatetimeFromStringEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_TIME_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     )
                 )

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -184,7 +184,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
                         (source, fieldEval) -> new ToStringFromDatetimeEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_TIME_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     ),
                     Map.entry(
@@ -192,7 +192,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
                         (source, fieldEval) -> new ToStringFromDateNanosEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_NANOS_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_NANOS_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     ),
                     Map.entry(
@@ -200,7 +200,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
                         (source, fieldEval) -> new ToStringFromDateRangeEvaluator.Factory(
                             source,
                             fieldEval,
-                            DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                            DEFAULT_DATE_TIME_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                         )
                     )
                 )

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
@@ -302,7 +302,7 @@ public class DateDiff extends EsqlConfigurationFunction {
 
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
-        ZoneId zoneId = QuerySettings.TIME_ZONE.get(configuration().resolvedSettings());
+        ZoneId zoneId = configuration().setting(QuerySettings.TIME_ZONE);
         if (startTimestamp.dataType() == DATETIME && endTimestamp.dataType() == DATETIME) {
             return toEvaluator(toEvaluator, DateDiffConstantMillisEvaluator.Factory::new, DateDiffMillisEvaluator.Factory::new, zoneId);
         } else if (startTimestamp.dataType() == DATE_NANOS && endTimestamp.dataType() == DATE_NANOS) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
@@ -145,14 +145,14 @@ public class DateExtract extends EsqlConfigurationFunction {
                     source(),
                     fieldEvaluator,
                     chrono,
-                    QuerySettings.TIME_ZONE.get(configuration().resolvedSettings())
+                    configuration().setting(QuerySettings.TIME_ZONE)
                 );
             } else {
                 return new DateExtractConstantMillisEvaluator.Factory(
                     source(),
                     fieldEvaluator,
                     chrono,
-                    QuerySettings.TIME_ZONE.get(configuration().resolvedSettings())
+                    configuration().setting(QuerySettings.TIME_ZONE)
                 );
             }
         }
@@ -164,14 +164,14 @@ public class DateExtract extends EsqlConfigurationFunction {
                 source(),
                 fieldEvaluator,
                 chronoEvaluator,
-                QuerySettings.TIME_ZONE.get(configuration().resolvedSettings())
+                configuration().setting(QuerySettings.TIME_ZONE)
             );
         } else {
             return new DateExtractMillisEvaluator.Factory(
                 source(),
                 fieldEvaluator,
                 chronoEvaluator,
-                QuerySettings.TIME_ZONE.get(configuration().resolvedSettings())
+                configuration().setting(QuerySettings.TIME_ZONE)
             );
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateFormat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateFormat.java
@@ -183,7 +183,7 @@ public class DateFormat extends EsqlConfigurationFunction implements OptionalArg
                 source(),
                 fieldEvaluator,
                 formatEvaluator,
-                QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+                configuration().setting(QuerySettings.TIME_ZONE),
                 configuration().locale()
             );
         }
@@ -191,7 +191,7 @@ public class DateFormat extends EsqlConfigurationFunction implements OptionalArg
             source(),
             fieldEvaluator,
             formatEvaluator,
-            QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+            configuration().setting(QuerySettings.TIME_ZONE),
             configuration().locale()
         );
     }
@@ -203,8 +203,7 @@ public class DateFormat extends EsqlConfigurationFunction implements OptionalArg
             return getConstantEvaluator(
                 field().dataType(),
                 fieldEvaluator,
-                DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()))
-                    .withLocale(configuration().locale())
+                DEFAULT_DATE_TIME_FORMATTER.withZone(configuration().setting(QuerySettings.TIME_ZONE)).withLocale(configuration().locale())
             );
         }
         if (DataType.isString(format.dataType()) == false) {
@@ -213,7 +212,7 @@ public class DateFormat extends EsqlConfigurationFunction implements OptionalArg
         if (format.foldable()) {
             DateFormatter formatter = toFormatter(
                 format.fold(toEvaluator.foldCtx()),
-                QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+                configuration().setting(QuerySettings.TIME_ZONE),
                 configuration().locale()
             );
             return getConstantEvaluator(field.dataType(), fieldEvaluator, formatter);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -273,7 +273,7 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
         Locale locale = localeAsString == null ? Locale.ROOT : LocaleUtils.parse(localeAsString);
 
         String timezoneAsString = (String) parsedOptions.get(TIME_ZONE_PARAM_NAME);
-        ZoneId timezone = QuerySettings.TIME_ZONE.get(configuration().resolvedSettings());
+        ZoneId timezone = configuration().setting(QuerySettings.TIME_ZONE);
         try {
             if (timezoneAsString != null) {
                 timezone = ZoneId.of(timezoneAsString);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateTrunc.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateTrunc.java
@@ -130,7 +130,7 @@ public class DateTrunc extends EsqlConfigurationFunction {
     }
 
     public ZoneId zoneId() {
-        return QuerySettings.TIME_ZONE.get(configuration().resolvedSettings());
+        return configuration().setting(QuerySettings.TIME_ZONE);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateUnitCount.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateUnitCount.java
@@ -154,7 +154,7 @@ public class DateUnitCount extends EsqlConfigurationFunction {
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         var dateEvaluator = toEvaluator.apply(date);
-        var zoneId = QuerySettings.TIME_ZONE.get(configuration().resolvedSettings());
+        var zoneId = configuration().setting(QuerySettings.TIME_ZONE);
 
         DateDiff.Part dst = foldedPart(toUnit, toEvaluator.foldCtx());
         DateDiff.Part src = foldedPart(fromUnit, toEvaluator.foldCtx());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DayName.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DayName.java
@@ -117,14 +117,14 @@ public class DayName extends EsqlConfigurationFunction {
             return new DayNameNanosEvaluator.Factory(
                 source(),
                 fieldEvaluator,
-                QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+                configuration().setting(QuerySettings.TIME_ZONE),
                 configuration().locale()
             );
         }
         return new DayNameMillisEvaluator.Factory(
             source(),
             fieldEvaluator,
-            QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+            configuration().setting(QuerySettings.TIME_ZONE),
             configuration().locale()
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/MonthName.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/MonthName.java
@@ -123,14 +123,14 @@ public class MonthName extends EsqlConfigurationFunction {
             return new MonthNameNanosEvaluator.Factory(
                 source(),
                 fieldEvaluator,
-                QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+                configuration().setting(QuerySettings.TIME_ZONE),
                 configuration().locale()
             );
         }
         return new MonthNameMillisEvaluator.Factory(
             source(),
             fieldEvaluator,
-            QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()),
+            configuration().setting(QuerySettings.TIME_ZONE),
             configuration().locale()
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/TRange.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/TRange.java
@@ -278,7 +278,7 @@ public class TRange extends EsqlConfigurationFunction
 
     private Instant timeWithOffset(Object offset, Instant base) {
         if (offset instanceof TemporalAmount amount) {
-            var zonedDateTime = ZonedDateTime.ofInstant(base, QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()));
+            var zonedDateTime = ZonedDateTime.ofInstant(base, configuration().setting(QuerySettings.TIME_ZONE));
             return zonedDateTime.minus(amount).toInstant();
         }
         throw new InvalidArgumentException("Unsupported offset type [{}]", offset.getClass().getSimpleName());
@@ -293,7 +293,7 @@ public class TRange extends EsqlConfigurationFunction
             try {
                 long millis = dateTimeToLong(
                     bytesRef.utf8ToString(),
-                    DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration().resolvedSettings()))
+                    DEFAULT_DATE_TIME_FORMATTER.withZone(configuration().setting(QuerySettings.TIME_ZONE))
                 );
                 return Instant.ofEpochMilli(millis);
             } catch (Exception e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
@@ -180,7 +180,7 @@ public abstract class DateTimeArithmeticOperation extends DenseVectorArithmeticO
 
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
-        ZoneId zoneId = QuerySettings.TIME_ZONE.get(configuration().resolvedSettings());
+        ZoneId zoneId = configuration().setting(QuerySettings.TIME_ZONE);
         if (dataType() == DATETIME) {
             // One of the arguments has to be a datetime and the other a temporal amount.
             Expression datetimeArgument;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteApproximationPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteApproximationPlan.java
@@ -22,7 +22,7 @@ public final class SubstituteApproximationPlan extends ParameterizedRule<Logical
 
     @Override
     public LogicalPlan apply(LogicalPlan logicalPlan, LogicalOptimizerContext context) {
-        if (QuerySettings.APPROXIMATION.get(context.configuration().resolvedSettings()) == null) {
+        if (context.configuration().setting(QuerySettings.APPROXIMATION) == null) {
             // Approximation is not enabled
             return logicalPlan;
         } else {
@@ -33,11 +33,7 @@ public final class SubstituteApproximationPlan extends ParameterizedRule<Logical
             } else {
                 // Returns an approximation plan with placeholders for the sample probabilities.
                 // This placeholder will be replaced after executing the corresponding subplans.
-                return ApproximationPlan.get(
-                    logicalPlan,
-                    queryProperties,
-                    QuerySettings.APPROXIMATION.get(context.configuration().resolvedSettings())
-                );
+                return ApproximationPlan.get(logicalPlan, queryProperties, context.configuration().setting(QuerySettings.APPROXIMATION));
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
@@ -438,7 +438,7 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
             Object lower = null;
             Object upper = null;
             Queries.Clause clause = queryExec.hasScoring() ? Queries.Clause.MUST : Queries.Clause.FILTER;
-            ZoneId zoneId = QuerySettings.TIME_ZONE.get(ctx.configuration().resolvedSettings());
+            ZoneId zoneId = ctx.configuration().setting(QuerySettings.TIME_ZONE);
             for (int i = 1; i < count; i++) {
                 upper = points.get(i);
                 // build predicates and range queries for RoundTo ranges

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettingDef.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettingDef.java
@@ -116,8 +116,12 @@ import java.util.function.UnaryOperator;
  * <h2>Reading</h2>
  *
  * <pre>{@code
- *   ZoneId tz = QuerySettings.TIME_ZONE.get(resolved);
+ *   ZoneId tz = configuration.setting(QuerySettings.TIME_ZONE);
  * }</pre>
+ *
+ * {@link #get(ResolvedSettings)} is the low-level accessor used by {@code Configuration.setting}; call
+ * it directly only where a {@code Configuration} does not yet exist, e.g. resolving settings up front
+ * in {@code EsqlSession} before the {@code Configuration} that needs them is constructed.
  *
  * <h2>Reconciliation</h2>
  *
@@ -282,6 +286,10 @@ public final class QuerySettingDef<T> {
         return reconciler;
     }
 
+    /**
+     * Reads this setting's resolved value directly. Prefer {@code Configuration.setting(this)} — call
+     * this only where a {@code Configuration} isn't available yet (see class javadoc).
+     */
     public T get(ResolvedSettings settings) {
         return settings.get(this);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/ResolvedSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/ResolvedSettings.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 /**
  * Immutable typed view of resolved query setting values, produced by {@link QuerySettings#resolve}.
- * Read via {@link QuerySettingDef#get(ResolvedSettings)} on each setting's constant.
+ * Read via {@code Configuration.setting} on each setting's constant.
  *
  * <p>Travels with {@link org.elasticsearch.xpack.esql.session.Configuration} across the wire to data
  * nodes; every node and driver that holds a Configuration also holds the full resolved view.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -553,7 +553,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
                 asyncExecutionId,
                 false,
                 request.async(),
-                QuerySettings.TIME_ZONE.get(result.configuration().resolvedSettings()),
+                result.configuration().setting(QuerySettings.TIME_ZONE),
                 task.getStartTime(),
                 ((EsqlQueryTask) task).getExpirationTimeMillis(),
                 result.executionInfo()
@@ -573,7 +573,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             null,
             false,
             request.async(),
-            QuerySettings.TIME_ZONE.get(result.configuration().resolvedSettings()),
+            result.configuration().setting(QuerySettings.TIME_ZONE),
             task.getStartTime(),
             threadPool.absoluteTimeInMillis() + request.keepAlive().millis(),
             result.executionInfo()

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Configuration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Configuration.java
@@ -257,7 +257,7 @@ public class Configuration implements Writeable {
         // Exactly one of {legacy slots, resolvedSettings block} is written, so there is no redundant double-write.
         boolean writeLegacySettings = out.getTransportVersion().supports(ESQL_RESOLVED_SETTINGS) == false;
         if (writeLegacySettings) {
-            out.writeZoneId(QuerySettings.TIME_ZONE.get(resolvedSettings));
+            out.writeZoneId(setting(QuerySettings.TIME_ZONE));
         }
         out.writeVLong(now.getEpochSecond());
         out.writeVInt(now.getNano());
@@ -279,7 +279,7 @@ public class Configuration implements Writeable {
             out.writeVInt(resultTruncationDefaultSizeTimeseries);
         }
         if (writeLegacySettings && out.getTransportVersion().supports(QUERY_APPROXIMATION)) {
-            out.writeOptionalWriteable(QuerySettings.APPROXIMATION.get(resolvedSettings));
+            out.writeOptionalWriteable(setting(QuerySettings.APPROXIMATION));
         }
         if (out.getTransportVersion().supports(ESQL_VIEW_QUERIES)) {
             out.writeMap(viewQueries, StreamOutput::writeString);
@@ -295,7 +295,7 @@ public class Configuration implements Writeable {
     /**
      * The resolved view of every {@link org.elasticsearch.xpack.esql.plan.QuerySettingDef} for this
      * query. Reads of any SET-mirror knob (time_zone, project_routing, approximation, unmapped_fields,
-     * any future setting) go through this — e.g. {@code QuerySettings.TIME_ZONE.get(configuration.resolvedSettings())}.
+     * any future setting) go through this — e.g. {@code configuration.setting(QuerySettings.TIME_ZONE)}.
      */
     public ResolvedSettings resolvedSettings() {
         return resolvedSettings;
@@ -417,6 +417,14 @@ public class Configuration implements Writeable {
      */
     public <T> Configuration withSetting(QuerySettingDef<T> def, T value) {
         return new ConfigurationBuilder(this).setting(def, value).build();
+    }
+
+    /**
+     * Reads one resolved {@link QuerySettingDef} value — the preferred way to read any per-query
+     * setting, e.g. {@code configuration.setting(QuerySettings.TIME_ZONE)}.
+     */
+    public <T> T setting(QuerySettingDef<T> def) {
+        return def.get(resolvedSettings());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -439,7 +439,7 @@ public class EsqlSession {
 
         analyzedPlan(
             plan,
-            QuerySettings.UNMAPPED_FIELDS.get(finalConfiguration.resolvedSettings()),
+            finalConfiguration.setting(QuerySettings.UNMAPPED_FIELDS),
             finalConfiguration,
             executionInfo,
             request.filter(),
@@ -483,11 +483,7 @@ public class EsqlSession {
                         )
                         .<Result>andThen((l, p) -> {
                             columnMetadata.set(
-                                createColumnMetadata(
-                                    p,
-                                    foldContext,
-                                    QuerySettings.COLUMN_METADATA.get(finalConfiguration.resolvedSettings())
-                                )
+                                createColumnMetadata(p, foldContext, finalConfiguration.setting(QuerySettings.COLUMN_METADATA))
                             );
                             executeOptimizedPlan(
                                 request,
@@ -889,7 +885,7 @@ public class EsqlSession {
         LogicalPlan plan = subPlanAndCallback != null ? subPlanAndCallback.subPlan() : mainPlan;
         if (ApproximationPlan.is(plan)) {
             if (approximation.get() == null) {
-                approximation.set(ApproximationDriver.create(plan, QuerySettings.APPROXIMATION.get(configuration.resolvedSettings())));
+                approximation.set(ApproximationDriver.create(plan, configuration.setting(QuerySettings.APPROXIMATION)));
             }
             LogicalPlan subPlan = approximation.get().firstSubPlan();
             if (subPlan != null) {
@@ -1867,7 +1863,7 @@ public class EsqlSession {
                 (e, r, l) -> preAnalyzeFlatMainIndices(
                     e.getKey(),
                     e.getValue(),
-                    QuerySettings.PROJECT_ROUTING.get(configuration.resolvedSettings()),
+                    configuration.setting(QuerySettings.PROJECT_ROUTING),
                     preAnalysis,
                     executionInfo,
                     trackUnmappedFieldIndices,
@@ -1881,7 +1877,7 @@ public class EsqlSession {
                         strictResult,
                         (sp, r, ll) -> preAnalyzeLinkedIndices(
                             sp,
-                            QuerySettings.PROJECT_ROUTING.get(configuration.resolvedSettings()),
+                            configuration.setting(QuerySettings.PROJECT_ROUTING),
                             preAnalysis,
                             executionInfo,
                             trackUnmappedFieldIndices,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -275,13 +275,13 @@ public class EsqlDataTypeConverter {
             if (to == DataType.DATETIME) {
                 return l -> EsqlDataTypeConverter.dateTimeToLong(
                     BytesRefs.toString(l),
-                    DEFAULT_DATE_TIME_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                    DEFAULT_DATE_TIME_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                 );
             }
             if (to == DATE_NANOS) {
                 return l -> EsqlDataTypeConverter.dateNanosToLong(
                     BytesRefs.toString(l),
-                    DEFAULT_DATE_NANOS_FORMATTER.withZone(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()))
+                    DEFAULT_DATE_NANOS_FORMATTER.withZone(configuration.setting(QuerySettings.TIME_ZONE))
                 );
             }
             if (to == DataType.IP) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiffTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiffTests.java
@@ -183,7 +183,7 @@ public class DateDiffTests extends AbstractConfigurationFunctionTestCase {
                                 ),
                                 "DateDiffMillisEvaluator[unit=Attribute[channel=0], startTimestamp=Attribute[channel=1], "
                                     + "endTimestamp=Attribute[channel=2], zoneId="
-                                    + QuerySettings.TIME_ZONE.get(configuration.resolvedSettings())
+                                    + configuration.setting(QuerySettings.TIME_ZONE)
                                     + "]",
                                 DataType.INTEGER,
                                 equalTo(expected)
@@ -214,7 +214,7 @@ public class DateDiffTests extends AbstractConfigurationFunctionTestCase {
                                 ),
                                 "DateDiffNanosEvaluator[unit=Attribute[channel=0], startTimestamp=Attribute[channel=1], "
                                     + "endTimestamp=Attribute[channel=2], zoneId="
-                                    + QuerySettings.TIME_ZONE.get(configuration.resolvedSettings())
+                                    + configuration.setting(QuerySettings.TIME_ZONE)
                                     + "]",
                                 DataType.INTEGER,
                                 equalTo(expected)
@@ -245,7 +245,7 @@ public class DateDiffTests extends AbstractConfigurationFunctionTestCase {
                                 ),
                                 "DateDiffNanosMillisEvaluator[unit=Attribute[channel=0], startTimestampNanos=Attribute[channel=1], "
                                     + "endTimestampMillis=Attribute[channel=2], zoneId="
-                                    + QuerySettings.TIME_ZONE.get(configuration.resolvedSettings())
+                                    + configuration.setting(QuerySettings.TIME_ZONE)
                                     + "]",
                                 DataType.INTEGER,
                                 equalTo(expected)
@@ -276,7 +276,7 @@ public class DateDiffTests extends AbstractConfigurationFunctionTestCase {
                                 ),
                                 "DateDiffMillisNanosEvaluator[unit=Attribute[channel=0], startTimestampMillis=Attribute[channel=1], "
                                     + "endTimestampNanos=Attribute[channel=2], zoneId="
-                                    + QuerySettings.TIME_ZONE.get(configuration.resolvedSettings())
+                                    + configuration.setting(QuerySettings.TIME_ZONE)
                                     + "]",
                                 DataType.INTEGER,
                                 equalTo(expected)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
@@ -130,8 +130,7 @@ public class DateExtractTests extends AbstractConfigurationFunctionTestCase {
 
     public void testAllChronoFields() {
         long epochMilli = 1687944333123L;
-        ZonedDateTime date = Instant.ofEpochMilli(epochMilli)
-            .atZone(QuerySettings.TIME_ZONE.get(EsqlTestUtils.TEST_CFG.resolvedSettings()));
+        ZonedDateTime date = Instant.ofEpochMilli(epochMilli).atZone(EsqlTestUtils.TEST_CFG.setting(QuerySettings.TIME_ZONE));
         for (ChronoField value : ChronoField.values()) {
             DateExtract instance = new DateExtract(
                 Source.EMPTY,
@@ -142,11 +141,7 @@ public class DateExtractTests extends AbstractConfigurationFunctionTestCase {
 
             assertThat(instance.fold(FoldContext.small()), is(date.getLong(value)));
             assertThat(
-                DateExtract.processMillis(
-                    epochMilli,
-                    new BytesRef(value.name()),
-                    QuerySettings.TIME_ZONE.get(EsqlTestUtils.TEST_CFG.resolvedSettings())
-                ),
+                DateExtract.processMillis(epochMilli, new BytesRef(value.name()), EsqlTestUtils.TEST_CFG.setting(QuerySettings.TIME_ZONE)),
                 is(date.getLong(value))
             );
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DayNameTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DayNameTests.java
@@ -119,7 +119,7 @@ public class DayNameTests extends AbstractConfigurationFunctionTestCase {
         long randomMillis = randomMillisUpToYear9999();
         Configuration cfg = configurationForTimezoneAndLocale(randomZone(), randomLocale(random()));
         String expected = Instant.ofEpochMilli(randomMillis)
-            .atZone(QuerySettings.TIME_ZONE.get(cfg.resolvedSettings()))
+            .atZone(cfg.setting(QuerySettings.TIME_ZONE))
             .getDayOfWeek()
             .getDisplayName(TextStyle.FULL, cfg.locale());
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/MonthNameTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/MonthNameTests.java
@@ -122,7 +122,7 @@ public class MonthNameTests extends AbstractConfigurationFunctionTestCase {
         long randomMillis = randomMillisUpToYear9999();
         Configuration cfg = configurationForTimezoneAndLocale(randomZone(), randomLocale(random()));
         String expected = Instant.ofEpochMilli(randomMillis)
-            .atZone(QuerySettings.TIME_ZONE.get(cfg.resolvedSettings()))
+            .atZone(cfg.setting(QuerySettings.TIME_ZONE))
             .getMonth()
             .getDisplayName(TextStyle.FULL, cfg.locale());
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/ConfigurationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/ConfigurationSerializationTests.java
@@ -59,7 +59,7 @@ public class ConfigurationSerializationTests extends AbstractWireSerializingTest
         switch (between(0, 10)) {
             case 0 -> builder.setting(
                 QuerySettings.TIME_ZONE,
-                randomValueOtherThan(QuerySettings.TIME_ZONE.get(in.resolvedSettings()), () -> randomZone().normalized())
+                randomValueOtherThan(in.setting(QuerySettings.TIME_ZONE), () -> randomZone().normalized())
             );
             case 1 -> builder.now(
                 randomValueOtherThan(in.now(), () -> randomInstantBetween(Instant.EPOCH, Instant.ofEpochMilli(Long.MAX_VALUE)))
@@ -112,8 +112,8 @@ public class ConfigurationSerializationTests extends AbstractWireSerializingTest
         // Tier 1 — both peers understand esql_resolved_settings. Settings cross only in the generic resolvedSettings
         // block; the legacy time_zone/approximation slots are not written. Both values must survive intact.
         Configuration roundTripped = copyInstance(configWithTimeZoneAndApproximation(), TransportVersion.current());
-        assertThat(QuerySettings.TIME_ZONE.get(roundTripped.resolvedSettings()), equalTo(ZoneId.of("Europe/Paris")));
-        assertThat(QuerySettings.APPROXIMATION.get(roundTripped.resolvedSettings()).rows(), equalTo(10000));
+        assertThat(roundTripped.setting(QuerySettings.TIME_ZONE), equalTo(ZoneId.of("Europe/Paris")));
+        assertThat(roundTripped.setting(QuerySettings.APPROXIMATION).rows(), equalTo(10000));
     }
 
     public void testOldNodeSynthesizesResolvedSettingsFromLegacyWire() throws IOException {
@@ -123,8 +123,8 @@ public class ConfigurationSerializationTests extends AbstractWireSerializingTest
             TransportVersion.fromName("esql_resolved_settings")
         );
         Configuration roundTripped = copyInstance(configWithTimeZoneAndApproximation(), preResolvedSettings);
-        assertThat(QuerySettings.TIME_ZONE.get(roundTripped.resolvedSettings()), equalTo(ZoneId.of("Europe/Paris")));
-        assertThat(QuerySettings.APPROXIMATION.get(roundTripped.resolvedSettings()).rows(), equalTo(10000));
+        assertThat(roundTripped.setting(QuerySettings.TIME_ZONE), equalTo(ZoneId.of("Europe/Paris")));
+        assertThat(roundTripped.setting(QuerySettings.APPROXIMATION).rows(), equalTo(10000));
     }
 
     public void testVeryOldNodeWithoutApproximationSlot() throws IOException {
@@ -132,7 +132,7 @@ public class ConfigurationSerializationTests extends AbstractWireSerializingTest
         // its legacy field-1 slot, but approximation has nowhere to go on the wire and is dropped (back to default).
         TransportVersion preApproximation = TransportVersionUtils.getPreviousVersion(TransportVersion.fromName("esql_query_approximation"));
         Configuration roundTripped = copyInstance(configWithTimeZoneAndApproximation(), preApproximation);
-        assertThat(QuerySettings.TIME_ZONE.get(roundTripped.resolvedSettings()), equalTo(ZoneId.of("Europe/Paris")));
-        assertThat(QuerySettings.APPROXIMATION.get(roundTripped.resolvedSettings()), is(nullValue()));
+        assertThat(roundTripped.setting(QuerySettings.TIME_ZONE), equalTo(ZoneId.of("Europe/Paris")));
+        assertThat(roundTripped.setting(QuerySettings.APPROXIMATION), is(nullValue()));
     }
 }


### PR DESCRIPTION
Closes #152741

Adds `Configuration.setting(QuerySettingDef<T>)` as the preferred way to read a resolved query setting, and migrates call sites that already have a `Configuration` in scope from the older `QuerySettingDef.get(configuration.resolvedSettings())` form to the new delegate.

`QuerySettingDef.get(ResolvedSettings)` remains available for the handful of legitimate pre-`Configuration` reads in `EsqlSession`, where settings must be resolved before a `Configuration` can be constructed.

No behavior change; this is a mechanical readability cleanup.