### PR TITLE
ES|QL: read a declared `unsigned_long` from CSV/TSV/NDJSON

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -5711,7 +5711,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 // the file format. Fractional and scientific tokens truncate toward zero, matching ::unsigned_long
                 // and deliberately unlike the round-half behavior of the long/integer coercers.
                 return DeclaredTypeCoercions.coerceToUnsignedLong(value);
-            } catch (IllegalArgumentException | InvalidArgumentException e) {
+            } catch (IllegalArgumentException e) {
+                // coerceToUnsignedLong signals every bad token with an IllegalArgumentException (its range guard, the
+                // ArithmeticException remap, and the NumberFormatException subclass from BigDecimal); unlike
+                // strictParseBoolean it never throws InvalidArgumentException, so one catch clause covers it.
                 lastFieldError = "Failed to parse CSV value [" + value + "] as [UNSIGNED_LONG]";
                 return null;
             }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -3814,7 +3814,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 keywordScratch = new BytesRef[columnCount];
                 directElements = new ElementType[columnCount];
                 for (int i = 0; i < columnCount; i++) {
-                    directElements[i] = ElementType.fromJava(javaClassForDataType(projectedTypes[i]));
+                    directElements[i] = DeclaredTypeCoercions.elementTypeFor(projectedTypes[i]);
                 }
                 stageLong = new long[columnCount];
                 stageInt = new int[columnCount];
@@ -3885,7 +3885,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 for (int i = 0; i < columnCount; i++) {
                     builders[i] = BlockUtils.wrapperFor(
                         blockFactory,
-                        ElementType.fromJava(javaClassForDataType(projectedTypes[i])),
+                        DeclaredTypeCoercions.elementTypeFor(projectedTypes[i]),
                         rows.size(),
                         byteHints[i]
                     );
@@ -4041,7 +4041,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 for (int i = 0; i < columnCount; i++) {
                     builders[i] = BlockUtils.wrapperFor(
                         blockFactory,
-                        ElementType.fromJava(javaClassForDataType(projectedTypes[i])),
+                        DeclaredTypeCoercions.elementTypeFor(projectedTypes[i]),
                         lines.size()
                     );
                 }
@@ -4296,7 +4296,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     builders[i] = BlockUtils.wrapperFor(
                         blockFactory,
-                        ElementType.fromJava(javaClassForDataType(projectedTypes[i])),
+                        DeclaredTypeCoercions.elementTypeFor(projectedTypes[i]),
                         batchSize
                     );
                 }
@@ -5955,18 +5955,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     errorPolicy.maxErrorRatio()
                 );
             }
-        }
-
-        private Class<?> javaClassForDataType(DataType dataType) {
-            return switch (dataType) {
-                case INTEGER -> Integer.class;
-                case LONG, DATETIME, DATE_NANOS -> Long.class;
-                case DOUBLE -> Double.class;
-                case KEYWORD, TEXT, IP, VERSION -> BytesRef.class;
-                case BOOLEAN -> Boolean.class;
-                case NULL -> Void.class;
-                default -> throw new IllegalArgumentException("Unsupported data type: " + dataType);
-            };
         }
 
         /**

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -1830,6 +1830,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             case "SHORT", "BYTE" -> DataType.INTEGER;
             case "INTEGER", "INT", "I" -> DataType.INTEGER;
             case "LONG", "L" -> DataType.LONG;
+            case "UNSIGNED_LONG", "UL" -> DataType.UNSIGNED_LONG;
             case "FLOAT", "F", "HALF_FLOAT", "SCALED_FLOAT" -> DataType.DOUBLE;
             case "DOUBLE", "D" -> DataType.DOUBLE;
             case "KEYWORD", "K", "STRING", "S", "TEXT", "TXT" -> DataType.KEYWORD;
@@ -4294,11 +4295,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     if (useByteHint && columnToByteHintSlot[i] >= 0) {
                         continue;
                     }
-                    builders[i] = BlockUtils.wrapperFor(
-                        blockFactory,
-                        DeclaredTypeCoercions.elementTypeFor(projectedTypes[i]),
-                        batchSize
-                    );
+                    builders[i] = BlockUtils.wrapperFor(blockFactory, DeclaredTypeCoercions.elementTypeFor(projectedTypes[i]), batchSize);
                 }
                 if (useByteHint) {
                     resetByteHintRetain();
@@ -4806,7 +4803,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         return emitConvertedStageField(new String(buf, start, len), bufIdx, dt);
                     }
                 }
-                case DATETIME, DATE_NANOS, BOOLEAN, IP, VERSION, NULL -> {
+                // UNSIGNED_LONG must stay on this cold path: the LONG fast arm above accumulates a raw signed
+                // value and can neither sign-flip nor represent anything above Long.MAX_VALUE, so routing
+                // unsigned_long through it would silently corrupt exactly the (2^63, 2^64) values it exists for.
+                case UNSIGNED_LONG, DATETIME, DATE_NANOS, BOOLEAN, IP, VERSION, NULL -> {
                     return emitConvertedStageField(new String(buf, start, len), bufIdx, dt);
                 }
                 default -> throw new IllegalArgumentException("Unsupported data type: " + dt);
@@ -5528,6 +5528,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);
                 case LONG -> tryParseLong(value);
+                case UNSIGNED_LONG -> tryParseUnsignedLong(value);
                 case DOUBLE -> tryParseDouble(value);
                 case KEYWORD, TEXT -> new BytesRef(value);
                 case BOOLEAN -> tryParseBoolean(value);
@@ -5636,6 +5637,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
             return switch (dataType) {
                 case INTEGER -> tryParseInt(value);
                 case LONG -> tryParseLong(value);
+                case UNSIGNED_LONG -> tryParseUnsignedLong(value);
                 case DOUBLE -> tryParseDouble(value);
                 case KEYWORD, TEXT -> new BytesRef(value);
                 case BOOLEAN -> tryParseBoolean(value);
@@ -5697,6 +5699,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 return Double.parseDouble(value);
             } catch (NumberFormatException e) {
                 lastFieldError = "Failed to parse CSV value [" + value + "] as [DOUBLE]";
+                return null;
+            }
+        }
+
+        private Object tryParseUnsignedLong(String value) {
+            try {
+                // Delegate to the single unsigned_long authority (DeclaredTypeCoercions.coerceToUnsignedLong), the
+                // same scalar the Parquet and ORC declared-read paths use. It parses, range-checks [0, 2^64-1] and
+                // returns the sign-flip block encoding, so a declared unsigned_long reads bit-identically whatever
+                // the file format. Fractional and scientific tokens truncate toward zero, matching ::unsigned_long
+                // and deliberately unlike the round-half behavior of the long/integer coercers.
+                return DeclaredTypeCoercions.coerceToUnsignedLong(value);
+            } catch (IllegalArgumentException | InvalidArgumentException e) {
+                lastFieldError = "Failed to parse CSV value [" + value + "] as [UNSIGNED_LONG]";
                 return null;
             }
         }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDirectBlockParityTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalStatsCapture;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
@@ -36,6 +37,7 @@ import org.junit.After;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -217,6 +219,31 @@ public class CsvDirectBlockParityTests extends ESTestCase {
     public void testLongMaxMin() throws IOException {
         List<List<Object>> rows = read(false, Map.of(), "a:long\n" + Long.MAX_VALUE + "\n" + Long.MIN_VALUE + "\n");
         assertEquals(List.of(row(Long.MAX_VALUE), row(Long.MIN_VALUE)), rows);
+    }
+
+    /**
+     * unsigned_long is stored in a LongBlock as the sign-flip encoding, and it is decoded by two entirely
+     * separate paths — the direct-to-block byte parser and the Jackson bulk reader. The read() harness runs both
+     * and asserts they agree, so these cases pin that the two paths produce bit-identical blocks across the full
+     * domain, including the (2^63, 2^64) range where a naive signed accumulate would diverge.
+     */
+    public void testUnsignedLongDirectVsJacksonParity() throws IOException {
+        List<List<Object>> rows = read(false, Map.of(), "a:unsigned_long\n0\n9223372036854775808\n18446744073709551615\n");
+        assertEquals(List.of(row(ul("0")), row(ul("9223372036854775808")), row(ul("18446744073709551615"))), rows);
+    }
+
+    public void testUnsignedLongTruncatingTokensParity() throws IOException {
+        List<List<Object>> rows = read(false, Map.of(), "a:unsigned_long\n42.9\n1e3\n");
+        assertEquals(List.of(row(ul("42")), row(ul("1000"))), rows);
+    }
+
+    public void testUnsignedLongOutOfRangeNullFieldParity() throws IOException {
+        List<List<Object>> rows = read(false, nullField(), "a:unsigned_long\n-1\n18446744073709551616\n1e999999999\n7\n");
+        assertEquals(List.of(row((Object) null), row((Object) null), row((Object) null), row(ul("7"))), rows);
+    }
+
+    private static long ul(String magnitude) {
+        return NumericUtils.asLongUnsigned(new BigInteger(magnitude));
     }
 
     public void testNumericWhitespaceTrimmed() throws IOException {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -7980,6 +7980,38 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertEquals("the good cell still reads", encoded("5"), block.getLong(3));
     }
 
+    /** Multivalue unsigned_long cells parse element-by-element through the same coercer. */
+    public void testDeclaredUnsignedLongMultivalue() throws IOException {
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "brackets"));
+        LongBlock block = readOneUnsignedLongColumn(reader, "v\n[1,18446744073709551615]\n");
+        assertEquals(2, block.getValueCount(0));
+        int first = block.getFirstValueIndex(0);
+        assertEquals(encoded("1"), block.getLong(first));
+        assertEquals(encoded("18446744073709551615"), block.getLong(first + 1));
+    }
+
+    /**
+     * A token whose decimal exponent is large enough that expanding it would overflow BigInteger --
+     * "1e999999999" -- makes BigDecimal.toBigInteger() throw ArithmeticException, which is not an
+     * IllegalArgumentException. Unhandled it escapes the per-field catch and hard-fails the whole read on every
+     * error_mode, which is precisely the failure declared unsigned_long support exists to remove. It must instead
+     * be an ordinary out-of-range cell.
+     */
+    public void testDeclaredUnsignedLongExoticExponentIsAPerCellFailure() throws IOException {
+        String csv = "v\n1e999999999\n1e-999999999\n5\n";
+
+        FormatReader lenient = new CsvFormatReader(blockFactory).withConfig(Map.of("error_mode", "null_field", "max_errors", 100));
+        LongBlock block = readOneUnsignedLongColumn(lenient, csv);
+        assertTrue("huge positive exponent nulls the cell", block.isNull(0));
+        assertTrue("huge negative exponent nulls the cell", block.isNull(1));
+        assertEquals("the good cell still reads", encoded("5"), block.getLong(2));
+
+        // fail_fast still fails, but as an ordinary bad-value failure, not an escaped ArithmeticException.
+        FormatReader failFast = new CsvFormatReader(blockFactory);
+        Exception e = expectThrows(Exception.class, () -> readOneUnsignedLongColumn(failFast, csv));
+        assertFalse("ArithmeticException must not escape the coercer", e instanceof ArithmeticException);
+    }
+
     /** TSV rides the same reader; a declared unsigned_long must read identically there. */
     public void testDeclaredUnsignedLongReadsFromTsv() throws IOException {
         FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("delimiter", "\t"));

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -8012,6 +8012,29 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertFalse("ArithmeticException must not escape the coercer", e instanceof ArithmeticException);
     }
 
+    /**
+     * skip_row drops the whole row carrying a bad unsigned_long cell rather than nulling it — completing the
+     * error_mode matrix (fail_fast and null_field are pinned above). The bad value rides the same per-field policy
+     * channel every other declared type uses, so this confirms unsigned_long is wired into it, not special-cased.
+     */
+    public void testDeclaredUnsignedLongBadValueSkipRowDropsTheRow() throws IOException {
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "v", DataType.UNSIGNED_LONG)
+        );
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("error_mode", "skip_row", "max_errors", 100));
+        try (CloseableIterator<Page> it = reader.read(createStorageObject("id,v\n1,5\n2,-1\n3,7\n"), declaredCtx(schema))) {
+            assertTrue(it.hasNext());
+            Page page = it.next();
+            // Row 2 (v=-1, out of range) is dropped; rows 1 and 3 survive.
+            assertEquals(2, page.getPositionCount());
+            LongBlock v = (LongBlock) page.getBlock(1);
+            assertEquals(encoded("5"), v.getLong(0));
+            assertEquals(encoded("7"), v.getLong(1));
+            page.releaseBlocks();
+        }
+    }
+
     /** TSV rides the same reader; a declared unsigned_long must read identically there. */
     public void testDeclaredUnsignedLongReadsFromTsv() throws IOException {
         FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("delimiter", "\t"));

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -18,10 +18,12 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -35,7 +37,10 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
+import org.elasticsearch.xpack.esql.datasources.DeclaredSchemaValidator;
 import org.elasticsearch.xpack.esql.datasources.DrainSimulatingStorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -55,6 +60,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -7889,5 +7895,145 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         }
         assertEquals("bracket-aware lenient must drop the oversized row and keep the surrounding rows", 2L, total);
+    }
+
+    // --- declared unsigned_long reads ---
+
+    private static List<Attribute> declared(String name, DataType type) {
+        return List.of(new ReferenceAttribute(Source.EMPTY, null, name, type));
+    }
+
+    private static FormatReadContext declaredCtx(List<Attribute> schema) {
+        return FormatReadContext.builder().firstSplit(true).recordAligned(true).batchSize(10).readSchema(schema).build();
+    }
+
+    /** Reads one declared column and returns its block, or fails if the reader produced no page. */
+    private LongBlock readOneUnsignedLongColumn(FormatReader reader, String csv) throws IOException {
+        try (CloseableIterator<Page> it = reader.read(createStorageObject(csv), declaredCtx(declared("v", DataType.UNSIGNED_LONG)))) {
+            assertTrue("reader produced no page", it.hasNext());
+            return (LongBlock) it.next().getBlock(0);
+        }
+    }
+
+    private static long encoded(String magnitude) {
+        return NumericUtils.asLongUnsigned(new BigInteger(magnitude));
+    }
+
+    /**
+     * The bug this fixes: a declared unsigned_long was accepted by DeclaredSchemaValidator and then threw at
+     * block-builder construction, so every FROM over the column failed regardless of error_mode. Values across
+     * the whole [0, 2^64-1] domain — crucially the (2^63, 2^64) range that overflows a signed long — must now
+     * read back at full magnitude, in the sign-flip encoding every downstream unsigned_long surface decodes.
+     */
+    public void testDeclaredUnsignedLongReadsFullDomain() throws IOException {
+        String csv = "v\n0\n12345\n9223372036854775808\n18446744073709551615\n";
+        FormatReader reader = new CsvFormatReader(blockFactory);
+        LongBlock block = readOneUnsignedLongColumn(reader, csv);
+        assertEquals(4, block.getPositionCount());
+        assertEquals(encoded("0"), block.getLong(0));
+        assertEquals(encoded("12345"), block.getLong(1));
+        assertEquals(encoded("9223372036854775808"), block.getLong(2));   // 2^63, overflows signed long
+        assertEquals(encoded("18446744073709551615"), block.getLong(3));  // 2^64-1
+    }
+
+    /** Fractional and scientific tokens truncate toward zero — matching ::unsigned_long, deliberately unlike long's rounding. */
+    public void testDeclaredUnsignedLongTruncatesTowardZero() throws IOException {
+        FormatReader reader = new CsvFormatReader(blockFactory);
+        LongBlock block = readOneUnsignedLongColumn(reader, "v\n42.9\n1e3\n");
+        assertEquals(encoded("42"), block.getLong(0));
+        assertEquals(encoded("1000"), block.getLong(1));
+    }
+
+    /** An absent/empty cell nulls the cell exactly as it does for a declared long — no special arm. */
+    public void testDeclaredUnsignedLongNullsEmptyCell() throws IOException {
+        // Two columns so the empty trailing cell is unambiguous — a blank line would be a skipped row, not a cell.
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "k", DataType.KEYWORD),
+            new ReferenceAttribute(Source.EMPTY, null, "v", DataType.UNSIGNED_LONG)
+        );
+        FormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> it = reader.read(createStorageObject("k,v\nrow1,\nrow2,7\n"), declaredCtx(schema))) {
+            assertTrue(it.hasNext());
+            LongBlock block = (LongBlock) it.next().getBlock(1);
+            assertTrue("empty cell must be null", block.isNull(0));
+            assertEquals(encoded("7"), block.getLong(1));
+        }
+    }
+
+    /**
+     * A bad VALUE is a data failure the error policy governs — not a schema failure. Before this change every
+     * mode hard-failed at page setup; now fail_fast aborts and null_field nulls just the offending cell.
+     */
+    public void testDeclaredUnsignedLongBadValueHonorsErrorMode() throws IOException {
+        // negative and out-of-range are both outside [0, 2^64-1]
+        String csv = "v\n-1\n18446744073709551616\nabc\n5\n";
+
+        FormatReader failFast = new CsvFormatReader(blockFactory);
+        expectThrows(Exception.class, () -> readOneUnsignedLongColumn(failFast, csv));
+
+        FormatReader lenient = new CsvFormatReader(blockFactory).withConfig(Map.of("error_mode", "null_field", "max_errors", 100));
+        LongBlock block = readOneUnsignedLongColumn(lenient, csv);
+        assertEquals(4, block.getPositionCount());
+        assertTrue("negative must null the cell", block.isNull(0));
+        assertTrue("2^64 must null the cell", block.isNull(1));
+        assertTrue("garbage must null the cell", block.isNull(2));
+        assertEquals("the good cell still reads", encoded("5"), block.getLong(3));
+    }
+
+    /** TSV rides the same reader; a declared unsigned_long must read identically there. */
+    public void testDeclaredUnsignedLongReadsFromTsv() throws IOException {
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("delimiter", "\t"));
+        LongBlock block = readOneUnsignedLongColumn(reader, "v\n18446744073709551615\n");
+        assertEquals(encoded("18446744073709551615"), block.getLong(0));
+    }
+
+    /** The typed-header intake is the second schema surface; it must know unsigned_long under both spellings. */
+    public void testTypedHeaderAcceptsUnsignedLongAliases() throws IOException {
+        for (String spelling : List.of("unsigned_long", "UNSIGNED_LONG", "ul", "UL")) {
+            CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("typed_header", true));
+            List<Attribute> schema = reader.metadata(createStorageObject("v:" + spelling + "\n18446744073709551615\n")).schema();
+            assertEquals("spelling [" + spelling + "]", DataType.UNSIGNED_LONG, schema.get(0).dataType());
+        }
+    }
+
+    /**
+     * Drift pin. Every type a user may declare must be buildable by this reader with exactly the block shape the
+     * shared authority prescribes. CsvFormatReader used to re-derive that mapping locally and silently omitted
+     * unsigned_long; deriving it from DeclaredTypeCoercions.elementTypeFor is what makes this assertion hold, and
+     * this test is what stops the next declarable type from repeating the bug.
+     */
+    public void testEveryDeclarableTypeBuildsTheAuthorityShape() throws IOException {
+        Map<DataType, String> token = Map.of(
+            DataType.KEYWORD,
+            "abc",
+            DataType.TEXT,
+            "abc",
+            DataType.LONG,
+            "123",
+            DataType.INTEGER,
+            "123",
+            DataType.DOUBLE,
+            "1.5",
+            DataType.BOOLEAN,
+            "true",
+            DataType.DATETIME,
+            "2020-01-01T00:00:00.000Z",
+            DataType.UNSIGNED_LONG,
+            "18446744073709551615",
+            DataType.IP,
+            "192.168.0.1"
+        );
+        for (DataType type : DeclaredSchemaValidator.declarableTypes()) {
+            String cell = token.get(type);
+            assertNotNull("no fixture token for declarable type [" + type + "] — add one", cell);
+            FormatReader reader = new CsvFormatReader(blockFactory);
+            try (CloseableIterator<Page> it = reader.read(createStorageObject("v\n" + cell + "\n"), declaredCtx(declared("v", type)))) {
+                assertTrue("no page for declared [" + type + "]", it.hasNext());
+                Block block = it.next().getBlock(0);
+                ElementType expected = DeclaredTypeCoercions.elementTypeFor(type);
+                assertEquals("shape drift for declared [" + type + "]", expected, block.elementType());
+                assertFalse("declared [" + type + "] produced a null cell — missing tokenization arm?", block.isNull(0));
+            }
+        }
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -7991,11 +7991,11 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * A token whose decimal exponent is large enough that expanding it would overflow BigInteger --
-     * "1e999999999" -- makes BigDecimal.toBigInteger() throw ArithmeticException, which is not an
-     * IllegalArgumentException. Unhandled it escapes the per-field catch and hard-fails the whole read on every
-     * error_mode, which is precisely the failure declared unsigned_long support exists to remove. It must instead
-     * be an ordinary out-of-range cell.
+     * A token whose decimal exponent is large enough that materializing the integer would overflow BigInteger --
+     * "1e999999999", and "1e-999999999" which truncates toward 0 but cannot be computed to get there -- makes
+     * BigDecimal.toBigInteger() throw ArithmeticException, which is not an IllegalArgumentException. Unhandled it
+     * escapes the per-field catch and hard-fails the whole read on every error_mode, precisely the failure declared
+     * unsigned_long support exists to remove. It must instead be an ordinary per-cell failure.
      */
     public void testDeclaredUnsignedLongExoticExponentIsAPerCellFailure() throws IOException {
         String csv = "v\n1e999999999\n1e-999999999\n5\n";

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -1346,7 +1346,7 @@ public class NdJsonPageDecoder implements Closeable {
                 try {
                     blockBuilder = DeclaredTypeCoercions.builderFor(dataType, blockFactory, batchSize);
                 } catch (IllegalArgumentException e) {
-                    throw unsupportedTypeForNdjson(dataType);
+                    throw unsupportedTypeForNdjson(dataType, e);
                 }
                 blockBuilders[blockIdx] = blockBuilder;
             }
@@ -1367,8 +1367,13 @@ public class NdJsonPageDecoder implements Closeable {
          * supported type takes the per-cell error policy instead.
          */
         private IllegalArgumentException unsupportedTypeForNdjson(DataType type) {
+            return unsupportedTypeForNdjson(type, null);
+        }
+
+        private IllegalArgumentException unsupportedTypeForNdjson(DataType type, Throwable cause) {
             return new IllegalArgumentException(
-                "column [" + name + "] has declared type [" + type.typeName() + "] which is not supported for NDJSON reads"
+                "column [" + name + "] has declared type [" + type.typeName() + "] which is not supported for NDJSON reads",
+                cause
             );
         }
 
@@ -1806,7 +1811,10 @@ public class NdJsonPageDecoder implements Closeable {
                 try {
                     long encoded = DeclaredTypeCoercions.coerceToUnsignedLong(parser.getValueAsString());
                     ((LongBlock.Builder) blockBuilder).appendLong(encoded);
-                } catch (IllegalArgumentException | InvalidArgumentException e) {
+                } catch (IllegalArgumentException e) {
+                    // coerceToUnsignedLong signals every bad token with an IllegalArgumentException (its range guard,
+                    // the ArithmeticException remap, and the NumberFormatException subclass from BigDecimal); unlike
+                    // strictParseBoolean it never throws InvalidArgumentException, so one catch clause covers it.
                     coercionFailure(blockBuilder, parser, inArray, DataType.UNSIGNED_LONG);
                 }
             } else {

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -1362,8 +1362,9 @@ public class NdJsonPageDecoder implements Closeable {
          * The declared type passed create + resolution (it is in {@code DeclaredSchemaValidator.DECLARABLE_TYPES})
          * but NDJSON has no decoder arm for it, or the declared-read SPI has no block shape for it. Names the
          * column and type so the failure is actionable rather than a bare internal error.
-         * Reserved for the {@code default} arm of the two type switches: an unexpected value there is a coverage
-         * gap, not a routine per-record condition.
+         * Raised from builder setup, where the SPI rejects the type, and from the {@code default} arm of the value
+         * decode switch. Either is a coverage gap, not a routine per-record condition: a bad <em>value</em> of a
+         * supported type takes the per-cell error policy instead.
          */
         private IllegalArgumentException unsupportedTypeForNdjson(DataType type) {
             return new IllegalArgumentException(

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -24,7 +24,6 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.ConstantNullBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -50,6 +49,7 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.nio.CharBuffer;
 import java.time.DateTimeException;
 import java.util.ArrayList;
@@ -1340,17 +1340,14 @@ public class NdJsonPageDecoder implements Closeable {
         // Builders setup independently as we need to create new ones for each page.
         void setupBuilders(Block.Builder[] blockBuilders) {
             if (dataType != null) {
-                blockBuilder = switch (dataType) {
-                    // Keep in sync with NdJsonSchemaInferrer.inferValueSchema
-                    case BOOLEAN -> blockFactory.newBooleanBlockBuilder(batchSize);
-                    case NULL -> new ConstantNullBlock.Builder(blockFactory);
-                    case INTEGER -> blockFactory.newIntBlockBuilder(batchSize);
-                    case LONG -> blockFactory.newLongBlockBuilder(batchSize);
-                    case DOUBLE -> blockFactory.newDoubleBlockBuilder(batchSize);
-                    case KEYWORD, TEXT, IP -> blockFactory.newBytesRefBlockBuilder(batchSize);
-                    case DATETIME -> blockFactory.newLongBlockBuilder(batchSize); // milliseconds since epoch
-                    default -> throw unsupportedTypeForNdjson(dataType);
-                };
+                // The type -> block-shape mapping is not re-derived here: it belongs to the declared-read SPI,
+                // which delegates the enumeration to PlannerUtils.toElementType. A reader-local copy of it is
+                // exactly how unsigned_long came to pass dataset validation and then throw at page setup.
+                try {
+                    blockBuilder = DeclaredTypeCoercions.builderFor(dataType, blockFactory, batchSize);
+                } catch (IllegalArgumentException e) {
+                    throw unsupportedTypeForNdjson(dataType);
+                }
                 blockBuilders[blockIdx] = blockBuilder;
             }
 
@@ -1363,8 +1360,8 @@ public class NdJsonPageDecoder implements Closeable {
 
         /**
          * The declared type passed create + resolution (it is in {@code DeclaredSchemaValidator.DECLARABLE_TYPES})
-         * but NDJSON has no builder/decoder arm for it — for example {@code unsigned_long}, which no text format
-         * reads yet. Names the column and type so the failure is actionable rather than a bare internal error.
+         * but NDJSON has no decoder arm for it, or the declared-read SPI has no block shape for it. Names the
+         * column and type so the failure is actionable rather than a bare internal error.
          * Reserved for the {@code default} arm of the two type switches: an unexpected value there is a coverage
          * gap, not a routine per-record condition.
          */
@@ -1670,6 +1667,7 @@ public class NdJsonPageDecoder implements Closeable {
                 case BOOLEAN -> decodeBooleanValue(parser, token, inArray);
                 case INTEGER -> decodeIntValue(parser, token, inArray);
                 case LONG -> decodeLongValue(parser, token, inArray);
+                case UNSIGNED_LONG -> decodeUnsignedLongValue(parser, token, inArray);
                 case DOUBLE -> decodeDoubleValue(parser, token, inArray);
                 case DATETIME -> decodeDatetimeValue(parser, token, inArray);
                 case KEYWORD, TEXT -> {
@@ -1783,6 +1781,35 @@ public class NdJsonPageDecoder implements Closeable {
                 }
             } else {
                 crossKindDrift(parser, inArray, DataType.LONG); // boolean in a number column: unsupported cross-kind drift
+            }
+        }
+
+        /**
+         * The {@code unsigned_long} twin of {@link #decodeLongValue}. A JSON integer is read as a
+         * {@link BigInteger} rather than a {@code long} because the interesting half of the domain --
+         * {@code (2^63, 2^64)} -- does not fit a signed long and would trip {@code getLongValue}. Float and
+         * string tokens go through the same {@link DeclaredTypeCoercions#coerceToUnsignedLong} scalar the CSV
+         * and columnar readers use, so truncation-toward-zero and the {@code [0, 2^64-1]} range check are
+         * identical across every format. A bad value fails the cell through the error policy; only a
+         * cross-kind token (a boolean in a numeric column) takes the drift path.
+         */
+        private void decodeUnsignedLongValue(JsonParser parser, JsonToken token, boolean inArray) throws IOException {
+            if (token == JsonToken.VALUE_NUMBER_INT) {
+                try {
+                    long encoded = DeclaredTypeCoercions.coerceToUnsignedLong(parser.getBigIntegerValue());
+                    ((LongBlock.Builder) blockBuilder).appendLong(encoded);
+                } catch (IllegalArgumentException | InputCoercionException e) {
+                    coercionFailure(blockBuilder, parser, inArray, DataType.UNSIGNED_LONG);
+                }
+            } else if (token == JsonToken.VALUE_NUMBER_FLOAT || token == JsonToken.VALUE_STRING) {
+                try {
+                    long encoded = DeclaredTypeCoercions.coerceToUnsignedLong(parser.getValueAsString());
+                    ((LongBlock.Builder) blockBuilder).appendLong(encoded);
+                } catch (IllegalArgumentException | InvalidArgumentException e) {
+                    coercionFailure(blockBuilder, parser, inArray, DataType.UNSIGNED_LONG);
+                }
+            } else {
+                crossKindDrift(parser, inArray, DataType.UNSIGNED_LONG);
             }
         }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -672,6 +672,21 @@ public class NdJsonPageDecoderTests extends ESTestCase {
         }
     }
 
+    /**
+     * "1e999999999" makes BigDecimal.toBigInteger() throw ArithmeticException -- not an IllegalArgumentException, so
+     * an unhandled one escapes the per-cell catch and hard-fails the read on every error_mode. It must be an
+     * ordinary out-of-range cell instead.
+     */
+    public void testDeclaredUnsignedLongExoticExponentIsAPerCellFailure() throws IOException {
+        String ndjson = "{\"v\":\"1e999999999\"}\n{\"v\":1e999999999}\n{\"v\":5}\n";
+        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.LENIENT)) {
+            LongBlock block = page.getBlock(0);
+            assertTrue("string exotic exponent nulls the cell", block.isNull(0));
+            assertTrue("numeric exotic exponent nulls the cell", block.isNull(1));
+            assertEquals("the good cell still decodes", encoded("5"), block.getLong(2));
+        }
+    }
+
     /** Multivalue unsigned_long arrays decode element-by-element through the same coercer. */
     public void testDeclaredUnsignedLongMultivalue() throws IOException {
         try (Page page = decodeOneColumn("{\"v\":[1,18446744073709551615]}\n", DataType.UNSIGNED_LONG, ErrorPolicy.STRICT)) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.IntBlock;
@@ -21,6 +22,9 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
+import org.elasticsearch.xpack.esql.datasources.DeclaredSchemaValidator;
+import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.hamcrest.Matchers;
@@ -29,6 +33,7 @@ import org.junit.After;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -587,5 +592,133 @@ public class NdJsonPageDecoderTests extends ESTestCase {
         f.setAccessible(true);
         BytesRef ref = (BytesRef) f.get(decoder);
         return ref.bytes.length;
+    }
+
+    // --- declared unsigned_long reads ---
+
+    private static long encoded(String magnitude) {
+        return NumericUtils.asLongUnsigned(new BigInteger(magnitude));
+    }
+
+    private Page decodeOneColumn(String ndjson, DataType type, ErrorPolicy policy) throws IOException {
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                null,
+                List.of(attribute("v", type)),
+                null,
+                10,
+                blockFactory,
+                policy,
+                "test://ul",
+                new NdJsonReaderCounters()
+            )
+        ) {
+            return decoder.decodePage();
+        }
+    }
+
+    /**
+     * Before this change setupBuilders threw for a declared unsigned_long at block-builder construction — up
+     * front, per page — so the read failed regardless of error_mode. The full [0, 2^64-1] domain must now decode,
+     * from JSON integer tokens that overflow a signed long and from string tokens alike.
+     */
+    public void testDeclaredUnsignedLongDecodesFullDomain() throws IOException {
+        String ndjson =
+            "{\"v\":0}\n{\"v\":12345}\n{\"v\":9223372036854775808}\n{\"v\":18446744073709551615}\n{\"v\":\"18446744073709551614\"}\n";
+        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.STRICT)) {
+            assertNotNull(page);
+            LongBlock block = page.getBlock(0);
+            assertEquals(5, block.getPositionCount());
+            assertEquals(encoded("0"), block.getLong(0));
+            assertEquals(encoded("12345"), block.getLong(1));
+            assertEquals(encoded("9223372036854775808"), block.getLong(2));   // 2^63 — getLongValue would overflow
+            assertEquals(encoded("18446744073709551615"), block.getLong(3));  // 2^64-1
+            assertEquals(encoded("18446744073709551614"), block.getLong(4));  // string token
+        }
+    }
+
+    /** Fractional and scientific tokens truncate toward zero, matching ::unsigned_long and the CSV reader. */
+    public void testDeclaredUnsignedLongTruncatesTowardZero() throws IOException {
+        try (Page page = decodeOneColumn("{\"v\":42.9}\n{\"v\":\"1e3\"}\n", DataType.UNSIGNED_LONG, ErrorPolicy.STRICT)) {
+            LongBlock block = page.getBlock(0);
+            assertEquals(encoded("42"), block.getLong(0));
+            assertEquals(encoded("1000"), block.getLong(1));
+        }
+    }
+
+    /** A missing field nulls the cell, exactly as for a declared long. */
+    public void testDeclaredUnsignedLongNullsMissingField() throws IOException {
+        try (Page page = decodeOneColumn("{\"other\":1}\n{\"v\":7}\n", DataType.UNSIGNED_LONG, ErrorPolicy.STRICT)) {
+            LongBlock block = page.getBlock(0);
+            assertTrue("absent field must null the cell", block.isNull(0));
+            assertEquals(encoded("7"), block.getLong(1));
+        }
+    }
+
+    /**
+     * A bad VALUE is a per-cell data failure the error policy governs — never the blanket
+     * unsupportedTypeForNdjson throw that used to fire before any cell was even looked at.
+     */
+    public void testDeclaredUnsignedLongBadValueIsPerCellUnderLenient() throws IOException {
+        String ndjson = "{\"v\":-1}\n{\"v\":18446744073709551616}\n{\"v\":\"abc\"}\n{\"v\":5}\n";
+        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.LENIENT)) {
+            LongBlock block = page.getBlock(0);
+            assertEquals(4, block.getPositionCount());
+            assertTrue("negative nulls the cell", block.isNull(0));
+            assertTrue("2^64 nulls the cell", block.isNull(1));
+            assertTrue("garbage nulls the cell", block.isNull(2));
+            assertEquals("the good cell still decodes", encoded("5"), block.getLong(3));
+        }
+    }
+
+    /** Multivalue unsigned_long arrays decode element-by-element through the same coercer. */
+    public void testDeclaredUnsignedLongMultivalue() throws IOException {
+        try (Page page = decodeOneColumn("{\"v\":[1,18446744073709551615]}\n", DataType.UNSIGNED_LONG, ErrorPolicy.STRICT)) {
+            LongBlock block = page.getBlock(0);
+            assertEquals(2, block.getValueCount(0));
+            int first = block.getFirstValueIndex(0);
+            assertEquals(encoded("1"), block.getLong(first));
+            assertEquals(encoded("18446744073709551615"), block.getLong(first + 1));
+        }
+    }
+
+    /**
+     * Drift pin. setupBuilders no longer enumerates the type -> shape mapping; it derives it from the shared
+     * authority. Every declarable type must therefore build, with the shape that authority prescribes, and no
+     * type may reach unsupportedTypeForNdjson. This is what stops the next declarable type repeating the
+     * unsigned_long bug.
+     */
+    public void testEveryDeclarableTypeBuildsTheAuthorityShape() throws IOException {
+        Map<DataType, String> token = Map.of(
+            DataType.KEYWORD,
+            "\"abc\"",
+            DataType.TEXT,
+            "\"abc\"",
+            DataType.LONG,
+            "123",
+            DataType.INTEGER,
+            "123",
+            DataType.DOUBLE,
+            "1.5",
+            DataType.BOOLEAN,
+            "true",
+            DataType.DATETIME,
+            "\"2020-01-01T00:00:00.000Z\"",
+            DataType.UNSIGNED_LONG,
+            "18446744073709551615",
+            DataType.IP,
+            "\"192.168.0.1\""
+        );
+        for (DataType type : DeclaredSchemaValidator.declarableTypes()) {
+            String cell = token.get(type);
+            assertNotNull("no fixture token for declarable type [" + type + "] — add one", cell);
+            try (Page page = decodeOneColumn("{\"v\":" + cell + "}\n", type, ErrorPolicy.STRICT)) {
+                assertNotNull("no page for declared [" + type + "]", page);
+                Block block = page.getBlock(0);
+                assertEquals("shape drift for declared [" + type + "]", DeclaredTypeCoercions.elementTypeFor(type), block.elementType());
+                assertFalse("declared [" + type + "] produced a null cell — missing decode arm?", block.isNull(0));
+            }
+        }
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -77,6 +77,8 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
 
     private Path csvFixture;
     private Path csvFixtureAlt;
+    private Path csvUnsignedLongFixture;
+    private Path ndjsonUnsignedLongFixture;
     private Path ndjsonFixture;
     private Path csvDateFixture;
     private Path ndjsonDateFixture;
@@ -106,6 +108,18 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         Files.writeString(csvFixture, String.join("\n", "emp_no:integer,first_name:keyword", "1,Alice", "2,Bob", "3,Carol") + "\n");
         csvFixtureAlt = createTempFile("dataset-fixture-alt-", ".csv");
         Files.writeString(csvFixtureAlt, String.join("\n", "emp_no:integer,first_name:keyword", "10,Diana", "11,Eve") + "\n");
+        // unsigned_long fixtures: the interesting values live in (2^63, 2^64) — they overflow a signed long, so a
+        // reader that quietly routes them through the long path corrupts them rather than failing.
+        csvUnsignedLongFixture = createTempFile("dataset-ul-fixture-", ".csv");
+        Files.writeString(
+            csvUnsignedLongFixture,
+            String.join("\n", "id,v", "1,0", "2,9223372036854775808", "3,18446744073709551615") + "\n"
+        );
+        ndjsonUnsignedLongFixture = createTempFile("dataset-ul-fixture-", ".ndjson");
+        Files.writeString(
+            ndjsonUnsignedLongFixture,
+            String.join("\n", "{\"id\":1,\"v\":0}", "{\"id\":2,\"v\":9223372036854775808}", "{\"id\":3,\"v\":18446744073709551615}") + "\n"
+        );
         // NDJSON fixture with the SAME physical field names (emp_no/first_name) as the CSV fixture, so rename tests can
         // exercise the by-name (JSON key) read path: a declared `source` maps the logical column to its JSON field.
         ndjsonFixture = createTempFile("dataset-fixture-", ".ndjson");
@@ -3275,5 +3289,69 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
 
     private static DeleteDatasetAction.Request deleteDatasetRequest(String name) {
         return new DeleteDatasetAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+
+    /**
+     * A declared {@code unsigned_long} was accepted by PUT dataset and then failed every
+     * {@code FROM} over it on the text formats — the readers re-derived the type→block-shape mapping locally and
+     * omitted the type, so they threw at page setup, before {@code error_mode} could apply. End-to-end, the full
+     * {@code [0, 2^64-1]} domain must now come back at full magnitude, identically from CSV and NDJSON, and equal
+     * to what an explicit {@code ::unsigned_long} cast of the same token produces.
+     */
+    private void assertDeclaredUnsignedLongReadsFullMagnitude(String datasetName, Path fixture, String format) throws Exception {
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("id", new DatasetFieldMapping("long", null));
+        properties.put("v", new DatasetFieldMapping("unsigned_long", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    datasetName,
+                    "local_ds",
+                    fixture.toUri().toString(),
+                    null,
+                    new HashMap<>(Map.of("format", format)),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM " + datasetName + " | SORT id | LIMIT 10"), TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(3));
+            // Column type must survive as unsigned_long, not silently widen.
+            assertThat(response.columns().get(1).type().typeName(), equalTo("unsigned_long"));
+            assertThat(rows.get(0).get(1).toString(), equalTo("0"));
+            assertThat(rows.get(1).get(1).toString(), equalTo("9223372036854775808"));   // 2^63
+            assertThat(rows.get(2).get(1).toString(), equalTo("18446744073709551615"));  // 2^64-1
+        }
+
+        // Cast parity: the declared read agrees with an explicit ::unsigned_long over the same magnitudes.
+        try (
+            var response = run(
+                syncEsqlQueryRequest(
+                    "FROM " + datasetName + " | SORT id | EVAL same = (v == \"18446744073709551615\"::unsigned_long) | LIMIT 10"
+                ),
+                TIMEOUT
+            )
+        ) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.get(2).get(rows.get(2).size() - 1), equalTo(true));
+            assertThat(rows.get(0).get(rows.get(0).size() - 1), equalTo(false));
+        }
+    }
+
+    public void testDeclaredUnsignedLongReadsFromCsv() throws Exception {
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertDeclaredUnsignedLongReadsFullMagnitude("ul_csv", csvUnsignedLongFixture, "csv");
+    }
+
+    public void testDeclaredUnsignedLongReadsFromNdjson() throws Exception {
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertDeclaredUnsignedLongReadsFullMagnitude("ul_ndjson", ndjsonUnsignedLongFixture, "ndjson");
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
@@ -33,8 +33,8 @@ import java.util.TreeSet;
  *
  * <p>What is deliberately <b>not</b> checked here (deferred to first-query mapping resolution, because PUT does no
  * I/O and the files may not exist yet): that the {@code _id.path} column exists when it is inferred rather than declared; that
- * a declared {@code path}/type matches the physical file; per-format narrowing (e.g. {@code unsigned_long} is
- * Parquet-only) — the producing format is authoritative at read time.
+ * a declared {@code path}/type matches the physical file; per-format narrowing, should a format ever be unable to
+ * read a declarable type — the producing format is authoritative at read time.
  */
 public final class DeclaredSchemaValidator {
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
@@ -58,6 +58,16 @@ public final class DeclaredSchemaValidator {
         DataType.IP
     );
 
+    /**
+     * The types a user may declare on a dataset mapping. Exposed so a format reader's tests can pin that the reader
+     * actually builds every declarable type with the shape {@link
+     * org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions#elementTypeFor} prescribes — the drift
+     * that let a declared {@code unsigned_long} pass validation and then fail at read.
+     */
+    public static Set<DataType> declarableTypes() {
+        return DECLARABLE_TYPES;
+    }
+
     public static void validate(DatasetMapping mapping) {
         if (mapping == null) {
             return;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.type.Converter;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -459,14 +460,25 @@ public final class DeclaredTypeCoercions {
      */
     public static long coerceToUnsignedLong(Object value) {
         BigInteger big;
-        if (value instanceof BigInteger bigInteger) {
-            big = bigInteger;
-        } else if (value instanceof Double || value instanceof Float) {
-            big = BigDecimal.valueOf(((Number) value).doubleValue()).toBigInteger();
-        } else if (value instanceof Number number) {
-            big = BigInteger.valueOf(number.longValue());
-        } else {
-            big = new BigDecimal(value.toString()).toBigInteger();
+        try {
+            if (value instanceof BigInteger bigInteger) {
+                big = bigInteger;
+            } else if (value instanceof Double || value instanceof Float) {
+                big = BigDecimal.valueOf(((Number) value).doubleValue()).toBigInteger();
+            } else if (value instanceof Number number) {
+                big = BigInteger.valueOf(number.longValue());
+            } else {
+                big = new BigDecimal(value.toString()).toBigInteger();
+            }
+        } catch (ArithmeticException e) {
+            // BigDecimal.toBigInteger() throws (rather than returning a value we could range-check) when the
+            // decimal exponent is large enough that expanding it would overflow BigInteger's supported range --
+            // e.g. "1e999999999" or "1e-999999999". Such a token is out of [0, 2^64-1] by definition, so it is the
+            // same failure as any other out-of-range value and must reach callers as the same exception type. It is
+            // remapped here, at the one place that parses, rather than in each caller's catch clause: an
+            // ArithmeticException escaping this method would bypass every reader's per-cell error policy and hard-
+            // fail the whole read, which is exactly the class of failure declared unsigned_long support removes.
+            throw new IllegalArgumentException("Value [" + value + "] is out of range for an unsigned_long", e);
         }
         if (big.signum() < 0 || NumericUtils.isUnsignedLong(big) == false) {
             throw new IllegalArgumentException("Value [" + value + "] is out of range for an unsigned_long");
@@ -501,21 +513,32 @@ public final class DeclaredTypeCoercions {
     }
 
     /**
-     * The one {@link DataType} &rarr; {@link ElementType} authority for every reader that materializes a declared or
-     * projected column into a block. The <em>enumeration</em> is not repeated here: it is delegated to
-     * {@link PlannerUtils#toElementType}, the engine-wide mapping, so exactly one {@code DataType} switch over block
-     * shape exists in the codebase. What this method adds is the declared-read <em>guard</em>, expressed on the
-     * {@link ElementType} axis rather than as a second {@code DataType} enumeration: the scalar shapes this SPI's
-     * {@link #valueWriter} knows how to append, plus {@link ElementType#NULL}.
+     * The {@link DataType} &rarr; {@link ElementType} authority for the declared-read path: every format reader that
+     * materializes a declared or projected column into a block resolves its shape here. The <em>enumeration</em> is
+     * not repeated: it is delegated to {@link PlannerUtils#toElementType}, the engine-wide mapping, so the
+     * declared-read path holds no second {@code DataType} switch over block shape. What this method adds is the
+     * declared-read <em>guard</em>, expressed on the {@link ElementType} axis rather than as a second {@code DataType}
+     * enumeration: the scalar shapes this SPI's {@link #valueWriter} knows how to append, plus {@link ElementType#NULL}.
      * <p>
      * Expressing the guard on the shape axis is what keeps the readers honest. A future declarable type inherits its
      * block shape automatically, while a {@code DOC}/{@code COMPOSITE}/{@code AGGREGATE_METRIC_DOUBLE}-shaped type
      * still fails loudly at page setup instead of silently building the wrong block. Format readers must call this
      * rather than re-deriving the mapping locally — the reader-local copies are exactly how {@code unsigned_long}
      * came to be accepted at dataset-create time and then unreadable at query time.
+     *
+     * @throws IllegalArgumentException if the type has no block shape this SPI can write. This is the only exception
+     *         this method throws: {@link PlannerUtils#toElementType} signals its own unmappable types with an
+     *         {@code EsqlIllegalArgumentException}, which is <em>not</em> an {@code IllegalArgumentException}, so it
+     *         is remapped here. Callers therefore need one catch clause, and the contract matches the per-reader
+     *         mappings this method replaced.
      */
     public static ElementType elementTypeFor(DataType type) {
-        ElementType elementType = PlannerUtils.toElementType(type);
+        final ElementType elementType;
+        try {
+            elementType = PlannerUtils.toElementType(type);
+        } catch (EsqlIllegalArgumentException e) {
+            throw new IllegalArgumentException("type [" + type.typeName() + "] is not readable as a declared column", e);
+        }
         return switch (elementType) {
             case BOOLEAN, INT, LONG, DOUBLE, BYTES_REF, NULL -> elementType;
             default -> throw new IllegalArgumentException("type [" + type.typeName() + "] is not readable as a declared column");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -472,9 +472,10 @@ public final class DeclaredTypeCoercions {
             }
         } catch (ArithmeticException e) {
             // BigDecimal.toBigInteger() throws (rather than returning a value we could range-check) when the
-            // decimal exponent is large enough that expanding it would overflow BigInteger's supported range --
-            // e.g. "1e999999999" or "1e-999999999". Such a token is out of [0, 2^64-1] by definition, so it is the
-            // same failure as any other out-of-range value and must reach callers as the same exception type. It is
+            // decimal exponent is large enough that materializing the integer would overflow BigInteger's supported
+            // range -- e.g. "1e999999999", or "1e-999999999" which mathematically truncates to 0 but cannot be
+            // computed to get there. Such a token cannot be materialized and so cannot be range-checked; treat it as
+            // the same failure as any other unrepresentable value and reach callers as the same exception type. It is
             // remapped here, at the one place that parses, rather than in each caller's catch clause: an
             // ArithmeticException escaping this method would bypass every reader's per-cell error policy and hard-
             // fail the whole read, which is exactly the class of failure declared unsigned_long support removes.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.core.Nullable;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypeConverter;
 import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.math.BigDecimal;
@@ -449,8 +451,13 @@ public final class DeclaredTypeCoercions {
      * NumberType.parse} with {@code coerce=true}: numeric strings parse, decimals truncate toward
      * zero, out-of-[0, 2^64-1]-range throws. Returns the sign-flip block encoding
      * ({@link NumericUtils#asLongUnsigned(BigInteger)}), matching the index path.
+     * <p>
+     * Public for the same reason as {@link #strictParseBoolean} and {@link #parseDatetimeMillis}: the text
+     * readers (CSV/TSV, NDJSON) decode a token to a {@link String} or {@link Number} themselves and then
+     * delegate the declared-type conversion here, so a declared {@code unsigned_long} produces the identical
+     * block encoding regardless of file format.
      */
-    private static long coerceToUnsignedLong(Object value) {
+    public static long coerceToUnsignedLong(Object value) {
         BigInteger big;
         if (value instanceof BigInteger bigInteger) {
             big = bigInteger;
@@ -493,15 +500,34 @@ public final class DeclaredTypeCoercions {
         };
     }
 
-    private static Block.Builder builderFor(DataType to, BlockFactory blockFactory, int positions) {
-        return switch (to) {
-            case INTEGER -> blockFactory.newIntBlockBuilder(positions);
-            case LONG, UNSIGNED_LONG, DATETIME, DATE_NANOS -> blockFactory.newLongBlockBuilder(positions);
-            case DOUBLE -> blockFactory.newDoubleBlockBuilder(positions);
-            case BOOLEAN -> blockFactory.newBooleanBlockBuilder(positions);
-            case KEYWORD, TEXT, IP -> blockFactory.newBytesRefBlockBuilder(positions);
-            default -> throw new IllegalArgumentException("cannot coerce into [" + to.typeName() + "] blocks");
+    /**
+     * The one {@link DataType} &rarr; {@link ElementType} authority for every reader that materializes a declared or
+     * projected column into a block. The <em>enumeration</em> is not repeated here: it is delegated to
+     * {@link PlannerUtils#toElementType}, the engine-wide mapping, so exactly one {@code DataType} switch over block
+     * shape exists in the codebase. What this method adds is the declared-read <em>guard</em>, expressed on the
+     * {@link ElementType} axis rather than as a second {@code DataType} enumeration: the scalar shapes this SPI's
+     * {@link #valueWriter} knows how to append, plus {@link ElementType#NULL}.
+     * <p>
+     * Expressing the guard on the shape axis is what keeps the readers honest. A future declarable type inherits its
+     * block shape automatically, while a {@code DOC}/{@code COMPOSITE}/{@code AGGREGATE_METRIC_DOUBLE}-shaped type
+     * still fails loudly at page setup instead of silently building the wrong block. Format readers must call this
+     * rather than re-deriving the mapping locally — the reader-local copies are exactly how {@code unsigned_long}
+     * came to be accepted at dataset-create time and then unreadable at query time.
+     */
+    public static ElementType elementTypeFor(DataType type) {
+        ElementType elementType = PlannerUtils.toElementType(type);
+        return switch (elementType) {
+            case BOOLEAN, INT, LONG, DOUBLE, BYTES_REF, NULL -> elementType;
+            default -> throw new IllegalArgumentException("type [" + type.typeName() + "] is not readable as a declared column");
         };
+    }
+
+    /**
+     * The block builder for a declared column's target type, derived from {@link #elementTypeFor} so the builder and
+     * the {@link ElementType} a reader projects can never disagree.
+     */
+    public static Block.Builder builderFor(DataType to, BlockFactory blockFactory, int positions) {
+        return elementTypeFor(to).newBlockBuilder(positions, blockFactory);
     }
 
     private interface ValueWriter {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -39,8 +39,10 @@ import java.util.function.IntFunction;
 /**
  * The single source of truth for declared-type coercion on external datasets: which
  * (physical file type &rarr; declared type) pairs an external reader coerces at read time, how a
- * decoded physical block becomes a declared-type block ({@link #castBlock}), and the one scalar
- * conversion the string &rarr; date pair uses everywhere ({@link #parseDatetimeMillis}).
+ * decoded physical block becomes a declared-type block ({@link #castBlock}), the block shape a
+ * declared type reads into ({@link #elementTypeFor}/{@link #builderFor}, which every text and
+ * columnar reader consults instead of re-deriving it), and the one scalar conversion the
+ * string &rarr; date pair uses everywhere ({@link #parseDatetimeMillis}).
  *
  * <h2>The one concept: reading a file IS ingesting it</h2>
  * A dataset mapping may declare a column type that differs from the type physically in the file
@@ -481,7 +483,7 @@ public final class DeclaredTypeCoercions {
             // fail the whole read, which is exactly the class of failure declared unsigned_long support removes.
             throw new IllegalArgumentException("Value [" + value + "] is out of range for an unsigned_long", e);
         }
-        if (big.signum() < 0 || NumericUtils.isUnsignedLong(big) == false) {
+        if (NumericUtils.isUnsignedLong(big) == false) {  // isUnsignedLong already rejects negatives (signum >= 0)
             throw new IllegalArgumentException("Value [" + value + "] is out of range for an unsigned_long");
         }
         return NumericUtils.asLongUnsigned(big);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
@@ -24,6 +24,8 @@ import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.datasources.DeclaredSchemaValidator;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.math.BigInteger;
@@ -674,5 +676,41 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
                 into.add(detail);
             }
         };
+    }
+
+    /**
+     * BigDecimal.toBigInteger() throws ArithmeticException -- not an IllegalArgumentException -- when the decimal
+     * exponent is large enough that expanding it would overflow BigInteger. Escaping this method, it would bypass
+     * every reader's per-cell error policy and hard-fail the whole read. It is remapped to the ordinary
+     * out-of-range failure at the one place that parses.
+     */
+    public void testCoerceToUnsignedLongExoticExponentIsOutOfRangeNotArithmetic() {
+        for (String token : List.of("1e999999999", "1e-999999999")) {
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> DeclaredTypeCoercions.coerceToUnsignedLong(token)
+            );
+            assertThat(e.getMessage(), containsString("out of range for an unsigned_long"));
+        }
+    }
+
+    /** Every declarable type resolves to the shape PlannerUtils prescribes -- one enumeration, not two. */
+    public void testElementTypeForAgreesWithPlannerUtils() {
+        for (DataType type : DeclaredSchemaValidator.declarableTypes()) {
+            assertThat(DeclaredTypeCoercions.elementTypeFor(type), equalTo(PlannerUtils.toElementType(type)));
+        }
+    }
+
+    /**
+     * PlannerUtils.toElementType signals an unmappable type with EsqlIllegalArgumentException, which is NOT an
+     * IllegalArgumentException. elementTypeFor remaps it, so callers -- including NdJsonPageDecoder.setupBuilders,
+     * which wraps this in a catch(IllegalArgumentException) -- need exactly one catch clause.
+     */
+    public void testElementTypeForThrowsIllegalArgumentForUnmappableType() {
+        // SHORT is in toElementType's throw-set; DOC_DATA_TYPE maps to a shape this SPI cannot write.
+        for (DataType type : List.of(DataType.SHORT, DataType.DOC_DATA_TYPE)) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DeclaredTypeCoercions.elementTypeFor(type));
+            assertThat(e.getMessage(), containsString("is not readable as a declared column"));
+        }
     }
 }


### PR DESCRIPTION
## What this is about

A user declares a column as `unsigned_long` in a text dataset's mapping. `PUT _query/dataset` accepts it — `unsigned_long` is on `DeclaredSchemaValidator`'s declarable set. Every `FROM <dataset>` over that column then fails. Not a bad cell, not a warning: the whole query, on every `error_mode`, including `null_field` and `skip_row`.

The same declaration over Parquet or ORC works. So a 64-bit-unsigned column — counters, IDs, hashes, byte totals above `long`'s `2^63-1` — is readable from a Parquet lake and unreadable from the same data stored as CSV.

## Reproduction

Declare the column. This succeeds — `unsigned_long` is on `DeclaredSchemaValidator`'s declarable set, so `PUT` takes it:

```console
PUT _query/data_source/lake
{ "type": "s3", "settings": { "auth": "anonymous" } }

PUT _query/dataset/counters_csv
{
  "data_source": "lake",
  "resource": "s3://my-bucket/counters/*.csv",
  "settings": { "format": "csv" },
  "mappings": {
    "dynamic": "false",
    "properties": {
      "id": { "type": "long" },
      "v":  { "type": "unsigned_long" }
    }
  }
}
```

`counters/*.csv` holds the values that motivate the type at all — the third one needs all 64 bits:

```csv
id,v
1,0
2,9223372036854775808
3,18446744073709551615
```

Now read it:

```console
POST _query
{ "query": "FROM counters_csv | SORT id" }
```

```json
{ "error": { "type": "illegal_argument_exception",
             "reason": "Unsupported data type: UNSIGNED_LONG" }, "status": 400 }
```

The same declaration over an NDJSON resource:

```json
{ "error": { "type": "illegal_argument_exception",
             "reason": "column [v] has declared type [unsigned_long] which is not supported for NDJSON reads" },
  "status": 400 }
```

Both readers fail at block-builder construction, before a single cell is parsed — so `error_mode` never applies. Re-creating the dataset with `"settings": { "format": "csv", "error_mode": "null_field" }` returns the identical 400: the column is not nulled, the query dies. `skip_row` does not drop the rows either. There is no lenient path, because nothing ever reaches the per-cell error policy.

The identical mapping over a Parquet resource reads all three rows correctly.

After this change, `FROM counters_csv | SORT id` returns `v` typed `unsigned_long`, with `18446744073709551615` intact, and a bad cell (`-1`, `2^64`, `abc`) becomes a per-cell failure that `error_mode` governs.

## What this PR does

The readers throw at *block-builder construction*, before a single cell is parsed. That is why `error_mode` never gets a say.

They throw because each one hand-rolled its own private copy of the `DataType` → block-shape mapping, and both copies forgot `unsigned_long`. The mapping already had two central authorities, and **both already handled the type**:

- `PlannerUtils.toElementType` — public, engine-wide: `case LONG, DATETIME, DATE_NANOS, UNSIGNED_LONG, ... -> ElementType.LONG`
- `DeclaredTypeCoercions.builderFor` / `valueWriter` — the declared-read SPI, whose javadoc already says the `unsigned_long` coercer returns the sign-flip encoding

`DeclaredSchemaValidator` knew. `ColumnStatTypeSupport` knew. Only the two reader-local re-enumerations disagreed. The contract layer and the shape layer were right the whole time; the duplicates drifted.

So we did not add a `case UNSIGNED_LONG` to two more switches. That lands this type and leaves the next one to drift again — nothing links the copies at compile time. Instead:

- `DeclaredTypeCoercions.elementTypeFor` becomes the one accessor, delegating the enumeration to `PlannerUtils.toElementType`, so the declared-read path holds no second `DataType` switch over block shape. (`OrcFormatReader.createBlockAs` and `ArrowToEsql.forMinorType` still hand-roll their own; both are off this path and out of scope here.) `builderFor` collapses onto it and is promoted; `coerceToUnsignedLong` is promoted alongside its already-public twins `strictParseBoolean` and `parseDatetimeMillis`.
- `CsvFormatReader.javaClassForDataType` is **deleted**, not extended. Its four call sites read the SPI.
- `NdJsonPageDecoder.setupBuilders` derives its builders from the SPI. `unsupportedTypeForNdjson` stays as the backstop for a type the SPI itself has no shape for.

Adding `unsigned_long` then costs zero per-reader builder arms.

Shape converges; tokenization stays per-format, because a `String` range is not a JSON token. What each reader keeps is the arm that turns bytes into a value — and every arm delegates the conversion itself to the shared coercer, as the `boolean` and `datetime` arms already did.

Three surfaces the text readers also needed:

- **The CSV typed header.** `col:long` is a second schema intake, and it did not know `unsigned_long`. It learns `unsigned_long` and `ul`, so the two intakes stay 1:1.
- **The CSV direct-to-block fast path.** `unsigned_long` joins the cold fallback and must never join the `LONG` fast arm, which accumulates `neg ? -acc : acc` — no sign-flip, and nothing above `Long.MAX_VALUE`. Routing it there would have silently corrupted precisely the `(2^63, 2^64)` values this fixes. `CsvDirectBlockParityTests` pins that.
- **NDJSON integer tokens.** `decodeUnsignedLongValue` reads them as `BigInteger`, because the interesting half of the domain does not fit the `getLongValue()` the `long` arm uses.

With the type supported, a bad value finally becomes what it always should have been: a per-cell failure the error policy governs. `fail_fast` → 400, `null_field` → null cell, `skip_row` → row dropped. Identical across CSV, TSV and NDJSON, and matching Parquet on the same cell.

## Does it work?

CSV 800, NDJSON 253, Parquet 1132, ORC 191, `FromDatasetIT` 84, ES|QL datasources 2031 — green. Parquet and ORC are the regression surface, since `builderFor` sits on their declared-coercion path.

`FromDatasetIT` reads the `(2^63, 2^64)` range from CSV and NDJSON fixtures through a real cluster, asserts the column returns typed `unsigned_long` at full magnitude, and pins parity with an explicit `::unsigned_long` cast of the same token.

Each reader carries a drift pin: for every type in `DeclaredSchemaValidator.declarableTypes()`, the reader must build the shape the shared authority prescribes. These are not decoration — we removed the CSV tokenization arm and the NDJSON decode arm in turn and watched each pin go red.

An adversarial pass over the finished branch turned up one real hole, now closed. A declared `unsigned_long` cell of `1e999999999` made `BigDecimal.toBigInteger()` throw `ArithmeticException` — not an `IllegalArgumentException`, so caught nowhere on the chain, hard-failing the whole read on every `error_mode`. That is the very failure mode this PR removes for the type as a whole, surviving in one token class. It is remapped to the ordinary out-of-range failure at the one place that parses, so no caller grows a second catch clause. `elementTypeFor` likewise remaps `PlannerUtils.toElementType`'s `EsqlIllegalArgumentException`, which is not an `IllegalArgumentException` either, so the SPI throws exactly one exception type — restoring the contract of the per-reader mappings it replaced. Both are pinned by tests that go red without the fix.

## What's in the diff

| | |
|---|---|
| `DeclaredTypeCoercions` | `elementTypeFor` added; `builderFor` collapsed onto it and promoted; `coerceToUnsignedLong` promoted |
| `DeclaredSchemaValidator` | `declarableTypes()` accessor, for the reader drift pins |
| `CsvFormatReader` | `javaClassForDataType` deleted; `tryParseUnsignedLong`; arms in `tryConvertValue` and `parseElement`; typed-header aliases; `emitPlainField` cold-path routing |
| `NdJsonPageDecoder` | `setupBuilders` derives from the SPI; `decodeUnsignedLongValue`; `unsupportedTypeForNdjson` javadoc corrected |

## What's out of scope

**Teaching the inferrers to emit `unsigned_long`.** Neither text inferrer produces it and neither should: inference cannot distinguish a large `unsigned_long` from a `double` without declared intent, and widening is the documented behavior. This is a declared-schema capability, reachable only when the user asks for the type by name.

**Stats parity.** `ColumnStatsAccumulator` deliberately untracks `unsigned_long` — it is stored as a signed long, so a signed compare flips above `2^63`. Parquet can serve `unsigned_long` stats because it sign-flip-encodes them into its footer. Text `unsigned_long` therefore reaches value-parity with Parquet but not stats-parity: no min/max, hence no stat-based pruning. Correct but slower, never wrong. Called out so it is not later mistaken for a regression.

**ORC and parquet-rs.** Untouched. ORC already reads the type through the shared coercion path; Parquet is the parity oracle here, as a read-only reference.
