### PR TITLE
Fix Math.clamp min > max in supplementCentroids

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -811,12 +811,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.RemoteFetchServiceTests
   method: testExchangeSetupRequestRoundTripsPushdownPlanWithFieldAttributes
   issue: https://github.com/elastic/elasticsearch/issues/153567
-- class: org.elasticsearch.index.codec.vectors.diskbbq.es95.ES950DiskBBQVectorsFormatTests
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/153568
-- class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/153569
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:lookup-join.intJoinByte}
   issue: https://github.com/elastic/elasticsearch/issues/153571

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
@@ -723,7 +723,7 @@ public class HierarchicalKMeans<V> {
 
         Random random = new Random(42L);
         int n = vectors.size();
-        int sampleSize = Math.clamp(needed * 64L, 4096, n);
+        int sampleSize = (int) Math.clamp(needed * 64L, Math.min(4096L, n), n);
 
         // Reservoir-sample sampleSize vector indices, deterministic with seed 42.
         int[] sample = new int[sampleSize];

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
@@ -723,7 +723,8 @@ public class HierarchicalKMeans<V> {
 
         Random random = new Random(42L);
         int n = vectors.size();
-        int sampleSize = (int) Math.clamp(needed * 64L, Math.min(4096L, n), n);
+        // select a minimum of 4096 vectors (n may be smaller than 4096)
+        int sampleSize = Math.clamp(needed * 64L, Math.min(4096, n), n);
 
         // Reservoir-sample sampleSize vector indices, deterministic with seed 42.
         int[] sample = new int[sampleSize];


### PR DESCRIPTION
When the vector count `n` is less than 4096, `Math.clamp(needed*64, 4096, n)` throws `IllegalArgumentException` because min exceeds max. This happens during merge-time clustering in `HierarchicalKMeans.supplementCentroids` when `forceMerge(1)` is called on a segment with fewer than 4096 vectors.

The fix uses `Math.min(4096L, n)` as the lower bound so small segments simply use all available vectors as the reservoir sample.

Also removes the corresponding mute entries.

Closes #153568
Closes #153569
Introduced by d8e1b1e9e0ba049a7d880f4b4565bc869fa1bdc8