### PR TITLE
Lower log level in TransportStatelessUnpromotableRelocationAction PITrelocation

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessUnpromotableRelocationAction.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessUnpromotableRelocationAction.java
@@ -387,12 +387,12 @@ public class TransportStatelessUnpromotableRelocationAction extends TransportAct
 
     private void getOpenPITContextInfos(ShardId shardId, ActionListener<PITHandoffResponse> listener) {
         List<PitReaderContext> activeContexts = searchService.getActivePITContexts(shardId);
-        logger.info("getting pit context infos for shard {}. Active contexts: {}", shardId, activeContexts.size());
+        logger.debug("getting pit context infos for shard {}. Active contexts: {}", shardId, activeContexts.size());
         List<OpenPITContextInfo> pitContextInfos = Collections.synchronizedList(new ArrayList<>(activeContexts.size()));
         AtomicLong warningCounter = new AtomicLong();
 
         try (var listeners = new RefCountingListener(listener.map(r -> {
-            logger.info("returning {} context infos for shard {}. Warnings: {}", pitContextInfos.size(), shardId, warningCounter.get());
+            logger.debug("returning {} context infos for shard {}. Warnings: {}", pitContextInfos.size(), shardId, warningCounter.get());
             return new PITHandoffResponse(pitContextInfos);
         }))) {
             for (PitReaderContext context : activeContexts) {


### PR DESCRIPTION
Lowers the log level during PIT relocation handoff on the source node from info to debug. This was accidentally changed in #152754 during test debugging.