### PR TITLE
Fix NPE in PROMQL parsing when index-pattern is used for non-index params

### DIFF
--- a/docs/changelog/153633.yaml
+++ b/docs/changelog/153633.yaml
@@ -1,0 +1,6 @@
+area: PromQL
+issues:
+ - 148338
+pr: 153633
+summary: Fix NPE in PROMQL parsing when index-pattern is used for non-index params
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -1881,17 +1881,22 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
     private String parseParamValueString(EsqlBaseParser.PromqlParamValueContext ctx) {
         if (ctx.NAMED_OR_POSITIONAL_PARAM() != null) {
             QueryParam param = paramByNameOrPosition(ctx.NAMED_OR_POSITIONAL_PARAM());
+            if (param == null) {
+                throw new ParsingException(source(ctx), "No value found for parameter [{}]", ctx.NAMED_OR_POSITIONAL_PARAM().getText());
+            }
             return param.value().toString();
         } else if (ctx.QUOTED_IDENTIFIER() != null) {
             throw new ParsingException(source(ctx), "Parameter value [{}] must not be a quoted identifier", ctx.getText());
         } else if (ctx.promqlIndexPattern().size() == 1) {
             EsqlBaseParser.PromqlIndexStringContext string = ctx.promqlIndexPattern().getFirst().promqlIndexString();
-            if (string.UNQUOTED_SOURCE() != null) {
-                return string.UNQUOTED_SOURCE().getText();
-            } else if (string.UNQUOTED_IDENTIFIER() != null) {
-                return string.UNQUOTED_IDENTIFIER().getText();
-            } else if (string.QUOTED_STRING() != null) {
-                return AbstractBuilder.unquote(string.QUOTED_STRING().getText());
+            if (string != null) {
+                if (string.UNQUOTED_SOURCE() != null) {
+                    return string.UNQUOTED_SOURCE().getText();
+                } else if (string.UNQUOTED_IDENTIFIER() != null) {
+                    return string.UNQUOTED_IDENTIFIER().getText();
+                } else if (string.QUOTED_STRING() != null) {
+                    return AbstractBuilder.unquote(string.QUOTED_STRING().getText());
+                }
             }
         }
         throw new ParsingException(source(ctx), "Invalid parameter value [{}]", ctx.getText());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParserTests.java
@@ -128,6 +128,24 @@ public class PromqlParserTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("1:24: Parameter value [`1m`] must not be a quoted identifier"));
     }
 
+    public void testParamValueRemoteClusterPatternRejected() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("PROMQL step=foo:bar (avg(foo))"));
+        assertThat(e.getMessage(), containsString("Invalid parameter value [foo:bar]"));
+    }
+
+    public void testParamValueSelectorPatternRejected() {
+        ParsingException e = assertThrows(ParsingException.class, () -> parse("PROMQL step=foo::bar (avg(foo))"));
+        assertThat(e.getMessage(), containsString("Invalid parameter value [foo::bar]"));
+    }
+
+    public void testParamValueUnknownParamRejected() {
+        ParsingException e = assertThrows(
+            ParsingException.class,
+            () -> TEST_PARSER.parseQuery("PROMQL step=?_unknown (avg(foo))", new QueryParams(List.of()))
+        );
+        assertThat(e.getMessage(), containsString("No value found for parameter [?_unknown]"));
+    }
+
     public void testMissingParams() {
         Stream.of(
             parse("PROMQL foo / bar"),


### PR DESCRIPTION
Fixes #148338

`PROMQL` parsing throws a `NullPointerException` when a non-index parameter (`time`, `start`, `end`, `step`, `buckets`, `scrape_interval`) is given a value shaped like a remote (`cluster:index`) or selector (`index::selector`) index pattern, e.g. `PROMQL step=foo:bar (avg(foo))`. 
This PR replaces the NPE crash with a clear parsing error.

### Cause
Parameter values share the `promqlIndexPattern` grammar rule, so a scalar value is extracted from its `promqlIndexString` child. The `cluster:index` and `index::selector` alternatives never populate that child, so [reading the value dereferenced a null `promqlIndexString`](https://github.com/elastic/elasticsearch/blob/6294c70cc336bb27b9181aa10ef18ae5e636b87e/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java#L1888-L1889). 
An unresolved query-parameter value (e.g. `step=?missing`) hit a similar null dereference (with a slightly differnt stack trace from the one in the linked issue).

### Approach
Guard both cases in `parseParamValueString`: values that are not a plain string (the `:`/`::` shapes) fall through to the existing `Invalid parameter value [...]` error, and an unresolved parameter reports `No value found for parameter [...]`. Valid values are unaffected and no grammar change is required.