### PR TITLE
Complete listener and release region reference on gap completion

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
@@ -1379,27 +1380,26 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
             try {
                 incRefEnsureOpen();
                 try (RefCountingRunnable refs = new RefCountingRunnable(CacheFileRegion.this::decRef)) {
-                    final var gapsOpt = tracker.waitForRange(
-                        rangeToWrite,
-                        rangeToWrite,
-                        Assertions.ENABLED ? ActionListener.releaseAfter(ActionListener.running(() -> {
+                    final var claimed = new AtomicBoolean(false);
+                    final ActionListener<Void> rangeListener = ActionListener.notifyOnce(
+                        ActionListener.releaseAfter(listener.map(unused -> {
                             assert blobCacheService.regionOwners.get(nonVolatileIO()) == this;
-                        }), refs.acquire()) : refs.acquireListener()
+                            return claimed.get();
+                        }), refs.acquire())
                     );
+
+                    final var gapsOpt = tracker.waitForRange(rangeToWrite, rangeToWrite, rangeListener);
                     if (gapsOpt.isEmpty()) {
-                        listener.onResponse(false);
                         return;
                     }
                     executor.execute(new AbstractRunnable() {
-                        private final Releasable dispatchRef = refs.acquire();
-
                         @Override
                         protected void doRun() {
                             final List<SparseFileTracker.Gap> gaps = gapsOpt.get().claim();
                             if (gaps.isEmpty()) {
-                                listener.onResponse(false);
                                 return;
                             }
+                            claimed.set(true);
                             final SourceInputStreamFactory streamFactory = writer.sharedInputStreamFactory(gaps);
                             logger.trace(
                                 () -> Strings.format(
@@ -1408,30 +1408,21 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
                                     streamFactory == null ? "without" : "with"
                                 )
                             );
-                            final ActionListener<Void> gapsDoneListener = streamFactory != null
-                                ? ActionListener.releaseBefore(streamFactory, listener.map(unused -> true))
-                                : listener.map(unused -> true);
-                            try (var gapsListener = new RefCountingListener(gapsDoneListener)) {
+
+                            final Runnable gapsDoneRunnable = () -> {
+                                if (streamFactory != null) Releasables.closeWhileHandlingException(streamFactory);
+                            };
+                            try (var gapsListener = new RefCountingRunnable(gapsDoneRunnable)) {
                                 // Use current thread to fill the gaps in order
                                 for (SparseFileTracker.Gap gap : gaps) {
-                                    fillGapRunnable(
-                                        gap,
-                                        writer,
-                                        streamFactory,
-                                        ActionListener.releaseAfter(gapsListener.acquire(), refs.acquire())
-                                    ).run();
+                                    fillGapRunnable(gap, writer, streamFactory, gapsListener.acquireListener()).run();
                                 }
                             }
                         }
 
                         @Override
                         public void onFailure(Exception e) {
-                            listener.onFailure(e);
-                        }
-
-                        @Override
-                        public void onAfter() {
-                            dispatchRef.close();
+                            rangeListener.onFailure(e);
                         }
                     });
                 }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -63,6 +63,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -3485,6 +3486,70 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             // Exactly one caller claimed the gaps and wrote the data; the other got an empty claim
             assertThat(future1.get(10L, TimeUnit.SECONDS) || future2.get(10L, TimeUnit.SECONDS), is(true));
             assertThat(future1.get(10L, TimeUnit.SECONDS) && future2.get(10L, TimeUnit.SECONDS), is(false));
+            assertThat(bytesWritten.get(), equalTo(regionSize - 1));
+        }
+    }
+
+    public void testPopulateListenerShouldCompleteOnRangeFillFromAnotherThread() throws Exception {
+        final long regionSize = size(1L);
+        Settings settings = Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)))
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(regionSize))
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put("path.home", createTempDir())
+            .build();
+
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<>(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                BlobCacheMetrics.NOOP
+            )
+        ) {
+            final var cacheKey = generateCacheKey();
+            final var blobLength = size(12L);
+            final var entry = cacheService.get(cacheKey, blobLength, 0);
+            final AtomicLong bytesWritten = new AtomicLong(0L);
+            final RangeMissingHandler writer = (
+                channel,
+                channelPos,
+                streamFactory,
+                relativePos,
+                length,
+                progressUpdater,
+                completionListener) -> completeWith(completionListener, () -> {
+                    bytesWritten.addAndGet(length);
+                    progressUpdater.accept(length);
+                });
+
+            // The first caller's executor captures its task without running it, simulating a busy/blocked executor.
+            final AtomicReference<Runnable> blockedTask = new AtomicReference<>();
+            final Executor blockedExecutor = task -> assertTrue(blockedTask.compareAndSet(null, task));
+
+            final PlainActionFuture<Boolean> future1 = new PlainActionFuture<>();
+            entry.populate(ByteRange.of(0, regionSize - 1), writer, blockedExecutor, future1);
+            assertThat(blockedTask.get(), notNullValue());
+            assertThat(future1.isDone(), is(false));
+
+            // The second caller uses a free executor and runs immediately, claiming and filling the gap first.
+            final PlainActionFuture<Boolean> future2 = new PlainActionFuture<>();
+            entry.populate(ByteRange.of(0, regionSize - 1), writer, EsExecutors.DIRECT_EXECUTOR_SERVICE, future2);
+            assertThat(safeGet(future2), is(true));
+            assertThat(bytesWritten.get(), equalTo(regionSize - 1));
+
+            // Range is filled which should complete the first future as well and release the region reference
+            assertThat(future1.isDone(), is(true));
+            assertThat(safeGet(future1), is(false));
+            assertThat(entry.refCount(), equalTo(1));
+
+            // Unblock the first caller's executor so it observes the gap was already claimed and filled, and to
+            // release the region reference it is still holding.
+            blockedTask.get().run();
             assertThat(bytesWritten.get(), equalTo(regionSize - 1));
         }
     }


### PR DESCRIPTION
IIUC, one goal of #150118 is to promptly complete the listener registered by one thread when the gaps are filled by another thread. This PR does that so that the listener completion and releasing of region reference do not have to wait until the task runs. Raising this PR as a draft in case my understanding is off.

Relates #150118