### PR TITLE
[ES|QL] Split NdJsonCompressedFormatSpecIT base on csv-spec

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -340,10 +340,10 @@ tests:
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/data_frame_analytics_crud/Test put valid config with default outlier detection, query, and filter}
   issue: https://github.com/elastic/elasticsearch/issues/150630
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
+- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedExternalBasicIT
   method: test {csv-spec:external-basic.forkTwoBranches [ndjson.bz/AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150651
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
+- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedExternalBasicIT
   method: test {csv-spec:external-basic.inlineStatsMaxSalary [ndjson.bz2/AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150652
 - class: org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT
@@ -679,7 +679,7 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecApproximationIT
   method: test {csv-spec:approximation.Lookup join before and after stats by}
   issue: https://github.com/elastic/elasticsearch/issues/153178
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
+- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedExternalBasicIT
   method: test {csv-spec:external-basic.fileMetadataFilterPathLike [ndjson.bz2/S3]}
   issue: https://github.com/elastic/elasticsearch/issues/153182
 - class: org.elasticsearch.xpack.esql.CsvIT
@@ -736,12 +736,6 @@ tests:
 - class: org.elasticsearch.packaging.test.PackageUpgradeTests
   method: test21CheckUpgradedVersion
   issue: https://github.com/elastic/elasticsearch/issues/153329
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
-  method: test {csv-spec:external-basic.fileMetadataFilterPathInExcludesAll [ndjson.bz/S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/153339
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
-  method: test {csv-spec:external-multifile.aggregateMultiFileByGender [ndjson.bz/S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/153340
 - class: org.elasticsearch.xpack.downsample.DownsampleRateIT
   method: testTimeSeriesQuerying_RandomDocuments
   issue: https://github.com/elastic/elasticsearch/issues/153348
@@ -790,12 +784,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
   method: testPointInTimeRelocationClosingSourceContexts
   issue: https://github.com/elastic/elasticsearch/issues/153452
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
-  method: test {csv-spec:external-multifile-resolution.ubnSalaryStats [ndjson.zstd/AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/153470
-- class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
-  method: test {csv-spec:external-multivalue.mvMinFromSplit [ndjson.zst/GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/153471
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testRegistrationOnBccWithLastHollowCommitAndDifferentPrimaryTerm
   issue: https://github.com/elastic/elasticsearch/issues/153472

--- a/x-pack/plugin/esql-datasource-ndjson/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/build.gradle
@@ -123,12 +123,12 @@ tasks.named('javaRestTest') {
   }
 }
 
-// The csvSpecTest source set (created by the plugin above) hosts NdJsonFormatSpecIT and
-// NdJsonCompressedFormatSpecIT plus their shared abstract base. Keeping them out of
-// javaRestTest prevents tests in that JVM fork from poisoning the JVM-global INGEST guard.
-// No variants are declared — the IT classes are hand-written in src/csvSpecTest/java/ because
-// the generator hardcodes a 6-parameter constructor and these tests need 7+ (StorageBackend,
-// format).
+// The csvSpecTest source set (created by the plugin above) hosts NdJsonFormatSpecIT and the
+// per-csv-spec-file compressed suites (NdJsonCompressedExternal*IT) plus their shared abstract
+// bases. Keeping them out of javaRestTest prevents tests in that JVM fork from poisoning the
+// JVM-global INGEST guard. No variants are declared — the IT classes are hand-written in
+// src/csvSpecTest/java/ because the generator hardcodes a 6-parameter constructor and these tests
+// need 7+ (StorageBackend, format).
 esqlCsvSpecTests {
   specFilesDir = project(xpackModule('esql:qa:testFixtures')).file('src/main/resources')
   packageName = 'org.elasticsearch.xpack.esql.qa.ndjson'
@@ -141,8 +141,8 @@ tasks.named('processCsvSpecTestResources').configure {
   dependsOn 'generateStandaloneNdjsonFixtures'
 }
 
-// Runs the two csv-spec ITs (NdJsonFormatSpecIT, NdJsonCompressedFormatSpecIT) in their own
-// JVM, separate from javaRestTest. Both extend AbstractNdJsonExternalSpecTestCase, which
+// Runs the csv-spec ITs (NdJsonFormatSpecIT and the NdJsonCompressedExternal*IT suites) in their
+// own JVM, separate from javaRestTest. They all extend AbstractNdJsonExternalSpecTestCase, which
 // declares the shared ElasticsearchCluster at the abstract-class level — INGEST fires exactly
 // once for the entire suite.
 def csvSpecTests = tasks.register('csvSpecTests', StandaloneRestIntegTestTask) {

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/AbstractNdJsonCompressedFormatSpecTestCase.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/AbstractNdJsonCompressedFormatSpecTestCase.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.qa.ndjson;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.elasticsearch.Build;
@@ -20,15 +19,24 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Parameterized integration tests for compressed NDJSON files (.ndjson.gz, .ndjson.zst, .ndjson.zstd, .ndjson.bz2, .ndjson.bz).
- * Each csv-spec test is run against every configured storage backend (S3, HTTP, LOCAL, GCS) and compression format.
+ * Shared base for the per-csv-spec-file compressed-NDJSON suites. Each concrete subclass covers a
+ * single csv-spec file (mirroring the "one IT suite per csv-spec file" split in #152372) and should
+ * complete well within the JVM suite timeout; the single {@code NdJsonCompressedFormatSpecIT} that
+ * bundled every spec file crossed the 600s suite timeout because its
+ * {@code formats × storage-backends} cross product produced a couple thousand tests.
+ * <p>
+ * This base holds the parts every compressed suite shares — the compressed-format matrix, the
+ * multi-file skip list, the 8-arg constructor, and the {@link ThreadLeakFilters} — so each concrete
+ * class is just a spec-file selector. All subclasses inherit the shared cluster declared on
+ * {@link AbstractNdJsonExternalSpecTestCase}, so the cluster starts once and data is ingested once
+ * for the whole JVM run.
  */
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
-public class NdJsonCompressedFormatSpecIT extends AbstractNdJsonExternalSpecTestCase {
+abstract class AbstractNdJsonCompressedFormatSpecTestCase extends AbstractNdJsonExternalSpecTestCase {
 
     // bzip2 is outside the GA text-format codec surface (uncompressed/gzip/zstd) and is rejected on release
     // builds, so .ndjson.bz2/.ndjson.bz are exercised on snapshot builds only. See elastic/esql-planning#938.
-    private static final List<String> COMPRESSED_FORMATS = Build.current().isSnapshot()
+    protected static final List<String> COMPRESSED_FORMATS = Build.current().isSnapshot()
         ? List.of("ndjson.gz", "ndjson.zst", "ndjson.zstd", "ndjson.bz2", "ndjson.bz")
         : List.of("ndjson.gz", "ndjson.zst", "ndjson.zstd");
 
@@ -46,7 +54,7 @@ public class NdJsonCompressedFormatSpecIT extends AbstractNdJsonExternalSpecTest
         "multiFileMetadataSizePositive"
     );
 
-    public NdJsonCompressedFormatSpecIT(
+    protected AbstractNdJsonCompressedFormatSpecTestCase(
         String fileName,
         String groupName,
         String testName,
@@ -65,16 +73,5 @@ public class NdJsonCompressedFormatSpecIT extends AbstractNdJsonExternalSpecTest
             assumeTrue(testName + " not supported by NDJSON multi-file path (SchemaAdaptingIterator limitation)", false);
         }
         super.shouldSkipTest(testName);
-    }
-
-    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s [%7$s/%8$s]")
-    public static List<Object[]> readScriptSpec() throws Exception {
-        return readExternalSpecTestsWithFormats(
-            COMPRESSED_FORMATS,
-            "/external-basic.csv-spec",
-            "/external-multifile.csv-spec",
-            "/external-multifile-resolution.csv-spec",
-            "/external-multivalue.csv-spec"
-        );
     }
 }

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/AbstractNdJsonExternalSpecTestCase.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/AbstractNdJsonExternalSpecTestCase.java
@@ -16,9 +16,10 @@ import org.junit.ClassRule;
  * Shared cluster base for NDJSON csv-spec tests.
  * <p>
  * Declaring the cluster here — at the abstract-class level — means all concrete subclasses
- * ({@link NdJsonFormatSpecIT}, {@link NdJsonCompressedFormatSpecIT}) inherit the same static
- * {@code cluster} field and therefore share a single {@code ElasticsearchCluster} instance
- * across the entire JVM run. This mirrors the pattern used in
+ * ({@link NdJsonFormatSpecIT} and the per-csv-spec-file compressed suites extending
+ * {@link AbstractNdJsonCompressedFormatSpecTestCase}) inherit the same static {@code cluster} field
+ * and therefore share a single {@code ElasticsearchCluster} instance across the entire JVM run.
+ * This mirrors the pattern used in
  * {@code AbstractParquetExternalSpecTestCase} and lets the JVM-level {@code INGEST} guard in
  * {@code EsqlSpecTestCase} fire exactly once: data is loaded on the first suite and the cluster
  * remains live for subsequent suites without re-loading.

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalBasicIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalBasicIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.ndjson;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+
+import java.util.List;
+
+/**
+ * Compressed-NDJSON csv-spec tests for {@code external-basic.csv-spec}, run against every configured
+ * compression format and storage backend. Split out of the former {@code NdJsonCompressedFormatSpecIT}
+ * so each csv-spec file is its own junit suite (see {@link AbstractNdJsonCompressedFormatSpecTestCase}).
+ */
+public class NdJsonCompressedExternalBasicIT extends AbstractNdJsonCompressedFormatSpecTestCase {
+
+    public NdJsonCompressedExternalBasicIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        String format,
+        StorageBackend storageBackend
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, format, storageBackend);
+    }
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s [%7$s/%8$s]")
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return readExternalSpecTestsWithFormats(COMPRESSED_FORMATS, "/external-basic.csv-spec");
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalMultifileIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalMultifileIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.ndjson;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+
+import java.util.List;
+
+/**
+ * Compressed-NDJSON csv-spec tests for {@code external-multifile.csv-spec}, run against every configured
+ * compression format and storage backend. Split out of the former {@code NdJsonCompressedFormatSpecIT}
+ * so each csv-spec file is its own junit suite (see {@link AbstractNdJsonCompressedFormatSpecTestCase}).
+ */
+public class NdJsonCompressedExternalMultifileIT extends AbstractNdJsonCompressedFormatSpecTestCase {
+
+    public NdJsonCompressedExternalMultifileIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        String format,
+        StorageBackend storageBackend
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, format, storageBackend);
+    }
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s [%7$s/%8$s]")
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return readExternalSpecTestsWithFormats(COMPRESSED_FORMATS, "/external-multifile.csv-spec");
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalMultifileResolutionIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalMultifileResolutionIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.ndjson;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+
+import java.util.List;
+
+/**
+ * Compressed-NDJSON csv-spec tests for {@code external-multifile-resolution.csv-spec}, run against every
+ * configured compression format and storage backend. Split out of the former
+ * {@code NdJsonCompressedFormatSpecIT} so each csv-spec file is its own junit suite (see
+ * {@link AbstractNdJsonCompressedFormatSpecTestCase}).
+ */
+public class NdJsonCompressedExternalMultifileResolutionIT extends AbstractNdJsonCompressedFormatSpecTestCase {
+
+    public NdJsonCompressedExternalMultifileResolutionIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        String format,
+        StorageBackend storageBackend
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, format, storageBackend);
+    }
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s [%7$s/%8$s]")
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return readExternalSpecTestsWithFormats(COMPRESSED_FORMATS, "/external-multifile-resolution.csv-spec");
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalMultivalueIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedExternalMultivalueIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.ndjson;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+
+import java.util.List;
+
+/**
+ * Compressed-NDJSON csv-spec tests for {@code external-multivalue.csv-spec}, run against every configured
+ * compression format and storage backend. Split out of the former {@code NdJsonCompressedFormatSpecIT}
+ * so each csv-spec file is its own junit suite (see {@link AbstractNdJsonCompressedFormatSpecTestCase}).
+ */
+public class NdJsonCompressedExternalMultivalueIT extends AbstractNdJsonCompressedFormatSpecTestCase {
+
+    public NdJsonCompressedExternalMultivalueIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        String format,
+        StorageBackend storageBackend
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, format, storageBackend);
+    }
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s [%7$s/%8$s]")
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return readExternalSpecTestsWithFormats(COMPRESSED_FORMATS, "/external-multivalue.csv-spec");
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonMultiScanPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonMultiScanPushdownIT.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Regression coverage for the COUNT(*)-doubling bug on the streaming-compressed read path
- * (issues #150598, #150620, #150723 and the rest of the NdJsonCompressedFormatSpecIT
+ * (issues #150598, #150620, #150723 and the rest of the NdJsonCompressedExternal* spec-IT
  * "expected &lt;100L&gt; but was &lt;200L&gt;" family).
  * <p>
  * The aggregate-metadata cache captures per-chunk row-count stats during a cold scan and serves


### PR DESCRIPTION

Fixes: #153339 
Fixes: #153340 
Fixes: #153470 
Fixes: #153471 

Split `NdJsonCompressedFormatSpecIT` based on csv-spec to reduce the possibility of timeout

``` 
  ┌───────────────────────────────────────────────┬─────────────────────────────────────────┬─────────────────────────┐
  │ New suite                                     │ csv-spec file                           │ ~tests (was 2352 total) │
  ├───────────────────────────────────────────────┼─────────────────────────────────────────┼─────────────────────────┤
  │ NdJsonCompressedExternalBasicIT               │ /external-basic.csv-spec                │ 1586                    │
  ├───────────────────────────────────────────────┼─────────────────────────────────────────┼─────────────────────────┤
  │ NdJsonCompressedExternalMultifileResolutionIT │ /external-multifile-resolution.csv-spec │ 280                     │
  ├───────────────────────────────────────────────┼─────────────────────────────────────────┼─────────────────────────┤
  │ NdJsonCompressedExternalMultivalueIT          │ /external-multivalue.csv-spec           │ 276                     │
  ├───────────────────────────────────────────────┼─────────────────────────────────────────┼─────────────────────────┤
  │ NdJsonCompressedExternalMultifileIT           │ /external-multifile.csv-spec            │ 209                     │
  └───────────────────────────────────────────────┴─────────────────────────────────────────┴─────────────────────────┘
```
