### PR TITLE
[8.19] [ML] Add exponential-backoff retry for AD job opening during system-initiated reassignments (#144478)

### DIFF
--- a/docs/changelog/144478.yaml
+++ b/docs/changelog/144478.yaml
@@ -1,0 +1,6 @@
+area: Machine Learning
+issues: []
+pr: 144478
+summary: Add exponential-backoff retry for AD job opening during system-initiated
+  reassignments
+type: enhancement

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AdJobRetryResilienceIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AdJobRetryResilienceIT.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.NodeRoles.addRoles;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests for the AD Job Retry Resilience feature.
+ *
+ * These tests verify key behaviors introduced by the retry resilience changes:
+ * <ol>
+ *   <li>The {@code xpack.ml.job_open_retry_timeout} cluster setting is correctly registered,
+ *       defaults to 60 minutes, and can be updated dynamically.</li>
+ *   <li>A basic smoke test: normal user-initiated job open/close still works end-to-end
+ *       (no regression from the retry mechanism).</li>
+ *   <li>System-initiated reassignment: when a node fails, the job reassigns and eventually
+ *       reopens on another node.</li>
+ *   <li>Index unavailability during reassignment: when ML indices are temporarily unavailable
+ *       during a system-initiated reassignment, retries eventually succeed after recovery.</li>
+ * </ol>
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class AdJobRetryResilienceIT extends BaseMlIntegTestCase {
+
+    /**
+     * Smoke test: verify that a normal user-initiated job open and close cycle still works
+     * correctly after the retry resilience changes (no regression).
+     */
+    public void testNormalJobOpenClose_smokeTest() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        ensureStableCluster(1);
+
+        String jobId = "retry-resilience-smoke-test-job";
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+
+        ensureYellow();
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+        awaitJobOpenedAndAssigned(jobId, null);
+
+        // Verify the job is OPENED
+        GetJobsStatsAction.Response statsResponse = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+            .actionGet();
+        assertThat(statsResponse.getResponse().results().get(0).getState(), equalTo(JobState.OPENED));
+
+        // Close the job
+        client().execute(CloseJobAction.INSTANCE, new CloseJobAction.Request(jobId)).actionGet();
+
+        // Verify the job is CLOSED
+        assertBusy(() -> {
+            GetJobsStatsAction.Response stats = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+                .actionGet();
+            assertThat(stats.getResponse().results().get(0).getState(), equalTo(JobState.CLOSED));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Verifies that after a node failure and job reassignment, the job eventually reopens.
+     * This exercises the retry resilience path (system-initiated reassignment) with the
+     * new retry infrastructure in place.
+     *
+     * This is a lightweight smoke test for the reassignment + retry path. The unit tests
+     * (OpenJobPersistentTasksExecutorTests) provide detailed behavioral coverage of the
+     * retry logic itself.
+     */
+    public void testJobReopensAfterNodeFailure() throws Exception {
+        // Need at least 2 nodes: one for the job to run on, another for failover.
+        // Use 2 nodes so the job can be reassigned when one goes down.
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        ensureStableCluster(2);
+
+        String jobId = "retry-resilience-failover-job";
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+
+        ensureYellow();
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+        String origNode = awaitJobOpenedAndAssigned(jobId, null);
+        assertNotNull(origNode);
+
+        setMlIndicesDelayedNodeLeftTimeoutToZero();
+        ensureGreen();
+
+        // Stop the node running the job; this triggers reassignment via the system-initiated path.
+        // The new OpenJobRetryableAction (with exponential backoff) will handle the reassignment.
+        internalCluster().stopNode(origNode);
+        ensureStableCluster(1);
+
+        // The job should eventually reopen on the remaining node via the retry path.
+        awaitJobOpenedAndAssigned(jobId, null);
+
+        // Verify the job is open and not stuck in a failure state
+        GetJobsStatsAction.Response stats = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+            .actionGet();
+        assertThat(stats.getResponse().results().get(0).getState(), equalTo(JobState.OPENED));
+    }
+
+    /**
+     * Verifies that when ML indices are temporarily unavailable during a system-initiated
+     * reassignment, the retry path eventually succeeds after the indices recover.
+     *
+     * Scenario: 3 nodes - state (holds .ml-state, .ml-anomalies-shared), config (holds .ml-config),
+     * and ml-only (runs the job). Job opens on ml-only. We stop state node (indices go red), then
+     * stop ml-only (job reassigns to config). Config's open attempts fail (state indices red).
+     * We update allocation to allow config, shards relocate, and the retry succeeds.
+     */
+    public void testJobReopensAfterIndexUnavailabilityDuringReassignment() throws Exception {
+        internalCluster().ensureAtMostNumDataNodes(0);
+
+        String stateNode = internalCluster().startNode(
+            Settings.builder()
+                .put("node.attr.ml-indices", "state-and-results")
+                .put(removeRoles(Set.of(DiscoveryNodeRole.ML_ROLE)))
+                .put(addRoles(Set.of(DiscoveryNodeRole.DATA_ROLE)))
+                .build()
+        );
+        ensureStableCluster(1);
+
+        String configNode = internalCluster().startNode(
+            Settings.builder()
+                .put("node.attr.ml-indices", "config")
+                .put(addRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)))
+                .build()
+        );
+        ensureStableCluster(2);
+
+        String mlOnlyNode = internalCluster().startNode(
+            Settings.builder()
+                .put("node.attr.ml-indices", "ml-only")
+                .put(addRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)))
+                .build()
+        );
+        ensureStableCluster(3);
+
+        // Create indices: state/results on state-and-results, config on config
+        indicesAdmin().prepareCreate(".ml-anomalies-shared-000001")
+            .setSettings(
+                Settings.builder()
+                    .put("index.routing.allocation.include.ml-indices", "state-and-results")
+                    .put("index.routing.allocation.exclude.ml-indices", "config,ml-only")
+                    .build()
+            )
+            .get();
+        indicesAdmin().prepareCreate(".ml-state")
+            .setSettings(
+                Settings.builder()
+                    .put("index.routing.allocation.include.ml-indices", "state-and-results")
+                    .put("index.routing.allocation.exclude.ml-indices", "config,ml-only")
+                    .build()
+            )
+            .get();
+        indicesAdmin().prepareCreate(".ml-config")
+            .setSettings(
+                Settings.builder()
+                    .put("index.routing.allocation.exclude.ml-indices", "state-and-results")
+                    .put("index.routing.allocation.include.ml-indices", "config")
+                    .build()
+            )
+            .get();
+
+        ClusterUpdateSettingsRequest timeoutRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
+        timeoutRequest.persistentSettings(Settings.builder().put(MachineLearning.JOB_OPEN_RETRY_TIMEOUT.getKey(), "2m").build());
+        client().admin().cluster().updateSettings(timeoutRequest).actionGet();
+
+        String jobId = "retry-resilience-index-unavailable-job";
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+
+        ensureYellow();
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+        String jobNode = awaitJobOpenedAndAssigned(jobId, null);
+        assertNotNull(jobNode);
+        // Job must run on mlOnlyNode so we can stop it and reassign to configNode (which has .ml-config)
+        org.junit.Assume.assumeTrue("job must run on ml-only node for this test; got " + jobNode, jobNode.equals(mlOnlyNode));
+
+        setMlIndicesDelayedNodeLeftTimeoutToZero();
+        ensureGreen();
+
+        // Stop state node first: .ml-state and .ml-anomalies-shared go red
+        internalCluster().stopNode(stateNode);
+        ensureStableCluster(2);
+
+        // Stop the node running the job: triggers reassignment to config node
+        internalCluster().stopNode(jobNode);
+        ensureStableCluster(1, configNode);
+
+        // Config node's open attempts fail (state indices red). Allow allocation to config so shards relocate.
+        indicesAdmin().prepareUpdateSettings(".ml-state", ".ml-anomalies-shared-000001")
+            .setSettings(Settings.builder().put("index.routing.allocation.include.ml-indices", "state-and-results,config").build())
+            .get();
+
+        // Wait for shards to allocate on the config node so GetJobsStats (used by awaitJobOpenedAndAssigned) can search the indices.
+        // Use a longer timeout than default ensureYellow (30s); on CI shard relocation after 2 node stops can take longer.
+        ensureGreen(TimeValue.timeValueMinutes(2), ".ml-state", ".ml-anomalies-shared-000001");
+
+        awaitJobOpenedAndAssigned(jobId, null);
+
+        GetJobsStatsAction.Response stats = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+            .actionGet();
+        assertThat(stats.getResponse().results().get(0).getState(), equalTo(JobState.OPENED));
+
+        ClusterUpdateSettingsRequest resetRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
+        resetRequest.persistentSettings(Settings.builder().putNull(MachineLearning.JOB_OPEN_RETRY_TIMEOUT.getKey()).build());
+        client().admin().cluster().updateSettings(resetRequest).actionGet();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -744,6 +744,55 @@ public class MachineLearning extends Plugin
     );
 
     /**
+     * Maximum total time to retry the job opening pipeline when a system-initiated reassignment encounters transient failures
+     * (e.g. during rolling upgrades). User-initiated opens are not retried. Minimum is 1 minute.
+     */
+    public static final Setting<TimeValue> JOB_OPEN_RETRY_TIMEOUT = Setting.timeSetting(
+        "xpack.ml.job_open_retry_timeout",
+        TimeValue.timeValueMinutes(60),
+        TimeValue.timeValueMinutes(1),
+        TimeValue.timeValueDays(365),
+        Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * The time that has to pass after scaling up, before scaling down is allowed.
+     * Note that the ML autoscaling has its own cooldown time to release the hardware.
+     */
+    public static final Setting<TimeValue> SCALE_UP_COOLDOWN_TIME = Setting.timeSetting(
+        "xpack.ml.trained_models.adaptive_allocations.scale_up_cooldown_time",
+        TimeValue.timeValueMinutes(5),
+        TimeValue.timeValueMinutes(1),
+        Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * The time interval without any requests that has to pass, before scaling down
+     * to zero allocations (in case min_allocations = 0). After this time interval
+     * without requests, the number of allocations is set to zero. When this time
+     * interval hasn't passed, the minimum number of allocations will always be
+     * larger than zero.
+     */
+    public static final Setting<TimeValue> SCALE_TO_ZERO_AFTER_NO_REQUESTS_TIME = Setting.timeSetting(
+        "xpack.ml.trained_models.adaptive_allocations.scale_to_zero_time",
+        TimeValue.timeValueHours(24),
+        TimeValue.timeValueMinutes(1),
+        Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    // These 3 settings enable parts of ML to be enabled or disabled at a more granular level than the entire plugin
+    public static final Setting<Boolean> ANOMALY_DETECTION_ENABLED = Setting.boolSetting("xpack.ml.ad.enabled", true, Property.NodeScope);
+    public static final Setting<Boolean> DATA_FRAME_ANALYTICS_ENABLED = Setting.boolSetting(
+        "xpack.ml.dfa.enabled",
+        true,
+        Property.NodeScope
+    );
+    public static final Setting<Boolean> NLP_ENABLED = Setting.boolSetting("xpack.ml.nlp.enabled", true, Property.NodeScope);
+
+    /**
      * Each model deployment results in one or more entries in the cluster state
      * for the model allocations. In order to prevent the cluster state from
      * potentially growing uncontrollably we impose a limit on the number of
@@ -817,6 +866,7 @@ public class MachineLearning extends Plugin
             MachineLearningField.USE_AUTO_MACHINE_MEMORY_PERCENT,
             MAX_ML_NODE_SIZE,
             DELAYED_DATA_CHECK_FREQ,
+            JOB_OPEN_RETRY_TIMEOUT,
             DUMMY_ENTITY_MEMORY,
             DUMMY_ENTITY_PROCESSORS
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.RetryableAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -30,7 +29,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.indices.InvalidAliasNameException;
-import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -38,7 +36,6 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
-import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.GetFiltersAction;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
@@ -78,6 +75,7 @@ import org.elasticsearch.xpack.ml.job.process.normalizer.ScoresUpdater;
 import org.elasticsearch.xpack.ml.job.process.normalizer.ShortCircuitingRenormalizer;
 import org.elasticsearch.xpack.ml.job.snapshot.upgrader.SnapshotUpgradeTask;
 import org.elasticsearch.xpack.ml.job.task.JobTask;
+import org.elasticsearch.xpack.ml.job.task.UpdateStateRetryableAction;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.process.NativeStorageProvider;
 
@@ -664,6 +662,12 @@ public class AutodetectProcessManager implements ClusterStateListener {
                             setJobState(jobTask, JobState.OPENED, null, e -> {
                                 if (e != null) {
                                     logSetJobStateFailure(JobState.OPENED, job.getId(), e);
+                                    auditor.warning(
+                                        job.getId(),
+                                        "Failed to set job state to OPENED. The job may be stuck in the OPENING state. "
+                                            + "It will recover automatically once the cluster master is available. Reason: "
+                                            + e.getMessage()
+                                    );
                                     if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
                                         // Don't leave a process with no persistent task hanging around
                                         processContext.newKillBuilder().setAwaitCompletion(false).setFinish(false).kill();
@@ -686,7 +690,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
             });
         }, e1 -> {
             logger.warn("Failed to gather information required to open job [" + job.getId() + "]", e1);
-            setJobState(jobTask, JobState.FAILED, e1.getMessage(), e2 -> closeHandler.accept(e1, true));
+            closeHandler.accept(e1, true);
         });
     }
 
@@ -1096,48 +1100,4 @@ public class AutodetectProcessManager implements ClusterStateListener {
         return ByteSizeValue.ofBytes(memoryUsedBytes);
     }
 
-    private static class UpdateStateRetryableAction extends RetryableAction<PersistentTasksCustomMetadata.PersistentTask<?>> {
-
-        private static final int MIN_RETRY_SLEEP_MILLIS = 500;
-        private final JobTask jobTask;
-        private final JobTaskState jobTaskState;
-
-        /**
-         * @param logger        The logger (use AutodetectProcessManager.logger)
-         * @param threadPool    The ThreadPool to schedule retries on
-         * @param jobTask       The JobTask whose state we’re updating
-         * @param jobTaskState  The new state to persist
-         */
-        UpdateStateRetryableAction(
-            Logger logger,
-            ThreadPool threadPool,
-            JobTask jobTask,
-            JobTaskState jobTaskState,
-            ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> delegateListener
-        ) {
-            super(
-                logger,
-                threadPool,
-                TimeValue.timeValueMillis(UpdateStateRetryableAction.MIN_RETRY_SLEEP_MILLIS),
-                MlTasks.PERSISTENT_TASK_MASTER_NODE_TIMEOUT,
-                delegateListener,
-                // executor for retries
-                threadPool.generic()
-            );
-            this.jobTask = Objects.requireNonNull(jobTask);
-            this.jobTaskState = Objects.requireNonNull(jobTaskState);
-        }
-
-        @Override
-        public void tryAction(ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> listener) {
-            // this will call back either onResponse(...) or onFailure(...)
-            jobTask.updatePersistentTaskState(jobTaskState, listener);
-        }
-
-        @Override
-        public boolean shouldRetry(Exception e) {
-            // retry everything *except* when the task truly no longer exists
-            return (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) == false;
-        }
-    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.engine.DocumentMissingException;
@@ -104,6 +105,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
     private final JobResultsProvider jobResultsProvider;
     private final AnomalyDetectionAuditor auditor;
     private final XPackLicenseState licenseState;
+    private final ClusterSettings clusterSettings;
 
     private volatile ClusterState clusterState;
 
@@ -125,6 +127,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         this.jobResultsProvider = new JobResultsProvider(client, settings, expressionResolver);
         this.auditor = auditor;
         this.licenseState = licenseState;
+        this.clusterSettings = clusterService.getClusterSettings();
         clusterService.addListener(event -> clusterState = event.state());
     }
 
@@ -242,21 +245,62 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         JobTask jobTask = (JobTask) task;
         jobTask.setAutodetectProcessManager(autodetectProcessManager);
         JobTaskState jobTaskState = (JobTaskState) state;
+
+        // This indicates a system-initiated reassignment as an opposite to a user-initiated open.
+        boolean isReassignment = jobTaskState != null && jobTaskState.getAllocationId() != task.getAllocationId();
+
+        if (isReassignment) {
+            // System-initiated reassignment: wrap the pipeline in retry logic with exponential backoff.
+            // The task was previously assigned; this is a reopen after node failure/upgrade.
+            createOpenJobRetryableAction(
+                jobTask,
+                jobTaskState,
+                params,
+                ActionListener.wrap(success -> { /* job is OPENED; state transition handled inside pipeline */ }, e -> {
+                    if (autodetectProcessManager.isNodeDying() == false) {
+                        failTask(jobTask, "failed after retries: " + e.getMessage());
+                    }
+                })
+            ).run();
+        } else {
+            // User-initiated (new open or fresh state): run pipeline directly (fail-fast on any error)
+            executeOpenJobPipeline(jobTask, jobTaskState, params, ActionListener.wrap(success -> { /* job is OPENED */ }, e -> {
+                if (autodetectProcessManager.isNodeDying() == false) {
+                    failTask(jobTask, e.getMessage());
+                }
+            }));
+        }
+    }
+
+    /**
+     * Executes the full job opening pipeline: mapping updates -> snapshot verification ->
+     * forecast cleanup -> datafeed check -> revert -> openJob.
+     *
+     * Errors are routed to {@code listener.onFailure()} rather than calling {@code failTask()}
+     * directly, so that the caller (e.g. {@link OpenJobRetryableAction}) can decide whether
+     * to retry or fail.
+     */
+    void executeOpenJobPipeline(
+        JobTask jobTask,
+        JobTaskState jobTaskState,
+        OpenJobAction.JobParams params,
+        ActionListener<Boolean> listener
+    ) {
         JobState jobState = jobTaskState == null ? null : jobTaskState.getState();
         ActionListener<Boolean> checkSnapshotVersionListener = ActionListener.wrap(
             mappingsUpdate -> jobResultsProvider.setRunningForecastsToFailed(
                 params.getJobId(),
-                ActionListener.wrap(r -> runJob(jobTask, jobState, params), e -> {
+                ActionListener.wrap(r -> runJob(jobTask, jobState, params, listener), e -> {
                     if (autodetectProcessManager.isNodeDying() == false) {
                         logger.warn(() -> "[" + params.getJobId() + "] failed to set forecasts to failed", e);
-                        runJob(jobTask, jobState, params);
+                        runJob(jobTask, jobState, params, listener);
                     }
                 })
             ),
             e -> {
                 if (autodetectProcessManager.isNodeDying() == false) {
                     logger.error(() -> "[" + params.getJobId() + "] Failed verifying snapshot version", e);
-                    failTask(jobTask, "failed snapshot verification; cause: " + e.getMessage());
+                    listener.onFailure(e);
                 }
             }
         );
@@ -266,12 +310,12 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
             e -> {
                 if (autodetectProcessManager.isNodeDying() == false) {
                     logger.error(() -> "[" + params.getJobId() + "] Failed to update results mapping", e);
-                    failTask(jobTask, "failed to update results mapping; cause: " + e.getMessage());
+                    listener.onFailure(e);
                 }
             }
         );
 
-        // We need to update the results index as we MAY update the current forecast results, setting the running forcasts to failed
+        // We need to update the results index as we MAY update the current forecast results, setting the running forecasts to failed
         // This writes to the results index, which might need updating
         ElasticsearchMappings.addDocMappingIfMissing(
             AnomalyDetectorsIndex.jobResultsAliasedName(params.getJobId()),
@@ -284,10 +328,22 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         );
     }
 
+    /**
+     * Factory method for {@link OpenJobRetryableAction}. Protected to allow test spies to intercept creation.
+     */
+    protected OpenJobRetryableAction createOpenJobRetryableAction(
+        JobTask jobTask,
+        JobTaskState jobTaskState,
+        OpenJobAction.JobParams params,
+        ActionListener<Boolean> listener
+    ) {
+        return new OpenJobRetryableAction(jobTask, jobTaskState, params, listener);
+    }
+
     // Exceptions that occur while the node is dying, i.e. after the JVM has received a SIGTERM,
     // are ignored. Core services will be stopping in response to the SIGTERM and we want the
     // job to try to open again on another node, not spuriously fail on the dying node.
-    private void runJob(JobTask jobTask, JobState jobState, OpenJobAction.JobParams params) {
+    private void runJob(JobTask jobTask, JobState jobState, OpenJobAction.JobParams params, ActionListener<Boolean> listener) {
         // If the node is already running its exit handlers then do nothing - shortly
         // the persistent task will get assigned to a new node and the code below will
         // run there instead.
@@ -319,41 +375,73 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
 
                 // This job has a running datafeed attached to it.
                 // In order to prevent gaps in the model we revert to the current snapshot deleting intervening results.
-                RevertToCurrentSnapshotAction revertToCurrentSnapshotAction = new RevertToCurrentSnapshotAction(
-                    jobTask,
-                    ActionListener.wrap(response -> openJob(jobTask), e -> {
-                        if (autodetectProcessManager.isNodeDying() == false) {
-                            logger.error(() -> "[" + jobTask.getJobId() + "] failed to revert to current snapshot", e);
-                            failTask(jobTask, "failed to revert to current snapshot");
-                        }
-                    })
-                );
-                revertToCurrentSnapshotAction.run();
+                revertToCurrentSnapshot(jobTask, ActionListener.wrap(response -> openJob(jobTask, listener), e -> {
+                    if (autodetectProcessManager.isNodeDying() == false) {
+                        logger.error(() -> "[" + jobTask.getJobId() + "] failed to revert to current snapshot", e);
+                        listener.onFailure(e);
+                    }
+                }));
             } else {
-                openJob(jobTask);
+                openJob(jobTask, listener);
             }
         }, e -> {
             if (autodetectProcessManager.isNodeDying() == false) {
                 logger.error(() -> "[" + jobTask.getJobId() + "] failed to search for associated datafeed", e);
-                failTask(jobTask, "failed to search for associated datafeed");
+                listener.onFailure(e);
             }
         });
 
         getRunningDatafeed(jobTask.getJobId(), getRunningDatafeedListener);
     }
 
-    private void failTask(JobTask jobTask, String reason) {
+    private void revertToCurrentSnapshot(JobTask jobTask, ActionListener<Boolean> listener) {
+        ActionListener<GetJobsAction.Response> jobListener = ActionListener.wrap(jobResponse -> {
+            List<Job> jobPage = jobResponse.getResponse().results();
+            assert jobPage.size() == 1;
+
+            String jobSnapshotId = jobPage.get(0).getModelSnapshotId();
+            if (jobSnapshotId == null) {
+                logger.info("[{}] job has running datafeed task; resetting as no snapshot exists", jobTask.getJobId());
+                ResetJobAction.Request request = new ResetJobAction.Request(jobTask.getJobId());
+                request.setSkipJobStateValidation(true);
+                request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+                request.ackTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+                executeAsyncWithOrigin(client, ML_ORIGIN, ResetJobAction.INSTANCE, request, listener.map(response -> true));
+            } else {
+                logger.info("[{}] job has running datafeed task; reverting to current snapshot", jobTask.getJobId());
+                RevertModelSnapshotAction.Request request = new RevertModelSnapshotAction.Request(jobTask.getJobId(), jobSnapshotId);
+                request.setForce(true);
+                request.setDeleteInterveningResults(true);
+                request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+                request.ackTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+                executeAsyncWithOrigin(client, ML_ORIGIN, RevertModelSnapshotAction.INSTANCE, request, listener.map(response -> true));
+            }
+        }, error -> listener.onFailure(ExceptionsHelper.serverError("[{}] error getting job", error, jobTask.getJobId())));
+
+        GetJobsAction.Request request = new GetJobsAction.Request(jobTask.getJobId());
+        request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
+        executeAsyncWithOrigin(client, ML_ORIGIN, GetJobsAction.INSTANCE, request, jobListener);
+    }
+
+    void failTask(JobTask jobTask, String reason) {
         String jobId = jobTask.getJobId();
         auditor.error(jobId, reason);
         JobTaskState failedState = new JobTaskState(JobState.FAILED, jobTask.getAllocationId(), reason, Instant.now());
-        jobTask.updatePersistentTaskState(failedState, ActionListener.wrap(r -> {
-            logger.debug("[{}] updated task state to failed", jobId);
-            stopAssociatedDatafeedForFailedJob(jobId);
-        }, e -> {
-            logger.error(() -> "[" + jobId + "] error while setting task state to failed; marking task as failed", e);
-            jobTask.markAsFailed(e);
-            stopAssociatedDatafeedForFailedJob(jobId);
-        }));
+        new UpdateStateRetryableAction(
+            logger,
+            client.threadPool(),
+            jobTask,
+            failedState,
+            clusterSettings.get(MachineLearning.JOB_OPEN_RETRY_TIMEOUT),
+            ActionListener.wrap(r -> {
+                logger.debug("[{}] updated task state to failed", jobId);
+                stopAssociatedDatafeedForFailedJob(jobId);
+            }, e -> {
+                logger.error(() -> "[" + jobId + "] failed to set task state to failed after retries", e);
+                jobTask.markAsFailed(e);
+                stopAssociatedDatafeedForFailedJob(jobId);
+            })
+        ).run();
     }
 
     private void stopAssociatedDatafeedForFailedJob(String jobId) {
@@ -464,102 +552,10 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
         executeAsyncWithOrigin(client, ML_ORIGIN, GetJobsAction.INSTANCE, request, jobListener);
     }
 
-    /**
-     * This action reverts a job to its current snapshot if one exists or resets the job.
-     * This action is retryable. As this action happens when a job is relocating to another node,
-     * it is common that this happens during rolling upgrades. During a rolling upgrade, it is
-     * probable that data nodes containing shards of the ML indices might not be available temporarily
-     * which results to failures in the revert/reset action. Thus, it is important to retry a few times
-     * so that the job manages to successfully recover without user intervention.
-     */
-    private class RevertToCurrentSnapshotAction extends RetryableAction<Boolean> {
-
-        private final JobTask jobTask;
-        private volatile boolean hasFailedAtLeastOnce;
-
-        private RevertToCurrentSnapshotAction(JobTask jobTask, ActionListener<Boolean> listener) {
-            super(
-                logger,
-                client.threadPool(),
-                // No need to wait before first execution
-                TimeValue.timeValueMillis(1),
-                // Retry for 15 minutes. This should be enough time for at least some replicas
-                // to be available so that and data deletion can succeed.
-                TimeValue.timeValueMinutes(15),
-                listener,
-                client.threadPool().executor(MachineLearning.UTILITY_THREAD_POOL_NAME)
-            );
-            this.jobTask = Objects.requireNonNull(jobTask);
-        }
-
-        @Override
-        public void tryAction(ActionListener<Boolean> listener) {
-            ActionListener<GetJobsAction.Response> jobListener = ActionListener.wrap(jobResponse -> {
-                List<Job> jobPage = jobResponse.getResponse().results();
-                // We requested a single concrete job so if it didn't exist we would get an error
-                assert jobPage.size() == 1;
-
-                String jobSnapshotId = jobPage.get(0).getModelSnapshotId();
-                if (jobSnapshotId == null
-                    // If the minimum TransportVersion is on or above ResetJobAction.TRANSPORT_VERSION_INTRODUCED then so must be
-                    // the version associated with the master node, which is what is required to perform this action
-                    && TransportVersionUtils.isMinTransportVersionOnOrAfter(clusterState, ResetJobAction.TRANSPORT_VERSION_INTRODUCED)) {
-                    logger.info("[{}] job has running datafeed task; resetting as no snapshot exists", jobTask.getJobId());
-                    ResetJobAction.Request request = new ResetJobAction.Request(jobTask.getJobId());
-                    request.setSkipJobStateValidation(true);
-                    request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
-                    request.ackTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
-                    executeAsyncWithOrigin(
-                        client,
-                        ML_ORIGIN,
-                        ResetJobAction.INSTANCE,
-                        request,
-                        ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure)
-                    );
-                } else {
-                    logger.info("[{}] job has running datafeed task; reverting to current snapshot", jobTask.getJobId());
-                    RevertModelSnapshotAction.Request request = new RevertModelSnapshotAction.Request(
-                        jobTask.getJobId(),
-                        jobSnapshotId == null ? ModelSnapshot.EMPTY_SNAPSHOT_ID : jobSnapshotId
-                    );
-                    request.setForce(true);
-                    request.setDeleteInterveningResults(true);
-                    request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
-                    request.ackTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
-                    executeAsyncWithOrigin(
-                        client,
-                        ML_ORIGIN,
-                        RevertModelSnapshotAction.INSTANCE,
-                        request,
-                        ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure)
-                    );
-                }
-            }, error -> listener.onFailure(ExceptionsHelper.serverError("[{}] error getting job", error, jobTask.getJobId())));
-
-            // We need to refetch the job in order to learn what is its current model snapshot
-            // as the one that exists in the task params is outdated.
-            GetJobsAction.Request request = new GetJobsAction.Request(jobTask.getJobId());
-            request.masterNodeTimeout(PERSISTENT_TASK_MASTER_NODE_TIMEOUT);
-            executeAsyncWithOrigin(client, ML_ORIGIN, GetJobsAction.INSTANCE, request, jobListener);
-        }
-
-        @Override
-        public boolean shouldRetry(Exception e) {
-            if (jobTask.isClosing() || jobTask.isVacating()) {
-                return false;
-            }
-            if (hasFailedAtLeastOnce == false) {
-                hasFailedAtLeastOnce = true;
-                logger.error(() -> "[" + jobTask.getJobId() + "] error reverting job to its current snapshot; attempting retry", e);
-            }
-            return true;
-        }
-    }
-
     // Exceptions that occur while the node is dying, i.e. after the JVM has received a SIGTERM,
     // are ignored. Core services will be stopping in response to the SIGTERM and we want the
     // job to try to open again on another node, not spuriously fail on the dying node.
-    private void openJob(JobTask jobTask) {
+    private void openJob(JobTask jobTask, ActionListener<Boolean> listener) {
         String jobId = jobTask.getJobId();
         autodetectProcessManager.openJob(jobTask, clusterState, PERSISTENT_TASK_MASTER_NODE_TIMEOUT, (e2, shouldFinalizeJob) -> {
             if (e2 == null) {
@@ -576,7 +572,10 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                         ML_ORIGIN,
                         FinalizeJobExecutionAction.INSTANCE,
                         finalizeRequest,
-                        ActionListener.wrap(response -> jobTask.markAsCompleted(), e -> {
+                        ActionListener.wrap(response -> {
+                            jobTask.markAsCompleted();
+                            listener.onResponse(true);
+                        }, e -> {
                             // This error is logged even if the node is dying. This is a nasty place for the node to get killed,
                             // as most of the job's close sequence has executed, just not the finalization step. The job will
                             // restart on a different node. If the coordinating node for the close request notices that the job
@@ -587,21 +586,24 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
                             Throwable unwrapped = ExceptionsHelper.unwrapCause(e);
                             if (unwrapped instanceof DocumentMissingException || unwrapped instanceof ResourceNotFoundException) {
                                 jobTask.markAsCompleted();
+                                listener.onResponse(true);
                             } else if (autodetectProcessManager.isNodeDying() == false) {
                                 // In this case we prefer to mark the task as failed, which means the job
                                 // will appear closed. The reason is that the job closed successfully and
                                 // we just failed to update some fields like the finish time. It is preferable
                                 // to let the job close than setting it to failed.
                                 jobTask.markAsFailed(e);
+                                listener.onFailure(e);
                             }
                         })
                     );
                 } else {
                     jobTask.markAsCompleted();
+                    listener.onResponse(true);
                 }
             } else if (autodetectProcessManager.isNodeDying() == false) {
                 logger.error(() -> "[" + jobTask.getJobId() + "] failed to open job", e2);
-                failTask(jobTask, "failed to open job: " + e2.getMessage());
+                listener.onFailure(e2);
             }
         });
     }
@@ -671,5 +673,56 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
     @Override
     protected String getJobId(OpenJobAction.JobParams params) {
         return params.getJobId();
+    }
+
+    /**
+     * Retries the entire job opening pipeline for system-initiated reassignments.
+     *
+     * Uses exponential backoff with:
+     * - Initial delay: 5 seconds
+     * - Max delay: 5 minutes
+     * - Total timeout: from {@link MachineLearning#JOB_OPEN_RETRY_TIMEOUT} (default 60 minutes)
+     *
+     * Only applies to reassignments (detected via {@link JobTaskState#isStatusStale(PersistentTask)}).
+     * User-initiated opens fail fast.
+     */
+    class OpenJobRetryableAction extends RetryableAction<Boolean> {
+
+        private final JobTask jobTask;
+        private final JobTaskState jobTaskState;
+        private final OpenJobAction.JobParams params;
+
+        OpenJobRetryableAction(
+            JobTask jobTask,
+            JobTaskState jobTaskState,
+            OpenJobAction.JobParams params,
+            ActionListener<Boolean> listener
+        ) {
+            super(
+                logger,
+                client.threadPool(),
+                TimeValue.timeValueSeconds(5),
+                TimeValue.timeValueMinutes(5),
+                clusterSettings.get(MachineLearning.JOB_OPEN_RETRY_TIMEOUT),
+                listener,
+                client.threadPool().generic()
+            );
+            this.jobTask = Objects.requireNonNull(jobTask);
+            this.jobTaskState = jobTaskState;
+            this.params = Objects.requireNonNull(params);
+        }
+
+        @Override
+        public void tryAction(ActionListener<Boolean> listener) {
+            executeOpenJobPipeline(jobTask, jobTaskState, params, listener);
+        }
+
+        @Override
+        public boolean shouldRetry(Exception e) {
+            if (jobTask.isClosing() || jobTask.isVacating()) {
+                return false;
+            }
+            return org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier.isRecoverable(e);
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/UpdateStateRetryableAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/UpdateStateRetryableAction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.task;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.RetryableAction;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
+
+import java.util.Objects;
+
+/**
+ * A {@link RetryableAction} that robustly persists a {@link JobTaskState} to cluster state.
+ *
+ * Retries on all exceptions except {@link ResourceNotFoundException}, which indicates the
+ * persistent task no longer exists and retrying would be pointless.
+ *
+ * Two timeout modes:
+ * <ul>
+ *   <li>Default (no timeout arg): uses {@link MlTasks#PERSISTENT_TASK_MASTER_NODE_TIMEOUT} (365 days) --
+ *       appropriate for long-running state transitions like OPENED where a native process is running.</li>
+ *   <li>Custom timeout: use for bounded transitions like FAILED during the opening phase (e.g. 60 minutes).</li>
+ * </ul>
+ *
+ * <p><b>Design decision: why different timeouts?</b> For FAILED, no native process is running; we are
+ * only recording the failure. A bounded timeout (e.g. 60 minutes) is acceptable: if the master is
+ * unavailable that long, we eventually fall back to {@code markAsFailed()}. For OPENED, a native
+ * process is already running and we must commit the state so cluster state matches reality. A bounded
+ * timeout would orphan the process (running process, cluster state stuck in OPENING). We therefore
+ * use an effectively unbounded timeout (365 days) for OPENED so we keep retrying until the master
+ * acknowledges the transition.
+ */
+public class UpdateStateRetryableAction extends RetryableAction<PersistentTasksCustomMetadata.PersistentTask<?>> {
+
+    private static final int MIN_RETRY_SLEEP_MILLIS = 500;
+
+    private final JobTask jobTask;
+    private final JobTaskState jobTaskState;
+
+    /**
+     * Default constructor -- uses {@link MlTasks#PERSISTENT_TASK_MASTER_NODE_TIMEOUT} (365 days).
+     * Appropriate for OPENED state transitions where a native process is running.
+     */
+    public UpdateStateRetryableAction(
+        Logger logger,
+        ThreadPool threadPool,
+        JobTask jobTask,
+        JobTaskState jobTaskState,
+        ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> delegateListener
+    ) {
+        this(logger, threadPool, jobTask, jobTaskState, MlTasks.PERSISTENT_TASK_MASTER_NODE_TIMEOUT, delegateListener);
+    }
+
+    /**
+     * Custom timeout constructor -- use when a bounded retry window is appropriate (e.g. 60 minutes for FAILED state).
+     */
+    public UpdateStateRetryableAction(
+        Logger logger,
+        ThreadPool threadPool,
+        JobTask jobTask,
+        JobTaskState jobTaskState,
+        TimeValue timeout,
+        ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> delegateListener
+    ) {
+        super(logger, threadPool, TimeValue.timeValueMillis(MIN_RETRY_SLEEP_MILLIS), timeout, delegateListener, threadPool.generic());
+        this.jobTask = Objects.requireNonNull(jobTask);
+        this.jobTaskState = Objects.requireNonNull(jobTaskState);
+    }
+
+    @Override
+    public void tryAction(ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> listener) {
+        jobTask.updatePersistentTaskState(jobTaskState, listener);
+    }
+
+    @Override
+    public boolean shouldRetry(Exception e) {
+        return (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) == false;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/package-info.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/package-info.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Manages the lifecycle of Anomaly Detection (AD) job persistent tasks on an assigned ML node.
+ *
+ * <h2>Responsibility</h2>
+ * <p>
+ * {@link org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor} is the entry point
+ * invoked by the persistent task framework whenever a job is assigned to this node. It orchestrates
+ * the full opening pipeline: results-index mapping update → snapshot-version verification →
+ * forecast cleanup → datafeed check → snapshot revert (if needed) → native-process creation and
+ * state restore.
+ *
+ * <h2>Retry Resilience (system-initiated reassignments)</h2>
+ * <p>
+ * The opening pipeline distinguishes two request sources:
+ * <p>
+ * 1. <b>User-initiated opens</b> (no prior {@code JobTaskState}, i.e. allocation IDs match):
+ *    the pipeline runs directly. Any error immediately calls
+ *    {@link org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor#failTask failTask()},
+ *    giving the user fast, clear feedback.
+ * <p>
+ * 2. <b>System-initiated reassignments</b> (allocation ID in persisted {@code JobTaskState} differs
+ *    from the current task allocation ID, indicating the task was previously assigned elsewhere):
+ *    the pipeline is wrapped in {@code OpenJobRetryableAction}, which retries with exponential
+ *    backoff (5 s initial delay, 5 min cap, configurable total timeout via
+ *    {@code xpack.ml.job_open_retry_timeout}, default 60 min). Only errors classified as
+ *    recoverable by
+ *    {@link org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier MlRecoverableErrorClassifier}
+ *    trigger a retry; irrecoverable errors (bad request, not found, task cancelled, etc.) still
+ *    fail fast. The retry loop also stops immediately if the task is closing or vacating.
+ * <p>
+ * This design ensures jobs survive transient infrastructure disruptions (master unavailability,
+ * shard relocations, thread-pool saturation, transport errors) during rolling upgrades and node
+ * failures, without degrading the user experience for interactive job opens.
+ *
+ * <h2>State Transition Robustness</h2>
+ * <p>
+ * Committing job state to cluster state (both {@code OPENED} and {@code FAILED}) is wrapped in
+ * {@link org.elasticsearch.xpack.ml.job.task.UpdateStateRetryableAction UpdateStateRetryableAction},
+ * which retries the {@code updatePersistentTaskState} call until the master acknowledges it or a
+ * timeout is reached. This prevents ghost tasks stuck in {@code OPENING} when the master is
+ * temporarily unavailable. {@code setJobState(OPENED)} uses a 365-day timeout (a running native
+ * process must be matched with a committed state). {@code failTask()} uses the same configurable
+ * timeout as the open-pipeline retry window.
+ *
+ * <h2>Process Boundary</h2>
+ * <p>
+ * All pre-process operations (mapping updates, searches, index creation, {@code getAutodetectParams})
+ * are idempotent and safe to repeat on retry. Errors in these steps propagate through the listener
+ * callback to the orchestrator, which decides whether to retry. Once the native process is created
+ * (the process boundary), errors instead trigger process cleanup and {@code setJobState(FAILED)};
+ * process creation is not retriable.
+ */
+package org.elasticsearch.xpack.ml.job.task;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifier.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.utils;
+
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.client.internal.transport.NoNodeAvailableException;
+import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.discovery.MasterNotDiscoveredException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.shard.IllegalIndexShardStateException;
+import org.elasticsearch.indices.IndexPrimaryShardNotAllocatedException;
+import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.transport.TransportException;
+
+import java.util.Set;
+
+import static org.elasticsearch.ExceptionsHelper.status;
+
+/**
+ * Classifies exceptions as recoverable (transient, safe to retry) or irrecoverable (permanent, should not retry).
+ *
+ * Design: defaults to irrecoverable (explicit allowlist). Only exceptions that are known to be transient
+ * infrastructure failures are classified as recoverable. Unknown exception types fail fast to ensure
+ * clear diagnostics rather than masking real bugs with silent retries.
+ *
+ * Layers:
+ *   Layer 1 - Data Plane: shard/search failures that resolve when shards recover
+ *   Layer 2 - Control Plane: master election transients
+ *   Layer 3 - Resource Plane: circuit breakers and thread pool saturation (conditional)
+ *   Layer 4 - Transport Plane: connection and timeout failures
+ */
+public final class MlRecoverableErrorClassifier {
+
+    private static final Set<RestStatus> IRRECOVERABLE_REST_STATUSES = Set.of(
+        RestStatus.GONE,
+        RestStatus.NOT_IMPLEMENTED,
+        RestStatus.NOT_FOUND,
+        RestStatus.BAD_REQUEST,
+        RestStatus.UNAUTHORIZED,
+        RestStatus.FORBIDDEN,
+        RestStatus.METHOD_NOT_ALLOWED,
+        RestStatus.NOT_ACCEPTABLE
+    );
+
+    private MlRecoverableErrorClassifier() {}
+
+    /**
+     * Returns {@code true} if the exception is a transient infrastructure failure that is safe to retry.
+     * Returns {@code false} for any unknown exception type (irrecoverable by default).
+     *
+     * @param e the exception to classify; wrapping exceptions are unwrapped before classification
+     * @return true if the error is recoverable via retry
+     */
+    public static boolean isRecoverable(Exception e) {
+        Throwable cause = ExceptionsHelper.unwrapCause(e);
+
+        // TaskCancelledException: the persistent task was removed from cluster state; retrying fights user intent
+        if (cause instanceof TaskCancelledException) {
+            return false;
+        }
+
+        // IllegalIndexShardStateException: shard in wrong state (e.g. RECOVERING) – transient; retry when shard is ready.
+        // Overrides NOT_FOUND status; TransportActions treats it as shard-not-available (retryable).
+        if (cause instanceof IllegalIndexShardStateException) {
+            return true;
+        }
+
+        // Status-based irrecoverable check: covers all ElasticsearchStatusException variants with bad statuses
+        RestStatus restStatus = status(cause);
+        if (IRRECOVERABLE_REST_STATUSES.contains(restStatus)) {
+            return false;
+        }
+
+        // Layer 1: Data Plane -- shard/search failures that resolve when shards recover
+        if (cause instanceof SearchPhaseExecutionException) {
+            return true;
+        }
+        if (cause instanceof NoShardAvailableActionException) {
+            return true;
+        }
+        if (cause instanceof IndexPrimaryShardNotAllocatedException) {
+            return true;
+        }
+
+        // Layer 2: Control Plane -- master election transients
+        if (cause instanceof MasterNotDiscoveredException) {
+            return true;
+        }
+        if (cause instanceof NotMasterException) {
+            return true;
+        }
+        if (cause instanceof ClusterBlockException cbe) {
+            return cbe.retryable();
+        }
+
+        // Layer 3: Resource Plane -- conditional checks
+        if (cause instanceof CircuitBreakingException cbe) {
+            return cbe.getDurability() == CircuitBreaker.Durability.TRANSIENT;
+        }
+        if (cause instanceof EsRejectedExecutionException ere) {
+            return ere.isExecutorShutdown() == false;
+        }
+        if (cause instanceof VersionConflictEngineException) {
+            return true;
+        }
+
+        // Layer 3 continued: TOO_MANY_REQUESTS covers circuit breakers and thread pool rejections
+        // that reach us as generic ElasticsearchStatusException (e.g. from ProcessContext.tryLock)
+        if (restStatus == RestStatus.TOO_MANY_REQUESTS) {
+            return true;
+        }
+
+        // Layer 3 continued: SERVICE_UNAVAILABLE (503) is a transient cluster unavailability signal
+        if (restStatus == RestStatus.SERVICE_UNAVAILABLE) {
+            return true;
+        }
+
+        // Layer 4: Transport Plane -- all TransportException subclasses (connect, timeout, receive, send)
+        if (cause instanceof TransportException) {
+            return true;
+        }
+        if (cause instanceof NodeClosedException) {
+            return true;
+        }
+        if (cause instanceof NoNodeAvailableException) {
+            return true;
+        }
+        // ElasticsearchTimeoutException has no specific RestStatus; check by class hierarchy
+        if (cause instanceof ElasticsearchTimeoutException) {
+            return true;
+        }
+
+        // Default: irrecoverable. Unknown exception types fail fast for clear diagnostics.
+        return false;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/package-info.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/package-info.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Cross-cutting ML utilities shared across the ML plugin.
+ *
+ * <h2>Error Classification</h2>
+ * <p>
+ * {@link org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier MlRecoverableErrorClassifier}
+ * is a stateless utility that classifies exceptions as <i>recoverable</i> (transient, safe to
+ * retry) or <i>irrecoverable</i> (permanent, should fail fast). It uses an explicit allowlist
+ * across four infrastructure layers, defaulting to irrecoverable for unknown exception types:
+ * <p>
+ * 1. <b>Data Plane</b> — {@code SearchPhaseExecutionException}: shard-level search failures that
+ *    resolve when shards recover.
+ * <p>
+ * 2. <b>Control Plane</b> — {@code MasterNotDiscoveredException}, {@code NotMasterException},
+ *    and {@code ClusterBlockException} (only when {@code retryable()} is true, i.e. transient
+ *    blocks such as no-master; permanent blocks like index-closed are irrecoverable).
+ * <p>
+ * 3. <b>Resource Plane</b> — {@code CircuitBreakingException} (only when durability is
+ *    {@code TRANSIENT}; {@code PERMANENT} durability such as fielddata breaker trips is
+ *    irrecoverable), {@code EsRejectedExecutionException} (only when the executor is not shutting
+ *    down), {@code VersionConflictEngineException}, and generic {@code TOO_MANY_REQUESTS} /
+ *    {@code SERVICE_UNAVAILABLE} status exceptions.
+ * <p>
+ * 4. <b>Transport Plane</b> — {@code TransportException} and all its subclasses
+ *    (connect, receive-timeout, send failures), {@code NodeClosedException},
+ *    {@code NoNodeAvailableException}, and {@code ElasticsearchTimeoutException}.
+ * <p>
+ * {@code TaskCancelledException} and exceptions with irrecoverable REST statuses (NOT_FOUND,
+ * BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, GONE, etc.) are always irrecoverable.
+ * <p>
+ * This classifier is used by
+ * {@link org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor OpenJobPersistentTasksExecutor}
+ * to decide whether to retry a failed job-open attempt, and by
+ * {@link org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService ResultsPersisterService}
+ * to decide whether to retry a failed result-persistence attempt. Centralising the classification
+ * in one place ensures consistent retry behaviour across all ML code paths.
+ */
+package org.elasticsearch.xpack.ml.utils;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -52,20 +53,6 @@ import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 
 public class ResultsPersisterService {
-    /**
-     * List of rest statuses that we consider irrecoverable
-     */
-    public static final Set<RestStatus> IRRECOVERABLE_REST_STATUSES = Set.of(
-        RestStatus.GONE,
-        RestStatus.NOT_IMPLEMENTED,
-        // Not found is returned when we require an alias but the index is NOT an alias.
-        RestStatus.NOT_FOUND,
-        RestStatus.BAD_REQUEST,
-        RestStatus.UNAUTHORIZED,
-        RestStatus.FORBIDDEN,
-        RestStatus.METHOD_NOT_ALLOWED,
-        RestStatus.NOT_ACCEPTABLE
-    );
 
     private static final Logger LOGGER = LogManager.getLogger(ResultsPersisterService.class);
 
@@ -320,8 +307,12 @@ public class ResultsPersisterService {
      * @return true when the failure will persist no matter how many times we retry.
      */
     private static boolean isIrrecoverable(Exception ex) {
-        Throwable t = ExceptionsHelper.unwrapCause(ex);
-        return IRRECOVERABLE_REST_STATUSES.contains(status(t));
+        // RecoverableException is our internal retry signal; always treat as recoverable.
+        if (ex instanceof RecoverableException) {
+            return false;
+        }
+        // Delegate to the centralised classifier, which uses an explicit allowlist.
+        return MlRecoverableErrorClassifier.isRecoverable(ex) == false;
     }
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/annotations/AnnotationPersisterTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -220,11 +222,19 @@ public class AnnotationPersisterTests extends ESTestCase {
         );
     }
 
+    /**
+     * Recoverable bulk failure (SearchPhaseExecutionException) so the retry flow is exercised.
+     * Plain Exception would be irrecoverable per MlRecoverableErrorClassifier.
+     */
     private static BulkItemResponse bulkItemFailure(String docId) {
         return BulkItemResponse.failure(
             2,
             DocWriteRequest.OpType.INDEX,
-            new BulkItemResponse.Failure("my-index", docId, new Exception("boom"))
+            new BulkItemResponse.Failure(
+                "my-index",
+                docId,
+                new SearchPhaseExecutionException("query", "partial results", ShardSearchFailure.EMPTY_ARRAY)
+            )
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -986,6 +986,97 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         assertSame(rnfe, holder.get());
     }
 
+    public void testStartProcess_preProcessError_doesNotSetJobStateFailed() {
+        // When getAutodetectParams fails (pre-process error), setJobState(FAILED) should NOT be called.
+        // The error should be propagated directly to closeHandler.
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+            listener.onResponse(createJobDetails("foo"));
+            return null;
+        }).when(jobManager).getJob(eq("foo"), any());
+
+        // Make getAutodetectParams fail
+        RuntimeException getParamsError = new RuntimeException("getAutodetectParams failed");
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            Consumer<Exception> errorHandler = (Consumer<Exception>) invocationOnMock.getArguments()[2];
+            errorHandler.accept(getParamsError);
+            return null;
+        }).when(jobResultsProvider).getAutodetectParams(any(), any(), any());
+
+        AutodetectProcessManager manager = createSpyManager();
+        JobTask jobTask = mock(JobTask.class);
+        when(jobTask.getJobId()).thenReturn("foo");
+        when(jobTask.getAllocationId()).thenReturn(1L);
+
+        AtomicReference<Exception> closeHandlerError = new AtomicReference<>();
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> closeHandlerError.set(e));
+
+        // The closeHandler should have received the error
+        assertThat(closeHandlerError.get(), is(getParamsError));
+        // setJobState(FAILED) should NOT have been called for a pre-process error
+        verify(manager, org.mockito.Mockito.never()).setJobState(any(), eq(JobState.FAILED), any(), any());
+    }
+
+    public void testStartProcess_postProcessError_setsJobStateFailed() throws IOException {
+        // When createProcessAndSetRunning throws (post-process error), setJobState(FAILED) SHOULD be called.
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Job> listener = (ActionListener<Job>) invocationOnMock.getArguments()[1];
+            listener.onResponse(createJobDetails("foo"));
+            return null;
+        }).when(jobManager).getJob(eq("foo"), any());
+
+        AutodetectProcessManager manager = createSpyManager();
+
+        // Make create() throw, which is called inside createProcessAndSetRunning
+        RuntimeException processCreateError = new RuntimeException("process creation failed");
+        doThrow(processCreateError).when(manager).create(any(), any(), any(), any());
+
+        // Wire setJobState(FAILED) to invoke the handler
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            CheckedConsumer<Exception, IOException> handler = (CheckedConsumer<Exception, IOException>) invocation.getArguments()[3];
+            handler.accept(null);
+            return null;
+        }).when(manager).setJobState(any(), eq(JobState.FAILED), any(), any());
+
+        JobTask jobTask = mock(JobTask.class);
+        when(jobTask.getJobId()).thenReturn("foo");
+        when(jobTask.getAllocationId()).thenReturn(1L);
+
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
+
+        // setJobState(FAILED) SHOULD have been called for a post-process error
+        verify(manager).setJobState(any(), eq(JobState.FAILED), any(), any());
+    }
+
+    public void testSetJobStateOpened_onFailure_emitsAuditWarning() throws IOException {
+        // When setJobState(OPENED) fails, an audit warning should be issued so operators
+        // can detect a job stuck in the OPENING state.
+        // Setup: getAutodetectParams and create() succeed (via @Before + createSpyManager),
+        // but setJobState(OPENED) reports failure.
+        AutodetectProcessManager manager = createSpyManager();
+
+        Exception openedStateFailure = new RuntimeException("master not available");
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            CheckedConsumer<Exception, IOException> handler = (CheckedConsumer<Exception, IOException>) invocation.getArguments()[3];
+            handler.accept(openedStateFailure);
+            return null;
+        }).when(manager).setJobState(any(), eq(JobState.OPENED), any(), any());
+
+        JobTask jobTask = mock(JobTask.class);
+        when(jobTask.getJobId()).thenReturn("foo");
+        when(jobTask.getAllocationId()).thenReturn(1L);
+
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
+
+        // Audit warning must be issued for the stuck OPENING state
+        verify(auditor).warning(eq("foo"), org.mockito.ArgumentMatchers.contains("OPENED"));
+    }
+
     private AutodetectProcessManager createNonSpyManager(String jobId) {
         ExecutorService executorService = mock(ExecutorService.class);
         when(threadPool.executor(anyString())).thenReturn(executorService);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
@@ -76,7 +77,12 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutor.validateJobAndId;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
@@ -109,7 +115,8 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
                     MachineLearningField.MAX_LAZY_ML_NODES,
                     MachineLearning.MAX_ML_NODE_SIZE,
                     MachineLearning.MAX_OPEN_JOBS_PER_NODE,
-                    MachineLearningField.USE_AUTO_MACHINE_MEMORY_PERCENT
+                    MachineLearningField.USE_AUTO_MACHINE_MEMORY_PERCENT,
+                    MachineLearning.JOB_OPEN_RETRY_TIMEOUT
                 )
             )
         );
@@ -298,6 +305,138 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);
         return job.build(new Date());
+    }
+
+    public void testNodeOperation_userInitiated_nullState_doesNotRetry() {
+        // When state is null (user-initiated fresh open), pipeline runs directly (no retry action created)
+        var executor = spy(createExecutor(Settings.EMPTY));
+        var jobTask = mock(JobTask.class);
+        when(jobTask.getAllocationId()).thenReturn(1L);
+        var params = new OpenJobAction.JobParams("test_job");
+
+        doAnswer(inv -> null).when(executor).executeOpenJobPipeline(any(), any(), any(), any());
+
+        executor.nodeOperation(jobTask, params, null);
+
+        // executeOpenJobPipeline called once, not in a retry loop
+        verify(executor).executeOpenJobPipeline(any(), any(), any(), any());
+        // No retry action was created
+        verify(executor, never()).createOpenJobRetryableAction(any(), any(), any(), any());
+    }
+
+    public void testNodeOperation_staleState_createsRetryableAction() {
+        // When state.getAllocationId() != task.getAllocationId() (system reassignment), retry logic is used
+        var executor = spy(createExecutor(Settings.EMPTY));
+        var jobTask = mock(JobTask.class);
+        when(jobTask.getAllocationId()).thenReturn(2L); // current allocation
+        var params = new OpenJobAction.JobParams("test_job");
+
+        // stale state: allocationId 1 != jobTask allocationId 2
+        var staleState = new JobTaskState(JobState.OPENED, 1L, null, Instant.now());
+
+        // Mock createOpenJobRetryableAction to return a no-op action
+        var mockAction = mock(OpenJobPersistentTasksExecutor.OpenJobRetryableAction.class);
+        doAnswer(inv -> mockAction).when(executor).createOpenJobRetryableAction(any(), any(), any(), any());
+
+        executor.nodeOperation(jobTask, params, staleState);
+
+        // createOpenJobRetryableAction should be called for reassignments
+        verify(executor).createOpenJobRetryableAction(any(), any(), any(), any());
+        // executeOpenJobPipeline NOT called directly
+        verify(executor, never()).executeOpenJobPipeline(any(), any(), any(), any());
+    }
+
+    public void testNodeOperation_freshState_notStale_doesNotRetry() {
+        // When state is present but NOT stale (same allocation), treat as user-initiated: no retry
+        var executor = spy(createExecutor(Settings.EMPTY));
+        var jobTask = mock(JobTask.class);
+        when(jobTask.getAllocationId()).thenReturn(1L); // current allocation matches state
+        var params = new OpenJobAction.JobParams("test_job");
+
+        // fresh state: allocationId 1 == jobTask allocationId 1 (not stale)
+        var freshState = new JobTaskState(JobState.OPENED, 1L, null, Instant.now());
+
+        doAnswer(inv -> null).when(executor).executeOpenJobPipeline(any(), any(), any(), any());
+
+        executor.nodeOperation(jobTask, params, freshState);
+
+        // For non-stale state, pipeline runs directly (user-initiated path)
+        verify(executor).executeOpenJobPipeline(any(), any(), any(), any());
+        verify(executor, never()).createOpenJobRetryableAction(any(), any(), any(), any());
+    }
+
+    public void testFailTask_retriesStateUpdate() throws Exception {
+        // failTask() should retry updatePersistentTaskState on transient failure
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.generic()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        // schedule retries synchronously
+        when(threadPool.schedule(any(Runnable.class), any(TimeValue.class), any(java.util.concurrent.Executor.class))).thenAnswer(inv -> {
+            Runnable r = inv.getArgument(0);
+            r.run();
+            return mock(org.elasticsearch.threadpool.ThreadPool.Cancellable.class);
+        });
+        when(client.threadPool()).thenReturn(threadPool);
+
+        var executor = createExecutor(Settings.EMPTY);
+        var jobTask = mock(JobTask.class);
+        when(jobTask.getJobId()).thenReturn("test_job");
+        when(jobTask.getAllocationId()).thenReturn(1L);
+
+        java.util.concurrent.atomic.AtomicInteger attempts = new java.util.concurrent.atomic.AtomicInteger();
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            org.elasticsearch.action.ActionListener<org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask<?>> listener =
+                (org.elasticsearch.action.ActionListener<org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask<?>>) inv
+                    .getArguments()[1];
+            if (attempts.incrementAndGet() < 3) {
+                listener.onFailure(new RuntimeException("transient"));
+            } else {
+                listener.onResponse(null);
+            }
+            return null;
+        }).when(jobTask).updatePersistentTaskState(any(), any());
+
+        executor.failTask(jobTask, "test failure");
+
+        // Should have been retried
+        verify(jobTask, org.mockito.Mockito.atLeast(2)).updatePersistentTaskState(any(), any());
+    }
+
+    public void testFailTask_fallsBackToMarkAsFailed_onResourceNotFoundException() {
+        // Set up client.threadPool() mock
+        ThreadPool tp = mock(ThreadPool.class);
+        when(tp.generic()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        when(tp.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(client.threadPool()).thenReturn(tp);
+
+        var executor = createExecutor(Settings.EMPTY);
+        var jobTask = mock(JobTask.class);
+        when(jobTask.getJobId()).thenReturn("test_job");
+        when(jobTask.getAllocationId()).thenReturn(1L);
+
+        var rnfe = new ResourceNotFoundException("task not found");
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            org.elasticsearch.action.ActionListener<org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask<?>> listener =
+                (org.elasticsearch.action.ActionListener<org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask<?>>) inv
+                    .getArguments()[1];
+            listener.onFailure(rnfe);
+            return null;
+        }).when(jobTask).updatePersistentTaskState(any(), any());
+
+        // markAsFailed is final on LicensedAllocatedPersistentTask so we can't verify it on a mock,
+        // but we verify that no retry was attempted (only one call to updatePersistentTaskState)
+        try {
+            executor.failTask(jobTask, "test failure");
+        } catch (AssertionError e) {
+            // The mock's markAsFailed() is final and calls licensedFeature.stopTracking() which
+            // NPEs on a basic mock; the important assertion is the call count below
+        }
+
+        // ResourceNotFoundException -> UpdateStateRetryableAction.shouldRetry() = false -> no retry
+        verify(jobTask, org.mockito.Mockito.times(1)).updatePersistentTaskState(any(), any());
     }
 
     private OpenJobPersistentTasksExecutor createExecutor(Settings settings) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/UpdateStateRetryableActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/UpdateStateRetryableActionTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.task;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
+import org.junit.After;
+import org.junit.Before;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class UpdateStateRetryableActionTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    private JobTask jobTask;
+    private JobTaskState jobTaskState;
+
+    @Before
+    public void setup() {
+        threadPool = new TestThreadPool("test");
+        jobTask = mock(JobTask.class);
+        jobTaskState = new JobTaskState(JobState.FAILED, 1L, "test reason", Instant.now());
+    }
+
+    @After
+    public void teardown() {
+        threadPool.shutdownNow();
+    }
+
+    public void testShouldRetry_returnsTrue_forGenericException() {
+        var action = new UpdateStateRetryableAction(logger, threadPool, jobTask, jobTaskState, ActionListener.noop());
+        assertTrue(action.shouldRetry(new RuntimeException("transient")));
+        assertTrue(action.shouldRetry(new IllegalStateException("state error")));
+        assertTrue(
+            action.shouldRetry(
+                new org.elasticsearch.ElasticsearchStatusException(
+                    "service unavailable",
+                    org.elasticsearch.rest.RestStatus.SERVICE_UNAVAILABLE
+                )
+            )
+        );
+    }
+
+    public void testShouldRetry_returnsFalse_forResourceNotFoundException() {
+        var action = new UpdateStateRetryableAction(logger, threadPool, jobTask, jobTaskState, ActionListener.noop());
+        assertFalse(action.shouldRetry(new ResourceNotFoundException("task not found")));
+    }
+
+    public void testShouldRetry_returnsFalse_forWrappedResourceNotFoundException() {
+        var action = new UpdateStateRetryableAction(logger, threadPool, jobTask, jobTaskState, ActionListener.noop());
+        var wrapped = new org.elasticsearch.transport.RemoteTransportException("remote", new ResourceNotFoundException("task not found"));
+        assertFalse(action.shouldRetry(wrapped));
+    }
+
+    public void testTryAction_callsUpdatePersistentTaskState() {
+        var listenerCalled = new AtomicBoolean(false);
+        @SuppressWarnings("unchecked")
+        ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> listener = ActionListener.wrap(
+            r -> listenerCalled.set(true),
+            e -> fail("unexpected failure: " + e)
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> l = invocation.getArgument(1);
+            l.onResponse(null);
+            return null;
+        }).when(jobTask).updatePersistentTaskState(any(), any());
+
+        var action = new UpdateStateRetryableAction(logger, threadPool, jobTask, jobTaskState, listener);
+        action.tryAction(listener);
+
+        verify(jobTask).updatePersistentTaskState(any(), any());
+        assertTrue(listenerCalled.get());
+    }
+
+    public void testCustomTimeout_constructor_usesProvidedTimeout() {
+        var customTimeout = TimeValue.timeValueMinutes(60);
+        // Just verify the action can be constructed with a custom timeout (no exception thrown)
+        var action = new UpdateStateRetryableAction(logger, threadPool, jobTask, jobTaskState, customTimeout, ActionListener.noop());
+        assertNotNull(action);
+    }
+
+    public void testDefaultTimeout_usesDefaultLongTimeout() {
+        // Default constructor uses PERSISTENT_TASK_MASTER_NODE_TIMEOUT (365 days)
+        // Verify it can be constructed without specifying a timeout
+        var action = new UpdateStateRetryableAction(logger, threadPool, jobTask, jobTaskState, ActionListener.noop());
+        assertNotNull(action);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifierTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/MlRecoverableErrorClassifierTests.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.utils;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.internal.transport.NoNodeAvailableException;
+import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.discovery.MasterNotDiscoveredException;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.shard.IllegalIndexShardStateException;
+import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndexPrimaryShardNotAllocatedException;
+import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.NodeNotConnectedException;
+import org.elasticsearch.transport.ReceiveTimeoutTransportException;
+import org.elasticsearch.transport.RemoteTransportException;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class MlRecoverableErrorClassifierTests extends ESTestCase {
+
+    // -------------------------------------------------------------------------
+    // Layer 1: Data Plane (always recoverable)
+    // -------------------------------------------------------------------------
+
+    public void testSearchPhaseExecutionException_isRecoverable() {
+        var e = new SearchPhaseExecutionException("query", "partial results", ShardSearchFailure.EMPTY_ARRAY);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchStatusException_serviceUnavailable_isRecoverable() {
+        var e = new ElasticsearchStatusException("service unavailable", RestStatus.SERVICE_UNAVAILABLE);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testIndexPrimaryShardNotAllocatedException_isRecoverable() {
+        var e = new IndexPrimaryShardNotAllocatedException(new Index("my-index", "uuid"));
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testNoShardAvailableActionException_isRecoverable() {
+        var e = new NoShardAvailableActionException(new ShardId("my-index", "uuid", 0));
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testIllegalIndexShardStateException_isRecoverable() {
+        var e = new IllegalIndexShardStateException(new ShardId("my-index", "uuid", 0), IndexShardState.RECOVERING, "shard not ready");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    // -------------------------------------------------------------------------
+    // Layer 2: Control Plane (conditional)
+    // -------------------------------------------------------------------------
+
+    public void testMasterNotDiscoveredException_isRecoverable() {
+        var e = new MasterNotDiscoveredException();
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testNotMasterException_isRecoverable() {
+        var e = new NotMasterException("not master");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testClusterBlockException_retryableTrue_isRecoverable() {
+        var block = new ClusterBlock(
+            1,
+            "test block",
+            true,
+            false,
+            false,
+            RestStatus.SERVICE_UNAVAILABLE,
+            EnumSet.of(ClusterBlockLevel.READ)
+        );
+        var e = new ClusterBlockException(Set.of(block));
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testClusterBlockException_retryableFalse_isNotRecoverable() {
+        var block = new ClusterBlock(2, "permanent block", false, false, false, RestStatus.FORBIDDEN, EnumSet.of(ClusterBlockLevel.WRITE));
+        var e = new ClusterBlockException(Set.of(block));
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testTaskCancelledException_isNotRecoverable() {
+        var e = new TaskCancelledException("task was cancelled");
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    // -------------------------------------------------------------------------
+    // Layer 3: Resource Plane (conditional)
+    // -------------------------------------------------------------------------
+
+    public void testCircuitBreakingException_transient_isRecoverable() {
+        var e = new CircuitBreakingException("transient circuit break", CircuitBreaker.Durability.TRANSIENT);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testCircuitBreakingException_permanent_isNotRecoverable() {
+        var e = new CircuitBreakingException("permanent circuit break", CircuitBreaker.Durability.PERMANENT);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testEsRejectedExecutionException_poolFull_isRecoverable() {
+        var e = new EsRejectedExecutionException("pool full", false);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testEsRejectedExecutionException_shutdown_isNotRecoverable() {
+        var e = new EsRejectedExecutionException("executor shutdown", true);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testVersionConflictEngineException_isRecoverable() {
+        var shardId = new ShardId("index", "uuid", 0);
+        var e = new VersionConflictEngineException(shardId, "doc1", "version conflict");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchStatusException_tooManyRequests_isRecoverable() {
+        var e = new ElasticsearchStatusException("too many requests", RestStatus.TOO_MANY_REQUESTS);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    // -------------------------------------------------------------------------
+    // Layer 4: Transport Plane (always recoverable)
+    // -------------------------------------------------------------------------
+
+    public void testConnectTransportException_isRecoverable() {
+        var node = DiscoveryNodeUtils.create("node1");
+        var e = new ConnectTransportException(node, "connection failed");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testNodeNotConnectedException_isRecoverable() {
+        var node = DiscoveryNodeUtils.create("node1");
+        var e = new NodeNotConnectedException(node, "node not connected");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testReceiveTimeoutTransportException_isRecoverable() {
+        var node = DiscoveryNodeUtils.create("node1");
+        var e = new ReceiveTimeoutTransportException(node, "action", "timeout");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testNodeClosedException_isRecoverable() {
+        var e = new NodeClosedException((org.elasticsearch.cluster.node.DiscoveryNode) null);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testNoNodeAvailableException_isRecoverable() {
+        var e = new NoNodeAvailableException("no node available");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchTimeoutException_isRecoverable() {
+        var e = new ElasticsearchTimeoutException("timed out");
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    // -------------------------------------------------------------------------
+    // Irrecoverable: status-code-based
+    // -------------------------------------------------------------------------
+
+    public void testElasticsearchStatusException_badRequest_isNotRecoverable() {
+        var e = new ElasticsearchStatusException("bad request", RestStatus.BAD_REQUEST);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchStatusException_notFound_isNotRecoverable() {
+        var e = new ElasticsearchStatusException("not found", RestStatus.NOT_FOUND);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchStatusException_gone_isNotRecoverable() {
+        var e = new ElasticsearchStatusException("gone", RestStatus.GONE);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchStatusException_unauthorized_isNotRecoverable() {
+        var e = new ElasticsearchStatusException("unauthorized", RestStatus.UNAUTHORIZED);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testElasticsearchStatusException_forbidden_isNotRecoverable() {
+        var e = new ElasticsearchStatusException("forbidden", RestStatus.FORBIDDEN);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testResourceNotFoundException_isNotRecoverable() {
+        var e = new ResourceNotFoundException("resource not found");
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(e));
+    }
+
+    public void testIllegalArgumentException_isNotRecoverable() {
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(new IllegalArgumentException("bad arg")));
+    }
+
+    public void testIllegalStateException_isNotRecoverable() {
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(new IllegalStateException("bad state")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    public void testUnknownException_isNotRecoverable() {
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(new RuntimeException("something weird")));
+    }
+
+    public void testNullPointerException_isNotRecoverable() {
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(new NullPointerException("npe")));
+    }
+
+    public void testWrappedRecoverableException_isRecoverable() {
+        var inner = new SearchPhaseExecutionException("query", "partial results", ShardSearchFailure.EMPTY_ARRAY);
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(wrapped));
+    }
+
+    public void testWrappedIrrecoverableException_isNotRecoverable() {
+        var inner = new IllegalArgumentException("bad arg");
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(wrapped));
+    }
+
+    public void testWrappedTransientCircuitBreaker_isRecoverable() {
+        var inner = new CircuitBreakingException("transient", CircuitBreaker.Durability.TRANSIENT);
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertTrue(MlRecoverableErrorClassifier.isRecoverable(wrapped));
+    }
+
+    public void testWrappedPermanentCircuitBreaker_isNotRecoverable() {
+        var inner = new CircuitBreakingException("permanent", CircuitBreaker.Durability.PERMANENT);
+        var wrapped = new RemoteTransportException("remote", inner);
+        assertFalse(MlRecoverableErrorClassifier.isRecoverable(wrapped));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
@@ -122,10 +123,18 @@ public class ResultsPersisterServiceTests extends ESTestCase {
             true
         )
     );
+    /**
+     * Recoverable bulk failure (SearchPhaseExecutionException) used by tests that expect retry.
+     * Plain Exception would be irrecoverable per MlRecoverableErrorClassifier.
+     */
     private static final BulkItemResponse BULK_ITEM_RESPONSE_FAILURE = BulkItemResponse.failure(
         2,
         DocWriteRequest.OpType.INDEX,
-        new BulkItemResponse.Failure("my-index", "fail", new Exception("boom"))
+        new BulkItemResponse.Failure(
+            "my-index",
+            "fail",
+            new SearchPhaseExecutionException("query", "partial results", ShardSearchFailure.EMPTY_ARRAY)
+        )
     );
 
     private Client client;
@@ -247,6 +256,23 @@ public class ResultsPersisterServiceTests extends ESTestCase {
         );
         assertThat(e.getMessage(), containsString("bad search request"));
 
+        verify(client, times(1)).execute(eq(TransportSearchAction.TYPE), eq(SEARCH_REQUEST), any());
+    }
+
+    public void testSearchWithRetries_TaskCancelledException_isIrrecoverable() {
+        // TaskCancelledException should not be retried (classified irrecoverable by MlRecoverableErrorClassifier)
+        resultsPersisterService.setMaxFailureRetries(5);
+
+        doAnswer(withFailure(new org.elasticsearch.tasks.TaskCancelledException("task was cancelled"))).when(client)
+            .execute(eq(TransportSearchAction.TYPE), eq(SEARCH_REQUEST), any());
+
+        ElasticsearchException e = expectThrows(
+            ElasticsearchException.class,
+            () -> resultsPersisterService.searchWithRetry(SEARCH_REQUEST, JOB_ID, () -> true, (s) -> {})
+        );
+        assertThat(e.getMessage(), containsString("task was cancelled"));
+
+        // No retry: only one call to client.execute
         verify(client, times(1)).execute(eq(TransportSearchAction.TYPE), eq(SEARCH_REQUEST), any());
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Add exponential-backoff retry for AD job opening during system-initiated reassignments (#144478)](https://github.com/elastic/elasticsearch/pull/144478)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)