### PR TITLE
Fixed flaky MultiClustersIT test

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/MultiClustersIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/MultiClustersIT.java
@@ -270,7 +270,11 @@ public class MultiClustersIT extends ESRestTestCase {
         final boolean sorted = randomBoolean();
         if (sorted) {
             searchSource.startArray("sort");
-            searchSource.value("message_id");
+            searchSource.startObject();
+            searchSource.startObject("message_id");
+            searchSource.field("unmapped_type", "long"); // message_id can be unmapped if no doc is indexed.
+            searchSource.endObject();
+            searchSource.endObject();
             searchSource.endArray();
         }
         final Predicate<String> filterHost;


### PR DESCRIPTION
`indexDocuments` uses between(0, 100). With 0 docs, `message_id` is a dynamic field that never gets mapped resulting in the error:

```
{"error":{"root_cause":[{"type":"query_shard_exception","reason":"No mapping found for [message_id] in order to sort on","index_uuid":"xwHLEP2dQQqQgY_ZL8AXtw","index":".ds-logs-apache-kafka-2026.07.07-000001"},{"type":"query_shard_exception","reason":"No mapping found for [message_id] in order to sort on","index_uuid":"XuURLAoYRGOnC4LzD_eKjg","index":".ds-standard-apache-kafka-2026.07.07-000001"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":".ds-logs-apache-kafka-2026.07.07-000001","node":"GgBINCgBQFGW5ZshHzaFmA","reason":{"type":"query_shard_exception","reason":"No mapping found for [message_id] in order to sort on","index_uuid":"xwHLEP2dQQqQgY_ZL8AXtw","index":".ds-logs-apache-kafka-2026.07.07-000001"}},{"shard":0,"index":".ds-standard-apache-kafka-2026.07.07-000001","node":"GgBINCgBQFGW5ZshHzaFmA","reason":{"type":"query_shard_exception","reason":"No mapping found for [message_id] in order to sort on","index_uuid":"XuURLAoYRGOnC4LzD_eKjg","index":".ds-standard-apache-kafka-2026.07.07-000001"}}]},"status":400}
```

This hasn't happened yet here, but did on serverless: https://github.com/elastic/elasticsearch-serverless/issues/7188