### PR TITLE
test: unmute `LogsdbRestIT` runtime field tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -427,12 +427,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
-  method: testSyntheticSourceRuntimeFieldQueries
-  issue: https://github.com/elastic/elasticsearch/issues/151546
-- class: org.elasticsearch.xpack.logsdb.LogsdbRestIT
-  method: testEsqlRuntimeFields
-  issue: https://github.com/elastic/elasticsearch/issues/151547
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/149746


### PR DESCRIPTION
## Summary

`LogsdbRestIT.testSyntheticSourceRuntimeFieldQueries` and `LogsdbRestIT.testEsqlRuntimeFields` were muted after #151494 made the `logsdb_columnar` index mode reject mapping-level runtime fields. When the random `cluster.logsdb_columnar.enabled` toggle promoted a `logs-*` data stream to `logsdb_columnar`, the bulk requests were rejected with a 400 and the tests saw indexing errors.

#151591 pins each template to `index.mode: logsdb` so the runtime field tests always run on the intended mode, and adds negative counterparts for the rejection path. That PR was meant to remove the mutes as well but left the entries in place, so both tests stayed muted despite being fixed. This PR removes their `muted-tests.yml` entries.

## Changes

`muted-tests.yml`: removes the entries for #151546 and #151547.

## Testing

```
./gradlew :x-pack:plugin:logsdb:javaRestTest --tests "org.elasticsearch.xpack.logsdb.LogsdbRestIT"
```

Fixes #151546.
Fixes #151547.