### PR TITLE
[9.5] ESQL: warm multi-file COUNT(*) survives per-file cache eviction (#153473)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractWarmDatasetAggregateIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractWarmDatasetAggregateIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.junit.Before;
+
+import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Shared scaffold for the warm multi-file {@code COUNT(*)} dataset-aggregate regression suites
+ * ({@link ExternalNdJsonManyFileWarmFoldIT}, {@link ExternalWarmDatasetAggregatePartialEvictionIT}):
+ * the NDJSON/CSV fixture writers, the glob-URI builder, the single-row count assertion, the
+ * parallel-parse pragmas, and the coordinator-pinned {@code run} override. Subclasses keep their own
+ * file counts and node settings — the two suites deliberately sit at opposite ends of the cache-budget
+ * spectrum (tiny LRU vs generous-plus-surgical-eviction).
+ */
+public abstract class AbstractWarmDatasetAggregateIT extends AbstractExternalDataSourceIT {
+
+    /** Each file clears several 64kb segments so the parallel-parse / per-stripe fold path is exercised per file. */
+    protected static final int FILE_BYTES = 512_000;
+
+    /**
+     * These suites drive the {@code parsing_parallelism} pragma to select the SEGMENTABLE_UNCOMPRESSED
+     * parallel-parse regime the dataset-aggregate fold is built for. Pragmas are rejected on release
+     * builds, so skip the whole suite there rather than run it in an unintended serial-parse shape — the
+     * snapshot {@code internalClusterTest} run is the real coverage. Mirrors {@link AbstractPausableIntegTestCase}.
+     */
+    @Before
+    public void requireQueryPragmas() {
+        assumeTrue("requires the snapshot-only parsing_parallelism pragma", canUseQueryPragmas());
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        // parsing_parallelism > 1 selects the SEGMENTABLE_UNCOMPRESSED parallel-parse path (the bench regime).
+        return new QueryPragmas(Settings.builder().put("parsing_parallelism", 8).put("max_concurrent_open_segments", 2).build());
+    }
+
+    /**
+     * The warm-stats cache is coordinator-local (per-node), so cold and warm MUST run on the same
+     * coordinator or the warm lookup misses for a reason unrelated to the fold. Pin both to master
+     * (mirrors {@link ExternalNdJsonMultiStripeFoldIT}) and apply the parallel-parse pragmas.
+     */
+    @Override
+    public EsqlQueryResponse run(EsqlQueryRequest request, TimeValue timeout) {
+        request.pragmas(getPragmas());
+        return client(internalCluster().getMasterName()).execute(EsqlQueryAction.INSTANCE, request).actionGet(timeout);
+    }
+
+    protected static void assertCount(EsqlQueryResponse response, long expected) {
+        List<List<Object>> rows = getValuesList(response);
+        assertThat(rows.size(), equalTo(1));
+        assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo(expected));
+    }
+
+    protected static String globUri(Path dir, String pattern) {
+        String dirUri = StoragePath.fileUri(dir).toString();
+        if (dirUri.endsWith("/") == false) {
+            dirUri += "/";
+        }
+        return dirUri + pattern;
+    }
+
+    protected static long writeNdjsonFile(Path file, long base) throws Exception {
+        long rows = 0;
+        try (BufferedWriter w = Files.newBufferedWriter(file)) {
+            int written = 0;
+            while (written < FILE_BYTES) {
+                long a = base + rows;
+                String line = "{\"a\":" + a + ",\"b\":" + (a * 10) + "}\n";
+                w.write(line);
+                written += line.length();
+                rows++;
+            }
+        }
+        return rows;
+    }
+
+    protected static long writeCsvFile(Path file, long base) throws Exception {
+        long rows = 0;
+        try (BufferedWriter w = Files.newBufferedWriter(file)) {
+            String header = "a,b\n";
+            w.write(header);
+            int written = header.length();
+            while (written < FILE_BYTES) {
+                long a = base + rows;
+                String line = a + "," + (a * 10) + "\n";
+                w.write(line);
+                written += line.length();
+                rows++;
+            }
+        }
+        return rows;
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonManyFileWarmFoldIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonManyFileWarmFoldIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheTestAccess;
+import org.elasticsearch.xpack.esql.execution.PlanExecutor;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Regression tests for the ClickBench {@code ndjson,uncompressed,1rg count_hits} pathology: a warm
+ * {@code FROM <many-file-glob> | STATS COUNT(*)} that RE-SCANS every file instead of serving the
+ * cached row count. The warm multi-file fold is all-or-nothing (the per-file stats aggregate fails the
+ * moment ONE file lacks {@code _stats.row_count}), so under schema-cache LRU pressure — simulated here
+ * with a deliberately tiny {@code esql.source.cache.size} — a single evicted per-file entry used to
+ * force every file to re-scan. The fix is the DATASET-LEVEL row-count aggregate: a single entry keyed
+ * by the listing's file-set fingerprint (path+mtime+size of every file), materialized by the cold scan's
+ * reconcile and served when the per-file merge comes back incomplete, so warm {@code COUNT(*)} needs
+ * exactly one cache survival instead of N.
+ * <p>
+ * The CSV arm is the control (same shape, same fix); the surgical arm below removes ONE per-file entry
+ * explicitly, making the failure mode deterministic instead of load-dependent; the file-set mutation
+ * arm proves the file-set-fingerprint key is correct-or-miss (any add/touch re-scans and serves the NEW truth,
+ * then re-warms).
+ */
+public class ExternalNdJsonManyFileWarmFoldIT extends AbstractWarmDatasetAggregateIT {
+
+    // Enough files that at least one straggler (incomplete stripe coverage) is near-certain, mirroring the
+    // ClickBench cell where the ~50-file glob warmed but the 226-file glob did not.
+    private static final int FILE_COUNT = 40;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(NdJsonDataSourcePlugin.class, CsvDataSourcePlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            // Small stripe grid so every file spans many canonical stripes across multiple read chunks.
+            .put("esql.source.cache.stripe.size", "64kb")
+            // Simulate the cache pressure a loaded cluster creates: a tiny budget so the 40 per-file
+            // entries cannot all coexist, forcing LRU eviction of already-committed siblings.
+            .put("esql.source.cache.size", "48kb")
+            .build();
+    }
+
+    public void testNdjsonManyFileCountStarWarmShortCircuits() throws Exception {
+        Path dir = createTempDir();
+        long total = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            total += writeNdjsonFile(dir.resolve("part-" + f + ".ndjson"), total);
+        }
+        String dataset = registerDataset(
+            "ndjson_manyfile",
+            globUri(dir, "*.ndjson"),
+            Map.of("segment_size", "64kb", "target_split_size", "256mb")
+        );
+        assertWarmCountShortCircuits(dataset, total);
+    }
+
+    /**
+     * The deterministic arm: after the cold scan materializes the dataset aggregate, surgically evict
+     * EVERY per-file schema entry of the dataset (the worst case LRU pressure can produce — the tiny
+     * suite budget may already have evicted an arbitrary subset, so evicting the remainder is the only
+     * deterministic construction). The per-file all-or-nothing merge then fails by construction, so a
+     * green warm assertion proves the dataset-level fallback — not per-file luck — served the count.
+     */
+    public void testNdjsonWarmCountSurvivesPerFileEntryEviction() throws Exception {
+        Path dir = createTempDir();
+        long total = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            total += writeNdjsonFile(dir.resolve("part-" + f + ".ndjson"), total);
+        }
+        String dataset = registerDataset(
+            "ndjson_evict_all",
+            globUri(dir, "*.ndjson"),
+            Map.of("segment_size", "64kb", "target_split_size", "256mb")
+        );
+        String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, total);
+        }
+        ExternalSourceCacheService cacheService = internalCluster().getInstance(PlanExecutor.class, internalCluster().getMasterName())
+            .cacheService();
+        // Evict by directory substring so the count is deterministic regardless of what the tiny LRU
+        // budget already dropped; the dataset-aggregate entry (marker-keyed) is deliberately spared.
+        ExternalSourceCacheTestAccess.invalidatePerFileSchemaEntries(cacheService, dir.getFileName().toString());
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, total);
+            assertThat(
+                "warm COUNT(*) must survive per-file entry eviction via the dataset aggregate",
+                response.documentsFound(),
+                equalTo(0L)
+            );
+        }
+    }
+
+    /**
+     * The correct-or-miss arm: the dataset aggregate is keyed by the listing's file-set fingerprint, so ANY
+     * file-set change (a file added, a file's mtime touched) must MISS it — the next query re-scans and
+     * returns the new truth — and the re-scan's reconcile re-materializes the aggregate for the NEW set,
+     * so the query after that warms again. Serving a stale count at any step is the wrong-answer failure
+     * this arm exists to catch.
+     */
+    public void testNdjsonFileSetChangeInvalidatesDatasetAggregate() throws Exception {
+        Path dir = createTempDir();
+        long total = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            total += writeNdjsonFile(dir.resolve("part-" + f + ".ndjson"), total);
+        }
+        String dataset = registerDataset(
+            "ndjson_mutate_set",
+            globUri(dir, "*.ndjson"),
+            Map.of("segment_size", "64kb", "target_split_size", "256mb")
+        );
+        assertWarmCountShortCircuits(dataset, total);
+
+        // ADD a file: the aggregate for the old set must not serve; the scan returns the new total.
+        long newTotal = total + writeNdjsonFile(dir.resolve("part-added.ndjson"), total);
+        String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, newTotal);
+            assertThat("a grown file set must re-scan, not serve the stale count", response.documentsFound(), equalTo(newTotal));
+        }
+        // ... and the re-scan re-materialized the aggregate for the grown set.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, newTotal);
+            assertThat("the grown set must warm again after one scan", response.documentsFound(), equalTo(0L));
+        }
+
+        // TOUCH one file's mtime (content unchanged): still a different set identity — must re-scan.
+        Path touched = dir.resolve("part-0.ndjson");
+        Files.setLastModifiedTime(touched, FileTime.fromMillis(Files.getLastModifiedTime(touched).toMillis() + 2_000));
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, newTotal);
+            assertThat("a touched mtime must re-scan, not serve the stale aggregate", response.documentsFound(), equalTo(newTotal));
+        }
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, newTotal);
+            assertThat("the touched set must warm again after one scan", response.documentsFound(), equalTo(0L));
+        }
+    }
+
+    public void testCsvManyFileCountStarWarmShortCircuits() throws Exception {
+        // Control: the same many-file warm-fold shape on CSV must short-circuit. If this passes and the
+        // NDJSON arm fails, the defect is NDJSON-specific (not the all-or-nothing fold in the abstract).
+        Path dir = createTempDir();
+        long total = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            total += writeCsvFile(dir.resolve("part-" + f + ".csv"), total);
+        }
+        String dataset = registerDataset("csv_manyfile", globUri(dir, "*.csv"), Map.of("target_split_size", "256mb"));
+        assertWarmCountShortCircuits(dataset, total);
+    }
+
+    private void assertWarmCountShortCircuits(String dataset, long total) {
+        String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+        // Cold: reads every row across every file.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, total);
+            assertThat("cold scan reads all rows", response.documentsFound(), equalTo(total));
+        }
+        // Warm: must serve the cached fold with ZERO documents scanned across ALL files.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, total);
+            assertThat("warm COUNT(*) over a many-file glob must short-circuit (0 docs scanned)", response.documentsFound(), equalTo(0L));
+        }
+    }
+
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalWarmDatasetAggregatePartialEvictionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalWarmDatasetAggregatePartialEvictionIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheTestAccess;
+import org.elasticsearch.xpack.esql.execution.PlanExecutor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Deterministic PARTIAL-eviction regression tests for the warm multi-file {@code COUNT(*)} fold — the
+ * realistic bench failure shape: SOME per-file schema-cache entries are evicted under load while the
+ * rest survive, and the all-or-nothing per-file stats merge fails on the FIRST missing file, which
+ * (pre-fix) forced the warm query to re-scan every file (the ClickBench 20-minute
+ * {@code ndjson,uncompressed,1rg count_hits} warm re-scan).
+ * <p>
+ * Unlike {@link ExternalNdJsonManyFileWarmFoldIT} (a deliberately tiny cache budget, so LRU decides
+ * nondeterministically what survives), this suite runs with a GENEROUS budget where every entry
+ * survives on its own, and then surgically invalidates an exact subset — the minimal trigger (exactly
+ * one file's entry) and the midpoint (half the files) — via {@link ExternalSourceCacheTestAccess}. A
+ * green warm assertion therefore proves the dataset-level aggregate served the count while the
+ * per-file merge was failing by construction; it cannot pass through per-file luck. These arms are
+ * red on a build without the dataset-level aggregate.
+ */
+public class ExternalWarmDatasetAggregatePartialEvictionIT extends AbstractWarmDatasetAggregateIT {
+
+    private static final int FILE_COUNT = 40;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(NdJsonDataSourcePlugin.class, CsvDataSourcePlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            // Small stripe grid so every file spans many canonical stripes across multiple read chunks.
+            .put("esql.source.cache.stripe.size", "64kb")
+            // GENEROUS budget — the opposite end of the spectrum from ExternalNdJsonManyFileWarmFoldIT:
+            // every per-file entry fits, so the ONLY missing entries are the ones each test evicts
+            // explicitly, making "exactly one file missing" a deterministic construction.
+            .put("esql.source.cache.size", "10mb")
+            .build();
+    }
+
+    public void testNdjsonWarmCountSurvivesOneMissingPerFileEntry() throws Exception {
+        runPartialEvictionArm("ndjson", List.of("part-3.ndjson"));
+    }
+
+    public void testNdjsonWarmCountSurvivesHalfMissingPerFileEntries() throws Exception {
+        List<String> evictions = new ArrayList<>();
+        for (int f = 0; f < FILE_COUNT; f += 2) {
+            evictions.add("part-" + f + ".ndjson");
+        }
+        runPartialEvictionArm("ndjson", evictions);
+    }
+
+    public void testCsvWarmCountSurvivesOneMissingPerFileEntry() throws Exception {
+        runPartialEvictionArm("csv", List.of("part-3.csv"));
+    }
+
+    /**
+     * Cold scan (materializes the dataset aggregate via the scan's reconcile), surgical invalidation of
+     * exactly the given files' schema entries, then warm {@code COUNT(*)}: the total must be correct
+     * AND zero documents scanned — the per-file all-or-nothing merge fails on the first missing entry,
+     * so only the dataset-level aggregate can have served it.
+     */
+    private void runPartialEvictionArm(String format, List<String> filesToEvict) throws Exception {
+        Path dir = createTempDir();
+        long total = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            Path file = dir.resolve("part-" + f + "." + format);
+            total += format.equals("csv") ? writeCsvFile(file, total) : writeNdjsonFile(file, total);
+        }
+        Map<String, Object> options = format.equals("csv")
+            ? Map.of("target_split_size", "256mb")
+            : Map.of("segment_size", "64kb", "target_split_size", "256mb");
+        String dataset = registerDataset("partial_evict_" + format + "_" + filesToEvict.size(), globUri(dir, "*." + format), options);
+        String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, total);
+            assertThat("cold scan reads all rows", response.documentsFound(), equalTo(total));
+        }
+
+        ExternalSourceCacheService cacheService = internalCluster().getInstance(PlanExecutor.class, internalCluster().getMasterName())
+            .cacheService();
+        for (String fileName : filesToEvict) {
+            // Bounded to exactly one entry per named file: this arm's contract is an EXACT missing
+            // subset, and under the generous budget every per-file entry survived the cold query, so
+            // each surgical invalidation must remove precisely the file's own entry — otherwise the
+            // arm would assert the fallback against a state it never constructed.
+            int evicted = ExternalSourceCacheTestAccess.invalidatePerFileSchemaEntries(cacheService, fileName, 1);
+            assertThat("surgical eviction of [" + fileName + "] must remove exactly its entry", evicted, equalTo(1));
+        }
+
+        try (var response = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(response, total);
+            assertThat(
+                "warm COUNT(*) must survive " + filesToEvict.size() + " missing per-file entr(ies) via the dataset aggregate",
+                response.documentsFound(),
+                equalTo(0L)
+            );
+        }
+    }
+
+    /**
+     * The "cannot use the aggregate" safe-miss guard. The dataset aggregate is row-count-only, so once it
+     * is materialized and a per-file entry is evicted (per-file merge fails by construction), a warm
+     * {@code COUNT(col)}/{@code MIN}/{@code MAX} must FALL THROUGH to a real scan and return the CORRECT
+     * value — it must never fold {@code COUNT(col)} to 0 (the footer implicit-nulls trap) nor serve a
+     * stale extremum from the row-count-only map. Column {@code a} runs 0..total-1 globally, so the
+     * expected values are exact, and {@code documentsFound == total} proves the query actually scanned.
+     */
+    public void testWarmNonCountAggregatesSafeMissUnderEviction() throws Exception {
+        Path dir = createTempDir();
+        long total = 0;
+        for (int f = 0; f < FILE_COUNT; f++) {
+            total += writeNdjsonFile(dir.resolve("part-" + f + ".ndjson"), total);
+        }
+        String dataset = registerDataset(
+            "safe_miss_ndjson",
+            globUri(dir, "*.ndjson"),
+            Map.of("segment_size", "64kb", "target_split_size", "256mb")
+        );
+        // Cold COUNT(*) materializes the dataset-level aggregate via the scan's reconcile.
+        try (var r = run(syncEsqlQueryRequest("FROM " + dataset + " | STATS c = COUNT(*)").profile(true), TimeValue.timeValueMinutes(5))) {
+            assertCount(r, total);
+        }
+        // Evict one per-file entry so the per-file all-or-nothing merge fails and only the dataset
+        // aggregate (row-count-only) is available.
+        ExternalSourceCacheService cacheService = internalCluster().getInstance(PlanExecutor.class, internalCluster().getMasterName())
+            .cacheService();
+        assertThat(ExternalSourceCacheTestAccess.invalidatePerFileSchemaEntries(cacheService, "part-3.ndjson", 1), equalTo(1));
+
+        String query = "FROM " + dataset + " | STATS c = COUNT(a), lo = MIN(a), hi = MAX(a)";
+        try (var r = run(syncEsqlQueryRequest(query).profile(true), TimeValue.timeValueMinutes(5))) {
+            List<List<Object>> rows = getValuesList(r);
+            assertThat(
+                "COUNT(col) must scan to the correct total, never fold to 0",
+                ((Number) rows.get(0).get(0)).longValue(),
+                equalTo(total)
+            );
+            assertThat("MIN(a) served from scan", ((Number) rows.get(0).get(1)).longValue(), equalTo(0L));
+            assertThat("MAX(a) served from scan", ((Number) rows.get(0).get(2)).longValue(), equalTo(total - 1));
+            assertThat(
+                "COUNT(col)/MIN/MAX must safe-miss to a scan — the row-count-only aggregate cannot serve them",
+                r.documentsFound(),
+                equalTo(total)
+            );
+        }
+    }
+
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheTestAccess.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheTestAccess.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test-only bridge into {@link ExternalSourceCacheService}'s package-private schema cache, so
+ * internal-cluster tests can surgically evict individual PER-FILE entries (deterministically simulating
+ * LRU pressure) without widening the production API. Lives in the internalClusterTest source set only.
+ */
+public final class ExternalSourceCacheTestAccess {
+
+    private ExternalSourceCacheTestAccess() {}
+
+    /**
+     * Invalidates every per-file schema-cache entry whose canonical path contains {@code pathSubstring},
+     * leaving dataset-aggregate entries (marker-suffixed formatType) in place — the surgical arms of the
+     * warm-fold regression tests must remove FILE entries, never the dataset aggregate under test.
+     * Returns the number of entries invalidated.
+     */
+    public static int invalidatePerFileSchemaEntries(ExternalSourceCacheService service, String pathSubstring) {
+        return invalidatePerFileSchemaEntries(service, pathSubstring, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Bounded variant of {@link #invalidatePerFileSchemaEntries(ExternalSourceCacheService, String)}:
+     * invalidates at most {@code maxEntries} matching per-file entries. The deterministic PARTIAL
+     * eviction arms use this to construct an exact missing subset — e.g. exactly ONE per-file entry,
+     * the minimal trigger of the all-or-nothing multi-file stats merge — rather than sweeping
+     * everything under a directory.
+     */
+    public static int invalidatePerFileSchemaEntries(ExternalSourceCacheService service, String pathSubstring, int maxEntries) {
+        List<SchemaCacheKey> victims = new ArrayList<>();
+        service.schemaCache().forEach((key, entry) -> {
+            if (victims.size() < maxEntries && key.canonicalPath().contains(pathSubstring) && key.isDatasetAggregate() == false) {
+                victims.add(key);
+            }
+        });
+        for (SchemaCacheKey victim : victims) {
+            service.schemaCache().invalidate(victim);
+        }
+        return victims.size();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -746,9 +746,13 @@ public class ExternalSourceResolver {
                 // into the async aggregation so text-format multi-file merges force a re-scan instead of serving
                 // a subset COUNT/MIN/MAX (see foldsAbsentColumnAsImplicitNull / SourceStatisticsSerializer).
                 boolean implicitNulls = foldsAbsentColumnAsImplicitNull(base.sourceType());
+                // Prefetch the dataset-level aggregate BEFORE the per-file stats gather — see
+                // applyDatasetAggregate for why post-gather reads self-defeat under cache pressure.
+                DatasetAggregatePrefetch datasetPrefetch = prefetchDatasetAggregate(listing, config, cacheable);
                 ActionListener<Map<String, Object>> statsListener = ActionListener.wrap(aggregatedStats -> {
                     try {
-                        listener.onResponse(finishFirstFileWins(listing, applyFirstFileWinsAggregatedStats(base, aggregatedStats)));
+                        Map<String, Object> effective = applyDatasetAggregate(datasetPrefetch, aggregatedStats, listing, base, config);
+                        listener.onResponse(finishFirstFileWins(listing, applyFirstFileWinsAggregatedStats(base, effective)));
                     } catch (Exception e) {
                         listener.onFailure(e);
                     }
@@ -1032,6 +1036,188 @@ public class ExternalSourceResolver {
         };
     }
 
+    /**
+     * The dataset-level aggregate key for one multi-file resolve, or {@code null} when the shape does not
+     * qualify: single file, no file-set fingerprint, a non-cacheable provider (handled by callers), or — the
+     * format gate — a format that folds an absent column stat as implicit nulls (Parquet/ORC). The
+     * aggregate is ROW-COUNT-ONLY, and under the footer implicit-nulls contract an absent per-column
+     * stat reads as "all null", so serving the aggregate to a footer-format {@code COUNT(col)} would
+     * fold {@code rowCount - rowCount = 0} — a wrong answer. Text formats safe-miss absent columns
+     * instead, so only they may carry the aggregate; a {@code null} key disables put, serve, and
+     * promise registration together. (Precedent: {@code strictSingleFileMetadata} refuses
+     * {@code FILE_TYPED_FORMATS} on its warm rail for the same reason family.)
+     * <p>
+     * Keyed on the listing's file-set fingerprint (see {@link SchemaCacheKey#forDatasetAggregate}), so it
+     * needs no invalidation: any add/remove/mtime/size change in the set derives a different key. The
+     * {@code formatType} slot uses the same extension-based detection the per-file keys use — a stable
+     * identity input; the logical source type may only diverge from it via config keys that are already
+     * part of the key's config fingerprint, with one benign exception: the {@code reader} override is
+     * absent from the fingerprint but can only select footer-format (Parquet-family) readers, which the
+     * format gate above refuses — so no dataset key is ever minted for a reader-overridden resolve.
+     * Package-private for testing.
+     */
+    @Nullable
+    SchemaCacheKey datasetAggregateKey(FileList listing, Map<String, Object> config) {
+        if (listing == null || listing.fileSetFingerprint() == null || listing.fileCount() < 2) {
+            return null;
+        }
+        if (datasetAggregateSafeForFormat(listing, config) == false) {
+            return null;
+        }
+        return SchemaCacheKey.forDatasetAggregate(
+            listing.originalPattern(),
+            listing.fileSetFingerprint(),
+            detectFormatType(listing.path(0)),
+            config
+        );
+    }
+
+    /**
+     * Whether the listing's format treats an ABSENT per-column stat as "not harvested" (safe-miss to a
+     * re-scan) rather than "all null" — the text-format contract that makes a row-count-only aggregate
+     * safe to serve. The format is resolved exactly the way the READ path resolves it
+     * ({@link FormatNameResolver#resolveFormatName}: config {@code format}/{@code reader} override
+     * first, then the compound-extension-aware registry lookup), so this gate can never disagree with
+     * the reader that actually scans — a footer file under a {@code .ndjson} name with
+     * {@code format=parquet} is gated as parquet, and compressed text ({@code .ndjson.gz}) resolves to
+     * {@code ndjson} and qualifies. The {@code formatName() -> findByName} round-trip deliberately
+     * unwraps {@code CompressionDelegatingFormatReader} to the inner reader, whose
+     * {@code aggregatePushdownSupport} is the authoritative one (the wrapper does not forward it).
+     * Any resolution failure refuses: the registry throws {@code QlIllegalArgumentException} (not
+     * {@code java.lang.IllegalArgumentException}) on an unregistered extension, and the aggregate is an
+     * optimization that must never turn a resolvable read into a throw — hence the broad catch.
+     */
+    private boolean datasetAggregateSafeForFormat(FileList listing, Map<String, Object> config) {
+        try {
+            String formatName = FormatNameResolver.resolveFormatName(
+                config,
+                listing.path(0).objectName(),
+                dataSourceModule.formatReaderRegistry()
+            );
+            // Same predicate as foldsAbsentColumnAsImplicitNull, negated: an absent-column stat is only
+            // safe to fold as an implicit null (and thus a dataset COUNT aggregate only correct) for a
+            // KNOWN format that does NOT treat an absent column as implicit null. Delegate so the two
+            // callers can't drift. This rail re-resolves the format from config because it prefetches
+            // before any SourceMetadata (and thus sourceType) exists.
+            return foldsAbsentColumnAsImplicitNull(formatName) == false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * One multi-file resolve's dataset-aggregate prefetch: the key (or {@code null} when the shape does
+     * not qualify — including the non-cacheable case, gated here so it lives in one place) and the
+     * memoized aggregate if present. Read BEFORE the per-file gather; see {@link #applyDatasetAggregate}
+     * for why post-gather reads self-defeat under cache pressure. Package-private for testing.
+     */
+    record DatasetAggregatePrefetch(@Nullable SchemaCacheKey key, @Nullable Map<String, Object> prefetched) {}
+
+    private DatasetAggregatePrefetch prefetchDatasetAggregate(FileList listing, Map<String, Object> config, boolean cacheable) {
+        SchemaCacheKey key = cacheable ? datasetAggregateKey(listing, config) : null;
+        return new DatasetAggregatePrefetch(key, key != null ? cacheService.getDatasetAggregate(key) : null);
+    }
+
+    /**
+     * Resolves the effective multi-file aggregate: the per-file merge when it succeeded, else the
+     * memoized dataset-level aggregate. Centralizes the dataset-aggregate lifecycle both multi-file
+     * rails share:
+     * <ul>
+     *   <li><b>Per-file merge succeeded</b> — write-through on the FIRST such merge for this file set
+     *   (i.e. the prefetch missed): memoize its row count under the dataset key so the NEXT warm query
+     *   survives per-file entry loss (LRU pressure) without re-merging. A later warm resolve whose
+     *   prefetch already hit skips the re-put (the entry is current and was just revived).</li>
+     *   <li><b>Per-file merge failed, prefetch hit</b> — serve the memoized aggregate. The prefetch was
+     *   read (and TTL/LRU-revived) BEFORE the per-file gather on purpose: under cache pressure the
+     *   gather's own {@code putSchema} calls can evict the dataset entry, so reading it after the gather
+     *   would lose exactly the entry this fallback exists to serve. The served map is row-count-only
+     *   ({@code _stats.row_count}), so only COUNT(*) warms from it — MIN/MAX keep re-scanning until the
+     *   per-file rail can serve them (see {@code ExternalSourceCacheService#getDatasetAggregate}).</li>
+     *   <li><b>Both missed (the cold query)</b> — register a pending-descriptor promise so the scan's
+     *   reconcile materializes the aggregate the moment every file folds to whole-file completeness;
+     *   the FIRST warm query is then already protected.</li>
+     * </ul>
+     * The descriptor's expected fingerprint is taken from the reference file's reader-stamped metadata
+     * (the exact value data-node contributions will carry), falling back to the coordinator-side
+     * canonical config only when the probe did not stamp one. Package-private for testing.
+     */
+    @Nullable
+    Map<String, Object> applyDatasetAggregate(
+        DatasetAggregatePrefetch prefetch,
+        @Nullable Map<String, Object> aggregatedStats,
+        FileList listing,
+        SourceMetadata referenceMeta,
+        Map<String, Object> config
+    ) {
+        SchemaCacheKey datasetKey = prefetch.key();
+        if (datasetKey == null) {
+            return aggregatedStats;
+        }
+        if (aggregatedStats != null) {
+            // Write-through only on the FIRST successful merge for this file set — i.e. when the prefetch
+            // missed. Once the aggregate is memoized under the fingerprint key (a set-identity key: same
+            // files => same key => same count), repeat warm resolves needn't re-scan paths or re-put; the
+            // prefetch's getDatasetAggregate already LRU/TTL-revived the entry, so skipping the put here
+            // costs it no liveness. Keeps the common warm-non-evicted path off the O(N) scan + write.
+            if (prefetch.prefetched() == null) {
+                Object rowCount = aggregatedStats.get(SourceStatisticsSerializer.STATS_ROW_COUNT);
+                // Duplicate-path guard on the write-through: a comma-separated list can name the same file
+                // twice, and the reconciliation rail's per-file merge folds a per-path MAP (deduplicated)
+                // while the scan reads the listing MULTISET — memoizing that merge under the fingerprint would
+                // persist an undercount beyond eviction. NOTE: the per-file rail SERVING that dedup merge
+                // immediately is a pre-existing main bug tracked separately (GA issue); this guard only
+                // keeps the dataset aggregate from memoizing it.
+                if (rowCount instanceof Number n && listingPathsAreDistinct(listing)) {
+                    cacheService.putDatasetAggregate(datasetKey, n.longValue(), referenceMeta.sourceType(), listing.originalPattern());
+                }
+            }
+            return aggregatedStats;
+        }
+        cacheService.recordStatsAggregateIncomplete();
+        if (prefetch.prefetched() != null) {
+            // Needed (per-file merge incomplete) AND present: the fallback actually served.
+            cacheService.recordDatasetAggregateHit();
+            return prefetch.prefetched();
+        }
+        // Needed AND absent: the fallback was wanted but missing. Counted symmetrically with the hit above
+        // (both only on the needed path — healthy warm resolves never reach here), so hits/(hits+misses)
+        // is a real fallback hit rate.
+        cacheService.recordDatasetAggregateMiss();
+        Map<String, Long> pathToMtime = new HashMap<>(listing.fileCount());
+        for (int i = 0; i < listing.fileCount(); i++) {
+            pathToMtime.put(listing.path(i).toString(), listing.lastModifiedMillis(i));
+        }
+        Map<String, Object> referenceMetadata = referenceMeta.sourceMetadata();
+        Object stamped = referenceMetadata != null ? referenceMetadata.get(ExternalStats.CONFIG_FINGERPRINT_KEY) : null;
+        String fingerprint = stamped instanceof String s ? s : SchemaCacheKey.buildFormatConfig(config);
+        cacheService.registerPendingDatasetAggregate(
+            datasetKey,
+            pathToMtime,
+            listing.fileCount(),
+            fingerprint,
+            referenceMeta.sourceType(),
+            listing.originalPattern()
+        );
+        return null;
+    }
+
+    /**
+     * True when no path appears twice in the listing (comma-lists may repeat a file; globs cannot). O(N),
+     * resolve-time only. Same duplicate-path guard as the promise rail's {@code size != expectedFileCount}
+     * check in {@code ExternalSourceCacheService#registerPendingDatasetAggregate}, encoded here as a set on
+     * the write-through path so the common warm-non-evicted resolve pays the O(N) scan only when it writes,
+     * not on every key-mint.
+     */
+    private static boolean listingPathsAreDistinct(FileList listing) {
+        Set<String> unique = new HashSet<>(listing.fileCount());
+        for (int i = 0; i < listing.fileCount(); i++) {
+            if (unique.add(listing.path(i).toString()) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private void resolveMultiFileWithReconciliation(
         FileList fileList,
         Map<String, Object> config,
@@ -1040,6 +1226,7 @@ public class ExternalSourceResolver {
         ActionListener<ExternalSourceResolution.ResolvedSource> listener
     ) {
         long startNanos = System.nanoTime();
+        DatasetAggregatePrefetch datasetPrefetch = prefetchDatasetAggregate(fileList, config, cacheable);
         readAllFileMetadata(fileList, config, cacheable, ActionListener.wrap(allMetadata -> {
             try {
                 long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
@@ -1086,6 +1273,7 @@ public class ExternalSourceResolver {
                     reconciledTypes,
                     foldsAbsentColumnAsImplicitNull(firstMeta.sourceType())
                 );
+                aggregatedStats = applyDatasetAggregate(datasetPrefetch, aggregatedStats, fileList, firstMeta, config);
                 ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config, aggregatedStats);
 
                 // Mirror the FFW invariants: file count enables canSkipSplitDiscovery; partial-stats
@@ -1318,7 +1506,10 @@ public class ExternalSourceResolver {
         for (Map.Entry<StoragePath, SourceMetadata> entry : allMetadata.entrySet()) {
             Map<String, Object> flat = flatStatsOf(entry.getValue());
             if (flat == null) {
-                // At least one file has no statistics — cannot produce accurate global stats.
+                // At least one file has no statistics — cannot produce accurate global stats. Name the
+                // first offender: an all-or-nothing miss over hundreds of files is otherwise
+                // undiagnosable (the 20-minute warm re-scan with no trace of WHICH file broke it).
+                LOGGER.debug("multi-file stats aggregate incomplete: [{}] has no statistics", entry.getKey());
                 return null;
             }
             Map<String, DataType> fileTypes = perFileTypes.get(entry.getKey());
@@ -1345,6 +1536,7 @@ public class ExternalSourceResolver {
         for (SourceMetadata meta : allMetadata) {
             Map<String, Object> flat = flatStatsOf(meta);
             if (flat == null) {
+                LOGGER.debug("multi-file stats aggregate incomplete: [{}] has no statistics", meta.location());
                 return null;
             }
             perFileFlatStats.add(flat);
@@ -1453,7 +1645,9 @@ public class ExternalSourceResolver {
             for (SourceMetadata meta : allMeta) {
                 Map<String, Object> fileMeta = meta.sourceMetadata();
                 if (fileMeta == null || fileMeta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false) {
-                    // This file has no statistics — cannot produce accurate global stats.
+                    // This file has no statistics — cannot produce accurate global stats. Name the first
+                    // offender; the all-or-nothing miss is otherwise undiagnosable at glob scale.
+                    LOGGER.debug("multi-file stats aggregate incomplete: [{}] has no row count", meta.location());
                     listener.onResponse(null);
                     return;
                 }
@@ -1972,8 +2166,11 @@ public class ExternalSourceResolver {
      * schema-cache lookup — the post-query stats reconcile keys on path+mtime+config_fingerprint (NOT the format-type),
      * so the harvested row-count still lands on this entry. It does NOT isolate the *stats* across declarations; that is
      * why {@link #strictSingleFileMetadata} serves only the declaration-independent row-count (see there).
+     * <p>
+     * Declared in {@link SchemaCacheKey} next to its sibling reserved suffix so the two markers'
+     * distinctness is visible at one declaration site.
      */
-    private static final String STRICT_DECLARED_SCHEMA_MARKER = "#strict-declared";
+    private static final String STRICT_DECLARED_SCHEMA_MARKER = SchemaCacheKey.STRICT_DECLARED_SCHEMA_MARKER;
 
     /**
      * Builds the strict single-file source metadata, warming the ungrouped-{@code COUNT(*)} metadata fast path for

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSetFingerprint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSetFingerprint.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+/**
+ * The 128-bit fingerprint of a resolved file SET, carried as two 64-bit Murmur3 lanes.
+ * <p>
+ * Computed by {@code FileSetFingerprints#compute} as a commutative fold over every file's
+ * {@code (path, mtime, size)}, with the file count mixed into the final avalanche: the same set listed
+ * in any order yields the same fingerprint, and any file added, removed, or modified yields a different
+ * one. That makes fingerprint-derived cache keys correct-or-miss by construction — no invalidation
+ * protocol.
+ * <p>
+ * 128 bits, not 64, because a collision serves one set's row count for a different set — a wrong answer,
+ * not a slow path. A 64-bit hash birthday-collides around 2^32 distinct sets (reachable on a long-lived
+ * coordinator); 128 bits (~2^64) makes it negligible. Non-cryptographic (Murmur3): guards accidental
+ * staleness, not an adversary crafting a collision.
+ * <p>
+ * Lives in {@code datasources} (not the {@code glob} impl package) because it is the return type of the
+ * {@code spi.FileList} SPI method, alongside its sibling value type {@code PartitionMetadata}.
+ */
+public record FileSetFingerprint(long high, long low) {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.ColumnStatTypeSupport;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
@@ -28,11 +29,15 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongFunction;
 
 /**
  * Coordinator-only, in-memory cache service for external source metadata.
@@ -61,6 +66,57 @@ public class ExternalSourceCacheService implements Closeable {
      * it once no thread holds it.
      */
     private final KeyedLock<String> stripeCommitLocks = new KeyedLock<>();
+
+    /**
+     * A resolve-registered promise that a dataset-level aggregate should be materialized once the
+     * in-flight cold scan's reconcile proves every file of the set whole-file complete. Registered by
+     * the resolver when the multi-file per-file aggregate comes back incomplete (the cold query);
+     * fulfilled — sum of per-file row counts committed under the dataset key — only when EVERY path
+     * folded to whole-file completeness in one reconcile with the expected mtime and config
+     * fingerprint. A poisoned, incomplete, or mid-flight-modified file leaves the descriptor
+     * unfulfilled: correct-or-miss, exactly like the per-file rail.
+     */
+    private record PendingDatasetAggregate(
+        SchemaCacheKey datasetKey,
+        Map<String, Long> pathToMtimeMillis,
+        String configFingerprint,
+        String sourceType,
+        String location,
+        long registeredAtNanos
+    ) {}
+
+    /**
+     * Bounded registry of pending dataset aggregates, insertion-ordered so overflow drops the oldest.
+     * Bounded on TWO axes: descriptor count ({@link #MAX_PENDING_DATASET_AGGREGATES}) and total stored
+     * paths across all descriptors ({@link #MAX_PENDING_TOTAL_PATHS}) — each descriptor copies a
+     * path→mtime map for every file of its glob, so without the path budget 64 descriptors of
+     * MAX_DISCOVERED_FILES-sized globs would pin unbounded coordinator heap outside any cache budget.
+     * Guarded by its own monitor ({@code synchronized (pendingDatasetAggregates)}): registration is
+     * per-resolve and fulfillment is per-reconcile, both rare, so a plain lock never contends.
+     * Deliberately NOT a {@link CacheBuilder} cache: that offers a count bound or a weight bound but not
+     * both at once, has no fulfill-then-remove semantics (a promise is consumed exactly once, not
+     * evicted), and its {@code expireAfterWrite} TTL is the wrong clock — the promise horizon must be
+     * decoupled from the schema TTL (see {@link #PENDING_DATASET_AGGREGATE_TTL_NANOS}).
+     */
+    private static final int MAX_PENDING_DATASET_AGGREGATES = 64;
+    private static final int MAX_PENDING_TOTAL_PATHS = 65_536;
+    private final LinkedHashMap<SchemaCacheKey, PendingDatasetAggregate> pendingDatasetAggregates = new LinkedHashMap<>();
+
+    /**
+     * Pending-descriptor expiry horizon. Deliberately a FIXED constant DECOUPLED from the schema TTL:
+     * the promise is registered at resolve time (before the scan) and fulfilled at reconcile time
+     * (after the scan), so it must comfortably outlive the longest realistic cold scan — a schema-TTL
+     * horizon (5m default) would expire the promise of exactly the multi-minute scans this mechanism
+     * exists for, before their own reconcile could fulfill it. A stale promise costs nothing: the
+     * registry is tiny and doubly bounded, and fulfillment re-validates every path's mtime and config
+     * fingerprint, so correctness never depends on this horizon. (Fulfillment writes a FRESH cache
+     * entry whose own TTL starts at write time — the promise's age does not leak into the entry's.)
+     */
+    private static final long PENDING_DATASET_AGGREGATE_TTL_NANOS = TimeUnit.HOURS.toNanos(1);
+
+    private final LongAdder datasetAggregateHits = new LongAdder();
+    private final LongAdder datasetAggregateMisses = new LongAdder();
+    private final LongAdder statsAggregateIncomplete = new LongAdder();
 
     public ExternalSourceCacheService(Settings settings) {
         ByteSizeValue totalBudget = ExternalSourceCacheSettings.CACHE_SIZE.get(settings);
@@ -129,6 +185,156 @@ public class ExternalSourceCacheService implements Closeable {
     }
 
     /**
+     * Returns the dataset-level aggregate stats stored under {@code key} (see
+     * {@link SchemaCacheKey#forDatasetAggregate}), or {@code null} on a miss. The map carries only
+     * dataset-INDEPENDENT-of-declaration keys — today just {@code _stats.row_count} — never per-column
+     * stats, so serving it can never leak a wrongly-normalized MIN/MAX (those keep re-scanning until the
+     * per-file rail serves them). A found entry is re-put to refresh the {@code expireAfterWrite} clock
+     * and LRU position: the entry is the warm path's single survival dependency, so a hot dataset must not
+     * decay mid-use while its per-file siblings churn (same revive the per-file reconcile applies to
+     * recovered entries). Does NOT touch the hit/miss counters — those are resolver-driven at the serve
+     * decision (see {@link #recordDatasetAggregateHit} / {@link #recordDatasetAggregateMiss}).
+     */
+    @Nullable
+    public Map<String, Object> getDatasetAggregate(SchemaCacheKey key) {
+        if (enabled == false || key == null) {
+            return null;
+        }
+        SchemaCacheEntry entry = schemaCache.get(key);
+        if (entry == null || entry.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT) instanceof Number == false) {
+            return null;
+        }
+        // No hit/miss counting here: every resolve prefetches (including healthy warm resolves whose
+        // per-file merge will succeed and never need the aggregate), so a get-side counter would count
+        // non-events. The resolver counts a hit/miss only when the fallback was actually needed — see
+        // recordDatasetAggregateHit / recordDatasetAggregateMiss.
+        schemaCache.put(key, entry); // refresh write-time TTL + LRU recency
+        return entry.safeMetadata();
+    }
+
+    /**
+     * Stores the dataset-level row-count aggregate for one resolved file set. The entry is a synthetic
+     * {@link SchemaCacheEntry} (no columns; {@code safeMetadata} = the row count) so all existing schema
+     * cache plumbing — weigher, TTL, enable/disable, clearAll, usage stats — applies unchanged.
+     */
+    public void putDatasetAggregate(SchemaCacheKey key, long rowCount, String sourceType, String location) {
+        if (enabled == false || key == null || rowCount < 0) {
+            return;
+        }
+        SchemaCacheEntry entry = new SchemaCacheEntry(
+            new String[0],
+            new DataType[0],
+            new Nullability[0],
+            new boolean[0],
+            sourceType,
+            location,
+            Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount),
+            Map.of(),
+            System.currentTimeMillis()
+        );
+        schemaCache.put(key, entry);
+    }
+
+    /**
+     * Registers a {@link PendingDatasetAggregate} promise for the reconcile of the in-flight cold scan
+     * to fulfill. Doubly bounded ({@value #MAX_PENDING_DATASET_AGGREGATES} descriptors /
+     * {@value #MAX_PENDING_TOTAL_PATHS} total stored paths, oldest dropped) and expired on
+     * {@link #PENDING_DATASET_AGGREGATE_TTL_NANOS}, so an abandoned promise (query failed, scan
+     * partial) costs nothing. Re-registering the same dataset key replaces the previous promise
+     * (same content, refreshed clock).
+     * <p>
+     * {@code expectedFileCount} is the resolved listing's file COUNT (a multiset count: a
+     * comma-separated source list can name the same file twice, and the scan then counts its rows
+     * twice). {@code pathToMtimeMillis} is a map and therefore deduplicates; when the two disagree the
+     * promise-side sum over unique paths would publish an undercount relative to the scan, so
+     * registration is refused — the dataset stays on the re-scan path (correct-or-miss).
+     */
+    public void registerPendingDatasetAggregate(
+        SchemaCacheKey datasetKey,
+        Map<String, Long> pathToMtimeMillis,
+        int expectedFileCount,
+        String configFingerprint,
+        String sourceType,
+        String location
+    ) {
+        if (enabled == false || datasetKey == null || pathToMtimeMillis == null || pathToMtimeMillis.size() < 2) {
+            return;
+        }
+        if (pathToMtimeMillis.size() != expectedFileCount) {
+            // Duplicate paths in the listing — a unique-path sum would undercount the multiset scan. Same
+            // guard as ExternalSourceResolver#listingPathsAreDistinct on the write-through rail, encoded
+            // here as size-vs-count because the map has already deduplicated.
+            return;
+        }
+        if (pathToMtimeMillis.size() > MAX_PENDING_TOTAL_PATHS) {
+            return; // one glob beyond the whole registry's path budget — safe-miss rather than pin the heap
+        }
+        PendingDatasetAggregate pending = new PendingDatasetAggregate(
+            datasetKey,
+            Map.copyOf(pathToMtimeMillis),
+            configFingerprint,
+            sourceType,
+            location,
+            System.nanoTime()
+        );
+        synchronized (pendingDatasetAggregates) {
+            pendingDatasetAggregates.remove(datasetKey); // re-insert at tail so eviction order tracks freshness
+            pendingDatasetAggregates.put(datasetKey, pending);
+            Iterator<PendingDatasetAggregate> it = pendingDatasetAggregates.values().iterator();
+            int totalPaths = 0;
+            for (PendingDatasetAggregate p : pendingDatasetAggregates.values()) {
+                totalPaths += p.pathToMtimeMillis().size();
+            }
+            while ((pendingDatasetAggregates.size() > MAX_PENDING_DATASET_AGGREGATES || totalPaths > MAX_PENDING_TOTAL_PATHS)
+                && it.hasNext()) {
+                PendingDatasetAggregate evicted = it.next();
+                if (evicted == pending) {
+                    break; // never evict the entry just registered; both bounds are already satisfied for it alone
+                }
+                totalPaths -= evicted.pathToMtimeMillis().size();
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Counts a resolve whose per-file stats aggregate came back incomplete (observability). Only
+     * aggregate-QUALIFYING resolves are counted (multi-file, text-format, file-set-fingerprint-bearing,
+     * cacheable provider): the caller sits after the {@code datasetKey == null} early-return in
+     * {@code ExternalSourceResolver#applyDatasetAggregate}, so non-qualifying incompletes never reach it.
+     * <p>
+     * Today {@code stats_aggregate.incomplete == dataset_aggregate.hits + dataset_aggregate.misses}
+     * exactly (every incomplete then resolves to precisely one of hit/miss on the same needed path). Kept
+     * as its own counter so the "the per-file merge was incomplete" signal survives a future serve path
+     * that grows a third outcome and breaks that identity.
+     */
+    public void recordStatsAggregateIncomplete() {
+        statsAggregateIncomplete.increment();
+    }
+
+    /**
+     * Counts a dataset-aggregate fallback that was NEEDED (the per-file merge came back incomplete) AND
+     * PRESENT — i.e. the memoized aggregate was actually served. Resolver-driven and symmetric with
+     * {@link #recordDatasetAggregateMiss} so that {@code hits / (hits + misses)} is a true fallback hit
+     * rate over the resolves that actually needed the aggregate.
+     */
+    public void recordDatasetAggregateHit() {
+        datasetAggregateHits.increment();
+    }
+
+    /**
+     * Counts a dataset-aggregate fallback that was NEEDED (the per-file merge came back incomplete) but
+     * ABSENT. Deliberately resolver-driven rather than incremented inside {@link #getDatasetAggregate}:
+     * every multi-file resolve prefetches the aggregate — including healthy warm resolves whose per-file
+     * merge succeeds and never consumes it — so a get-side counter would count non-events. Its hit twin
+     * ({@link #recordDatasetAggregateHit}) is counted at the same serve decision, so the two share a
+     * denominator (resolves that needed the fallback) and their ratio is meaningful.
+     */
+    public void recordDatasetAggregateMiss() {
+        datasetAggregateMisses.increment();
+    }
+
+    /**
      * Returns a cached file listing or stores the provided one. The loader is only invoked
      * on a cache miss. When the cache is disabled, the loader is called directly (bypassing the cache).
      */
@@ -160,6 +366,18 @@ public class ExternalSourceCacheService implements Closeable {
         // than dependent on path hashCode. Final per-entry state is order-independent (each path keys a
         // distinct entry; a swept sibling is recovered per key), so this only pins reproducibility.
         Map<String, Map<String, Object>> merged = new LinkedHashMap<>(contributionsPerFile.size());
+        // Per-path whole-file stats this reconcile PROVED complete (a whole-file contribution, or a
+        // stripe delta whose committed fold reached 0..K+EOF). Input to the pending dataset-aggregate
+        // fulfillment below: a dataset promise is honored only when every one of its paths lands here.
+        // Only worth tracking while a promise is actually pending — the common no-promise reconcile
+        // skips the bookkeeping and the direct delta fold entirely. A promise registered concurrently
+        // after this check belongs to a resolve whose own scan has not reconciled yet, so skipping it
+        // this reconcile loses nothing (its own reconcile fulfills it).
+        final boolean anyPendingDatasetAggregate;
+        synchronized (pendingDatasetAggregates) {
+            anyPendingDatasetAggregate = pendingDatasetAggregates.isEmpty() == false;
+        }
+        Map<String, Map<String, Object>> completedWholeFile = new HashMap<>(contributionsPerFile.size());
         for (Map.Entry<String, List<Map<String, Object>>> e : contributionsPerFile.entrySet()) {
             List<Map<String, Object>> contributions = e.getValue();
             if (contributions == null || contributions.isEmpty()) {
@@ -198,6 +416,9 @@ public class ExternalSourceCacheService implements Closeable {
                 Map<String, Object> mergedForFile = mergeWholeFileContributions(wholeFile);
                 if (mergedForFile != null && mergedForFile.isEmpty() == false) {
                     merged.put(e.getKey(), mergedForFile);
+                    if (anyPendingDatasetAggregate) {
+                        completedWholeFile.put(e.getKey(), mergedForFile);
+                    }
                 }
                 continue;
             }
@@ -206,9 +427,163 @@ public class ExternalSourceCacheService implements Closeable {
                 logger.debug("dropping captured stats for [{}]: no complete stripe among fragments", e.getKey());
                 continue;
             }
-            commitStripeDelta(e.getKey(), delta, preCommitSnapshot.get(e.getKey()));
+            Map<String, Object> foldedWholeFile = commitStripeDelta(e.getKey(), delta, preCommitSnapshot.get(e.getKey()));
+            if (anyPendingDatasetAggregate) {
+                if (foldedWholeFile == null) {
+                    // The entry-side fold requires a matching schema entry to still be cached, but under the
+                    // exact LRU pressure the dataset aggregate exists for, those entries are already
+                    // weight-evicted at reconcile time. A full cold scan's delta is whole-file complete on
+                    // its own (every stripe 0..EOF observed by THIS query), so fold it directly — the
+                    // dataset promise must not depend on per-file cache survival.
+                    foldedWholeFile = foldQueryDeltaStripes(delta);
+                }
+                if (foldedWholeFile != null) {
+                    completedWholeFile.put(e.getKey(), foldedWholeFile);
+                }
+            }
         }
         reconcileSourceStats(merged, preCommitSnapshot);
+        if (anyPendingDatasetAggregate) {
+            fulfillPendingDatasetAggregates(completedWholeFile);
+        }
+    }
+
+    /**
+     * Honors every {@link PendingDatasetAggregate} promise this reconcile fully covers: each of the
+     * promise's paths must appear in {@code completedWholeFile} with a numeric row count, the promised
+     * mtime, and the promised config fingerprint. The sum is committed under the dataset key so the very
+     * FIRST warm query survives per-file entry loss (eviction under pressure — the observed 20-minute
+     * warm re-scan) without waiting for a second successful per-file merge. Expired promises are dropped
+     * on the way through; an unfulfillable promise (poisoned file, cover gap, mid-flight modification)
+     * stays registered until it expires — a later scan of the same set may still complete it.
+     */
+    private void fulfillPendingDatasetAggregates(Map<String, Map<String, Object>> completedWholeFile) {
+        List<PendingDatasetAggregate> candidates;
+        synchronized (pendingDatasetAggregates) {
+            if (pendingDatasetAggregates.isEmpty()) {
+                return;
+            }
+            long now = System.nanoTime();
+            pendingDatasetAggregates.values().removeIf(p -> now - p.registeredAtNanos() > PENDING_DATASET_AGGREGATE_TTL_NANOS);
+            candidates = List.copyOf(pendingDatasetAggregates.values());
+        }
+        for (PendingDatasetAggregate pending : candidates) {
+            Long sum = sumIfFullyCovered(pending, completedWholeFile);
+            if (sum != null) {
+                putDatasetAggregate(pending.datasetKey(), sum, pending.sourceType(), pending.location());
+                synchronized (pendingDatasetAggregates) {
+                    pendingDatasetAggregates.remove(pending.datasetKey());
+                }
+                logger.debug(
+                    "materialized dataset aggregate for [{}]: row_count=[{}] across [{}] files",
+                    pending.location(),
+                    sum,
+                    pending.pathToMtimeMillis().size()
+                );
+            }
+        }
+    }
+
+    /**
+     * Folds ONE query's stripe delta to whole-file {@code _stats.*} keys, or {@code null} when the delta
+     * alone is not whole-file complete (EOF unseen, or an ordinal missing). The stateless counterpart of
+     * {@link #foldCommittedStripes}: no schema-cache entry involved, so it works for files whose entries
+     * were already evicted — a full scan's delta carries every stripe by itself. Cross-query assembly is
+     * deliberately NOT attempted here; a partial scan simply does not fulfill the dataset promise.
+     */
+    @Nullable
+    private static Map<String, Object> foldQueryDeltaStripes(StripeDelta delta) {
+        // TRIPWIRE — coercion asymmetry vs foldCommittedStripes: the stripes folded here are the delta's
+        // RAW per-stripe stats, while foldCommittedStripes folds entry-committed stripes that went through
+        // coerceColumnStatsToResolvedTypes. Safe today because this fold's only consumer is the dataset
+        // aggregate (sumIfFullyCovered), which reads row_count/mtime/fingerprint — never per-column
+        // min/max. If GA extends the dataset aggregate to MIN/MAX, this fold must coerce like the
+        // committed path (or the two folds must share the coercion) before per-column keys are served.
+        return foldStripes(delta.lastStripeOrdinal(), k -> delta.stripes().get(k), delta.mtimeMillis(), delta.fingerprint());
+    }
+
+    /**
+     * The one owner of the whole-file stripe fold: walks stripes {@code 0..lastOrdinal} through
+     * {@code stripeAt}, requiring every ordinal present (all-or-nothing — a gap means knowledge is
+     * incomplete and the fold safe-misses with {@code null}), then merges and re-keys via
+     * {@link #mergeStripesAndRekey}. {@link #foldCommittedStripes} walks the entry-committed
+     * {@code _stats.stripe.<k>} sub-entries; {@link #foldQueryDeltaStripes} walks one query's raw delta.
+     */
+    @Nullable
+    private static Map<String, Object> foldStripes(
+        long lastOrdinal,
+        LongFunction<Map<String, Object>> stripeAt,
+        long mtimeMillis,
+        String fingerprint
+    ) {
+        if (lastOrdinal < 0) {
+            return null;
+        }
+        List<Map<String, Object>> stripes = new ArrayList<>(Math.toIntExact(lastOrdinal) + 1);
+        for (long k = 0; k <= lastOrdinal; k++) {
+            Map<String, Object> stripe = stripeAt.apply(k);
+            if (stripe == null) {
+                return null; // ordinal missing — knowledge incomplete, safe-miss
+            }
+            stripes.add(stripe);
+        }
+        return mergeStripesAndRekey(stripes, mtimeMillis, fingerprint);
+    }
+
+    /**
+     * Merges a list of flat per-stripe stats maps into one whole map and re-attaches the keying fields
+     * (mtime, config fingerprint) that {@code mergeStatistics} — which rebuilds from the {@code _stats.*}
+     * keys only — would drop. {@code implicitNullsForAbsentColumn=false} always: every stripe fold is
+     * text-only, and under the default PROJECTED scope different cold queries harvest different columns,
+     * so a column absent from a stripe means "not harvested by that scan," NOT "all-null" — the footer
+     * ({@code true}) contract would fold that stripe's rows into the column's null_count and under-count
+     * {@code COUNT(col)} / serve a subset MIN/MAX. {@code false} drops a column missing from any stripe
+     * so it safe-misses, matching the cross-file text merge in {@code ExternalSourceResolver}.
+     */
+    @Nullable
+    private static Map<String, Object> mergeStripesAndRekey(List<Map<String, Object>> stripes, long mtimeMillis, String fingerprint) {
+        Map<String, Object> whole = stripes.size() == 1
+            ? new HashMap<>(stripes.get(0))
+            : SourceStatisticsSerializer.mergeStatistics(stripes, false);
+        if (whole != null) {
+            if (mtimeMillis >= 0) {
+                whole.put(ExternalStats.MTIME_MILLIS_KEY, mtimeMillis);
+            }
+            if (fingerprint != null) {
+                whole.put(ExternalStats.CONFIG_FINGERPRINT_KEY, fingerprint);
+            }
+        }
+        return whole;
+    }
+
+    /**
+     * The promise's row-count sum, or {@code null} unless EVERY promised path is whole-file complete in
+     * this reconcile under the promised (mtime, config fingerprint). All-or-nothing at the dataset
+     * level on purpose: a partial sum served as the dataset count would be a wrong answer, whereas a
+     * miss merely re-scans.
+     */
+    @Nullable
+    private static Long sumIfFullyCovered(PendingDatasetAggregate pending, Map<String, Map<String, Object>> completedWholeFile) {
+        long sum = 0;
+        for (Map.Entry<String, Long> expected : pending.pathToMtimeMillis().entrySet()) {
+            Map<String, Object> stats = completedWholeFile.get(expected.getKey());
+            if (stats == null) {
+                return null;
+            }
+            Object rowCount = stats.get(SourceStatisticsSerializer.STATS_ROW_COUNT);
+            Object mtime = stats.get(ExternalStats.MTIME_MILLIS_KEY);
+            if (rowCount instanceof Number == false) {
+                return null;
+            }
+            if (mtime instanceof Number == false || ((Number) mtime).longValue() != expected.getValue()) {
+                return null; // file changed between the resolve's listing and the scan — different version, safe-miss
+            }
+            if (Objects.equals(stats.get(ExternalStats.CONFIG_FINGERPRINT_KEY), pending.configFingerprint()) == false) {
+                return null; // harvested under a different row-interpretation config — not this promise's stats
+            }
+            sum += ((Number) rowCount).longValue();
+        }
+        return sum;
     }
 
     /**
@@ -233,11 +608,12 @@ public class ExternalSourceCacheService implements Closeable {
             return Map.of(); // no sibling to evict — the fallback is never consulted; skip the whole-cache sweep
         }
         // One whole-cache forEach, filtered to the contribution paths. This cannot be a set of per-path
-        // get()s: SchemaCacheKey is a 6-tuple (path, mtime, formatType, formatConfig, endpoint, region), so
-        // a contribution path alone does not reconstruct a key, and forEach is the only path-agnostic
-        // enumeration the Cache exposes that is safe against concurrent LRU mutation (keys()/values() walk
-        // the lock-free LRU list). The sweep is O(cache) for a multi-path reconcile, but that is the price of
-        // capturing each sibling's pre-eviction entry before the first commit's put() prunes the expired ones.
+        // get()s: SchemaCacheKey is a 7-component record (path, mtime, formatType, formatConfig, endpoint,
+        // region, fileSetFingerprint), so a contribution path alone does not reconstruct a key, and forEach
+        // is the only path-agnostic enumeration the Cache exposes that is safe against concurrent LRU
+        // mutation (keys()/values() walk the lock-free LRU list). The sweep is O(cache) for a multi-path
+        // reconcile, but that is the price of capturing each sibling's pre-eviction entry before the first
+        // commit's put() prunes the expired ones.
         Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> byPath = new HashMap<>();
         schemaCache.forEach((key, entry) -> {
             if (paths.contains(key.canonicalPath())) {
@@ -300,7 +676,14 @@ public class ExternalSourceCacheService implements Closeable {
         return matches;
     }
 
-    /** True when the entry is for {@code path}, observed at the contribution's mtime, under the same format config. */
+    /**
+     * True when the entry is for {@code path}, observed at the contribution's mtime, under the same format
+     * config. Dataset-aggregate entries ({@link SchemaCacheKey#DATASET_AGGREGATE_MARKER}) are excluded
+     * explicitly: their canonicalPath is a multi-file glob pattern and their mtime is 0, so a per-file
+     * contribution can never match one structurally, but a per-file enrichment landing on a dataset entry
+     * would corrupt its row-count-only contract — enforce it rather than rely on the structural accident.
+     * (Strict-declared per-file entries, the other reserved suffix, MUST remain matchable.)
+     */
     private static boolean matchesContribution(
         SchemaCacheKey key,
         SchemaCacheEntry entry,
@@ -308,7 +691,8 @@ public class ExternalSourceCacheService implements Closeable {
         long mtimeMillis,
         Object fingerprint
     ) {
-        return path.equals(key.canonicalPath())
+        return key.isDatasetAggregate() == false
+            && path.equals(key.canonicalPath())
             && key.lastModifiedEpochMillis() == mtimeMillis
             && Objects.equals(entry.safeMetadata().get(ExternalStats.CONFIG_FINGERPRINT_KEY), fingerprint);
     }
@@ -491,18 +875,10 @@ public class ExternalSourceCacheService implements Closeable {
         for (SourceStatsContribution.StripeFragment f : chain) {
             maps.add(toFlatMap(f.stats(), f.mtimeMillis(), f.configFingerprint()));
         }
-        // false: text-only fold (see foldCommittedStripes) — an absent column is "not harvested", not all-null.
-        Map<String, Object> folded = maps.size() == 1 ? maps.get(0) : SourceStatisticsSerializer.mergeStatistics(maps, false);
-        if (folded != null && maps.size() > 1) {
-            // mergeStatistics rebuilds from the _stats.* keys only; re-attach the keying fields.
-            if (mtimeMillis >= 0) {
-                folded.put(ExternalStats.MTIME_MILLIS_KEY, mtimeMillis);
-            }
-            if (fingerprint != null) {
-                folded.put(ExternalStats.CONFIG_FINGERPRINT_KEY, fingerprint);
-            }
-        }
-        return folded;
+        // Shared merge+rekey tail: for a single-fragment chain toFlatMap already attached the same
+        // mtime/fingerprint (foldStripeFragments enforces they agree across the chain), so the rekey
+        // is an idempotent overwrite.
+        return mergeStripesAndRekey(maps, mtimeMillis, fingerprint);
     }
 
     /**
@@ -513,28 +889,45 @@ public class ExternalSourceCacheService implements Closeable {
      * whole-file {@code _stats.*} keys — the optimizer's existing warm short-circuit input —
      * making the short-circuit deterministic: complete knowledge implies enrichment, possibly
      * assembled across queries.
+     *
+     * @return the whole-file {@code _stats.*} fold when this commit brought (any matching entry for)
+     *         the file to whole-file completeness, else {@code null}. Input to the dataset-aggregate
+     *         promise fulfillment: the fold is a pure function of the file's bytes at
+     *         {@code (mtime, fingerprint)}, so whichever matching entry completed first is authoritative.
      */
-    private void commitStripeDelta(String path, StripeDelta delta, @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback) {
+    @Nullable
+    private Map<String, Object> commitStripeDelta(
+        String path,
+        StripeDelta delta,
+        @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback
+    ) {
         if (enabled == false || path == null) {
-            return;
+            return null;
         }
         if (delta.mtimeMillis() < 0) {
-            return; // no freshness key — cannot match an entry
+            return null; // no freshness key — cannot match an entry
         }
         // Serialize the read-modify-write per file path: concurrent commits of different stripes for the
         // same file would otherwise each copy the same entry snapshot and the later put would drop the
         // earlier stripe (lost update). Commits are coordinator-side and infrequent.
         try (Releasable ignored = stripeCommitLocks.acquire(path)) {
-            applyStripeDelta(path, delta, fallback);
+            return applyStripeDelta(path, delta, fallback);
         }
     }
 
     /**
      * The locked read-modify-write of {@link #commitStripeDelta}: collect matching entries via
      * {@link #collectMatchingEntries} (live cache, snapshot fallback), then enrich and re-put each.
-     * Must run holding the per-path {@link #stripeCommitLocks} lock.
+     * Must run holding the per-path {@link #stripeCommitLocks} lock. Returns the first completed
+     * whole-file fold (see {@link #commitStripeDelta}).
      */
-    private void applyStripeDelta(String path, StripeDelta delta, @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback) {
+    @Nullable
+    private Map<String, Object> applyStripeDelta(
+        String path,
+        StripeDelta delta,
+        @Nullable List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> fallback
+    ) {
+        Map<String, Object> completedFold = null;
         List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>> matchingEntries = collectMatchingEntries(
             path,
             delta.mtimeMillis(),
@@ -577,9 +970,13 @@ public class ExternalSourceCacheService implements Closeable {
             if (wholeFile != null) {
                 clearStripeState(enriched); // compaction: the fold subsumes the stripes; entry weight back to O(1)
                 enriched.putAll(wholeFile);
+                if (completedFold == null) {
+                    completedFold = wholeFile;
+                }
             }
             schemaCache.put(key, existing.withSafeMetadata(enriched));
         }
+        return completedFold;
     }
 
     /**
@@ -732,37 +1129,16 @@ public class ExternalSourceCacheService implements Closeable {
      */
     private static Map<String, Object> foldCommittedStripes(Map<String, Object> enriched, StripeDelta delta) {
         long lastIndex = enriched.get(ExternalStats.STRIPE_LAST_INDEX_KEY) instanceof Number n ? n.longValue() : -1L;
-        if (lastIndex < 0) {
-            return null;
-        }
-        List<Map<String, Object>> stripes = new ArrayList<>(Math.toIntExact(lastIndex) + 1);
-        for (long k = 0; k <= lastIndex; k++) {
+        // The stripes folded here went through coerceColumnStatsToResolvedTypes when committed — see the
+        // TRIPWIRE on foldQueryDeltaStripes for the coercion asymmetry between the two foldStripes callers.
+        return foldStripes(lastIndex, k -> {
             if (enriched.get(ExternalStats.STRIPE_ENTRY_PREFIX + k) instanceof Map<?, ?> stripe) {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> stripeMap = (Map<String, Object>) stripe;
-                stripes.add(stripeMap);
-            } else {
-                return null; // ordinal missing — knowledge incomplete, keep accumulating
+                return stripeMap;
             }
-        }
-        // implicitNullsForAbsentColumn=false: stripe deltas are text-only, and under the default PROJECTED
-        // scope different cold queries harvest different columns, so an entry's stripes can carry non-uniform
-        // column sets. A column absent from a stripe means "not harvested by that scan," NOT "all-null" — the
-        // footer (true) contract would fold that stripe's rows into the column's null_count and under-count
-        // COUNT(col) / serve a subset MIN/MAX. false drops a column missing from any stripe so it safe-misses,
-        // matching the cross-file text merge in ExternalSourceResolver.
-        Map<String, Object> whole = stripes.size() == 1
-            ? new HashMap<>(stripes.get(0))
-            : SourceStatisticsSerializer.mergeStatistics(stripes, false);
-        if (whole != null) {
-            if (delta.mtimeMillis() >= 0) {
-                whole.put(ExternalStats.MTIME_MILLIS_KEY, delta.mtimeMillis());
-            }
-            if (delta.fingerprint() != null) {
-                whole.put(ExternalStats.CONFIG_FINGERPRINT_KEY, delta.fingerprint());
-            }
-        }
-        return whole;
+            return null; // ordinal missing — knowledge incomplete, keep accumulating
+        }, delta.mtimeMillis(), delta.fingerprint());
     }
 
     /**
@@ -888,8 +1264,8 @@ public class ExternalSourceCacheService implements Closeable {
             long mtimeMillis = ((Number) mtimeObj).longValue();
             // Enrich the schema entry whose config matches the contribution. SchemaCacheKey is keyed on
             // path + mtime + formatType + formatConfig + endpoint + region, so the SAME file can have
-            // several entries — one per (formatType, formatConfig) tuple (e.g. WITH {"header_row": true}
-            // vs {"header_row": false} count rows differently). The config fingerprint disambiguates
+            // several entries — one per (formatType, formatConfig) tuple (e.g. header_row=true vs
+            // header_row=false count rows differently). The config fingerprint disambiguates
             // them, and it is node-stable: both the data node's contribution and the coordinator's entry
             // derive it from SchemaCacheKey.buildFormatConfig of the same logical config, so the guard
             // holds across JVMs (coordinator != data node) — the warm short-circuit's whole point.
@@ -940,6 +1316,9 @@ public class ExternalSourceCacheService implements Closeable {
     public void clearAll() {
         schemaCache.invalidateAll();
         listingCache.invalidateAll();
+        synchronized (pendingDatasetAggregates) {
+            pendingDatasetAggregates.clear();
+        }
     }
 
     public Map<String, Object> usageStats() {
@@ -956,6 +1335,13 @@ public class ExternalSourceCacheService implements Closeable {
         stats.put("listing_cache.hits", listingCache.stats().getHits());
         stats.put("listing_cache.misses", listingCache.stats().getMisses());
         stats.put("listing_cache.evictions", listingCache.stats().getEvictions());
+
+        stats.put("dataset_aggregate.hits", datasetAggregateHits.sum());
+        stats.put("dataset_aggregate.misses", datasetAggregateMisses.sum());
+        synchronized (pendingDatasetAggregates) {
+            stats.put("dataset_aggregate.pending", pendingDatasetAggregates.size());
+        }
+        stats.put("stats_aggregate.incomplete", statsAggregateIncomplete.sum());
 
         return stats;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKey.java
@@ -7,7 +7,11 @@
 
 package org.elasticsearch.xpack.esql.datasources.cache;
 
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
+
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -15,6 +19,11 @@ import java.util.TreeMap;
  * Cache key for schema inference results. Includes mtime-in-key for invalidation.
  * Endpoint and region are included because the same canonical path on different
  * endpoints resolves to different objects.
+ * <p>
+ * {@code fileSetFingerprint} carries the 128-bit fingerprint of the resolved file set for a
+ * dataset-level aggregate key (see {@link #forDatasetAggregate}); it is {@code null} for every
+ * per-file key. A named component rather than smuggling the fingerprint into the mtime/path slots —
+ * record equality/hashCode pick it up automatically.
  */
 public record SchemaCacheKey(
     String canonicalPath,
@@ -22,7 +31,8 @@ public record SchemaCacheKey(
     String formatType,
     String formatConfig,
     String endpoint,
-    String region
+    String region,
+    @Nullable FileSetFingerprint fileSetFingerprint
 ) {
     // Keep this set in sync with every option keyed off the WITH map by a FormatReader's
     // parseOptionsFromConfig / withConfig. The intent is broader than "changes the inferred
@@ -90,7 +100,65 @@ public record SchemaCacheKey(
         String endpoint = config != null ? String.valueOf(config.getOrDefault("endpoint", "")) : "";
         String region = config != null ? String.valueOf(config.getOrDefault("region", "")) : "";
         String formatConfig = buildFormatConfig(config);
-        return new SchemaCacheKey(canonicalPath, mtime, formatType != null ? formatType : "", formatConfig, endpoint, region);
+        return new SchemaCacheKey(canonicalPath, mtime, formatType != null ? formatType : "", formatConfig, endpoint, region, null);
+    }
+
+    /**
+     * Reserved {@code formatType} suffix namespace: extension detection ({@code detectFormatType})
+     * derives {@code formatType} from a file name's last dot, so for any sane object name a
+     * {@code '#'}-suffixed formatType is minted only by an explicit factory. (A pathological object name
+     * literally containing {@code '#dataset-agg'} would collide on the suffix, but a per-file key carries a
+     * null {@code fileSetFingerprint} so it can never equal a dataset key - the only cost is that one file
+     * losing its warm enrichment, a miss, never a wrong answer.) Two members exist:
+     * {@link #STRICT_DECLARED_SCHEMA_MARKER} (per-file entries on the strict-declared warm rail, which
+     * the reconcile's contribution matching MUST still reach) and {@link #DATASET_AGGREGATE_MARKER}
+     * (dataset-level aggregate entries, which contribution matching must NEVER reach - enforced in
+     * {@code ExternalSourceCacheService#matchesContribution}). Co-located here so their distinctness is
+     * visible at the declaration site.
+     */
+    public static final String STRICT_DECLARED_SCHEMA_MARKER = "#strict-declared";
+    public static final String DATASET_AGGREGATE_MARKER = "#dataset-agg";
+
+    /**
+     * Key for a dataset-level aggregate entry: the memoized multi-file stats fold for one resolved file
+     * SET under one format config. Identity is the listing's 128-bit file-set fingerprint (a commutative
+     * fold of every file's path + mtime + size, plus the file count - see
+     * {@code FileList#fileSetFingerprint}), which makes the key correct-or-miss by construction: any file
+     * added, removed, or modified derives a different key, and the stale entry simply ages out via
+     * LRU/TTL - no invalidation protocol. The fingerprint rides the dedicated {@code fileSetFingerprint}
+     * record component; {@code canonicalPath} is the glob pattern (diagnostics-friendly) and the
+     * marker-suffixed {@code formatType} keeps these entries out of the per-file contribution-matching
+     * paths.
+     * <p>
+     * Known residual, inherited from the per-file rail: under a lenient error policy
+     * ({@code skip_row}/{@code null_field}) a harvested row count can be declaration-dependent (see the
+     * {@code warmsRowCountSafely} discussion on the strict single-file rail). The dataset aggregate
+     * memoizes exactly what the per-file rail serves, so it neither narrows nor widens that residual -
+     * both must be closed together by the declared-schema fingerprint follow-up.
+     */
+    public static SchemaCacheKey forDatasetAggregate(
+        String pattern,
+        FileSetFingerprint fingerprint,
+        String sourceType,
+        Map<String, Object> config
+    ) {
+        // A dataset key is identified two ways — the marker suffix on formatType and a non-null
+        // fileSetFingerprint (isDatasetAggregate() vs the collision defense). Require the fingerprint here
+        // so a marker-suffixed key with a null fingerprint is never representable and the two agree.
+        Objects.requireNonNull(fingerprint, "dataset aggregate key requires a non-null file-set fingerprint");
+        String endpoint = config != null ? String.valueOf(config.getOrDefault("endpoint", "")) : "";
+        String region = config != null ? String.valueOf(config.getOrDefault("region", "")) : "";
+        String formatType = (sourceType == null ? "" : sourceType) + DATASET_AGGREGATE_MARKER;
+        return new SchemaCacheKey(pattern == null ? "" : pattern, 0L, formatType, buildFormatConfig(config), endpoint, region, fingerprint);
+    }
+
+    /**
+     * True when this key addresses a dataset-level aggregate entry (minted by {@link #forDatasetAggregate})
+     * rather than a per-file schema entry. Centralizes the {@link #DATASET_AGGREGATE_MARKER} check so the
+     * taxonomy lives with the key instead of being re-derived at each call site.
+     */
+    public boolean isDatasetAggregate() {
+        return formatType().endsWith(DATASET_AGGREGATE_MARKER);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/DictionaryFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/DictionaryFileList.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources.glob;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -34,6 +35,13 @@ final class DictionaryFileList implements FileList {
     @Nullable
     private final PartitionMetadata partitionMetadata;
     private final int fileCount;
+    /**
+     * File-set fingerprint carried over from the raw list this was compacted from — compaction preserves
+     * the file set exactly and the fingerprint is order-independent, so the pass-through value equals what
+     * a recomputation over the compacted representation would produce, without re-materializing paths.
+     */
+    @Nullable
+    private final FileSetFingerprint fileSetFingerprint;
 
     DictionaryFileList(
         String basePath,
@@ -45,7 +53,8 @@ final class DictionaryFileList implements FileList {
         @Nullable String sharedExtension,
         @Nullable String originalPattern,
         @Nullable PartitionMetadata partitionMetadata,
-        int fileCount
+        int fileCount,
+        @Nullable FileSetFingerprint fileSetFingerprint
     ) {
         this.basePath = basePath;
         this.tokens = tokens;
@@ -57,6 +66,13 @@ final class DictionaryFileList implements FileList {
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
         this.fileCount = fileCount;
+        this.fileSetFingerprint = fileSetFingerprint;
+    }
+
+    @Override
+    @Nullable
+    public FileSetFingerprint fileSetFingerprint() {
+        return fileSetFingerprint;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -224,7 +224,8 @@ final class FileListCompactor {
             sharedExt,
             raw.originalPattern(),
             raw.partitionMetadata(),
-            count
+            count,
+            raw.fileSetFingerprint()
         );
     }
 
@@ -349,7 +350,8 @@ final class FileListCompactor {
             sharedExt,
             raw.originalPattern(),
             raw.partitionMetadata(),
-            count
+            count,
+            raw.fileSetFingerprint()
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileSetFingerprints.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileSetFingerprints.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.glob;
+
+import org.elasticsearch.common.hash.MurmurHash3;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
+import org.elasticsearch.xpack.esql.datasources.StorageEntry;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Computes the 128-bit {@linkplain FileList#fileSetFingerprint() file-set fingerprint} of a resolved
+ * file set.
+ * <p>
+ * Each file contributes a 128-bit Murmur3 hash of its path (the same primitive
+ * {@code ListingCacheKey.computeCredentialHash} already uses for identity hashing in the listing
+ * cache), perturbed by its mtime and size with a different multiplier per lane so the two lanes stay
+ * independent. Per-file contributions are folded <em>commutatively</em> (wrapping addition), so the
+ * fingerprint is a pure function of the file SET — the same files listed in a different order produce
+ * the same fingerprint, and any add/remove/mtime/size change produces a different one. The file count
+ * is mixed into the final avalanche so that pathological cancellations across files still perturb the
+ * result.
+ * <p>
+ * The fingerprint is an identity for cache keying (correct-or-miss dataset-level derived state), not a
+ * cryptographic commitment: a 128-bit non-adversarial collision is negligible, matching the
+ * listing-cache credential-hash precedent.
+ */
+final class FileSetFingerprints {
+
+    private FileSetFingerprints() {}
+
+    /** Distinct odd multipliers so mtime and size perturb the two lanes independently. */
+    private static final long MTIME_LANE_MULTIPLIER = 0x9E3779B97F4A7C15L;
+    private static final long SIZE_LANE_MULTIPLIER = 0xC2B2AE3D27D4EB4FL;
+
+    /**
+     * Computes the fingerprint over a raw {@link StorageEntry} list (the {@link GenericFileList}
+     * storage). O(N), intended to run exactly once at listing build.
+     */
+    static FileSetFingerprint compute(List<StorageEntry> files) {
+        MurmurHash3.Hash128 scratch = new MurmurHash3.Hash128();
+        long sum1 = 0;
+        long sum2 = 0;
+        for (StorageEntry file : files) {
+            byte[] pathBytes = file.path().toString().getBytes(StandardCharsets.UTF_8);
+            MurmurHash3.hash128(pathBytes, 0, pathBytes.length, 0, scratch);
+            long mtime = file.lastModified().toEpochMilli();
+            long size = file.length();
+            sum1 += scratch.h1 ^ MurmurHash3.fmix(mtime * MTIME_LANE_MULTIPLIER + size);
+            sum2 += scratch.h2 ^ MurmurHash3.fmix(size * SIZE_LANE_MULTIPLIER + mtime);
+        }
+        return new FileSetFingerprint(MurmurHash3.fmix(sum1 + files.size()), MurmurHash3.fmix(sum2 ^ files.size()));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileList.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources.glob;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -25,6 +26,8 @@ final class GenericFileList implements FileList {
     private final List<StorageEntry> files;
     private final String originalPattern;
     private final PartitionMetadata partitionMetadata;
+    @Nullable
+    private final FileSetFingerprint fileSetFingerprint;
 
     GenericFileList(List<StorageEntry> files, String originalPattern) {
         this(files, originalPattern, null);
@@ -37,6 +40,12 @@ final class GenericFileList implements FileList {
         this.files = files;
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
+        // The fingerprint only ever keys a dataset aggregate, which requires a multi-file listing
+        // (see ExternalSourceResolver#datasetAggregateKey — fileCount >= 2). Skip the Murmur3 fold for
+        // single-file listings so the common single-file resolve does not pay for machinery it cannot use.
+        // Computed eagerly (once per listing build) rather than lazily: consumers need it O(1) at resolve
+        // time, and construction is the one place the entry walk is already paid.
+        this.fileSetFingerprint = files.size() >= 2 ? FileSetFingerprints.compute(files) : null;
     }
 
     List<StorageEntry> files() {
@@ -82,6 +91,12 @@ final class GenericFileList implements FileList {
     public long estimatedBytes() {
         // 64B object header + ~700B per StorageEntry (path String + Instant + long)
         return 64 + files.size() * 700L;
+    }
+
+    @Override
+    @Nullable
+    public FileSetFingerprint fileSetFingerprint() {
+        return fileSetFingerprint;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/HiveFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/HiveFileList.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources.glob;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -37,6 +38,13 @@ final class HiveFileList implements FileList {
     @Nullable
     private final PartitionMetadata partitionMetadata;
     private final int fileCount;
+    /**
+     * File-set fingerprint carried over from the raw list this was compacted from — compaction preserves
+     * the file set exactly and the fingerprint is order-independent, so the pass-through value equals what
+     * a recomputation over the compacted representation would produce, without re-materializing paths.
+     */
+    @Nullable
+    private final FileSetFingerprint fileSetFingerprint;
 
     HiveFileList(
         String basePath,
@@ -51,7 +59,8 @@ final class HiveFileList implements FileList {
         @Nullable String sharedExtension,
         @Nullable String originalPattern,
         @Nullable PartitionMetadata partitionMetadata,
-        int fileCount
+        int fileCount,
+        @Nullable FileSetFingerprint fileSetFingerprint
     ) {
         this.basePath = basePath;
         this.partitionColumnNames = partitionColumnNames;
@@ -66,6 +75,13 @@ final class HiveFileList implements FileList {
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
         this.fileCount = fileCount;
+        this.fileSetFingerprint = fileSetFingerprint;
+    }
+
+    @Override
+    @Nullable
+    public FileSetFingerprint fileSetFingerprint() {
+        return fileSetFingerprint;
     }
 
     private int findGroup(int fileIndex) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileList.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 
 /**
@@ -148,4 +149,21 @@ public interface FileList {
     boolean isEmpty();
 
     long estimatedBytes();
+
+    /**
+     * The 128-bit fingerprint identifying the resolved file SET: a commutative fold over every file's
+     * {@code (path, mtime, size)} plus the file count, computed once when the listing is built. The same
+     * set listed in any order yields the same fingerprint; any file added, removed, or modified (mtime
+     * or size) yields a different one. This makes the fingerprint a content-addressed cache key for
+     * dataset-level derived state (e.g. the warm COUNT(*) aggregate): keys derived from it are
+     * correct-or-miss by construction, with no separate invalidation protocol — and they survive listing
+     * refreshes (the 30s listing TTL) as long as the underlying files are unchanged, because the
+     * fingerprint derives from listing CONTENT, not listing object identity.
+     * <p>
+     * {@code null} for the sentinels and for implementations that do not compute one.
+     */
+    @Nullable
+    default FileSetFingerprint fileSetFingerprint() {
+        return null;
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -30,6 +30,9 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
+import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheKey;
+import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -885,6 +888,245 @@ public class ExternalSourceResolverTests extends ESTestCase {
             () -> false
         );
 
+        return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, cacheService);
+    }
+
+    // ===== dataset-level aggregate key gating =====
+
+    /**
+     * The dataset-level aggregate is ROW-COUNT-ONLY, and under the footer implicit-nulls contract an
+     * absent per-column stat reads as "all null" — a footer-format {@code COUNT(col)} served from it
+     * would fold {@code rowCount - rowCount = 0}, a wrong answer. The key factory is the single gate
+     * that disables put, serve, and promise registration together, so it must refuse implicit-nulls
+     * formats and admit text formats (the positive control keeps this test from passing vacuously).
+     */
+    public void testDatasetAggregateKeyRefusedForImplicitNullsFormats() {
+        ExternalSourceResolver resolver = datasetGateResolver(null);
+
+        FileList parquetListing = GlobExpander.fileListOf(
+            List.of(entry("s3://bucket/data/a.parquet", 100), entry("s3://bucket/data/b.parquet", 200)),
+            "s3://bucket/data/*.parquet"
+        );
+        assertNull(
+            "an implicit-nulls (footer) format must not carry a row-count-only dataset aggregate",
+            resolver.datasetAggregateKey(parquetListing, Map.of())
+        );
+
+        FileList textListing = GlobExpander.fileListOf(
+            List.of(entry("s3://bucket/data/a.ndjson", 100), entry("s3://bucket/data/b.ndjson", 200)),
+            "s3://bucket/data/*.ndjson"
+        );
+        assertNotNull("a text-format listing must qualify (positive control)", resolver.datasetAggregateKey(textListing, Map.of()));
+    }
+
+    /**
+     * The gate resolves the format the way the READ path does, and any resolution failure refuses
+     * rather than throws: the registry throws {@code QlIllegalArgumentException} (not
+     * {@code java.lang.IllegalArgumentException}) on an unregistered extension, and the aggregate is
+     * an optimization that must never turn a resolvable read into a throw.
+     */
+    public void testDatasetAggregateKeyUnregisteredExtensionRefusesWithoutThrowing() {
+        ExternalSourceResolver resolver = datasetGateResolver(null);
+        FileList unknownListing = GlobExpander.fileListOf(
+            List.of(entry("s3://bucket/data/a.xyz", 100), entry("s3://bucket/data/b.xyz", 200)),
+            "s3://bucket/data/*.xyz"
+        );
+        assertNull(
+            "an unregistered extension must refuse the aggregate, not throw",
+            resolver.datasetAggregateKey(unknownListing, Map.of())
+        );
+    }
+
+    /**
+     * The config {@code format} override wins over the file extension, exactly like the read path:
+     * {@code format=parquet} over {@code .ndjson}-named files reads the footer contract, so the
+     * row-count-only aggregate must be refused even though the extension alone would qualify.
+     */
+    public void testDatasetAggregateKeyConfigFormatOverridesExtension() {
+        ExternalSourceResolver resolver = datasetGateResolver(null);
+        FileList ndjsonNamed = GlobExpander.fileListOf(
+            List.of(entry("s3://bucket/data/a.ndjson", 100), entry("s3://bucket/data/b.ndjson", 200)),
+            "s3://bucket/data/*.ndjson"
+        );
+        assertNull(
+            "format=parquet must gate .ndjson-named files as parquet (config wins over extension)",
+            resolver.datasetAggregateKey(ndjsonNamed, Map.of("format", "parquet"))
+        );
+    }
+
+    /**
+     * Duplicate-path guard on the write-through: a comma-separated list can name the same file twice;
+     * the reconciliation rail's per-file merge folds a per-path MAP (deduplicated) while the scan reads
+     * the listing MULTISET, so memoizing that merge under the file-set fingerprint would persist an undercount
+     * beyond eviction. A distinct listing is the positive control.
+     */
+    public void testDatasetAggregateWriteThroughRefusedForDuplicatePaths() {
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(Settings.EMPTY)) {
+            ExternalSourceResolver resolver = datasetGateResolver(cacheService);
+            SourceMetadata referenceMeta = new SimpleSourceMetadata(List.of(), "ndjson", "s3://bucket/data/a.ndjson");
+            Map<String, Object> aggregated = Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+
+            String path = "s3://bucket/data/a.ndjson";
+            FileList duplicated = GlobExpander.fileListOf(List.of(entry(path, 100), entry(path, 100)), path + "," + path);
+            SchemaCacheKey duplicatedKey = resolver.datasetAggregateKey(duplicated, Map.of());
+            assertNotNull("the key factory itself does not police duplicates", duplicatedKey);
+            Map<String, Object> served = resolver.applyDatasetAggregate(
+                new ExternalSourceResolver.DatasetAggregatePrefetch(duplicatedKey, null),
+                aggregated,
+                duplicated,
+                referenceMeta,
+                Map.of()
+            );
+            assertSame("the per-file merge is still served to this query", aggregated, served);
+            assertNull("a duplicate-path merge must not be memoized", cacheService.getDatasetAggregate(duplicatedKey));
+
+            FileList distinct = GlobExpander.fileListOf(
+                List.of(entry("s3://bucket/data/a.ndjson", 100), entry("s3://bucket/data/b.ndjson", 200)),
+                "s3://bucket/data/*.ndjson"
+            );
+            SchemaCacheKey distinctKey = resolver.datasetAggregateKey(distinct, Map.of());
+            resolver.applyDatasetAggregate(
+                new ExternalSourceResolver.DatasetAggregatePrefetch(distinctKey, null),
+                aggregated,
+                distinct,
+                referenceMeta,
+                Map.of()
+            );
+            Map<String, Object> memoized = cacheService.getDatasetAggregate(distinctKey);
+            assertNotNull("a distinct-path merge writes through (positive control)", memoized);
+            assertEquals(100L, memoized.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    /**
+     * Hot-path guard: once the aggregate is memoized under the fingerprint key, a repeat warm resolve
+     * whose prefetch HIT must NOT re-scan paths and re-write it — the set-identity key guarantees the
+     * memoized count is current, and the prefetch's read already kept the entry alive. The differing
+     * merge count here is only a probe to observe whether the (skipped) write-through fired.
+     */
+    public void testDatasetAggregateWriteThroughSkippedWhenPrefetchHit() {
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(Settings.EMPTY)) {
+            ExternalSourceResolver resolver = datasetGateResolver(cacheService);
+            SourceMetadata referenceMeta = new SimpleSourceMetadata(List.of(), "ndjson", "s3://bucket/data/a.ndjson");
+            FileList distinct = GlobExpander.fileListOf(
+                List.of(entry("s3://bucket/data/a.ndjson", 100), entry("s3://bucket/data/b.ndjson", 200)),
+                "s3://bucket/data/*.ndjson"
+            );
+            SchemaCacheKey key = resolver.datasetAggregateKey(distinct, Map.of());
+
+            // First warm resolve, prefetch missed (null): the successful merge writes through.
+            resolver.applyDatasetAggregate(
+                new ExternalSourceResolver.DatasetAggregatePrefetch(key, null),
+                Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L),
+                distinct,
+                referenceMeta,
+                Map.of()
+            );
+            Map<String, Object> memoized = cacheService.getDatasetAggregate(key);
+            assertNotNull("first merge writes through", memoized);
+            assertEquals(100L, memoized.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+
+            // Second warm resolve, prefetch HIT (non-null): the write-through is skipped, so the probe
+            // count (999) is NOT persisted — the memoized value stays as first written.
+            Map<String, Object> served = resolver.applyDatasetAggregate(
+                new ExternalSourceResolver.DatasetAggregatePrefetch(key, memoized),
+                Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 999L),
+                distinct,
+                referenceMeta,
+                Map.of()
+            );
+            assertEquals("the current merge is still served to this query", 999L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+            assertEquals(
+                "prefetch hit => write-through skipped, memoized value unchanged",
+                100L,
+                cacheService.getDatasetAggregate(key).get(SourceStatisticsSerializer.STATS_ROW_COUNT)
+            );
+        }
+    }
+
+    /**
+     * The needed-path counters must fire from the serve decision: a needed-and-present serve bumps
+     * dataset_aggregate.hits, a needed-and-absent serve bumps dataset_aggregate.misses, and they share
+     * the "the per-file merge was incomplete" denominator. Guards against silently zeroing the metric
+     * (the get side deliberately counts nothing).
+     */
+    public void testApplyDatasetAggregateCountsHitAndMissOnNeededPath() {
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(Settings.EMPTY)) {
+            ExternalSourceResolver resolver = datasetGateResolver(cacheService);
+            SourceMetadata referenceMeta = new SimpleSourceMetadata(List.of(), "ndjson", "s3://bucket/data/a.ndjson");
+            FileList distinct = GlobExpander.fileListOf(
+                List.of(entry("s3://bucket/data/a.ndjson", 100), entry("s3://bucket/data/b.ndjson", 200)),
+                "s3://bucket/data/*.ndjson"
+            );
+            SchemaCacheKey key = resolver.datasetAggregateKey(distinct, Map.of());
+
+            // Needed (per-file merge null) AND present (prefetch hit) -> one hit, no miss.
+            resolver.applyDatasetAggregate(
+                new ExternalSourceResolver.DatasetAggregatePrefetch(key, Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L)),
+                null,
+                distinct,
+                referenceMeta,
+                Map.of()
+            );
+            assertEquals(1L, cacheService.usageStats().get("dataset_aggregate.hits"));
+            assertEquals(0L, cacheService.usageStats().get("dataset_aggregate.misses"));
+
+            // Needed AND absent (prefetch miss) -> one miss, hit unchanged.
+            resolver.applyDatasetAggregate(
+                new ExternalSourceResolver.DatasetAggregatePrefetch(key, null),
+                null,
+                distinct,
+                referenceMeta,
+                Map.of()
+            );
+            assertEquals(1L, cacheService.usageStats().get("dataset_aggregate.hits"));
+            assertEquals(1L, cacheService.usageStats().get("dataset_aggregate.misses"));
+        }
+    }
+
+    /** Shared parquet+ndjson module for the dataset-aggregate gate tests; see {@link TextAggregatePushdownSupport}. */
+    private ExternalSourceResolver datasetGateResolver(ExternalSourceCacheService cacheService) {
+        StubFormatReaderWithStats footerReader = new StubFormatReaderWithStats(Map.of(), Map.of());
+        // Same stub, but named ndjson and declaring the text contract: an absent column stat safe-misses
+        // to a re-scan. formatName() must round-trip through the registry back to THIS reader — the gate
+        // resolves reader -> formatName -> findByName, exactly like the read path.
+        StubFormatReaderWithStats textReader = new StubFormatReaderWithStats(Map.of(), Map.of()) {
+            @Override
+            public String formatName() {
+                return "ndjson";
+            }
+
+            @Override
+            public List<String> fileExtensions() {
+                return List.of(".ndjson");
+            }
+
+            @Override
+            public AggregatePushdownSupport aggregatePushdownSupport() {
+                return new TextAggregatePushdownSupport();
+            }
+        };
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"), FormatSpec.of("ndjson", ".ndjson"));
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> footerReader, "ndjson", (s, bf) -> textReader);
+            }
+        };
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            DataSourceCapabilities.build(plugins),
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            new DataSourceCredentials(ENCRYPTION_SERVICE),
+            () -> false
+        );
         return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, cacheService);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.SplitStats;
@@ -1654,6 +1655,338 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         long[] noCredHash = ListingCacheKey.computeCredentialHash(Map.of("format", "parquet"));
         assertEquals(0L, noCredHash[0]);
         assertEquals(0L, noCredHash[1]);
+    }
+
+    // --- dataset-level aggregate (warm COUNT(*) survival independent of per-file entries) ---
+
+    private static SchemaCacheKey datasetKey() {
+        return SchemaCacheKey.forDatasetAggregate(
+            "s3://bucket/data/*.csv",
+            new FileSetFingerprint(111, 222),
+            "csv",
+            Map.of("format", "csv")
+        );
+    }
+
+    public void testDatasetAggregateRoundtrip() {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            SchemaCacheKey key = datasetKey();
+            assertNull("miss before put", service.getDatasetAggregate(key));
+            service.putDatasetAggregate(key, 123L, "csv", "s3://bucket/data/*.csv");
+            Map<String, Object> served = service.getDatasetAggregate(key);
+            assertNotNull(served);
+            assertEquals(123L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+            // Row-count-only contract: the aggregate must never carry per-column stats, so a warm
+            // MIN/MAX can never be served from it (it would skip type normalization).
+            assertEquals(1, served.size());
+            // Neither hit nor miss is counted get-side: every resolve prefetches, including healthy warm
+            // resolves that never need the aggregate. Both counters are resolver-driven at the serve
+            // decision (needed-and-present / needed-and-absent), so they share a denominator.
+            Map<String, Object> usage = service.usageStats();
+            assertEquals(0L, usage.get("dataset_aggregate.hits"));
+            assertEquals(0L, usage.get("dataset_aggregate.misses"));
+            service.recordDatasetAggregateHit();
+            service.recordDatasetAggregateMiss();
+            Map<String, Object> after = service.usageStats();
+            assertEquals(1L, after.get("dataset_aggregate.hits"));
+            assertEquals(1L, after.get("dataset_aggregate.misses"));
+        }
+    }
+
+    public void testPendingDatasetAggregateRefusedWhenSingleGlobExceedsPathBudget() {
+        // A single glob whose file count exceeds the whole registry's path budget is refused up front
+        // (safe-miss) — never registered, so it cannot pin the heap. Observable via the pending gauge.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            int overBudget = 65_536 + 1;
+            Map<String, Long> paths = new LinkedHashMap<>();
+            for (int i = 0; i < overBudget; i++) {
+                paths.put("s3://bucket/data/f" + i + ".csv", (long) i);
+            }
+            service.registerPendingDatasetAggregate(datasetKey(), paths, overBudget, "fp", "csv", "s3://bucket/data/*.csv");
+            assertEquals("an over-budget glob registers no promise", 0, service.usageStats().get("dataset_aggregate.pending"));
+        }
+    }
+
+    public void testPendingDatasetAggregateRegistryEvictsWhenTotalPathBudgetExceeded() {
+        // Cross-descriptor path budget: many mid-size globs whose stored paths sum past the budget must
+        // evict the oldest descriptors (not just the count bound), keeping total stored paths in check.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            int pathsPerGlob = 2_000; // 33 * 2000 = 66000 > 65536, so the count bound (64) is not what trips
+            int globs = 33;
+            for (int g = 0; g < globs; g++) {
+                Map<String, Long> paths = new LinkedHashMap<>();
+                for (int i = 0; i < pathsPerGlob; i++) {
+                    paths.put("s3://bucket/g" + g + "/f" + i + ".csv", (long) i);
+                }
+                SchemaCacheKey key = SchemaCacheKey.forDatasetAggregate(
+                    "s3://bucket/g" + g + "/*.csv",
+                    new FileSetFingerprint(g, g),
+                    "csv",
+                    Map.of("format", "csv")
+                );
+                service.registerPendingDatasetAggregate(key, paths, pathsPerGlob, "fp", "csv", "s3://bucket/g" + g + "/*.csv");
+            }
+            int pending = (Integer) service.usageStats().get("dataset_aggregate.pending");
+            // Well under the count bound (64), so the path budget is what evicted, deterministically:
+            // 33 * 2000 = 66000 > 65536, dropping the single oldest descriptor (2000 paths) brings it to
+            // 64000 <= 65536, so exactly 32 survive. Pin the count to catch an eviction-order regression.
+            assertEquals(globs - 1, pending);
+        }
+    }
+
+    public void testReconcileNeverOverwritesDatasetAggregateRowCount() {
+        // Enforcement test for the dataset-marker exclusion in matchesContribution. A dataset-aggregate
+        // entry holds a WHOLE-SET row count. Here a stray contribution is crafted to match its key on
+        // EVERY other axis — same glob path, mtime 0, and (like the entry) no config fingerprint — so the
+        // isDatasetAggregate() marker guard is the ONLY thing that excludes it. Without that guard the
+        // reconcile would enrich the entry and overwrite the whole-set 100 with the contribution's 42.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String glob = "s3://bucket/data/*.csv";
+            SchemaCacheKey key = SchemaCacheKey.forDatasetAggregate(glob, new FileSetFingerprint(1, 2), "csv", Map.of("format", "csv"));
+            service.putDatasetAggregate(key, 100L, "csv", glob);
+
+            Map<String, Object> strayContribution = new LinkedHashMap<>();
+            strayContribution.put(ExternalStats.MTIME_MILLIS_KEY, 0L); // matches the dataset key's mtime
+            strayContribution.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 42L);
+            // No CONFIG_FINGERPRINT_KEY: matches the dataset entry's absent fingerprint too.
+            service.reconcileSourceStats(Map.of(glob, strayContribution));
+
+            Map<String, Object> served = service.getDatasetAggregate(key);
+            assertNotNull(served);
+            assertEquals(
+                "the dataset aggregate's whole-set count must be untouched",
+                100L,
+                served.get(SourceStatisticsSerializer.STATS_ROW_COUNT)
+            );
+        }
+    }
+
+    public void testPendingDatasetAggregateFulfilledByWholeFileReconcile() {
+        // The cold-scan flow: resolve registers the promise (per-file aggregate incomplete), the scan's
+        // reconcile proves every file whole-file complete, and the dataset aggregate materializes so the
+        // FIRST warm query survives per-file entry loss.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "s3://bucket/data/*.csv");
+            assertNull("promise alone must not serve", service.getDatasetAggregate(key));
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "fp", 200L)))
+            );
+
+            Map<String, Object> served = service.getDatasetAggregate(key);
+            assertNotNull("fully covered promise must materialize", served);
+            assertEquals(300L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    public void testPendingDatasetAggregateFulfilledByStripeFoldReconcile() throws Exception {
+        // Same promise, but the files arrive as stripe fragments (the parallel-parse path): fulfillment
+        // must ride the committed whole-file FOLD, which requires a matching schema entry per file.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "file:///data/a.ndjson";
+            String pathB = "file:///data/b.ndjson";
+            long mtime = 1000L;
+            seedSchemaCache(service, SchemaCacheKey.build(pathA, mtime, ".ndjson", Map.of("format", "ndjson")), pathA, "fp");
+            seedSchemaCache(service, SchemaCacheKey.build(pathB, mtime, ".ndjson", Map.of("format", "ndjson")), pathB, "fp");
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, mtime, pathB, mtime), 2, "fp", "ndjson", "file:///data/*.ndjson");
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(
+                    pathA,
+                    List.of(stripeFragment(mtime, "fp", 40L, 64L, 0L, 0L, 30L, true, true, true)),
+                    pathB,
+                    List.of(stripeFragment(mtime, "fp", 60L, 64L, 0L, 0L, 30L, true, true, true))
+                )
+            );
+
+            Map<String, Object> served = service.getDatasetAggregate(key);
+            assertNotNull("stripe folds reaching whole-file completeness must fulfill the promise", served);
+            assertEquals(100L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    public void testPendingDatasetAggregateFulfilledByDirectDeltaFoldWithNoSeededEntry() {
+        // The eviction-pressure variant of the stripe-fold fulfillment: the files' schema entries are
+        // NOT in the cache at reconcile time (exactly the LRU pressure the dataset aggregate exists
+        // for), so the entry-side commitStripeDelta fold cannot run. Fulfillment must ride the direct
+        // per-query delta fold (foldQueryDeltaStripes) — proving the dataset promise does not depend
+        // on per-file cache survival.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "file:///data/a.ndjson";
+            String pathB = "file:///data/b.ndjson";
+            long mtime = 1000L;
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, mtime, pathB, mtime), 2, "fp", "ndjson", "file:///data/*.ndjson");
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(
+                    pathA,
+                    List.of(stripeFragment(mtime, "fp", 40L, 64L, 0L, 0L, 30L, true, true, true)),
+                    pathB,
+                    List.of(stripeFragment(mtime, "fp", 60L, 64L, 0L, 0L, 30L, true, true, true))
+                )
+            );
+
+            Map<String, Object> served = service.getDatasetAggregate(key);
+            assertNotNull("a whole-file-complete delta must fulfill the promise without a cached schema entry", served);
+            assertEquals(100L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    public void testPendingDatasetAggregateUnfulfilledByPoisonedFile() {
+        // The poison negative: one file's scan did not complete cleanly. Its contributions are
+        // discarded, the promise stays unfulfilled, and the warm query re-scans (correct-or-miss) —
+        // materializing the sum anyway would serve an under-count.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "s3://bucket/data/*.csv");
+
+            Map<String, Object> poison = new LinkedHashMap<>();
+            poison.put(ExternalStats.CHUNK_HAD_ERRORS_KEY, Boolean.TRUE);
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "fp", 200L), poison))
+            );
+
+            assertNull("a poisoned file must leave the promise unfulfilled", service.getDatasetAggregate(key));
+        }
+    }
+
+    public void testPendingDatasetAggregateUnfulfilledOnMtimeMismatch() {
+        // A file modified between the resolve's listing and the scan describes a DIFFERENT file
+        // version; summing it under the promised listing identity would bind a wrong count to the key.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "s3://bucket/data/*.csv");
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2001L, "fp", 200L)))
+            );
+
+            assertNull(service.getDatasetAggregate(key));
+        }
+    }
+
+    public void testPendingDatasetAggregateUnfulfilledOnFingerprintMismatch() {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "s3://bucket/data/*.csv");
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "other-fp", 200L)))
+            );
+
+            assertNull(service.getDatasetAggregate(key));
+        }
+    }
+
+    public void testPendingDatasetAggregateUnfulfilledOnPartialCoverage() {
+        // All-or-nothing at the dataset level: a reconcile covering only some of the promised files
+        // must not materialize a partial sum.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "s3://bucket/data/*.csv");
+
+            service.reconcileSourceStatsFromContributions(Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L))));
+
+            assertNull(service.getDatasetAggregate(key));
+        }
+    }
+
+    public void testPendingDatasetAggregateRegistryBoundDropsOldest() {
+        // The registry is bounded; overflowing it drops the OLDEST promise, whose later fulfillment
+        // must then be a no-op (safe-miss: that dataset's first warm query re-scans).
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            Map<String, Long> paths = Map.of(pathA, 1000L, pathB, 2000L);
+            SchemaCacheKey oldest = SchemaCacheKey.forDatasetAggregate("g0", new FileSetFingerprint(0, 0), "csv", Map.of());
+            service.registerPendingDatasetAggregate(oldest, paths, 2, "fp", "csv", "g0");
+            for (int i = 1; i <= 64; i++) {
+                SchemaCacheKey k = SchemaCacheKey.forDatasetAggregate("g" + i, new FileSetFingerprint(i, i), "csv", Map.of());
+                service.registerPendingDatasetAggregate(k, paths, 2, "fp", "csv", "g" + i);
+            }
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "fp", 200L)))
+            );
+
+            assertNull("evicted oldest promise must not materialize", service.getDatasetAggregate(oldest));
+            SchemaCacheKey newest = SchemaCacheKey.forDatasetAggregate("g64", new FileSetFingerprint(64, 64), "csv", Map.of());
+            Map<String, Object> served = service.getDatasetAggregate(newest);
+            assertNotNull("surviving promise must materialize", served);
+            assertEquals(300L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    public void testPendingDatasetAggregateSingleFileRefused() {
+        // Single-file sources never take the multi-file aggregate rail (their per-file entry IS the
+        // dataset), so a one-path promise is refused at registration.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L), 1, "fp", "csv", "s3://bucket/data/*.csv");
+            service.reconcileSourceStatsFromContributions(Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L))));
+            assertNull(service.getDatasetAggregate(key));
+        }
+    }
+
+    public void testPendingDatasetAggregateRefusedOnDuplicateListingPaths() {
+        // A comma-separated source list can name the same file twice; the scan then counts its rows
+        // TWICE (multiset), but the promise's path map deduplicates — a unique-path sum would publish
+        // an undercount relative to the scan. Registration must be refused when the unique-path count
+        // disagrees with the listing's file count, keeping the dataset on the re-scan path.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            // 3 listed files (b.csv listed twice) but only 2 unique paths.
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 3, "fp", "csv", "dup-glob");
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "fp", 200L)))
+            );
+
+            assertNull("a deduplicating promise over a multiset listing must be refused", service.getDatasetAggregate(key));
+        }
+    }
+
+    public void testPendingDatasetAggregateOutlivesSchemaTtl() throws Exception {
+        // The promise is registered BEFORE the scan and fulfilled AFTER it, so its expiry horizon must
+        // be decoupled from the schema TTL: with a promise horizon tied to the schema TTL, a scan
+        // longer than the TTL (the motivating 20-minute ClickBench cell vs the 5m default) would expire
+        // its OWN promise before its own reconcile — making the whole mechanism inert exactly where it
+        // matters. Shrink the schema TTL far below the register→fulfill gap and prove fulfillment
+        // still materializes the aggregate.
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("50ms"))) {
+            String pathA = "s3://bucket/data/a.csv";
+            String pathB = "s3://bucket/data/b.csv";
+            SchemaCacheKey key = datasetKey();
+            service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "slow-scan-glob");
+
+            Thread.sleep(200); // the "cold scan": several schema TTLs long
+
+            service.reconcileSourceStatsFromContributions(
+                Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "fp", 200L)))
+            );
+
+            // Read immediately: the entry was written by the reconcile just above (its own TTL starts
+            // at write), so only the PROMISE's age is under test here.
+            Map<String, Object> served = service.getDatasetAggregate(key);
+            assertNotNull("a promise must outlive a scan longer than the schema TTL", served);
+            assertEquals(300L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
     }
 
     // --- test helpers ---

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKeyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKeyTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
+
+import java.util.Map;
+
+/**
+ * Locks the identity contract of {@link SchemaCacheKey#forDatasetAggregate}: the key must change with
+ * the listing's file-set fingerprint, the format-affecting config, and the source type — and must be
+ * structurally distinct from every per-file key so the per-file reconcile/lookup paths can never
+ * touch a dataset-aggregate entry.
+ */
+public class SchemaCacheKeyTests extends ESTestCase {
+
+    private static final String PATTERN = "s3://bucket/data/*.ndjson";
+
+    public void testDatasetAggregateKeyStableForSameInputs() {
+        SchemaCacheKey a = SchemaCacheKey.forDatasetAggregate(
+            PATTERN,
+            new FileSetFingerprint(11, 22),
+            "ndjson",
+            Map.of("format", "ndjson")
+        );
+        SchemaCacheKey b = SchemaCacheKey.forDatasetAggregate(
+            PATTERN,
+            new FileSetFingerprint(11, 22),
+            "ndjson",
+            Map.of("format", "ndjson")
+        );
+        assertEquals(a, b);
+    }
+
+    public void testDatasetAggregateKeyChangesWithEitherFingerprintLane() {
+        SchemaCacheKey base = SchemaCacheKey.forDatasetAggregate(PATTERN, new FileSetFingerprint(11, 22), "ndjson", Map.of());
+        assertNotEquals(base, SchemaCacheKey.forDatasetAggregate(PATTERN, new FileSetFingerprint(12, 22), "ndjson", Map.of()));
+        assertNotEquals(base, SchemaCacheKey.forDatasetAggregate(PATTERN, new FileSetFingerprint(11, 23), "ndjson", Map.of()));
+    }
+
+    public void testDatasetAggregateKeyChangesWithFormatAffectingConfig() {
+        // error_mode changes which rows survive a scan, so a count harvested under one policy must
+        // never serve a query running under another — the config fingerprint is part of the key.
+        SchemaCacheKey strict = SchemaCacheKey.forDatasetAggregate(
+            PATTERN,
+            new FileSetFingerprint(11, 22),
+            "ndjson",
+            Map.of("error_mode", "fail_fast")
+        );
+        SchemaCacheKey lenient = SchemaCacheKey.forDatasetAggregate(
+            PATTERN,
+            new FileSetFingerprint(11, 22),
+            "ndjson",
+            Map.of("error_mode", "skip_row")
+        );
+        assertNotEquals(strict, lenient);
+    }
+
+    public void testDatasetAggregateKeyIgnoresCredentials() {
+        // Mirrors buildFormatConfig: credentials are not row-interpretation-affecting, so two users
+        // over the same files share the aggregate (the schema cache is shared by design).
+        SchemaCacheKey a = SchemaCacheKey.forDatasetAggregate(
+            PATTERN,
+            new FileSetFingerprint(11, 22),
+            "ndjson",
+            Map.of("access_key", "userA")
+        );
+        SchemaCacheKey b = SchemaCacheKey.forDatasetAggregate(
+            PATTERN,
+            new FileSetFingerprint(11, 22),
+            "ndjson",
+            Map.of("access_key", "userB")
+        );
+        assertEquals(a, b);
+    }
+
+    public void testDatasetAggregateKeyChangesWithSourceType() {
+        SchemaCacheKey ndjson = SchemaCacheKey.forDatasetAggregate(PATTERN, new FileSetFingerprint(11, 22), "ndjson", Map.of());
+        SchemaCacheKey csv = SchemaCacheKey.forDatasetAggregate(PATTERN, new FileSetFingerprint(11, 22), "csv", Map.of());
+        assertNotEquals(ndjson, csv);
+    }
+
+    public void testDatasetAggregateKeyDistinctFromPerFileKeys() {
+        // Even a per-file key crafted over the same strings cannot equal a dataset key: the file-set
+        // fingerprint rides the dedicated fileSetFingerprint component, which every per-file key leaves
+        // null (so a pathological '#dataset-agg'-bearing object name at most loses warm enrichment, never
+        // collides). canonicalPath stays the plain glob pattern (diagnostics-friendly, no smuggled
+        // separators).
+        SchemaCacheKey dataset = SchemaCacheKey.forDatasetAggregate(PATTERN, new FileSetFingerprint(11, 22), "ndjson", Map.of());
+        SchemaCacheKey perFile = SchemaCacheKey.build(PATTERN, 11L, "ndjson", Map.of());
+        assertNotEquals(dataset, perFile);
+        assertTrue(dataset.isDatasetAggregate());
+        assertFalse(perFile.isDatasetAggregate());
+        assertEquals(PATTERN, dataset.canonicalPath());
+        assertEquals(new FileSetFingerprint(11, 22), dataset.fileSetFingerprint());
+        assertNull(perFile.fileSetFingerprint());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileSetFingerprintsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileSetFingerprintsTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.glob;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
+import org.elasticsearch.xpack.esql.datasources.StorageEntry;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Locks the {@link FileList} file-set-fingerprint contract the dataset-level aggregate cache key
+ * depends on: the fingerprint is a pure function of the file SET (order-independent), and ANY
+ * membership or per-file (mtime, size) change produces a different fingerprint — which is exactly what
+ * makes a fingerprint-derived cache key correct-or-miss with no invalidation protocol.
+ */
+public class FileSetFingerprintsTests extends ESTestCase {
+
+    private static StorageEntry entry(String path, long size, long mtimeMillis) {
+        return new StorageEntry(StoragePath.of(path), size, Instant.ofEpochMilli(mtimeMillis));
+    }
+
+    private static List<StorageEntry> sampleEntries(int count) {
+        List<StorageEntry> entries = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            entries.add(entry("s3://bucket/data/part-" + i + ".ndjson", 1000L + i, 5_000L + i));
+        }
+        return entries;
+    }
+
+    public void testFingerprintIsOrderIndependent() {
+        List<StorageEntry> entries = sampleEntries(20);
+        FileList inOrder = GlobExpander.fileListOf(entries, "s3://bucket/data/*.ndjson");
+        List<StorageEntry> shuffled = new ArrayList<>(entries);
+        Collections.shuffle(shuffled, new Random(randomLong()));
+        FileList outOfOrder = GlobExpander.fileListOf(shuffled, "s3://bucket/data/*.ndjson");
+
+        assertNotNull(inOrder.fileSetFingerprint());
+        assertNotNull(outOfOrder.fileSetFingerprint());
+        assertEquals(inOrder.fileSetFingerprint(), outOfOrder.fileSetFingerprint());
+    }
+
+    public void testMtimeChangeChangesFingerprint() {
+        List<StorageEntry> entries = sampleEntries(5);
+        FileList before = GlobExpander.fileListOf(entries, "p");
+        List<StorageEntry> touched = new ArrayList<>(entries);
+        StorageEntry victim = touched.get(2);
+        touched.set(2, entry(victim.path().toString(), victim.length(), victim.lastModified().toEpochMilli() + 1));
+        FileList after = GlobExpander.fileListOf(touched, "p");
+        assertFingerprintsDiffer(before, after);
+    }
+
+    public void testSizeChangeChangesFingerprint() {
+        List<StorageEntry> entries = sampleEntries(5);
+        FileList before = GlobExpander.fileListOf(entries, "p");
+        List<StorageEntry> touched = new ArrayList<>(entries);
+        StorageEntry victim = touched.get(4);
+        touched.set(4, entry(victim.path().toString(), victim.length() + 1, victim.lastModified().toEpochMilli()));
+        FileList after = GlobExpander.fileListOf(touched, "p");
+        assertFingerprintsDiffer(before, after);
+    }
+
+    public void testAddedFileChangesFingerprint() {
+        List<StorageEntry> entries = sampleEntries(5);
+        FileList before = GlobExpander.fileListOf(entries, "p");
+        List<StorageEntry> grown = new ArrayList<>(entries);
+        grown.add(entry("s3://bucket/data/part-99.ndjson", 7L, 9L));
+        FileList after = GlobExpander.fileListOf(grown, "p");
+        assertFingerprintsDiffer(before, after);
+    }
+
+    public void testRemovedFileChangesFingerprint() {
+        List<StorageEntry> entries = sampleEntries(5);
+        FileList before = GlobExpander.fileListOf(entries, "p");
+        List<StorageEntry> shrunk = new ArrayList<>(entries);
+        shrunk.remove(1);
+        FileList after = GlobExpander.fileListOf(shrunk, "p");
+        assertFingerprintsDiffer(before, after);
+    }
+
+    public void testCompactionPreservesFingerprint() {
+        // Dictionary compaction preserves the file set exactly, so the pass-through fingerprint must
+        // equal the raw list's — the dataset-aggregate key must not depend on which representation the
+        // listing cache happens to hold.
+        FileList raw = GlobExpander.fileListOf(sampleEntries(10), "s3://bucket/data/*.ndjson");
+        FileList compact = GlobExpander.compact(raw, "s3://bucket/data/");
+        assertNotSame(raw, compact);
+        assertNotNull(compact.fileSetFingerprint());
+        assertEquals(raw.fileSetFingerprint(), compact.fileSetFingerprint());
+    }
+
+    public void testSentinelsCarryNoFingerprint() {
+        assertNull(FileList.UNRESOLVED.fileSetFingerprint());
+        assertNull(FileList.EMPTY.fileSetFingerprint());
+    }
+
+    public void testSingleFileListingCarriesNoFingerprint() {
+        // A single-file listing can never key a dataset aggregate (that needs fileCount >= 2), so the
+        // Murmur3 fold is skipped and the accessor returns null — keeping the common single-file resolve
+        // off the hash path. A two-file listing is the positive control.
+        FileList single = GlobExpander.fileListOf(sampleEntries(1), "s3://bucket/data/part-0.ndjson");
+        assertNull(single.fileSetFingerprint());
+        FileList two = GlobExpander.fileListOf(sampleEntries(2), "s3://bucket/data/*.ndjson");
+        assertNotNull(two.fileSetFingerprint());
+    }
+
+    private static void assertFingerprintsDiffer(FileList a, FileList b) {
+        FileSetFingerprint fingerprintA = a.fileSetFingerprint();
+        FileSetFingerprint fingerprintB = b.fileSetFingerprint();
+        assertNotNull(fingerprintA);
+        assertNotNull(fingerprintB);
+        // A single-field change must perturb the fingerprint: at least one lane differs. (Both lanes flip
+        // in practice via the per-lane perturbation; asserting only "not identical" avoids a spurious
+        // failure if one lane's avalanche happens to coincide.)
+        assertFalse(fingerprintA.high() == fingerprintB.high() && fingerprintA.low() == fingerprintB.low());
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ESQL: warm multi-file COUNT(*) survives per-file cache eviction (#153473)](https://github.com/elastic/elasticsearch/pull/153473)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)