### PR TITLE
Push down TopN into count aggregation

### DIFF
--- a/docs/changelog/153615.yaml
+++ b/docs/changelog/153615.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153615
+summary: Push down TopN into count aggregation
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountGroupingAggregatorFunction.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import org.apache.lucene.util.PriorityQueue;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -21,6 +23,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class CountGroupingAggregatorFunction implements GroupingAggregatorFunction {
@@ -306,6 +309,57 @@ public class CountGroupingAggregatorFunction implements GroupingAggregatorFuncti
                 }
             }
             blocks[offset] = builder.build().asBlock();
+        }
+    }
+
+    @Override
+    public IntVector selectTopN(IntVector selected, int limit, boolean asc) {
+        int positionCount = selected.getPositionCount();
+        if (positionCount <= limit) {
+            selected.incRef();
+            return selected;
+        }
+        record GroupIdAndCount(int groupId, long count) {
+
+        }
+        long usedBytes = ((long) RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2L + Long.BYTES + Integer.BYTES + Integer.BYTES) * limit;
+        driverContext.blockFactory().adjustBreaker(usedBytes);
+        try {
+            final PriorityQueue<GroupIdAndCount> pq;
+            if (asc) {
+                pq = new PriorityQueue<>(limit) {
+                    @Override
+                    protected boolean lessThan(GroupIdAndCount a, GroupIdAndCount b) {
+                        return a.count > b.count;
+                    }
+                };
+            } else {
+                pq = new PriorityQueue<>(limit) {
+                    @Override
+                    protected boolean lessThan(GroupIdAndCount a, GroupIdAndCount b) {
+                        return a.count < b.count;
+                    }
+                };
+            }
+            for (int i = 0; i < positionCount; i++) {
+                final int groupId = selected.getInt(i);
+                final long count = groupId < counts.size() ? counts.get(groupId) : 0L;
+                pq.insertWithOverflow(new GroupIdAndCount(groupId, count));
+            }
+            final int[] topGroupIds = new int[pq.size()];
+            int idx = 0;
+            for (GroupIdAndCount groupIdAndCount : pq) {
+                topGroupIds[idx++] = groupIdAndCount.groupId;
+            }
+            // sort the new selected
+            Arrays.sort(topGroupIds);
+            IntVector vector = driverContext.blockFactory().newIntArrayVector(topGroupIds, topGroupIds.length, usedBytes);
+            usedBytes = 0;
+            return vector;
+        } finally {
+            if (usedBytes > 0) {
+                driverContext.blockFactory().adjustBreaker(-usedBytes);
+            }
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunction.java
@@ -142,6 +142,11 @@ public record FilteredGroupingAggregatorFunction(GroupingAggregatorFunction next
     }
 
     @Override
+    public IntVector selectTopN(IntVector selected, int limit, boolean asc) {
+        return next.selectTopN(selected, limit, asc);
+    }
+
+    @Override
     public int intermediateBlockCount() {
         return next.intermediateBlockCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunction.java
@@ -211,6 +211,21 @@ public interface GroupingAggregatorFunction extends Releasable {
      */
     PreparedForEvaluation prepareEvaluateFinal(IntVector selected, GroupingAggregatorEvaluationContext ctx);
 
+    /**
+     * Selects the top-N groups from {@code selected}, ranked by this aggregation's values.
+     * This method is optional and a grouping aggregation function can freely return the input {@code selected}.
+     * The caller needs to release the returned selected in either case.
+     *
+     * @param selected the groupIds that have been selected to be included in the results
+     * @param limit    the N top values
+     * @param asc      sorted ascending or descending?
+     * @return a subset of {@code selected}
+     */
+    default IntVector selectTopN(IntVector selected, int limit, boolean asc) {
+        selected.incRef();
+        return selected;
+    }
+
     /** The number of blocks used by intermediate state. */
     int intermediateBlockCount();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesNextPreparedForEmitting.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesNextPreparedForEmitting.java
@@ -57,7 +57,6 @@ public class ValuesNextPreparedForEmitting implements Releasable {
     }
 
     private final BlockFactory blockFactory;
-    private final IntVector selected;
     private final int min;
     private final int max;
     private int[] selectedCounts;
@@ -66,7 +65,6 @@ public class ValuesNextPreparedForEmitting implements Releasable {
 
     private ValuesNextPreparedForEmitting(BlockFactory blockFactory, IntVector selected) {
         this.blockFactory = blockFactory;
-        this.selected = selected;
         this.min = selected.min();
         this.max = selected.max();
     }
@@ -153,10 +151,10 @@ public class ValuesNextPreparedForEmitting implements Releasable {
      */
     private int total() {
         int total = 0;
-        for (int s = 0; s < selected.getPositionCount(); s++) {
-            int group = selected.getInt(s);
-            int count = -selectedCounts[group - min];
-            selectedCounts[group - min] = total;
+        for (int group = min; group <= max; group++) {
+            int g = group - min;
+            int count = -selectedCounts[g];
+            selectedCounts[g] = total;
             total += count;
         }
         return total;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -166,6 +166,8 @@ public class HashAggregationOperator implements Operator {
     public static final int DEFAULT_PARTIAL_EMIT_KEYS_THRESHOLD = 100_000;
     public static final double DEFAULT_PARTIAL_EMIT_UNIQUENESS_THRESHOLD = 0.1;
 
+    public record TopAggregation(int aggregatorIndex, boolean asc, int limit) {}
+
     /**
      * Builder for {@link HashAggregationOperator}. {@link #groups(List)}, {@link #mode(AggregatorMode)},
      * and {@link #aggregators(List)} are required. The other parameters default to reasonable values
@@ -180,6 +182,7 @@ public class HashAggregationOperator implements Operator {
         private int maxPageSize = Operator.TARGET_PAGE_SIZE / Long.SIZE;
         private int aggregationBatchSize = Operator.TARGET_PAGE_SIZE / Long.SIZE;
         private AnalysisRegistry analysisRegistry;
+        private TopAggregation topAggregation;
 
         public Builder groups(List<BlockHash.GroupSpec> groups) {
             this.groups = groups;
@@ -217,6 +220,11 @@ public class HashAggregationOperator implements Operator {
             return this;
         }
 
+        public Builder topAggregation(TopAggregation topAggregation) {
+            this.topAggregation = topAggregation;
+            return this;
+        }
+
         public Factory build() {
             return new Factory(this);
         }
@@ -231,6 +239,7 @@ public class HashAggregationOperator implements Operator {
         private final int maxPageSize;
         private final int aggregationBatchSize;
         private final AnalysisRegistry analysisRegistry;
+        private final TopAggregation topAggregation;
 
         protected Factory(Builder builder) {
             this.groups = requireNonNull(builder.groups, "groups");
@@ -241,6 +250,7 @@ public class HashAggregationOperator implements Operator {
             this.maxPageSize = builder.maxPageSize;
             this.aggregationBatchSize = builder.aggregationBatchSize;
             this.analysisRegistry = builder.analysisRegistry;
+            this.topAggregation = builder.topAggregation;
         }
 
         @Override
@@ -262,6 +272,7 @@ public class HashAggregationOperator implements Operator {
                     Integer.MAX_VALUE, // disable partial emit for CATEGORIZE. it doesn't support it.
                     1.0,
                     Integer.MAX_VALUE, // disable splitting aggs pages for CATEGORIZE. it doesn't support it.
+                    topAggregation,
                     driverContext
                 );
             }
@@ -272,6 +283,7 @@ public class HashAggregationOperator implements Operator {
                 partialEmitKeysThreshold,
                 partialEmitUniquenessThreshold,
                 maxPageSize,
+                topAggregation,
                 driverContext
             );
         }
@@ -337,6 +349,8 @@ public class HashAggregationOperator implements Operator {
 
     protected long emitCount;
 
+    private final TopAggregation topAggregation;
+
     protected long rowsAddedInCurrentBatch;
 
     /**
@@ -351,6 +365,7 @@ public class HashAggregationOperator implements Operator {
         int partialEmitKeysThreshold,
         double partialEmitUniquenessThreshold,
         int maxPageSize,
+        TopAggregation topAggregation,
         DriverContext driverContext
     ) {
         if (partialEmitKeysThreshold <= 0) {
@@ -364,6 +379,7 @@ public class HashAggregationOperator implements Operator {
         this.aggregatorFactories = aggregatorFactories;
         this.blockHashSupplier = blockHashSupplier;
         this.aggregators = new ArrayList<>();
+        this.topAggregation = topAggregation;
         boolean success = false;
         try {
             this.blockHash = blockHashSupplier.get();
@@ -852,7 +868,17 @@ public class HashAggregationOperator implements Operator {
             List<GroupingAggregatorFunction.PreparedForEvaluation> preparedAggregators = new ArrayList<>(count);
             boolean success = false;
             try {
-                selected = new Selected(blockHash.nonEmpty(), new IntVector[count]);
+                final IntVector keys;
+                if (aggregatorMode.isOutputPartial() == false && topAggregation != null) {
+                    try (var allKeys = blockHash.nonEmpty()) {
+                        keys = aggregators.get(topAggregation.aggregatorIndex())
+                            .aggregatorFunction()
+                            .selectTopN(allKeys, topAggregation.limit(), topAggregation.asc());
+                    }
+                } else {
+                    keys = blockHash.nonEmpty();
+                }
+                selected = new Selected(keys, new IntVector[count]);
                 for (int a = 0; a < count; a++) {
                     selected.aggs[a] = customizeSelected(aggregators.get(a), selected.keys);
                     preparedAggregators.add(aggregators.get(a).prepareForEvaluate(selected.aggs[a], ctx));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -166,6 +166,7 @@ public class HashAggregationOperator implements Operator {
     public static final int DEFAULT_PARTIAL_EMIT_KEYS_THRESHOLD = 100_000;
     public static final double DEFAULT_PARTIAL_EMIT_UNIQUENESS_THRESHOLD = 0.1;
 
+    // TODO: Push down LIMIT only
     public record TopAggregation(int aggregatorIndex, boolean asc, int limit) {}
 
     /**
@@ -870,6 +871,7 @@ public class HashAggregationOperator implements Operator {
             try {
                 final IntVector keys;
                 if (aggregatorMode.isOutputPartial() == false && topAggregation != null) {
+                    // push down TopN by selecting a subset of keys
                     try (var allKeys = blockHash.nonEmpty()) {
                         keys = aggregators.get(topAggregation.aggregatorIndex())
                             .aggregatorFunction()

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -150,7 +150,7 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         int targetChunkRows,
         DriverContext driverContext
     ) {
-        super(aggregatorMode, aggregators, blockHash, Integer.MAX_VALUE, 1.0, targetChunkRows, driverContext);
+        super(aggregatorMode, aggregators, blockHash, Integer.MAX_VALUE, 1.0, targetChunkRows, null, driverContext);
         this.timeBucket = timeBucket;
         this.timeResolution = timeResolution;
         this.outputTimeBucket = outputTimeBucket;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesCollapseOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesCollapseOperator.java
@@ -189,7 +189,7 @@ public class TimeSeriesCollapseOperator extends HashAggregationOperator {
         Supplier<BlockHash> blockHash,
         DriverContext driverContext
     ) {
-        super(AggregatorMode.SINGLE, aggregators(state), blockHash, Integer.MAX_VALUE, 1.0, maxPageSize, driverContext);
+        super(AggregatorMode.SINGLE, aggregators(state), blockHash, Integer.MAX_VALUE, 1.0, maxPageSize, null, driverContext);
         this.groups = groups;
         this.valueChannel = valueChannel;
         this.stepChannel = stepChannel;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -2067,6 +2067,80 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    public void testPushTopNToAggregate() {
+        String indexName = "test-pushdown-topn";
+        assertAcked(client().admin().indices().prepareCreate(indexName).setMapping("value", "type=long", "tag", "type=keyword"));
+        Map<String, Long> counts = new HashMap<>();
+        Map<String, Double> sums = new HashMap<>();
+        int numDocs = between(10, 500);
+        BulkRequestBuilder bulk = client().prepareBulk();
+        for (int i = 0; i < numDocs; i++) {
+            String tag = "tag-" + randomIntBetween(10, 50);
+            int value = randomIntBetween(1, 1000);
+            bulk.add(new IndexRequest(indexName).id("1" + i).source("value", value, "tag", tag));
+            counts.merge(tag, 1L, Long::sum);
+            sums.merge(tag, (double) value, Double::sum);
+        }
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        int limit = between(1, 100);
+        boolean asc = randomBoolean();
+        var request = syncEsqlQueryRequest(
+            "FROM test-pushdown-topn | STATS c = COUNT(*), avg = AVG(value) BY tag | SORT c " + (asc ? "ASC" : "DESC") + " | LIMIT " + limit
+        ).profile(true);
+        Comparator<Long> ordering = asc ? Comparator.naturalOrder() : Comparator.reverseOrder();
+        List<Long> expectedTopCounts = counts.values().stream().sorted(ordering).limit(limit).toList();
+        try (var result = run(request)) {
+            List<List<Object>> rows = getValuesList(result);
+            int expectedRows = Math.min(limit, counts.size());
+            assertThat(rows, hasSize(expectedRows));
+            Long previousCount = null;
+            for (List<Object> row : rows) {
+                long c = ((Number) row.get(0)).longValue();
+                double avg = ((Number) row.get(1)).doubleValue();
+                String tag = (String) row.get(2);
+                if (previousCount != null) {
+                    assertThat(
+                        "rows must be sorted by count " + (asc ? "asc" : "desc"),
+                        ordering.compare(previousCount, c),
+                        lessThanOrEqualTo(0)
+                    );
+                }
+                previousCount = c;
+                assertThat("count mismatch for tag " + tag, c, equalTo(counts.get(tag)));
+                assertEquals("avg mismatch for tag " + tag, sums.get(tag) / counts.get(tag), avg, 0.01);
+            }
+            // the returned groups must be exactly the true top-N groups by count
+            List<Long> actualCounts = rows.stream().map(r -> ((Number) r.get(0)).longValue()).sorted(ordering).toList();
+            assertThat(actualCounts, equalTo(expectedTopCounts));
+
+            EsqlQueryResponse.Profile profile = result.profile();
+            assertNotNull(profile);
+            DriverProfile finalDriver = profile.drivers().stream().filter(d -> d.description().contains("final")).findFirst().get();
+            HashAggregationOperator.Status status = finalDriver.operators()
+                .stream()
+                .filter(o -> o.status() instanceof HashAggregationOperator.Status)
+                .map(o -> (HashAggregationOperator.Status) o.status())
+                .findFirst()
+                .get();
+            assertThat(status.rowsEmitted(), equalTo((long) expectedRows));
+        }
+        request = syncEsqlQueryRequest("""
+            FROM test-pushdown-topn | STATS c = COUNT(*), avg = AVG(value) BY tag | WHERE avg > 100 | SORT c DESC | LIMIT
+            """ + limit).profile(true);
+        try (var result = run(request)) {
+            EsqlQueryResponse.Profile profile = result.profile();
+            assertNotNull(profile);
+            DriverProfile finalDriver = profile.drivers().stream().filter(d -> d.description().contains("final")).findFirst().get();
+            HashAggregationOperator.Status status = finalDriver.operators()
+                .stream()
+                .filter(o -> o.status() instanceof HashAggregationOperator.Status)
+                .map(o -> (HashAggregationOperator.Status) o.status())
+                .findFirst()
+                .get();
+            assertThat(status.rowsEmitted(), equalTo((long) counts.size()));
+        }
+    }
+
     public void testLookupJoin() {
         Settings lookupSettings = Settings.builder().put("index.number_of_shards", 1).put("index.mode", "lookup").build();
         assertAcked(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
+import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountApproximate;
@@ -39,10 +40,13 @@ import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ExternalSourceAggregatePushdown;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
@@ -204,7 +208,7 @@ public abstract class AbstractPhysicalOperationProviders {
                 );
             } else {
                 QueryPragmas pragmas = context.queryPragmas();
-                operatorFactory = new HashAggregationOperator.Builder().groups(groupSpecs.stream().map(GroupSpec::toHashGroupSpec).toList())
+                var builder = new HashAggregationOperator.Builder().groups(groupSpecs.stream().map(GroupSpec::toHashGroupSpec).toList())
                     .mode(aggregatorMode)
                     .aggregators(aggregatorFactories)
                     .partialEmit(
@@ -213,8 +217,12 @@ public abstract class AbstractPhysicalOperationProviders {
                     )
                     .maxPageSize(maxPageSize)
                     .aggregationBatchSize(aggregationBatchSize)
-                    .analysisRegistry(analysisRegistry)
-                    .build();
+                    .analysisRegistry(analysisRegistry);
+                HashAggregationOperator.TopAggregation topAggregation = extractTopAggregation(aggregateExec, context);
+                if (topAggregation != null) {
+                    builder.topAggregation(topAggregation);
+                }
+                operatorFactory = builder.build();
             }
         }
         if (operatorFactory != null) {
@@ -411,6 +419,65 @@ public abstract class AbstractPhysicalOperationProviders {
     private static BlockHash.TopNDef extractPushedTopN(PhysicalPlan child) {
         ExternalSourceExec ext = ExternalSourceAggregatePushdown.findExternalSource(child);
         return ext == null ? null : ext.pushedTopN();
+    }
+
+    /**
+     * Extract the TopN that follows the aggregation, for example: {@code FROM .. | STATS c=COUNT(*), AVG(f) BY k | SORT c | LIMIT 10}.
+     * It's hard for the current optimization rules to keep these two nodes, {@link TopNExec} and {@link AggregateExec}, in sync as they
+     * can be rewritten independently; hence we detect the relation here instead, at the last step, when creating operators.
+     */
+    private static HashAggregationOperator.TopAggregation extractTopAggregation(
+        AggregateExec aggregateExec,
+        LocalExecutionPlannerContext context
+    ) {
+        if (aggregateExec.getMode().isOutputPartial()) {
+            return null;
+        }
+        TopNExec topN = context.lastVisitedTopN().get();
+        if (topN == null || topN.order().size() != 1) {
+            return null;
+        }
+        PhysicalPlan child = topN.child();
+        while (child != aggregateExec) {
+            if (child instanceof EvalExec eval) {
+                child = eval.child();
+            } else if (child instanceof ProjectExec project) {
+                child = project.child();
+            } else {
+                return null;
+            }
+        }
+        int limit = -1;
+        if (topN.limit().fold(context.foldCtx()) instanceof Number number) {
+            try {
+                limit = Math.toIntExact(number.longValue());
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        if (limit < 0) {
+            return null;
+        }
+        Order order = topN.order().getFirst();
+        if (topN.limit().foldable() == false) {
+            return null;
+        }
+        Attribute sortAttribute = Expressions.attribute(order.child());
+        if (sortAttribute == null) {
+            return null;
+        }
+        int aggregatorIndex = 0;
+        for (NamedExpression aggregate : aggregateExec.aggregates()) {
+            Expression unwrapped = Alias.unwrap(aggregate);
+            if (unwrapped instanceof AggregateFunction == false) {
+                continue;
+            }
+            if (aggregate.toAttribute().semanticEquals(sortAttribute)) {
+                return new HashAggregationOperator.TopAggregation(aggregatorIndex, order.direction() == Order.OrderDirection.ASC, limit);
+            }
+            aggregatorIndex++;
+        }
+        return null;
     }
 
     public abstract Operator.OperatorFactory timeSeriesAggregatorOperatorFactory(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -330,7 +330,8 @@ public class LocalExecutionPlanner {
             timeSeries,
             settings,
             shardContexts,
-            physicalOperationProviders.analysisRegistry()
+            physicalOperationProviders.analysisRegistry(),
+            new Holder<>()
         );
 
         // workaround for https://github.com/elastic/elasticsearch/issues/99782
@@ -780,6 +781,7 @@ public class LocalExecutionPlanner {
     }
 
     private PhysicalOperation planTopN(TopNExec topNExec, LocalExecutionPlannerContext context) {
+        context.lastVisitedTopN.set(topNExec);
         final Integer rowSize = topNExec.estimatedRowSize();
         PhysicalOperation source = plan(topNExec.child(), context);
         // Specialisation: a single-key sort over an ExternalSourceExec narrowed by
@@ -2267,7 +2269,8 @@ public class LocalExecutionPlanner {
         boolean timeSeries,
         Settings settings,
         IndexedByShardId<? extends ShardContext> shardContexts,
-        @Nullable AnalysisRegistry analysisRegistry
+        @Nullable AnalysisRegistry analysisRegistry,
+        Holder<TopNExec> lastVisitedTopN
     ) {
         void addDriverFactory(DriverFactory driverFactory) {
             driverFactories.add(driverFactory);


### PR DESCRIPTION
For queries like

```
FROM .. | STATS c=COUNT(*), ... BY k1, k2... | SORT c | LIMIT N
```

We can push down the TopN into the aggregation to avoid emitting a large number of keys and aggregated values. This skips the costly emit phase for large keys/values and the TopN time - even though TopN itself has been sped up significantly with ParallelTopN.

To keep the PR small, only the count aggregation supports this pushdown for now.

<img width="411" height="101" alt="q32" src="https://github.com/user-attachments/assets/f10602c4-8ec1-465d-a0c5-d8b0e1c54f5f" />