### PR TITLE
Fix instability of SharedBlobCacheServiceTests.testFetchRegion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -640,9 +640,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
-- class: org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTests
-  method: testFetchRegion
-  issue: https://github.com/elastic/elasticsearch/issues/153058
 - class: org.elasticsearch.xpack.transform.integration.TransformTaskFailedStateIT
   method: testStartFailedTransform
   issue: https://github.com/elastic/elasticsearch/issues/153065

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -44,7 +44,6 @@ import org.elasticsearch.telemetry.RecordingMeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -2781,11 +2782,15 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
         final var bulkTaskCount = new AtomicInteger(0);
         final var threadPool = new TestThreadPool("test");
+        final var currentLatch = new AtomicReference<CountDownLatch>();
         final var bulkExecutor = new StoppableExecutorServiceWrapper(threadPool.generic()) {
             @Override
             public void execute(Runnable command) {
-                super.execute(command);
                 bulkTaskCount.incrementAndGet();
+                super.execute(() -> {
+                    command.run();
+                    currentLatch.get().countDown();
+                });
             }
         };
 
@@ -2806,6 +2811,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 final long blobLength = size(250); // 3 regions
                 AtomicLong bytesRead = new AtomicLong(0L);
                 final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+                currentLatch.set(new CountDownLatch(1));
                 cacheService.fetchRegion(
                     cacheKey,
                     0,
@@ -2824,6 +2830,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 );
 
                 var fetched = future.get(10, TimeUnit.SECONDS);
+                safeAwait(currentLatch.get());
                 assertThat("Region has been fetched", fetched, is(true));
                 assertEquals(regionSize, bytesRead.get());
                 assertEquals(4, cacheService.freeRegionCount());
@@ -2840,6 +2847,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
                 final PlainActionFuture<Collection<Boolean>> future = new PlainActionFuture<>();
                 final var listener = new GroupedActionListener<>(remainingFreeRegions, future);
+                currentLatch.set(new CountDownLatch(remainingFreeRegions));
                 for (int region = 0; region < remainingFreeRegions; region++) {
                     cacheService.fetchRegion(
                         cacheKey,
@@ -2860,6 +2868,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 }
 
                 var results = future.get(10, TimeUnit.SECONDS);
+                safeAwait(currentLatch.get());
                 assertThat(results.stream().allMatch(result -> result), is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
@@ -2896,6 +2905,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 var regionsToFetch = randomIntBetween(1, (int) (cacheSize / regionSize));
                 final var listener = new GroupedActionListener<>(regionsToFetch, future);
                 long blobLength = regionsToFetch * regionSize;
+                currentLatch.set(new CountDownLatch(regionsToFetch));
                 for (int region = 0; region < regionsToFetch; region++) {
                     cacheService.fetchRegion(
                         cacheKey,
@@ -2916,6 +2926,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 }
 
                 var results = future.get(10, TimeUnit.SECONDS);
+                safeAwait(currentLatch.get());
                 assertThat(results.stream().allMatch(result -> result), is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
@@ -2931,6 +2942,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 long blobLength = randomLongBetween(1L, regionSize);
                 AtomicLong bytesRead = new AtomicLong(0L);
                 final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+                currentLatch.set(new CountDownLatch(1));
                 cacheService.fetchRegion(
                     cacheKey,
                     0,
@@ -2949,6 +2961,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 );
 
                 var fetched = future.get(10, TimeUnit.SECONDS);
+                safeAwait(currentLatch.get());
                 assertThat("Region has been fetched", fetched, is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -2971,11 +2971,11 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
         return new StoppableExecutorServiceWrapper(threadPool.generic()) {
             @Override
             public void execute(Runnable command) {
-                bulkTaskCount.incrementAndGet();
                 super.execute(() -> {
                     command.run();
                     executionFinishedLatch.countDown();
                 });
+                bulkTaskCount.incrementAndGet();
             }
         };
     }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.telemetry.RecordingMeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -2780,19 +2781,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             .put("path.home", createTempDir())
             .build();
 
-        final var bulkTaskCount = new AtomicInteger(0);
         final var threadPool = new TestThreadPool("test");
-        final var currentLatch = new AtomicReference<CountDownLatch>();
-        final var bulkExecutor = new StoppableExecutorServiceWrapper(threadPool.generic()) {
-            @Override
-            public void execute(Runnable command) {
-                bulkTaskCount.incrementAndGet();
-                super.execute(() -> {
-                    command.run();
-                    currentLatch.get().countDown();
-                });
-            }
-        };
 
         try (
             NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
@@ -2809,9 +2798,10 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 final var cacheKey = generateCacheKey();
                 assertEquals(5, cacheService.freeRegionCount());
                 final long blobLength = size(250); // 3 regions
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final AtomicLong bytesRead = new AtomicLong(0L);
                 final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
-                currentLatch.set(new CountDownLatch(1));
+                final var bulkTaskCount = new AtomicInteger(0);
+                final var executionFinishedLatch = new CountDownLatch(1);
                 cacheService.fetchRegion(
                     cacheKey,
                     0,
@@ -2824,13 +2814,13 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             progressUpdater.accept(length);
                         }
                     ),
-                    bulkExecutor,
+                    bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                     true,
                     future
                 );
 
                 var fetched = future.get(10, TimeUnit.SECONDS);
-                safeAwait(currentLatch.get());
+                safeAwait(executionFinishedLatch);
                 assertThat("Region has been fetched", fetched, is(true));
                 assertEquals(regionSize, bytesRead.get());
                 assertEquals(4, cacheService.freeRegionCount());
@@ -2843,11 +2833,12 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
                 final var cacheKey = generateCacheKey();
                 final long blobLength = regionSize * remainingFreeRegions;
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final AtomicLong bytesRead = new AtomicLong(0L);
 
                 final PlainActionFuture<Collection<Boolean>> future = new PlainActionFuture<>();
                 final var listener = new GroupedActionListener<>(remainingFreeRegions, future);
-                currentLatch.set(new CountDownLatch(remainingFreeRegions));
+                final var bulkTaskCount = new AtomicInteger(0);
+                final var executionFinishedLatch = new CountDownLatch(remainingFreeRegions);
                 for (int region = 0; region < remainingFreeRegions; region++) {
                     cacheService.fetchRegion(
                         cacheKey,
@@ -2861,18 +2852,18 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                                 progressUpdater.accept(length);
                             }
                         ),
-                        bulkExecutor,
+                        bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                         true,
                         listener
                     );
                 }
 
                 var results = future.get(10, TimeUnit.SECONDS);
-                safeAwait(currentLatch.get());
+                safeAwait(executionFinishedLatch);
                 assertThat(results.stream().allMatch(result -> result), is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
-                assertEquals(1 + remainingFreeRegions, bulkTaskCount.get());
+                assertEquals(remainingFreeRegions, bulkTaskCount.get());
             }
             {
                 // cache fully used, no entry old enough to be evicted and force=false should not evict entries
@@ -2889,7 +2880,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             throw new AssertionError("should not be executed");
                         }
                     ),
-                    bulkExecutor,
+                    threadPool.generic(),
                     false,
                     future
                 );
@@ -2899,13 +2890,14 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             {
                 // cache fully used, but force=true, so the cache should evict regions to make space for the requested regions
                 assertEquals(0, cacheService.freeRegionCount());
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final AtomicLong bytesRead = new AtomicLong(0L);
                 final var cacheKey = generateCacheKey();
                 final PlainActionFuture<Collection<Boolean>> future = new PlainActionFuture<>();
-                var regionsToFetch = randomIntBetween(1, (int) (cacheSize / regionSize));
+                final var regionsToFetch = randomIntBetween(1, (int) (cacheSize / regionSize));
                 final var listener = new GroupedActionListener<>(regionsToFetch, future);
-                long blobLength = regionsToFetch * regionSize;
-                currentLatch.set(new CountDownLatch(regionsToFetch));
+                final long blobLength = regionsToFetch * regionSize;
+                final var bulkTaskCount = new AtomicInteger(0);
+                final var executionFinishedLatch = new CountDownLatch(regionsToFetch);
                 for (int region = 0; region < regionsToFetch; region++) {
                     cacheService.fetchRegion(
                         cacheKey,
@@ -2919,30 +2911,31 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                                 progressUpdater.accept(length);
                             }
                         ),
-                        bulkExecutor,
+                        bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                         true,
                         listener
                     );
                 }
 
                 var results = future.get(10, TimeUnit.SECONDS);
-                safeAwait(currentLatch.get());
+                safeAwait(executionFinishedLatch);
                 assertThat(results.stream().allMatch(result -> result), is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
-                assertEquals(regionsToFetch + 5, bulkTaskCount.get());
+                assertEquals(regionsToFetch, bulkTaskCount.get());
             }
             {
+                final var bulkTaskCount = new AtomicInteger(0);
                 cacheService.computeDecay();
 
                 // We explicitly called computeDecay, meaning that some regions must have been demoted to level 0,
                 // therefore there should be enough room to fetch the requested range regardless of the force flag.
                 final var cacheKey = generateCacheKey();
                 assertEquals(0, cacheService.freeRegionCount());
-                long blobLength = randomLongBetween(1L, regionSize);
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final long blobLength = randomLongBetween(1L, regionSize);
+                final AtomicLong bytesRead = new AtomicLong(0L);
                 final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
-                currentLatch.set(new CountDownLatch(1));
+                final var executionFinishedLatch = new CountDownLatch(1);
                 cacheService.fetchRegion(
                     cacheKey,
                     0,
@@ -2955,13 +2948,13 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             progressUpdater.accept(length);
                         }
                     ),
-                    bulkExecutor,
+                    bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                     randomBoolean(),
                     future
                 );
 
                 var fetched = future.get(10, TimeUnit.SECONDS);
-                safeAwait(currentLatch.get());
+                safeAwait(executionFinishedLatch);
                 assertThat("Region has been fetched", fetched, is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
@@ -2969,6 +2962,23 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
         } finally {
             TestThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }
+    }
+
+    private static StoppableExecutorServiceWrapper bulkExecutor(
+        final TestThreadPool threadPool,
+        final AtomicInteger bulkTaskCount,
+        final CountDownLatch executionFinishedLatch
+    ) {
+        return new StoppableExecutorServiceWrapper(threadPool.generic()) {
+            @Override
+            public void execute(Runnable command) {
+                bulkTaskCount.incrementAndGet();
+                super.execute(() -> {
+                    command.run();
+                    executionFinishedLatch.countDown();
+                });
+            }
+        };
     }
 
     public void testMaybeFetchRange() throws Exception {


### PR DESCRIPTION
 ### Context
When a fetch task finishes, it does two things in order:
  1. Notifies the caller - this completes the `future`                                                                                                                      
  2. Releases its hold on the region (`onAfter`) - this decrements the region's reference count, potentially making it "free" again
  
The problem: step 1 and step 2 happen back-to-back inside the task, but `future.get()` unblocks after step 1. Step 2 (`onAfter`) hasn't necessarily finished yet. So when the test immediately checks `freeRegionCount()` after `future.get()`, the region ref might still be held, so the count could be wrong. 

This is a race condition. We can easily reproduce that by introducing an artificial sleep in `org.elasticsearch.blobcache.shared.SharedBlobCacheService.CacheFileRegion#populate` listener's `onAfter` method.

### Solution
To solve this problem, I added a `CountDownLatch` to `bulkExecutor` to wait for the process to finish, and only then validate assertions. 
The bulk executor was used multiple times and the related task counter was taking previous executions into account (see ` assertEquals(regionsToFetch + 5, bulkTaskCount.get())` in the previous code). I extracted it and pass a different executor for each test case, which is simpler in my opinion, and each sub-test-case is more independent now, and there's no need to restart the `CountDownLatch`.

With this change the test is stable and there are no new `assertBusy` method invocations.

Closes: #153058