### PR TITLE
Grant kibana_system access to .context-idx-sml-data

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -710,6 +710,12 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // For connectors telemetry. Will be removed once we switched to connectors API
                 RoleDescriptor.IndicesPrivileges.builder().indices(".elastic-connectors*").privileges("read").build(),
+                // Context Engine's SML storage. A regular (non-system) index that Kibana
+                // creates and manages itself at startup, including its alias.
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".context-idx-sml-data", ".context-idx-sml-data-*")
+                    .privileges("all")
+                    .build(),
                 // Significant events. Kibana system user manages index plumbing and document access.
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".significant_events-*")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1275,6 +1275,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
             );
         });
 
+        // Context Engine's SML storage: a regular (non-system) index that Kibana
+        // creates and manages itself, including its alias.
+        Arrays.asList(".context-idx-sml-data", ".context-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+            .forEach(index -> assertReadWriteAndManage(kibanaRole, index));
+
         // Agent Builder OTLP telemetry (traces + logs from span events)
         Arrays.asList(
             "traces-agent_builder.otel-" + randomAlphaOfLength(randomIntBetween(0, 13)),


### PR DESCRIPTION
## Summary

- Grants `kibana_system` `all` privileges on `.context-idx-sml-data` and `.context-idx-sml-data-*`.
- This is the storage the Context Engine's SML (Knowledge Indicator store) is moving to, off the current `.chat-sml-data` system index.
- Unlike the system-index approach explored in #153466, `.context-idx-sml-data` is a **plain, non-system index**: Kibana creates and manages the backing index and its alias itself at startup. This keeps the index genuinely customer-queryable (including via `_query`/ES|QL) rather than subject to the system-index deprecation path that will eventually block unheadered direct access.
- A follow-on ES-side index template registry (mirroring `ConnectorTemplateRegistry`) is planned but out of scope here — this PR only unblocks the permission Kibana needs to own index/alias lifecycle itself in the interim.

supplants https://github.com/elastic/elasticsearch/pull/153466

## Test plan

- [x] Added coverage in `ReservedRolesStoreTests#testKibanaSystemRole` asserting `kibana_system` has read/write/manage access on `.context-idx-sml-data` and a `.context-idx-sml-data-*` suffixed index.
- [x] `./gradlew :x-pack:plugin:core:test --tests "...ReservedRolesStoreTests.testKibanaSystemRole"` passes.
- [x] `./gradlew :x-pack:plugin:core:spotlessJavaCheck` passes.
