### PR TITLE
Rename `recovery_type` metrics attribute

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/MetricValidator.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/MetricValidator.java
@@ -131,7 +131,7 @@ public class MetricValidator {
 
         static final Set<String> REINDEX_ATTRIBUTES = Set.of("reindex_source");
 
-        static final Set<String> RECOVERY_ATTRIBUTES = Set.of("primary", "recovery_type");
+        static final Set<String> RECOVERY_ATTRIBUTES = Set.of("primary");
 
         static final Set<String> ESQL_ATTRIBUTES = Set.of("feature_name", "success");
 
@@ -213,7 +213,6 @@ public class MetricValidator {
             Map.entry("es.ml.trained_models.adaptive_allocations.actual_number_of_allocations.current", ML_ATTRIBUTES),
             Map.entry("es.ml.trained_models.adaptive_allocations.needed_number_of_allocations.current", ML_ATTRIBUTES),
             Map.entry("es.projects.linked.connections.error.total", LINKED_PROJECT_ATTRIBUTES),
-            Map.entry("es.recovery.shard.count.total", RECOVERY_ATTRIBUTES),
             Map.entry("es.recovery.shard.index.time", RECOVERY_ATTRIBUTES),
             Map.entry("es.recovery.shard.indexing_node.bytes_read.total", RECOVERY_ATTRIBUTES),
             Map.entry("es.recovery.shard.indexing_node.bytes_warmed.total", RECOVERY_ATTRIBUTES),

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/RecoveryMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/RecoveryMetricsIT.java
@@ -141,7 +141,7 @@ public class RecoveryMetricsIT extends AbstractIndexRecoveryIntegTestCase {
         Measurement metric = totalTime.getFirst();
         assertThat("Total time value", metric.getLong(), greaterThanOrEqualTo(0L));
         assertThat("Primary attribute", metric.attributes().get("primary"), equalTo(true));
-        assertThat("Recovery type", metric.attributes().get("recovery_type"), equalTo("EMPTY_STORE"));
+        assertThat("Recovery type", metric.attributes().get("es_recovery_type"), equalTo("EMPTY_STORE"));
     }
 
     public void testRecoveryMetricsOnPeerRecovery() {
@@ -239,7 +239,7 @@ public class RecoveryMetricsIT extends AbstractIndexRecoveryIntegTestCase {
             Measurement metric = totalTime.getFirst();
             assertThat("Total time value", metric.getLong(), greaterThanOrEqualTo(0L));
             assertThat("Primary attribute", metric.attributes().get("primary"), equalTo(false));
-            assertThat("Recovery type", metric.attributes().get("recovery_type"), equalTo("PEER"));
+            assertThat("Recovery type", metric.attributes().get("es_recovery_type"), equalTo("PEER"));
 
             List<Measurement> indexTime = targetTelemetry.getLongHistogramMeasurement(
                 RecoveryMetricsCollector.RECOVERY_INDEX_TIME_METRIC_IN_SECONDS
@@ -353,7 +353,7 @@ public class RecoveryMetricsIT extends AbstractIndexRecoveryIntegTestCase {
             Measurement metric = totalTime.getFirst();
             assertThat("Total time value", metric.getLong(), greaterThanOrEqualTo(0L));
             assertThat("Primary attribute", metric.attributes().get("primary"), equalTo(true));
-            assertThat("Recovery type", metric.attributes().get("recovery_type"), equalTo("PEER"));
+            assertThat("Recovery type", metric.attributes().get("es_recovery_type"), equalTo("PEER"));
 
             awaitRecoveryCountMetrics(node1, node1Telemetry, Map.of(RecoveryMetricsCollector.CURRENT_PEER_RECOVERIES_AS_SOURCE, 0L));
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryMetricsCollector.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryMetricsCollector.java
@@ -140,12 +140,11 @@ public class RecoveryMetricsCollector implements IndexEventListener, RecoverySch
         }
     }
 
-    // TODO: rename "recovery_type" to "es_recovery_type" to match ES OTel attribute naming convention
     private static Map<String, Object> recoveryTimeMetricLabels(IndexShard indexShard) {
         return Map.of(
             "primary",
             indexShard.routingEntry().primary(),
-            "recovery_type",
+            "es_recovery_type",
             indexShard.recoveryState().getRecoverySource().getType().name()
         );
     }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/StatelessRecoveryMetricsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/StatelessRecoveryMetricsIT.java
@@ -111,7 +111,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThan(0L));
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("PEER"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("PEER"));
         });
 
         assertBusy(() -> {
@@ -123,7 +123,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThanOrEqualTo(0L));
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("PEER"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("PEER"));
         });
 
         assertBusy(() -> {
@@ -135,7 +135,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThanOrEqualTo(0L));
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("PEER"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("PEER"));
         });
     }
 
@@ -162,7 +162,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             assertThat(measurements.size(), equalTo(1));
             final Measurement metric = measurements.get(0);
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("EMPTY_STORE"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("EMPTY_STORE"));
         });
 
         // ensure that index shard is allocated on `indexingNode1` only
@@ -208,7 +208,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThan(0L));
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("EXISTING_STORE"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("EXISTING_STORE"));
         });
 
         assertBusy(() -> {
@@ -220,7 +220,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThanOrEqualTo(0L));
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("EXISTING_STORE"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("EXISTING_STORE"));
         });
 
         assertBusy(() -> {
@@ -232,7 +232,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThanOrEqualTo(0L));
             assertThat(metric.attributes().get("primary"), equalTo(true));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("EXISTING_STORE"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("EXISTING_STORE"));
         });
     }
 
@@ -270,7 +270,7 @@ public class StatelessRecoveryMetricsIT extends AbstractStatelessPluginIntegTest
             final Measurement metric = measurements.get(0);
             assertThat(metric.value().longValue(), greaterThan(0L));
             assertThat(metric.attributes().get("primary"), equalTo(false));
-            assertThat(metric.attributes().get("recovery_type"), equalTo("PEER"));
+            assertThat(metric.attributes().get("es_recovery_type"), equalTo("PEER"));
         });
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/metering/StatelessRecoveryMetricsCollector.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/metering/StatelessRecoveryMetricsCollector.java
@@ -187,7 +187,7 @@ public class StatelessRecoveryMetricsCollector implements IndexEventListener {
     private static Map<String, Object> recoveryMetricLabels(IndexShard indexShard) {
         return Maps.copyMapWithAddedEntry(
             commonMetricLabels(indexShard),
-            "recovery_type",
+            "es_recovery_type",
             indexShard.recoveryState().getRecoverySource().getType().name()
         );
     }


### PR DESCRIPTION
This changes the recovery metrics to consistently use the attribute name `es_recovery_type`, which follows the ES OTel naming convention. Previously, newer metrics used this, but older ones used the legacy `recovery_type` name.

Relates elastic/elasticsearch-team#4256
