### PR TITLE
ES|QL: NDJSON error_mode governs every unrepresentable cell — declared and inferred alike

### DIFF
--- a/docs/changelog/153580.yaml
+++ b/docs/changelog/153580.yaml
@@ -1,5 +1,5 @@
 pr: 153580
-summary: "ES|QL: reconcile external-dataset `error_mode` so `skip_row` drops the row on NDJSON like CSV/TSV"
+summary: "ES|QL: NDJSON `error_mode` treats every unrepresentable cell the same for declared and inferred columns — `skip_row` drops the row (like CSV/TSV), `null_field` nulls the cell, strict fails"
 area: ES|QL
 type: bug
 issues: []

--- a/docs/changelog/153580.yaml
+++ b/docs/changelog/153580.yaml
@@ -1,0 +1,5 @@
+pr: 153580
+summary: "ES|QL: reconcile external-dataset `error_mode` so `skip_row` drops the row on NDJSON like CSV/TSV"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -106,14 +106,6 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
      */
     private final Map<String, String> declaredDateFormats;
     /**
-     * Physical (file) names of declared-type columns; empty when none. Set via {@link #withDeclaredTypeColumns} and
-     * threaded to each {@link NdJsonPageDecoder} so a cross-kind token on a declared column routes through the error
-     * policy instead of silently reading as null (an inferred column keeps the schema-on-read null tolerance). The
-     * text formats keep the SPI no-op default for the whole-column null-fill decision; NDJSON only needs the set to
-     * pick the per-value cross-kind policy, so it consumes it here rather than in the SPI default.
-     */
-    private final Set<String> declaredTypeColumns;
-    /**
      * Node-stable identity of the row-interpretation-affecting {@code WITH} config, per
      * {@link SchemaCacheKey#buildFormatConfig} — the external-stats cache fingerprint. Derived from
      * the canonical config rather than the projected/resolved schema so a data node's shipped-back
@@ -125,7 +117,7 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
     private final NdJsonReaderCounters counters = new NdJsonReaderCounters();
 
     public NdJsonFormatReader(Settings settings, BlockFactory blockFactory, List<Attribute> resolvedSchema) {
-        this(settings, blockFactory, resolvedSchema, schemaSampleSize(settings), segmentSize(settings), null, "", Map.of(), Set.of());
+        this(settings, blockFactory, resolvedSchema, schemaSampleSize(settings), segmentSize(settings), null, "", Map.of());
     }
 
     NdJsonFormatReader(Settings settings, BlockFactory blockFactory) {
@@ -140,8 +132,7 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         long segmentSizeBytes,
         DateFormatter datetimeFormatter,
         String canonicalConfig,
-        Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Map<String, String> declaredDateFormats
     ) {
         this.blockFactory = blockFactory;
         this.settings = settings == null ? Settings.EMPTY : settings;
@@ -151,7 +142,6 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         this.datetimeFormatter = datetimeFormatter;
         this.canonicalConfig = canonicalConfig;
         this.declaredDateFormats = declaredDateFormats != null ? Map.copyOf(declaredDateFormats) : Map.of();
-        this.declaredTypeColumns = declaredTypeColumns != null ? Set.copyOf(declaredTypeColumns) : Set.of();
     }
 
     @Override
@@ -164,8 +154,7 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             segmentSizeBytes,
             datetimeFormatter,
             canonicalConfig,
-            declaredDateFormats,
-            declaredTypeColumns
+            declaredDateFormats
         );
     }
 
@@ -182,31 +171,7 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             segmentSizeBytes,
             datetimeFormatter,
             canonicalConfig,
-            physicalNameToPattern,
-            declaredTypeColumns
-        );
-    }
-
-    /**
-     * Declared-type columns keyed by physical (file) name. NDJSON does not make the whole-column null-fill
-     * decision the by-name columnar readers do; it consumes this set to decide, per value, whether a cross-kind
-     * token routes through the error policy (declared) or keeps the schema-on-read silent null (inferred).
-     */
-    @Override
-    public NdJsonFormatReader withDeclaredTypeColumns(Set<String> physicalDeclaredColumns) {
-        if (physicalDeclaredColumns == null || physicalDeclaredColumns.isEmpty()) {
-            return this;
-        }
-        return new NdJsonFormatReader(
-            settings,
-            blockFactory,
-            resolvedSchema,
-            schemaSampleSize,
-            segmentSizeBytes,
-            datetimeFormatter,
-            canonicalConfig,
-            declaredDateFormats,
-            physicalDeclaredColumns
+            physicalNameToPattern
         );
     }
 
@@ -231,8 +196,7 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             newSegmentSize,
             newDatetimeFormatter,
             canon,
-            declaredDateFormats,
-            declaredTypeColumns
+            declaredDateFormats
         );
         return Configured.fromKnownSubset(result, config, RECOGNIZED_KEYS);
     }
@@ -550,7 +514,6 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             context.maxRecordBytes(),
             datetimeFormatter,
             declaredDateFormats,
-            declaredTypeColumns,
             context.statsBaseOffset(),
             context.statsStripeSize(),
             context.statsFileFinal(),

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -58,7 +58,6 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -233,15 +232,6 @@ public class NdJsonPageDecoder implements Closeable {
      * and parses that column's timestamps with it instead of {@link #datetimeFormatter}.
      */
     private final Map<String, String> declaredDateFormats;
-    /**
-     * Physical (file) column names whose target type came from an explicit declaration. A cross-kind token
-     * (a boolean in a numeric/datetime column, a number in a boolean column, a non-string in an IP column)
-     * on such a column has no silent-null tolerance — it routes through {@link BlockDecoder#coercionFailure}
-     * per the declared-type invariant that no declared type may silently read as null. An INFERRED column
-     * (not in this set) keeps the schema-on-read {@link BlockDecoder#unexpectedValue} tolerance. Empty when
-     * no column type was declared.
-     */
-    private final Set<String> declaredTypeColumns;
 
     /**
      * Set by {@link BlockDecoder#coercionFailure} while decoding the current record when the policy is
@@ -326,7 +316,6 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of(),
             null
         );
     }
@@ -342,8 +331,7 @@ public class NdJsonPageDecoder implements Closeable {
         ErrorPolicy errorPolicy,
         String sourceLocation,
         NdJsonReaderCounters counters,
-        Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Map<String, String> declaredDateFormats
     ) throws IOException {
         this(
             input,
@@ -356,7 +344,6 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             declaredDateFormats,
-            declaredTypeColumns,
             null
         );
     }
@@ -385,7 +372,6 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of(),
             warningSink
         );
     }
@@ -401,7 +387,6 @@ public class NdJsonPageDecoder implements Closeable {
         String sourceLocation,
         NdJsonReaderCounters counters,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns,
         @Nullable Consumer<String> warningSink
     ) throws IOException {
         this(
@@ -419,7 +404,6 @@ public class NdJsonPageDecoder implements Closeable {
             counters,
             NdJsonUtils.JSON_FACTORY,
             declaredDateFormats,
-            declaredTypeColumns,
             warningSink
         );
     }
@@ -451,7 +435,6 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of(),
             null
         );
     }
@@ -475,8 +458,7 @@ public class NdJsonPageDecoder implements Closeable {
         ErrorPolicy errorPolicy,
         String sourceLocation,
         NdJsonReaderCounters counters,
-        Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Map<String, String> declaredDateFormats
     ) throws IOException {
         this(
             data,
@@ -491,7 +473,6 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             declaredDateFormats,
-            declaredTypeColumns,
             null
         );
     }
@@ -524,7 +505,6 @@ public class NdJsonPageDecoder implements Closeable {
             sourceLocation,
             counters,
             Map.of(),
-            Set.of(),
             warningSink
         );
     }
@@ -542,7 +522,6 @@ public class NdJsonPageDecoder implements Closeable {
         String sourceLocation,
         NdJsonReaderCounters counters,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns,
         @Nullable Consumer<String> warningSink
     ) throws IOException {
         this(
@@ -560,7 +539,6 @@ public class NdJsonPageDecoder implements Closeable {
             counters,
             NdJsonUtils.JSON_FACTORY,
             declaredDateFormats,
-            declaredTypeColumns,
             warningSink
         );
     }
@@ -610,7 +588,6 @@ public class NdJsonPageDecoder implements Closeable {
             new NdJsonReaderCounters(),
             factory,
             Map.of(),
-            Set.of(),
             warningSink
         );
     }
@@ -630,7 +607,6 @@ public class NdJsonPageDecoder implements Closeable {
         NdJsonReaderCounters counters,
         JsonFactory factory,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns,
         @Nullable Consumer<String> warningSink
     ) throws IOException {
         this.jsonFactory = factory;
@@ -659,7 +635,6 @@ public class NdJsonPageDecoder implements Closeable {
         this.counters = counters;
         this.datetimeFormatter = datetimeFormatter != null ? datetimeFormatter : NdJsonSchemaInferrer.STRICT_DATE_OPTIONAL_TIME;
         this.declaredDateFormats = declaredDateFormats != null ? Map.copyOf(declaredDateFormats) : Map.of();
-        this.declaredTypeColumns = declaredTypeColumns != null ? Set.copyOf(declaredTypeColumns) : Set.of();
         this.skipWarnings = SkipWarnings.of(
             errorPolicy,
             "NDJSON read from ["
@@ -1519,24 +1494,24 @@ public class NdJsonPageDecoder implements Closeable {
         /**
          * Decodes the current JSON value into this decoder's block (or, for a structural prefix node, recurses into
          * its children). NDJSON is schema-on-read: the inferred/bound schema flattens nested objects to dotted leaf
-         * columns, so most value/schema shape mismatches are not a hard error and are null-filled for the affected
-         * column(s) rather than failing the query:
+         * columns. Purely STRUCTURAL shape mismatches are not errors — they are null-filled for the affected column(s)
+         * and {@code DEBUG}-logged, never failing the query regardless of {@code error_mode}:
          * <ul>
          *   <li>a JSON {@code null} where an object was expected on a structural prefix node leaves its leaf columns
          *       null for that row (e.g. an intermittently-null nested object across millions of records) — logged at
          *       {@code DEBUG} only, never {@code WARN}, since surfacing it by default would flood the log without
          *       giving the cluster admin an actionable signal;</li>
-         *   <li>a stray scalar among a heterogeneous array of objects is likewise null-filled and {@code DEBUG}-logged
-         *       (a distinct, supported shape from the point below), and symmetrically a stray object among a
-         *       heterogeneous array of scalars is simply omitted from that column's multi-value entry and
-         *       {@code DEBUG}-logged — neither direction is the record-level conflict below;</li>
-         *   <li>a scalar of the wrong primitive type is reported via {@link #unexpectedValue} and null-filled.</li>
+         *   <li>a stray scalar among a heterogeneous array of objects is likewise null-filled and {@code DEBUG}-logged,
+         *       and symmetrically a stray object among a heterogeneous array of scalars is simply omitted from that
+         *       column's multi-value entry and {@code DEBUG}-logged — neither direction is a value error.</li>
          * </ul>
-         * The one genuine hard-error case is a top-level (non-array) scalar/object shape conflict — a field that is a
-         * scalar in some records and an object in others — handled by {@link #shapeConflict}: this is routed through
-         * {@link ErrorPolicy} like any other unparseable value ({@code FAIL_FAST} fails the query, other modes
-         * null-fill and warn) rather than silently decoded, because core ES dynamic mapping treats the same ambiguity
-         * as a hard document-parsing conflict. See elastic/esql-planning#1028.
+         * A cell that genuinely cannot be REPRESENTED under the column's type, by contrast, is governed by
+         * {@code error_mode} — identically for a declared or an inferred column: a bad value or a cross-kind token
+         * ({@link #coercionFailure} / {@link #crossKindDrift}), and a top-level scalar/object shape conflict — a field
+         * that is a scalar in some records and an object in others ({@link #shapeConflict}) — all route through
+         * {@link ErrorPolicy}: {@code FAIL_FAST} fails the query, {@code SKIP_ROW} drops the whole record,
+         * {@code NULL_FIELD} nulls the cell and warns. Core ES dynamic mapping treats the shape ambiguity as a hard
+         * document-parsing conflict. See elastic/esql-planning#1028.
          */
         private void decodeValue(JsonParser parser, boolean inArray) throws IOException {
             JsonToken token = parser.currentToken();
@@ -1697,31 +1672,28 @@ public class NdJsonPageDecoder implements Closeable {
                     ((BytesRefBlock.Builder) blockBuilder).appendBytesRef(toScratchBytesRef(chars));
                 }
                 case IP -> decodeIpValue(parser, token, inArray);
-                // A NULL-typed column expects no value; a stray scalar keeps the policy-blind channel (edge case).
-                case NULL -> unexpectedValue(blockBuilder, parser, inArray);
+                // Unreachable: a NULL-typed column returns at the top of decodeValue (its cell is null-filled at
+                // end-of-page), so the switch is never entered for it.
+                case NULL -> throw new AssertionError("NULL-typed column must be handled by the early return in decodeValue");
                 default -> throw unsupportedTypeForNdjson(dataType);
             }
         }
 
         /**
-         * The scalar-coercion arms below make an NDJSON declared read match the columnar and CSV readers,
-         * drawing the same line the reader already draws between {@link #shapeConflict} (policy-routed) and
-         * {@link #unexpectedValue} (schema-on-read tolerant):
+         * The scalar-coercion arms below make an NDJSON read match the columnar and CSV readers, routing every
+         * unrepresentable cell through {@link #coercionFailure} so the outcome depends only on {@code error_mode}:
          * <ul>
          *   <li>A <b>supported</b> coercion — a JSON string for any scalar column, a fractional number for a
          *       whole-number column, an epoch number for a datetime column — is coerced through the same
          *       {@code ::} cast engine (string→number rounds like {@code ::long}; string→boolean is strict
          *       case-insensitive; string→double preserves NaN). A parse failure or numeric overflow on such a
          *       token is a genuine value error and is routed through {@link #coercionFailure} — so it fails
-         *       {@code fail_fast}, warns, and counts against the error budget exactly like a malformed CSV
-         *       value, closing the "policy-blind silent null" gap for the coercible cases.</li>
+         *       {@code fail_fast}, warns, and counts against the error budget exactly like a malformed CSV value.</li>
          *   <li>An <b>unsupported cross-kind</b> token — a boolean in a numeric/datetime column, a number in a
          *       boolean column: {@code supports(from, to)} is false, the pair the columnar readers reject at
-         *       resolution. NDJSON has no physical schema to reject upfront, so {@link #crossKindDrift} splits by
-         *       whether the column was DECLARED: a declared column routes the drift through {@link #coercionFailure}
-         *       (no declared type may silently read as null), while an inferred column keeps the pre-existing
-         *       {@link #unexpectedValue} silent null — schema-on-read tolerance of a heterogeneous JSON field,
-         *       the same tolerance {@code unexpectedValue} already gave primitive type drift.</li>
+         *       resolution. NDJSON has no physical schema to reject upfront, so {@link #crossKindDrift} routes the
+         *       drift through {@link #coercionFailure} for a declared or an inferred column alike — no silent null,
+         *       because {@code error_mode} governs the outcome regardless of where the type came from.</li>
          * </ul>
          * The common case (a JSON number in a numeric column, a JSON boolean in a boolean column) still decodes
          * straight from the parser with no string allocation.
@@ -1748,25 +1720,17 @@ public class NdJsonPageDecoder implements Closeable {
         }
 
         /**
-         * A cross-kind token — a JSON kind that has no coercion to this column's declared type (a boolean in a
-         * numeric/datetime column, a number in a boolean column, a non-string in an IP column). The columnar
-         * readers reject such a pair at schema resolution; NDJSON has no physical schema to reject upfront, so it
-         * splits by whether the target type was DECLARED:
-         * <ul>
-         *   <li>a DECLARED column has no third state — {@link DeclaredTypeCoercions} requires that a declared type
-         *       which cannot be produced from the physical value must never silently read as null — so the drift is
-         *       routed through {@link #coercionFailure} ({@code fail_fast} fails, other modes warn + null + budget);</li>
-         *   <li>an INFERRED column keeps the pre-existing {@link #unexpectedValue} silent null — schema-on-read
-         *       tolerance of a heterogeneous JSON field, the same tolerance {@code unexpectedValue} already gave
-         *       primitive type drift.</li>
-         * </ul>
+         * A cross-kind token — a JSON kind that has no coercion to this column's type (a boolean in a
+         * numeric/datetime column, a number in a boolean column, a non-string in an IP column). The columnar readers
+         * reject such a pair at schema resolution; NDJSON has no physical schema to reject upfront, so it routes the
+         * drift through {@link #coercionFailure}, the single policy sink — for a DECLARED or an INFERRED column alike,
+         * because {@code error_mode} is one axis independent of where the type came from: {@code fail_fast} fails,
+         * {@code null_field} warns + nulls + budget, {@code skip_row} drops the record + budget. (A declared type
+         * additionally may never silently read as null, per {@link DeclaredTypeCoercions}; routing every column the
+         * same way satisfies that and removes the former inferred-only silent null.)
          */
         private void crossKindDrift(JsonParser parser, boolean inArray, DataType target) throws IOException {
-            if (declaredTypeColumns.contains(name)) {
-                coercionFailure(blockBuilder, parser, inArray, target);
-            } else {
-                unexpectedValue(blockBuilder, parser, inArray);
-            }
+            coercionFailure(blockBuilder, parser, inArray, target);
         }
 
         private void decodeIntValue(JsonParser parser, JsonToken token, boolean inArray) throws IOException {
@@ -1916,18 +1880,6 @@ public class NdJsonPageDecoder implements Closeable {
             }
         }
 
-        private void unexpectedValue(Block.Builder builder, JsonParser parser, boolean inArray) throws IOException {
-            // Append a null and log the problem
-            if (inArray == false) {
-                // See previous comment about nulls and arrays
-                builder.appendNull();
-            }
-
-            logger.debug("Unexpected token type: {} for attribute: {} at {}", parser.currentToken(), name, parser.getTokenLocation());
-            // Ignore any children to keep reading other values
-            parser.skipChildren();
-        }
-
         /**
          * Handles a scalar value that cannot be coerced into a column's declared type — a string that is not a
          * number for a numeric column, a non-{@code true}/{@code false} token for a boolean column, a number that
@@ -1936,11 +1888,10 @@ public class NdJsonPageDecoder implements Closeable {
          * {@link DeclaredTypeCoercions#onCoercionFailure} so a declared-coercion failure produces the SAME
          * observable outcome across every format: {@link ErrorPolicy.Mode#FAIL_FAST} fails the query with an
          * actionable message; {@link ErrorPolicy.Mode#NULL_FIELD} nulls this cell only and warns; and
-         * {@link ErrorPolicy.Mode#SKIP_ROW} drops the whole record and warns (both subject to the error budget). A
-         * DECLARED column behaves the same whether it is violated by a bad value here or by an object shape in
-         * {@link #shapeConflict} — both drop under skip_row — because no declared type may silently read as null; only
-         * an INFERRED shape conflict null-fills. This is distinct from {@link #unexpectedValue}, the policy-blind
-         * channel the file-level (undeclared) datetime path and other per-field type mismatches keep.
+         * {@link ErrorPolicy.Mode#SKIP_ROW} drops the whole record and warns (both subject to the error budget). Every
+         * unrepresentable cell reaches this one sink — a bad value here, a cross-kind token ({@link #crossKindDrift}),
+         * or an object where a scalar was expected ({@link #shapeConflict}) — for a DECLARED or an INFERRED column
+         * alike, so the observable outcome depends only on {@code error_mode}, never on where the type came from.
          */
         private void coercionFailure(Block.Builder builder, JsonParser parser, boolean inArray, DataType target) throws IOException {
             if (rowDroppedBySkipRow) {
@@ -1972,9 +1923,8 @@ public class NdJsonPageDecoder implements Closeable {
             }
             // A value coercion failure under skip_row drops the whole record (matching CsvFormatReader and the
             // Mode.SKIP_ROW "drop the entire bad row" contract); null_field keeps the record and nulls this one cell.
-            // Both warn. shapeConflict draws the same declared-vs-inferred line (see its javadoc): a DECLARED column
-            // violated by an object shape also drops under skip_row, so the two agree for declared columns; only an
-            // INFERRED shape conflict keeps the null-fill.
+            // Both warn. crossKindDrift and shapeConflict route here too, for declared and inferred columns alike, so
+            // every unrepresentable cell drops under skip_row uniformly.
             boolean skipRow = errorPolicy.mode() == ErrorPolicy.Mode.SKIP_ROW;
             String message = base + (skipRow ? " — this record is skipped" : " — this record's [" + name + "] is null");
             if (inArray == false) {
@@ -1994,20 +1944,14 @@ public class NdJsonPageDecoder implements Closeable {
          * resolved to from earlier records: a scalar-typed leaf receiving {@code START_OBJECT}, or an
          * object-shaped (structural) node receiving a non-null scalar. Core ES dynamic mapping treats this
          * as a hard document-parsing conflict; here it is routed through {@link ErrorPolicy} instead of the
-         * pre-#1028 silent {@code skipChildren()}: {@link ErrorPolicy.Mode#FAIL_FAST} fails the query with
-         * an actionable message naming both shapes. Non-strict handling splits on declared-vs-inferred, the
-         * same line {@link #crossKindDrift} draws for a cross-kind scalar value — so the SAME declared column
-         * behaves identically whether it is violated by a bad scalar value or by an object shape:
-         * <ul>
-         *   <li>a DECLARED scalar column ({@code fieldLabel} is in {@link #declaredTypeColumns}) has no third
-         *       state — an object cannot produce the declared type — so under {@link ErrorPolicy.Mode#SKIP_ROW}
-         *       the whole record is dropped (as {@link #coercionFailure} does), and under
-         *       {@link ErrorPolicy.Mode#NULL_FIELD} this field is nulled; both warn;</li>
-         *   <li>an INFERRED column (or a structural-node path, {@code fieldLabel} not declared) null-fills this
-         *       field only — schema-on-read tolerance, the row's other columns already decoded — even under
-         *       skip_row, as pinned by the inferred-schema conflict ITs (NdJsonScalarObjectConflictIT).</li>
-         * </ul>
-         * See elastic/esql-planning#1028.
+         * pre-#1028 silent {@code skipChildren()}, exactly the same policy sink {@link #crossKindDrift} routes a
+         * cross-kind scalar value to — a DECLARED and an INFERRED column behave identically, because {@code error_mode}
+         * is one axis independent of where the type came from: {@link ErrorPolicy.Mode#FAIL_FAST} fails the query with
+         * an actionable message naming both shapes; {@link ErrorPolicy.Mode#SKIP_ROW} drops the whole record; and
+         * {@link ErrorPolicy.Mode#NULL_FIELD} nulls this field only (schema-on-read tolerance, the row's other columns
+         * already decoded — this is the mode that means "keep the record"). Both non-strict modes warn and budget. A
+         * structural-node path with no attributable field name ({@code fieldLabel == null}) cannot drop a row, so it
+         * null-fills regardless of mode. See elastic/esql-planning#1028.
          */
         private void shapeConflict(JsonParser parser, String fieldLabel, String actualShape, String resolvedShape) throws IOException {
             if (rowDroppedBySkipRow) {
@@ -2016,12 +1960,11 @@ public class NdJsonPageDecoder implements Closeable {
                 parser.skipChildren();
                 return;
             }
-            // A declared scalar column receiving an object is a hard declared-type violation, dropped under
-            // skip_row like a bad scalar value for the same column (crossKindDrift -> coercionFailure). An
-            // inferred column (or a structural-node path with no declared name) keeps the null-fill.
-            boolean skipRow = fieldLabel != null
-                && declaredTypeColumns.contains(fieldLabel)
-                && errorPolicy.mode() == ErrorPolicy.Mode.SKIP_ROW;
+            // A scalar column receiving an object cannot be represented, so error_mode decides the outcome the same
+            // way for a declared or an inferred column (crossKindDrift routes to the same coercionFailure sink): under
+            // skip_row the whole record is dropped, under null_field the cell is nulled + warned. A structural-node
+            // path with no field name cannot be attributed to a single row, so it falls back to null-fill.
+            boolean skipRow = fieldLabel != null && errorPolicy.mode() == ErrorPolicy.Mode.SKIP_ROW;
             // Built via concatenation, not LoggerMessageFormat.format: a String-typed first vararg
             // would resolve to the ambiguous format(String prefix, String pattern, Object... args)
             // overload instead of format(String pattern, Object... args), silently mangling the message.

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -243,6 +243,14 @@ public class NdJsonPageDecoder implements Closeable {
      */
     private final Set<String> declaredTypeColumns;
 
+    /**
+     * Set by {@link BlockDecoder#coercionFailure} while decoding the current record when the policy is
+     * {@link ErrorPolicy.Mode#SKIP_ROW}: the record carries an uncoercible value and must be dropped whole
+     * rather than committed with a null cell. Reset per record by {@link #decodePageLenient}, which is the
+     * only decode loop that can drop a record ({@code FAIL_FAST} throws instead).
+     */
+    private boolean rowDroppedBySkipRow;
+
     /** Number of malformed records observed during decoding (lenient policies swallow these). */
     long errorCount() {
         return errorCount;
@@ -1051,6 +1059,7 @@ public class NdJsonPageDecoder implements Closeable {
 
             totalRowCount++;
             this.blockTracker.clear();
+            this.rowDroppedBySkipRow = false;
             // Capture before decodeObject / recovery advance the parser. The slice-relative offset feeds
             // the max_record_size span check; the file-global offset feeds _rowPosition and truncation.
             boolean trackOffset = capEnforced || rowPositionSlot >= 0;
@@ -1108,6 +1117,13 @@ public class NdJsonPageDecoder implements Closeable {
                 if (rowPositionSlot >= 0) {
                     ((LongBlock.Builder) rowScratch[rowPositionSlot]).appendLong(recordOffset);
                     blockTracker.set(rowPositionSlot);
+                }
+                if (rowDroppedBySkipRow) {
+                    // error_mode: skip_row. An uncoercible value makes the whole record bad, so it never reaches
+                    // the page — matching CsvFormatReader, and matching ErrorPolicy.Mode.SKIP_ROW's contract
+                    // ("drop the entire bad row"). The scratch builders are released by the finally below and
+                    // rebuilt for the next record; nothing partial is committed. NULL_FIELD still null-fills.
+                    continue;
                 }
                 for (int i = 0; i < rowScratch.length; i++) {
                     if (blockTracker.get(i) == false) {
@@ -1916,18 +1932,29 @@ public class NdJsonPageDecoder implements Closeable {
          * Handles a scalar value that cannot be coerced into a column's declared type — a string that is not a
          * number for a numeric column, a non-{@code true}/{@code false} token for a boolean column, a number that
          * overflows the target, a string the declared date {@code format} cannot parse, or a token whose JSON kind
-         * has no coercion to the target. Routed through {@link ErrorPolicy} exactly like {@link #shapeConflict}
-         * and {@link DeclaredTypeCoercions#onCoercionFailure} so a declared-coercion failure produces the SAME
+         * has no coercion to the target. Routed through {@link ErrorPolicy} and
+         * {@link DeclaredTypeCoercions#onCoercionFailure} so a declared-coercion failure produces the SAME
          * observable outcome across every format: {@link ErrorPolicy.Mode#FAIL_FAST} fails the query with an
-         * actionable message; other modes null this cell only and surface the message as a client warning (subject to
-         * the error budget). This is distinct from {@link #unexpectedValue}, the policy-blind channel the file-level
-         * (undeclared) datetime path and other per-field type mismatches keep.
+         * actionable message; {@link ErrorPolicy.Mode#NULL_FIELD} nulls this cell only and warns; and
+         * {@link ErrorPolicy.Mode#SKIP_ROW} drops the whole record and warns (both subject to the error budget). A
+         * DECLARED column behaves the same whether it is violated by a bad value here or by an object shape in
+         * {@link #shapeConflict} — both drop under skip_row — because no declared type may silently read as null; only
+         * an INFERRED shape conflict null-fills. This is distinct from {@link #unexpectedValue}, the policy-blind
+         * channel the file-level (undeclared) datetime path and other per-field type mismatches keep.
          */
         private void coercionFailure(Block.Builder builder, JsonParser parser, boolean inArray, DataType target) throws IOException {
+            if (rowDroppedBySkipRow) {
+                // This record is already being dropped by an earlier skip_row error. Advance past this value but do
+                // not double-count it: CsvFormatReader charges the error budget once per dropped row (it stops at the
+                // first bad field), not once per bad field. The record's scratch is discarded, so no null-fill is
+                // needed and further coercion failures on the same doomed record must not consume the budget again.
+                parser.skipChildren();
+                return;
+            }
             String value = parser.getValueAsString();
             // Not "the declared type": this path also fires for a supported-pair failure on an INFERRED column
             // (e.g. a bad string in an inferred long), where the target type was not declared.
-            String message = "column ["
+            String base = "column ["
                 + name
                 + "] at line ["
                 + totalRowCount
@@ -1935,18 +1962,26 @@ public class NdJsonPageDecoder implements Closeable {
                 + value
                 + "] could not be coerced to type ["
                 + target.typeName()
-                + "] — this record's ["
-                + name
-                + "] is null";
+                + "]";
             parser.skipChildren();
             if (errorPolicy.isStrict()) {
                 // Mirror CsvFormatReader.onRowErrorImpl's field-error hint so the fail-fast message is actionable.
                 throw new EsqlIllegalArgumentException(
-                    message + "; set error_mode=null_field (or skip_row) to null-fill/skip and warn instead of failing"
+                    base + "; set error_mode=null_field (or skip_row) to null-fill/skip and warn instead of failing"
                 );
             }
+            // A value coercion failure under skip_row drops the whole record (matching CsvFormatReader and the
+            // Mode.SKIP_ROW "drop the entire bad row" contract); null_field keeps the record and nulls this one cell.
+            // Both warn. shapeConflict draws the same declared-vs-inferred line (see its javadoc): a DECLARED column
+            // violated by an object shape also drops under skip_row, so the two agree for declared columns; only an
+            // INFERRED shape conflict keeps the null-fill.
+            boolean skipRow = errorPolicy.mode() == ErrorPolicy.Mode.SKIP_ROW;
+            String message = base + (skipRow ? " — this record is skipped" : " — this record's [" + name + "] is null");
             if (inArray == false) {
                 builder.appendNull();
+            }
+            if (skipRow) {
+                rowDroppedBySkipRow = true;
             }
             errorCount++;
             skipWarnings.add(message);
@@ -1960,11 +1995,33 @@ public class NdJsonPageDecoder implements Closeable {
          * object-shaped (structural) node receiving a non-null scalar. Core ES dynamic mapping treats this
          * as a hard document-parsing conflict; here it is routed through {@link ErrorPolicy} instead of the
          * pre-#1028 silent {@code skipChildren()}: {@link ErrorPolicy.Mode#FAIL_FAST} fails the query with
-         * an actionable message naming both shapes; other modes null-fill this field only (the row's other
-         * columns already decoded) and surface the same message as a client warning. See
-         * elastic/esql-planning#1028.
+         * an actionable message naming both shapes. Non-strict handling splits on declared-vs-inferred, the
+         * same line {@link #crossKindDrift} draws for a cross-kind scalar value — so the SAME declared column
+         * behaves identically whether it is violated by a bad scalar value or by an object shape:
+         * <ul>
+         *   <li>a DECLARED scalar column ({@code fieldLabel} is in {@link #declaredTypeColumns}) has no third
+         *       state — an object cannot produce the declared type — so under {@link ErrorPolicy.Mode#SKIP_ROW}
+         *       the whole record is dropped (as {@link #coercionFailure} does), and under
+         *       {@link ErrorPolicy.Mode#NULL_FIELD} this field is nulled; both warn;</li>
+         *   <li>an INFERRED column (or a structural-node path, {@code fieldLabel} not declared) null-fills this
+         *       field only — schema-on-read tolerance, the row's other columns already decoded — even under
+         *       skip_row, as pinned by the inferred-schema conflict ITs (NdJsonScalarObjectConflictIT).</li>
+         * </ul>
+         * See elastic/esql-planning#1028.
          */
         private void shapeConflict(JsonParser parser, String fieldLabel, String actualShape, String resolvedShape) throws IOException {
+            if (rowDroppedBySkipRow) {
+                // This record is already being dropped by an earlier skip_row error; skip the conflicting value and do
+                // not double-count it against the error budget (one error per dropped record, matching CsvFormatReader).
+                parser.skipChildren();
+                return;
+            }
+            // A declared scalar column receiving an object is a hard declared-type violation, dropped under
+            // skip_row like a bad scalar value for the same column (crossKindDrift -> coercionFailure). An
+            // inferred column (or a structural-node path with no declared name) keeps the null-fill.
+            boolean skipRow = fieldLabel != null
+                && declaredTypeColumns.contains(fieldLabel)
+                && errorPolicy.mode() == ErrorPolicy.Mode.SKIP_ROW;
             // Built via concatenation, not LoggerMessageFormat.format: a String-typed first vararg
             // would resolve to the ambiguous format(String prefix, String pattern, Object... args)
             // overload instead of format(String pattern, Object... args), silently mangling the message.
@@ -1978,14 +2035,17 @@ public class NdJsonPageDecoder implements Closeable {
                 + fieldLabel
                 + "] resolved to "
                 + resolvedShape
-                + " from earlier records — this record's ["
-                + fieldLabel
-                + "] is null. A field that appears as both a scalar and an object across NDJSON "
+                + " from earlier records — "
+                + (skipRow ? "this record is skipped" : "this record's [" + fieldLabel + "] is null")
+                + ". A field that appears as both a scalar and an object across NDJSON "
                 + "records cannot be represented as one type; make the field's shape consistent, or "
                 + "model it as separate fields.";
             parser.skipChildren();
             if (errorPolicy.isStrict()) {
                 throw new EsqlIllegalArgumentException(message);
+            }
+            if (skipRow) {
+                rowDroppedBySkipRow = true;
             }
             errorCount++;
             skipWarnings.add(message);

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -1863,7 +1863,7 @@ public class NdJsonPageDecoder implements Closeable {
          * Decodes a declared {@code ip} column. A {@code VALUE_STRING} is parsed and encoded to the 16-byte
          * {@link InetAddressPoint} form (matching {@code CsvFormatReader.tryParseIp} so identical bytes yield the
          * same value across formats); a string that is not a valid IP is a {@link #coercionFailure}. A cross-kind
-         * non-string token uses the declared/inferred gate ({@link #crossKindDrift}).
+         * non-string token routes through {@link #crossKindDrift} to the same policy sink.
          */
         private void decodeIpValue(JsonParser parser, JsonToken token, boolean inArray) throws IOException {
             if (token == JsonToken.VALUE_STRING) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -1511,7 +1511,7 @@ public class NdJsonPageDecoder implements Closeable {
          * that is a scalar in some records and an object in others ({@link #shapeConflict}) — all route through
          * {@link ErrorPolicy}: {@code FAIL_FAST} fails the query, {@code SKIP_ROW} drops the whole record,
          * {@code NULL_FIELD} nulls the cell and warns. Core ES dynamic mapping treats the shape ambiguity as a hard
-         * document-parsing conflict. See elastic/esql-planning#1028.
+         * document-parsing conflict.
          */
         private void decodeValue(JsonParser parser, boolean inArray) throws IOException {
             JsonToken token = parser.currentToken();
@@ -1601,7 +1601,7 @@ public class NdJsonPageDecoder implements Closeable {
                         return;
                     }
                     // Scalar leaf receiving an object value outside an array: a genuine scalar/object schema
-                    // conflict (elastic/esql-planning#1028), not routine schema-on-read flattening. With
+                    // conflict, not routine schema-on-read flattening. With
                     // single-shape schema inference (see NdJsonSchemaInferrer) this can only happen when
                     // the actual data diverges from the shape observed during sampling, so — unlike the
                     // routine mismatches above — it is routed through ErrorPolicy instead of silently
@@ -1634,7 +1634,7 @@ public class NdJsonPageDecoder implements Closeable {
                             );
                         }
                     } else {
-                        // Genuine scalar/object schema conflict (elastic/esql-planning#1028): route
+                        // Genuine scalar/object schema conflict: route
                         // through ErrorPolicy instead of silently null-filling. Structural nodes never
                         // receive setAttribute(), so `name` is null here; derive the JSON path (e.g.
                         // /userIdentity/sessionContext) from the parser context to identify the field.
@@ -1951,7 +1951,7 @@ public class NdJsonPageDecoder implements Closeable {
          * {@link ErrorPolicy.Mode#NULL_FIELD} nulls this field only (schema-on-read tolerance, the row's other columns
          * already decoded — this is the mode that means "keep the record"). Both non-strict modes warn and budget. A
          * structural-node path with no attributable field name ({@code fieldLabel == null}) cannot drop a row, so it
-         * null-fills regardless of mode. See elastic/esql-planning#1028.
+         * null-fills regardless of mode.
          */
         private void shapeConflict(JsonParser parser, String fieldLabel, String actualShape, String resolvedShape) throws IOException {
             if (rowDroppedBySkipRow) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -213,7 +212,6 @@ final class NdJsonPageIterator extends BufferingPageIterator {
         int maxRecordBytes,
         DateFormatter datetimeFormatter,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns,
         long statsBaseOffset,
         long statsStripeSize,
         boolean statsFileFinal,
@@ -309,7 +307,6 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 this.sourceLocation,
                 counters,
                 declaredDateFormats,
-                declaredTypeColumns,
                 warningSink
             );
         } else {
@@ -332,7 +329,6 @@ final class NdJsonPageIterator extends BufferingPageIterator {
                 this.sourceLocation,
                 counters,
                 declaredDateFormats,
-                declaredTypeColumns,
                 warningSink
             );
         }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -295,7 +295,7 @@ public class NdJsonPageDecoderTests extends ESTestCase {
      * e.g. {@code address.city}/{@code address.zip}, but a row's {@code address} is a plain string) is a genuine
      * scalar/object schema conflict: core ES dynamic mapping treats the same ambiguity as a hard document-parsing
      * conflict, so under {@link ErrorPolicy#STRICT} it must fail the query with an actionable message naming the
-     * field and both shapes rather than silently null-filling (elastic/esql-planning#1028). Before that fix, this
+     * field and both shapes rather than silently null-filling. Before that fix, this
      * mismatch was silently null-filled even under {@code STRICT} (see the pre-#1028 revision of
      * {@code testNullOrScalarWhereNestedObjectExpected}).
      */
@@ -319,7 +319,7 @@ public class NdJsonPageDecoderTests extends ESTestCase {
      * Same conflict as {@link #testScalarWhereNestedObjectExpectedStrictFails}, but under skip_row: the conflicting
      * record is dropped whole and a client warning is surfaced, while the other records still decode. error_mode
      * governs the outcome the same for a bound/declared or an inferred schema; null_field keeps the record and nulls
-     * the conflicting field instead (see the NdJsonPageIteratorTests null_field pin). See elastic/esql-planning#1028.
+     * the conflicting field instead (see the NdJsonPageIteratorTests null_field pin).
      */
     public void testScalarWhereNestedObjectExpectedSkipRowDropsRecordAndWarns() throws IOException {
         String ndjson = "{\"address\": {\"city\": \"NYC\", \"zip\": \"10001\"}, \"id\": 1}\n"
@@ -473,7 +473,7 @@ public class NdJsonPageDecoderTests extends ESTestCase {
      * Mirror of {@link #testArrayOfObjectsWithScalarElements}: an array of scalars on a leaf column whose
      * elements are occasionally objects (e.g. {@code ["a", {"x":1}, "b"]}). A stray object among array
      * scalars is a distinct, supported shape — not the record-level scalar/object conflict
-     * elastic/esql-planning#1028 targets — so it must be silently omitted from the multi-value entry under
+     * the record-level shape-conflict path targets — so it must be silently omitted from the multi-value entry under
      * every {@link ErrorPolicy}, including {@code STRICT}; only a genuine top-level (non-array) conflict
      * (see {@link #testScalarWhereNestedObjectExpectedStrictFails}) fails the query. Covers leading-object,
      * mid-object, and all-object arrays against a scalar {@code id} column that pins the expected row count.

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -660,9 +660,9 @@ public class NdJsonPageDecoderTests extends ESTestCase {
      * A bad VALUE is a per-cell data failure the error policy governs — never the blanket
      * unsupportedTypeForNdjson throw that used to fire before any cell was even looked at.
      */
-    public void testDeclaredUnsignedLongBadValueIsPerCellUnderLenient() throws IOException {
+    public void testDeclaredUnsignedLongBadValueIsPerCellUnderNullField() throws IOException {
         String ndjson = "{\"v\":-1}\n{\"v\":18446744073709551616}\n{\"v\":\"abc\"}\n{\"v\":5}\n";
-        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.LENIENT)) {
+        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.PERMISSIVE)) {
             LongBlock block = page.getBlock(0);
             assertEquals(4, block.getPositionCount());
             assertTrue("negative nulls the cell", block.isNull(0));
@@ -679,7 +679,7 @@ public class NdJsonPageDecoderTests extends ESTestCase {
      */
     public void testDeclaredUnsignedLongExoticExponentIsAPerCellFailure() throws IOException {
         String ndjson = "{\"v\":\"1e999999999\"}\n{\"v\":1e999999999}\n{\"v\":5}\n";
-        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.LENIENT)) {
+        try (Page page = decodeOneColumn(ndjson, DataType.UNSIGNED_LONG, ErrorPolicy.PERMISSIVE)) {
             LongBlock block = page.getBlock(0);
             assertTrue("string exotic exponent nulls the cell", block.isNull(0));
             assertTrue("numeric exotic exponent nulls the cell", block.isNull(1));

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Targeted unit tests for {@link NdJsonPageDecoder}'s keyword-decode path. Sibling
@@ -317,12 +316,12 @@ public class NdJsonPageDecoderTests extends ESTestCase {
     }
 
     /**
-     * Same conflict as {@link #testScalarWhereNestedObjectExpectedStrictFails}, but under a non-strict policy: the
-     * conflicting field is null-filled and a client warning is surfaced, while the row's other columns (and other
-     * rows) still decode normally. This is a per-field null-fill, not a whole-row skip — elastic/esql-planning#1028
-     * notes the conflict path already decodes the rest of the record, so there is no need to drop it wholesale.
+     * Same conflict as {@link #testScalarWhereNestedObjectExpectedStrictFails}, but under skip_row: the conflicting
+     * record is dropped whole and a client warning is surfaced, while the other records still decode. error_mode
+     * governs the outcome the same for a bound/declared or an inferred schema; null_field keeps the record and nulls
+     * the conflicting field instead (see the NdJsonPageIteratorTests null_field pin). See elastic/esql-planning#1028.
      */
-    public void testScalarWhereNestedObjectExpectedLenientWarnsAndNullFills() throws IOException {
+    public void testScalarWhereNestedObjectExpectedSkipRowDropsRecordAndWarns() throws IOException {
         String ndjson = "{\"address\": {\"city\": \"NYC\", \"zip\": \"10001\"}, \"id\": 1}\n"
             + "{\"address\": \"unstructured\", \"id\": 2}\n"
             + "{\"address\": {\"city\": \"London\", \"zip\": \"SW1A\"}, \"id\": 3}\n";
@@ -339,18 +338,17 @@ public class NdJsonPageDecoderTests extends ESTestCase {
             )
         ) {
             assertNotNull(page);
-            assertEquals(3, page.getPositionCount());
+            // The scalar-where-object record is dropped whole under skip_row; the two structured records survive.
+            assertEquals(2, page.getPositionCount());
             BytesRefBlock city = page.getBlock(0);
             BytesRefBlock zip = page.getBlock(1);
             IntBlock id = page.getBlock(2);
             BytesRef scratch = new BytesRef();
             assertEquals(new BytesRef("NYC"), BytesRef.deepCopyOf(city.getBytesRef(0, scratch)));
-            assertTrue("scalar-where-object row -> city null", city.isNull(1));
-            assertTrue("scalar-where-object row -> zip null", zip.isNull(1));
-            assertFalse("scalar-where-object row's sibling column must still decode", id.isNull(1));
-            assertEquals(2, id.getInt(id.getFirstValueIndex(1)));
-            assertEquals(new BytesRef("London"), BytesRef.deepCopyOf(city.getBytesRef(2, scratch)));
-            assertEquals(new BytesRef("SW1A"), BytesRef.deepCopyOf(zip.getBytesRef(2, scratch)));
+            assertEquals(1, id.getInt(id.getFirstValueIndex(0)));
+            assertEquals(new BytesRef("London"), BytesRef.deepCopyOf(city.getBytesRef(1, scratch)));
+            assertEquals(new BytesRef("SW1A"), BytesRef.deepCopyOf(zip.getBytesRef(1, scratch)));
+            assertEquals(3, id.getInt(id.getFirstValueIndex(1)));
         }
 
         List<String> warnings = drainWarnings();
@@ -359,7 +357,7 @@ public class NdJsonPageDecoderTests extends ESTestCase {
     }
 
     /**
-     * Same shape conflict as {@link #testScalarWhereNestedObjectExpectedLenientWarnsAndNullFills}, but with a
+     * Same shape conflict as {@link #testScalarWhereNestedObjectExpectedSkipRowDropsRecordAndWarns}, but with a
      * {@code warningSink} supplied: the decoder must route every emitted message through the sink instead of
      * {@link HeaderWarning}, since {@link NdJsonPageDecoder}'s decode loop can run on a background reader thread
      * whose thread-local response headers never reach the client (see {@link SkipWarnings}).
@@ -541,8 +539,7 @@ public class NdJsonPageDecoderTests extends ESTestCase {
                 ErrorPolicy.STRICT,
                 "test://declared-date",
                 new NdJsonReaderCounters(),
-                Map.of("ts", "dd/MMM/yyyy:HH:mm:ss Z"),
-                Set.of()
+                Map.of("ts", "dd/MMM/yyyy:HH:mm:ss Z")
             )
         ) {
             try (Page page = decoder.decodePage()) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1383,6 +1383,44 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
     }
 
+    public void testSkipRowMixedCoercionAndShapeConflictChargesBudgetOnce() throws IOException {
+        // A record that fails BOTH ways — a bad scalar VALUE (coercionFailure) and a declared-scalar column that got
+        // an OBJECT (shapeConflict) — is still one dropped row and must charge the budget once. The first failure sets
+        // rowDroppedBySkipRow; the second hits shapeConflict's already-dropped early-return, which must NOT count again.
+        // With max_errors=1 the record must not trip the budget. This pins shapeConflict's short-circuit branch.
+        String ndjson = """
+            {"a": "1", "user": "alice"}
+            {"a": "bad", "user": {"id": 7}}
+            {"a": "3", "user": "carol"}
+            """;
+        var object = new BytesStorageObject("file:///mixed.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("a", "user"));
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "a", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "user", DataType.KEYWORD)
+        );
+        ErrorPolicy skipRowBudgetOne = new ErrorPolicy(1, true); // max_errors=1, skip_row
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .projectedColumns(List.of("a", "user"))
+                    .batchSize(100)
+                    .errorPolicy(skipRowBudgetOne)
+                    .readSchema(schema)
+                    .build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals("the record failing both ways is one budget unit; both good records remain", 2, page.getPositionCount());
+            LongBlock a = page.getBlock(0);
+            assertEquals(1L, a.getLong(a.getFirstValueIndex(0)));
+            assertEquals(3L, a.getLong(a.getFirstValueIndex(1)));
+        }
+        assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
+    }
+
     public void testInferredCrossKindBooleanStaysSilentNull() throws IOException {
         // An inferred (not declared) long column keeps the pre-existing schema-on-read tolerance: a boolean on a
         // later line is silently null, unchanged. Mirrors testTypeDifferentFromSchema.

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1246,6 +1246,143 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         }
     }
 
+    /**
+     * The advice names {@code skip_row}, and {@link ErrorPolicy.Mode#SKIP_ROW} means "drop the entire bad
+     * row" — as {@code CsvFormatReader} does. The offending record is dropped whole; its neighbours still decode.
+     */
+    public void testDeclaredCoercionFailureSkipRowDropsLine() throws IOException {
+        String ndjson = """
+            {"n": "1"}
+            {"n": "notanumber"}
+            {"n": "3"}
+            """;
+        var object = new BytesStorageObject("file:///bad.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        List<Attribute> schema = List.of(new ReferenceAttribute(Source.EMPTY, null, "n", DataType.LONG));
+        ErrorPolicy skipRow = new ErrorPolicy(10, true);
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("n")).batchSize(100).errorPolicy(skipRow).readSchema(schema).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals("the record with the uncoercible value is dropped whole", 2, page.getPositionCount());
+            LongBlock n = page.getBlock(0);
+            assertEquals(1L, n.getLong(n.getFirstValueIndex(0)));
+            assertEquals(3L, n.getLong(n.getFirstValueIndex(1)));
+        }
+        assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
+    }
+
+    /**
+     * A coercion failure on a single element of a declared multivalue array under {@code skip_row} drops the WHOLE
+     * record (the {@code rowDroppedBySkipRow} flag is set regardless of {@code inArray}) — matching the scalar case
+     * and the "drop the entire bad row" contract. The surrounding records still decode.
+     */
+    public void testDeclaredArrayElementCoercionFailureSkipRowDropsRecord() throws IOException {
+        String ndjson = """
+            {"vals": ["1", "2"]}
+            {"vals": ["10", "notanumber", "30"]}
+            {"vals": ["7"]}
+            """;
+        var object = new BytesStorageObject("file:///arr.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        List<Attribute> schema = List.of(new ReferenceAttribute(Source.EMPTY, null, "vals", DataType.LONG));
+        ErrorPolicy skipRow = new ErrorPolicy(10, true);
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("vals")).batchSize(100).errorPolicy(skipRow).readSchema(schema).build()
+            )
+        ) {
+            var page = iterator.next();
+            assertEquals("the record with the uncoercible array element is dropped whole", 2, page.getPositionCount());
+            LongBlock v = page.getBlock(0);
+            assertEquals(2, v.getValueCount(0)); // {"vals":["1","2"]}
+            assertEquals(1, v.getValueCount(1)); // {"vals":["7"]} — the bad record between them is gone
+            assertEquals(7L, v.getLong(v.getFirstValueIndex(1)));
+        }
+        assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
+    }
+
+    public void testDeclaredScalarObjectConflictSkipRowDropsRecord() throws IOException {
+        // A DECLARED scalar column receiving an object shape is a hard declared-type violation. Under skip_row the
+        // whole record drops, consistent with a bad scalar VALUE for the same declared column (crossKindDrift). An
+        // INFERRED column keeps the null-fill (the NdJson*ScalarObjectConflictIT pinning ITs / the LENIENT decoder
+        // test). Before the split, shapeConflict null-filled here too, so all three records survived.
+        String ndjson = """
+            {"event": 1, "user": "alice"}
+            {"event": 2, "user": {"id": 7}}
+            {"event": 3, "user": "carol"}
+            """;
+        var object = new BytesStorageObject("file:///decl-shape.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("user"));
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "event", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "user", DataType.KEYWORD)
+        );
+        ErrorPolicy skipRow = new ErrorPolicy(10, true);
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .projectedColumns(List.of("event", "user"))
+                    .batchSize(100)
+                    .errorPolicy(skipRow)
+                    .readSchema(schema)
+                    .build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals("the record whose declared-scalar [user] is an object is dropped whole", 2, page.getPositionCount());
+            LongBlock event = page.getBlock(0);
+            assertEquals(1L, event.getLong(event.getFirstValueIndex(0)));
+            assertEquals(3L, event.getLong(event.getFirstValueIndex(1)));
+        }
+        assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
+    }
+
+    public void testSkipRowChargesErrorBudgetOncePerRecordNotPerField() throws IOException {
+        // Under skip_row a record with several bad DECLARED fields is ONE dropped row, so it charges the error budget
+        // once — matching CsvFormatReader, which stops at the first bad field. With max_errors=1 a two-bad-field
+        // record must NOT trip the budget. Before the fix each bad field counted, so the second field pushed the
+        // running total to 2 and failed the whole query.
+        String ndjson = """
+            {"a": "1", "b": "2"}
+            {"a": "bad", "b": "alsobad"}
+            {"a": "3", "b": "4"}
+            """;
+        var object = new BytesStorageObject("file:///budget.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("a", "b"));
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "a", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "b", DataType.LONG)
+        );
+        ErrorPolicy skipRowBudgetOne = new ErrorPolicy(1, true); // max_errors=1, skip_row
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .projectedColumns(List.of("a", "b"))
+                    .batchSize(100)
+                    .errorPolicy(skipRowBudgetOne)
+                    .readSchema(schema)
+                    .build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals("the two-bad-field record is one budget unit; both good records remain", 2, page.getPositionCount());
+            LongBlock a = page.getBlock(0);
+            assertEquals(1L, a.getLong(a.getFirstValueIndex(0)));
+            assertEquals(3L, a.getLong(a.getFirstValueIndex(1)));
+        }
+        assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
+    }
+
     public void testInferredCrossKindBooleanStaysSilentNull() throws IOException {
         // An inferred (not declared) long column keeps the pre-existing schema-on-read tolerance: a boolean on a
         // later line is silently null, unchanged. Mirrors testTypeDifferentFromSchema.

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.ConstantNullBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -63,7 +62,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -1258,34 +1256,28 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         var reader = new NdJsonFormatReader(settings, blockFactory);
         var object = new BytesStorageObject("file:///test.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
 
+        // The second record's [x] is a boolean where the inferred type is DATETIME — a cross-kind token. Under the
+        // DEFAULT (strict) read it fails the query: the inferred path honors error_mode identically to a declared
+        // column (previously the boolean was silently null). Lenient-mode behavior is covered by
+        // testInferredCrossKindBooleanHonorsErrorMode.
         try (var iterator = reader.read(object, List.of("x", "y"), 100)) {
-            assertTrue(iterator.hasNext());
-            var page = iterator.next();
-            assertPage(page, """
-                     LONG      |      INT     \s
-                ---------------+---------------
-                1704067200000  |1             \s
-                null           |2             \s
-                """);
-
-            assertEquals(ElementType.LONG, page.getBlock(0).elementType()); // DATETIME
-
-            assertEquals(2, page.getBlock(0).getPositionCount());
-            assertEquals(2, page.getBlock(1).getPositionCount());
-            assertEquals(2, page.getPositionCount());
-
-            assertEquals(Instant.parse("2024-01-01T00:00:00Z").toEpochMilli(), ((LongBlock) page.getBlock(0)).getLong(0));
-            assertTrue(page.getBlock(0).isNull(1)); // Boolean ignored
+            var e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            });
+            assertThat(e.getMessage(), Matchers.containsString("could not be coerced"));
         }
     }
 
-    public void testDeclaredCrossKindBooleanFailsUnderStrict() throws IOException {
-        // A boolean in a DECLARED long column is an unsupported cross-kind token with no coercion. On a declared
-        // column it must route through the error policy (strict fails) rather than silently reading as null — the
-        // declared-type invariant that no declared type may silently read as null.
+    public void testCrossKindBooleanWithBoundSchemaFailsUnderStrict() throws IOException {
+        // A boolean in a long column (here bound via an explicit read schema) is an unsupported cross-kind token
+        // with no coercion; under strict it routes through the error policy and fails rather than reading as null.
+        // error_mode governs this identically whether the type was declared/bound or inferred (see
+        // testInferredCrossKindBooleanHonorsErrorMode for the inferred-schema counterpart).
         String ndjson = "{\"n\": true}\n";
         var object = new BytesStorageObject("file:///xkind.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
-        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("n"));
+        var reader = new NdJsonFormatReader(null, blockFactory);
         List<Attribute> schema = List.of(new ReferenceAttribute(Source.EMPTY, null, "n", DataType.LONG));
         try (
             var iterator = reader.read(
@@ -1368,18 +1360,18 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
     }
 
-    public void testDeclaredScalarObjectConflictSkipRowDropsRecord() throws IOException {
-        // A DECLARED scalar column receiving an object shape is a hard declared-type violation. Under skip_row the
-        // whole record drops, consistent with a bad scalar VALUE for the same declared column (crossKindDrift). An
-        // INFERRED column keeps the null-fill (the NdJson*ScalarObjectConflictIT pinning ITs / the LENIENT decoder
-        // test). Before the split, shapeConflict null-filled here too, so all three records survived.
+    public void testScalarObjectConflictSkipRowDropsRecord() throws IOException {
+        // A scalar column (here bound KEYWORD via the read schema) receiving an object shape cannot be represented.
+        // Under skip_row the whole record drops, consistent with a bad scalar value for the same column. error_mode
+        // governs this identically for a bound/declared or an inferred column; null_field keeps the record instead
+        // (see testScalarObjectConflictNullFieldKeepsRecordAndNulls).
         String ndjson = """
             {"event": 1, "user": "alice"}
             {"event": 2, "user": {"id": 7}}
             {"event": 3, "user": "carol"}
             """;
-        var object = new BytesStorageObject("file:///decl-shape.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
-        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("user"));
+        var object = new BytesStorageObject("file:///skiprow-shape.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
         List<Attribute> schema = List.of(
             new ReferenceAttribute(Source.EMPTY, null, "event", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "user", DataType.KEYWORD)
@@ -1398,7 +1390,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         ) {
             assertTrue(iterator.hasNext());
             var page = iterator.next();
-            assertEquals("the record whose declared-scalar [user] is an object is dropped whole", 2, page.getPositionCount());
+            assertEquals("the record whose scalar [user] is an object is dropped whole", 2, page.getPositionCount());
             LongBlock event = page.getBlock(0);
             assertEquals(1L, event.getLong(event.getFirstValueIndex(0)));
             assertEquals(3L, event.getLong(event.getFirstValueIndex(1)));
@@ -1406,8 +1398,49 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
     }
 
+    public void testScalarObjectConflictNullFieldKeepsRecordAndNulls() throws IOException {
+        // The mode that means "keep the record": under null_field the object-valued [user] cell is nulled and the
+        // record survives, so all three rows return. This is where the pre-#1028 "keep it, null the cell" behavior
+        // now lives — skip_row drops (above), null_field keeps.
+        String ndjson = """
+            {"event": 1, "user": "alice"}
+            {"event": 2, "user": {"id": 7}}
+            {"event": 3, "user": "carol"}
+            """;
+        var object = new BytesStorageObject("file:///nullfield-shape.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "event", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "user", DataType.KEYWORD)
+        );
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .projectedColumns(List.of("event", "user"))
+                    .batchSize(100)
+                    .errorPolicy(ErrorPolicy.PERMISSIVE)
+                    .readSchema(schema)
+                    .build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals("null_field keeps all records", 3, page.getPositionCount());
+            LongBlock event = page.getBlock(0);
+            BytesRefBlock user = page.getBlock(1);
+            assertEquals(1L, event.getLong(event.getFirstValueIndex(0)));
+            assertFalse(user.isNull(0));
+            assertEquals(2L, event.getLong(event.getFirstValueIndex(1)));
+            assertTrue("the object-valued [user] cell is nulled, record kept", user.isNull(1));
+            assertEquals(3L, event.getLong(event.getFirstValueIndex(2)));
+            assertFalse(user.isNull(2));
+        }
+        assertFalse("null_field must warn about the nulled cell", drainWarnings().isEmpty());
+    }
+
     public void testSkipRowChargesErrorBudgetOncePerRecordNotPerField() throws IOException {
-        // Under skip_row a record with several bad DECLARED fields is ONE dropped row, so it charges the error budget
+        // Under skip_row a record with several bad fields is ONE dropped row, so it charges the error budget
         // once — matching CsvFormatReader, which stops at the first bad field. With max_errors=1 a two-bad-field
         // record must NOT trip the budget. Before the fix each bad field counted, so the second field pushed the
         // running total to 2 and failed the whole query.
@@ -1417,7 +1450,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
             {"a": "3", "b": "4"}
             """;
         var object = new BytesStorageObject("file:///budget.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
-        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("a", "b"));
+        var reader = new NdJsonFormatReader(null, blockFactory);
         List<Attribute> schema = List.of(
             new ReferenceAttribute(Source.EMPTY, null, "a", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "b", DataType.LONG)
@@ -1445,7 +1478,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     }
 
     public void testSkipRowMixedCoercionAndShapeConflictChargesBudgetOnce() throws IOException {
-        // A record that fails BOTH ways — a bad scalar VALUE (coercionFailure) and a declared-scalar column that got
+        // A record that fails BOTH ways — a bad scalar VALUE (coercionFailure) and a scalar column that got
         // an OBJECT (shapeConflict) — is still one dropped row and must charge the budget once. The first failure sets
         // rowDroppedBySkipRow; the second hits shapeConflict's already-dropped early-return, which must NOT count again.
         // With max_errors=1 the record must not trip the budget. This pins shapeConflict's short-circuit branch.
@@ -1455,7 +1488,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
             {"a": "3", "user": "carol"}
             """;
         var object = new BytesStorageObject("file:///mixed.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
-        var reader = new NdJsonFormatReader(null, blockFactory).withDeclaredTypeColumns(Set.of("a", "user"));
+        var reader = new NdJsonFormatReader(null, blockFactory);
         List<Attribute> schema = List.of(
             new ReferenceAttribute(Source.EMPTY, null, "a", DataType.LONG),
             new ReferenceAttribute(Source.EMPTY, null, "user", DataType.KEYWORD)
@@ -1482,25 +1515,63 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
     }
 
-    public void testInferredCrossKindBooleanStaysSilentNull() throws IOException {
-        // An inferred (not declared) long column keeps the pre-existing schema-on-read tolerance: a boolean on a
-        // later line is silently null, unchanged. Mirrors testTypeDifferentFromSchema.
+    public void testInferredCrossKindBooleanHonorsErrorMode() throws IOException {
+        // An INFERRED long column (the first record fixes the type) receiving a boolean on a later record is an
+        // unsupported cross-kind token. It is governed by error_mode exactly like a declared column: strict fails
+        // the query, skip_row drops the record, null_field nulls the cell and warns. (Was: silently null in every
+        // mode — the inferred-only tolerance this change removed, so declared and inferred now agree.)
         String ndjson = """
             {"n": 1}
             {"n": true}
             """;
         var settings = Settings.builder().put(NdJsonFormatReader.SCHEMA_SAMPLE_SIZE_SETTING, 1).build();
-        var reader = new NdJsonFormatReader(settings, blockFactory);
         var object = new BytesStorageObject("file:///inferred.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
 
-        try (var iterator = reader.read(object, List.of("n"), 100)) {
+        // strict: the cross-kind boolean fails the query
+        try (
+            var iterator = new NdJsonFormatReader(settings, blockFactory).read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("n")).batchSize(100).errorPolicy(ErrorPolicy.STRICT).build()
+            )
+        ) {
+            var e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            });
+            assertThat(e.getMessage(), Matchers.containsString("could not be coerced to type [integer]"));
+        }
+
+        // skip_row: the offending record is dropped whole; the good record survives
+        try (
+            var iterator = new NdJsonFormatReader(settings, blockFactory).read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("n")).batchSize(100).errorPolicy(ErrorPolicy.LENIENT).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            IntBlock n = page.getBlock(0);
+            assertEquals("the cross-kind record is dropped whole", 1, n.getPositionCount());
+            assertEquals(1, n.getInt(n.getFirstValueIndex(0)));
+        }
+        assertFalse("skip_row must warn about the dropped record", drainWarnings().isEmpty());
+
+        // null_field: the record is kept, the offending cell is nulled
+        try (
+            var iterator = new NdJsonFormatReader(settings, blockFactory).read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("n")).batchSize(100).errorPolicy(ErrorPolicy.PERMISSIVE).build()
+            )
+        ) {
             assertTrue(iterator.hasNext());
             var page = iterator.next();
             var n = page.getBlock(0);
             assertEquals(2, n.getPositionCount());
             assertFalse(n.isNull(0));
-            assertTrue(n.isNull(1)); // boolean cross-kind silently null on an inferred column
+            assertTrue(n.isNull(1));
         }
+        assertFalse("null_field must warn about the nulled cell", drainWarnings().isEmpty());
     }
 
     public void testDeclaredTextColumnReadsString() throws IOException {
@@ -1813,7 +1884,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
      * surfaced, while [event] (and the other records) decode normally -- a per-field null-fill, not a
      * whole-row skip (elastic/esql-planning#1028).
      */
-    public void testScalarThenObjectConflictLenientNullFillsAndWarns() throws IOException {
+    public void testScalarThenObjectConflictSkipRowDropsRecordAndWarns() throws IOException {
         String ndjson = """
             {"event":1,"user":"alice"}
             {"event":2,"user":{"id":"bob","tier":"gold"}}
@@ -1826,24 +1897,23 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         try (var iterator = reader.read(object, ctx)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
-            assertEquals(3, page.getPositionCount());
+            // Under skip_row the object-valued record is dropped whole; only the two scalar records survive.
+            assertEquals(2, page.getPositionCount());
             IntBlock event = page.getBlock(indexOf(schema, "event"));
             BytesRefBlock user = page.getBlock(indexOf(schema, "user"));
             BytesRef scratch = new BytesRef();
             assertEquals(1, event.getInt(event.getFirstValueIndex(0)));
             assertEquals("alice", user.getBytesRef(user.getFirstValueIndex(0), scratch).utf8ToString());
-            assertEquals(2, event.getInt(event.getFirstValueIndex(1)));
-            assertTrue("object-valued row -> user null", user.isNull(1));
-            assertEquals(3, event.getInt(event.getFirstValueIndex(2)));
-            assertEquals("carol", user.getBytesRef(user.getFirstValueIndex(2), scratch).utf8ToString());
+            assertEquals(3, event.getInt(event.getFirstValueIndex(1)));
+            assertEquals("carol", user.getBytesRef(user.getFirstValueIndex(1), scratch).utf8ToString());
         }
         List<String> warnings = drainWarnings();
         assertFalse("expected a warning for the shape conflict", warnings.isEmpty());
         assertTrue("warning should name the conflicting field, got: " + warnings, warnings.stream().anyMatch(w -> w.contains("user")));
     }
 
-    /** Mirror of {@link #testScalarThenObjectConflictLenientNullFillsAndWarns}: object shape observed first. */
-    public void testObjectThenScalarConflictLenientNullFillsAndWarns() throws IOException {
+    /** Mirror of {@link #testScalarThenObjectConflictSkipRowDropsRecordAndWarns}: object shape observed first. */
+    public void testObjectThenScalarConflictSkipRowDropsRecordAndWarns() throws IOException {
         String ndjson = """
             {"event":1,"user":{"id":"bob","tier":"gold"}}
             {"event":2,"user":"alice"}
@@ -1856,16 +1926,17 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         try (var iterator = reader.read(object, ctx)) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
-            assertEquals(3, page.getPositionCount());
+            // The scalar-valued record conflicts with the object-shaped (structural) node and is dropped whole under
+            // skip_row; the two object records survive. The structural direction carries a non-null field pointer,
+            // so it drops just like the scalar-column direction — declared and inferred agree.
+            assertEquals(2, page.getPositionCount());
             BytesRefBlock userId = page.getBlock(indexOf(schema, "user.id"));
             BytesRefBlock userTier = page.getBlock(indexOf(schema, "user.tier"));
             BytesRef scratch = new BytesRef();
             assertEquals("bob", userId.getBytesRef(userId.getFirstValueIndex(0), scratch).utf8ToString());
             assertEquals("gold", userTier.getBytesRef(userTier.getFirstValueIndex(0), scratch).utf8ToString());
-            assertTrue("scalar-valued row -> user.id null", userId.isNull(1));
-            assertTrue("scalar-valued row -> user.tier null", userTier.isNull(1));
-            assertEquals("carol", userId.getBytesRef(userId.getFirstValueIndex(2), scratch).utf8ToString());
-            assertEquals("silver", userTier.getBytesRef(userTier.getFirstValueIndex(2), scratch).utf8ToString());
+            assertEquals("carol", userId.getBytesRef(userId.getFirstValueIndex(1), scratch).utf8ToString());
+            assertEquals("silver", userTier.getBytesRef(userTier.getFirstValueIndex(1), scratch).utf8ToString());
         }
         List<String> warnings = drainWarnings();
         assertFalse("expected a warning for the shape conflict", warnings.isEmpty());
@@ -1873,7 +1944,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     }
 
     /**
-     * Same fixture as {@link #testScalarThenObjectConflictLenientNullFillsAndWarns}, but with
+     * Same fixture as {@link #testScalarThenObjectConflictSkipRowDropsRecordAndWarns}, but with
      * {@link FormatReadContext#informationalWarningSink()} supplied: the shape-conflict warning must route
      * through the sink instead of {@link org.elasticsearch.common.logging.HeaderWarning}, since
      * {@code read} can be invoked from a background reader thread whose thread-local response

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1880,9 +1880,9 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     }
 
     /**
-     * Under a non-strict policy, the conflicting record's [user] column is null-filled and a client warning is
-     * surfaced, while [event] (and the other records) decode normally -- a per-field null-fill, not a
-     * whole-row skip (elastic/esql-planning#1028).
+     * Under skip_row, the object-valued record is dropped whole and a client warning is surfaced, while the two
+     * scalar records decode normally. error_mode governs the outcome the same for a declared or an inferred column;
+     * null_field keeps the record and nulls the [user] cell instead (elastic/esql-planning#1028).
      */
     public void testScalarThenObjectConflictSkipRowDropsRecordAndWarns() throws IOException {
         String ndjson = """
@@ -2498,8 +2498,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
      * {@code childDecoder.decodeValue(...)}). So an exactly-2-block Page with the right values
      * across the nested object and the array - the most expensive shapes to materialise - implies
      * those fields were skipped at parse time, not silently materialised into a discarded buffer.
-     * (Note: {@code skipChildren} is also called by {@code unexpectedValue} and the {@code NULL}
-     * branch of {@code decodeValue}; this test does not depend on those paths.)
+     * (Note: {@code skipChildren} is also called by {@code coercionFailure} and the {@code NULL}-typed-column
+     * early return in {@code decodeValue}; this test does not depend on those paths.)
      */
     public void testWideSchemaProjectionDropsAllUnreferencedFields() throws IOException {
         StringBuilder sb = new StringBuilder();

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1803,7 +1803,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     }
 
     /**
-     * Reproduces the exact repro from elastic/esql-planning#1028: an NDJSON field ("user") that is a scalar in
+     * Reproduces the scalar/object shape-conflict repro: an NDJSON field ("user") that is a scalar in
      * some sampled records and a JSON object in others must resolve to exactly one shape in the inferred schema
      * -- never both a scalar "user" attribute and its nested "user.id"/"user.tier" children.
      */
@@ -1882,7 +1882,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     /**
      * Under skip_row, the object-valued record is dropped whole and a client warning is surfaced, while the two
      * scalar records decode normally. error_mode governs the outcome the same for a declared or an inferred column;
-     * null_field keeps the record and nulls the [user] cell instead (elastic/esql-planning#1028).
+     * null_field keeps the record and nulls the [user] cell instead.
      */
     public void testScalarThenObjectConflictSkipRowDropsRecordAndWarns() throws IOException {
         String ndjson = """
@@ -3298,7 +3298,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     }
 
     /**
-     * Regression for https://github.com/elastic/esql-planning/issues/894 and the issue 965 follow-up: on
+     * Regression for the byte-array max-record-size cap fix and its follow-up: on
      * the byte-array fast path the cap is now enforced per-record inside {@link NdJsonPageDecoder} (on the
      * pass Jackson already makes — no separate buffer sweep), instead of by a pre-read cap stream. Under
      * {@link ErrorPolicy#STRICT} an oversized record must still surface a {@code max_record_size [N]} error

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
@@ -47,7 +47,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 /**
  * End-to-end reproduction of elastic/esql-planning#1050, the cross-file completion of #1028: a
@@ -200,15 +199,14 @@ public class NdJsonCrossFileScalarObjectConflictIT extends AbstractEsqlIntegTest
     }
 
     /**
-     * Non-strict policy ({@code error_mode: skip_row}, set on {@code lenient_ds}): {@code
-     * b.ndjson}'s {@code user} column is null-filled — not the row or the whole file dropped —
-     * {@code a.ndjson}'s row is unaffected, and the client receives a {@code Warning} naming the
-     * conflict. Nothing silently vanishes, end to end, not just at the reconciliation-unit level.
-     * The query runs through a chosen coordinator and we read that node's accumulated response
-     * {@code Warning} headers, proving the warning recorded by the reader propagates all the way
-     * to the client.
+     * Non-strict policy ({@code error_mode: skip_row}, set on {@code lenient_ds}): {@code b.ndjson}'s conflicting
+     * record is dropped whole — not null-filled — while {@code a.ndjson}'s row is unaffected, and the client
+     * receives a {@code Warning} naming the conflict. Nothing silently vanishes, end to end. error_mode governs the
+     * outcome the same for an inferred or a declared schema; {@code null_field} would keep the record and null the
+     * cell instead. The query runs through a chosen coordinator and we read that node's accumulated response
+     * {@code Warning} headers, proving the warning recorded by the reader propagates all the way to the client.
      */
-    public void testSkipRowPolicyNullFillsAndWarnsClient() throws Exception {
+    public void testSkipRowPolicyDropsRecordAndWarnsClient() throws Exception {
         EsqlQueryRequest request = syncEsqlQueryRequest("FROM lenient_ds | KEEP event, user | SORT event");
 
         DiscoveryNode coordinator = randomFrom(clusterService().state().nodes().stream().toList());
@@ -245,11 +243,9 @@ public class NdJsonCrossFileScalarObjectConflictIT extends AbstractEsqlIntegTest
         assertThat(columns.get().get(1).name(), equalTo("user"));
 
         List<List<Object>> rows = values.get();
-        assertThat("both files' rows must still return, just [user] is null for the conflicting one", rows.size(), equalTo(2));
+        assertThat("b.ndjson's object-valued record is dropped whole under skip_row; only a.ndjson's row remains", rows.size(), equalTo(1));
         assertThat(((Number) rows.get(0).get(0)).intValue(), equalTo(1));
         assertThat(rows.get(0).get(1), equalTo("alice"));
-        assertThat("b.ndjson's [event] sibling column must survive", ((Number) rows.get(1).get(0)).intValue(), equalTo(2));
-        assertThat("b.ndjson's [user] must be null-filled, not the whole row dropped", rows.get(1).get(1), nullValue());
 
         assertTrue(
             "client must receive a Warning naming the conflicting field, got: " + warnings,

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonCrossFileScalarObjectConflictIT.java
@@ -49,7 +49,7 @@ import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQuery
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * End-to-end reproduction of elastic/esql-planning#1050, the cross-file completion of #1028: a
+ * End-to-end reproduction of the cross-file scalar/object shape-conflict handling: a
  * field that is a scalar leaf in one file's schema and a nested object (dotted-prefix parent) in
  * another's must reconcile to a single shape under the default {@code UNION_BY_NAME} schema
  * resolution, with the losing file's records routed through the same {@code ErrorPolicy}
@@ -121,7 +121,7 @@ public class NdJsonCrossFileScalarObjectConflictIT extends AbstractEsqlIntegTest
     }
 
     /**
-     * The exact repro shape from esql-planning#1050: {@code a.ndjson}'s {@code user} is a plain
+     * The exact cross-file repro shape: {@code a.ndjson}'s {@code user} is a plain
      * string, {@code b.ndjson}'s is a nested object. Lexicographic glob ordering (see
      * {@code GlobExpander}) makes {@code a.ndjson} the first file, so first-shape-wins schema
      * reconciliation resolves {@code user} to {@code KEYWORD} and {@code b.ndjson} is the one that
@@ -187,7 +187,7 @@ public class NdJsonCrossFileScalarObjectConflictIT extends AbstractEsqlIntegTest
      * silently return {@code with_user=1} rather than failing — the correctness bug this fix
      * closes. With the fix, the family collapses to {@code a.ndjson}'s scalar shape, so
      * {@code b.ndjson}'s now-pinned scalar {@code user} attribute hits its real object value and
-     * fails per elastic/esql-planning#1028's decode-time shape-conflict handling — mirroring
+     * fails per the decode-time shape-conflict handling — mirroring
      * {@link NdJsonScalarObjectConflictIT#testStrictPolicyFailsOnScalarObjectConflict}.
      */
     public void testDefaultSettingsFailsOnCrossFileScalarObjectConflict() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonScalarObjectConflictIT.java
@@ -49,7 +49,7 @@ import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQuery
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * End-to-end reproduction of elastic/esql-planning#1028, run through a real {@code FROM <dataset>}
+ * End-to-end reproduction of the NDJSON scalar/object shape-conflict handling, run through a real {@code FROM <dataset>}
  * query (planner + execution + client response), not just the reader-level unit tests in
  * {@code NdJsonPageIteratorTests}/{@code NdJsonPageDecoderTests}. A field ("user") that is a scalar in
  * some sampled NDJSON records and a JSON object in others must, per {@link ErrorPolicy}: fail the query
@@ -124,7 +124,7 @@ public class NdJsonScalarObjectConflictIT extends AbstractEsqlIntegTestCase {
     }
 
     /**
-     * The exact repro shape from elastic/esql-planning#1028: {@code user} is a plain string in most
+     * The exact repro shape: {@code user} is a plain string in most
      * records but a nested object in one of them. Scalar-first-wins schema inference resolves {@code user}
      * to {@code KEYWORD}, so the object-valued record is the one that hits the shape conflict at decode
      * time. Registers a data source and two datasets over the same fixture — {@code strict_ds} with the
@@ -196,8 +196,7 @@ public class NdJsonScalarObjectConflictIT extends AbstractEsqlIntegTestCase {
      * dropped whole and every other row still returns — {@code skip_row} means "skip the row", and error_mode
      * governs the outcome the same for an inferred or a declared schema ({@code null_field} keeps the record and
      * nulls just the cell instead). The query runs through a chosen coordinator and we read that node's accumulated
-     * response {@code Warning} headers, proving the warning recorded by the reader propagates to the client. See
-     * elastic/esql-planning#1028.
+     * response {@code Warning} headers, proving the warning recorded by the reader propagates to the client.
      */
     public void testSkipRowPolicyDropsRecordAndWarnsClient() throws Exception {
         EsqlQueryRequest request = syncEsqlQueryRequest("FROM lenient_ds | KEEP event, user | SORT event");

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonScalarObjectConflictIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/NdJsonScalarObjectConflictIT.java
@@ -47,16 +47,16 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 /**
  * End-to-end reproduction of elastic/esql-planning#1028, run through a real {@code FROM <dataset>}
  * query (planner + execution + client response), not just the reader-level unit tests in
  * {@code NdJsonPageIteratorTests}/{@code NdJsonPageDecoderTests}. A field ("user") that is a scalar in
  * some sampled NDJSON records and a JSON object in others must, per {@link ErrorPolicy}: fail the query
- * under the default strict policy with an actionable client-visible error, or null-fill just that field
- * and surface a client-visible {@code Warning} under a non-strict policy, while the rest of the record
- * (and the other rows) still return normally. This proves the reader's {@code ErrorPolicy} routing and
+ * under the default strict policy with an actionable client-visible error; drop the conflicting record
+ * whole under {@code skip_row}; or null-fill just that field under {@code null_field} — each surfacing a
+ * client-visible {@code Warning} under the non-strict modes, with the other rows returning normally. This
+ * proves the reader's {@code ErrorPolicy} routing and
  * {@code SkipWarnings} actually propagate all the way to the client through
  * {@code AsyncExternalSourceOperator} and the transport response, not just to a hand-bound test
  * {@code ThreadContext} (mirroring {@code FromDatasetIT} and {@code WarningsIT}).
@@ -192,15 +192,14 @@ public class NdJsonScalarObjectConflictIT extends AbstractEsqlIntegTestCase {
     }
 
     /**
-     * Non-strict policy ({@code error_mode: skip_row}, set on {@code lenient_ds}): the conflicting
-     * record's {@code user} column is null-filled and the rest of that record (and every other row)
-     * still returns, instead of failing the whole query or dropping the row outright —
-     * elastic/esql-planning#1028 notes the conflict path already decodes the rest of the record. The
-     * query runs through a chosen coordinator and we read that node's accumulated response
-     * {@code Warning} headers, proving the warning recorded by the reader propagates all the way to
-     * the client.
+     * Non-strict policy ({@code error_mode: skip_row}, set on {@code lenient_ds}): the conflicting record is
+     * dropped whole and every other row still returns — {@code skip_row} means "skip the row", and error_mode
+     * governs the outcome the same for an inferred or a declared schema ({@code null_field} keeps the record and
+     * nulls just the cell instead). The query runs through a chosen coordinator and we read that node's accumulated
+     * response {@code Warning} headers, proving the warning recorded by the reader propagates to the client. See
+     * elastic/esql-planning#1028.
      */
-    public void testSkipRowPolicyNullFillsAndWarnsClient() throws Exception {
+    public void testSkipRowPolicyDropsRecordAndWarnsClient() throws Exception {
         EsqlQueryRequest request = syncEsqlQueryRequest("FROM lenient_ds | KEEP event, user | SORT event");
 
         DiscoveryNode coordinator = randomFrom(clusterService().state().nodes().stream().toList());
@@ -237,13 +236,11 @@ public class NdJsonScalarObjectConflictIT extends AbstractEsqlIntegTestCase {
         assertThat(columns.get().get(1).name(), equalTo("user"));
 
         List<List<Object>> rows = values.get();
-        assertThat("all three records must still return, just [user] is null for the conflicting one", rows.size(), equalTo(3));
+        assertThat("the object-valued record is dropped whole under skip_row; the two scalar records remain", rows.size(), equalTo(2));
         assertThat(((Number) rows.get(0).get(0)).intValue(), equalTo(1));
         assertThat(rows.get(0).get(1), equalTo("alice"));
-        assertThat("the conflicting record's [event] sibling column must survive", ((Number) rows.get(1).get(0)).intValue(), equalTo(2));
-        assertThat("the conflicting record's [user] must be null-filled, not the whole row dropped", rows.get(1).get(1), nullValue());
-        assertThat(((Number) rows.get(2).get(0)).intValue(), equalTo(3));
-        assertThat(rows.get(2).get(1), equalTo("carol"));
+        assertThat(((Number) rows.get(1).get(0)).intValue(), equalTo(3));
+        assertThat(rows.get(1).get(1), equalTo("carol"));
 
         assertTrue(
             "client must receive a Warning naming the conflicting field, got: " + warnings,


### PR DESCRIPTION
## What this is about

`error_mode` on an external dataset promises one behavior per mode on every format, but NDJSON didn't deliver it — and it split on something it never should have: whether the column's type was **declared** or **inferred**. A bad `"abc"` in a `long` column under `skip_row` dropped the row on CSV/TSV but kept it null-filled on NDJSON; and an unrepresentable cell on an *inferred* NDJSON column silently read as null in **every** mode — even the default strict mode that is supposed to fail. This PR makes NDJSON honor `error_mode` as a single axis, identically for declared and inferred columns.

## What this PR does

Every unrepresentable NDJSON cell — a bad value, a cross-kind token (a boolean where numbers were seen), or a scalar/object shape conflict — routes through one policy sink:

- `fail_fast` (the default) fails the query,
- `null_field` nulls the cell and warns,
- `skip_row` drops the whole record and warns,
- the error budget is charged once per dropped record, not once per bad field.

Provenance drops out — a declared and an inferred column behave the same. The two places that kept an inferred-only silent null (`crossKindDrift` and `shapeConflict`) now route through the same sink. That makes `declaredTypeColumns` dead in the NDJSON reader, so we strip it end to end, restoring the SPI no-op `withDeclaredTypeColumns` default the text formats are documented to keep.

After this PR the three row-oriented formats (CSV, TSV, NDJSON) all drop the bad row under `skip_row`, and NDJSON's declared/inferred asymmetry is gone.

## Behavior change — worth a close look

Under the **default (strict)** mode, an inferred cross-kind token now **fails** the query instead of silently reading as null. Inferred *shape* conflicts already failed under strict, and a bad *string* in an inferred `long` already failed — so the only newly-failing case is cross-kind *kind* drift (a field that is a boolean in some records and a number in others). That is the correct meaning of strict, and `null_field` still keeps the record with a null cell. External datasets are a preview feature behind a flag.

## Does it work?

Full NDJSON reader suite green (262 tests), the two end-to-end scalar/object conflict ITs, plus `spotlessJavaCheck`, `checkstyle`, and `forbiddenApis` on both touched modules. Every behavior is pinned by a test that goes red against main: the flipped ITs and decoder tests now assert drop-under-`skip_row`, a mode-matrix test pins an inferred cross-kind under all three modes, and a `null_field` test pins the keep-the-record path.

## What's out of scope (tracked separately, GA)

- **Columnar Parquet/ORC** dropping under `skip_row` + wiring the error budget on columnar — a hot-path change that needs perf validation. Columnar keeps its documented `skip_row → null-fill` degrade until then (industry-standard: no columnar scan engine drops rows).
- Consolidating every reader's enforcement behind one shared SPI capability — a separate architecture effort.
- Isolating cached row counts per effective read schema in the stats-cache fingerprint, so a mapping change can't cross-fade a cached `COUNT(*)` — a separate correctness effort.
