### PR TITLE
ESQL: One more test for the `CsvFlattenedKeywordIT` list

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -182,6 +182,7 @@ public class CsvTestsDataLoader {
         new TestDataset("clientips").withIndex("clientips_lookup").withSetting("lookup-settings.json"),
         new TestDataset("message_types"),
         new TestDataset("message_types").withIndex("message_types_lookup").withSetting("lookup-settings.json"),
+        new TestDataset("hash_algorithms"),
         new TestDataset("firewall_logs").noData(),
         new TestDataset("threat_list").withSetting("lookup-settings.json").noData(),
         new TestDataset("app_logs").noData(),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/hash_algorithms.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/hash_algorithms.csv
@@ -1,0 +1,4 @@
+algorithm:keyword,input:keyword
+MD5,foo
+SHA-1,bar
+SHA-256,baz

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/hash.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/hash.csv-spec
@@ -47,6 +47,22 @@ input:keyword | md5:keyword                      | sha256:keyword
               | d41d8cd98f00b204e9800998ecf8427e | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ;
 
+hashWithAlgorithmFromField
+required_capability: hash_function
+
+FROM hash_algorithms
+| EVAL hash = hash(algorithm, input)
+| KEEP algorithm, input, hash
+| SORT algorithm
+;
+
+algorithm:keyword | input:keyword | hash:keyword
+MD5               | foo           | acbd18db4cc2f85cedef654fccc4a4d8
+SHA-1             | bar           | 62cdb7020ff920e5aa642c3d4066950dd1f01f4d
+SHA-256           | baz           | baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096
+;
+
+
 hashOfNullInput
 required_capability: hash_function
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-hash_algorithms.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-hash_algorithms.json
@@ -1,0 +1,10 @@
+{
+  "properties": {
+    "algorithm": {
+      "type": "keyword"
+    },
+    "input": {
+      "type": "keyword"
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -1329,7 +1329,6 @@ public class CsvFlattenedKeywordIT extends CsvIT {
         "GREATER_THAN_OR_EQUAL:rhs is missing",
         "GREATEST:first is missing",
         "GREATEST:rest is missing",
-        "HASH:algorithm is missing",
         "IN:field is missing",
         "JSON_EXTRACT:string is missing",
         "KNN:field is missing",


### PR DESCRIPTION
Adds a test for `HASH` where the algorithm comes directly from the index so we get another test for the checklist in `CsvFlattenedKeywordIT`.