### PR TITLE
ESQL: Extra tests for `>`, `>=`, `<`, and `<=`

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/comparison.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/comparison.csv-spec
@@ -213,3 +213,54 @@ from employees
 cnt:long
 5
 ;
+
+keywordGreaterThanKeywordField
+from employees
+| where first_name > last_name
+| stats cnt = count(*)
+;
+
+cnt:long
+49
+;
+
+keywordGreaterThanOrEqualKeywordField
+from employees
+| where first_name >= last_name
+| stats cnt = count(*)
+;
+
+cnt:long
+49
+;
+
+keywordLessThanKeywordField
+from employees
+| where first_name < last_name
+| stats cnt = count(*)
+;
+
+cnt:long
+41
+;
+
+keywordLessThanOrEqualKeywordField
+from employees
+| where first_name <= last_name
+| stats cnt = count(*)
+;
+
+cnt:long
+41
+;
+
+keywordNotEqualsKeywordField
+skip_flattened_rewrite: not_equals_desugars_to_not_of_equals_at_parse_time
+from employees
+| where first_name != last_name
+| stats cnt = count(*)
+;
+
+cnt:long
+90
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -1341,14 +1341,6 @@ public class CsvFlattenedKeywordIT extends CsvIT {
         // metadata, so it is excluded from the candidate set entirely (see the "constant".equals(kind)
         // check below) and never appears here as missing.
         "NETWORK_DIRECTION:internal_networks is missing",
-        // NOT_EQUALS can never be exercised by this variant: ExpressionBuilder#buildComparison desugars
-        // "!=" to Not(Equals(lhs, rhs)) at parse time (see EsqlBaseParser.NEQ), so the AST this variant walks
-        // (parsed, pre-analysis) never contains a NotEquals node - only Not wrapping Equals. A keyword field
-        // reference on either side of "!=" is therefore tracked and wrapped as an EQUALS:lhs/EQUALS:rhs argument,
-        // not NOT_EQUALS:lhs/NOT_EQUALS:rhs. comparison.csv-spec's keywordNotEqualsKeywordField test carries a
-        // skip_flattened_rewrite marker documenting this; see it for a query exercising both sides with field refs.
-        "NOT_EQUALS:lhs is missing",
-        "NOT_EQUALS:rhs is missing",
         "NOT_IN:field is missing",
         "NOT_IN:inlist is missing",
         "NOT_LIKE:pattern is missing",
@@ -1417,6 +1409,13 @@ public class CsvFlattenedKeywordIT extends CsvIT {
                         String name = (String) map.get("name");
                         if (name == null) return;
                         name = name.toUpperCase(Locale.ROOT);
+                        // NOT_EQUALS can never be exercised by this variant: ExpressionBuilder#buildComparison desugars
+                        // "!=" to Not(Equals(lhs, rhs)) at parse time (see EsqlBaseParser.NEQ), so the pre-analysis AST
+                        // this variant walks never contains a NotEquals node - only Not wrapping Equals. A keyword field
+                        // reference on either side of "!=" is therefore tracked and wrapped as an EQUALS:lhs/EQUALS:rhs
+                        // argument, never NOT_EQUALS:lhs/NOT_EQUALS:rhs, so the whole operator is excluded from
+                        // candidates here rather than left as a permanent EXPECTED_ERRORS entry.
+                        if ("NOT_EQUALS".equals(name)) return;
 
                         List<Map<String, Object>> signatures = (List<Map<String, Object>>) map.get("signatures");
                         if (signatures == null) return;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvFlattenedKeywordIT.java
@@ -1322,8 +1322,6 @@ public class CsvFlattenedKeywordIT extends CsvIT {
         "FIELD_EXTRACT:path is missing",
         "FIRST_OVER_TIME:field is missing",
         "FROM_BASE64:string is missing",
-        "GREATER_THAN:rhs is missing",
-        "GREATER_THAN_OR_EQUAL:rhs is missing",
         "GREATEST:first is missing",
         "GREATEST:rest is missing",
         "IN:field is missing",
@@ -1333,8 +1331,6 @@ public class CsvFlattenedKeywordIT extends CsvIT {
         "LAST_OVER_TIME:field is missing",
         "LEAST:first is missing",
         "LEAST:rest is missing",
-        "LESS_THAN:rhs is missing",
-        "LESS_THAN_OR_EQUAL:rhs is missing",
         "LIKE:pattern is missing",
         "MATCH:query is missing",
         "MATCH_OPERATOR:field is missing",
@@ -1345,6 +1341,12 @@ public class CsvFlattenedKeywordIT extends CsvIT {
         // metadata, so it is excluded from the candidate set entirely (see the "constant".equals(kind)
         // check below) and never appears here as missing.
         "NETWORK_DIRECTION:internal_networks is missing",
+        // NOT_EQUALS can never be exercised by this variant: ExpressionBuilder#buildComparison desugars
+        // "!=" to Not(Equals(lhs, rhs)) at parse time (see EsqlBaseParser.NEQ), so the AST this variant walks
+        // (parsed, pre-analysis) never contains a NotEquals node - only Not wrapping Equals. A keyword field
+        // reference on either side of "!=" is therefore tracked and wrapped as an EQUALS:lhs/EQUALS:rhs argument,
+        // not NOT_EQUALS:lhs/NOT_EQUALS:rhs. comparison.csv-spec's keywordNotEqualsKeywordField test carries a
+        // skip_flattened_rewrite marker documenting this; see it for a query exercising both sides with field refs.
         "NOT_EQUALS:lhs is missing",
         "NOT_EQUALS:rhs is missing",
         "NOT_IN:field is missing",


### PR DESCRIPTION
Adds some extra tests for `>`, `>=`, `<`, and `<=` that exercise a `keyword` field on both sides of the comparison. This brings in tests for `FIELD_EXTRACT(flattened, "v") > FIELD_EXTRACT(flattened2, "v")` and others via `CsvFlattenedKeywordIT`.