### PR TITLE
[9.5] Fix instability of SharedBlobCacheServiceTests.testFetchRegion (#153500)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -694,9 +694,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
-- class: org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTests
-  method: testFetchRegion
-  issue: https://github.com/elastic/elasticsearch/issues/153058
 - class: org.elasticsearch.xpack.transform.integration.TransformTaskFailedStateIT
   method: testStartFailedTransform
   issue: https://github.com/elastic/elasticsearch/issues/153065

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -2777,15 +2778,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             .put("path.home", createTempDir())
             .build();
 
-        final var bulkTaskCount = new AtomicInteger(0);
         final var threadPool = new TestThreadPool("test");
-        final var bulkExecutor = new StoppableExecutorServiceWrapper(threadPool.generic()) {
-            @Override
-            public void execute(Runnable command) {
-                super.execute(command);
-                bulkTaskCount.incrementAndGet();
-            }
-        };
 
         try (
             NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
@@ -2802,8 +2795,10 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 final var cacheKey = generateCacheKey();
                 assertEquals(5, cacheService.freeRegionCount());
                 final long blobLength = size(250); // 3 regions
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final AtomicLong bytesRead = new AtomicLong(0L);
                 final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+                final var bulkTaskCount = new AtomicInteger(0);
+                final var executionFinishedLatch = new CountDownLatch(1);
                 cacheService.fetchRegion(
                     cacheKey,
                     0,
@@ -2816,12 +2811,13 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             progressUpdater.accept(length);
                         }
                     ),
-                    bulkExecutor,
+                    bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                     true,
                     future
                 );
 
                 var fetched = future.get(10, TimeUnit.SECONDS);
+                safeAwait(executionFinishedLatch);
                 assertThat("Region has been fetched", fetched, is(true));
                 assertEquals(regionSize, bytesRead.get());
                 assertEquals(4, cacheService.freeRegionCount());
@@ -2834,10 +2830,12 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
                 final var cacheKey = generateCacheKey();
                 final long blobLength = regionSize * remainingFreeRegions;
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final AtomicLong bytesRead = new AtomicLong(0L);
 
                 final PlainActionFuture<Collection<Boolean>> future = new PlainActionFuture<>();
                 final var listener = new GroupedActionListener<>(remainingFreeRegions, future);
+                final var bulkTaskCount = new AtomicInteger(0);
+                final var executionFinishedLatch = new CountDownLatch(remainingFreeRegions);
                 for (int region = 0; region < remainingFreeRegions; region++) {
                     cacheService.fetchRegion(
                         cacheKey,
@@ -2851,17 +2849,18 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                                 progressUpdater.accept(length);
                             }
                         ),
-                        bulkExecutor,
+                        bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                         true,
                         listener
                     );
                 }
 
                 var results = future.get(10, TimeUnit.SECONDS);
+                safeAwait(executionFinishedLatch);
                 assertThat(results.stream().allMatch(result -> result), is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
-                assertEquals(1 + remainingFreeRegions, bulkTaskCount.get());
+                assertEquals(remainingFreeRegions, bulkTaskCount.get());
             }
             {
                 // cache fully used, no entry old enough to be evicted and force=false should not evict entries
@@ -2878,7 +2877,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             throw new AssertionError("should not be executed");
                         }
                     ),
-                    bulkExecutor,
+                    threadPool.generic(),
                     false,
                     future
                 );
@@ -2888,12 +2887,14 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             {
                 // cache fully used, but force=true, so the cache should evict regions to make space for the requested regions
                 assertEquals(0, cacheService.freeRegionCount());
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final AtomicLong bytesRead = new AtomicLong(0L);
                 final var cacheKey = generateCacheKey();
                 final PlainActionFuture<Collection<Boolean>> future = new PlainActionFuture<>();
-                var regionsToFetch = randomIntBetween(1, (int) (cacheSize / regionSize));
+                final var regionsToFetch = randomIntBetween(1, (int) (cacheSize / regionSize));
                 final var listener = new GroupedActionListener<>(regionsToFetch, future);
-                long blobLength = regionsToFetch * regionSize;
+                final long blobLength = regionsToFetch * regionSize;
+                final var bulkTaskCount = new AtomicInteger(0);
+                final var executionFinishedLatch = new CountDownLatch(regionsToFetch);
                 for (int region = 0; region < regionsToFetch; region++) {
                     cacheService.fetchRegion(
                         cacheKey,
@@ -2907,28 +2908,31 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                                 progressUpdater.accept(length);
                             }
                         ),
-                        bulkExecutor,
+                        bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                         true,
                         listener
                     );
                 }
 
                 var results = future.get(10, TimeUnit.SECONDS);
+                safeAwait(executionFinishedLatch);
                 assertThat(results.stream().allMatch(result -> result), is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
-                assertEquals(regionsToFetch + 5, bulkTaskCount.get());
+                assertEquals(regionsToFetch, bulkTaskCount.get());
             }
             {
+                final var bulkTaskCount = new AtomicInteger(0);
                 cacheService.computeDecay();
 
                 // We explicitly called computeDecay, meaning that some regions must have been demoted to level 0,
                 // therefore there should be enough room to fetch the requested range regardless of the force flag.
                 final var cacheKey = generateCacheKey();
                 assertEquals(0, cacheService.freeRegionCount());
-                long blobLength = randomLongBetween(1L, regionSize);
-                AtomicLong bytesRead = new AtomicLong(0L);
+                final long blobLength = randomLongBetween(1L, regionSize);
+                final AtomicLong bytesRead = new AtomicLong(0L);
                 final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+                final var executionFinishedLatch = new CountDownLatch(1);
                 cacheService.fetchRegion(
                     cacheKey,
                     0,
@@ -2941,12 +2945,13 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             progressUpdater.accept(length);
                         }
                     ),
-                    bulkExecutor,
+                    bulkExecutor(threadPool, bulkTaskCount, executionFinishedLatch),
                     randomBoolean(),
                     future
                 );
 
                 var fetched = future.get(10, TimeUnit.SECONDS);
+                safeAwait(executionFinishedLatch);
                 assertThat("Region has been fetched", fetched, is(true));
                 assertEquals(blobLength, bytesRead.get());
                 assertEquals(0, cacheService.freeRegionCount());
@@ -2954,6 +2959,23 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
         } finally {
             TestThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }
+    }
+
+    private static StoppableExecutorServiceWrapper bulkExecutor(
+        final TestThreadPool threadPool,
+        final AtomicInteger bulkTaskCount,
+        final CountDownLatch executionFinishedLatch
+    ) {
+        return new StoppableExecutorServiceWrapper(threadPool.generic()) {
+            @Override
+            public void execute(Runnable command) {
+                super.execute(() -> {
+                    command.run();
+                    executionFinishedLatch.countDown();
+                });
+                bulkTaskCount.incrementAndGet();
+            }
+        };
     }
 
     public void testMaybeFetchRange() throws Exception {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix instability of SharedBlobCacheServiceTests.testFetchRegion (#153500)