### PR TITLE
[Inference API] Switch custom service exceptions to illegal argument where necessary

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutor.java
@@ -36,7 +36,7 @@ public class ValidatingSubstitutor {
 
     /**
      * Substitutes placeholder values in a string that match the keys in a provided map with the map's corresponding values.
-     * After replacement, if the source still contains a placeholder an {@link IllegalStateException} is thrown.
+     * After replacement, if the source still contains a placeholder an {@link IllegalArgumentException} is thrown.
      * @param source the string that will be searched for placeholders to be replaced
      * @param field a description of the source string
      * @return a string with the placeholders replaced by string values
@@ -50,7 +50,7 @@ public class ValidatingSubstitutor {
     private static void ensureNoMorePlaceholdersExist(String substitutedString, String field) {
         Matcher matcher = VARIABLE_PLACEHOLDER_PATTERN.matcher(substitutedString);
         if (matcher.find()) {
-            throw new IllegalStateException(
+            throw new IllegalArgumentException(
                 Strings.format(
                     "Found placeholder [%s] in field [%s] after replacement call, "
                         + "please check that all templates have a corresponding field definition.",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomModelCreator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomModelCreator.java
@@ -74,7 +74,7 @@ public class CustomModelCreator implements ModelCreator<CustomModel> {
             // createHttpRequest() takes a listener, but we don't need to do anything with the HttpRequest here, so use a no-op listener
             ActionListener<HttpRequest> listener = ActionListener.noop();
             request.createHttpRequest(listener);
-        } catch (IllegalStateException e) {
+        } catch (Exception e) {
             var validationException = new ValidationException();
             validationException.addValidationError(Strings.format("Failed to validate model configuration: %s", e.getMessage()));
             throw validationException;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequest.java
@@ -109,7 +109,7 @@ public class CustomRequest implements OutboundRequest {
             }
             return builder.build();
         } catch (URISyntaxException e) {
-            throw new IllegalStateException(Strings.format("Failed to build URI, error: %s", e.getMessage()), e);
+            throw new IllegalArgumentException(Strings.format("Failed to build URI, error: %s", e.getMessage()), e);
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/response/BaseCustomResponseParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/response/BaseCustomResponseParser.java
@@ -76,7 +76,7 @@ public abstract class BaseCustomResponseParser implements CustomResponseParser {
         var keys = ((Map<?, ?>) obj).keySet();
         for (var key : keys) {
             if (key instanceof String == false) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                     Strings.format(
                         "Extracted field [%s] map has an invalid key type. Expected a string but received [%s]",
                         fieldName,
@@ -140,7 +140,7 @@ public abstract class BaseCustomResponseParser implements CustomResponseParser {
             try {
                 resultList.add(converter.apply(items.get(i), fieldName));
             } catch (Exception e) {
-                throw new IllegalStateException(Strings.format("Failed to parse list entry [%d], error: %s", i, e.getMessage()), e);
+                throw new IllegalArgumentException(Strings.format("Failed to parse list entry [%d], error: %s", i, e.getMessage()), e);
             }
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/ValidatingSubstitutorTests.java
@@ -35,7 +35,7 @@ public class ValidatingSubstitutorTests extends ESTestCase {
     public void testReplace_ThrowsException_WhenPlaceHolderStillExists() {
         {
             var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "key2", "value2"), "${", "}");
-            var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super:${key}", "setting"));
+            var exception = expectThrows(IllegalArgumentException.class, () -> sub.replace("super:${key}", "setting"));
 
             assertThat(
                 exception.getMessage(),
@@ -48,7 +48,7 @@ public class ValidatingSubstitutorTests extends ESTestCase {
         // only reports the first placeholder pattern
         {
             var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "some_key2", "value2"), "${", "}");
-            var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super, ${key}, ${key2}", "setting"));
+            var exception = expectThrows(IllegalArgumentException.class, () -> sub.replace("super, ${key}, ${key2}", "setting"));
 
             assertThat(
                 exception.getMessage(),
@@ -60,7 +60,7 @@ public class ValidatingSubstitutorTests extends ESTestCase {
         }
         {
             var sub = new ValidatingSubstitutor(Map.of("some_key", "value", "key2", "value2"), "${", "}");
-            var exception = expectThrows(IllegalStateException.class, () -> sub.replace("super:${     \\/\tkey\"}", "setting"));
+            var exception = expectThrows(IllegalArgumentException.class, () -> sub.replace("super:${     \\/\tkey\"}", "setting"));
 
             assertThat(
                 exception.getMessage(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequestTests.java
@@ -358,7 +358,7 @@ public class CustomRequestTests extends ESTestCase {
             ),
             model
         );
-        var exception = expectThrows(IllegalStateException.class, () -> RequestTests.getHttpRequestSync(request));
+        var exception = expectThrows(IllegalArgumentException.class, () -> RequestTests.getHttpRequestSync(request));
         assertThat(
             exception.getMessage(),
             is(
@@ -510,7 +510,7 @@ public class CustomRequestTests extends ESTestCase {
         );
 
         var exception = expectThrows(
-            IllegalStateException.class,
+            IllegalArgumentException.class,
             () -> new CustomRequest(
                 RerankParameters.of(
                     new QueryAndDocsInputs(InferenceString.ofText("query string"), InferenceString.fromStringList(List.of("abc", "123")))

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/BaseCustomResponseParserTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/BaseCustomResponseParserTests.java
@@ -41,7 +41,7 @@ public class BaseCustomResponseParserTests extends ESTestCase {
     public void testConvertToListOfFloats_ThrowsException_WhenAnItemInTheListIsNotANumber() {
         var list = List.of(1, "hello");
 
-        var exception = expectThrows(IllegalStateException.class, () -> convertToListOfFloats(list, "field"));
+        var exception = expectThrows(IllegalArgumentException.class, () -> convertToListOfFloats(list, "field"));
         assertThat(
             exception.getMessage(),
             is("Failed to parse list entry [1], error: Unable to convert field [field] of type [String] to Number")
@@ -63,7 +63,7 @@ public class BaseCustomResponseParserTests extends ESTestCase {
     public void testCastList_ThrowsException() {
         var list = List.of("abc");
 
-        var exception = expectThrows(IllegalStateException.class, () -> castList(list, (obj, fieldName) -> {
+        var exception = expectThrows(IllegalArgumentException.class, () -> castList(list, (obj, fieldName) -> {
             throw new IllegalArgumentException("failed");
         }, "field"));
 
@@ -80,7 +80,7 @@ public class BaseCustomResponseParserTests extends ESTestCase {
     }
 
     public void testValidateMap_ThrowsException_WhenKeysAreNotStrings() {
-        var exception = expectThrows(IllegalStateException.class, () -> validateMap(Map.of("key", "value", 1, "abc"), "field"));
+        var exception = expectThrows(IllegalArgumentException.class, () -> validateMap(Map.of("key", "value", 1, "abc"), "field"));
         assertThat(
             exception.getMessage(),
             is("Extracted field [field] map has an invalid key type. Expected a string but received [Integer]")

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/CompletionResponseParserTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/CompletionResponseParserTests.java
@@ -251,7 +251,7 @@ public class CompletionResponseParserTests extends AbstractBWCWireSerializationT
 
         var parser = new CompletionResponseParser("$.result");
         var exception = expectThrows(
-            IllegalStateException.class,
+            IllegalArgumentException.class,
             () -> parser.parse(new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8)))
         );
 


### PR DESCRIPTION
This PR switches a few `IllegalStateException` to `IllegalArgumentException` to avoid a 500 being returned when the issue is based on user input.