### PR TITLE
Replace deprecated logs policy with logs@lifecycle.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatures.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatures.java
@@ -25,6 +25,8 @@ public class XPackFeatures implements FeatureSpecification {
 
     public static final NodeFeature COLUMNAR_ENABLED_SETTING = new NodeFeature("columnar.enabled_setting");
 
+    public static final NodeFeature LOGS_ILM_POLICY_NAME = new NodeFeature("logs.ilm_policy_name");
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(AGGREGATE_METRIC_DOUBLE_DEPRECATED_DEFAULT_METRIC);
@@ -32,6 +34,6 @@ public class XPackFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
-        return Set.of(VECTORDB_DOCUMENT_USAGE, COLUMNAR_ENABLED_SETTING);
+        return Set.of(VECTORDB_DOCUMENT_USAGE, COLUMNAR_ENABLED_SETTING, LOGS_ILM_POLICY_NAME);
     }
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/logs@settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/logs@settings.json
@@ -3,7 +3,7 @@
     "settings": {
       "index": {
         "lifecycle": {
-          "name": "logs"
+          "name": "logs@lifecycle"
         },
         "codec": "best_compression",
         "mapping": {

--- a/x-pack/plugin/stack/build.gradle
+++ b/x-pack/plugin/stack/build.gradle
@@ -48,6 +48,7 @@ tasks.named('javaRestTest') { task ->
 tasks.named("yamlRestCompatTestTransform") { task ->
   task.skipTest("stack/10_basic/Test kibana reporting index auto creation", "warning does not exist for compatibility")
   task.skipTest("cat.shards/10_basic/Help", "sync_id is removed in 9.0")
+  task.skipTest("stack/10_basic/Test logs index auto creation", "logs template referred to the logs policy in the previous version")
 }
 
 configurations {

--- a/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
+++ b/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
@@ -80,6 +80,10 @@ setup:
 
 ---
 "Test logs index auto creation":
+  - requires:
+      cluster_features: ["logs.ilm_policy_name"]
+      reason: "the logs index template refers to the logs@lifecycle policy from this version onwards"
+
   - do:
       index:
         index: logs-foo-bar
@@ -110,7 +114,7 @@ setup:
 
   - is_true: .$idx0name.settings
   - is_true: .$idx0name.mappings
-  - match: { .$idx0name.settings.index.lifecycle.name: "logs" }
+  - match: { .$idx0name.settings.index.lifecycle.name: "logs@lifecycle" }
   - match: { .$idx0name.mappings.properties.data_stream.properties.type.type: "constant_keyword" }
   - match: { .$idx0name.mappings.properties.data_stream.properties.type.value: "logs" }
   - match: { .$idx0name.mappings.properties.data_stream.properties.dataset.type: "constant_keyword" }


### PR DESCRIPTION
The `logs@settings` component template was including the deprecated `logs` policy. We replace this with `logs@lifecycle`. Both policies have the same configuration. 

Closes #145876