### PR TITLE
ES|QL: Unmute BASELINE generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -517,9 +517,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalSourceProfileIT
   method: testCsvCountStarScansColdThenSkipsWarm
   issue: https://github.com/elastic/elasticsearch/issues/152132
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test {feature:BASELINE}
-  issue: https://github.com/elastic/elasticsearch/issues/149746
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:highlight.highlightFieldWithNoMatch}
   issue: https://github.com/elastic/elasticsearch/issues/152240

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -76,7 +76,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     @Rule(order = Integer.MIN_VALUE)
     public ProfileLogger profileLogger = new ProfileLogger();
 
-    public static final int ITERATIONS = 1000;
+    public static final int ITERATIONS = 100;
     public static final int MAX_DEPTH = 20;
 
     /**

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -76,7 +76,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     @Rule(order = Integer.MIN_VALUE)
     public ProfileLogger profileLogger = new ProfileLogger();
 
-    public static final int ITERATIONS = 100;
+    public static final int ITERATIONS = 1000;
     public static final int MAX_DEPTH = 20;
 
     /**
@@ -158,9 +158,15 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "must be \\[boolean, date, ip, string or numeric except unsigned_long or counter types\\]", // type mismatch in top() arguments
         "Does not support yet aggregations over constants", // https://github.com/elastic/elasticsearch/issues/118292
         "Field \\[.*\\] of type \\[.*\\] does not support match.* queries",
-        // https://github.com/elastic/elasticsearch/issues/145570
-        "function cannot operate on \\[.*\\], which is not a field from an index mapping",
-        "\\[:\\] operator cannot operate on \\[.*\\], which is not a field from an index mapping",
+
+        // https://github.com/elastic/elasticsearch/issues/153622
+        "ImmutableCollections\\$ListN cannot be cast to class org.apache.lucene.util.BytesRef",
+
+        // repeat() returns validation error when the Number parameter is a negative foldable
+        "Number parameter cannot be negative, found \\[",
+
+        // need to refine the MATCH function generation
+        "query value .* does not match the type .* of non-index-mapped field",
 
         // Awaiting fixes for correctness
         "Expecting at most \\[.*\\] columns, got \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/129561


### PR DESCRIPTION
Unmute BASELINE generative tests, remove some mutes for fixed issues and added a couple of exceptions to make it more lenient with generators that don't handle some corner cases properly.