### PR TITLE
Remove flaky search in SearchableSnapshotsCanMatchOnCoordinatorIntegTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -799,9 +799,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
   method: testRateGroupByNothing
   issue: https://github.com/elastic/elasticsearch/issues/153559
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsCanMatchOnCoordinatorIntegTests
-  method: testLogsDBSearchableSnapshotShardsThatHaveMatchingDataAreNotSkippedOnTheCoordinatingNode
-  issue: https://github.com/elastic/elasticsearch/issues/153564
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesIT
   method: test {csv-spec:k8s-timeseries.firstAndLastWithNullSort}
   issue: https://github.com/elastic/elasticsearch/issues/153565

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.searchablesnapshots;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchShardsGroup;
 import org.elasticsearch.action.search.SearchShardsRequest;
 import org.elasticsearch.action.search.SearchShardsResponse;
@@ -840,20 +839,8 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         SearchRequest request = new SearchRequest().indices(searchableSnapshotIndexWithinSearchRange)
             .source(new SearchSourceBuilder().query(rangeQuery));
 
-        // All shards failed, since all shards are unassigned and the IndexMetadata min/max timestamp
-        // is not available yet
-        expectThrows(SearchPhaseExecutionException.class, () -> {
-            SearchResponse response = client().search(request).actionGet();
-            logger.info(
-                "[TEST DEBUG INFO] Search hits: {} Successful shards: {}, failed shards: {}, skipped shards: {}, total shards: {}",
-                response.getHits().getTotalHits().value(),
-                response.getSuccessfulShards(),
-                response.getFailedShards(),
-                response.getSkippedShards(),
-                response.getTotalShards()
-            );
-            fail("This search call is expected to throw an exception but it did not");
-        });
+        // Deliberately no full search here: against recovering shards it can block on
+        // IndexShard#waitForSearchReady.
 
         // test with SearchShards API
         boolean allowPartialSearchResults = false;


### PR DESCRIPTION
This removes the first full search assertion in the shared helper of `SearchableSnapshotsCanMatchOnCoordinatorIntegTests`, which could hang the whole suite.

The test blocks the repository so the mounted searchable snapshot shards never finish recovering, then runs a search expecting it to fail fast. Since #146378 a search sent to a shard that is still initializing waits for it to become search-ready instead of failing. When the shards happen to be initializing at that moment (rare timing) the search parks and never returns, so the test hangs until the suite timeout. Most runs pass because the shards are usually still unassigned when the search runs, which is why this failed only rarely.

Removing the assertion is safe: it expected the old fast-fail behavior that #146378 intentionally changed, the "shards are not skipped on the coordinator" property is still verified by the SearchShards API right below it, and a full search against unavailable shards is still covered later once the node holding them is stopped.

Closes #153564