### PR TITLE
Add node.role and tier columns to _cat/shards API

### DIFF
--- a/docs/changelog/153583.yaml
+++ b/docs/changelog/153583.yaml
@@ -1,0 +1,5 @@
+area: Infra/REST API
+issues: [136895]
+pr: 153583
+summary: Add node.role and tier columns to _cat/shards API
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -1001,7 +1001,7 @@ public class ActionModule extends AbstractModule {
 
         // CAT API
         registerHandler.accept(new RestAllocationAction());
-        registerHandler.accept(new RestShardsAction());
+        registerHandler.accept(new RestShardsAction(projectResolver));
         registerHandler.accept(new RestMasterAction());
         registerHandler.accept(new RestNodesAction());
         registerHandler.accept(new RestClusterInfoAction(projectResolver));

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -17,6 +17,10 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.project.ProjectIdResolver;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.Strings;
@@ -27,7 +31,6 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.bulk.stats.BulkStats;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
-import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.index.fielddata.FieldDataStats;
 import org.elasticsearch.index.flush.FlushStats;
@@ -59,6 +62,12 @@ import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 @ServerlessScope(Scope.INTERNAL)
 public class RestShardsAction extends AbstractCatAction {
 
+    private final ProjectIdResolver projectIdResolver;
+
+    public RestShardsAction(ProjectIdResolver projectIdResolver) {
+        this.projectIdResolver = projectIdResolver;
+    }
+
     @Override
     public List<Route> routes() {
         return List.of(new Route(GET, "/_cat/shards"), new Route(GET, "/_cat/shards/{index}"));
@@ -85,7 +94,7 @@ public class RestShardsAction extends AbstractCatAction {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
         final var clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
-        clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices).indicesOptions(IndicesOptions.strictExpandHidden());
+        clusterStateRequest.clear().nodes(true).routingTable(true).metadata(true).indices(indices).indicesOptions(IndicesOptions.strictExpandHidden());
 
         return channel -> {
             final var clusterStateFuture = new ListenableFuture<ClusterStateResponse>();
@@ -121,7 +130,12 @@ public class RestShardsAction extends AbstractCatAction {
             .addCell("dataset", "text-align:right;desc:total size of dataset")
             .addCell("ip", "default:true;desc:ip of node where it lives")
             .addCell("id", "default:false;desc:unique id of node where it lives")
-            .addCell("node", "default:true;alias:n;desc:name of node where it lives");
+            .addCell("node", "default:true;alias:n;desc:name of node where it lives")
+            .addCell(
+                "node.role",
+                "default:false;alias:r,role,nodeRole;desc:roles of the node where it lives (m:master eligible, d:data, i:ingest, -:coordinating only)"
+            )
+            .addCell("tier", "default:false;alias:t,tierPreference;desc:tier preference of the index for this shard");
 
         if (request.getRestApiVersion() == RestApiVersion.V_8) {
             table.addCell("sync_id", "alias:sync_id;default:false;desc:sync id");
@@ -282,10 +296,8 @@ public class RestShardsAction extends AbstractCatAction {
         for (ShardRouting shard : state.getState().routingTable().allShardsIterator()) {
             ShardStats shardStats = stats.asMap().get(shard);
             CommonStats commonStats = null;
-            CommitStats commitStats = null;
             if (shardStats != null) {
                 commonStats = shardStats.getStats();
-                commitStats = shardStats.getCommitStats();
             }
 
             table.startRow();
@@ -303,10 +315,11 @@ public class RestShardsAction extends AbstractCatAction {
             table.addCell(getOrNull(commonStats, CommonStats::getStore, StoreStats::size));
             table.addCell(getOrNull(commonStats, CommonStats::getStore, StoreStats::totalDataSetSize));
             if (shard.assignedToNode()) {
-                String ip = state.getState().nodes().get(shard.currentNodeId()).getHostAddress();
+                DiscoveryNode node = state.getState().nodes().get(shard.currentNodeId());
+                String ip = node.getHostAddress();
                 String nodeId = shard.currentNodeId();
                 StringBuilder name = new StringBuilder();
-                name.append(state.getState().nodes().get(shard.currentNodeId()).getName());
+                name.append(node.getName());
                 if (shard.relocating()) {
                     String reloIp = state.getState().nodes().get(shard.relocatingNodeId()).getHostAddress();
                     String reloNme = state.getState().nodes().get(shard.relocatingNodeId()).getName();
@@ -321,9 +334,21 @@ public class RestShardsAction extends AbstractCatAction {
                 table.addCell(ip);
                 table.addCell(nodeId);
                 table.addCell(name);
+                table.addCell(node.getRoleAbbreviationString());
             } else {
                 table.addCell(null);
                 table.addCell(null);
+                table.addCell(null);
+                table.addCell(null);
+            }
+
+            // Retrieve tier preference from index metadata
+            final ProjectMetadata project = state.getState().metadata().getProject(projectIdResolver.getProjectId());
+            final IndexMetadata indexMetadata = project == null ? null : project.index(shard.index());
+            if (indexMetadata != null) {
+                List<String> tierPreference = indexMetadata.getTierPreference();
+                table.addCell(tierPreference.isEmpty() ? null : String.join(",", tierPreference));
+            } else {
                 table.addCell(null);
             }
 

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
@@ -15,14 +15,22 @@ import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.project.ProjectIdResolver;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.Table;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.test.ESTestCase;
@@ -45,11 +53,12 @@ public class RestShardsActionTests extends ESTestCase {
     private List<ShardRouting> shardRoutings;
     private ClusterStateResponse clusterStateResponse;
     private IndicesStatsResponse indicesStatsResponse;
+    private ProjectIdResolver projectIdResolver;
 
     public void testBuildTable() {
         mockShardStats(randomBoolean());
 
-        final RestShardsAction action = new RestShardsAction();
+        final RestShardsAction action = new RestShardsAction(projectIdResolver);
         final Table table = action.buildTable(new FakeRestRequest(), clusterStateResponse, indicesStatsResponse);
 
         // now, verify the table is correct
@@ -64,7 +73,9 @@ public class RestShardsActionTests extends ESTestCase {
         assertThat(headers.get(7).value, equalTo("ip"));
         assertThat(headers.get(8).value, equalTo("id"));
         assertThat(headers.get(9).value, equalTo("node"));
-        assertThat(headers.get(10).value, equalTo("unassigned.reason"));
+        assertThat(headers.get(10).value, equalTo("node.role"));
+        assertThat(headers.get(11).value, equalTo("tier"));
+        assertThat(headers.get(12).value, equalTo("unassigned.reason"));
 
         final List<List<Table.Cell>> rows = table.getRows();
         assertThat(rows.size(), equalTo(shardRoutings.size()));
@@ -79,27 +90,28 @@ public class RestShardsActionTests extends ESTestCase {
             assertThat(row.get(3).value, equalTo(shardRouting.state()));
             assertThat(row.get(7).value, equalTo(localNode.getHostAddress()));
             assertThat(row.get(8).value, equalTo(localNode.getId()));
-            assertThat(row.get(70).value, equalTo(shardStats.getDataPath()));
-            assertThat(row.get(71).value, equalTo(shardStats.getStatePath()));
+            assertThat(row.get(72).value, equalTo(shardStats.getDataPath()));
+            assertThat(row.get(73).value, equalTo(shardStats.getStatePath()));
         }
     }
 
     public void testShardStatsForIndexing() {
         mockShardStats(true);
 
-        final RestShardsAction action = new RestShardsAction();
+        final RestShardsAction action = new RestShardsAction(projectIdResolver);
         final Table table = action.buildTable(new FakeRestRequest(), clusterStateResponse, indicesStatsResponse);
 
         // now, verify the table is correct
         List<Table.Cell> headers = table.getHeaders();
-        assertThat(headers.get(29).value, equalTo("indexing.delete_current"));
-        assertThat(headers.get(30).value, equalTo("indexing.delete_time"));
-        assertThat(headers.get(31).value, equalTo("indexing.delete_total"));
-        assertThat(headers.get(32).value, equalTo("indexing.index_current"));
-        assertThat(headers.get(33).value, equalTo("indexing.index_time"));
-        assertThat(headers.get(34).value, equalTo("indexing.index_total"));
-        assertThat(headers.get(35).value, equalTo("indexing.index_failed"));
-        assertThat(headers.get(36).value, equalTo("indexing.index_failed_due_to_version_conflict"));
+        // the two new columns (node.role at 10, tier at 11) shift all subsequent headers by 2
+        assertThat(headers.get(31).value, equalTo("indexing.delete_current"));
+        assertThat(headers.get(32).value, equalTo("indexing.delete_time"));
+        assertThat(headers.get(33).value, equalTo("indexing.delete_total"));
+        assertThat(headers.get(34).value, equalTo("indexing.index_current"));
+        assertThat(headers.get(35).value, equalTo("indexing.index_time"));
+        assertThat(headers.get(36).value, equalTo("indexing.index_total"));
+        assertThat(headers.get(37).value, equalTo("indexing.index_failed"));
+        assertThat(headers.get(38).value, equalTo("indexing.index_failed_due_to_version_conflict"));
 
         final List<List<Table.Cell>> rows = table.getRows();
         assertThat(rows.size(), equalTo(shardRoutings.size()));
@@ -108,15 +120,15 @@ public class RestShardsActionTests extends ESTestCase {
         for (final List<Table.Cell> row : rows) {
             ShardRouting shardRouting = shardRoutingsIt.next();
             ShardStats shardStats = indicesStatsResponse.asMap().get(shardRouting);
-            assertThat(row.get(29).value, equalTo(shardStats.getStats().getIndexing().getTotal().getDeleteCurrent()));
-            assertThat(row.get(30).value, equalTo(shardStats.getStats().getIndexing().getTotal().getDeleteTime()));
-            assertThat(row.get(31).value, equalTo(shardStats.getStats().getIndexing().getTotal().getDeleteCount()));
-            assertThat(row.get(32).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexCurrent()));
-            assertThat(row.get(33).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexTime()));
-            assertThat(row.get(34).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexCount()));
-            assertThat(row.get(35).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexFailedCount()));
+            assertThat(row.get(31).value, equalTo(shardStats.getStats().getIndexing().getTotal().getDeleteCurrent()));
+            assertThat(row.get(32).value, equalTo(shardStats.getStats().getIndexing().getTotal().getDeleteTime()));
+            assertThat(row.get(33).value, equalTo(shardStats.getStats().getIndexing().getTotal().getDeleteCount()));
+            assertThat(row.get(34).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexCurrent()));
+            assertThat(row.get(35).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexTime()));
+            assertThat(row.get(36).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexCount()));
+            assertThat(row.get(37).value, equalTo(shardStats.getStats().getIndexing().getTotal().getIndexFailedCount()));
             assertThat(
-                row.get(36).value,
+                row.get(38).value,
                 equalTo(shardStats.getStats().getIndexing().getTotal().getIndexFailedDueToVersionConflictCount())
             );
         }
@@ -127,10 +139,16 @@ public class RestShardsActionTests extends ESTestCase {
         this.localNode = DiscoveryNodeUtils.create("local");
         this.shardRoutings = new ArrayList<>(numShards);
         Map<ShardRouting, ShardStats> shardStatsMap = new HashMap<>();
-        String index = "index";
+        String indexName = "index";
         for (int i = 0; i < numShards; i++) {
             ShardRoutingState shardRoutingState = ShardRoutingState.fromValue((byte) randomIntBetween(2, 3));
-            ShardRouting shardRouting = TestShardRouting.newShardRouting(index, i, localNode.getId(), randomBoolean(), shardRoutingState);
+            ShardRouting shardRouting = TestShardRouting.newShardRouting(
+                indexName,
+                i,
+                localNode.getId(),
+                randomBoolean(),
+                shardRoutingState
+            );
             Path path = createTempDir().resolve("indices")
                 .resolve(shardRouting.shardId().getIndex().getUUID())
                 .resolve(String.valueOf(shardRouting.shardId().id()));
@@ -180,12 +198,34 @@ public class RestShardsActionTests extends ESTestCase {
         DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
         when(discoveryNodes.get(localNode.getId())).thenReturn(localNode);
 
+        // Mock IndexMetadata with a tier preference for the test index
+        Index index = shardRoutings.get(0).shardId().getIndex();
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.routing.allocation.include._tier_preference", "data_hot")
+                    .build()
+            )
+            .build();
+
+        ProjectMetadata projectMetadata = mock(ProjectMetadata.class);
+        when(projectMetadata.index(index)).thenReturn(indexMetadata);
+
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.getProject(Metadata.DEFAULT_PROJECT_ID)).thenReturn(projectMetadata);
+
+        this.projectIdResolver = () -> Metadata.DEFAULT_PROJECT_ID;
+
         this.clusterStateResponse = mock(ClusterStateResponse.class);
         RoutingTable routingTable = mock(RoutingTable.class);
         when(routingTable.allShardsIterator()).thenReturn(shardRoutings);
         ClusterState clusterState = mock(ClusterState.class);
         when(clusterState.routingTable()).thenReturn(routingTable);
         when(clusterState.nodes()).thenReturn(discoveryNodes);
+        when(clusterState.metadata()).thenReturn(metadata);
         when(clusterStateResponse.getState()).thenReturn(clusterState);
     }
 }


### PR DESCRIPTION
Closes #136895

Add two new optional columns to the `_cat/shards` REST API:

- `node.role`: shows the abbreviated role string for the node hosting the shard (e.g. `dim` for data/ingest/master eligible)
- `tier`: shows the `index.routing.allocation.include._tier_preference` setting for the shard's index

Both columns are non-default (hidden unless explicitly requested) to maintain backwards compatibility.
