### PR TITLE
[9.5] ES|QL: declared-schema coercion test coverage and related fixes (#153485)

### DIFF
--- a/docs/changelog/153485.yaml
+++ b/docs/changelog/153485.yaml
@@ -1,0 +1,6 @@
+pr: 153485
+summary: Fix declared-schema read correctness on external datasets (Parquet filter-pushdown
+  unit, scale, and rounding mismatches)
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -4634,6 +4634,124 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    /**
+     * A declared boolean column accepts only {@code true}/{@code false} (case-insensitively) and rejects every
+     * other token loudly: under {@code fail_fast} the read aborts naming the value, under {@code null_field} the
+     * cell nulls and the reader warns. It must never silently become {@code false} the way {@code ::boolean}
+     * would - that deliberate divergence lives in {@code DeclaredTypeCoercions.strictParseBoolean}, which
+     * {@code tryParseBoolean} delegates to. Pinned here through the reader, not just at the SPI level.
+     */
+    public void testDeclaredBooleanRejectsNonBooleanTokenPerPolicy() throws IOException {
+        for (String badToken : List.of("yes", "1")) {
+            String csv = "active:boolean\n" + badToken + "\n";
+
+            // fail_fast: the read aborts, naming the offending token and the target type.
+            StorageObject strictObject = createStorageObject(csv);
+            CsvFormatReader strictReader = new CsvFormatReader(blockFactory);
+            ParsingException e = expectThrows(ParsingException.class, () -> {
+                try (
+                    CloseableIterator<Page> iterator = strictReader.read(
+                        strictObject,
+                        FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                    )
+                ) {
+                    while (iterator.hasNext()) {
+                        iterator.next();
+                    }
+                }
+            });
+            assertTrue("expected the rejected token in the message, got: " + e.getMessage(), e.getMessage().contains("[" + badToken + "]"));
+            assertTrue("expected the target type in the message, got: " + e.getMessage(), e.getMessage().contains("BOOLEAN"));
+            drainWarnings();
+
+            // null_field: the cell nulls - never reads as false - and the rejection is surfaced as a warning.
+            StorageObject nullFieldObject = createStorageObject(csv);
+            CsvFormatReader nullFieldReader = new CsvFormatReader(blockFactory);
+            ErrorPolicy nullField = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+            try (
+                CloseableIterator<Page> iterator = nullFieldReader.read(
+                    nullFieldObject,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(nullField).build()
+                )
+            ) {
+                assertTrue(iterator.hasNext());
+                Page page = iterator.next();
+                assertEquals(1, page.getPositionCount());
+                assertTrue("[" + badToken + "] must null the cell, never read as false", page.getBlock(0).isNull(0));
+            }
+            assertFalse("null_field must warn about the rejected token", drainWarnings().isEmpty());
+        }
+    }
+
+    /**
+     * A declared {@code double} column preserves the non-finite IEEE tokens {@code NaN}/{@code Infinity}/{@code -Infinity}
+     * (matching the columnar read and {@code ::double}, a deliberate divergence from the finite-only mapper rule).
+     */
+    public void testDoubleColumnAcceptsNaNAndInfinityTokens() throws IOException {
+        String csv = "d:double\nNaN\nInfinity\n-Infinity\n3.5\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            DoubleBlock d = (DoubleBlock) iterator.next().getBlock(0);
+            assertTrue("NaN token", Double.isNaN(d.getDouble(0)));
+            assertEquals(Double.POSITIVE_INFINITY, d.getDouble(1), 0.0);
+            assertEquals(Double.NEGATIVE_INFINITY, d.getDouble(2), 0.0);
+            assertEquals(3.5, d.getDouble(3), 0.0);
+        }
+    }
+
+    /** A declared {@code long} token above {@code Long.MAX_VALUE} is an overflow routed through the error policy. */
+    public void testStringToLongOverflowHonorsErrorPolicy() throws IOException {
+        String csv = "n:long\n99999999999999999999\n"; // > Long.MAX_VALUE
+
+        StorageObject strict = createStorageObject(csv);
+        expectThrows(ParsingException.class, () -> {
+            try (
+                CloseableIterator<Page> it = new CsvFormatReader(blockFactory).read(
+                    strict,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (it.hasNext()) {
+                    it.next();
+                }
+            }
+        });
+        drainWarnings();
+
+        StorageObject lenient = createStorageObject(csv);
+        ErrorPolicy nullField = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+        try (
+            CloseableIterator<Page> it = new CsvFormatReader(blockFactory).read(
+                lenient,
+                FormatReadContext.builder().batchSize(10).errorPolicy(nullField).build()
+            )
+        ) {
+            assertTrue("overflow nulls the cell under null_field", it.next().getBlock(0).isNull(0));
+        }
+        assertFalse("overflow warns", drainWarnings().isEmpty());
+    }
+
+    /** The TSV preset shares {@link CsvFormatReader}, so the strict declared-boolean rule must hold there too. */
+    public void testTsvDeclaredBooleanRejectsNonBooleanToken() throws IOException {
+        String tsv = "active:boolean\tname:keyword\nyes\tAlice\n";
+        StorageObject object = createStorageObject(tsv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(CsvFormatOptions.TSV);
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        assertTrue("expected the rejected token in the message, got: " + e.getMessage(), e.getMessage().contains("[yes]"));
+    }
+
     // --- Date-only and zone-less datetime tests (#323) ---
 
     public void testDatetimeDateOnly() throws IOException {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -1159,6 +1159,67 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         }
     }
 
+    /**
+     * {@code testDeclaredNumericBadStringFailsUnderStrict} advertises {@code error_mode=null_field} as the recovery.
+     * Honour that advice: the offending cell nulls, its neighbours decode, and the failure surfaces as a warning
+     * rather than vanishing silently.
+     */
+    public void testDeclaredCoercionFailureNullFieldWarnsAndNulls() throws IOException {
+        String ndjson = """
+            {"n": "1"}
+            {"n": "notanumber"}
+            {"n": "3"}
+            """;
+        var object = new BytesStorageObject("file:///bad.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        List<Attribute> schema = List.of(new ReferenceAttribute(Source.EMPTY, null, "n", DataType.LONG));
+        ErrorPolicy nullField = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 100, 0.0, false);
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("n")).batchSize(100).errorPolicy(nullField).readSchema(schema).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            var page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            LongBlock n = page.getBlock(0);
+            assertEquals(1L, n.getLong(n.getFirstValueIndex(0)));
+            assertTrue("the uncoercible token must null its cell", n.isNull(1));
+            assertEquals(3L, n.getLong(n.getFirstValueIndex(2)));
+        }
+        assertFalse("null_field must warn about the coercion failure", drainWarnings().isEmpty());
+    }
+
+    /** A declared {@code double} preserves the non-finite string tokens NaN/Infinity/-Infinity (IEEE passthrough). */
+    public void testDeclaredDoubleNaNInfinityStringTokens() throws IOException {
+        String ndjson = """
+            {"d": "NaN"}
+            {"d": "Infinity"}
+            {"d": "-Infinity"}
+            """;
+        var object = new BytesStorageObject("file:///nf.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        List<Attribute> schema = List.of(new ReferenceAttribute(Source.EMPTY, null, "d", DataType.DOUBLE));
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .projectedColumns(List.of("d"))
+                    .batchSize(100)
+                    .errorPolicy(ErrorPolicy.STRICT)
+                    .readSchema(schema)
+                    .build()
+            )
+        ) {
+            var page = iterator.next();
+            DoubleBlock d = page.getBlock(0);
+            assertTrue(Double.isNaN(d.getDouble(0)));
+            assertEquals(Double.POSITIVE_INFINITY, d.getDouble(1), 0.0);
+            assertEquals(Double.NEGATIVE_INFINITY, d.getDouble(2), 0.0);
+        }
+    }
+
     public void testDeclaredDatetimeFormatOverridesNumericEpochShortcut() throws IOException {
         // A column declared {datetime, format:"yyyyMMdd"} must read the numeric token 20260101 as
         // 2026-01-01 (the declared format is authoritative), NOT as epoch millis — matching CSV and the

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -90,6 +90,35 @@ final class ParquetColumnDecoding {
             && ts.getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS;
     }
 
+    /**
+     * Whether decoding a physical column with logical annotation {@code annotation} into an ESQL integral value
+     * ({@code long}/{@code integer}) applies a scaling factor that the raw parquet footer statistics do NOT carry, so
+     * a raw integral predicate pushed against those stats would mis-prune. This is the ground truth for the pushdown
+     * decline guard ({@code ParquetPushedExpressions.pushDeclinedForUnitMismatch}); it lives here, next to the decode
+     * transforms it summarizes, so the two cannot drift when a logical type is added:
+     * <ul>
+     *   <li>{@code DATE} — {@link #dateDaysToMillis} scales days ×86_400_000 to epoch-millis;</li>
+     *   <li>{@code TIMESTAMP(MICROS)} / {@code TIME(MICROS)} — {@link #convertTimestampToNanos} / the time nanos
+     *       multiplier scale ×1_000 to nanos ({@code MILLIS}/{@code NANOS} are identity);</li>
+     *   <li>{@code DECIMAL(scale>0)} — the value reader divides the unscaled integer by 10^scale.</li>
+     * </ul>
+     */
+    static boolean integralDecodeScalesRelativeToRawStats(LogicalTypeAnnotation annotation) {
+        if (annotation instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+            return true;
+        }
+        if (annotation instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return ts.getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS;
+        }
+        if (annotation instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation time) {
+            return time.getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS;
+        }
+        if (annotation instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation dec) {
+            return dec.getScale() != 0;
+        }
+        return false;
+    }
+
     /** Whether scaling a {@code TIMESTAMP(MICROS)} value to epoch-nanoseconds would overflow a {@code long}. */
     static boolean microsOverflowsNanos(long micros) {
         return micros > MAX_MICROS_AS_NANOS || micros < MIN_MICROS_AS_NANOS;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -418,9 +418,7 @@ final class ParquetPushedExpressions {
             return null;
         }
         return switch (dataType) {
-            case INTEGER -> physicalPrimitiveIs(schema, columnName, PrimitiveType.PrimitiveTypeName.INT32)
-                ? orderedPredicate(FilterApi.intColumn(columnName), value != null ? ((Number) value).intValue() : null, op)
-                : null;
+            case INTEGER -> buildIntPredicate(columnName, value, op, schema);
             case LONG -> buildLongPredicate(columnName, value, op, schema);
             case DOUBLE -> {
                 if (isPhysicalDouble(schema, columnName)) {
@@ -447,6 +445,19 @@ final class ParquetPushedExpressions {
             case DATE_NANOS -> buildDateNanosPredicate(columnName, value, op, schema);
             default -> null;
         };
+    }
+
+    /**
+     * Whether a raw integral predicate pushed against the file's raw footer statistics would mis-prune because the
+     * scan decodes the column with a scaling transform the stats do not carry (parquet-mr prunes against the raw
+     * physical values; the scan applies the transform on top, so any factor between them drops matching row groups).
+     * The set of scaling annotations is owned by {@link ParquetColumnDecoding#integralDecodeScalesRelativeToRawStats}
+     * — co-located with the decode transforms so the two cannot drift. This is the single authority every integral
+     * push path ({@link #buildLongPredicate}/{@link #translateLongIn} and the {@code INTEGER} arms of
+     * {@link #buildPredicate}/{@link #translateIn}) consults before pushing.
+     */
+    private static boolean pushDeclinedForUnitMismatch(LogicalTypeAnnotation annotation) {
+        return ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(annotation);
     }
 
     /**
@@ -497,8 +508,30 @@ final class ParquetPushedExpressions {
         if (ptype == null) {
             return null;
         }
+        // A temporal-annotated column reaching a LONG predicate has a unit transform between the block value and
+        // the raw physical value the row-group statistics hold: TIMESTAMP(MICROS)->epoch-nanos (x1000),
+        // DATE(days)->epoch-millis (x86_400_000), TIME(MICROS)->nanos-of-day (x1000). The literal is in the decoded
+        // unit, the stats are in the physical unit, so pushing it prunes row groups that genuinely match. Pruning is
+        // unrecoverable — RECHECK guards against false positives, not against rows we never read — so decline and let
+        // FilterExec apply the real semantics. Reached via a DECLARED long over a TIMESTAMP/DATE column or an
+        // inferred TIME(MICROS) column; inferred datetime/date_nanos go through the unit-aware build*Predicate arms.
+        if (pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
+            return null;
+        }
         return switch (ptype.getPrimitiveTypeName()) {
-            case INT64 -> orderedPredicate(FilterApi.longColumn(columnName), value != null ? ((Number) value).longValue() : null, op);
+            case INT64 -> {
+                if (ParquetColumnDecoding.isUnsignedInt64(ptype) && op != PredicateOp.EQ && op != PredicateOp.NOT_EQ) {
+                    // ORDERED comparison over an UNSIGNED_64 column: the block decodes uint64 via signed sign-wrap
+                    // (raws >= 2^63 read as negative), so signed-block ordering disagrees with parquet-mr's UNSIGNED
+                    // row-group comparator in BOTH directions and for either literal sign: lt/lte drop the negative-
+                    // block groups (large unsigned) that genuinely match, and gt/gte — though merely over-including on
+                    // their own — become UNDER-including once wrapped in NOT, which the schema-blind
+                    // isExactlyTranslatable pushes as if exact. So decline every ordered op; only eq/notEq (and IN)
+                    // are bit-exact and stay pushable. The INT32 sibling declines the analogous unsigned mismatch.
+                    yield null;
+                }
+                yield orderedPredicate(FilterApi.longColumn(columnName), value != null ? ((Number) value).longValue() : null, op);
+            }
             case INT32 -> {
                 if (value == null) {
                     yield orderedPredicate(FilterApi.intColumn(columnName), null, op);
@@ -508,6 +541,24 @@ final class ParquetPushedExpressions {
             }
             default -> null;
         };
+    }
+
+    /**
+     * Builds a predicate for an ESQL {@code INTEGER} column over a physical {@code INT32} column. Mirrors
+     * {@link #buildLongPredicate}: it consults {@link #pushDeclinedForUnitMismatch}, so a declared {@code integer}
+     * over a {@code DATE} (INT32, x86_400_000) or {@code DECIMAL(INT32, scale>0)} (÷10^scale) column — whose scan
+     * decode carries a transform the raw {@code INT32} footer stats do not — declines rather than mis-prunes.
+     * Declining is safe — INTEGER comparisons are RECHECK, so {@code FilterExec} re-applies the exact semantics.
+     */
+    private static FilterPredicate buildIntPredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT32) {
+            return null;
+        }
+        if (pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
+            return null;
+        }
+        return orderedPredicate(FilterApi.intColumn(columnName), value != null ? ((Number) value).intValue() : null, op);
     }
 
     /**
@@ -607,8 +658,13 @@ final class ParquetPushedExpressions {
         return switch (ptype.getPrimitiveTypeName()) {
             case INT32 -> {
                 if (logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
-                    int days = (int) Math.floorDiv(millis, MILLIS_PER_DAY);
-                    yield orderedPredicate(FilterApi.intColumn(columnName), days, op);
+                    // A DATE column stores whole days; the literal is epoch-millis. The bound must be rounded to a
+                    // day boundary OUTWARD per operator (floorDiv for every op silently prunes matching days on `<`
+                    // and `!=` — a non-midnight literal makes `< X` exclude the day it falls in, and `!= X` drop the
+                    // all-day-D row group that genuinely matches). boundToPhysicalUnit handles the direction and
+                    // declines EQ/NOT_EQ on a non-midnight literal.
+                    Long dayBound = boundToPhysicalUnit(millis, op, MILLIS_PER_DAY);
+                    yield dayBound == null ? null : orderedPredicate(FilterApi.intColumn(columnName), (int) (long) dayBound, op);
                 }
                 yield null;
             }
@@ -641,13 +697,13 @@ final class ParquetPushedExpressions {
     }
 
     /**
-     * Builds a predicate for an ESQL {@code DATE_NANOS} column. These columns come only from INT64
-     * {@code TIMESTAMP(MICROS|NANOS)} (see {@link ParquetFormatReader}'s type mapper), and the query literal is
-     * epoch-nanoseconds. For a physical {@code NANOS} column the bound is pushed exactly. For a physical
-     * {@code MICROS} column the nanosecond bound is converted to a microsecond bound rounded outward
-     * ({@link #nanosBoundToMicros}) so the pushed predicate is never stricter than the true nanosecond predicate —
-     * safe because temporal pushdown is always RECHECK (see {@link ParquetFilterPushdownSupport#isFullyEvaluable}),
-     * so {@code FilterExec} re-applies the exact semantics regardless.
+     * Builds a predicate for an ESQL {@code DATE_NANOS} column, whose query literal is epoch-nanoseconds. A
+     * {@code DATE_NANOS} column is only ever INFERRED from a physical {@code TIMESTAMP(MICROS)} (×1_000 to nanos) or
+     * {@code TIMESTAMP(NANOS)} (identity) column — {@code date_nanos} is not a declarable type, and {@code
+     * TIMESTAMP(MILLIS)} infers to {@code datetime} — so the nanosecond bound is converted to microseconds (or left
+     * as nanos), rounded outward via {@link #boundToPhysicalUnit} so the pushed predicate is never stricter than the
+     * true nanosecond predicate. Safe because temporal pushdown is always RECHECK (see
+     * {@link ParquetFilterPushdownSupport#isFullyEvaluable}), so {@code FilterExec} re-applies the exact semantics.
      */
     private static FilterPredicate buildDateNanosPredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
@@ -658,26 +714,29 @@ final class ParquetPushedExpressions {
             return orderedPredicate(FilterApi.longColumn(columnName), null, op);
         }
         long nanos = ((Number) value).longValue();
-        if (ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation()) == false) {
-            // Physical NANOS: literal and stored unit match, so the bound is exact.
-            return orderedPredicate(FilterApi.longColumn(columnName), nanos, op);
-        }
-        Long micros = nanosBoundToMicros(nanos, op);
-        return micros == null ? null : orderedPredicate(FilterApi.longColumn(columnName), micros, op);
+        long divisor = ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation())
+            ? ParquetColumnDecoding.NANOS_PER_MICRO
+            : 1L;
+        Long bound = boundToPhysicalUnit(nanos, op, divisor);
+        return bound == null ? null : orderedPredicate(FilterApi.longColumn(columnName), bound, op);
     }
 
     /**
-     * Converts an epoch-nanosecond bound to the epoch-microsecond bound to push against a physical {@code MICROS}
-     * column, rounding each comparison outward so the pushed predicate never excludes a matching row (a stored
-     * micro {@code m} represents the instant {@code m × 1_000} ns). Equality/inequality are only representable when
-     * the bound is an exact multiple of 1_000 ns; otherwise {@code null} is returned and no predicate is pushed
-     * (the scan plus {@code FilterExec} recheck still yields the correct result, only without pruning).
+     * Converts a bound expressed in a fine unit to the coarse physical-unit bound to push against a column stored in
+     * that coarse unit ({@code divisor} fine units per stored tick — e.g. nanos→micros is 1_000, nanos→millis is
+     * 1_000_000, epoch-millis→epoch-days is {@link #MILLIS_PER_DAY}), rounding each comparison OUTWARD so the pushed
+     * predicate never excludes a matching row (a stored tick {@code t} represents the fine value {@code t × divisor}):
+     * {@code >}/{@code <=} round down, {@code >=}/{@code <} round up, and {@code ==}/{@code !=} are only representable
+     * when the bound lands exactly on a tick — otherwise {@code null} is returned and no predicate is pushed (the scan
+     * plus {@code FilterExec} recheck still yields the correct result, only without pruning). Getting the direction
+     * wrong (e.g. floor for {@code <}) is a silent false-negative: it prunes a row group the query genuinely matches.
+     * {@code divisor == 1} is the identity case, where floor/ceil/mod all leave the bound unchanged.
      */
-    private static Long nanosBoundToMicros(long nanos, PredicateOp op) {
+    private static Long boundToPhysicalUnit(long value, PredicateOp op, long divisor) {
         return switch (op) {
-            case GT, LTE -> Math.floorDiv(nanos, ParquetColumnDecoding.NANOS_PER_MICRO);
-            case GTE, LT -> Math.ceilDiv(nanos, ParquetColumnDecoding.NANOS_PER_MICRO);
-            case EQ, NOT_EQ -> nanos % ParquetColumnDecoding.NANOS_PER_MICRO == 0 ? nanos / ParquetColumnDecoding.NANOS_PER_MICRO : null;
+            case GT, LTE -> Math.floorDiv(value, divisor);
+            case GTE, LT -> Math.ceilDiv(value, divisor);
+            case EQ, NOT_EQ -> value % divisor == 0 ? value / divisor : null;
         };
     }
 
@@ -708,9 +767,7 @@ final class ParquetPushedExpressions {
             return null;
         }
         return switch (dataType) {
-            case INTEGER -> physicalPrimitiveIs(schema, columnName, PrimitiveType.PrimitiveTypeName.INT32)
-                ? inPredicate(FilterApi.intColumn(columnName), rawValues, v -> ((Number) v).intValue())
-                : null;
+            case INTEGER -> translateIntIn(columnName, rawValues, schema);
             case LONG -> translateLongIn(columnName, rawValues, schema);
             case DOUBLE -> {
                 if (isPhysicalDouble(schema, columnName)) {
@@ -743,6 +800,11 @@ final class ParquetPushedExpressions {
         if (ptype == null) {
             return null;
         }
+        // Same unit-mismatch decline as buildLongPredicate — a temporal physical carries a unit transform the
+        // raw stats do not, so an IN over a declared/inferred LONG temporal column must not push a raw predicate.
+        if (pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
+            return null;
+        }
         return switch (ptype.getPrimitiveTypeName()) {
             case INT64 -> inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
             case INT32 -> {
@@ -759,6 +821,22 @@ final class ParquetPushedExpressions {
         };
     }
 
+    /**
+     * {@code IN} counterpart to {@link #buildIntPredicate}: pushes an {@code IN} over a physical {@code INT32} column,
+     * declining via {@link #pushDeclinedForUnitMismatch} when the declared {@code integer} sits over a {@code DATE} or
+     * {@code DECIMAL(scale>0)} column whose decode transform the raw footer stats do not carry.
+     */
+    private static FilterPredicate translateIntIn(String columnName, List<Object> rawValues, MessageType schema) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT32) {
+            return null;
+        }
+        if (pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
+            return null;
+        }
+        return inPredicate(FilterApi.intColumn(columnName), rawValues, v -> ((Number) v).intValue());
+    }
+
     private static FilterPredicate translateDatetimeIn(String columnName, List<Object> rawValues, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
         if (ptype == null) {
@@ -769,11 +847,17 @@ final class ParquetPushedExpressions {
             return switch (ptype.getPrimitiveTypeName()) {
                 case INT32 -> {
                     if (logical instanceof LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
-                        yield inPredicate(
-                            FilterApi.intColumn(columnName),
-                            rawValues,
-                            v -> (int) Math.floorDiv(((Number) v).longValue(), MILLIS_PER_DAY)
-                        );
+                        // Only a midnight literal can equal a stored day; a non-midnight literal matches no day, so
+                        // drop it from the pushed set (a correct subset). Unlike a floorDiv'd day that over-includes,
+                        // an exact set stays correct when this IN is wrapped in NOT. Empty set => push nothing.
+                        List<Object> days = new ArrayList<>();
+                        for (Object v : rawValues) {
+                            long m = ((Number) v).longValue();
+                            if (m % MILLIS_PER_DAY == 0) {
+                                days.add((int) (m / MILLIS_PER_DAY));
+                            }
+                        }
+                        yield days.isEmpty() ? null : inPredicate(FilterApi.intColumn(columnName), days, v -> (Integer) v);
                     }
                     yield null;
                 }
@@ -791,16 +875,17 @@ final class ParquetPushedExpressions {
 
     /**
      * {@code IN} counterpart to {@link #buildDateNanosPredicate}. The query literals are epoch-nanoseconds. For a
-     * physical {@code NANOS} column each value is pushed exactly. For a physical {@code MICROS} column, an element
-     * can only equal a stored value when it is an exact multiple of 1_000 ns; non-multiples are dropped (they can
-     * never match, so omitting them keeps the pushed set a correct subset). If every element is dropped, no
-     * predicate is pushed and the scan + recheck yields the (empty) result.
+     * physical {@code NANOS} column each value is pushed exactly. For a {@code MICROS} column, an element can only
+     * equal a stored value when it is an exact multiple of 1_000 ns; non-multiples are dropped (they can never match,
+     * so omitting them keeps the pushed set a correct subset). If every element is dropped, no predicate is pushed and
+     * the scan + recheck yields the (empty) result.
      */
     private static FilterPredicate translateDateNanosIn(String columnName, List<Object> rawValues, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
         if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
             return null;
         }
+        // A DATE_NANOS column is only ever inferred from TIMESTAMP(MICROS) (÷1_000) or TIMESTAMP(NANOS) (identity).
         if (ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation()) == false) {
             return inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -3337,6 +3337,189 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertTrue("Detail should name the declared type, got: " + warnings.get(1), warnings.get(1).contains("[long]"));
     }
 
+    /**
+     * The mundane user shape: a physical {@code DOUBLE} column declared {@code long}/{@code integer}. The read
+     * ROUNDS like {@code ::long}/{@code ::integer} (not truncates); an out-of-{@code int}-range value under a
+     * lenient policy nulls the cell and warns rather than wrapping to a garbage int.
+     */
+    public void testDoubleFileDeclaredLongAndIntegerRounds() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.DOUBLE).named("x").named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group a = factory.newGroup();
+            a.add("x", 2.5d);
+            Group b = factory.newGroup();
+            b.add("x", -1.9d);
+            return List.of(a, b);
+        });
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Attribute> asLong = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.LONG));
+        try (
+            CloseableIterator<Page> it = declaredReader("x").readRange(
+                storageObject,
+                new RangeReadContext(List.of("x"), 10, 0, parquetData.length, asLong, ErrorPolicy.STRICT)
+            )
+        ) {
+            LongBlock l = (LongBlock) it.next().getBlock(0);
+            assertEquals(3L, l.getLong(0));   // 2.5 rounds to 3
+            assertEquals(-2L, l.getLong(1));  // -1.9 rounds to -2
+        }
+
+        // Out-of-int-range double under a lenient policy: null + warn, never a wrapped int.
+        byte[] bigData = createParquetFile(
+            Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.DOUBLE).named("x").named("test_schema"),
+            factory -> {
+                Group g = factory.newGroup();
+                g.add("x", 3.0e9d); // > Integer.MAX_VALUE
+                return List.of(g);
+            }
+        );
+        List<Attribute> asInt = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER));
+        try (
+            CloseableIterator<Page> it = declaredReader("x").readRange(
+                createStorageObject(bigData),
+                new RangeReadContext(List.of("x"), 10, 0, bigData.length, asInt, ErrorPolicy.PERMISSIVE)
+            )
+        ) {
+            IntBlock i = (IntBlock) it.next().getBlock(0);
+            assertTrue("out-of-int-range double declared integer nulls the cell", i.isNull(0));
+        }
+        assertFalse("the out-of-range coercion warns", drainWarnings().isEmpty());
+    }
+
+    /**
+     * A physical string column declared {@code integer} — the string&rarr;integer columnar arm (only
+     * long/double/boolean/ip were driven before).
+     */
+    public void testStringDeclaredIntegerCoerces() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("x")
+            .named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group a = factory.newGroup();
+            a.add("x", "42");
+            Group b = factory.newGroup();
+            b.add("x", "-7");
+            return List.of(a, b);
+        });
+        List<Attribute> asInt = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER));
+        try (
+            CloseableIterator<Page> it = declaredReader("x").readRange(
+                createStorageObject(parquetData),
+                new RangeReadContext(List.of("x"), 10, 0, parquetData.length, asInt, ErrorPolicy.STRICT)
+            )
+        ) {
+            IntBlock i = (IntBlock) it.next().getBlock(0);
+            assertEquals(42, i.getInt(0));
+            assertEquals(-7, i.getInt(1));
+        }
+    }
+
+    /**
+     * A physical unsigned-64 column declared {@code keyword}/{@code double} renders the true unsigned magnitude,
+     * including a value above {@code 2^63} (stored as a negative Java long). Drives the columnar
+     * {@code unsigned_long}&rarr;target coercion on the one physical source that produces BigInteger magnitudes.
+     */
+    public void testUint64FileDeclaredKeywordAndDouble() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.intType(64, false))
+            .named("u")
+            .named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("u", -1L); // raw bits of 2^64 - 1, the unsigned maximum
+            return List.of(g);
+        });
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Attribute> asKeyword = List.of(new ReferenceAttribute(Source.EMPTY, "u", DataType.KEYWORD));
+        try (
+            CloseableIterator<Page> it = declaredReader("u").readRange(
+                storageObject,
+                new RangeReadContext(List.of("u"), 10, 0, parquetData.length, asKeyword, ErrorPolicy.STRICT)
+            )
+        ) {
+            BytesRefBlock k = (BytesRefBlock) it.next().getBlock(0);
+            assertEquals("18446744073709551615", k.getBytesRef(0, new BytesRef()).utf8ToString());
+        }
+        List<Attribute> asDouble = List.of(new ReferenceAttribute(Source.EMPTY, "u", DataType.DOUBLE));
+        try (
+            CloseableIterator<Page> it = declaredReader("u").readRange(
+                storageObject,
+                new RangeReadContext(List.of("u"), 10, 0, parquetData.length, asDouble, ErrorPolicy.STRICT)
+            )
+        ) {
+            DoubleBlock d = (DoubleBlock) it.next().getBlock(0);
+            assertEquals(new BigInteger("18446744073709551615").doubleValue(), d.getDouble(0), 0.0);
+        }
+    }
+
+    /**
+     * A physical {@code TIMESTAMP(MILLIS)} column declared {@code keyword} renders the ISO string; declared
+     * {@code long} reads the raw epoch millis. Drives the temporal&rarr;keyword and temporal&rarr;long columnar arms per-file.
+     */
+    public void testTimestampMillisFileDeclaredKeywordAndLong() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts")
+            .named("test_schema");
+        long millis = 1704067200000L; // 2024-01-01T00:00:00Z
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("ts", millis);
+            return List.of(g);
+        });
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Attribute> asKeyword = List.of(new ReferenceAttribute(Source.EMPTY, "ts", DataType.KEYWORD));
+        try (
+            CloseableIterator<Page> it = declaredReader("ts").readRange(
+                storageObject,
+                new RangeReadContext(List.of("ts"), 10, 0, parquetData.length, asKeyword, ErrorPolicy.STRICT)
+            )
+        ) {
+            BytesRefBlock k = (BytesRefBlock) it.next().getBlock(0);
+            assertEquals("2024-01-01T00:00:00.000Z", k.getBytesRef(0, new BytesRef()).utf8ToString());
+        }
+        List<Attribute> asLong = List.of(new ReferenceAttribute(Source.EMPTY, "ts", DataType.LONG));
+        try (
+            CloseableIterator<Page> it = declaredReader("ts").readRange(
+                storageObject,
+                new RangeReadContext(List.of("ts"), 10, 0, parquetData.length, asLong, ErrorPolicy.STRICT)
+            )
+        ) {
+            LongBlock l = (LongBlock) it.next().getBlock(0);
+            assertEquals(millis, l.getLong(0));
+        }
+    }
+
+    /** A physical DOUBLE column read as declared {@code double} preserves non-finite IEEE values (NaN/Infinity). */
+    public void testDoubleFileNonFiniteValuesPassThroughDeclared() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.DOUBLE).named("d").named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group a = factory.newGroup();
+            a.add("d", Double.NaN);
+            Group b = factory.newGroup();
+            b.add("d", Double.POSITIVE_INFINITY);
+            Group c = factory.newGroup();
+            c.add("d", Double.NEGATIVE_INFINITY);
+            return List.of(a, b, c);
+        });
+        List<Attribute> asDouble = List.of(new ReferenceAttribute(Source.EMPTY, "d", DataType.DOUBLE));
+        try (
+            CloseableIterator<Page> it = declaredReader("d").readRange(
+                createStorageObject(parquetData),
+                new RangeReadContext(List.of("d"), 10, 0, parquetData.length, asDouble, ErrorPolicy.STRICT)
+            )
+        ) {
+            DoubleBlock d = (DoubleBlock) it.next().getBlock(0);
+            assertTrue(Double.isNaN(d.getDouble(0)));
+            assertEquals(Double.POSITIVE_INFINITY, d.getDouble(1), 0.0);
+            assertEquals(Double.NEGATIVE_INFINITY, d.getDouble(2), 0.0);
+        }
+    }
+
     public void testStringDeclaredLongUnparseableFailFastFailsRead() throws Exception {
         // error_mode: fail_fast makes a coercion failure abort the read — the same outcome the
         // text readers produce for the same declared coercion on the same bad token.

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
@@ -54,6 +55,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Tests for {@link ParquetPushedExpressions#toFilterPredicate(MessageType)} verifying
@@ -103,6 +105,236 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         FilterPredicate fp = pushed.toFilterPredicate(schema);
         assertNotNull(fp);
         assertThat(fp.toString(), containsString(String.valueOf(millis * 1000)));
+    }
+
+    // --- Declared LONG over a TIMESTAMP column (unit mismatch) ---
+
+    /**
+     * A column DECLARED as {@code long} over a physical {@code TIMESTAMP(MICROS)} decodes through the temporal
+     * path, which scales micros to epoch-nanos — so the block value is 1000x the raw value the row-group
+     * statistics hold. Pushing that nanos literal against the raw micros stats prunes row groups that genuinely
+     * match, losing rows (RECHECK cannot resurrect a row group that was never read). We decline instead.
+     */
+    public void testDeclaredLongOverTimestampMicrosDeclinesPushdown() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test");
+
+        // The value a declared-long read of a 1_600_000_000_000_000-micros row actually yields.
+        long nanos = 1_600_000_000_000_000_000L;
+        Expression expr = eq("ts", DataType.LONG, nanos);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        assertNull("declared long over TIMESTAMP(MICROS) must not push a raw predicate", pushed.toFilterPredicate(schema));
+    }
+
+    /** A declared {@code long} over a plain (un-annotated) INT64 still pushes — the decline is scoped to timestamps. */
+    public void testDeclaredLongOverPlainInt64StillPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).named("n").named("test");
+
+        Expression expr = eq("n", DataType.LONG, 42L);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull("a plain INT64 column must still push", fp);
+        assertThat(fp.toString(), containsString("42"));
+    }
+
+    /** The IN path has the same unit hazard as the comparison path: a declared long over TIMESTAMP(MICROS) must decline. */
+    public void testDeclaredLongInOverTimestampMicrosDeclinesPushdown() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("ts")
+            .named("test");
+
+        Expression inExpr = new In(Source.EMPTY, attr("ts", DataType.LONG), List.of(lit(1600000000000000000L, DataType.LONG)));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(inExpr));
+
+        assertNull("declared long IN over TIMESTAMP(MICROS) must not push a raw predicate", pushed.toFilterPredicate(schema));
+    }
+
+    /**
+     * A declared {@code long} over a physical {@code DATE} (INT32, days) decodes to epoch-millis (days x 86_400_000)
+     * while the stats are day-valued — same 1000x-class unit mismatch. Comparison and IN must both decline.
+     */
+    public void testDeclaredLongOverDateDeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        // A sub-2^31 millis literal (~1970-01-01T12:00) DOES narrow to int32, so without the guard it would push
+        // `d == 43200000` against day-valued stats and mis-prune — the value must be small enough to reach the push.
+        Expression cmp = eq("d", DataType.LONG, 43200000L);
+        assertNull("declared long over DATE must not push", new ParquetPushedExpressions(List.of(cmp)).toFilterPredicate(schema));
+
+        Expression inExpr = new In(Source.EMPTY, attr("d", DataType.LONG), List.of(lit(43200000L, DataType.LONG)));
+        assertNull("declared long IN over DATE must not push", new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema));
+    }
+
+    /**
+     * A physical {@code TIME(MICROS)} column infers to {@code long} and decodes x1000 to nanos-of-day while its
+     * stats stay in micros — the same unit-mismatch class, so a LONG predicate over it must decline. {@code TIME(MILLIS)}
+     * stays pushable (identity widen; see {@code testTimeMillisAnalogousInt32WidenToLongIsPushed}).
+     */
+    public void testLongOverTimeMicrosDeclinesPushdown() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("t")
+            .named("test");
+
+        Expression cmp = eq("t", DataType.LONG, 43_200_000_000L);
+        assertNull("long over TIME(MICROS) must not push", new ParquetPushedExpressions(List.of(cmp)).toFilterPredicate(schema));
+
+        Expression inExpr = new In(Source.EMPTY, attr("t", DataType.LONG), List.of(lit(43_200_000_000L, DataType.LONG)));
+        assertNull("long IN over TIME(MICROS) must not push", new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema));
+    }
+
+    /**
+     * Only the scaling {@code MICROS} unit needs the decline: a declared {@code long} over {@code TIMESTAMP(MILLIS)}
+     * or {@code TIMESTAMP(NANOS)} is an identity read (block value == raw stat), so those still push — declining them
+     * would be a needless lost-pruning cost (reviewer note on the guard's over-declining).
+     */
+    public void testTimestampMillisAndNanosDeclaredLongStillPush() {
+        for (LogicalTypeAnnotation.TimeUnit unit : new LogicalTypeAnnotation.TimeUnit[] {
+            LogicalTypeAnnotation.TimeUnit.MILLIS,
+            LogicalTypeAnnotation.TimeUnit.NANOS }) {
+            MessageType schema = Types.buildMessage().required(INT64).as(timestampType(true, unit)).named("t").named("test");
+            FilterPredicate fp = new ParquetPushedExpressions(List.of(eq("t", DataType.LONG, 1_600_000_000_000L))).toFilterPredicate(
+                schema
+            );
+            assertNotNull("declared long over TIMESTAMP(" + unit + ") is identity and must still push", fp);
+            assertThat(fp.toString(), containsString("1600000000000"));
+        }
+    }
+
+    /** A plain INT64 IN still pushes — the decline is scoped to temporal-annotated columns. */
+    public void testPlainInt64InStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).named("n").named("test");
+
+        Expression inExpr = new In(Source.EMPTY, attr("n", DataType.LONG), List.of(lit(7L, DataType.LONG), lit(9L, DataType.LONG)));
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema);
+        assertNotNull("a plain INT64 IN must still push", fp);
+    }
+
+    // --- Declared LONG/INTEGER over a DECIMAL(scale>0) column (scale mismatch) ---
+
+    /**
+     * A declared {@code long} over a physical {@code DECIMAL(scale=2)} INT64 decodes to {@code unscaled / 100} (a
+     * double rounded to long) while the raw footer statistics hold the unscaled integer — an implicit ÷100. Pushing a
+     * raw long literal against those stats mis-prunes, so comparison and IN must both decline.
+     */
+    public void testDeclaredLongOverDecimalScaledDeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT64).as(decimalType(2, 18)).named("amt").named("test");
+
+        Expression cmp = eq("amt", DataType.LONG, 12L);
+        assertNull(
+            "declared long over DECIMAL(scale>0) must not push",
+            new ParquetPushedExpressions(List.of(cmp)).toFilterPredicate(schema)
+        );
+
+        Expression inExpr = new In(Source.EMPTY, attr("amt", DataType.LONG), List.of(lit(12L, DataType.LONG)));
+        assertNull(
+            "declared long IN over DECIMAL(scale>0) must not push",
+            new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema)
+        );
+    }
+
+    /** A {@code DECIMAL(scale=0)} is an integer decode (block == raw), so the guard must NOT decline — pruning stays correct. */
+    public void testDeclaredLongOverDecimalScaleZeroStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).as(decimalType(0, 18)).named("amt").named("test");
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(eq("amt", DataType.LONG, 12L))).toFilterPredicate(schema);
+        assertNotNull("declared long over DECIMAL(scale=0) is identity and must still push", fp);
+        assertThat(fp.toString(), containsString("12"));
+    }
+
+    // --- Declared INTEGER over a unit-transformed INT32 column ---
+
+    /**
+     * A declared {@code integer} over a physical {@code DATE}(INT32) column decodes days→millis (×86_400_000) then
+     * narrows to int, while the stats stay day-valued — the same class of mismatch the LONG path guards. The INTEGER
+     * comparison and IN arms must consult the guard and decline. A sub-2^31 millis literal is used so it would
+     * otherwise reach the push.
+     */
+    public void testDeclaredIntegerOverDateInt32DeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        Expression cmp = eq("d", DataType.INTEGER, 86_400_000); // one day in millis, fits int32
+        assertNull("declared integer over DATE must not push", new ParquetPushedExpressions(List.of(cmp)).toFilterPredicate(schema));
+
+        Expression inExpr = new In(Source.EMPTY, attr("d", DataType.INTEGER), List.of(lit(86_400_000, DataType.INTEGER)));
+        assertNull("declared integer IN over DATE must not push", new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema));
+    }
+
+    /** The INTEGER decline is scoped to unit-transformed columns; a plain INT32 still pushes. */
+    public void testDeclaredIntegerOverPlainInt32StillPushes() {
+        MessageType schema = Types.buildMessage().required(INT32).named("n").named("test");
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(eq("n", DataType.INTEGER, 42))).toFilterPredicate(schema);
+        assertNotNull("declared integer over a plain INT32 must still push", fp);
+        assertThat(fp.toString(), containsString("42"));
+    }
+
+    /** A declared {@code integer} over a physical {@code DECIMAL(INT32, scale>0)} column decodes ÷10^scale, so it declines. */
+    public void testDeclaredIntegerOverDecimalInt32ScaledDeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT32).as(decimalType(2, 9)).named("amt").named("test");
+
+        assertNull(
+            "declared integer over DECIMAL(INT32, scale>0) must not push",
+            new ParquetPushedExpressions(List.of(eq("amt", DataType.INTEGER, 12))).toFilterPredicate(schema)
+        );
+    }
+
+    /** {@code IN} over a declared integer routes through translateIntIn: it declines over DATE and pushes over a plain INT32. */
+    public void testDeclaredIntegerInConsultsGuard() {
+        MessageType dateSchema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+        Expression inOverDate = new In(
+            Source.EMPTY,
+            attr("d", DataType.INTEGER),
+            List.of(lit(86_400_000, DataType.INTEGER), lit(172_800_000, DataType.INTEGER))
+        );
+        assertNull(
+            "declared integer IN over DATE must not push",
+            new ParquetPushedExpressions(List.of(inOverDate)).toFilterPredicate(dateSchema)
+        );
+
+        MessageType plainSchema = Types.buildMessage().required(INT32).named("n").named("test");
+        Expression inOverPlain = new In(
+            Source.EMPTY,
+            attr("n", DataType.INTEGER),
+            List.of(lit(7, DataType.INTEGER), lit(9, DataType.INTEGER))
+        );
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inOverPlain)).toFilterPredicate(plainSchema);
+        assertNotNull("declared integer IN over a plain INT32 must still push", fp);
+    }
+
+    /**
+     * Direct pin for the single-home decline inventory {@link ParquetColumnDecoding#integralDecodeScalesRelativeToRawStats}
+     * that {@code pushDeclinedForUnitMismatch} delegates to: it must flag exactly the annotations whose integral decode
+     * scales relative to the raw footer stats, and nothing else.
+     */
+    public void testIntegralDecodeScalesInventory() {
+        assertTrue(ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(dateType()));
+        assertTrue(
+            ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+        );
+        assertTrue(
+            ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(
+                LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS)
+            )
+        );
+        assertTrue(ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(decimalType(2, 9)));
+
+        assertFalse(
+            ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+        );
+        assertFalse(
+            ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
+        );
+        assertFalse(ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(decimalType(0, 9)));
+        assertFalse(ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(null));
     }
 
     // --- TIMESTAMP_NANOS (INT64) ---
@@ -227,6 +459,175 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         FilterPredicate fp = pushed.toFilterPredicate(schema);
         assertNotNull(fp);
         assertThat(fp.toString(), containsString(String.valueOf(expectedDays)));
+    }
+
+    /**
+     * A DATE column stores whole days; {@code d < <non-midnight millis>} must round the day bound UP (ceilDiv), not
+     * down. With floorDiv the predicate becomes {@code day < floor(millis)} and prunes the row group holding the very
+     * day the literal falls in — silent data loss. Reachable with a plain inferred date column, no declared schema.
+     */
+    public void testDateColumnLessThanNonMidnightRoundsBoundUp() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long day = 19723L;
+        long nonMidnight = day * ParquetPushedExpressions.MILLIS_PER_DAY + 1; // 1ms past midnight of day 19723
+        Expression lt = new LessThan(Source.EMPTY, attr("d", DataType.DATETIME), datetimeLit(nonMidnight), null);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(lt)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        // ceilDiv(nonMidnight) == day + 1, so lt keeps day 19723; floorDiv would push lt(day 19723) and prune it.
+        assertThat(fp.toString(), containsString(String.valueOf(day + 1)));
+    }
+
+    /**
+     * {@code d != <non-midnight millis>} is true for every day (no day equals a non-midnight instant), so pushing a
+     * {@code notEq(day)} — which parquet-mr uses to prune an all-that-day row group — would drop matching rows. A
+     * non-midnight {@code !=} must decline pushdown (only a midnight literal is exactly representable).
+     */
+    public void testDateColumnNotEqualsNonMidnightDeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long nonMidnight = 19723L * ParquetPushedExpressions.MILLIS_PER_DAY + 1;
+        Expression ne = new NotEquals(Source.EMPTY, attr("d", DataType.DATETIME), datetimeLit(nonMidnight), null);
+
+        assertNull(
+            "d != <non-midnight> must not push a notEq day predicate",
+            new ParquetPushedExpressions(List.of(ne)).toFilterPredicate(schema)
+        );
+    }
+
+    /** {@code d <= <non-midnight>} rounds DOWN (floorDiv) — that direction is correct, so it must still push. */
+    public void testDateColumnLessThanOrEqualNonMidnightStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long day = 19723L;
+        long nonMidnight = day * ParquetPushedExpressions.MILLIS_PER_DAY + 1;
+        Expression lte = new LessThanOrEqual(Source.EMPTY, attr("d", DataType.DATETIME), datetimeLit(nonMidnight), null);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(lte)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(day))); // floorDiv == day 19723, correct for <=
+    }
+
+    /** {@code d == <non-midnight>} matches no day, so it must decline (only a midnight literal is exactly representable). */
+    public void testDateColumnEqualsNonMidnightDeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long nonMidnight = 19723L * ParquetPushedExpressions.MILLIS_PER_DAY + 1;
+        assertNull(
+            "d == <non-midnight> must not push an eq day predicate",
+            new ParquetPushedExpressions(List.of(eq("d", DataType.DATETIME, nonMidnight))).toFilterPredicate(schema)
+        );
+    }
+
+    /** {@code d > <non-midnight>} rounds DOWN (floorDiv) — the correct direction for {@code >} — so it still pushes. */
+    public void testDateColumnGreaterThanNonMidnightStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long day = 19723L;
+        long nonMidnight = day * ParquetPushedExpressions.MILLIS_PER_DAY + 1;
+        Expression gt = new GreaterThan(Source.EMPTY, attr("d", DataType.DATETIME), datetimeLit(nonMidnight), null);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(gt)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(day))); // floorDiv == day 19723, correct for >
+    }
+
+    /** {@code d >= <non-midnight>} rounds UP (ceilDiv), which only over-includes the boundary day — safe, still pushes. */
+    public void testDateColumnGreaterThanOrEqualNonMidnightStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long day = 19723L;
+        long nonMidnight = day * ParquetPushedExpressions.MILLIS_PER_DAY + 1;
+        Expression gte = new GreaterThanOrEqual(Source.EMPTY, attr("d", DataType.DATETIME), datetimeLit(nonMidnight), null);
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(gte)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(day + 1))); // ceilDiv == day 19724
+    }
+
+    /** {@code d == <midnight>} is exactly representable and must still push the eq day predicate. */
+    public void testDateColumnEqualsMidnightStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long day = 19723L;
+        long midnight = day * ParquetPushedExpressions.MILLIS_PER_DAY;
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(eq("d", DataType.DATETIME, midnight))).toFilterPredicate(schema);
+        assertNotNull("d == <midnight> is exact and must still push", fp);
+        assertThat(fp.toString(), containsString(String.valueOf(day)));
+    }
+
+    /** {@code d IN (midnight, non-midnight)} keeps only the midnight day; the non-midnight literal can equal no day. */
+    public void testDateColumnInDropsNonMidnightElement() {
+        MessageType schema = Types.buildMessage().required(INT32).as(dateType()).named("d").named("test");
+
+        long midnightDay = 19723L;
+        long midnight = midnightDay * ParquetPushedExpressions.MILLIS_PER_DAY;
+        long nonMidnight = 20000L * ParquetPushedExpressions.MILLIS_PER_DAY + 5;
+        Expression in = new In(Source.EMPTY, attr("d", DataType.DATETIME), List.of(datetimeLit(midnight), datetimeLit(nonMidnight)));
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(in)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        String repr = fp.toString();
+        assertThat("the midnight day is pushed", repr, containsString(String.valueOf(midnightDay)));
+        assertThat("the non-midnight day must be dropped, not floorDiv'd in", repr, not(containsString(String.valueOf(20000L))));
+    }
+
+    // --- Declared LONG over an UNSIGNED_64 column (signed/unsigned comparator mismatch) ---
+
+    /**
+     * A {@code uint64} column DECLARED as {@code long} decodes via signed sign-wrap (raws >= 2^63 read as negative),
+     * so signed-block ordering disagrees with parquet-mr's UNSIGNED row-group comparator for EVERY ordered op and
+     * either literal sign. {@code u < 100} would prune the negative-block groups (large unsigned) that genuinely match
+     * (a false negative RECHECK cannot undo); {@code u > 5}, though over-including on its own, mis-prunes once wrapped
+     * in {@code NOT}. So every ordered comparison must decline, whatever the literal sign.
+     */
+    public void testDeclaredLongOverUnsignedInt64OrderedDeclinesPushdown() {
+        MessageType schema = Types.buildMessage().required(INT64).as(LogicalTypeAnnotation.intType(64, false)).named("u").named("test");
+
+        for (long literal : new long[] { -5L, 100L }) {
+            Expression gt = new GreaterThan(Source.EMPTY, attr("u", DataType.LONG), lit(literal, DataType.LONG), null);
+            assertNull(
+                "u > " + literal + " over uint64 must not push",
+                new ParquetPushedExpressions(List.of(gt)).toFilterPredicate(schema)
+            );
+
+            Expression lt = new LessThan(Source.EMPTY, attr("u", DataType.LONG), lit(literal, DataType.LONG), null);
+            assertNull(
+                "u < " + literal + " over uint64 must not push",
+                new ParquetPushedExpressions(List.of(lt)).toFilterPredicate(schema)
+            );
+
+            Expression lte = new LessThanOrEqual(Source.EMPTY, attr("u", DataType.LONG), lit(literal, DataType.LONG), null);
+            assertNull(
+                "u <= " + literal + " over uint64 must not push",
+                new ParquetPushedExpressions(List.of(lte)).toFilterPredicate(schema)
+            );
+        }
+    }
+
+    /** {@code eq}/{@code notEq} are bit-pattern exact regardless of sign, so an equality literal over uint64 still pushes. */
+    public void testDeclaredLongOverUnsignedInt64EqStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).as(LogicalTypeAnnotation.intType(64, false)).named("u").named("test");
+
+        assertNotNull(
+            "u == -5 over uint64 is bit-exact and must still push",
+            new ParquetPushedExpressions(List.of(eq("u", DataType.LONG, -5L))).toFilterPredicate(schema)
+        );
+        assertNotNull(
+            "u == 5 over uint64 is bit-exact and must still push",
+            new ParquetPushedExpressions(List.of(eq("u", DataType.LONG, 5L))).toFilterPredicate(schema)
+        );
+    }
+
+    /** A plain (signed) INT64 still pushes ordered comparisons — the decline is scoped to the unsigned annotation. */
+    public void testDeclaredLongOverSignedInt64OrderedStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).named("n").named("test");
+
+        Expression lt = new LessThan(Source.EMPTY, attr("n", DataType.LONG), lit(100L, DataType.LONG), null);
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(lt)).toFilterPredicate(schema);
+        assertNotNull("a plain signed INT64 must still push ordered comparisons", fp);
+        assertThat(fp.toString(), containsString("100"));
     }
 
     // --- INT96 (skip pushdown) ---

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -218,14 +218,23 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         "logs_bad_date_failfast",
         "logs_csv_bad_date_failfast",
         "logs_ndjson_bad_date_failfast",
-        "logs_ndjson_bad_date_permissive"
+        "logs_ndjson_bad_date_permissive",
+        "employees_divergent_multi",
+        "tsv_declared_type",
+        "tsv_declared_date",
+        "tsv_declared_rename",
+        "mapped_ds_for_view",
+        "mapped_ds_for_subquery",
+        "ndjson_mv_coerce",
+        "logs_ts_declared_long",
+        "logs_date_inferred"
     );
 
     /**
      * Names every {@code testXxx} body creates via {@link PutViewAction}. As with datasets, the SUITE-scoped
      * cluster requires explicit teardown so views don't leak across methods.
      */
-    private static final Set<String> CREATED_VIEWS = Set.of("employees_view", "employees_filtered_view");
+    private static final Set<String> CREATED_VIEWS = Set.of("employees_view", "employees_filtered_view", "mapped_dataset_view");
 
     @After
     public void cleanupViews() throws Exception {
@@ -2044,6 +2053,144 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         assertThat(e.getMessage(), containsString("long"));
     }
 
+    private byte[] timestampMicrosFixtureBytes(long... microsValues) throws IOException {
+        MessageType schema = MessageTypeParser.parseMessageType("message logs { required int64 ts (TIMESTAMP(MICROS,true)); }");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(baos))
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (long micros : microsValues) {
+                Group g = factory.newGroup();
+                g.add("ts", micros);
+                writer.write(g);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private byte[] dateFixtureBytes(int... days) throws IOException {
+        MessageType schema = MessageTypeParser.parseMessageType("message logs { required int32 d (DATE); }");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(baos))
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (int day : days) {
+                Group g = factory.newGroup();
+                g.add("d", day);
+                writer.write(g);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * End-to-end regression pin for the declared-{@code long}-over-{@code TIMESTAMP(MICROS)} filter-pushdown bug:
+     * such a column decodes to epoch-NANOS, but the file's row-group statistics are in MICROS. Before the fix a
+     * pushed {@code WHERE ts == <nanos>} predicate was compared against micros stats and pruned the matching row
+     * group, so the query returned zero rows — filtering for exactly the value the column reads back found nothing.
+     */
+    public void testWhereOnDeclaredLongTimestampMatchesThroughEngine() throws Exception {
+        Path root = createTempDir();
+        long microsA = 1_600_000_000_000_000L; // reads back as 1_600_000_000_000_000_000 nanos
+        long microsB = 1_700_000_000_000_000L;
+        Files.write(root.resolve("logs.parquet"), timestampMicrosFixtureBytes(microsA, microsB));
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("ts", new DatasetFieldMapping("long", null)); // declare the timestamp column as long (epoch-nanos)
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "logs_ts_declared_long",
+                    "local_ds",
+                    root.toUri() + "*.parquet",
+                    null,
+                    new HashMap<>(Map.of("format", "parquet")),
+                    mapping
+                )
+            )
+        );
+
+        // Filter for exactly the nanos value the first row reads back; it must be found (row group not wrongly pruned).
+        try (
+            var response = run(
+                syncEsqlQueryRequest("FROM logs_ts_declared_long | WHERE ts == 1600000000000000000 | STATS c = COUNT(*)"),
+                TIMEOUT
+            )
+        ) {
+            assertThat("the matching row must survive filter pushdown", getValuesList(response).get(0).get(0), equalTo(1L));
+        }
+        // The IN path had the same hazard (translateLongIn); the row must survive it too.
+        try (
+            var response = run(
+                syncEsqlQueryRequest("FROM logs_ts_declared_long | WHERE ts IN (1600000000000000000) | STATS c = COUNT(*)"),
+                TIMEOUT
+            )
+        ) {
+            assertThat("the matching row must survive IN pushdown", getValuesList(response).get(0).get(0), equalTo(1L));
+        }
+    }
+
+    /**
+     * End-to-end regression pin for the DATE-column filter-pushdown rounding bug (no declared mapping — a plain
+     * inferred {@code date} column). A DATE stores whole days; the row group holds day 19723 (2024-01-01). Before the
+     * fix the day bound was rounded with {@code floorDiv} for every operator, so {@code d < 2024-01-01T00:00:00.001Z}
+     * pushed {@code day < 19723} and pruned the [19723,19723] row group, and {@code d != 2024-01-01T00:00:00.001Z}
+     * pushed {@code notEq(19723)} and pruned it too — both dropped the row that genuinely matches.
+     */
+    public void testWhereLessThanAndNotEqualsOnDateColumnMatchThroughEngine() throws Exception {
+        Path root = createTempDir();
+        Files.write(root.resolve("dates.parquet"), dateFixtureBytes(19723)); // 2024-01-01, single row group
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "logs_date_inferred",
+                    "local_ds",
+                    root.toUri() + "*.parquet",
+                    null,
+                    new HashMap<>(Map.of("format", "parquet")),
+                    null // inferred: no declared mapping, the column reads back as datetime
+                )
+            )
+        );
+
+        try (
+            var response = run(
+                syncEsqlQueryRequest("FROM logs_date_inferred | WHERE d < TO_DATETIME(\"2024-01-01T00:00:00.001Z\") | STATS c = COUNT(*)"),
+                TIMEOUT
+            )
+        ) {
+            assertThat("the matching day must survive < pushdown", getValuesList(response).get(0).get(0), equalTo(1L));
+        }
+        try (
+            var response = run(
+                syncEsqlQueryRequest("FROM logs_date_inferred | WHERE d != TO_DATETIME(\"2024-01-01T00:00:00.001Z\") | STATS c = COUNT(*)"),
+                TIMEOUT
+            )
+        ) {
+            assertThat("the matching day must survive != pushdown", getValuesList(response).get(0).get(0), equalTo(1L));
+        }
+    }
+
     private Path writeParquetRenameFixture() throws IOException {
         Path tempFile = createTempDir().resolve("employees.parquet");
         Files.write(tempFile, parquetRenameFixtureBytes());
@@ -2207,6 +2354,252 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
             assertThat(rows, hasSize(3));
             assertThat(rows.get(0).get(0), equalTo(1L)); // declared LONG override across files
             assertThat(rows.get(2).get(0), equalTo(3L));
+        }
+    }
+
+    /**
+     * The declared schema must win uniformly across a multi-file glob whose files DISAGREE on a column's physical
+     * type — every existing glob test uses identical files, so the reconcile-under-declaration path never runs here.
+     * part1 stores {@code val} as integer, part2 as long with a value that overflows int; declared {@code val: long}
+     * reads both as long, and part2's large value survives (an inferred integer reconcile would have clashed/nulled it).
+     */
+    public void testDeclaredSchemaOverDivergentTypeMultiFileGlob() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("part1.csv"), "val:integer\n100\n");
+        Files.writeString(root.resolve("part2.csv"), "val:long\n5000000000\n"); // 5e9 > Integer.MAX_VALUE
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("val", new DatasetFieldMapping("long", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "employees_divergent_multi",
+                    "local_ds",
+                    root.toUri() + "*.csv",
+                    null,
+                    new HashMap<>(Map.of("format", "csv")),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM employees_divergent_multi | SORT val | LIMIT 10"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(1));
+            assertThat(columns.get(0).name(), equalTo("val"));
+            assertThat(columns.get(0).outputType(), equalTo("long"));
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(2));
+            assertThat(rows.get(0).get(0), equalTo(100L));          // integer-file value read as long
+            assertThat(rows.get(1).get(0), equalTo(5000000000L));   // long-file value that would overflow an int
+        }
+    }
+
+    /** TSV (shares the CSV reader via the tsv preset): a declared type coerces the file value like CSV/Parquet. */
+    public void testTsvDeclaredTypeCoercionReadsAsDeclared() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("data.tsv"), "val:integer\tname:keyword\n100\tAlice\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("val", new DatasetFieldMapping("long", null)); // retype integer file column to long
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "tsv_declared_type",
+                    "local_ds",
+                    root.toUri() + "*.tsv",
+                    null,
+                    new HashMap<>(Map.of("format", "tsv")),
+                    mapping
+                )
+            )
+        );
+        try (var response = run(syncEsqlQueryRequest("FROM tsv_declared_type | KEEP val | LIMIT 1"), TIMEOUT)) {
+            assertThat(response.columns().get(0).outputType(), equalTo("long"));
+            assertThat(getValuesList(response).get(0).get(0), equalTo(100L));
+        }
+    }
+
+    /** TSV declared per-column date {@code format}: a string field declared date parses zone-aware, like the CSV path. */
+    public void testTsvDeclaredDateFormatParsesZoneAware() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("logs.tsv"), "ts:keyword\tnote:keyword\n10/Oct/2000:13:55:36 -0700\thello\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("ts", DatasetFieldMapping.withFormat("date", null, ACCESS_LOG_FORMAT));
+        properties.put("note", new DatasetFieldMapping("keyword", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "tsv_declared_date",
+                    "local_ds",
+                    root.toUri() + "*.tsv",
+                    null,
+                    new HashMap<>(Map.of("format", "tsv")),
+                    mapping
+                )
+            )
+        );
+        try (var response = run(syncEsqlQueryRequest("FROM tsv_declared_date | EVAL ms = ts::long | KEEP ms | LIMIT 1"), TIMEOUT)) {
+            assertThat(getValuesList(response).get(0).get(0), equalTo(ACCESS_LOG_EPOCH_MILLIS)); // -0700 offset honored
+        }
+    }
+
+    /** TSV declared rename (`path`): a logical column reads from a differently-named physical TSV column. */
+    public void testTsvDeclaredRenameReadsByPhysicalColumn() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("e.tsv"), "emp_no:integer\tfirst_name:keyword\n1\tAlice\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("id", new DatasetFieldMapping("long", "emp_no"));      // logical id <- physical emp_no
+        properties.put("name", new DatasetFieldMapping("keyword", "first_name"));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "tsv_declared_rename",
+                    "local_ds",
+                    root.toUri() + "*.tsv",
+                    null,
+                    new HashMap<>(Map.of("format", "tsv")),
+                    mapping
+                )
+            )
+        );
+        try (var response = run(syncEsqlQueryRequest("FROM tsv_declared_rename | KEEP id, name | LIMIT 1"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns.get(0).name(), equalTo("id"));
+            assertThat(columns.get(1).name(), equalTo("name"));
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.get(0).get(0), equalTo(1L));
+            assertThat(rows.get(0).get(1), equalTo("Alice"));
+        }
+    }
+
+    /**
+     * A multivalue (array) column declared a coerced type coerces element-by-element — every element of the
+     * position is converted, not just the first, and the position keeps its multivalue shape.
+     */
+    public void testNdjsonMultiValueColumnCoercesElementwise() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("mv.ndjson"), "{\"vals\":[\"10\",\"20\",\"30\"]}\n{\"vals\":[\"40\"]}\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("vals", new DatasetFieldMapping("long", null)); // declare the string array as long
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "ndjson_mv_coerce",
+                    "local_ds",
+                    root.toUri() + "*.ndjson",
+                    null,
+                    new HashMap<>(Map.of("format", "ndjson")),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM ndjson_mv_coerce | KEEP vals | LIMIT 10"), TIMEOUT)) {
+            assertThat(response.columns().get(0).outputType(), equalTo("long"));
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(2));
+            // The 3-element position keeps all three elements, each coerced to long.
+            assertThat(rows.get(0).get(0), equalTo(List.of(10L, 20L, 30L)));
+            assertThat(rows.get(1).get(0), equalTo(40L)); // single-element position renders as a scalar
+        }
+    }
+
+    /**
+     * A view whose body targets a dataset carrying a DECLARED mapping: the declared coercion must survive view
+     * inlining (view resolution rewrites the inlined leaf into the external relation, which must keep the mapping —
+     * a dropped mapping here would silently read the file's physical type instead of the declared one).
+     */
+    public void testViewOverMappedDatasetPreservesCoercion() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("d.csv"), "val:integer\n100\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("val", new DatasetFieldMapping("long", null)); // declare integer file column as long
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "mapped_ds_for_view",
+                    "local_ds",
+                    root.toUri() + "*.csv",
+                    null,
+                    new HashMap<>(Map.of("format", "csv")),
+                    mapping
+                )
+            )
+        );
+        assertAcked(client().execute(PutViewAction.INSTANCE, putViewRequest("mapped_dataset_view", "FROM mapped_ds_for_view")));
+
+        try (var response = run(syncEsqlQueryRequest("FROM mapped_dataset_view | KEEP val | LIMIT 1"), TIMEOUT)) {
+            assertThat("declared type must survive view inlining", response.columns().get(0).outputType(), equalTo("long"));
+            assertThat(getValuesList(response).get(0).get(0), equalTo(100L));
+        }
+    }
+
+    /**
+     * A dataset carrying a DECLARED mapping used inside a subquery ({@code FROM (FROM mapped)}): the declared
+     * coercion must survive the subquery planning rewrite, not just a top-level {@code FROM}.
+     */
+    public void testSubqueryOverMappedDatasetPreservesCoercion() throws Exception {
+        Path root = createTempDir();
+        Files.writeString(root.resolve("d.csv"), "val:integer\n100\n");
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("val", new DatasetFieldMapping("long", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "mapped_ds_for_subquery",
+                    "local_ds",
+                    root.toUri() + "*.csv",
+                    null,
+                    new HashMap<>(Map.of("format", "csv")),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM (FROM mapped_ds_for_subquery) | KEEP val | LIMIT 1"), TIMEOUT)) {
+            assertThat("declared type must survive the subquery rewrite", response.columns().get(0).outputType(), equalTo("long"));
+            assertThat(getValuesList(response).get(0).get(0), equalTo(100L));
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
@@ -318,6 +318,159 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
     }
 
     /**
+     * A physical DOUBLE column declared {@code long}/{@code integer} rounds like {@code ::long}/{@code ::integer}
+     * (not truncates) — the "declared read is value-identical to the cast engine" claim, exercised for a numeric
+     * (non-string) source. {@code testDeclaredNumericReadMatchesCastEngineRounding} only proves it for strings.
+     */
+    public void testCastDoubleToLongAndIntegerRounds() {
+        try (
+            Block src = blockFactory.newDoubleArrayVector(new double[] { 2.5, -1.9, 1000.0 }, 3).asBlock();
+            Block cast = castStrict(src, DataType.DOUBLE, DataType.LONG)
+        ) {
+            LongBlock l = (LongBlock) cast;
+            assertEquals(3L, l.getLong(0));   // 2.5 rounds to 3, not truncates to 2
+            assertEquals(-2L, l.getLong(1));  // -1.9 rounds to -2
+            assertEquals(1000L, l.getLong(2));
+        }
+        try (
+            Block src = blockFactory.newDoubleArrayVector(new double[] { 2.5, -2.6 }, 2).asBlock();
+            Block cast = castStrict(src, DataType.DOUBLE, DataType.INTEGER)
+        ) {
+            org.elasticsearch.compute.data.IntBlock i = (org.elasticsearch.compute.data.IntBlock) cast;
+            assertEquals(3, i.getInt(0));
+            assertEquals(-3, i.getInt(1));
+        }
+    }
+
+    /**
+     * Whole-number sources (integer/long, and the temporal epochs that surface as longs) coerce into
+     * {@code unsigned_long} — value-preserving, sign-flip-encoded. Only the string→unsigned_long arm was
+     * exercised before ({@code testCastStringToUnsignedLongSignFlipEncodes}).
+     */
+    public void testCastWholeNumberSourcesToUnsignedLong() {
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { 42L }, 1).asBlock();
+            Block cast = castStrict(src, DataType.LONG, DataType.UNSIGNED_LONG)
+        ) {
+            assertThat(NumericUtils.unsignedLongAsNumber(((LongBlock) cast).getLong(0)).longValue(), equalTo(42L));
+        }
+        try (
+            Block src = blockFactory.newIntArrayVector(new int[] { 7 }, 1).asBlock();
+            Block cast = castStrict(src, DataType.INTEGER, DataType.UNSIGNED_LONG)
+        ) {
+            assertThat(NumericUtils.unsignedLongAsNumber(((LongBlock) cast).getLong(0)).longValue(), equalTo(7L));
+        }
+        // A negative whole number has no unsigned representation: lenient nulls + warns, never a wrap-around value.
+        List<String> warnings = new ArrayList<>();
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { -1L }, 1).asBlock();
+            Block cast = DeclaredTypeCoercions.castBlock(
+                src,
+                DataType.LONG,
+                DataType.UNSIGNED_LONG,
+                null,
+                blockFactory,
+                "col",
+                capturing(warnings)
+            )
+        ) {
+            assertTrue("negative -> unsigned_long nulls the cell", cast.isNull(0));
+            assertThat(warnings, hasSize(1));
+        }
+    }
+
+    /**
+     * An {@code unsigned_long} source (values held sign-flip-encoded in a LongBlock, including magnitudes above
+     * {@code 2^63}) coerces to double and to keyword, rendering the true unsigned magnitude. This drives the
+     * {@code converterFor(UNSIGNED_LONG, …)} arms on the BigInteger the decode produces.
+     */
+    public void testCastUnsignedLongSourcesToDoubleAndKeyword() {
+        long big = NumericUtils.asLongUnsigned(new BigInteger("18446744073709551610")); // 2^64 - 6, above 2^63
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { big }, 1).asBlock();
+            Block cast = castStrict(src, DataType.UNSIGNED_LONG, DataType.KEYWORD)
+        ) {
+            assertThat(((BytesRefBlock) cast).getBytesRef(0, new BytesRef()).utf8ToString(), equalTo("18446744073709551610"));
+        }
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { big }, 1).asBlock();
+            Block cast = castStrict(src, DataType.UNSIGNED_LONG, DataType.DOUBLE)
+        ) {
+            assertThat(((DoubleBlock) cast).getDouble(0), equalTo(new BigInteger("18446744073709551610").doubleValue()));
+        }
+    }
+
+    /**
+     * A whole-number source declared {@code datetime} is reinterpreted as epoch-millis (the non-string DATETIME
+     * arm), value-identical to a {@code long} read of the same token. Only the string→datetime arm was covered.
+     */
+    public void testCastIntegerAndLongToDatetimeUsesEpochMillis() {
+        try (
+            Block src = blockFactory.newIntArrayVector(new int[] { 42 }, 1).asBlock();
+            Block cast = castStrict(src, DataType.INTEGER, DataType.DATETIME)
+        ) {
+            assertEquals(42L, ((LongBlock) cast).getLong(0)); // epoch millis
+        }
+        long epochMillis = 1704067200000L;
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { epochMillis }, 1).asBlock();
+            Block cast = castStrict(src, DataType.LONG, DataType.DATETIME)
+        ) {
+            assertEquals(epochMillis, ((LongBlock) cast).getLong(0));
+        }
+    }
+
+    /**
+     * Temporal sources declared {@code double} yield the epoch value as a double — the untested temporal→double arm.
+     */
+    public void testCastTemporalToDouble() {
+        long epochMillis = 1704067200000L;
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { epochMillis }, 1).asBlock();
+            Block cast = castStrict(src, DataType.DATETIME, DataType.DOUBLE)
+        ) {
+            assertThat(((DoubleBlock) cast).getDouble(0), equalTo((double) epochMillis));
+        }
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { epochMillis }, 1).asBlock();
+            Block cast = castStrict(src, DataType.DATE_NANOS, DataType.DOUBLE)
+        ) {
+            assertThat(((DoubleBlock) cast).getDouble(0), equalTo((double) epochMillis));
+        }
+    }
+
+    /**
+     * The pairs {@link DeclaredTypeCoercions#fusedInDecode} claims as fusable are exactly the ones the columnar
+     * readers decode without boxing; pin the boxed {@link DeclaredTypeCoercions#castBlock} reference value for
+     * each so the fused fast path (exercised end-to-end in the per-format reader tests) has an authoritative
+     * value to match. This is the SPI-level half; {@code ParquetFormatReaderTests} drives the fused path itself.
+     */
+    public void testFusedPairsCastBlockReferenceValues() {
+        // integer -> long (lossless widen)
+        try (
+            Block src = blockFactory.newIntArrayVector(new int[] { 5, -7 }, 2).asBlock();
+            Block cast = castStrict(src, DataType.INTEGER, DataType.LONG)
+        ) {
+            assertTrue(DeclaredTypeCoercions.fusedInDecode(DataType.INTEGER, DataType.LONG));
+            assertEquals(5L, ((LongBlock) cast).getLong(0));
+            assertEquals(-7L, ((LongBlock) cast).getLong(1));
+        }
+        // long -> datetime (epoch-millis reinterpret, same bits)
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { 1704067200000L }, 1).asBlock();
+            Block cast = castStrict(src, DataType.LONG, DataType.DATETIME)
+        ) {
+            assertTrue(DeclaredTypeCoercions.fusedInDecode(DataType.LONG, DataType.DATETIME));
+            assertEquals(1704067200000L, ((LongBlock) cast).getLong(0));
+        }
+        // keyword <-> text (same bytes relabel)
+        try (Block src = bytesBlock("hello"); Block cast = castStrict(src, DataType.KEYWORD, DataType.TEXT)) {
+            assertTrue(DeclaredTypeCoercions.fusedInDecode(DataType.KEYWORD, DataType.TEXT));
+            assertThat(((BytesRefBlock) cast).getBytesRef(0, new BytesRef()).utf8ToString(), equalTo("hello"));
+        }
+    }
+
+    /**
      * The declared {@code boolean} read is STRICT and case-insensitive ({@code true}/{@code false} in
      * any case; every other token fails). This deliberately diverges from {@code ::boolean}, which maps
      * a non-{@code true} token silently to {@code false} — the read rejects the token loudly instead

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_dataset.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_dataset.yml
@@ -177,3 +177,50 @@ setup:
 
   # Counterpart assertion for the data source side: even if one existed, it would not appear here.
   - is_false: metadata.esql_datasource
+
+---
+"mappings-validator-rejections":
+  # Semantic validator rejections (DeclaredSchemaValidator) run inside validatePutDataset, after the parent data
+  # source is resolved — so create one, then assert an undeclarable type and a [format] on a non-date column are
+  # both rejected with an actionable message.
+  - requires:
+      capabilities:
+        - method: PUT
+          path: /_query/dataset/{name}
+          capabilities: [dataset_declared_schema]
+      test_runner_features: capabilities
+      reason: "declared mappings validation"
+
+  - do:
+      esql.put_data_source:
+        name: parent
+        body:
+          type: s3
+          settings:
+            auth: anonymous
+
+  - do:
+      catch: /unsupported declared type \[geo_point\] for column \[g\]/
+      esql.put_dataset:
+        name: ds
+        body:
+          data_source: parent
+          resource: "s3://x/*.csv"
+          mappings:
+            properties:
+              g: { type: geo_point }
+
+  - do:
+      catch: /\[format\] on column \[msg\] is only supported on \[date\] columns/
+      esql.put_dataset:
+        name: ds
+        body:
+          data_source: parent
+          resource: "s3://x/*.csv"
+          mappings:
+            properties:
+              msg: { type: keyword, format: "yyyy-MM-dd" }
+
+  - do:
+      esql.delete_data_source:
+        name: parent


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL: declared-schema coercion test coverage and related fixes (#153485)](https://github.com/elastic/elasticsearch/pull/153485)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)