### PR TITLE
ES|QL: fix SORT crash and partition-filter wrong answers on hive-partitioned datasets

### DIFF
--- a/docs/changelog/153579.yaml
+++ b/docs/changelog/153579.yaml
@@ -1,0 +1,6 @@
+pr: 153579
+summary: Fix `SORT` crash and partition-column `WHERE` wrong answers on Hive-partitioned external datasets
+area: ES|QL
+type: bug
+issues:
+ - 153503

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractDelimitedHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractDelimitedHivePartitionParityIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+/** Shared writer for the delimited text legs (CSV, TSV) of the hive-partition parity sweep. */
+public abstract class AbstractDelimitedHivePartitionParityIT extends AbstractHivePartitionParityIT {
+
+    /** The field delimiter ({@code ','} for CSV, {@code '\t'} for TSV). */
+    protected abstract char delimiter();
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class);
+    }
+
+    @Override
+    protected void writeFlat(Path file, List<int[]> rows) throws IOException {
+        char d = delimiter();
+        StringBuilder sb = new StringBuilder("id").append(d)
+            .append("region")
+            .append(d)
+            .append("tier")
+            .append(d)
+            .append("w")
+            .append(d)
+            .append("x")
+            .append(d)
+            .append("y")
+            .append(d)
+            .append("z")
+            .append('\n');
+        for (int[] r : rows) {
+            sb.append(r[2])
+                .append(d)
+                .append(REGION[r[0]])
+                .append(d)
+                .append(TIER[r[1]])
+                .append(d)
+                .append(r[3])
+                .append(d)
+                .append(r[4])
+                .append(d)
+                .append(r[5])
+                .append(d)
+                .append(r[6])
+                .append('\n');
+        }
+        Files.writeString(file, sb.toString(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected void writePartitioned(Path file, List<int[]> rows) throws IOException {
+        char d = delimiter();
+        StringBuilder sb = new StringBuilder("id").append(d)
+            .append("w")
+            .append(d)
+            .append("x")
+            .append(d)
+            .append("y")
+            .append(d)
+            .append("z")
+            .append('\n');
+        for (int[] r : rows) {
+            sb.append(r[2]).append(d).append(r[3]).append(d).append(r[4]).append(d).append(r[5]).append(d).append(r[6]).append('\n');
+        }
+        Files.writeString(file, sb.toString(), StandardCharsets.UTF_8);
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Cross-cutting parity guarantee for Hive-partitioned datasets: a path-derived (partition) column must
+ * behave IDENTICALLY to the same column stored in the file payload, across every ES|QL operation.
+ *
+ * <p>Runs one operation sweep over TWIN datasets on a forced-distributed leg ({@code round_robin}, ≥2 data
+ * nodes — the node where the partition-identity bugs live): dataset A carries {@code region}/{@code tier}
+ * as real file columns; dataset B carries the same values as Hive partition directories
+ * ({@code region=…/tier=…/}). Every query must return identical rows on both twins. Any future consumer
+ * that mishandles partition identity on either node shows up here as a parity failure.
+ *
+ * <p>The partition columns are strings on purpose: it keeps the twins' column types identical (a keyword is
+ * a keyword whether it comes from the path or the payload), so a value divergence means a real bug rather
+ * than a text-vs-path type-inference artefact. Subclasses supply the per-format file writers.
+ *
+ * <p>This suite would have caught both bugs fixed alongside it: the parquet {@code SORT} cell (the #1162
+ * TopN crash) and the parquet {@code WHERE region LIKE …} cell (the silent filter-pushdown wrong answer).
+ */
+public abstract class AbstractHivePartitionParityIT extends AbstractExternalDataSourceIT {
+
+    // Columns: regionIdx, tierIdx, id, w, x, y, z. region/tier are the (string) partition keys; id is the
+    // sort key; w/x/y/z are four extra data columns so the parquet TopN late-materialisation rule fires
+    // (>= DEFERRED_COLUMN_MIN deferred after pinning id + the partition columns eager).
+    protected static final int[][] ROWS = {
+        { 0, 0, 0, 10, 100, 1000, 10000 },
+        { 0, 0, 1, 11, 101, 1001, 10001 },
+        { 0, 1, 2, 12, 102, 1002, 10002 },
+        { 1, 0, 3, 13, 103, 1003, 10003 },
+        { 1, 1, 4, 14, 104, 1004, 10004 },
+        { 1, 1, 5, 15, 105, 1005, 10005 }, };
+    protected static final String[] REGION = { "east", "west" };
+    protected static final String[] TIER = { "gold", "silver" };
+
+    /** File extension for this format (also the format selector, e.g. {@code "parquet"}, {@code "csv"}). */
+    protected abstract String extension();
+
+    /** Writes all columns (id, region, tier, w, x, y, z) for {@code rows} to {@code file}. */
+    protected abstract void writeFlat(Path file, List<int[]> rows) throws IOException;
+
+    /** Writes only the data columns (id, w, x, y, z) for {@code rows} to {@code file}; region/tier come from the path. */
+    protected abstract void writePartitioned(Path file, List<int[]> rows) throws IOException;
+
+    private String registerFlatTwin() throws IOException {
+        Path dir = createTempDir().resolve("parity_flat_" + extension());
+        Files.createDirectories(dir);
+        // Split across two files so the flat twin produces >= 2 splits and distributes across data nodes too
+        // (the partition twin already has one file per partition dir) — the forced-distributed leg asserts
+        // spread on both twins.
+        List<int[]> all = List.of(ROWS);
+        int mid = all.size() / 2;
+        writeFlat(dir.resolve("data_0." + extension()), new ArrayList<>(all.subList(0, mid)));
+        writeFlat(dir.resolve("data_1." + extension()), new ArrayList<>(all.subList(mid, all.size())));
+        return registerDataset("parity_flat_" + extension(), StoragePath.fileUri(dir) + "/*." + extension(), Map.of());
+    }
+
+    private String registerPartitionedTwin() throws IOException {
+        Path root = createTempDir().resolve("parity_part_" + extension());
+        Map<String, List<int[]>> byPartition = new LinkedHashMap<>();
+        for (int[] r : ROWS) {
+            byPartition.computeIfAbsent("region=" + REGION[r[0]] + "/tier=" + TIER[r[1]], k -> new ArrayList<>()).add(r);
+        }
+        for (Map.Entry<String, List<int[]>> e : new TreeMap<>(byPartition).entrySet()) {
+            String[] parts = e.getKey().split("/");
+            Path dir = root.resolve(parts[0]).resolve(parts[1]);
+            Files.createDirectories(dir);
+            writePartitioned(dir.resolve("data." + extension()), e.getValue());
+        }
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*." + extension();
+        return registerDataset("parity_part_" + extension(), glob, Map.of("hive_partitioning", true));
+    }
+
+    public void testParitySweep() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String flat = registerFlatTwin();
+        String part = registerPartitionedTwin();
+
+        List<String> ops = List.of(
+            "| SORT id",
+            "| SORT region, id",
+            "| SORT region DESC, id",
+            "| WHERE region == \"east\" | SORT id",
+            "| WHERE region != \"east\" | SORT id",
+            "| WHERE region LIKE \"eas*\" | SORT id",
+            "| WHERE region IN (\"east\", \"west\") | SORT id",
+            "| WHERE STARTS_WITH(region, \"e\") | SORT id",
+            "| WHERE region == \"east\" AND tier == \"gold\" | SORT id",
+            "| WHERE region == \"east\" AND id >= 1 | SORT id",
+            "| STATS c = COUNT(*) BY region | SORT region",
+            "| STATS c = COUNT(region) BY tier | SORT tier",
+            "| STATS c = COUNT(*) BY region, tier | SORT region, tier",
+            "| EVAL r2 = CONCAT(region, \"_x\") | SORT id",
+            "| EVAL up = TO_UPPER(region) | SORT id",
+            "| KEEP region, id | SORT id",
+            "| DROP region | SORT id",
+            "| RENAME region AS r | WHERE r == \"east\" | SORT id"
+        );
+
+        List<String> divergences = new ArrayList<>();
+        for (String op : ops) {
+            String flatResult;
+            String partResult;
+            try {
+                flatResult = normalized(runDistributed("FROM " + flat + " " + op));
+            } catch (Exception e) {
+                divergences.add("op [" + op + "] THREW on the FLAT twin (harness bug): " + rootMessage(e));
+                continue;
+            }
+            try {
+                partResult = normalized(runDistributed("FROM " + part + " " + op));
+            } catch (Exception e) {
+                divergences.add("op [" + op + "] THREW on the PARTITION twin but not the flat one: " + rootMessage(e));
+                continue;
+            }
+            if (flatResult.equals(partResult) == false) {
+                divergences.add("op [" + op + "] DIVERGED\n    flat: " + flatResult + "\n    part: " + partResult);
+            }
+        }
+
+        if (divergences.isEmpty() == false) {
+            fail(
+                "["
+                    + extension()
+                    + "] PARITY DIVERGENCES ("
+                    + divergences.size()
+                    + "/"
+                    + ops.size()
+                    + "):\n"
+                    + String.join("\n", divergences)
+            );
+        }
+    }
+
+    private List<List<Object>> runDistributed(String query) {
+        QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
+        var request = syncEsqlQueryRequest(query);
+        request.pragmas(pragmas);
+        request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+        request.profile(true);
+        try (var response = run(request)) {
+            assertThat(
+                "external scan must distribute across >= 2 data nodes for [" + query + "]",
+                externalScanNodeNames(response).size(),
+                greaterThanOrEqualTo(2)
+            );
+            List<String> names = response.columns().stream().map(c -> c.name()).toList();
+            List<List<Object>> raw = getValuesList(response);
+            List<List<Object>> tagged = new ArrayList<>();
+            for (List<Object> row : raw) {
+                List<Object> withNames = new ArrayList<>();
+                for (int i = 0; i < names.size(); i++) {
+                    withNames.add(names.get(i) + "=" + row.get(i));
+                }
+                tagged.add(withNames);
+            }
+            return tagged;
+        }
+    }
+
+    /** Column-order- and (for non-SORT queries) row-order-insensitive normal form of a tagged result. */
+    private static String normalized(List<List<Object>> taggedRows) {
+        List<String> rows = new ArrayList<>();
+        for (List<Object> row : taggedRows) {
+            List<String> cells = new ArrayList<>();
+            for (Object cell : row) {
+                cells.add(String.valueOf(cell));
+            }
+            cells.sort(String::compareTo);
+            rows.add(cells.toString());
+        }
+        rows.sort(String::compareTo);
+        return rows.toString();
+    }
+
+    private static String rootMessage(Throwable t) {
+        Throwable c = t;
+        while (c.getCause() != null && c.getCause() != c) {
+            c = c.getCause();
+        }
+        return c.getClass().getSimpleName() + ": " + c.getMessage();
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
@@ -168,13 +168,15 @@ public abstract class AbstractHivePartitionParityIT extends AbstractExternalData
                 externalScanNodeNames(response).size(),
                 greaterThanOrEqualTo(2)
             );
-            List<String> names = response.columns().stream().map(c -> c.name()).toList();
+            // Tag each cell name:type=value so the diff catches a column-TYPE regression (a partition column
+            // surfacing as a different type than the file-resident twin), not just a value regression.
+            List<String> tags = response.columns().stream().map(c -> c.name() + ":" + c.outputType()).toList();
             List<List<Object>> raw = getValuesList(response);
             List<List<Object>> tagged = new ArrayList<>();
             for (List<Object> row : raw) {
                 List<Object> withNames = new ArrayList<>();
-                for (int i = 0; i < names.size(); i++) {
-                    withNames.add(names.get(i) + "=" + row.get(i));
+                for (int i = 0; i < tags.size(); i++) {
+                    withNames.add(tags.get(i) + "=" + row.get(i));
                 }
                 tagged.add(withNames);
             }
@@ -182,7 +184,12 @@ public abstract class AbstractHivePartitionParityIT extends AbstractExternalData
         }
     }
 
-    /** Column-order- and (for non-SORT queries) row-order-insensitive normal form of a tagged result. */
+    /**
+     * Normal form of a tagged result: cells within a row are sorted (column-order-insensitive, since the twins
+     * append partition columns in a different position), but ROW order is preserved. Every op in the sweep ends
+     * in a total SORT, so both twins return rows in the same deterministic order — comparing rows in order means a
+     * SORT-ORDER regression on the partition twin is caught rather than normalised away.
+     */
     private static String normalized(List<List<Object>> taggedRows) {
         List<String> rows = new ArrayList<>();
         for (List<Object> row : taggedRows) {
@@ -193,7 +200,6 @@ public abstract class AbstractHivePartitionParityIT extends AbstractExternalData
             cells.sort(String::compareTo);
             rows.add(cells.toString());
         }
-        rows.sort(String::compareTo);
         return rows.toString();
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  * a keyword whether it comes from the path or the payload), so a value divergence means a real bug rather
  * than a text-vs-path type-inference artefact. Subclasses supply the per-format file writers.
  *
- * <p>This suite would have caught both bugs fixed alongside it: the parquet {@code SORT} cell (the #1162
+ * <p>This suite would have caught both bugs fixed alongside it: the parquet {@code SORT} cell (the #153503
  * TopN crash) and the parquet {@code WHERE region LIKE …} cell (the silent filter-pushdown wrong answer).
  */
 public abstract class AbstractHivePartitionParityIT extends AbstractExternalDataSourceIT {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CsvHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CsvHivePartitionParityIT.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+/** CSV leg of the hive-partition parity sweep (immune to both fixed bugs; guards parity as a regression net). */
+public class CsvHivePartitionParityIT extends AbstractDelimitedHivePartitionParityIT {
+
+    @Override
+    protected String extension() {
+        return "csv";
+    }
+
+    @Override
+    protected char delimiter() {
+        return ',';
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 /**
- * End-to-end guard for the partition-filter wrong-answer (part of elastic/esql-planning#1162):
+ * End-to-end guard for the partition-filter wrong-answer, fixed alongside the #153503 hive partition-identity work:
  * {@code FROM <hive-partitioned parquet> | WHERE <partition col> LIKE …} must return only the matching
  * partitions, on a distributed read.
  *

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
@@ -105,4 +105,20 @@ public class ExternalParquetHivePartitionFilterPushdownIT extends AbstractExtern
         // p=a holds ids 0,1,2; id >= 1 keeps 1,2 → 2 rows.
         assertThat("mixed partition-LIKE + data filter must apply both", rows.size(), equalTo(2));
     }
+
+    /** Prune-all boundary: a partition predicate matching nothing must return zero rows, not all of them. */
+    public void testWherePartitionPrunesAll() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String dataset = twoPartitionDataset("hive_where_prune_all");
+        List<List<Object>> rows = runDistributed("FROM " + dataset + " | WHERE p == \"zz\"");
+        assertThat("a partition filter matching no partition must return no rows", rows.size(), equalTo(0));
+    }
+
+    /** Ordered comparison directly on the partition column (a RECHECK op): p > "a" keeps only p=b. */
+    public void testWhereRangeOnPartitionColumn() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String dataset = twoPartitionDataset("hive_where_range");
+        List<List<Object>> rows = runDistributed("FROM " + dataset + " | WHERE p > \"a\"");
+        assertThat("p > a must keep only the two p=b rows", rows.size(), equalTo(2));
+    }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * End-to-end guard for the partition-filter wrong-answer (part of elastic/esql-planning#1162):
+ * {@code FROM <hive-partitioned parquet> | WHERE <partition col> LIKE …} must return only the matching
+ * partitions, on a distributed read.
+ *
+ * <p>Root cause it locks: on a data node the coordinator {@code FileList} is {@code UNRESOLVED}, so the
+ * old {@code PushFiltersToSource} partition-name lookup (which read the fileList) returned empty and let
+ * the partition conjunct be minted into the parquet reader predicate. Parquet classifies the LIKE-family
+ * ({@code LIKE}, {@code STARTS_WITH}) as fully-pushed ({@code Pushability.YES}) and drops the
+ * {@code FilterExec}, so the predicate — over a column absent from the file payload — never filters and
+ * every partition's rows survive (5 where 3 are correct). Equality/range are {@code RECHECK} and were
+ * corrected by the retained {@code FilterExec}, which is why only the LIKE-family showed the bug. The fix
+ * reads partition names from the serialized stamp (node-safe) so the conjunct is held in the
+ * {@code FilterExec} on every node.
+ *
+ * <p>Forced distributed ({@code round_robin}, ≥2 data nodes) on purpose: a coordinator-local run has a
+ * resolved fileList and would false-green the whole class.
+ */
+public class ExternalParquetHivePartitionFilterPushdownIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    private String twoPartitionDataset(String name) throws Exception {
+        Path root = createTempDir().resolve(name);
+        writeSingleColumnIdParquet(root.resolve("p=a"), 3); // ids 0,1,2
+        writeSingleColumnIdParquet(root.resolve("p=b"), 2); // ids 0,1
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.parquet";
+        return registerDataset(name, glob, Map.of("hive_partitioning", true));
+    }
+
+    private List<List<Object>> runDistributed(String query) {
+        QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
+        var request = syncEsqlQueryRequest(query);
+        request.pragmas(pragmas);
+        request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+        request.profile(true);
+        try (var response = run(request)) {
+            assertThat(
+                "external scan must distribute across >= 2 data nodes to exercise the UNRESOLVED-FileList path",
+                externalScanNodeNames(response).size(),
+                greaterThanOrEqualTo(2)
+            );
+            return getValuesList(response);
+        }
+    }
+
+    /** LIKE on a partition column: the regression cell — YES-pushed, dropped from FilterExec, all rows leaked pre-fix. */
+    public void testWhereLikePartitionReturnsOnlyMatchingPartition() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String dataset = twoPartitionDataset("hive_where_like");
+        List<List<Object>> rows = runDistributed("FROM " + dataset + " | WHERE p LIKE \"a*\"");
+        assertThat("WHERE p LIKE a* must return only the 3 rows under p=a", rows.size(), equalTo(3));
+    }
+
+    /** STARTS_WITH is also YES-pushed — same leak family. */
+    public void testWhereStartsWithPartitionReturnsOnlyMatchingPartition() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String dataset = twoPartitionDataset("hive_where_startswith");
+        List<List<Object>> rows = runDistributed("FROM " + dataset + " | WHERE STARTS_WITH(p, \"a\")");
+        assertThat("WHERE STARTS_WITH(p, a) must return only the 3 rows under p=a", rows.size(), equalTo(3));
+    }
+
+    /** Equality was RECHECK (correct even pre-fix); pin it so the fix doesn't regress the working path. */
+    public void testWhereEqPartitionReturnsOnlyMatchingPartition() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String dataset = twoPartitionDataset("hive_where_eq");
+        List<List<Object>> rows = runDistributed("FROM " + dataset + " | WHERE p == \"a\"");
+        assertThat("WHERE p == a must return only the 3 rows under p=a", rows.size(), equalTo(3));
+    }
+
+    /** Mixed partition (LIKE) + data conjunct: the partition half must be held, the data half may push. */
+    public void testWhereMixedPartitionAndDataConjunct() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String dataset = twoPartitionDataset("hive_where_mixed");
+        List<List<Object>> rows = runDistributed("FROM " + dataset + " | WHERE p LIKE \"a*\" AND id >= 1");
+        // p=a holds ids 0,1,2; id >= 1 keeps 1,2 → 2 rows.
+        assertThat("mixed partition-LIKE + data filter must apply both", rows.size(), equalTo(2));
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
@@ -59,68 +59,69 @@ public class ExternalParquetHivePartitionNullValueIT extends AbstractExternalDat
 
     public void testSortMaterializesNullPartitionValue() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
-        String ds = dataset("hive_null_sort");
-        try (var response = runDistributed("FROM " + ds + " | SORT id")) {
-            List<List<Object>> rows = getValuesList(response);
-            assertThat("all five rows return", rows.size(), equalTo(5));
-            int region = columnIndex(response, "region");
-            int id = columnIndex(response, "id");
-            for (List<Object> row : rows) {
-                long rid = ((Number) row.get(id)).longValue();
-                if (rid <= 2) {
-                    assertThat("non-sentinel partition materialises its value", row.get(region), equalTo("east"));
-                } else {
-                    assertThat("sentinel partition materialises a null under SORT", row.get(region), nullValue());
-                }
+        QueryResult result = runDistributed("FROM " + dataset("hive_null_sort") + " | SORT id");
+        assertThat("all five rows return", result.rows().size(), equalTo(5));
+        int region = result.index("region");
+        int id = result.index("id");
+        for (List<Object> row : result.rows()) {
+            long rid = ((Number) row.get(id)).longValue();
+            if (rid <= 2) {
+                assertThat("non-sentinel partition materialises its value", row.get(region), equalTo("east"));
+            } else {
+                assertThat("sentinel partition materialises a null under SORT", row.get(region), nullValue());
             }
         }
     }
 
     public void testWhereRegionIsNull() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
-        String ds = dataset("hive_null_isnull");
-        try (var response = runDistributed("FROM " + ds + " | WHERE region IS NULL | SORT id")) {
-            List<List<Object>> rows = getValuesList(response);
-            assertThat("only the two sentinel-partition rows match IS NULL", rows.size(), equalTo(2));
-            int region = columnIndex(response, "region");
-            for (List<Object> row : rows) {
-                assertThat(row.get(region), nullValue());
-            }
+        QueryResult result = runDistributed("FROM " + dataset("hive_null_isnull") + " | WHERE region IS NULL | SORT id");
+        assertThat("only the two sentinel-partition rows match IS NULL", result.rows().size(), equalTo(2));
+        int region = result.index("region");
+        for (List<Object> row : result.rows()) {
+            assertThat(row.get(region), nullValue());
         }
     }
 
     public void testWhereRegionIsNotNull() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
-        String ds = dataset("hive_null_isnotnull");
-        try (var response = runDistributed("FROM " + ds + " | WHERE region IS NOT NULL | SORT id")) {
-            List<List<Object>> rows = getValuesList(response);
-            assertThat("only the three region=east rows match IS NOT NULL", rows.size(), equalTo(3));
-            int region = columnIndex(response, "region");
-            for (List<Object> row : rows) {
-                assertThat(row.get(region), equalTo("east"));
-            }
+        QueryResult result = runDistributed("FROM " + dataset("hive_null_isnotnull") + " | WHERE region IS NOT NULL | SORT id");
+        assertThat("only the three region=east rows match IS NOT NULL", result.rows().size(), equalTo(3));
+        int region = result.index("region");
+        for (List<Object> row : result.rows()) {
+            assertThat(row.get(region), equalTo("east"));
         }
     }
 
-    private org.elasticsearch.xpack.esql.action.EsqlQueryResponse runDistributed(String query) {
+    /**
+     * Runs {@code query} forced-distributed and extracts rows + column names INSIDE the try-with-resources, so the
+     * refcounted response is closed on every path — including if the distribution assertion throws (a leaked response
+     * would fire a misleading second failure in cluster teardown).
+     */
+    private QueryResult runDistributed(String query) {
         QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
         var request = syncEsqlQueryRequest(query);
         request.pragmas(pragmas);
         request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
         request.profile(true);
-        var response = run(request);
-        assertThat("external scan must distribute across >= 2 data nodes", externalScanNodeNames(response).size(), greaterThanOrEqualTo(2));
-        return response;
+        try (var response = run(request)) {
+            assertThat(
+                "external scan must distribute across >= 2 data nodes",
+                externalScanNodeNames(response).size(),
+                greaterThanOrEqualTo(2)
+            );
+            return new QueryResult(getValuesList(response), response.columns().stream().map(c -> c.name()).toList());
+        }
     }
 
-    private static int columnIndex(EsqlQueryResponse response, String name) {
-        var columns = response.columns();
-        for (int i = 0; i < columns.size(); i++) {
-            if (columns.get(i).name().equals(name)) {
-                return i;
+    private record QueryResult(List<List<Object>> rows, List<String> columns) {
+        int index(String name) {
+            int i = columns.indexOf(name);
+            if (i < 0) {
+                throw new AssertionError("column [" + name + "] not found in " + columns);
             }
+            return i;
         }
-        throw new AssertionError("column [" + name + "] not found in " + columns);
     }
 
     private static Path writeFiveColParquet(Path dir, List<Integer> ids) throws IOException {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * A Hive partition value can be null: the sentinel directory {@code region=__HIVE_DEFAULT_PARTITION__/}
+ * decodes to a null partition value ({@link org.elasticsearch.xpack.esql.datasources.HivePartitionDetector#HIVE_DEFAULT_PARTITION}).
+ * This guards two things touched by the #153503 hive partition-identity convergence:
+ * <ul>
+ *   <li>The partition column pinned eager under {@code SORT} (the fix) must materialise a null constant block
+ *       through {@code VirtualColumnIterator}, not crash or mis-attach — the null cell of the TopN materialisation
+ *       matrix, which the non-null hive ITs never exercised.</li>
+ *   <li>{@code WHERE region IS NULL} / {@code IS NOT NULL} over the path-derived column must be held in the
+ *       {@code FilterExec} and evaluated against the injected constants on every node.</li>
+ * </ul>
+ * Forced distributed ({@code round_robin}, ≥2 data nodes) so the data-node path (UNRESOLVED fileList) is the one
+ * exercised. Five data columns keep the deferred count ≥ {@code DEFERRED_COLUMN_MIN} so the TopN rule actually fires.
+ */
+public class ExternalParquetHivePartitionNullValueIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    /** region=east has ids 0,1,2; region=__HIVE_DEFAULT_PARTITION__ (null) has ids 3,4. */
+    private String dataset(String name) throws Exception {
+        Path root = createTempDir().resolve(name);
+        writeFiveColParquet(root.resolve("region=east"), List.of(0, 1, 2));
+        writeFiveColParquet(root.resolve("region=__HIVE_DEFAULT_PARTITION__"), List.of(3, 4));
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.parquet";
+        return registerDataset(name, glob, Map.of("hive_partitioning", true));
+    }
+
+    public void testSortMaterializesNullPartitionValue() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String ds = dataset("hive_null_sort");
+        try (var response = runDistributed("FROM " + ds + " | SORT id")) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("all five rows return", rows.size(), equalTo(5));
+            int region = columnIndex(response, "region");
+            int id = columnIndex(response, "id");
+            for (List<Object> row : rows) {
+                long rid = ((Number) row.get(id)).longValue();
+                if (rid <= 2) {
+                    assertThat("non-sentinel partition materialises its value", row.get(region), equalTo("east"));
+                } else {
+                    assertThat("sentinel partition materialises a null under SORT", row.get(region), nullValue());
+                }
+            }
+        }
+    }
+
+    public void testWhereRegionIsNull() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String ds = dataset("hive_null_isnull");
+        try (var response = runDistributed("FROM " + ds + " | WHERE region IS NULL | SORT id")) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("only the two sentinel-partition rows match IS NULL", rows.size(), equalTo(2));
+            int region = columnIndex(response, "region");
+            for (List<Object> row : rows) {
+                assertThat(row.get(region), nullValue());
+            }
+        }
+    }
+
+    public void testWhereRegionIsNotNull() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String ds = dataset("hive_null_isnotnull");
+        try (var response = runDistributed("FROM " + ds + " | WHERE region IS NOT NULL | SORT id")) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("only the three region=east rows match IS NOT NULL", rows.size(), equalTo(3));
+            int region = columnIndex(response, "region");
+            for (List<Object> row : rows) {
+                assertThat(row.get(region), equalTo("east"));
+            }
+        }
+    }
+
+    private org.elasticsearch.xpack.esql.action.EsqlQueryResponse runDistributed(String query) {
+        QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
+        var request = syncEsqlQueryRequest(query);
+        request.pragmas(pragmas);
+        request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+        request.profile(true);
+        var response = run(request);
+        assertThat("external scan must distribute across >= 2 data nodes", externalScanNodeNames(response).size(), greaterThanOrEqualTo(2));
+        return response;
+    }
+
+    private static int columnIndex(EsqlQueryResponse response, String name) {
+        var columns = response.columns();
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).name().equals(name)) {
+                return i;
+            }
+        }
+        throw new AssertionError("column [" + name + "] not found in " + columns);
+    }
+
+    private static Path writeFiveColParquet(Path dir, List<Integer> ids) throws IOException {
+        Files.createDirectories(dir);
+        return writeParquet(
+            dir.resolve("data.parquet"),
+            "message t { required int64 id; required int32 w; required int32 x; required int32 y; required int32 z; }",
+            ids.size(),
+            1024,
+            (g, i) -> {
+                int id = ids.get(i);
+                g.add("id", (long) id);
+                g.add("w", id * 10);
+                g.add("x", id * 100);
+                g.add("y", id * 1000);
+                g.add("z", id * 10000);
+            }
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedTopNIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedTopNIT.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 /**
- * End-to-end guard for elastic/esql-planning#1162: {@code FROM <hive-partitioned parquet> | SORT …}
+ * End-to-end guard for #153503: {@code FROM <hive-partitioned parquet> | SORT …}
  * must return rows with the path-derived partition columns materialised, not crash.
  *
  * <p>Partition columns live in the directory path, not the file payload. The eager scan path

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedTopNIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedTopNIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * End-to-end guard for elastic/esql-planning#1162: {@code FROM <hive-partitioned parquet> | SORT …}
+ * must return rows with the path-derived partition columns materialised, not crash.
+ *
+ * <p>Partition columns live in the directory path, not the file payload. The eager scan path
+ * ({@code LIMIT} without {@code SORT}) strips them from the file schema and injects them as constant
+ * blocks via {@code VirtualColumnIterator} — which is why {@code LIMIT} always worked. {@code SORT …}
+ * instead enters TopN late materialisation: {@code InsertExternalFieldExtraction} narrows the forward
+ * scan and defers the remaining columns to a positional parquet read. Partition columns are plain
+ * {@code ReferenceAttribute}s (no {@code VirtualAttribute} marker), so before the fix they landed in
+ * the deferred set and reached {@code ParquetColumnExtractor.extract}, which throws
+ * {@code column [STATION] is missing or has an unsupported type} because the column is not in the file.
+ *
+ * <p>The sibling {@link ExternalParquetHivePartitionedIT} only exercises {@code COUNT(p)} and so never
+ * hit this path — hence this dedicated SORT/TopN suite. Fixtures carry five data columns so that with
+ * the partition columns correctly pinned eager the deferred set still clears
+ * {@code InsertExternalFieldExtraction.DEFERRED_COLUMN_MIN} and the optimisation actually fires.
+ */
+public class ExternalParquetHivePartitionedTopNIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    /**
+     * Case 1 (the report): a fully pinned hive glob ({@code STATION=A/ELEMENT=TMAX/*.parquet}) with
+     * zero partition settings — AUTO detection is on by default and recognises {@code KEY=VALUE}
+     * directories. {@code SORT} used to crash with {@code column [STATION] is missing}; it must now
+     * return every row with STATION/ELEMENT carrying the pinned path values.
+     */
+    public void testSortOverPinnedHivePartitionReturnsRowsAndPartitionValues() throws Exception {
+        Path root = createTempDir().resolve("hive_parquet_topn_pinned");
+        writeMultiColumnParquet(root.resolve("STATION=A").resolve("ELEMENT=TMAX"), 5);
+        String glob = StoragePath.fileUri(root) + "/STATION=A/ELEMENT=TMAX/*.parquet";
+        String dataset = registerDataset("hive_parquet_topn_pinned", glob, Map.of());
+
+        String query = "FROM " + dataset + " | SORT id";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("SORT over a pinned hive-partitioned dataset must return all rows", rows.size(), equalTo(5));
+
+            int station = columnIndex(response, "STATION");
+            int element = columnIndex(response, "ELEMENT");
+            for (List<Object> row : rows) {
+                assertThat("partition column STATION materialised from the path", row.get(station), equalTo("A"));
+                assertThat("partition column ELEMENT materialised from the path", row.get(element), equalTo("TMAX"));
+            }
+        }
+    }
+
+    /**
+     * Case 2: an unpinned glob ({@code /**}{@code /*.parquet}) across two partitions with explicit
+     * {@code hive_partitioning:true} and a {@code SORT}, forced to distribute across {@code >= 2} data
+     * nodes via {@code external_distribution=round_robin}. Closes the SORT-over-partitioned coverage
+     * gap AND exercises the genuinely distributed path: with the coordinator {@code FileList}
+     * UNRESOLVED on the data node, the partition-column pin must read the serialized
+     * {@code _partition.columns} stamp. Pins that the pinned-vs-unpinned glob was never the bug — an
+     * unpinned glob fails identically without the fix (the partition columns are still deferred).
+     */
+    public void testSortOverUnpinnedHivePartitionSpansBothPartitions() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        Path root = createTempDir().resolve("hive_parquet_topn_unpinned");
+        writeMultiColumnParquet(root.resolve("STATION=A").resolve("ELEMENT=TMAX"), 3);
+        writeMultiColumnParquet(root.resolve("STATION=B").resolve("ELEMENT=TMIN"), 2);
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.parquet";
+        String dataset = registerDataset("hive_parquet_topn_unpinned", glob, Map.of("hive_partitioning", true));
+
+        // round_robin distributes every split to a data node regardless of plan shape, so the TopN
+        // late-materialisation (and the partition-column pin) runs where the coordinator FileList is
+        // UNRESOLVED and partition names come only from the serialized _partition.columns stamp.
+        QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
+        var request = syncEsqlQueryRequest("FROM " + dataset + " | SORT id");
+        request.pragmas(pragmas);
+        request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+        request.profile(true);
+        try (var response = run(request)) {
+            assertThat(
+                "external scan must distribute across >= 2 data nodes to exercise the UNRESOLVED-FileList path",
+                externalScanNodeNames(response).size(),
+                greaterThanOrEqualTo(2)
+            );
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("SORT over an unpinned hive-partitioned dataset must return rows from both partitions", rows.size(), equalTo(5));
+
+            int station = columnIndex(response, "STATION");
+            List<String> stations = rows.stream().map(row -> (String) row.get(station)).sorted().toList();
+            assertThat("both partitions' path-derived STATION values materialise", stations, equalTo(List.of("A", "A", "A", "B", "B")));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Writes a {@code data.parquet} with one sort key ({@code id: int64}) and four projection-only data
+     * columns under {@code dir}, {@code rowCount} rows. Five payload columns keep the deferred set above
+     * {@code DEFERRED_COLUMN_MIN} once the two path-derived partition columns are (correctly) pinned eager.
+     */
+    private static Path writeMultiColumnParquet(Path dir, int rowCount) throws IOException {
+        Files.createDirectories(dir);
+        return writeParquet(
+            dir.resolve("data.parquet"),
+            "message test { required int64 id; required int32 v1; required int32 v2; required int32 v3; required int32 v4; }",
+            rowCount,
+            1024,
+            (g, i) -> {
+                g.add("id", (long) i);
+                g.add("v1", i);
+                g.add("v2", i * 2);
+                g.add("v3", i * 3);
+                g.add("v4", i * 4);
+            }
+        );
+    }
+
+    private static int columnIndex(EsqlQueryResponse response, String name) {
+        var columns = response.columns();
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).name().equals(name)) {
+                return i;
+            }
+        }
+        throw new AssertionError("column [" + name + "] not found in response columns " + columns);
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdjsonHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdjsonHivePartitionParityIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+/** NDJSON leg of the hive-partition parity sweep. */
+public class NdjsonHivePartitionParityIT extends AbstractHivePartitionParityIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(NdJsonDataSourcePlugin.class);
+    }
+
+    @Override
+    protected String extension() {
+        return "ndjson";
+    }
+
+    @Override
+    protected void writeFlat(Path file, List<int[]> rows) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int[] r : rows) {
+            sb.append("{\"id\":")
+                .append(r[2])
+                .append(",\"region\":\"")
+                .append(REGION[r[0]])
+                .append("\",\"tier\":\"")
+                .append(TIER[r[1]])
+                .append("\",\"w\":")
+                .append(r[3])
+                .append(",\"x\":")
+                .append(r[4])
+                .append(",\"y\":")
+                .append(r[5])
+                .append(",\"z\":")
+                .append(r[6])
+                .append("}\n");
+        }
+        Files.writeString(file, sb.toString(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected void writePartitioned(Path file, List<int[]> rows) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int[] r : rows) {
+            sb.append("{\"id\":")
+                .append(r[2])
+                .append(",\"w\":")
+                .append(r[3])
+                .append(",\"x\":")
+                .append(r[4])
+                .append(",\"y\":")
+                .append(r[5])
+                .append(",\"z\":")
+                .append(r[6])
+                .append("}\n");
+        }
+        Files.writeString(file, sb.toString(), StandardCharsets.UTF_8);
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ParquetHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ParquetHivePartitionParityIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+/** parquet-java leg of the hive-partition parity sweep — the only format where the two fixed bugs were reachable. */
+public class ParquetHivePartitionParityIT extends AbstractHivePartitionParityIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    @Override
+    protected String extension() {
+        return "parquet";
+    }
+
+    @Override
+    protected void writeFlat(Path file, List<int[]> rows) throws IOException {
+        writeParquet(
+            file,
+            "message t { required int64 id; required binary region (UTF8); required binary tier (UTF8); "
+                + "required int32 w; required int32 x; required int32 y; required int32 z; }",
+            rows.size(),
+            1024,
+            (g, i) -> {
+                int[] r = rows.get(i);
+                g.add("id", (long) r[2]);
+                g.add("region", REGION[r[0]]);
+                g.add("tier", TIER[r[1]]);
+                g.add("w", r[3]);
+                g.add("x", r[4]);
+                g.add("y", r[5]);
+                g.add("z", r[6]);
+            }
+        );
+    }
+
+    @Override
+    protected void writePartitioned(Path file, List<int[]> rows) throws IOException {
+        writeParquet(
+            file,
+            "message t { required int64 id; required int32 w; required int32 x; required int32 y; required int32 z; }",
+            rows.size(),
+            1024,
+            (g, i) -> {
+                int[] r = rows.get(i);
+                g.add("id", (long) r[2]);
+                g.add("w", r[3]);
+                g.add("x", r[4]);
+                g.add("y", r[5]);
+                g.add("z", r[6]);
+            }
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TsvHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TsvHivePartitionParityIT.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+/** TSV leg of the hive-partition parity sweep (served by the CSV reader with a tab delimiter). */
+public class TsvHivePartitionParityIT extends AbstractDelimitedHivePartitionParityIT {
+
+    @Override
+    protected String extension() {
+        return "tsv";
+    }
+
+    @Override
+    protected char delimiter() {
+        return '\t';
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -2024,7 +2024,8 @@ public class ExternalSourceResolver {
         // Stamp the partition column names into the serialized sourceMetadata. The fileList that carries
         // PartitionMetadata is coordinator-only (ExternalRelation deserializes it to UNRESOLVED), so the data-node
         // fold reads this key instead to safe-miss COUNT(partition_col). Read by
-        // ExternalSourceAggregatePushdown.partitionColumnNames.
+        // SourceStatisticsSerializer.partitionColumnNames (via the partitionColumnNames() accessors on
+        // ExternalSourceExec / ExternalRelation, which every node-agnostic consumer goes through).
         Map<String, Object> stampedMetadata = new HashMap<>(schemaEnriched.sourceMetadata());
         stampedMetadata.put(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.copyOf(partitionNames));
         return replaceSourceMetadata(schemaEnriched, Map.copyOf(stampedMetadata));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -13,7 +13,10 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,6 +74,28 @@ public final class SourceStatisticsSerializer {
     static final String MAX_UNSERVABLE_SUFFIX = ".max_unservable";
 
     private SourceStatisticsSerializer() {}
+
+    /**
+     * The names of the Hive-partition (path-derived) columns for a source, read from the serialized
+     * {@link #PARTITION_COLUMNS_KEY} stamp in {@code sourceMetadata}. This is the ONE node-safe channel for
+     * partition identity: the {@code FileList} that carries {@code PartitionMetadata} is coordinator-only and
+     * deserializes to {@code UNRESOLVED} on a data node, so any consumer that reads partition names off the
+     * fileList sees an empty set there. Every node-agnostic consumer reads partition identity through this
+     * method (usually via the {@code partitionColumnNames()} accessor on {@code ExternalSourceExec} /
+     * {@code ExternalRelation}), never off the fileList. Returns an empty set when the source is not
+     * partitioned. The returned set preserves the stamped order.
+     */
+    @SuppressWarnings("unchecked")
+    public static Set<String> partitionColumnNames(Map<String, Object> sourceMetadata) {
+        if (sourceMetadata == null) {
+            return Set.of();
+        }
+        Object names = sourceMetadata.get(PARTITION_COLUMNS_KEY);
+        if (names instanceof Collection<?> collection && collection.isEmpty() == false) {
+            return Collections.unmodifiableSet(new LinkedHashSet<>((Collection<String>) collection));
+        }
+        return Set.of();
+    }
 
     /**
      * Merges statistics entries into a new map that includes both the original sourceMetadata

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -14,9 +14,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -83,7 +81,8 @@ public final class SourceStatisticsSerializer {
      * fileList sees an empty set there. Every node-agnostic consumer reads partition identity through this
      * method (usually via the {@code partitionColumnNames()} accessor on {@code ExternalSourceExec} /
      * {@code ExternalRelation}), never off the fileList. Returns an empty set when the source is not
-     * partitioned. The returned set preserves the stamped order.
+     * partitioned. Every consumer reads the result by membership ({@code contains} / {@code isEmpty}), so the
+     * set is unordered.
      */
     @SuppressWarnings("unchecked")
     public static Set<String> partitionColumnNames(Map<String, Object> sourceMetadata) {
@@ -91,8 +90,9 @@ public final class SourceStatisticsSerializer {
             return Set.of();
         }
         Object names = sourceMetadata.get(PARTITION_COLUMNS_KEY);
-        if (names instanceof Collection<?> collection && collection.isEmpty() == false) {
-            return Collections.unmodifiableSet(new LinkedHashSet<>((Collection<String>) collection));
+        if (names instanceof Collection<?> collection) {
+            // The stamp is written as List.copyOf(names), which rejects nulls, so copyOf cannot NPE here.
+            return Set.copyOf((Collection<String>) collection);
         }
         return Set.of();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -14,7 +14,9 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,8 +83,15 @@ public final class SourceStatisticsSerializer {
      * fileList sees an empty set there. Every node-agnostic consumer reads partition identity through this
      * method (usually via the {@code partitionColumnNames()} accessor on {@code ExternalSourceExec} /
      * {@code ExternalRelation}), never off the fileList. Returns an empty set when the source is not
-     * partitioned. Every consumer reads the result by membership ({@code contains} / {@code isEmpty}), so the
-     * set is unordered.
+     * partitioned, and otherwise preserves the stamped order (the partition nesting, e.g. {@code region} then
+     * {@code tier}).
+     * <p>
+     * Deliberately a {@link LinkedHashSet} rather than {@code Set.copyOf}: no consumer reads this set by
+     * iteration today (they all use {@code contains} / {@code isEmpty}), but {@code Set.copyOf} randomizes
+     * iteration order <em>per JVM</em>, so a coordinator and a data node would order it differently. The day
+     * these names surface anywhere user-visible — an error message, a plan string, debug output — that would be
+     * nondeterministic and divergent across nodes. Ordering a handful of strings once per plan costs nothing and
+     * removes the failure mode.
      */
     @SuppressWarnings("unchecked")
     public static Set<String> partitionColumnNames(Map<String, Object> sourceMetadata) {
@@ -91,8 +100,8 @@ public final class SourceStatisticsSerializer {
         }
         Object names = sourceMetadata.get(PARTITION_COLUMNS_KEY);
         if (names instanceof Collection<?> collection) {
-            // The stamp is written as List.copyOf(names), which rejects nulls, so copyOf cannot NPE here.
-            return Set.copyOf((Collection<String>) collection);
+            // The stamp is written as List.copyOf(names), which rejects nulls, so the copy cannot NPE here.
+            return Collections.unmodifiableSet(new LinkedHashSet<>((Collection<String>) collection));
         }
         return Set.of();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
@@ -36,7 +36,6 @@ import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -199,30 +198,6 @@ public final class ExternalSourceAggregatePushdown {
             }
         }
         return true;
-    }
-
-    /**
-     * The columns whose values are derived from the file's directory PATH (Hive-style partition keys), not its
-     * payload. They are absent from every file's column stats, so the implicit-nulls contract reads them as
-     * all-null — any {@code COUNT} over one would serve 0. Both the fold and the split-discovery gate feed this
-     * set to {@link #resolveFromStats} so a partition-column aggregate safe-misses on footer formats.
-     * <p>
-     * Read from the SERIALIZED {@code sourceMetadata} (stamped at resolution — see
-     * {@code SourceStatisticsSerializer#PARTITION_COLUMNS_KEY}), NOT the {@code FileList}: the fileList that carries
-     * {@code PartitionMetadata} is coordinator-only and deserializes to {@code UNRESOLVED} on a data node, so the
-     * data-node fold would otherwise see an empty set and fold {@code COUNT(partition_col)} to 0. Empty when the
-     * source is not partitioned (no {@code hive_partitioning}).
-     */
-    @SuppressWarnings("unchecked")
-    public static Set<String> partitionColumnNames(Map<String, Object> sourceMetadata) {
-        if (sourceMetadata == null) {
-            return Set.of();
-        }
-        Object names = sourceMetadata.get(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY);
-        if (names instanceof Collection<?> collection && collection.isEmpty() == false) {
-            return Set.copyOf((Collection<String>) collection);
-        }
-        return Set.of();
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtraction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Inserts a deferred field-extraction step above a per-driver {@link TopNExec} that sits on top of
@@ -164,18 +165,28 @@ public class InsertExternalFieldExtraction extends PhysicalOptimizerRules.Parame
                 break;
             }
         }
+        // The second non-file-resident family: hive-style partition columns. Unlike {@code _file.*}
+        // they carry no {@link VirtualAttribute} marker — they are surfaced as plain
+        // {@link org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute}s on purpose, so
+        // they stay user-addressable (WHERE / STATS BY / EVAL) and prunable by partition-filter
+        // pushdown. Their names travel out-of-band in {@code sourceMetadata} under
+        // {@code PARTITION_COLUMNS_KEY}; read them through the node-safe accessor (never the
+        // coordinator-only fileList) so we can pin them eager below.
+        Set<String> partitionColumns = externalSource.partitionColumnNames();
         List<Attribute> eagerColumns = new ArrayList<>(sourceOutput.size());
         List<Attribute> deferredColumns = new ArrayList<>(sourceOutput.size());
         for (Attribute a : sourceOutput) {
-            // Virtual columns (today: {@code _file.*}) are materialised on the producer thread by
+            // Non-file-resident columns are materialised on the producer thread by
             // {@link org.elasticsearch.xpack.esql.datasources.VirtualColumnIterator} from per-file
             // metadata, not by the format reader. They must stay in the source's narrowed output
             // (so the iterator still injects them and downstream operators see them) and they
             // must not be deferred (the {@link ColumnExtractor} positional read path cannot
-            // produce values that don't exist in the file). Pin every {@link VirtualAttribute}
-            // as eager unconditionally; relying on the marker rather than a specific subclass
-            // keeps future virtual attributes correct by construction.
-            if (a instanceof VirtualAttribute || eagerRefs.contains(a)) {
+            // produce values that don't exist in the file). Two families qualify: every
+            // {@link VirtualAttribute} (today: {@code _file.*}, relying on the marker rather than a
+            // specific subclass keeps future virtual attributes correct by construction) and every
+            // hive partition column (a plain ReferenceAttribute, matched by name against the
+            // {@code PARTITION_COLUMNS_KEY} stamp).
+            if (a instanceof VirtualAttribute || eagerRefs.contains(a) || partitionColumns.contains(a.name())) {
                 eagerColumns.add(a);
             } else if (sourceProjected && a instanceof ExternalMetadataAttribute == false) {
                 // File-resident data column under `_source` projection — must be eager.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -21,9 +21,7 @@ import org.elasticsearch.xpack.esql.core.util.Queries;
 import org.elasticsearch.xpack.esql.datasources.FilterEvaluationOrderEstimator;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
-import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.PhysicalNames;
-import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
@@ -267,11 +265,15 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
 
         // Conjuncts that reference partition columns are evaluated against the constant blocks
         // injected by VirtualColumnIterator (and used as L1 pruning hints in FileSplitProvider).
-        // Pushing them into the format reader would translate them against file column data,
-        // but partition columns are not present in the file payload -- the reader would then
-        // either drop all rows (parquet) or behave format-specifically. Keep these conjuncts in
-        // the FilterExec so the post-injection evaluator handles them.
-        Set<String> partitionColumnNames = partitionColumnNames(externalExec);
+        // They must NOT be minted into the format-reader predicate: partition columns are path-derived
+        // and absent from the file payload. A RECHECK conjunct (==, IN, range) would be re-corrected by
+        // the retained FilterExec, but a YES-pushed conjunct (the LIKE family — see
+        // ParquetFilterPushdownSupport) is dropped from the FilterExec entirely and never re-checked, so
+        // every row survives and the query silently returns rows from every partition. Hold these
+        // conjuncts in the FilterExec on every node. The names come from the serialized stamp via the
+        // node-safe accessor — never the coordinator-only fileList, which is UNRESOLVED on a data node
+        // (reading it there returned an empty set and pushed the partition conjunct: the bug this fixes).
+        Set<String> partitionColumnNames = externalExec.partitionColumnNames();
         List<Expression> partitionConjuncts = new ArrayList<>();
         List<Expression> pushableCandidates = new ArrayList<>();
         if (partitionColumnNames.isEmpty()) {
@@ -329,18 +331,6 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
 
         // No pushable filters - return original plan
         return filterExec;
-    }
-
-    private static Set<String> partitionColumnNames(ExternalSourceExec externalExec) {
-        FileList fileList = externalExec.fileList();
-        if (fileList == null) {
-            return Set.of();
-        }
-        PartitionMetadata partitionMetadata = fileList.partitionMetadata();
-        if (partitionMetadata == null || partitionMetadata.isEmpty()) {
-            return Set.of();
-        }
-        return partitionMetadata.partitionColumns().keySet();
     }
 
     static boolean referencesAnyColumn(Expression expr, Set<String> columnNames) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -136,7 +136,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.Parameteri
         // constant block. Symmetric with PushFiltersToSource keeping partition predicates in FilterExec.
         // Read the partition set from serialized sourceMetadata (not the coordinator-only fileList): on a data node
         // externalExec.fileList() is UNRESOLVED, so COUNT(partition_col) would otherwise fold to 0 there.
-        Set<String> pathDerivedColumns = ExternalSourceAggregatePushdown.partitionColumnNames(externalExec.sourceMetadata());
+        Set<String> pathDerivedColumns = externalExec.partitionColumnNames();
         if (filterForClassification != null && referencesAnyColumn(filterForClassification, pathDerivedColumns)) {
             return aggregateExec;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelation.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.datasources.DeclaredReadSpec;
 import org.elasticsearch.xpack.esql.datasources.ExternalSchema;
-import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -328,6 +327,17 @@ public class ExternalRelation extends LeafPlan implements ExecutesOn.Coordinator
     }
 
     /**
+     * Names of the Hive-partition (path-derived) columns for this relation, read from the serialized stamp in
+     * {@code metadata.sourceMetadata()} — never from {@link #fileList()}, so the answer is identical on the
+     * coordinator and a data node (where the fileList deserializes to {@code UNRESOLVED}). Empty when the
+     * source is not partitioned. Delegates to the one canonical stamp reader, like the
+     * {@code partitionColumnNames()} accessor on {@code ExternalSourceExec}.
+     */
+    public Set<String> partitionColumnNames() {
+        return SourceStatisticsSerializer.partitionColumnNames(metadata.sourceMetadata());
+    }
+
+    /**
      * Returns the pre-enrichment Unified schema — the data-only view that {@link SchemaReconciliation}
      * built the per-file {@link org.elasticsearch.xpack.esql.datasources.ColumnMapping}s against. The
      * post-enrichment {@code metadata.schema()} includes partition attributes appended by
@@ -335,12 +345,13 @@ public class ExternalRelation extends LeafPlan implements ExecutesOn.Coordinator
      * than the per-file mapping. Seeding {@code ExternalSourceExec.unifiedSchema} from the
      * wider view causes {@code ColumnMapping.pruneToPerFileQuery} to read past
      * {@code index.length} when the optimizer also prunes the projection.
+     * <p>
+     * Partition names come from the serialized stamp ({@link #partitionColumnNames()}), NOT the fileList, so
+     * this produces the same narrow schema on a data node (where the fileList is {@code UNRESOLVED}) as on the
+     * coordinator — previously the data-node build silently kept the wider, partition-inclusive view.
      */
     private List<Attribute> dataOnlyUnifiedSchema() {
-        PartitionMetadata partitionInfo = fileList != null ? fileList.partitionMetadata() : null;
-        Set<String> partitionNames = partitionInfo != null && partitionInfo.isEmpty() == false
-            ? partitionInfo.partitionColumns().keySet()
-            : Set.of();
+        Set<String> partitionNames = partitionColumnNames();
         return metadata.schema()
             .stream()
             .filter(a -> a instanceof VirtualAttribute == false && partitionNames.contains(a.name()) == false)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.datasources.DeclaredReadSpec;
 import org.elasticsearch.xpack.esql.datasources.ExternalSchema;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
 import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.SplitStats;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Generic physical plan node for reading from external data sources (e.g., Iceberg tables, Parquet files).
@@ -483,6 +485,16 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
 
     public Map<String, Object> sourceMetadata() {
         return sourceMetadata;
+    }
+
+    /**
+     * Names of the Hive-partition (path-derived) columns, read from the serialized stamp in
+     * {@link #sourceMetadata()} — never from {@link #fileList()}, so the answer is correct on any node (the
+     * fileList is {@code UNRESOLVED} on a data node). Empty when the source is not partitioned. This is the
+     * single chokepoint every node-agnostic consumer uses to recognize path-derived columns.
+     */
+    public Set<String> partitionColumnNames() {
+        return SourceStatisticsSerializer.partitionColumnNames(sourceMetadata);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -126,7 +126,6 @@ import org.elasticsearch.xpack.esql.datasources.ExternalFieldExtractOperator;
 import org.elasticsearch.xpack.esql.datasources.ExternalSliceQueue;
 import org.elasticsearch.xpack.esql.datasources.FileMetadataColumns;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
-import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.PhysicalNames;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -149,7 +148,6 @@ import org.elasticsearch.xpack.esql.inference.InferenceService;
 import org.elasticsearch.xpack.esql.inference.completion.CompletionOperator;
 import org.elasticsearch.xpack.esql.inference.rerank.RerankOperator;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.ProjectAwayColumns;
-import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ExternalSourceAggregatePushdown;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.HighlightOptions;
@@ -1905,21 +1903,23 @@ public class LocalExecutionPlanner {
         // output only via METADATA, or the temporary EXTERNAL shim — they are no longer auto-attached
         // to every external schema). Passed through SourceOperatorContext.partitionColumnNames
         // (legacy method name kept to avoid an SPI rename on this PR).
-        Set<String> virtualColumnNames = new LinkedHashSet<>();
-        if (fileList != null) {
-            PartitionMetadata pm = fileList.partitionMetadata();
-            if (pm != null && pm.isEmpty() == false) {
-                virtualColumnNames.addAll(pm.partitionColumns().keySet());
-            }
-        }
-        // On a data node the resolved FileList is not serialized (see the slice-queue note above), so the
-        // partition columns above are absent there. Their names ARE serialized via the PARTITION_COLUMNS_KEY
-        // stamp in sourceMetadata — the same stamp the aggregate fold reads
-        // (ExternalSourceAggregatePushdown.partitionColumnNames). Union them in so VirtualColumnIterator
-        // materialises the partition column as a constant block even when ONLY a partition column is projected
-        // (e.g. COUNT(p) that safe-missed to a scan): otherwise the operator treats it as a data column, the
-        // reader emits a 0-block page, and the downstream aggregator reads a non-existent block.
-        virtualColumnNames.addAll(ExternalSourceAggregatePushdown.partitionColumnNames(externalSource.sourceMetadata()));
+        // Partition column names come from the serialized PARTITION_COLUMNS_KEY stamp via the node-safe
+        // accessor, NOT the fileList: on a data node the resolved FileList is not serialized (see the
+        // slice-queue note above), so reading it there yields nothing, whereas the stamp travels with the
+        // relation. VirtualColumnIterator materialises each as a constant block even when ONLY a partition
+        // column is projected (e.g. COUNT(p) that safe-missed to a scan): otherwise the operator treats it as
+        // a data column, the reader emits a 0-block page, and the downstream aggregator reads a non-existent
+        // block. The assert checks — rather than trusts — that on the coordinator (where the fileList IS
+        // resolved) the stamp already covers every fileList partition name, so dropping the fileList read
+        // here is a strict no-op.
+        Set<String> virtualColumnNames = new LinkedHashSet<>(externalSource.partitionColumnNames());
+        assert fileList == null
+            || fileList.partitionMetadata() == null
+            || virtualColumnNames.containsAll(fileList.partitionMetadata().partitionColumns().keySet())
+            : "partition stamp "
+                + virtualColumnNames
+                + " is missing resolved fileList partition columns "
+                + fileList.partitionMetadata().partitionColumns().keySet();
         for (Attribute attr : externalSource.output()) {
             if (FileMetadataColumns.isFileMetadataColumn(attr.name())) {
                 virtualColumnNames.add(attr.name());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -497,7 +497,7 @@ public class ComputeService {
         // Feed the same partition-column set the fold uses (read from serialized sourceMetadata, so it matches the
         // data-node fold): COUNT(partition_col) must safe-miss on both paths, or the gate skips discovery for a
         // fold that then bails -> the zero-split crash above.
-        Set<String> pathDerivedColumns = ExternalSourceAggregatePushdown.partitionColumnNames(meta);
+        Set<String> pathDerivedColumns = SourceStatisticsSerializer.partitionColumnNames(meta);
         return ExternalSourceAggregatePushdown.canServeAllFromStats(
             agg.aggregates(),
             stats,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdownTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdownTests.java
@@ -530,15 +530,15 @@ public class ExternalSourceAggregatePushdownTests extends ESTestCase {
         // resolution under PARTITION_COLUMNS_KEY. This is what makes the guard survive to the DATA-NODE fold,
         // where the coordinator-only FileList is UNRESOLVED. A null/absent/empty key yields the empty set (an
         // unpartitioned source is unguarded, so its physical columns serve normally).
-        assertEquals(Set.of(), ExternalSourceAggregatePushdown.partitionColumnNames(null));
-        assertEquals(Set.of(), ExternalSourceAggregatePushdown.partitionColumnNames(Map.of()));
+        assertEquals(Set.of(), SourceStatisticsSerializer.partitionColumnNames(null));
+        assertEquals(Set.of(), SourceStatisticsSerializer.partitionColumnNames(Map.of()));
         assertEquals(
             Set.of("p"),
-            ExternalSourceAggregatePushdown.partitionColumnNames(Map.of(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.of("p")))
+            SourceStatisticsSerializer.partitionColumnNames(Map.of(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.of("p")))
         );
         assertEquals(
             Set.of("year", "month"),
-            ExternalSourceAggregatePushdown.partitionColumnNames(
+            SourceStatisticsSerializer.partitionColumnNames(
                 Map.of(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.of("year", "month"))
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtractionTests.java
@@ -306,7 +306,7 @@ public class InsertExternalFieldExtractionTests extends ESTestCase {
     }
 
     public void testPartitionColumnsPinnedEagerNotDeferred() {
-        // The regression cell (elastic/esql-planning#1162): hive-style partition columns are plain
+        // The regression cell (#153503): hive-style partition columns are plain
         // ReferenceAttributes carrying no VirtualAttribute marker, but they are NOT file-resident —
         // deferring them to the positional ColumnExtractor read throws "column [X] is missing" at
         // runtime. Their names are stamped in sourceMetadata under PARTITION_COLUMNS_KEY. Sort on a

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertExternalFieldExtractionTests.java
@@ -13,10 +13,12 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.SyntheticColumns;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorAware;
@@ -303,12 +305,149 @@ public class InsertExternalFieldExtractionTests extends ESTestCase {
         assertEquals(List.of("a", "b", "c", "d"), deferredNames);
     }
 
+    public void testPartitionColumnsPinnedEagerNotDeferred() {
+        // The regression cell (elastic/esql-planning#1162): hive-style partition columns are plain
+        // ReferenceAttributes carrying no VirtualAttribute marker, but they are NOT file-resident —
+        // deferring them to the positional ColumnExtractor read throws "column [X] is missing" at
+        // runtime. Their names are stamped in sourceMetadata under PARTITION_COLUMNS_KEY. Sort on a
+        // data column so the partition columns are projection-only; they must still stay eager.
+        List<Attribute> schema = List.of(
+            field("id", DataType.LONG),
+            refField("STATION", DataType.KEYWORD),
+            refField("ELEMENT", DataType.KEYWORD),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD),
+            field("c", DataType.INTEGER),
+            field("d", DataType.DOUBLE)
+        );
+        ExternalSourceExec source = parquetSource(schema, null, partitionMetadata("STATION", "ELEMENT"));
+        TopNExec topN = topN(schema.get(0), 100, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        // Partition columns must NOT be deferred — only the plain data columns are.
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("a", "b", "c", "d"), deferredNames);
+
+        // The narrowed forward scan keeps id (sort key), both partition columns, and _rowPosition —
+        // VirtualColumnIterator materialises STATION/ELEMENT there as constant blocks.
+        ExternalSourceExec narrowed = (ExternalSourceExec) ((TopNExec) extract.child()).child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        assertEquals(List.of("id", "STATION", "ELEMENT", ColumnExtractor.ROW_POSITION_COLUMN), narrowedNames);
+    }
+
+    public void testWithoutPartitionStampSameColumnsAreDeferred() {
+        // Control for the test above: partition-ness is driven solely by the PARTITION_COLUMNS_KEY
+        // stamp. With no stamp, the very same ReferenceAttributes are ordinary deferrable data
+        // columns (this is why the eager pin must read the stamp, not the attribute subtype).
+        List<Attribute> schema = List.of(
+            field("id", DataType.LONG),
+            refField("STATION", DataType.KEYWORD),
+            refField("ELEMENT", DataType.KEYWORD),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD),
+            field("c", DataType.INTEGER),
+            field("d", DataType.DOUBLE)
+        );
+        ExternalSourceExec source = parquetSource(schema, null, Map.of());
+        TopNExec topN = topN(schema.get(0), 100, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("STATION", "ELEMENT", "a", "b", "c", "d"), deferredNames);
+    }
+
+    public void testBailsWhenPartitionPinningLeavesTooFewDeferred() {
+        // Blast-radius guard: pinning partition columns eager only ever removes columns from the
+        // deferred set. If that pushes the deferred count below DEFERRED_COLUMN_MIN, the rule must
+        // bail and return the plan unchanged — the query then runs fully eager (correct, just not
+        // late-materialised). id (sort) + STATION + ELEMENT eager leaves only {a, b} = 2 deferred.
+        List<Attribute> schema = List.of(
+            field("id", DataType.LONG),
+            refField("STATION", DataType.KEYWORD),
+            refField("ELEMENT", DataType.KEYWORD),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD)
+        );
+        ExternalSourceExec source = parquetSource(schema, null, partitionMetadata("STATION", "ELEMENT"));
+        TopNExec topN = topN(schema.get(0), 100, source);
+
+        PhysicalPlan result = applyRule(topN, columnExtractorAwareRegistry());
+        assertSame("rule must bail when pinning partition columns leaves too few deferred", topN, result);
+    }
+
+    public void testPartitionColumnAsSortKeyStaysEager() {
+        // A partition column used as the sort key is caught by both the eagerRefs arm and the
+        // partition-name arm; it must remain eager exactly once and never be deferred.
+        List<Attribute> schema = List.of(
+            refField("STATION", DataType.KEYWORD),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD),
+            field("c", DataType.INTEGER),
+            field("d", DataType.DOUBLE)
+        );
+        ExternalSourceExec source = parquetSource(schema, null, partitionMetadata("STATION"));
+        TopNExec topN = topN(schema.get(0), 100, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("a", "b", "c", "d"), deferredNames);
+
+        ExternalSourceExec narrowed = (ExternalSourceExec) ((TopNExec) extract.child()).child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        assertEquals(List.of("STATION", ColumnExtractor.ROW_POSITION_COLUMN), narrowedNames);
+    }
+
+    public void testPartitionColumnReferencedByPushedFilterStaysEager() {
+        // A partition column that is also read by a pushed filter is eager on two independent grounds
+        // (the eagerRefs filter-expression arm and the partition-name arm). It must be pinned exactly
+        // once and never deferred — no interaction between the two paths.
+        List<Attribute> schema = List.of(
+            field("id", DataType.LONG),
+            refField("STATION", DataType.KEYWORD),
+            field("a", DataType.KEYWORD),
+            field("b", DataType.KEYWORD),
+            field("c", DataType.INTEGER),
+            field("d", DataType.DOUBLE)
+        );
+        ExternalSourceExec source = parquetSource(schema, null, partitionMetadata("STATION")).withPushedFilterAndExpressions(
+            "opaque",
+            List.of((Expression) schema.get(1)) // pushed filter reads STATION
+        );
+        TopNExec topN = topN(schema.get(0), 100, source);
+
+        PhysicalPlan rewritten = applyRule(topN, columnExtractorAwareRegistry());
+        ExternalFieldExtractExec extract = (ExternalFieldExtractExec) rewritten;
+
+        List<String> deferredNames = extract.attributesToExtract().stream().map(Attribute::name).toList();
+        assertEquals(List.of("a", "b", "c", "d"), deferredNames);
+
+        ExternalSourceExec narrowed = (ExternalSourceExec) ((TopNExec) extract.child()).child();
+        List<String> narrowedNames = narrowed.output().stream().map(Attribute::name).toList();
+        assertEquals(List.of("id", "STATION", ColumnExtractor.ROW_POSITION_COLUMN), narrowedNames);
+    }
+
     // ---------------------------------------------------------------------------------------------
     // helpers
     // ---------------------------------------------------------------------------------------------
 
     private static FieldAttribute field(String name, DataType type) {
         return new FieldAttribute(Source.EMPTY, name, new EsField(name, type, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    /** A plain {@link ReferenceAttribute}, the shape hive partition columns are surfaced as. */
+    private static ReferenceAttribute refField(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, name, type);
+    }
+
+    /** sourceMetadata stamping the given names as hive partition columns (see {@code PARTITION_COLUMNS_KEY}). */
+    private static Map<String, Object> partitionMetadata(String... names) {
+        return Map.of(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.of(names));
     }
 
     private static Literal literal(int value) {
@@ -321,7 +460,20 @@ public class InsertExternalFieldExtractionTests extends ESTestCase {
     }
 
     private static ExternalSourceExec parquetSource(List<Attribute> schema, Object pushedFilter) {
-        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", schema, Map.of(), Map.of(), pushedFilter, null);
+        return parquetSource(schema, pushedFilter, Map.of());
+    }
+
+    private static ExternalSourceExec parquetSource(List<Attribute> schema, Object pushedFilter, Map<String, Object> sourceMetadata) {
+        return new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            schema,
+            Map.of(),
+            sourceMetadata,
+            pushedFilter,
+            null
+        );
     }
 
     private static FormatReaderRegistry columnExtractorAwareRegistry() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelationTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -368,7 +369,12 @@ public class ExternalRelationTests extends ESTestCase {
         Attribute name = attr("name", DataType.KEYWORD);
         Attribute year = attr("year", DataType.INTEGER); // partition column
 
-        SourceMetadata partitionedMetadata = createMetadataWithSchema(List.of(id, name, year));
+        // Coordinator shape: partition identity comes from the serialized stamp (written at resolution
+        // alongside the resolved fileList), which is what dataOnlyUnifiedSchema now reads.
+        SourceMetadata partitionedMetadata = createMetadataWithSchema(
+            List.of(id, name, year),
+            Map.of(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.of("year"))
+        );
         FileList partitionedFiles = createPartitionedFileList(Map.of("year", DataType.INTEGER));
         ExternalRelation relation = new ExternalRelation(
             Source.EMPTY,
@@ -388,7 +394,38 @@ public class ExternalRelationTests extends ESTestCase {
         assertTrue("data columns preserved", exec.unifiedSchema().names().contains("name"));
     }
 
+    public void testToPhysicalExecStripsPartitionAttributesOnDataNodeShape() {
+        // Data-node shape: the relation deserializes with FileList.UNRESOLVED, so the OLD fileList-based
+        // strip kept the wider, partition-inclusive unifiedSchema here (the P6 latent inconsistency). Reading
+        // the serialized stamp strips partition attributes identically to the coordinator.
+        Attribute id = attr("id", DataType.LONG);
+        Attribute name = attr("name", DataType.KEYWORD);
+        Attribute year = attr("year", DataType.INTEGER); // partition column
+
+        SourceMetadata partitionedMetadata = createMetadataWithSchema(
+            List.of(id, name, year),
+            Map.of(SourceStatisticsSerializer.PARTITION_COLUMNS_KEY, List.of("year"))
+        );
+        ExternalRelation relation = new ExternalRelation(
+            Source.EMPTY,
+            "s3://bucket/year=*/*.parquet",
+            partitionedMetadata,
+            List.of(id, name, year),
+            FileList.UNRESOLVED,
+            Map.of()
+        );
+
+        ExternalSourceExec exec = relation.toPhysicalExec();
+
+        assertEquals("partition attr stripped from the stamp even with an UNRESOLVED fileList", 2, exec.unifiedSchema().size());
+        assertFalse("partition column not present in seeded unified", exec.unifiedSchema().names().contains("year"));
+    }
+
     private static SourceMetadata createMetadataWithSchema(List<Attribute> schema) {
+        return createMetadataWithSchema(schema, Map.of());
+    }
+
+    private static SourceMetadata createMetadataWithSchema(List<Attribute> schema, Map<String, Object> sourceMetadata) {
         return new SourceMetadata() {
             @Override
             public List<Attribute> schema() {
@@ -403,6 +440,11 @@ public class ExternalRelationTests extends ESTestCase {
             @Override
             public String location() {
                 return "s3://bucket/data/*.parquet";
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return sourceMetadata;
             }
 
             @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -486,20 +486,20 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
     }
 
     /**
-     * Guards the {@code virtualColumnNames} union in {@link LocalExecutionPlanner} {@code planExternalSource}: on a
-     * data node the coordinator's {@link FileList} is not serialized ({@code ExternalSourceExec.writeTo} drops it, so
-     * it deserializes to {@code null}), so the Hive partition-column NAMES must instead be recovered from the
-     * serialized {@code _partition.columns} stamp in {@code sourceMetadata} (see
-     * {@code ExternalSourceAggregatePushdown#partitionColumnNames}). Without that union
+     * Guards the partition-column seeding in {@link LocalExecutionPlanner} {@code planExternalSource}: on a data node
+     * the coordinator's {@link FileList} is not serialized ({@code ExternalSourceExec.writeTo} drops it, so it
+     * deserializes to {@code null}), so the Hive partition-column NAMES must instead be recovered from the serialized
+     * {@code _partition.columns} stamp in {@code sourceMetadata} — read through the node-safe
+     * {@code ExternalSourceExec.partitionColumnNames()} accessor. Without it
      * {@link SourceOperatorContext#partitionColumnNames()} is empty on the data node, {@code VirtualColumnIterator}
      * never materialises the partition column, and a distributed partition-column read attaches SQL {@code NULL}.
      * <p>
      * Here {@code fileList} is deliberately left {@code null} (the data-node shape) and the partition name {@code p} is
      * present in NEITHER the output attributes NOR a {@code FileList} — its only possible source is the stamp, so
-     * seeing it in the resolved set pins exactly this union. The end-to-end value-attachment twin is
+     * seeing it in the resolved set pins exactly this read. The end-to-end value-attachment twin is
      * {@code ExternalHivePartitionDistributedValueIT}.
      */
-    public void testExternalSourceUnionsPartitionColumnNamesFromSourceMetadataStamp() throws IOException {
+    public void testExternalSourceReadsPartitionColumnNamesFromSourceMetadataStamp() throws IOException {
         AtomicReference<SourceOperatorContext> captured = new AtomicReference<>();
         SourceOperatorFactoryProvider provider = capturingProvider(captured);
         OperatorFactoryRegistry operatorFactoryRegistry = new OperatorFactoryRegistry(Map.of(), Map.of("file", provider), Runnable::run);


### PR DESCRIPTION
## What this is about

Hive-partitioned external datasets (`region=…/tier=…/` directory layouts) had two failures that only show up when the read runs on a data node — a coordinator-local run masks both:

- `FROM <hive-partitioned parquet> | SORT <col>` crashed with `column [X] is missing or has an unsupported type`. Plain `LIMIT` worked; adding `SORT` broke the query.
- `FROM <hive-partitioned parquet> | WHERE <partition_col> LIKE "a*"` silently returned rows from **every** partition — no error, just wrong data (5 rows where 3 are correct). Equality filters happened to be correct by accident; the LIKE family (fully pushed, no re-check) leaked.

## What this PR does

A partition column is path-derived — it lives in the directory name, not the file payload. Its identity is reachable two ways: the `FileList` (rich, but coordinator-only — a data node deserializes it as UNRESOLVED) and a serialized name stamp in `sourceMetadata` (rides the wire). Several consumers read the `FileList`, so they saw "no partition columns" on a data node.

We converge every node-agnostic consumer onto one node-safe reader:

- `SourceStatisticsSerializer.partitionColumnNames(sourceMetadata)` — the single decoder.
- `ExternalSourceExec.partitionColumnNames()` / `ExternalRelation.partitionColumnNames()` accessors delegating to it.
- `InsertExternalFieldExtraction`, `PushFiltersToSource`, `PushStatsToExternalSource`, `ComputeService`, `LocalExecutionPlanner`, and `ExternalRelation.dataOnlyUnifiedSchema` all read partition identity from the single decoder — through the `partitionColumnNames()` accessor where a plan node is in scope, or the decoder directly (`ComputeService`, which holds a raw metadata map). None reads the `FileList` for partition identity anymore. `FileList.partitionMetadata()` is read only where the full object is genuinely needed and the code is provably coordinator-side — the resolver, the analyzer, and split discovery — plus a `LocalExecutionPlanner` tripwire assert that *checks* the stamp against the resolved fileList rather than sourcing identity from it.

The two fixes ride the convergence: partition columns are pinned eager under TopN (the SORT crash), and partition conjuncts are held in the `FilterExec` on every node instead of being minted into the reader predicate (the wrong answer). No wire or BWC change — the stamp already serializes with the relation.

## Does it work?

Both bugs reproduce red-before and pass after. New coverage:

- Unit cells on the TopN rule (partition-pinned-eager, no-stamp control, bail threshold, partition-as-sort-key, partition-in-pushed-filter).
- `ExternalParquetHivePartitionedTopNIT` (SORT) and `ExternalParquetHivePartitionFilterPushdownIT` (WHERE `LIKE`/`STARTS_WITH`/`==`/mixed, forced-distributed) — the LIKE cell was verified red with the fix reverted (returns all partitions), green with it.
- An `ExternalRelation` data-node-shape pin.
- `ExternalParquetHivePartitionNullValueIT` — a null partition value (the `__HIVE_DEFAULT_PARTITION__` sentinel) materialises correctly under `SORT` and is matched by `WHERE region IS NULL` / `IS NOT NULL`, forced-distributed.
- A cross-format parity harness (parquet, CSV, TSV, NDJSON): twin datasets — a column stored in the file vs the same values as partition directories — swept over SORT / WHERE / STATS / EVAL / KEEP / DROP / RENAME on a forced-distributed leg, asserting identical rows, row order, and column types. With both fixes reverted it reports 13/18 divergences.

## What's out of scope

- parquet-rs is not test-covered here — the fix protects it structurally (the partition-conjunct holdback runs before any format-specific pushdown); end-to-end rs parity is tracked as a separate GA follow-up.
- ORC hive support is GA.
- CSV/TSV/NDJSON are immune to both bugs (no filter pushdown, no deferred extraction) but are swept by the parity harness as a regression net.

## Size

Production code: **+37 / −44** non-comment lines (net **−7**) — the behavioral fix is a small reroute to one chokepoint, and it deletes more than it adds. The rest of the diff (24 files, ~+1200/−87 total) is tests (the ITs + the four-format parity harness + unit cells), comments, and the changelog.

Closes #153503
