### PR TITLE
[ES|QL] unmute inlinestats.doubleShadowingWithEval

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -646,9 +646,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testMultiTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/150101
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:inlinestats.doubleShadowingWithEval}
-  issue: https://github.com/elastic/elasticsearch/issues/153096
 - class: org.elasticsearch.search.telemetry.SearchCoordinatorPhaseShardBytesMetricsIT
   method: testBatchedQueryPhaseShardErrorRecordsBothRequestAndResultBytes
   issue: https://github.com/elastic/elasticsearch/issues/153109


### PR DESCRIPTION
Resolves: https://github.com/elastic/elasticsearch/issues/153096
It should be fixed by https://github.com/elastic/elasticsearch/pull/153171 already