### PR TITLE
Add permissions for .context-* Kibana index pattern

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -107,6 +107,14 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         .setAllowsTemplates()
         .build();
 
+    public static final SystemIndexDescriptor CONTEXT_ENGINE_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
+        .setIndexPattern(".context-*")
+        .setDescription("Context Engine system index")
+        .setType(Type.EXTERNAL_UNMANAGED)
+        .setAllowedElasticProductOrigins(KIBANA_PRODUCT_ORIGIN)
+        .setAllowsTemplates()
+        .build();
+
     public static final SystemIndexDescriptor APM_AGENT_CONFIG_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
         .setIndexPattern(".apm-agent-configuration*")
         .setDescription("system index for APM agent configuration")
@@ -135,6 +143,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
             KIBANA_INDEX_DESCRIPTOR,
             REPORTING_INDEX_DESCRIPTOR,
             ONECHAT_INDEX_DESCRIPTOR,
+            CONTEXT_ENGINE_INDEX_DESCRIPTOR,
             WORKFLOWS_INDEX_DESCRIPTOR,
             APM_AGENT_CONFIG_INDEX_DESCRIPTOR,
             APM_CUSTOM_LINK_INDEX_DESCRIPTOR

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -28,6 +28,7 @@ public class KibanaPluginTests extends ESTestCase {
                 ".kibana_*",
                 ".reporting-*",
                 ".chat-*",
+                ".context-*",
                 KibanaPlugin.WORKFLOWS_SYSTEM_INDEX_PATTERN,
                 ".apm-agent-configuration*",
                 ".apm-custom-link*"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -114,7 +114,7 @@ class KibanaOwnedReservedRoleDescriptors {
             new RoleDescriptor.IndicesPrivileges[] {
                 // System indices defined in KibanaPlugin
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".kibana*", ".reindexed-v8-kibana*", ".reporting-*", ".chat-*", ".workflows-*")
+                    .indices(".kibana*", ".reindexed-v8-kibana*", ".reporting-*", ".chat-*", ".workflows-*", ".context-*")
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),


### PR DESCRIPTION
The context engine will maintain system indices with a `.context-*` descriptor. This PR adds the appropriate permissions so Kibana can query indices with this prefix. 