### PR TITLE
Unmute EsqlClientYamlIT aggregate metadata test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -385,9 +385,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/jobs_get_result_overall_buckets/Test overall buckets given top_n is negative}
   issue: https://github.com/elastic/elasticsearch/issues/151160
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/140_metadata/Aggregate ignored field}
-  issue: https://github.com/elastic/elasticsearch/issues/151216
 - class: org.elasticsearch.xpack.ccr.CcrTimeSeriesDataStreamsIT
   method: testCrossClusterReplicationForTSDBWithSyntheticId
   issue: https://github.com/elastic/elasticsearch/issues/151326


### PR DESCRIPTION
- Should be good to unmute now: local exact reproduction for `EsqlClientYamlIT` (`esql/140_metadata/Aggregate ignored field`) passed.
- This unmute is contingent on CI confirming the mixed-cluster path remains stable.
- Closes #151216.