### PR TITLE
Unmute StatelessRealTimeGetIT.testDataVisibility

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -274,9 +274,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecWhereLikeIT
   method: test {csv-spec:where-like.likePrefixSuffix}
   issue: https://github.com/elastic/elasticsearch/issues/149964
-- class: org.elasticsearch.xpack.stateless.StatelessRealTimeGetIT
-  method: testDataVisibility
-  issue: https://github.com/elastic/elasticsearch/issues/150028
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:k8s-timeseries-increase.increase_of_double_no_grouping_promql}
   issue: https://github.com/elastic/elasticsearch/issues/150045


### PR DESCRIPTION
This test failure was resolved by commit
090341ea17081b1ca6171df59aae071c09e1e437. Specifically,
the threadpool assertion in tryPrefetch needed to include
the SHARD_READ_THREAD_POOL thread pool.

Closes #150028

---

[This comment](https://github.com/elastic/elasticsearch/issues/150028#issuecomment-4938096994) provides additional analysis