### PR TITLE
docs: add typed-es in community references

### DIFF
--- a/docs/reference/community-contributed/index.md
+++ b/docs/reference/community-contributed/index.md
@@ -66,6 +66,8 @@ Also see the [official Elasticsearch Java client](elasticsearch-java://reference
 
 See the [official Elasticsearch JavaScript client](elasticsearch-js://reference/index.md).
 
+* [typed-es](https://github.com/Vahor/typed-es): Extension for the official Elasticsearch JavaScript client, adding automatic TypeScript response type inference, directly from the query you pass in.
+
 ## Julia [julia]
 
 * [ElasticsearchClient.jl](https://github.com/OpenSesame/ElasticsearchClient.jl): Elasticsearch client inspired by the [official Elasticsearch Ruby client](elasticsearch-ruby://reference/index.md).


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅ 
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? ✅ 

Made a library last year [typed-es](https://github.com/Vahor/typed-es) as I didn't want to use `as any` or maintain types manually on each query. This is a type-only library that does not change any of the current behavior, it only adds types by inferring the search query.

Since last-year I made many improvements and made sure each use-case were correct. I'm using this lib daily. 

I think this can be useful for many.

Happy to answer any questions.
