### PR TITLE
Fix flaky PIT id check in PointInTimeRelocationIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -769,9 +769,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/153434
-- class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
-  method: testPointInTimeRelocationClosingSourceContexts
-  issue: https://github.com/elastic/elasticsearch/issues/153452
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-multifile-resolution.ubnSalaryStats [ndjson.zstd/AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/153470

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
@@ -765,9 +765,11 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
         ensureGreen(indexName);
         logger.info("Search node " + searchNodeCurrent + " excluded.");
 
-        // PIT id should have changed at some point, and all contexts on the source node should be closed
+        // All contexts on the source node should be closed once the shard has relocated away.
         waitForNoPITContextOnNode(searchNodeCurrent, 5);
-        assertFalse("pit1 should have changed.", isEquivalentId(pitId1.get(), testDataSetup.pitId1));
+        // pitId1 is updated asynchronously by the search threads, so it can briefly still hold the
+        // pre-relocation id even after the source node's contexts are gone; retry until it catches up.
+        assertBusy(() -> assertFalse("pit1 should have changed.", isEquivalentId(pitId1.get(), testDataSetup.pitId1)), 5, TimeUnit.SECONDS);
 
         thread1Running.set(false);
         thread2Running.set(false);


### PR DESCRIPTION
The test waits for a search node's PIT contexts to close, then checks that a shared `pitId1` value changed to the new node. The wait only checks a server side signal, while `pitId1` is set later by background threads once their next search response comes back. The server signal can fire before the threads catch up, so the check can run against the old value and fail. This wraps the check in `assertBusy` with the same 5 second budget already used for the context count wait, so it tolerates that small delay instead of checking once right away.

Closes #153452