### PR TITLE
[Docs] Document MongoDB datetime_conversion connector setting (8.19)

### DIFF
--- a/docs/reference/connector/docs/connectors-mongodb.asciidoc
+++ b/docs/reference/connector/docs/connectors-mongodb.asciidoc
@@ -499,6 +499,23 @@ Default value is `False`.
 We strongly recommend leaving this option disabled in production environments.
 ====
 
+`datetime_conversion`::
+How to handle MongoDB dates that fall outside the range supported by Python (years 1–9999).
+Available in the advanced configuration options.
+Available values:
++
+* `DATETIME` — Raise an error (legacy). The sync fails when it encounters an out-of-range date. This preserves the historical behavior.
+* `DATETIME_CLAMP` — Out-of-range dates are clamped to the minimum or maximum supported date and indexed as ordinary date strings, so the sync can continue.
+* `DATETIME_AUTO` — In-range dates are indexed as date strings, while out-of-range dates are indexed as raw milliseconds since the epoch.
+* `DATETIME_MS` — All dates are indexed as raw milliseconds since the epoch.
++
+Default value is `DATETIME`.
+[NOTE]
+====
+The `DATETIME_AUTO` option can produce mixed types for the same field (date strings and numbers), which might cause Elasticsearch mapping conflicts.
+Prefer `DATETIME_CLAMP` if you need the sync to continue past out-of-range dates.
+====
+
 [discrete#es-connectors-mongodb-create-connector-client]
 ===== Create a {service-name} connector
 include::_connectors-create-client.asciidoc[]

--- a/docs/reference/connector/docs/connectors-mongodb.asciidoc
+++ b/docs/reference/connector/docs/connectors-mongodb.asciidoc
@@ -101,6 +101,22 @@ Disabled by default.
 We strongly recommend leaving this option disabled in production environments.
 ====
 
+Out-of-range date handling::
+How to handle MongoDB dates that fall outside the range supported by Python (years 1–9999).
+Available in the advanced configuration options.
+The available options are:
++
+* *Raise an error (legacy)* — The default. The sync fails when it encounters an out-of-range date. This preserves the historical behavior.
+* *Clamp to the min/max date* — Out-of-range dates are clamped to the minimum or maximum supported date and indexed as ordinary date strings, so the sync can continue.
+* *Out-of-range dates as epoch milliseconds* — In-range dates are indexed as date strings, while out-of-range dates are indexed as raw milliseconds since the epoch.
+* *All dates as epoch milliseconds* — All dates are indexed as raw milliseconds since the epoch.
++
+[NOTE]
+====
+The *Out-of-range dates as epoch milliseconds* option can produce mixed types for the same field (date strings and numbers), which might cause Elasticsearch mapping conflicts.
+Prefer *Clamp to the min/max date* if you need the sync to continue past out-of-range dates.
+====
+
 [discrete#es-connectors-mongodb-create-native-connector]
 ===== Create a {service-name} connector
 include::_connectors-create-native.asciidoc[]


### PR DESCRIPTION
Backport of #153628 to `8.19`.

Documents the new `datetime_conversion` configuration field added to the MongoDB connector in [elastic/connectors#4148](https://github.com/elastic/connectors/pull/4148), which controls how the connector handles MongoDB dates that fall outside the range supported by Python (years 1–9999) instead of aborting the sync.

Because `8.19` still uses the legacy asciidoc docs (and, unlike `main`, retains both a managed/native and a self-managed configuration section), the field is documented in **both** sections of `connectors-mongodb.asciidoc`:
- Self-managed section: by its raw config key `datetime_conversion` with values `DATETIME`, `DATETIME_CLAMP`, `DATETIME_AUTO`, `DATETIME_MS` (matching the other `host`/`ssl_enabled`/`tls_insecure` entries and API/config.yml usage).
- Managed (native) section: by its Kibana UI label `Out-of-range date handling` with the corresponding dropdown options (matching that section's label-based style).

Both include the `DATETIME` (Raise an error) default and a note recommending clamping over epoch milliseconds to avoid mixed-type mapping conflicts.

Docs-only change; no code or console snippets affected.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`? (N/A — docs-only change)
- [ ] If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. (This is a backport of #153628 to 8.19.)
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [ ] If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. (N/A)

Made with [Cursor](https://cursor.com)