### PR TITLE
Unmute field name length limit YAML test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -376,9 +376,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testUnhollowOnUpdates
   issue: https://github.com/elastic/elasticsearch/issues/151100
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=index/100_field_name_length_limit/Test field name length limit synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/151117
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/151132


### PR DESCRIPTION
The cluster-state wait added in #151200 fixes #151117. Remove the obsolete test mute.

Closes #151117