### PR TITLE
Richer lifecycle on `ThrottlingRecoveryService`

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -335,7 +335,7 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
             previousLimit = this.maxConcurrentRecoveries;
             this.maxConcurrentRecoveries = newMaxConcurrentRecoveries;
         }
-        if (previousLimit < newMaxConcurrentRecoveries && lifecycle.started()) {
+        if (previousLimit < newMaxConcurrentRecoveries && lifecycle.started() /* calls before start can (must) be ignored */) {
             fillSlots();
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -27,7 +28,6 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.Closeable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 /// released when the recovery's [RecoveryListener] completes.
 /// The max number of concurrent recovery slots is controlled by the [#INDICES_RECOVERY_MAX_CONCURRENT_RECOVERIES_SETTING]
 /// dynamic setting.
-public final class ThrottlingRecoveryService implements ClusterStateListener, Closeable {
+public final class ThrottlingRecoveryService extends AbstractLifecycleComponent implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(ThrottlingRecoveryService.class);
 
@@ -77,8 +77,6 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
     /// Entries are pruned by [#clusterChanged] once the corresponding shard stops initializing or its allocationId changes.
     private final Map<String, ShardId> cancelledAllocationIds = new HashMap<>();
 
-    private boolean closed;
-
     public ThrottlingRecoveryService(
         ThreadPool threadPool,
         ProjectResolver projectResolver,
@@ -90,6 +88,10 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
         this.projectResolver = projectResolver;
         this.schedulingListener = schedulingListener;
         this.clusterService = clusterService;
+    }
+
+    @Override
+    protected void doStart() {
         clusterService.addListener(this);
         clusterService.getClusterSettings()
             .initializeAndWatchIfRegistered(INDICES_RECOVERY_MAX_CONCURRENT_RECOVERIES_SETTING, this::setMaxConcurrentRecoveries);
@@ -108,7 +110,7 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
         final PendingRecovery pendingRecovery;
         final boolean serviceClosed;
         synchronized (this) {
-            serviceClosed = closed;
+            serviceClosed = isClosed();
             if (serviceClosed || cancelledAllocationIds.remove(allocationId) != null) {
                 pendingRecovery = null;
             } else {
@@ -156,7 +158,7 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
     public Set<String> cancelRecoveries(Map<String, ShardId> cancellations) {
         final List<PendingRecovery> recoveriesToCancel = new ArrayList<>();
         synchronized (this) {
-            if (closed) {
+            if (isClosed()) {
                 return Set.of();
             }
             // Record every cancellation, even for recoveries that have already started (i.e. are not in the pending queue).
@@ -194,7 +196,7 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
         final RoutingNode localNode = event.state().getRoutingNodes().node(clusterService.localNode().getId());
         final List<PendingRecovery> staleRecoveries = new ArrayList<>();
         synchronized (this) {
-            if (closed) {
+            if (isClosed()) {
                 return;
             }
             if (localNode == null) {
@@ -250,14 +252,9 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
     }
 
     @Override
-    public void close() {
+    protected void doStop() {
         final List<PendingRecovery> recoveriesToAbort;
         synchronized (this) {
-            // idempotent
-            if (closed) {
-                return;
-            }
-            closed = true;
             recoveriesToAbort = new ArrayList<>(pendingRecoveries);
             pendingRecoveries.clear();
             cancelledAllocationIds.clear();
@@ -273,16 +270,19 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
         clusterService.removeListener(this);
     }
 
-    // visible for testing
-    synchronized boolean isClosed() {
-        return closed;
+    @Override
+    protected void doClose() {}
+
+    private boolean isClosed() {
+        assert lifecycle.initialized() == false : "service accessed before start";
+        return lifecycle.stoppedOrClosed();
     }
 
     /// Drains the pending queue up to the max slot capacity
     private void fillSlots() {
         final List<PendingRecovery> recoveriesToDispatch = new ArrayList<>();
         synchronized (this) {
-            if (closed) {
+            if (isClosed()) {
                 return;
             }
             while (pendingRecoveries.isEmpty() == false && runningRecoveries < maxConcurrentRecoveries) {
@@ -335,7 +335,7 @@ public final class ThrottlingRecoveryService implements ClusterStateListener, Cl
             previousLimit = this.maxConcurrentRecoveries;
             this.maxConcurrentRecoveries = newMaxConcurrentRecoveries;
         }
-        if (previousLimit < newMaxConcurrentRecoveries) {
+        if (previousLimit < newMaxConcurrentRecoveries && lifecycle.started()) {
             fillSlots();
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -274,6 +274,9 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
     @Override
     protected void doClose() {}
 
+    /// Is the service closed, and therefore rejecting further recoveries? It closes in a single step (there's no separate `stop()` call
+    /// first) so we count both [org.elasticsearch.common.component.Lifecycle.State#STOPPED] and
+    /// [org.elasticsearch.common.component.Lifecycle.State#CLOSED] as "closed".
     private boolean isClosed() {
         assert lifecycle.initialized() == false : "service accessed before start";
         return lifecycle.stoppedOrClosed();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -253,6 +253,7 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
 
     @Override
     protected void doStop() {
+        assert isClosed(); // state change happens-before this line: all recoveries are discarded here or rejected during enqueue, no leaks
         final List<PendingRecovery> recoveriesToAbort;
         synchronized (this) {
             recoveriesToAbort = new ArrayList<>(pendingRecoveries);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -317,6 +317,7 @@ public class Node implements Closeable {
         assert localNodeFactory.getNode() != null;
         assert transportService.getLocalNode().equals(localNodeFactory.getNode())
             : "transportService has a different local node than the factory provided";
+        injector.getInstance(ThrottlingRecoveryService.class).start();
         injector.getInstance(PeerRecoverySourceService.class).start();
 
         // Load (and maybe upgrade) the metadata stored on disk

--- a/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.project.AbstractProjectResolver;
 import org.elasticsearch.cluster.project.DefaultProjectResolver;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
@@ -24,6 +25,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -40,6 +42,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -98,12 +101,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         final var projectId2 = randomUniqueProjectId();
         final var projectId3 = randomUniqueProjectId();
 
-        final var service = new ThrottlingRecoveryService(
-            threadPool,
-            multiProjectResolver,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(threadPool, multiProjectResolver, newClusterService(1));
 
         final var firstRecoveryRunning = new CountDownLatch(1);
         final var firstRecoveryProceed = new CountDownLatch(1);
@@ -172,12 +170,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     public void testSynchronousTaskRunsOnProvidedThreadPoolAndNotifiesUserListener() {
         // Use real threads instead of DeterministicTaskQueue to verify actual threading behavior below
         final var recoveryType = randomFrom(RecoverySource.Type.values());
-        final var service = new ThrottlingRecoveryService(
-            threadPool,
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(threadPool, DefaultProjectResolver.INSTANCE, newClusterService(1));
         final var callerThread = Thread.currentThread();
         final var executionThread = new AtomicReference<Thread>();
         final var consumerReturned = new CountDownLatch(1);
@@ -212,12 +205,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     /// Asynchronous task: consumer returns before the scheduling listener receives a terminal callback.
     public void testAsynchronousTaskListenerNotificationAfterConsumerReturns() {
         // Use real threads instead of DeterministicTaskQueue to be able to use safeAwait below
-        final var service = new ThrottlingRecoveryService(
-            threadPool,
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(threadPool, DefaultProjectResolver.INSTANCE, newClusterService(1));
         final var consumerReturned = new CountDownLatch(1);
         final var recoveryDone = new CountDownLatch(1);
         final var userListener = new RecoveryListener() {
@@ -255,11 +243,10 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     public void testMaxConcurrencyBoundWithAsynchronousTasks() {
         final var taskQueue = new DeterministicTaskQueue();
         final int maxConcurrentRecoveries = between(2, 5);
-        final var service = new ThrottlingRecoveryService(
+        final var service = newStartedService(
             taskQueue.getThreadPool(),
             DefaultProjectResolver.INSTANCE,
-            newClusterService(maxConcurrentRecoveries),
-            RecoverySchedulingListener.NOOP
+            newClusterService(maxConcurrentRecoveries)
         );
         final var running = new AtomicInteger();
         final var completed = new AtomicInteger();
@@ -335,12 +322,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     public void testIncreasingMaxConcurrentRecoveriesStartsPendingTasks() {
         final var taskQueue = new DeterministicTaskQueue();
         final var clusterService = newClusterService(2);
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            clusterService,
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, clusterService);
         final var started = new AtomicInteger();
 
         for (int i = 0; i < 10; i++) {
@@ -375,12 +357,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     public void testDecreasingMaxConcurrentRecoveriesDefersQueueWithoutCancellingRunningTasks() {
         final var taskQueue = new DeterministicTaskQueue();
         final var clusterService = newClusterService(3);
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            clusterService,
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, clusterService);
         final var started = new AtomicInteger();
         final var done = new AtomicInteger();
 
@@ -451,12 +428,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testFifoWhenThrottledToOneConcurrentWithSynchronousCompletion() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
         final int total = between(10, 20);
         final var completionOrder = new CopyOnWriteArrayList<Integer>();
 
@@ -502,12 +474,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testFailureTriggersNextQueuedRecovery() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
 
         final var listener1 = new TestCaptureResultListener(ExpectedRecoveryOutcome.FAILED);
         service.enqueue(ProjectId.DEFAULT, listener1, newRecoveryState(), UUIDs.randomBase64UUID(), stats, ignored -> {
@@ -527,12 +494,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testRecoveryAbortedTriggersNextQueuedRecovery() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
 
         final var listener1 = new TestCaptureResultListener(ExpectedRecoveryOutcome.ABORTED);
         service.enqueue(
@@ -556,12 +518,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testCloseAbortsQueuedButNotDispatchedRecoveries() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
 
         final var runningTaskDispatched = new AtomicBoolean();
         final var listener1 = new TestCaptureResultListener(ExpectedRecoveryOutcome.COMPLETED);
@@ -596,12 +553,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testEnqueueAfterCloseImmediatelyAborts() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
         service.close();
 
         final var listener = new TestCaptureResultListener(ExpectedRecoveryOutcome.ABORTED);
@@ -619,12 +571,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testRecordedCancellationAppliedAtEnqueueTime() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(10),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(10));
         final var shardId = new ShardId(randomIndexName(), UUIDs.randomBase64UUID(), 0);
         final var allocationId = UUIDs.randomBase64UUID();
 
@@ -646,12 +593,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testCancellationAppliedWhenTaskInPendingQueue() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(1),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));
         final var shardId1 = new ShardId("index1", UUIDs.randomBase64UUID(), 0);
         final var allocationId1 = UUIDs.randomBase64UUID();
         final var shardId2 = new ShardId("index2", UUIDs.randomBase64UUID(), 0);
@@ -684,12 +626,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     public void testStaleRecordedEntryRemovedOnClusterStateChangeWithShardRelocated() {
         final var taskQueue = new DeterministicTaskQueue();
         final var clusterService = newClusterService(10);
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            clusterService,
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, clusterService);
         final var staleShardId = new ShardId(randomIndexName(), UUIDs.randomBase64UUID(), 0);
         final var staleAllocationId = UUIDs.randomBase64UUID();
         final var retainedShardId = new ShardId(randomIndexName(), UUIDs.randomBase64UUID(), 0);
@@ -744,12 +681,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
     public void testPendingRecoveryDiscardedWhenAllocationIdChangesWhileQueued() {
         final var taskQueue = new DeterministicTaskQueue();
         final var clusterService = newClusterService(1);
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            clusterService,
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, clusterService);
 
         final var blockerShardId = new ShardId(randomIndexName(), UUIDs.randomBase64UUID(), 0);
         final var blockerListener = new TestCaptureResultListener(ExpectedRecoveryOutcome.CANCELLED_STARTED);
@@ -798,12 +730,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
     public void testCancelRecoveryReturnsEmptyWhenNoLongerInQueue() {
         final var taskQueue = new DeterministicTaskQueue();
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            newClusterService(10),
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(10));
         final var shardId = new ShardId(randomIndexName(), UUIDs.randomBase64UUID(), 0);
         final var allocationId = UUIDs.randomBase64UUID();
         final var recoveryState = newRecoveryState(shardId);
@@ -838,12 +765,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
 
         final var maxConcurrency = new AtomicInteger(between(1, 20));
         final var clusterService = newClusterService(maxConcurrency.get());
-        final var service = new ThrottlingRecoveryService(
-            taskQueue.getThreadPool(),
-            DefaultProjectResolver.INSTANCE,
-            clusterService,
-            RecoverySchedulingListener.NOOP
-        );
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, clusterService);
 
         final var recoveryState = newRecoveryState();
         final var running = new AtomicInteger();
@@ -920,13 +842,13 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                 );
                 taskQueue.runAllRunnableTasks();
                 while (randomBoolean() && taskQueue.hasDeferredTasks()) {
-                    if (service.isClosed()) {
+                    if (service.lifecycleState() != Lifecycle.State.STARTED) {
                         assertThat(service.currentQueueSize(), equalTo(0));
                     }
                     taskQueue.advanceTime();
                     taskQueue.runAllRunnableTasks();
                 }
-                if (service.isClosed()) {
+                if (service.lifecycleState() != Lifecycle.State.STARTED) {
                     assertThat(service.currentQueueSize(), equalTo(0));
                 }
             }
@@ -948,12 +870,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         final int initialMaxConcurrentRecoveries = between(1, 20);
         final var clusterService = newClusterService(initialMaxConcurrentRecoveries);
         final var peakLimit = new AtomicInteger(initialMaxConcurrentRecoveries);
-        final var throttlingRecoveryService = new ThrottlingRecoveryService(
-            threadPool,
-            DefaultProjectResolver.INSTANCE,
-            clusterService,
-            RecoverySchedulingListener.NOOP
-        );
+        final var throttlingRecoveryService = newStartedService(threadPool, DefaultProjectResolver.INSTANCE, clusterService);
 
         final var currentMaxConcurrentRecoveries = new AtomicInteger(peakLimit.get());
         final var runningOrPending = new AtomicInteger();
@@ -1152,6 +1069,16 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.localNode()).thenReturn(DiscoveryNodeUtils.create("local-node"));
         return clusterService;
+    }
+
+    private static ThrottlingRecoveryService newStartedService(
+        ThreadPool threadPool,
+        ProjectResolver projectResolver,
+        ClusterService clusterService
+    ) {
+        final var service = new ThrottlingRecoveryService(threadPool, projectResolver, clusterService, RecoverySchedulingListener.NOOP);
+        service.start();
+        return service;
     }
 
     private static RecoveryState newRecoveryState() {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/TransportCancelRecoveriesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/TransportCancelRecoveriesActionTests.java
@@ -77,6 +77,7 @@ public class TransportCancelRecoveriesActionTests extends ESTestCase {
             clusterService,
             RecoverySchedulingListener.NOOP
         );
+        throttlingRecoveryService.start();
         action = new TransportCancelRecoveriesAction(
             MockUtils.setupTransportServiceWithThreadpoolExecutor(),
             new ActionFilters(Set.of()),

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -1319,6 +1319,7 @@ public class SnapshotResiliencyTestHelper {
                 coordinator.start();
                 clusterService.getClusterApplierService().setNodeConnectionsService(nodeConnectionsService);
                 nodeConnectionsService.start();
+                throttlingRecoveryService.start();
                 clusterService.start();
                 indicesService.start();
                 indicesClusterStateService.start();


### PR DESCRIPTION
Avoids the `this` escape by extending `AbstractLifecycleComponent` and
registering listeners during `doStart()` rather than the constructor.
Also makes use of the component's lifecycle rather than a separate
`closed` flag.