### PR TITLE
Propagate url.scheme from Netty to APM

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/OtelAttributesGetter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/instrumentation/OtelAttributesGetter.java
@@ -19,8 +19,7 @@ final class OtelAttributesGetter implements HttpServerAttributesGetter<RequestAn
 
     @Override
     public String getUrlScheme(RequestAndRoute request) {
-        // TODO pass the scheme from netty
-        return null;
+        return request.request().getHttpRequest().getScheme();
     }
 
     @Override

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/instrumentation/APMHttpServerInstrumentationTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/instrumentation/APMHttpServerInstrumentationTests.java
@@ -41,6 +41,7 @@ public class APMHttpServerInstrumentationTests extends ESTestCase {
 
     public void test_start_setsRequestAttributes_minimal() {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withScheme("https")
             .withPath("/my-index/_search")
             .withHeaders(Map.of("Accept-Encoding", List.of("gzip")))
             .build();
@@ -70,6 +71,7 @@ public class APMHttpServerInstrumentationTests extends ESTestCase {
                 request,
                 Attributes.builder()
                     .put(stringKey("http.request.method"), "GET")
+                    .put(stringKey("url.scheme"), "https")
                     .put(stringKey("http.route"), "/{index}/_search")
                     .put(stringKey("url.path"), "/my-index/_search")
                     .build()
@@ -79,6 +81,7 @@ public class APMHttpServerInstrumentationTests extends ESTestCase {
 
     public void test_start_setsRequestAttributes_full() {
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withScheme("http")
             .withPath("/my-index/_search?from=0")
             .withHeaders(
                 Map.ofEntries(

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -96,22 +96,26 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
     private final Queue<WriteOperation> queuedWrites = new ArrayDeque<>();
 
     private final Netty4HttpServerTransport serverTransport;
+    private final String scheme;
 
     /**
      * Construct a new pipelining handler; this handler should be used downstream of HTTP decoding/aggregation.
      *
      * @param maxEventsHeld the maximum number of channel events that will be retained prior to aborting the channel connection; this is
      *                      required as events cannot queue up indefinitely
+     * @param scheme        either {@code "http"} or {@code "https"} depending on whether TLS is enabled for this channel
      */
     public Netty4HttpPipeliningHandler(
         final int maxEventsHeld,
         final Netty4HttpServerTransport serverTransport,
-        final ThreadWatchdog.ActivityTracker activityTracker
+        final ThreadWatchdog.ActivityTracker activityTracker,
+        final String scheme
     ) {
         this.maxEventsHeld = maxEventsHeld;
         this.activityTracker = activityTracker;
         this.outboundHoldingQueue = new PriorityQueue<>(1, Comparator.comparingInt(t -> t.v1().getSequence()));
         this.serverTransport = serverTransport;
+        this.scheme = scheme;
     }
 
     @Override
@@ -130,12 +134,12 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
                     } else {
                         nonError = (Exception) cause;
                     }
-                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, nonError);
+                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, nonError, scheme);
                 } else {
                     assert currentRequestStream == null : "current stream must be null for new request";
                     var contentStream = new Netty4HttpRequestBodyStream(ctx, serverTransport.getThreadPool().getThreadContext());
                     currentRequestStream = contentStream;
-                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream);
+                    netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream, scheme);
                     shouldRead = false;
                 }
                 handlePipelinedRequest(ctx, netty4HttpRequest);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -46,13 +46,14 @@ public class Netty4HttpRequest implements HttpRequest {
     private final AtomicBoolean released;
     private final Exception inboundException;
     private final QueryStringDecoder queryStringDecoder;
+    private final String scheme;
 
-    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, Exception exception) {
-        this(sequence, nettyRequest, HttpBody.empty(), new AtomicBoolean(false), exception);
+    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, Exception exception, String scheme) {
+        this(sequence, nettyRequest, HttpBody.empty(), new AtomicBoolean(false), exception, scheme);
     }
 
-    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, HttpBody content) {
-        this(sequence, nettyRequest, content, new AtomicBoolean(false), null);
+    public Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest nettyRequest, HttpBody content, String scheme) {
+        this(sequence, nettyRequest, content, new AtomicBoolean(false), null, scheme);
     }
 
     private Netty4HttpRequest(
@@ -60,7 +61,8 @@ public class Netty4HttpRequest implements HttpRequest {
         io.netty.handler.codec.http.HttpRequest nettyRequest,
         HttpBody content,
         AtomicBoolean released,
-        Exception inboundException
+        Exception inboundException,
+        String scheme
     ) {
         this.sequence = sequence;
         this.nettyRequest = nettyRequest;
@@ -70,6 +72,7 @@ public class Netty4HttpRequest implements HttpRequest {
         this.released = released;
         this.inboundException = inboundException;
         this.queryStringDecoder = new QueryStringDecoder(nettyRequest.uri());
+        this.scheme = scheme;
     }
 
     private static boolean hasContentHeader(io.netty.handler.codec.http.HttpRequest nettyRequest) {
@@ -155,7 +158,12 @@ public class Netty4HttpRequest implements HttpRequest {
             nettyRequest.uri(),
             copiedHeadersWithout
         );
-        return new Netty4HttpRequest(sequence, requestWithoutHeader, content, released, null);
+        return new Netty4HttpRequest(sequence, requestWithoutHeader, content, released, null, scheme);
+    }
+
+    @Override
+    public String getScheme() {
+        return scheme;
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -477,7 +477,12 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             ch.pipeline()
                 .addLast(
                     "pipelining",
-                    new Netty4HttpPipeliningHandler(transport.pipeliningMaxEvents, transport, threadWatchdogActivityTracker)
+                    new Netty4HttpPipeliningHandler(
+                        transport.pipeliningMaxEvents,
+                        transport,
+                        threadWatchdogActivityTracker,
+                        tlsConfig.isTLSEnabled() ? "https" : "http"
+                    )
                 );
             transport.serverAcceptedChannel(nettyHttpChannel);
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -140,7 +140,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
 
     private EmbeddedChannel makeEmbeddedChannelWithSimulatedWork(int numberOfRequests) {
         return new EmbeddedChannel(
-            new Netty4HttpPipeliningHandler(numberOfRequests, httpServerTransport(), new ThreadWatchdog.ActivityTracker()) {
+            new Netty4HttpPipeliningHandler(numberOfRequests, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http") {
                 @Override
                 protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                     ctx.fireChannelRead(pipelinedRequest);
@@ -225,7 +225,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     public void testPipeliningRequestsAreReleased() {
         final int numberOfRequests = 10;
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
-            new Netty4HttpPipeliningHandler(numberOfRequests + 1, httpServerTransport(), new ThreadWatchdog.ActivityTracker())
+            new Netty4HttpPipeliningHandler(numberOfRequests + 1, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http")
         );
 
         for (int i = 0; i < numberOfRequests; i++) {
@@ -517,7 +517,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
         final var watchdog = new ThreadWatchdog();
         final var activityTracker = watchdog.getActivityTrackerForCurrentThread();
         final var requestHandled = new AtomicBoolean();
-        final var handler = new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), activityTracker) {
+        final var handler = new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), activityTracker, "http") {
             @Override
             protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                 // thread is not idle while handling the request
@@ -558,7 +558,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     }
 
     private Netty4HttpPipeliningHandler getTestHttpHandler() {
-        return new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), new ThreadWatchdog.ActivityTracker()) {
+        return new Netty4HttpPipeliningHandler(Integer.MAX_VALUE, httpServerTransport(), new ThreadWatchdog.ActivityTracker(), "http") {
             @Override
             protected void handlePipelinedRequest(ChannelHandlerContext ctx, Netty4HttpRequest pipelinedRequest) {
                 ctx.fireChannelRead(pipelinedRequest);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestTests.java
@@ -24,7 +24,12 @@ import org.elasticsearch.test.rest.FakeHttpBodyStream;
 public class Netty4HttpRequestTests extends ESTestCase {
 
     public void testEmptyFullContent() {
-        final var request = new Netty4HttpRequest(0, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"), HttpBody.empty());
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "http"
+        );
         assertFalse(request.hasContent());
     }
 
@@ -32,7 +37,8 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var request = new Netty4HttpRequest(
             0,
             new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
-            new FakeHttpBodyStream()
+            new FakeHttpBodyStream(),
+            "http"
         );
         assertFalse(request.hasContent());
     }
@@ -47,7 +53,8 @@ public class Netty4HttpRequestTests extends ESTestCase {
                 "/",
                 new DefaultHttpHeaders().add(HttpHeaderNames.CONTENT_LENGTH, len)
             ),
-            HttpBody.fromBytesReference(new BytesArray(new byte[len]))
+            HttpBody.fromBytesReference(new BytesArray(new byte[len])),
+            "http"
         );
         assertTrue(request.hasContent());
     }
@@ -56,12 +63,12 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var len = between(1, 1024);
         final var nettyRequestWithLen = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpUtil.setContentLength(nettyRequestWithLen, len);
-        final var requestWithLen = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream());
+        final var requestWithLen = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream(), "http");
         assertTrue(requestWithLen.hasContent());
 
         final var nettyChunkedRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", new DefaultHttpHeaders());
         HttpUtil.setTransferEncodingChunked(nettyChunkedRequest, true);
-        final var chunkedRequest = new Netty4HttpRequest(0, nettyChunkedRequest, new FakeHttpBodyStream());
+        final var chunkedRequest = new Netty4HttpRequest(0, nettyChunkedRequest, new FakeHttpBodyStream(), "http");
         assertTrue(chunkedRequest.hasContent());
     }
 
@@ -69,9 +76,29 @@ public class Netty4HttpRequestTests extends ESTestCase {
         final var len = between(1, 1024);
         final var nettyRequestWithLen = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpUtil.setContentLength(nettyRequestWithLen, len);
-        final var streamRequest = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream());
+        final var streamRequest = new Netty4HttpRequest(0, nettyRequestWithLen, new FakeHttpBodyStream(), "http");
 
         streamRequest.setBody(HttpBody.fromBytesReference(randomBytesReference(len)));
         assertTrue(streamRequest.hasContent());
+    }
+
+    public void testGetSchemeHttp() {
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "http"
+        );
+        assertEquals("http", request.getScheme());
+    }
+
+    public void testGetSchemeHttps() {
+        final var request = new Netty4HttpRequest(
+            0,
+            new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"),
+            HttpBody.empty(),
+            "https"
+        );
+        assertEquals("https", request.getScheme());
     }
 }

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -28,6 +28,9 @@ public interface HttpRequest extends HttpPreRequest {
         HTTP_1_1
     }
 
+    /** Returns the URI scheme for this request: either {@code "http"} or {@code "https"}. */
+    String getScheme();
+
     HttpBody body();
 
     void setBody(HttpBody body);

--- a/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
+++ b/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
@@ -73,6 +73,11 @@ public class TestHttpRequest implements HttpRequest {
     }
 
     @Override
+    public String getScheme() {
+        return "http";
+    }
+
+    @Override
     public HttpBody body() {
         return body;
     }

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -869,6 +869,11 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
+            public String getScheme() {
+                return "http";
+            }
+
+            @Override
             public HttpBody body() {
                 if (hasContent) {
                     return HttpBody.fromBytesReference(new BytesArray("test"));

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -60,21 +60,30 @@ public class FakeRestRequest extends RestRequest {
         private final Map<String, List<String>> headers;
         private HttpBody body;
         private final Exception inboundException;
+        private final String scheme;
 
         public FakeHttpRequest(Method method, String uri, BytesReference body, Map<String, List<String>> headers) {
-            this(method, uri, body == null ? HttpBody.empty() : HttpBody.fromBytesReference(body), headers, null);
+            this(method, uri, body == null ? HttpBody.empty() : HttpBody.fromBytesReference(body), headers, null, "http");
         }
 
         public FakeHttpRequest(Method method, String uri, Map<String, List<String>> headers, HttpBody body) {
-            this(method, uri, body, headers, null);
+            this(method, uri, body, headers, null, "http");
         }
 
-        private FakeHttpRequest(Method method, String uri, HttpBody body, Map<String, List<String>> headers, Exception inboundException) {
+        private FakeHttpRequest(
+            Method method,
+            String uri,
+            HttpBody body,
+            Map<String, List<String>> headers,
+            Exception inboundException,
+            String scheme
+        ) {
             this.method = method;
             this.uri = uri;
             this.body = body;
             this.headers = new FakeHttpHeaders(headers);
             this.inboundException = inboundException;
+            this.scheme = scheme;
         }
 
         @Override
@@ -85,6 +94,11 @@ public class FakeRestRequest extends RestRequest {
         @Override
         public String uri() {
             return uri;
+        }
+
+        @Override
+        public String getScheme() {
+            return scheme;
         }
 
         @Override
@@ -116,7 +130,7 @@ public class FakeRestRequest extends RestRequest {
         public HttpRequest removeHeader(String header) {
             final var filteredHeaders = new HashMap<>(headers);
             filteredHeaders.remove(header);
-            return new FakeHttpRequest(method, uri, body, filteredHeaders, inboundException);
+            return new FakeHttpRequest(method, uri, body, filteredHeaders, inboundException, scheme);
         }
 
         public int contentLength() {
@@ -296,6 +310,8 @@ public class FakeRestRequest extends RestRequest {
 
         private Exception inboundException;
 
+        private String scheme = "http";
+
         public Builder(NamedXContentRegistry registry) {
             this.parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE)
                 .withRegistry(registry);
@@ -356,8 +372,13 @@ public class FakeRestRequest extends RestRequest {
             return this;
         }
 
+        public Builder withScheme(String scheme) {
+            this.scheme = scheme;
+            return this;
+        }
+
         public FakeRestRequest build() {
-            FakeHttpRequest fakeHttpRequest = new FakeHttpRequest(method, path, content, headers, inboundException);
+            FakeHttpRequest fakeHttpRequest = new FakeHttpRequest(method, path, content, headers, inboundException, scheme);
             return new FakeRestRequest(parserConfig, fakeHttpRequest, params, new FakeHttpChannel(address));
         }
     }


### PR DESCRIPTION
A continuation of #149477: this PR propagates the URL scheme from the Netty layer to the APM module.

Closes #149020

Supersedes #149433 and #149529
