### PR TITLE
[9.5] Correctly detect is sub-query is performing remote lookup join (#153135)

### DIFF
--- a/docs/changelog/153135.yaml
+++ b/docs/changelog/153135.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153135
+summary: Correctly detect is sub-query is performing remote lookup join
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestAnalyzer.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestAnalyzer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
@@ -62,6 +63,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.groupingBy;
 import static junit.framework.Assert.assertTrue;
 import static org.elasticsearch.test.ESTestCase.expectThrows;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_IP_LOCATION_RESOLUTION;
@@ -907,8 +909,10 @@ public class TestAnalyzer {
      * Load a mapping file.
      */
     public static IndexResolution loadMapping(String resource, String indexName, IndexMode indexMode) {
+        var grouped = Arrays.stream(indexName.split(","))
+            .collect(groupingBy(index -> RemoteClusterAware.splitIndexName(index).getClusterGroupingKey()));
         return IndexResolution.valid(
-            new EsIndex(indexName, EsqlTestUtils.loadMapping(resource), Map.of(indexName, indexMode), Map.of(), Map.of())
+            new EsIndex(indexName, EsqlTestUtils.loadMapping(resource), Map.of(indexName, indexMode), grouped, grouped)
         );
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterSubqueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterSubqueryIT.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -503,6 +504,28 @@ public class CrossClusterSubqueryIT extends AbstractCrossClusterTestCase {
 
             EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
             assertCCSExecutionInfoDetails(executionInfo);
+        }
+    }
+
+    public void testLocalJoinAndRemoteSubquery() {
+        populateLookupIndex(LOCAL_CLUSTER, "values_lookup", 10);
+
+        try (var response = runQuery("""
+            FROM
+                (FROM logs-* | STATS mv = max(v) BY tag | LOOKUP JOIN values_lookup on mv == lookup_key),
+                (FROM *:logs-* | STATS mv = max(v) BY tag)
+            | KEEP tag, lookup_tag, mv
+            | SORT tag
+            """, randomBoolean())) {
+            assertEquals(
+                getValuesList(response),
+                List.of(
+                    List.of("local", "local", 9L),
+                    // lookup_tag is only populated on local indices above and not joined on remote indices below
+                    Arrays.asList("remote", null, 81L)
+                )
+            );
+            assertCCSExecutionInfoDetails(response.getExecutionInfo());
         }
     }
 
@@ -1306,18 +1329,21 @@ public class CrossClusterSubqueryIT extends AbstractCrossClusterTestCase {
         populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup", 20);
         populateLookupIndex(REMOTE_CLUSTER_2, "values_lookup", 20);
 
-        VerificationException ex = expectThrows(VerificationException.class, () -> runQuery("""
-            FROM
-                (FROM logs-* | STATS key = count(*) | EVAL src = "from-local"
-                 | LOOKUP JOIN values_lookup ON key == lookup_key | KEEP src, key, lookup_tag),
-                (TS *:metrics | WHERE host == "h1" | STATS key = TO_LONG(max(cpu)) | EVAL src = "ts-remote"
-                 | LOOKUP JOIN values_lookup ON key == lookup_key | KEEP src, key, lookup_tag),
-                (ROW src = "row", key = TO_LONG(5) | LOOKUP JOIN values_lookup ON key == lookup_key
-                 | KEEP src, key, lookup_tag)
-            | KEEP src, key, lookup_tag
-            | SORT src, key
-            """, randomBoolean()));
-        assertThat(ex.getMessage(), containsString("LOOKUP JOIN with remote indices can't be executed after [STATS key = count(*)]"));
+        expectThrows(
+            VerificationException.class,
+            containsString("LOOKUP JOIN with remote indices can't be executed after [STATS key = TO_LONG(max(cpu))]"),
+            () -> runQuery("""
+                FROM
+                    (FROM logs-* | STATS key = count(*) | EVAL src = "from-local"
+                     | LOOKUP JOIN values_lookup ON key == lookup_key | KEEP src, key, lookup_tag),
+                    (TS *:metrics | WHERE host == "h1" | STATS key = TO_LONG(max(cpu)) | EVAL src = "ts-remote"
+                     | LOOKUP JOIN values_lookup ON key == lookup_key | KEEP src, key, lookup_tag),
+                    (ROW src = "row", key = TO_LONG(5) | LOOKUP JOIN values_lookup ON key == lookup_key
+                     | KEEP src, key, lookup_tag)
+                | KEEP src, key, lookup_tag
+                | SORT src, key
+                """, randomBoolean())
+        );
     }
 
     private void populateTimeSeriesIndex(String clusterAlias, String indexName) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -21,6 +21,7 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.iplocation.api.DatabaseProperty;
 import org.elasticsearch.iplocation.api.IpDataLookupInfo;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.Column;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -1477,14 +1478,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         : resolveUsingColumns(config.rightFields(), join.right().output(), "right");
                 }
                 config = new JoinConfig(type, leftKeys, rightKeys, joinOnConditions);
-
-                // A lookup join is remote only when its left side actually streams data from indices that may live on remote clusters.
-                // {@code includesRemoteIndices()} is query-wide, so on its own it would also mark a join whose left side is purely local
-                // (e.g. {@code ROW ... | LOOKUP JOIN} in a subquery branch) as remote. Such a join has no data-node source to attach to,
-                // so flagging it remote would cause {@code CrossClusterSubqueryIT.testSubqueryWithRowAndLookupJoin} error out in
-                // ComputeService.
-                boolean isRemote = join.isRemote() || (context.includesRemoteIndices() && leftSideReadsFromIndices(join.left()));
-                return new LookupJoin(join.source(), join.left(), join.right(), config, isRemote);
+                boolean isRemote = join.left().anyMatch(node -> node instanceof EsRelation relation && hasRemoteIndices(relation));
+                return new LookupJoin(join.source(), join.left(), join.right(), config, join.isRemote() || isRemote);
             } else {
                 // everything else is unsupported for now
                 UnresolvedAttribute errorAttribute = new UnresolvedAttribute(join.source(), "unsupported", "Unsupported join type");
@@ -1493,16 +1488,12 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             }
         }
 
-        /**
-         * Whether {@code plan} reads from a non-lookup index, as opposed to a purely local source such as {@code ROW} /
-         * {@link LocalRelation}.
-         * <p>
-         * Only {@link EsRelation} needs to be considered: this runs from {@link #resolveLookupJoin} inside
-         * {@link ResolveRefs}, which is guarded by {@code childrenResolved()}, so by the time we get here the left
-         * subtree is fully resolved and cannot contain an {@link UnresolvedRelation}.
-         */
-        private static boolean leftSideReadsFromIndices(LogicalPlan plan) {
-            return plan.anyMatch(p -> p instanceof EsRelation relation && relation.indexMode() != IndexMode.LOOKUP);
+        private static boolean hasRemoteIndices(EsRelation relation) {
+            return switch (relation.concreteIndices().size()) {
+                case 0 -> false;// row
+                case 1 -> relation.concreteIndices().containsKey(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY) == false;
+                default -> true;
+            };
         }
 
         /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
@@ -44,7 +44,6 @@ public class AnalyzerContext {
     private final ExternalSourceResolution externalSourceResolution;
     private final TransportVersion minimumVersion;
     private final ProjectMetadata projectMetadata;
-    private Boolean hasRemoteIndices;
     private final UnmappedResolution unmappedResolution;
     private final Set<String> deferredHeaderWarnings = new LinkedHashSet<>();
     private final TimestampBounds timestampBounds;
@@ -172,14 +171,6 @@ public class AnalyzerContext {
 
     public ProjectMetadata projectMetadata() {
         return projectMetadata;
-    }
-
-    public boolean includesRemoteIndices() {
-        assert indexResolution != null;
-        if (hasRemoteIndices == null) {
-            hasRemoteIndices = indexResolution.values().stream().anyMatch(IndexResolution::includesRemoteIndices);
-        }
-        return hasRemoteIndices;
     }
 
     public UnmappedResolution unmappedResolution() {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Correctly detect is sub-query is performing remote lookup join (#153135)