### PR TITLE
ES|QL: prune partitions on hive-partitioned datasets

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
@@ -370,6 +370,60 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
         assertPrune(dataset, "WHERE year == 2025 | SORT id ASC | LIMIT 4", TOTAL_FILES, 4, idsWhere((y, m, d) -> y == 2025));
     }
 
+    // -- Keyed glob: the folder-LISTING layer. These are the only tests here where the glob rewrite is live. --
+
+    /**
+     * Positive control. On a glob that names its partition keys, a partition filter rewrites the glob itself, so the
+     * non-matching folders are never enumerated. This must keep working — the guards below restrict when a hint may be
+     * trusted, and a guard drawn too wide would silently turn every keyed dataset back into a full listing.
+     */
+    public void testKeyedGlobPrunesTheListing() throws Exception {
+        String dataset = registerKeyedTree("csv_keyed", "csv");
+        assertPrune(dataset, "WHERE year == 2025", TOTAL_FILES, 4, idsWhere((y, m, d) -> y == 2025));
+    }
+
+    /** Same, across all three keys, so every segment of the glob is rewritten. */
+    public void testKeyedGlobPrunesOnAllThreeKeys() throws Exception {
+        String dataset = registerKeyedTree("csv_keyed_full", "csv");
+        assertPrune(
+            dataset,
+            "WHERE year == 2025 AND month == 6 AND day == 15",
+            TOTAL_FILES,
+            1,
+            idsWhere((y, m, d) -> y == 2025 && m == 6 && d == 15)
+        );
+    }
+
+    /**
+     * The listing layer's cardinality guard, end to end. {@code SORT id | LIMIT 4 | WHERE year == 2025} takes the four
+     * lowest ids — all from 2024 — and filters them afterwards, so the answer is <b>no rows</b>. If the hint were
+     * allowed to rewrite the glob, only 2025's folders would be listed, the limit window would refill from them, and
+     * the query would return four rows nobody asked for.
+     *
+     * <p>Unlike its {@code **}-glob twin, this one genuinely discriminates the guard: remove it and the query returns
+     * four rows.
+     */
+    public void testKeyedGlobMustNotPruneListingAboveLimit() throws Exception {
+        String dataset = registerKeyedTree("csv_keyed_limit", "csv");
+        assertPrune(dataset, "SORT id ASC | LIMIT 4 | WHERE year == 2025", TOTAL_FILES, TOTAL_FILES, List.of());
+    }
+
+    /**
+     * The listing layer's shadow guard, end to end. {@code EVAL year = id % 10000} redefines {@code year} as a row
+     * value; {@code WHERE year == 615} must match the two June-15 rows. If the hint were trusted, the glob would be
+     * rewritten to {@code year=615/}, which matches no folder — historically an outright "matched no files" error.
+     */
+    public void testKeyedGlobMustNotPruneListingOnShadowedColumn() throws Exception {
+        String dataset = registerKeyedTree("csv_keyed_shadow", "csv");
+        assertPrune(
+            dataset,
+            "EVAL year = id % 10000 | WHERE year == 615",
+            TOTAL_FILES,
+            TOTAL_FILES,
+            idsWhere((y, m, d) -> idFor(y, m, d) % 10000 == 615)
+        );
+    }
+
     // -- End-to-end: pruning must be visible to a user, in the rendered profile JSON --
 
     /**
@@ -542,6 +596,38 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
     }
 
     /**
+     * The same 8-file tree, registered with a glob that <em>names</em> its partition keys — {@code year=*},
+     * {@code month=*}, {@code day=*} — instead of hiding them behind a bare {@code **}.
+     *
+     * <p>This is the shape that reaches the listing layer. {@code GlobExpander.rewriteSegment} only rewrites a segment
+     * spelled exactly {@code key=*}, so on the {@code **} glob every other test here uses, the rewrite is inert and the
+     * folders are always listed — only the read layer prunes. With the keys named, a partition hint rewrites the glob
+     * and the non-matching folders are never <em>enumerated</em>, which is a pruning decision taken before a
+     * {@code FileList} exists and which nothing downstream can undo. That is why the guards have to hold here too.
+     *
+     * <p>Two fixture details are load-bearing. The glob keeps a recursive wildcard and a concrete extension — the local
+     * file provider only recurses for globs containing one, and the format is inferred from the extension. And the
+     * month/day segments are written <em>unpadded</em>
+     * ({@code month=6}, not {@code month=06}) because the rewrite spells a hint's value with {@code String.valueOf} —
+     * {@code month == 6} would rewrite to {@code month=6} and match no zero-padded folder at all.
+     */
+    private String registerKeyedTree(String name, String format) throws IOException {
+        Path root = createTempDir().resolve(name);
+        for (int year : YEARS) {
+            for (int month : MONTHS) {
+                for (int day : DAYS) {
+                    Path dir = root.resolve("year=" + year).resolve("month=" + month).resolve("day=" + day);
+                    Files.createDirectories(dir);
+                    writeRow(dir, idFor(year, month, day), format);
+                }
+            }
+        }
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's trailing '/**' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/year=*/month=*/day=*/**/*." + format;
+        return registerDataset(name, glob, Map.of("hive_partitioning", true));
+    }
+
+    /**
      * Registers the 8-file {@code year/month/day} Hive tree for the given format ({@code csv} or {@code parquet}),
      * one single-row file per {@code (year, month, day)} triple, each row's {@code id} = {@link #idFor}. Returns the
      * registered dataset name.
@@ -604,11 +690,15 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
     private static void writeFile(Path root, int year, int month, int day, String format) throws IOException {
         Path dir = root.resolve("year=" + year).resolve("month=" + pad2(month)).resolve("day=" + pad2(day));
         Files.createDirectories(dir);
-        int id = idFor(year, month, day);
+        writeRow(dir, idFor(year, month, day), format);
+    }
+
+    /** Writes {@code dir/f.<format>} carrying one row with a single {@code id} column. */
+    private static void writeRow(Path dir, int id, String format) throws IOException {
         if (format.equals("csv")) {
             Files.writeString(dir.resolve("f.csv"), "id\n" + id + "\n", StandardCharsets.UTF_8);
         } else {
-            // One row, one int32 id column, value = YYYYMMDD. rowGroupSize 1024 keeps it a single row group -> one split.
+            // One row, one int32 id column. rowGroupSize 1024 keeps it a single row group -> one split.
             writeParquet(dir.resolve("f.parquet"), "message test { required int32 id; }", 1, 1024, (g, i) -> g.add("id", id));
         }
     }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
@@ -33,27 +33,27 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 /**
- * Coverage for elastic/elasticsearch#153618: partition pruning never fired on a Hive-partitioned external dataset, so
- * every query full-scanned every partition folder.
+ * Verifies that filtering a Hive-partitioned external dataset on a partition column reads only the matching partition
+ * folders, and returns exactly the matching rows.
  *
- * <p><b>Pruning was dead on every production query.</b> Since #143696 every {@code FROM <dataset>} is wrapped in a
- * {@code FragmentExec}, so the coordinator physical-plan walk ({@code ComputeService.discoverSplits}) never reaches a
- * top-level {@code ExternalSourceExec}; discovery runs on the <em>fragment</em> path
- * ({@code discoverSplitsFromFragments}), which lowered each {@code ExternalRelation} in isolation and dropped the
- * {@code Filter} ancestor — so {@code FileSplitProvider.matchesPartitionFilters} never saw the partition conjunct, on
- * single-node runs as well as distributed ones. Most tests here force distribution
- * ({@code external_distribution=round_robin} across {@code >=2} data nodes) and assert that the external scan ran on a
- * data node, so the fragment path is genuinely exercised rather than a coordinator-local warm-fold; a control
- * ({@link #testCsvYearPrunesUndistributed}) checks pruning still happens without forcing distribution.
+ * <p>A {@code FROM <dataset>} is wrapped in a {@code FragmentExec}, so the coordinator physical-plan walk never reaches
+ * a top-level {@code ExternalSourceExec}; discovery runs on the <em>fragment</em> path
+ * ({@code discoverSplitsFromFragments}), which lowers each {@code ExternalRelation} in isolation and would drop the
+ * {@code Filter} ancestor. {@code SplitDiscoveryPhase.guardedRelations} recovers the partition conjunct before that
+ * lowering so {@code FileSplitProvider.matchesPartitionFilters} can prune. Most tests here force distribution
+ * ({@code external_distribution=round_robin} across {@code >=2} data nodes) and assert the external scan ran on a data
+ * node, so the fragment path is genuinely exercised rather than a coordinator-local warm-fold; a control
+ * ({@link #testCsvYearPrunesUndistributed}) checks pruning without forcing distribution.
  *
- * <p><b>Wiring the filter through is necessary but not sufficient.</b> Once the conjunct reaches the split provider,
- * two latent defects in the matcher become reachable — and both return <em>wrong rows</em>, not merely slow ones:
- * a keyword partition value (a Java {@code String}) compared against an ES|QL literal (a Lucene {@code BytesRef}) never
- * matched, so {@code region == "US"} pruned every file and returned nothing; and a filter over a downstream-generated
- * column that merely shares a partition column's name (an {@code EVAL year = ...} shadowing the path's {@code year})
- * was matched by name, pruning on the path value and silently dropping matching rows. A numeric {@code year/month/day}
- * matrix dodges both, which is why {@link #testCsvKeywordPartitionEqualityPrunes} and
- * {@link #testCsvEvalShadowsPartitionColumnNoWrongPrune} carry the weight here.
+ * <p>Routing the conjunct to the matcher is necessary but not sufficient — the matcher itself has to compare partition
+ * values correctly, and two cases return <em>wrong rows</em> rather than merely slow ones:
+ * a keyword partition value (a Java {@code String}) compared against an ES|QL literal (a Lucene {@code BytesRef}) must
+ * normalize through {@code BytesRefs.toString}, or {@code region == "US"} prunes every file and returns nothing; and a
+ * filter over a downstream-generated column that merely shares a partition column's name (an {@code EVAL year = ...}
+ * shadowing the path's {@code year}) must be bound by {@code NameId}, or it prunes on the path value and silently drops
+ * matching rows. A numeric {@code year/month/day} matrix exercises neither, which is why
+ * {@link #testCsvKeywordPartitionEqualityPrunes} and {@link #testCsvEvalShadowsPartitionColumnNoWrongPrune} carry the
+ * weight here.
  *
  * <p><b>Fixture.</b> A three-dimension Hive tree {@code year=YYYY/month=MM/day=DD/f.<ext>}, over
  * years {@code {2024,2025}} × months {@code {01,06}} × days {@code {01,15}} = <b>8 single-row files</b>. Each file
@@ -63,15 +63,13 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  * 3-part spec spans 1.
  *
  * <p><b>Every case is asserted in both directions</b> (see {@link #assertPrune}): the exact surviving rows, against a
- * Java oracle over the fixture — which is what catches a file wrongly pruned away — <em>and</em> {@code files_scanned}
- * from the profile, which is what catches pruning that silently stopped happening. Neither alone is enough: a row count
- * cannot tell a dropped row from a never-matching one, and a file count cannot tell a correct answer from a lucky one.
+ * Java oracle over the fixture — which catches a file wrongly pruned away — <em>and</em> {@code files_scanned} from the
+ * profile, which catches a filter that does not prune when it should. Neither alone is enough: a row count cannot tell a
+ * dropped row from a never-matching one, and a file count cannot tell a correct answer from a lucky one.
  *
- * <p>The cases that expect <em>fewer</em> files than the fixture holds are the ones red on the parent commit, where the
- * count is always the full set. The cases that expect the full count are the opposite kind of guard — they pin that a
- * data-column filter, an un-evaluable {@code OR} arm, or a row-derived column does <em>not</em> prune, and they are
- * green on the parent precisely because nothing pruned there. They earn their place by failing if pruning is ever drawn
- * too wide.
+ * <p>Cases that expect <em>fewer</em> files than the fixture holds assert that pruning fired. Cases that expect the full
+ * count are the opposite guard — they pin that a data-column filter, an un-evaluable {@code OR} arm, or a row-derived
+ * column does <em>not</em> prune, so they fail if pruning is ever drawn too wide.
  */
 public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT {
 
@@ -350,10 +348,9 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
      * <p><b>What this test does and does not prove.</b> It pins the user-visible answer; it does <em>not</em>
      * discriminate {@code SplitDiscoveryPhase}'s seed guard, and passes with that guard removed. {@code LIMIT} is a
      * pipeline breaker, so the fragment ends beneath it and the filter never enters the fragment body that split
-     * discovery walks — the seed cannot leak here today. The guard is defence in depth against that boundary moving
-     * (which is precisely what #143696 did); the unit test {@code testGuardedRelationsDoesNotSeedPastLimit} is what
-     * actually holds it in place. This test is here so that if the boundary ever does move, the wrong answer is caught
-     * at the query level rather than shipped.
+     * discovery walks — the seed cannot leak here today. The guard is defence in depth against that boundary moving;
+     * the unit test {@code testGuardedRelationsDoesNotSeedPastLimit} is what actually holds it in place. This test is
+     * here so that if the boundary ever does move, the wrong answer is caught at the query level rather than shipped.
      */
     public void testFilterAboveLimitMustNotPrune() throws Exception {
         String dataset = registerTree("csv_limit", "csv");
@@ -431,9 +428,7 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
      * files, and the counters survive all the way out to the {@code profile} block of the response body a client
      * actually receives. Every other test here reads the profile as an in-process object, which never exercises the
      * XContent rendering — so a counter that is collected correctly but never serialized would pass all of them.
-     *
-     * <p>Before this fix {@code files_scanned} was always the full file count, so the number a client saw was the
-     * proof that pruning was dead. It is the number asserted here.
+     * {@code files_scanned} in the rendered body is the number a client sees, and it is the number asserted here.
      */
     public void testPruningIsVisibleInRenderedProfileJson() throws Exception {
         String dataset = registerTree("csv_profile_e2e", "csv");
@@ -453,7 +448,7 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
             // The profile a client sees. 4 of the 8 files opened, the other 4 skipped without being read.
             String json = Strings.toString(wrapAsToXContent(response), true, false);
             assertThat(
-                "the rendered profile must show only the 4 matching files were opened — it reported all 8 before this fix",
+                "the rendered profile must show only the 4 matching files were opened",
                 json,
                 containsString("\"files_scanned\" : 4")
             );
@@ -463,8 +458,8 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
     // -- Control: the SAME filter must prune without the round_robin pragma forcing distribution --
 
     /**
-     * Not a different code path — since #143696 every {@code FROM <dataset>} goes through the fragment path. This just
-     * drops the {@code round_robin} pragma the other tests use, pinning that pruning does not depend on it.
+     * Not a different code path — every {@code FROM <dataset>} goes through the fragment path. This just drops the
+     * {@code round_robin} pragma the other tests use, pinning that pruning does not depend on it.
      */
     public void testCsvYearPrunesUndistributed() throws Exception {
         String dataset = registerTree("csv_coord", "csv");
@@ -496,7 +491,7 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
      *       independently of ES|QL. This is what catches pruning that drops a file it should have kept: a row-count
      *       check cannot, because a lost row and a never-matching row produce the same number.</li>
      *   <li><b>Files (the optimization).</b> Exactly {@code expectedFilesScanned} of the fixture's {@code totalFiles}
-     *       may be opened. On the parent commit this number is always the full count, whatever the filter says.</li>
+     *       may be opened — the filter must narrow the scan to the matching partitions.</li>
      * </ul>
      *
      * <p>Both are asserted on <b>both plan shapes</b>: the projection path ({@code KEEP id | SORT id}) and the aggregate
@@ -532,8 +527,7 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
      */
     private List<List<Object>> runPruned(String dataset, String tail, int totalFiles, int expectedFilesScanned) {
         // round_robin distributes every surviving split to a data node regardless of plan shape, so the read lowers
-        // through a FragmentExec and split discovery runs on the fragment path (discoverSplitsFromFragments) — the
-        // #153618-buggy path.
+        // through a FragmentExec and split discovery runs on the fragment path (discoverSplitsFromFragments).
         QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
 
         String query = "FROM " + dataset + " | " + tail;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
@@ -1,0 +1,615 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.ChunkedToXContent.wrapAsToXContent;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Coverage for elastic/elasticsearch#153618: partition pruning never fired on a Hive-partitioned external dataset, so
+ * every query full-scanned every partition folder.
+ *
+ * <p><b>Pruning was dead on every production query.</b> Since #143696 every {@code FROM <dataset>} is wrapped in a
+ * {@code FragmentExec}, so the coordinator physical-plan walk ({@code ComputeService.discoverSplits}) never reaches a
+ * top-level {@code ExternalSourceExec}; discovery runs on the <em>fragment</em> path
+ * ({@code discoverSplitsFromFragments}), which lowered each {@code ExternalRelation} in isolation and dropped the
+ * {@code Filter} ancestor — so {@code FileSplitProvider.matchesPartitionFilters} never saw the partition conjunct, on
+ * single-node runs as well as distributed ones. Most tests here force distribution
+ * ({@code external_distribution=round_robin} across {@code >=2} data nodes) and assert that the external scan ran on a
+ * data node, so the fragment path is genuinely exercised rather than a coordinator-local warm-fold; a control
+ * ({@link #testCsvYearPrunesUndistributed}) checks pruning still happens without forcing distribution.
+ *
+ * <p><b>Wiring the filter through is necessary but not sufficient.</b> Once the conjunct reaches the split provider,
+ * two latent defects in the matcher become reachable — and both return <em>wrong rows</em>, not merely slow ones:
+ * a keyword partition value (a Java {@code String}) compared against an ES|QL literal (a Lucene {@code BytesRef}) never
+ * matched, so {@code region == "US"} pruned every file and returned nothing; and a filter over a downstream-generated
+ * column that merely shares a partition column's name (an {@code EVAL year = ...} shadowing the path's {@code year})
+ * was matched by name, pruning on the path value and silently dropping matching rows. A numeric {@code year/month/day}
+ * matrix dodges both, which is why {@link #testCsvKeywordPartitionEqualityPrunes} and
+ * {@link #testCsvEvalShadowsPartitionColumnNoWrongPrune} carry the weight here.
+ *
+ * <p><b>Fixture.</b> A three-dimension Hive tree {@code year=YYYY/month=MM/day=DD/f.<ext>}, over
+ * years {@code {2024,2025}} × months {@code {01,06}} × days {@code {01,15}} = <b>8 single-row files</b>. Each file
+ * carries one row whose {@code id} data column is {@code YYYYMMDD} (see {@link #idFor}), so every row is uniquely
+ * identifiable and a partial filter prunes to a <em>subset of several</em> files, not always one:
+ * {@code year==2025} spans 4 files, {@code month==06} spans 4, {@code year==2025 AND month==06} spans 2, the full
+ * 3-part spec spans 1.
+ *
+ * <p><b>Every case is asserted in both directions</b> (see {@link #assertPrune}): the exact surviving rows, against a
+ * Java oracle over the fixture — which is what catches a file wrongly pruned away — <em>and</em> {@code files_scanned}
+ * from the profile, which is what catches pruning that silently stopped happening. Neither alone is enough: a row count
+ * cannot tell a dropped row from a never-matching one, and a file count cannot tell a correct answer from a lucky one.
+ * Every {@code files_scanned} expectation here is red on the parent commit, where the number is always the full 8.
+ */
+public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT {
+
+    private static final int[] YEARS = { 2024, 2025 };
+    private static final int[] MONTHS = { 1, 6 };
+    private static final int[] DAYS = { 1, 15 };
+    private static final int TOTAL_FILES = 8; // 2 x 2 x 2, one single-row file each
+
+    /** The region fixture's three single-row files, each id fixed to its folder so the expected row is unambiguous. */
+    private static final String[] REGIONS = { "US", "EU", "AP" };
+    private static final long US_ID = 0L;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class, ParquetDataSourcePlugin.class);
+    }
+
+    // -- Single-dimension partial pushdown: leading, middle, and deepest dimension --
+
+    public void testCsvYearOnlyPrunesToFourFiles() throws Exception {
+        // Leading dimension. year=2025 spans months {01,06} x days {01,15} = 4 files.
+        assertPrune("csv_year", "csv", "WHERE year == 2025", 4, idsWhere((y, m, d) -> y == 2025));
+    }
+
+    public void testParquetYearOnlyPrunesToFourFiles() throws Exception {
+        assertPrune("pq_year", "parquet", "WHERE year == 2025", 4, idsWhere((y, m, d) -> y == 2025));
+    }
+
+    public void testCsvMonthOnlyPrunesNonLeadingDimension() throws Exception {
+        // Non-leading dimension. month=06 spans years {2024,2025} x days {01,15} = 4 files.
+        assertPrune("csv_month", "csv", "WHERE month == 6", 4, idsWhere((y, m, d) -> m == 6));
+    }
+
+    public void testParquetMonthOnlyPrunesNonLeadingDimension() throws Exception {
+        assertPrune("pq_month", "parquet", "WHERE month == 6", 4, idsWhere((y, m, d) -> m == 6));
+    }
+
+    public void testCsvDayOnlyPrunesDeepestDimension() throws Exception {
+        // Deepest dimension. day=15 spans years {2024,2025} x months {01,06} = 4 files.
+        assertPrune("csv_day", "csv", "WHERE day == 15", 4, idsWhere((y, m, d) -> d == 15));
+    }
+
+    public void testParquetDayOnlyPrunesDeepestDimension() throws Exception {
+        assertPrune("pq_day", "parquet", "WHERE day == 15", 4, idsWhere((y, m, d) -> d == 15));
+    }
+
+    // -- Multi-dimension conjunctive pushdown: 2-of-3 and full spec --
+
+    public void testCsvYearAndMonthPrunesToTwoFiles() throws Exception {
+        // 2-of-3 subset. year=2025 AND month=06 spans days {01,15} = 2 files.
+        assertPrune("csv_ym", "csv", "WHERE year == 2025 AND month == 6", 2, idsWhere((y, m, d) -> y == 2025 && m == 6));
+    }
+
+    public void testParquetYearAndMonthPrunesToTwoFiles() throws Exception {
+        assertPrune("pq_ym", "parquet", "WHERE year == 2025 AND month == 6", 2, idsWhere((y, m, d) -> y == 2025 && m == 6));
+    }
+
+    public void testCsvFullSpecPrunesToOneFile() throws Exception {
+        // Full 3-part spec pins exactly one file.
+        assertPrune(
+            "csv_ymd",
+            "csv",
+            "WHERE year == 2025 AND month == 6 AND day == 15",
+            1,
+            idsWhere((y, m, d) -> y == 2025 && m == 6 && d == 15)
+        );
+    }
+
+    public void testParquetFullSpecPrunesToOneFile() throws Exception {
+        assertPrune(
+            "pq_ymd",
+            "parquet",
+            "WHERE year == 2025 AND month == 6 AND day == 15",
+            1,
+            idsWhere((y, m, d) -> y == 2025 && m == 6 && d == 15)
+        );
+    }
+
+    // -- Range + IN on a partition column --
+
+    public void testCsvYearInMatchingBothYearsScansAll() throws Exception {
+        // IN over both existing years matches every folder -> no prune (8 files), rows still correct.
+        assertPrune("csv_in2", "csv", "WHERE year IN (2024, 2025)", TOTAL_FILES, idsWhere((y, m, d) -> y == 2024 || y == 2025));
+    }
+
+    public void testCsvYearInSingleYearPrunesToFour() throws Exception {
+        // IN over a single existing year prunes to that year's 4 files.
+        assertPrune("csv_in1", "csv", "WHERE year IN (2025)", 4, idsWhere((y, m, d) -> y == 2025));
+    }
+
+    public void testCsvMonthRangePrunesToSubset() throws Exception {
+        // month > 1 keeps only month=06 -> 4 files.
+        assertPrune("csv_mrange", "csv", "WHERE month > 1", 4, idsWhere((y, m, d) -> m > 1));
+    }
+
+    public void testParquetMonthRangePrunesToSubset() throws Exception {
+        assertPrune("pq_mrange", "parquet", "WHERE month > 1", 4, idsWhere((y, m, d) -> m > 1));
+    }
+
+    // -- Mixed partition + data column: partition prunes folders, data column stays a row filter --
+
+    public void testCsvYearPlusDataColumnDoesNotOverPrune() throws Exception {
+        // year=2025 prunes to its 4 files; the id>N conjunct must NOT further prune files (id is a data column,
+        // not path-derived) — it only filters rows. So files_scanned stays 4 while the surviving rows reflect both
+        // conjuncts. 2025 file ids are 20250101, 20250115, 20250601, 20250615; id > 20250200 keeps the two June rows.
+        assertPrune(
+            "csv_mixed",
+            "csv",
+            "WHERE year == 2025 AND id > 20250200",
+            4,
+            idsWhere((y, m, d) -> y == 2025 && idFor(y, m, d) > 20250200)
+        );
+    }
+
+    public void testParquetYearPlusDataColumnDoesNotOverPrune() throws Exception {
+        assertPrune(
+            "pq_mixed",
+            "parquet",
+            "WHERE year == 2025 AND id > 20250200",
+            4,
+            idsWhere((y, m, d) -> y == 2025 && idFor(y, m, d) > 20250200)
+        );
+    }
+
+    // -- Negative / no-prune sanity: filter on a data-only column must never prune a partition file --
+
+    public void testCsvDataColumnOnlyFilterScansAllFiles() throws Exception {
+        // id is a data column present in every file; filtering on it must scan ALL 8 files (never prune on a
+        // non-partition column -> no wrong results). Exactly one row matches.
+        assertPrune("csv_data", "csv", "WHERE id == 20250615", TOTAL_FILES, idsWhere((y, m, d) -> idFor(y, m, d) == 20250615));
+    }
+
+    public void testParquetDataColumnOnlyFilterScansAllFiles() throws Exception {
+        assertPrune("pq_data", "parquet", "WHERE id == 20250615", TOTAL_FILES, idsWhere((y, m, d) -> idFor(y, m, d) == 20250615));
+    }
+
+    // -- Zero-match: a partition filter matching no folder prunes to the empty set (not an error, not a full scan) --
+
+    public void testCsvZeroMatchPrunesToNoFiles() throws Exception {
+        // year=2099 matches no folder -> every file pruned. files_scanned == 0, files_pruned == 8, no rows.
+        assertPrune("csv_zero", "csv", "WHERE year == 2099", 0, idsWhere((y, m, d) -> y == 2099));
+    }
+
+    public void testParquetZeroMatchPrunesToNoFiles() throws Exception {
+        assertPrune("pq_zero", "parquet", "WHERE year == 2099", 0, idsWhere((y, m, d) -> y == 2099));
+    }
+
+    // -- NOT-EQUALS on a partition column: prunes the excluded folder, keeps the rest --
+
+    public void testCsvNotEqualsPrunesExcludedYear() throws Exception {
+        // year != 2024 drops 2024's 4 files, keeps 2025's 4 files.
+        assertPrune("csv_ne", "csv", "WHERE year != 2024", 4, idsWhere((y, m, d) -> y != 2024));
+    }
+
+    public void testParquetNotEqualsPrunesExcludedYear() throws Exception {
+        assertPrune("pq_ne", "parquet", "WHERE year != 2024", 4, idsWhere((y, m, d) -> y != 2024));
+    }
+
+    // -- OR over partition-only arms: prunes to exactly the union of the named folders (nullableOr TRUE/FALSE path) --
+
+    public void testCsvOrOfPartitionArmsPrunesToUnion() throws Exception {
+        // (year=2024 AND month=01) OR (year=2025 AND month=06): each named (year,month) folder spans days {01,15},
+        // so the union is 4 files across the two folders.
+        assertPrune(
+            "csv_or",
+            "csv",
+            "WHERE (year == 2024 AND month == 1) OR (year == 2025 AND month == 6)",
+            4,
+            idsWhere((y, m, d) -> (y == 2024 && m == 1) || (y == 2025 && m == 6))
+        );
+    }
+
+    public void testParquetOrOfPartitionArmsPrunesToUnion() throws Exception {
+        assertPrune(
+            "pq_or",
+            "parquet",
+            "WHERE (year == 2024 AND month == 1) OR (year == 2025 AND month == 6)",
+            4,
+            idsWhere((y, m, d) -> (y == 2024 && m == 1) || (y == 2025 && m == 6))
+        );
+    }
+
+    // -- OR with a data-column arm: the un-evaluable arm forces keep-on-null -> no file may be pruned --
+
+    public void testCsvOrWithDataColumnDoesNotPrune() throws Exception {
+        // year=2025 OR id==20240101 : the id arm cannot be evaluated at partition time, so nullableOr(FALSE, null)
+        // == null for the 2024 files -> keep. No file may be pruned -> files_scanned == 8. The surviving rows are
+        // year 2025's four, plus the single 2024 row whose id matches.
+        assertPrune(
+            "csv_or_data",
+            "csv",
+            "WHERE year == 2025 OR id == 20240101",
+            TOTAL_FILES,
+            idsWhere((y, m, d) -> y == 2025 || idFor(y, m, d) == 20240101)
+        );
+    }
+
+    public void testParquetOrWithDataColumnDoesNotPrune() throws Exception {
+        assertPrune(
+            "pq_or_data",
+            "parquet",
+            "WHERE year == 2025 OR id == 20240101",
+            TOTAL_FILES,
+            idsWhere((y, m, d) -> y == 2025 || idFor(y, m, d) == 20240101)
+        );
+    }
+
+    // -- Keyword/string partition column: equality + range must prune correctly (BytesRef literal vs String value) --
+
+    public void testCsvKeywordPartitionEqualityPrunes() throws Exception {
+        // region partitions {US, EU, AP}. region == "US" must prune to exactly the US file. The literal is a BytesRef;
+        // the partition value is a Java String — a raw toString() compare would see hex and never match.
+        String dataset = registerRegionTree("csv_kw_eq", "csv");
+        assertPruneRegion(dataset, "WHERE region == \"US\"", 1, List.of(US_ID));
+    }
+
+    public void testParquetKeywordPartitionEqualityPrunes() throws Exception {
+        String dataset = registerRegionTree("pq_kw_eq", "parquet");
+        assertPruneRegion(dataset, "WHERE region == \"US\"", 1, List.of(US_ID));
+    }
+
+    public void testCsvKeywordPartitionEqualityIsCaseSensitive() throws Exception {
+        // Lowercase "us" must NOT match the uppercase US folder: keyword equality is byte-exact. Every folder pruned
+        // -> 0 files, 0 rows.
+        String dataset = registerRegionTree("csv_kw_case", "csv");
+        assertPruneRegion(dataset, "WHERE region == \"us\"", 0, List.of());
+    }
+
+    public void testCsvKeywordPartitionRangePrunes() throws Exception {
+        // region >= "M" keeps only US ('U'=0x55 >= 'M'=0x4D); EU ('E'=0x45) and AP ('A'=0x41) are < "M" -> dropped.
+        String dataset = registerRegionTree("csv_kw_range", "csv");
+        assertPruneRegion(dataset, "WHERE region >= \"M\"", 1, List.of(US_ID));
+    }
+
+    public void testParquetKeywordPartitionRangePrunes() throws Exception {
+        String dataset = registerRegionTree("pq_kw_range", "parquet");
+        assertPruneRegion(dataset, "WHERE region >= \"M\"", 1, List.of(US_ID));
+    }
+
+    // -- Shadowed/generated column named like a partition: EVAL redefines `year`, filter must use the ROW value --
+
+    public void testCsvEvalShadowsPartitionColumnNoWrongPrune() throws Exception {
+        // EVAL year = id % 10000 redefines `year` to the row-derived MMDD (0615 for both June-15 files, across BOTH
+        // path years 2024 and 2025). WHERE year == 615 must therefore return BOTH June-15 rows. If the seed prunes by
+        // the PATH partition `year` (a name-only match), no folder equals 615, everything is pruned, and the query
+        // silently returns nothing. The generated `year` is not a partition column, so NO file may be pruned either.
+        String dataset = registerTree("csv_shadow", "csv");
+        assertPrune(
+            dataset,
+            "EVAL year = id % 10000 | WHERE year == 615",
+            TOTAL_FILES,
+            TOTAL_FILES,
+            idsWhere((y, m, d) -> idFor(y, m, d) % 10000 == 615)
+        );
+    }
+
+    public void testParquetEvalShadowsPartitionColumnNoWrongPrune() throws Exception {
+        String dataset = registerTree("pq_shadow", "parquet");
+        assertPrune(
+            dataset,
+            "EVAL year = id % 10000 | WHERE year == 615",
+            TOTAL_FILES,
+            TOTAL_FILES,
+            idsWhere((y, m, d) -> idFor(y, m, d) % 10000 == 615)
+        );
+    }
+
+    // -- A filter below a row-selecting node must NOT prune: LIMIT does not commute with WHERE --
+
+    /**
+     * {@code SORT id | LIMIT 4 | WHERE year == 2025} means: take the four lowest-id rows — 2024's, since every 2024 id
+     * sorts below every 2025 id — and filter them <em>afterwards</em>. None is from 2025, so the correct answer is
+     * <b>no rows at all</b>. Were the {@code WHERE} used to prune first, the 2024 files would be skipped, the
+     * {@code LIMIT} window would refill from the 2025 files, and the query would return four rows nobody asked for.
+     *
+     * <p><b>What this test does and does not prove.</b> It pins the user-visible answer; it does <em>not</em>
+     * discriminate {@code SplitDiscoveryPhase}'s seed guard, and passes with that guard removed. {@code LIMIT} is a
+     * pipeline breaker, so the fragment ends beneath it and the filter never enters the fragment body that split
+     * discovery walks — the seed cannot leak here today. The guard is defence in depth against that boundary moving
+     * (which is precisely what #143696 did); the unit test {@code testGuardedRelationsDoesNotSeedPastLimit} is what
+     * actually holds it in place. This test is here so that if the boundary ever does move, the wrong answer is caught
+     * at the query level rather than shipped.
+     */
+    public void testFilterAboveLimitMustNotPrune() throws Exception {
+        String dataset = registerTree("csv_limit", "csv");
+        assertPrune(dataset, "SORT id ASC | LIMIT 4 | WHERE year == 2025", TOTAL_FILES, TOTAL_FILES, List.of());
+    }
+
+    /**
+     * The complement: with the filter <em>below</em> the limit, {@code WHERE} genuinely runs first, so it sits inside
+     * the fragment and must still prune. Pins that keeping the seed away from cardinality-sensitive nodes has not
+     * simply switched pruning off whenever a {@code LIMIT} appears in the query.
+     */
+    public void testFilterBelowLimitStillPrunes() throws Exception {
+        String dataset = registerTree("csv_limit_below", "csv");
+        assertPrune(dataset, "WHERE year == 2025 | SORT id ASC | LIMIT 4", TOTAL_FILES, 4, idsWhere((y, m, d) -> y == 2025));
+    }
+
+    // -- End-to-end: pruning must be visible to a user, in the rendered profile JSON --
+
+    /**
+     * The full stack in one assertion: a real Hive-partitioned query runs distributed, the partition filter prunes
+     * files, and the counters survive all the way out to the {@code profile} block of the response body a client
+     * actually receives. Every other test here reads the profile as an in-process object, which never exercises the
+     * XContent rendering — so a counter that is collected correctly but never serialized would pass all of them.
+     *
+     * <p>This is also the test that makes the fix self-evidencing. Before #153618, {@code files_pruned} was
+     * structurally absent from every query's profile (nothing was ever pruned) and {@code files_scanned} was always
+     * the full file count. Both halves are asserted here, because either one alone can be read the wrong way:
+     * {@code files_scanned: 4} looks healthy on a dataset that happens to have 4 files, and {@code files_pruned: 4}
+     * without its counterpart says nothing about what was actually read.
+     */
+    public void testPruningIsVisibleInRenderedProfileJson() throws Exception {
+        String dataset = registerTree("csv_profile_e2e", "csv");
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
+        var request = syncEsqlQueryRequest("FROM " + dataset + " | WHERE year == 2025 | KEEP id | SORT id ASC");
+        request.pragmas(pragmas);
+        request.acceptedPragmaRisks(true);
+        request.profile(true);
+
+        try (var response = run(request)) {
+            // The rows a client sees: exactly year 2025's four, none dropped by pruning.
+            List<Long> ids = getValuesList(response).stream().map(row -> ((Number) row.get(0)).longValue()).toList();
+            assertThat(ids, equalTo(idsWhere((y, m, d) -> y == 2025)));
+
+            // The profile a client sees. 4 of the 8 files opened, the other 4 skipped without being read.
+            String json = Strings.toString(wrapAsToXContent(response), true, false);
+            assertThat(
+                "the rendered profile must show only the 4 matching files were opened — it reported all 8 before this fix",
+                json,
+                containsString("\"files_scanned\" : 4")
+            );
+        }
+    }
+
+    // -- Control: the SAME filter must prune without the round_robin pragma forcing distribution --
+
+    /**
+     * Not a different code path — since #143696 every {@code FROM <dataset>} goes through the fragment path. This just
+     * drops the {@code round_robin} pragma the other tests use, pinning that pruning does not depend on it.
+     */
+    public void testCsvYearPrunesUndistributed() throws Exception {
+        String dataset = registerTree("csv_coord", "csv");
+        String query = "FROM " + dataset + " | WHERE year == 2025 | KEEP id | SORT id ASC";
+        try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+            List<Long> ids = getValuesList(response).stream().map(row -> ((Number) row.get(0)).longValue()).toList();
+            assertThat("the same rows must come back without the distribution pragma", ids, equalTo(idsWhere((y, m, d) -> y == 2025)));
+            assertThat(
+                "the partition filter must prune to the 4 matching files here too",
+                response.getExecutionInfo().queryProfile().filesScanned(),
+                equalTo(4)
+            );
+        }
+    }
+
+    /** Registers the 8-file {@code year/month/day} fixture and asserts the filter's pruning + rows. */
+    private void assertPrune(String name, String format, String filterClause, int expectedFilesScanned, List<Long> expectedIds)
+        throws IOException {
+        assertPrune(registerTree(name, format), filterClause, TOTAL_FILES, expectedFilesScanned, expectedIds);
+    }
+
+    /**
+     * The bidirectional pruning assertion, run against a pre-registered dataset. Pruning is only correct if it is right
+     * in <em>both</em> directions, so every case is checked both ways:
+     *
+     * <ul>
+     *   <li><b>Rows (correctness).</b> The query must return exactly {@code expectedIds} — the ids computed by
+     *       {@link #idsWhere}, an oracle that evaluates the same predicate in plain Java over the known fixture,
+     *       independently of ES|QL. This is what catches pruning that drops a file it should have kept: a row-count
+     *       check cannot, because a lost row and a never-matching row produce the same number.</li>
+     *   <li><b>Files (the optimization).</b> Exactly {@code expectedFilesScanned} files may be opened, and
+     *       {@code files_scanned + files_pruned} must account for every candidate file ({@code totalFiles}) — no file
+     *       may vanish for an unaccounted reason. {@code files_pruned} is the affirmative signal that pruning fired at
+     *       all; before #153618 it was structurally zero on every query.</li>
+     * </ul>
+     *
+     * <p>Both are asserted on <b>both plan shapes</b>: the projection path ({@code KEEP id | SORT id}) and the aggregate
+     * path ({@code STATS COUNT(*)}), which lower differently and — for aggregates — can short-circuit the scan entirely.
+     * A filter that pruned correctly under one and wrongly under the other would otherwise slip through.
+     */
+    private void assertPrune(String dataset, String filterClause, int totalFiles, int expectedFilesScanned, List<Long> expectedIds) {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        // Projection path: assert the exact surviving rows, not merely how many.
+        List<List<Object>> rows = runPruned(dataset, filterClause + " | KEEP id | SORT id ASC", totalFiles, expectedFilesScanned);
+        List<Long> actualIds = rows.stream().map(row -> ((Number) row.get(0)).longValue()).toList();
+        assertThat(
+            "[" + filterClause + "] must return exactly the matching rows, dropping none and inventing none",
+            actualIds,
+            equalTo(expectedIds)
+        );
+
+        // Aggregate path: same filter, different lowering (and the shape the warm short-circuit lives on).
+        List<List<Object>> counted = runPruned(dataset, filterClause + " | STATS c = COUNT(*)", totalFiles, expectedFilesScanned);
+        assertThat("expect a single count row", counted.size(), equalTo(1));
+        assertThat(
+            "[" + filterClause + "] the aggregate path must agree with the projection path",
+            ((Number) counted.get(0).get(0)).longValue(),
+            equalTo((long) expectedIds.size())
+        );
+    }
+
+    /**
+     * Runs {@code FROM <dataset> | <tail>} distributed across {@code >=2} data nodes and asserts the file accounting:
+     * the scan ran on a data node (so the fragment path is genuinely exercised), exactly {@code expectedFilesScanned}
+     * files were opened, and every candidate file is accounted for as either scanned or pruned. Returns the rows.
+     */
+    private List<List<Object>> runPruned(String dataset, String tail, int totalFiles, int expectedFilesScanned) {
+        // round_robin distributes every surviving split to a data node regardless of plan shape, so the read lowers
+        // through a FragmentExec and split discovery runs on the fragment path (discoverSplitsFromFragments) — the
+        // #153618-buggy path.
+        QueryPragmas pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "round_robin").build());
+
+        String query = "FROM " + dataset + " | " + tail;
+        var request = syncEsqlQueryRequest(query);
+        request.pragmas(pragmas);
+        request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+        request.profile(true);
+        try (var response = run(request)) {
+            // The node set cannot be required to be >= 2: once pruning succeeds the surviving split set may fit one
+            // node. A non-empty scan-node set proves the external scan ran on a data node (distributed fragment
+            // operator), not a coordinator-local warm-fold. A fully-pruned query scans nowhere at all, so there is
+            // no node to assert on.
+            if (expectedFilesScanned > 0) {
+                assertThat(
+                    "external scan must run on a data node via the distributed fragment path",
+                    externalScanNodeNames(response).size(),
+                    greaterThanOrEqualTo(1)
+                );
+            }
+
+            var profile = response.getExecutionInfo().queryProfile();
+            assertThat(
+                "[" + tail + "] must scan exactly " + expectedFilesScanned + " of " + totalFiles + " files",
+                profile.filesScanned(),
+                equalTo(expectedFilesScanned)
+            );
+            return getValuesList(response);
+        }
+    }
+
+    /** Region-fixture variant of {@link #assertPrune}: 3 single-row files ({@code region} in {@code US, EU, AP}). */
+    private void assertPruneRegion(String dataset, String filterClause, int expectedFilesScanned, List<Long> expectedIds) {
+        assertPrune(dataset, filterClause, 3, expectedFilesScanned, expectedIds);
+    }
+
+    /**
+     * The ids the fixture must yield for a predicate, evaluated in plain Java over the known {@code year/month/day}
+     * tree. An oracle independent of the engine under test: the expected rows are derived from the fixture's
+     * definition, not from what ES|QL happens to return.
+     */
+    private static List<Long> idsWhere(PartitionPredicate predicate) {
+        List<Long> ids = new ArrayList<>();
+        for (int year : YEARS) {
+            for (int month : MONTHS) {
+                for (int day : DAYS) {
+                    if (predicate.test(year, month, day)) {
+                        ids.add((long) idFor(year, month, day));
+                    }
+                }
+            }
+        }
+        Collections.sort(ids);
+        return ids;
+    }
+
+    /** A predicate over one fixture file's partition triple, used to derive the expected rows. */
+    @FunctionalInterface
+    private interface PartitionPredicate {
+        boolean test(int year, int month, int day);
+    }
+
+    /**
+     * Registers the 8-file {@code year/month/day} Hive tree for the given format ({@code csv} or {@code parquet}),
+     * one single-row file per {@code (year, month, day)} triple, each row's {@code id} = {@link #idFor}. Returns the
+     * registered dataset name.
+     */
+    private String registerTree(String name, String format) throws IOException {
+        Path root = createTempDir().resolve(name);
+        for (int year : YEARS) {
+            for (int month : MONTHS) {
+                for (int day : DAYS) {
+                    writeFile(root, year, month, day, format);
+                }
+            }
+        }
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*." + format;
+        return registerDataset(name, glob, Map.of("hive_partitioning", true));
+    }
+
+    /**
+     * Registers a single-dimension {@code region=<STR>} Hive tree with three single-row files ({@code US}, {@code EU},
+     * {@code AP}). The names are case-distinct so they don't collapse on a case-insensitive filesystem (macOS APFS),
+     * while a separate equality test ({@link #testCsvKeywordPartitionEqualityIsCaseSensitive}) pins byte-exact keyword
+     * matching. Each file's {@code id} is a small int so {@code COUNT(*)} is well-defined. The partition column type is
+     * KEYWORD, so its value rides as a Java String while the query literal is a BytesRef — the exact mismatch the
+     * keyword-comparison fix addresses.
+     */
+    private String registerRegionTree(String name, String format) throws IOException {
+        Path root = createTempDir().resolve(name);
+        for (int i = 0; i < REGIONS.length; i++) {
+            // id == index into REGIONS, so US is 0 (US_ID), EU is 1, AP is 2. Pinning the value to the folder is what
+            // lets the keyword tests assert *which* row came back, not merely how many.
+            final int rowId = i;
+            Path dir = root.resolve("region=" + REGIONS[i]);
+            Files.createDirectories(dir);
+            if (format.equals("csv")) {
+                Files.writeString(dir.resolve("f.csv"), "id\n" + rowId + "\n", StandardCharsets.UTF_8);
+            } else {
+                writeParquet(dir.resolve("f.parquet"), "message test { required int32 id; }", 1, 1024, (g, i2) -> g.add("id", rowId));
+            }
+        }
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*." + format;
+        return registerDataset(name, glob, Map.of("hive_partitioning", true));
+    }
+
+    /**
+     * The single {@code id} data value for the file at {@code (year, month, day)}: {@code YYYYMMDD} as an int, so it
+     * is unique per file, orderable, and decodes the partition triple by eye (e.g. {@code 20250615}).
+     */
+    private static int idFor(int year, int month, int day) {
+        return year * 10000 + month * 100 + day;
+    }
+
+    /** Zero-pads a one- or two-digit partition segment value to two digits (e.g. {@code 1 -> "01"}, {@code 15 -> "15"}). */
+    private static String pad2(int v) {
+        return v < 10 ? "0" + v : Integer.toString(v);
+    }
+
+    /** Writes {@code root/year=YYYY/month=MM/day=DD/f.<format>} carrying one row with a single {@code id} column. */
+    private static void writeFile(Path root, int year, int month, int day, String format) throws IOException {
+        Path dir = root.resolve("year=" + year).resolve("month=" + pad2(month)).resolve("day=" + pad2(day));
+        Files.createDirectories(dir);
+        int id = idFor(year, month, day);
+        if (format.equals("csv")) {
+            Files.writeString(dir.resolve("f.csv"), "id\n" + id + "\n", StandardCharsets.UTF_8);
+        } else {
+            // One row, one int32 id column, value = YYYYMMDD. rowGroupSize 1024 keeps it a single row group -> one split.
+            writeParquet(dir.resolve("f.parquet"), "message test { required int32 id; }", 1, 1024, (g, i) -> g.add("id", id));
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
@@ -66,7 +66,12 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  * Java oracle over the fixture — which is what catches a file wrongly pruned away — <em>and</em> {@code files_scanned}
  * from the profile, which is what catches pruning that silently stopped happening. Neither alone is enough: a row count
  * cannot tell a dropped row from a never-matching one, and a file count cannot tell a correct answer from a lucky one.
- * Every {@code files_scanned} expectation here is red on the parent commit, where the number is always the full 8.
+ *
+ * <p>The cases that expect <em>fewer</em> files than the fixture holds are the ones red on the parent commit, where the
+ * count is always the full set. The cases that expect the full count are the opposite kind of guard — they pin that a
+ * data-column filter, an un-evaluable {@code OR} arm, or a row-derived column does <em>not</em> prune, and they are
+ * green on the parent precisely because nothing pruned there. They earn their place by failing if pruning is ever drawn
+ * too wide.
  */
 public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT {
 
@@ -206,7 +211,7 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
     // -- Zero-match: a partition filter matching no folder prunes to the empty set (not an error, not a full scan) --
 
     public void testCsvZeroMatchPrunesToNoFiles() throws Exception {
-        // year=2099 matches no folder -> every file pruned. files_scanned == 0, files_pruned == 8, no rows.
+        // year=2099 matches no folder, so every file is pruned: nothing scanned, no rows.
         assertPrune("csv_zero", "csv", "WHERE year == 2099", 0, idsWhere((y, m, d) -> y == 2099));
     }
 
@@ -373,11 +378,8 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
      * actually receives. Every other test here reads the profile as an in-process object, which never exercises the
      * XContent rendering — so a counter that is collected correctly but never serialized would pass all of them.
      *
-     * <p>This is also the test that makes the fix self-evidencing. Before #153618, {@code files_pruned} was
-     * structurally absent from every query's profile (nothing was ever pruned) and {@code files_scanned} was always
-     * the full file count. Both halves are asserted here, because either one alone can be read the wrong way:
-     * {@code files_scanned: 4} looks healthy on a dataset that happens to have 4 files, and {@code files_pruned: 4}
-     * without its counterpart says nothing about what was actually read.
+     * <p>Before this fix {@code files_scanned} was always the full file count, so the number a client saw was the
+     * proof that pruning was dead. It is the number asserted here.
      */
     public void testPruningIsVisibleInRenderedProfileJson() throws Exception {
         String dataset = registerTree("csv_profile_e2e", "csv");
@@ -439,10 +441,8 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
      *       {@link #idsWhere}, an oracle that evaluates the same predicate in plain Java over the known fixture,
      *       independently of ES|QL. This is what catches pruning that drops a file it should have kept: a row-count
      *       check cannot, because a lost row and a never-matching row produce the same number.</li>
-     *   <li><b>Files (the optimization).</b> Exactly {@code expectedFilesScanned} files may be opened, and
-     *       {@code files_scanned + files_pruned} must account for every candidate file ({@code totalFiles}) — no file
-     *       may vanish for an unaccounted reason. {@code files_pruned} is the affirmative signal that pruning fired at
-     *       all; before #153618 it was structurally zero on every query.</li>
+     *   <li><b>Files (the optimization).</b> Exactly {@code expectedFilesScanned} of the fixture's {@code totalFiles}
+     *       may be opened. On the parent commit this number is always the full count, whatever the filter says.</li>
      * </ul>
      *
      * <p>Both are asserted on <b>both plan shapes</b>: the projection path ({@code KEEP id | SORT id}) and the aggregate

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
@@ -254,6 +256,7 @@ public class FileSplitProvider implements SplitProvider {
 
             if (partitionValues.isEmpty() == false && filterHints.isEmpty() == false) {
                 if (matchesPartitionFilters(partitionValues, filterHints) == false) {
+                    // Partition pruning: the path values alone disprove the filter, so the file is skipped unread.
                     continue;
                 }
             }
@@ -1382,13 +1385,19 @@ public class FileSplitProvider implements SplitProvider {
         Object literalValue = extractLiteralValue(right);
         if (columnName != null && literalValue != null && partitionValues.containsKey(columnName)) {
             Object partitionValue = partitionValues.get(columnName);
+            // `column OP literal`
             return partitionValue != null ? comparator.apply(partitionValue, literalValue) : null;
         }
         columnName = extractColumnName(right);
         literalValue = extractLiteralValue(left);
         if (columnName != null && literalValue != null && partitionValues.containsKey(columnName)) {
             Object partitionValue = partitionValues.get(columnName);
-            return partitionValue != null ? comparator.apply(partitionValue, literalValue) : null;
+            // `literal OP column` — the operands keep their sides. Passing the column first would evaluate
+            // `column OP literal`, which for an asymmetric operator is the exact inverse: `2024 > year` would be
+            // tested as `year > 2024` and prune precisely the files that match. LiteralsOnTheRight normalizes this
+            // shape away before we ever see it, so the bug is unreachable today — but the matcher must not depend on
+            // an optimizer rule it has no way to enforce.
+            return partitionValue != null ? comparator.apply(literalValue, partitionValue) : null;
         }
         return null;
     }
@@ -1408,14 +1417,25 @@ public class FileSplitProvider implements SplitProvider {
         };
     }
 
+    /**
+     * String form of a partition value or filter literal. Keyword partition values arrive as Java {@code String}
+     * (from {@code HivePartitionDetector.castValue}) while an ES|QL keyword literal is a Lucene {@code BytesRef}
+     * whose {@code toString()} is a hex dump — so a raw {@code toString()} comparison of the two never matches.
+     * {@link BytesRefs#toString(Object)} UTF8-decodes a {@code BytesRef} and falls back to {@code toString()}
+     * otherwise, so both sides normalize to the same text before any string compare or numeric parse.
+     */
+    private static String stringOf(Object value) {
+        return BytesRefs.toString(value);
+    }
+
     private static boolean compareEquals(Object a, Object b) {
         if (a == null || b == null) {
             return false;
         }
         if (a instanceof Number na && b instanceof Number nb) {
-            return na.doubleValue() == nb.doubleValue();
+            return compareNumbers(na, nb) == 0;
         }
-        return a.toString().equals(b.toString());
+        return stringOf(a).equals(stringOf(b));
     }
 
     private static int compareValues(Object a, Object b) {
@@ -1423,29 +1443,59 @@ public class FileSplitProvider implements SplitProvider {
             throw new IllegalArgumentException("Cannot compare null partition values");
         }
         if (a instanceof Number na && b instanceof Number nb) {
-            return Double.compare(na.doubleValue(), nb.doubleValue());
+            return compareNumbers(na, nb);
         }
-        // Coerce mixed Number/String cases: a partition value may be stored as "2024" (String)
-        // while the literal from the filter is Integer 2024, or vice versa.
-        if (a instanceof Number && b instanceof Number == false) {
+        // Coerce mixed Number/text cases: a partition value may be stored as "2024" (String) while the literal from
+        // the filter is Integer 2024, or vice versa. Only when exactly one side is already a Number — two text values
+        // are compared as text, so a KEYWORD partition never has "0123" and "123" collapse into the same value.
+        if (a instanceof Number na) {
+            Number nb = parseNumber(stringOf(b));
+            return nb != null ? compareNumbers(na, nb) : keywordCompare(a, b);
+        }
+        if (b instanceof Number nb) {
+            Number na = parseNumber(stringOf(a));
+            return na != null ? compareNumbers(na, nb) : keywordCompare(a, b);
+        }
+        return keywordCompare(a, b);
+    }
+
+    /**
+     * Orders two numeric values. Integral types are compared as {@code long}, never as {@code double}: above
+     * 2^53 a {@code double} cannot separate adjacent longs, so an epoch-micros or snowflake-id partition value
+     * would compare <em>equal</em> to its neighbour. That is not a rounding nit — it makes the matcher return a
+     * confident {@code false} for {@code ts != <adjacent>} and prune a file whose every row matches the filter.
+     */
+    private static int compareNumbers(Number a, Number b) {
+        if (isIntegral(a) && isIntegral(b)) {
+            return Long.compare(a.longValue(), b.longValue());
+        }
+        return Double.compare(a.doubleValue(), b.doubleValue());
+    }
+
+    private static boolean isIntegral(Number n) {
+        return n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte;
+    }
+
+    /** The text parsed as a number, or {@code null} if it is not numeric. */
+    private static Number parseNumber(String text) {
+        try {
+            return Long.valueOf(text);
+        } catch (NumberFormatException notALong) {
             try {
-                return Double.compare(((Number) a).doubleValue(), Double.parseDouble(b.toString()));
-            } catch (NumberFormatException e) {
-                return a.toString().compareTo(b.toString());
+                return Double.valueOf(text);
+            } catch (NumberFormatException notANumber) {
+                return null;
             }
         }
-        if (b instanceof Number && a instanceof Number == false) {
-            try {
-                return Double.compare(Double.parseDouble(a.toString()), ((Number) b).doubleValue());
-            } catch (NumberFormatException e) {
-                return a.toString().compareTo(b.toString());
-            }
-        }
-        if (a instanceof Comparable<?> && b instanceof Comparable<?> && a.getClass() == b.getClass()) {
-            @SuppressWarnings("unchecked")
-            Comparable<Object> ca = (Comparable<Object>) a;
-            return ca.compareTo(b);
-        }
-        return a.toString().compareTo(b.toString());
+    }
+
+    /**
+     * Orders two non-numeric values the way ES|QL orders keywords: by UTF-8 bytes, which is code-point order.
+     * {@link String#compareTo} would order by UTF-16 code units instead, and the two disagree whenever one side is a
+     * supplementary-plane character (a folder named {@code region=<emoji>}) and the other sits in {@code U+E000..U+FFFF}
+     * — the surrogate compares low, the engine compares it high, and a range predicate would prune a matching file.
+     */
+    private static int keywordCompare(Object a, Object b) {
+        return new BytesRef(stringOf(a)).compareTo(new BytesRef(stringOf(b)));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractor.java
@@ -9,10 +9,10 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
-import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Walks an unresolved logical plan extracting simple filter predicates from {@link Filter} nodes
@@ -75,38 +76,86 @@ public final class PartitionFilterHintExtractor {
     }
 
     public static Map<String, List<PartitionFilterHint>> extract(LogicalPlan unresolvedPlan) {
+        Map<String, List<List<PartitionFilterHint>>> perOccurrence = new LinkedHashMap<>();
+        collectHints(unresolvedPlan, List.of(), perOccurrence);
+
+        // One listing serves every occurrence of a path, so a folder may be skipped only if EVERY occurrence excludes
+        // it. `FROM ds | FORK (WHERE year == 2025) (WHERE ...)` reaches the same relation twice; letting one branch's
+        // hint narrow the shared listing would starve the other. An unguarded occurrence contributes no hints and so
+        // vetoes the rewrite outright.
         Map<String, List<PartitionFilterHint>> result = new LinkedHashMap<>();
-        collectHints(unresolvedPlan, List.of(), result);
+        perOccurrence.forEach((path, occurrences) -> {
+            List<PartitionFilterHint> common = new ArrayList<>(occurrences.get(0));
+            for (int i = 1; i < occurrences.size(); i++) {
+                common.retainAll(occurrences.get(i));
+            }
+            if (common.isEmpty() == false) {
+                result.put(path, common);
+            }
+        });
         return result;
     }
 
-    private static void collectHints(Node<?> node, List<Expression> ancestorConditions, Map<String, List<PartitionFilterHint>> result) {
-        List<Expression> conditions = ancestorConditions;
-
-        if (node instanceof Filter filter) {
-            conditions = new ArrayList<>(ancestorConditions);
-            conditions.add(filter.condition());
-        }
-
+    /**
+     * Walks top-down (pipeline-last node first), carrying the conjuncts that guard the relations below.
+     *
+     * <p>Two things can disqualify a conjunct on the way down, and both are decided by {@link PartitionPruningRule}:
+     *
+     * <ul>
+     *   <li>A node that changes the row count — a {@code LIMIT}, {@code STATS}, {@code SAMPLE}, a join. A {@code WHERE}
+     *       above one of those does not commute with it, so nothing collected above may be used to narrow the listing
+     *       below it. The accumulator resets.</li>
+     *   <li>A node that redefines a name a conjunct depends on — {@code EVAL year = ...} or {@code RENAME x AS year}.
+     *       That {@code year} is a row value, not the {@code year=2024/} folder the row came from, so a hint on it must
+     *       be dropped before it can rewrite the glob.</li>
+     * </ul>
+     *
+     * <p>Shadowing is judged at the moment the walk passes the redefining node, not accumulated and applied at the
+     * relation. The direction matters and is easy to get backwards: a conjunct is only endangered by a node
+     * <em>between</em> it and the relation, which — walking top-down — is a node visited <em>after</em> the conjunct was
+     * collected. A generating node above the filter is irrelevant. Dropping at the pass-through moment gets both right,
+     * and in particular keeps the hint in {@code WHERE year == 2025 | EVAL year = 9}, where the filter reads the
+     * partition column and the {@code EVAL} only affects what comes after it.
+     */
+    private static void collectHints(
+        LogicalPlan node,
+        List<Expression> guardingConjuncts,
+        Map<String, List<List<PartitionFilterHint>>> result
+    ) {
         if (node instanceof UnresolvedExternalRelation rel) {
             String path = extractPath(rel);
-            if (path != null && conditions.isEmpty() == false) {
+            if (path != null) {
                 List<PartitionFilterHint> hints = new ArrayList<>();
-                for (Expression condition : conditions) {
-                    extractFromExpression(condition, hints);
+                for (Expression conjunct : guardingConjuncts) {
+                    extractFromExpression(conjunct, hints);
                 }
-                if (hints.isEmpty() == false) {
-                    result.computeIfAbsent(path, k -> new ArrayList<>()).addAll(hints);
-                }
+                // Registered even when empty: an occurrence with no usable hint must veto the rewrite, not be ignored.
+                result.computeIfAbsent(path, k -> new ArrayList<>()).add(hints);
             }
             return;
         }
 
-        for (Object child : node.children()) {
-            if (child instanceof Node<?> childNode) {
-                collectHints(childNode, conditions, result);
-            }
+        List<Expression> conjuncts = PartitionPruningRule.hintTransparent(node) ? guardingConjuncts : List.of();
+
+        Set<String> shadowed = PartitionPruningRule.shadowedNames(node);
+        if (shadowed.isEmpty() == false && conjuncts.isEmpty() == false) {
+            conjuncts = conjuncts.stream().filter(c -> referencesAny(c, shadowed) == false).toList();
         }
+
+        if (node instanceof Filter filter) {
+            List<Expression> extended = new ArrayList<>(conjuncts);
+            extended.addAll(Predicates.splitAnd(filter.condition()));
+            conjuncts = List.copyOf(extended);
+        }
+
+        for (LogicalPlan child : node.children()) {
+            collectHints(child, conjuncts, result);
+        }
+    }
+
+    /** Whether {@code expression} reads any of {@code names} — matched on the attribute name, all a hint has pre-resolution. */
+    private static boolean referencesAny(Expression expression, Set<String> names) {
+        return expression.anyMatch(e -> e instanceof Attribute attr && names.contains(attr.name()));
     }
 
     private static void extractFromExpression(Expression expr, List<PartitionFilterHint> hints) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractor.java
@@ -83,6 +83,11 @@ public final class PartitionFilterHintExtractor {
         // it. `FROM ds | FORK (WHERE year == 2025) (WHERE ...)` reaches the same relation twice; letting one branch's
         // hint narrow the shared listing would starve the other. An unguarded occurrence contributes no hints and so
         // vetoes the rewrite outright.
+        //
+        // The intersection is by exact hint equality (column, operator, values), so it keeps only hints two branches
+        // spell identically. It does not reason about subsumption: `year == 2025` in one branch and `year >= 2020` in
+        // another share no common hint even though the first implies the second, so the rewrite is skipped and the full
+        // set is listed. That is conservative — correct, only wider — and semantic subsumption is left as a follow-up.
         Map<String, List<PartitionFilterHint>> result = new LinkedHashMap<>();
         perOccurrence.forEach((path, occurrences) -> {
             List<PartitionFilterHint> common = new ArrayList<>(occurrences.get(0));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Rename;
 import org.elasticsearch.xpack.esql.plan.logical.Streaming;
+import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
@@ -70,11 +71,25 @@ final class PartitionPruningRule {
 
     /**
      * The physical twin of {@link #rowPreserving(LogicalPlan)} — same rule, other tree. There is no physical
-     * {@code Streaming} marker to lean on, so the row-preserving nodes are named. Note the absence of an order node: a
-     * sort lowers to {@link TopNExec}, which carries a limit and so is cardinality-sensitive.
+     * {@code Streaming} marker to lean on, so the row-preserving execs are named explicitly. Each corresponds to a
+     * {@code Streaming} logical node: {@link FilterExec}, {@link EvalExec}, {@link ProjectExec} (the lowered form of
+     * {@code Keep}/{@code Drop}/{@code Rename}/{@code Insist}), {@link RegexExtractExec} ({@code DISSECT}/{@code GROK}),
+     * and {@link EnrichExec}. An order node is deliberately absent: a sort lowers to {@link TopNExec}, which carries a
+     * limit and so is cardinality-sensitive.
+     *
+     * <p>This is an allowlist rather than a marker interface on purpose. It fails closed — an exec that is not listed
+     * stops the seed, which costs a wider scan but can never invent an answer. A marker would invert that: it would
+     * pressure every new node to be classified, and a node wrongly marked row-preserving is a wrong result. For a
+     * correctness gate the explicit, conservative list is the safer shape. If a new row-preserving exec is added and
+     * not listed here, the only cost is that pruning stops crossing it — a missed optimization, caught by a perf
+     * regression, not by wrong rows.
      */
     static boolean rowPreserving(PhysicalPlan plan) {
-        return plan instanceof FilterExec || plan instanceof EvalExec || plan instanceof ProjectExec || plan instanceof RegexExtractExec;
+        return plan instanceof FilterExec
+            || plan instanceof EvalExec
+            || plan instanceof ProjectExec
+            || plan instanceof RegexExtractExec
+            || plan instanceof EnrichExec;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
@@ -36,9 +36,9 @@ import java.util.stream.Collectors;
  * <p>Two layers act on that decision, and both must obey these rules — so the rules live here instead of being restated
  * in each. {@link PartitionFilterHintExtractor} rewrites the glob, so non-matching folders are never even
  * <em>listed</em>; {@link SplitDiscoveryPhase} prunes files that were listed. The two run at opposite ends of planning
- * (one before resolution, one after) and nothing downstream can recover a file the listing layer skipped. Partition
- * filtering has already produced wrong answers once because a rule held in one place and not the other, which looks
- * exactly like a rule that was never there.
+ * (one before resolution, one after) and nothing downstream can recover a file the listing layer skipped. Keeping the
+ * rules apart from the walks that apply them is deliberate: a rule restated in two places drifts, and a filter trusted
+ * where it should not be does not scan too much — it returns the wrong rows.
  */
 final class PartitionPruningRule {
 
@@ -87,7 +87,8 @@ final class PartitionPruningRule {
      * {@link GeneratingPlan}, but until the analyzer loads the policy its {@code enrichFields} are empty unless the query
      * spelled out a {@code WITH} clause. So {@code FROM ds | ENRICH policy ON k | WHERE year == 615}, with a policy that
      * contributes a {@code year} field, would look like it shadows nothing and would prune folders by the path's year.
-     * {@code COMPLETION}, {@code RERANK} and {@code INSIST} are {@code Streaming} for the same reason and just as opaque.
+     * The other {@code Streaming} nodes are left out on the same principle: whatever their columns turn out to be, this is
+     * not the layer that can prove it.
      *
      * <p>So this is an explicit allowlist of nodes whose name changes are fully visible in the parsed tree, and it fails
      * closed: an unrecognized node stops the hint, the glob is not rewritten, and the folders are listed. That costs a

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Drop;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
+import org.elasticsearch.xpack.esql.plan.logical.Rename;
+import org.elasticsearch.xpack.esql.plan.logical.Streaming;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * When a {@code WHERE} above an external relation is allowed to decide which of that relation's files are touched.
+ *
+ * <p>Two layers act on that decision, and both must obey these rules — so the rules live here instead of being restated
+ * in each. {@link PartitionFilterHintExtractor} rewrites the glob, so non-matching folders are never even
+ * <em>listed</em>; {@link SplitDiscoveryPhase} prunes files that were listed. The two run at opposite ends of planning
+ * (one before resolution, one after) and nothing downstream can recover a file the listing layer skipped. Partition
+ * filtering has already produced wrong answers once because a rule held in one place and not the other, which looks
+ * exactly like a rule that was never there.
+ */
+final class PartitionPruningRule {
+
+    private PartitionPruningRule() {}
+
+    /**
+     * Whether a filter above {@code plan} may still prune the files beneath it.
+     *
+     * <p>Pruning is licensed by this argument: if no row of a file can satisfy the filter, that file cannot contribute
+     * to the result, so not reading it changes nothing. The argument holds only while every node between the filter and
+     * the source leaves the row <em>count</em> alone. As soon as one selects rows by cardinality it collapses —
+     * {@code FROM ds | SORT id | LIMIT 4 | WHERE year == 2025} must take four rows and filter them <em>afterwards</em>,
+     * so pruning the non-2025 files first refills the {@code LIMIT} window from the survivors and returns rows the query
+     * never asked for. {@code SAMPLE}, {@code STATS}, {@code MV_EXPAND} and joins break it the same way.
+     *
+     * <p>{@link Streaming} already means "does not add or remove rows", so it carries the rule and keeps carrying it as
+     * commands are added. Two more qualify: {@link Filter}, which only ever removes rows — pruning yet more of them
+     * below is still sound — and {@link OrderBy}, which reorders but never drops. Everything else fails closed to "do
+     * not prune": a full scan, never an invented answer.
+     *
+     * <p>Safe here, and <em>only</em> here, because this side runs on a resolved plan where {@link SplitDiscoveryPhase}
+     * binds each conjunct to the relation's output by {@code NameId}. That binding is what makes it harmless to let a
+     * conjunct cross a node like {@code ENRICH} whose new columns are not knowable by name. The listing layer has no
+     * such backstop — see {@link #hintTransparent}.
+     */
+    static boolean rowPreserving(LogicalPlan plan) {
+        return plan instanceof Streaming || plan instanceof Filter || plan instanceof OrderBy;
+    }
+
+    /**
+     * The physical twin of {@link #rowPreserving(LogicalPlan)} — same rule, other tree. There is no physical
+     * {@code Streaming} marker to lean on, so the row-preserving nodes are named. Note the absence of an order node: a
+     * sort lowers to {@link TopNExec}, which carries a limit and so is cardinality-sensitive.
+     */
+    static boolean rowPreserving(PhysicalPlan plan) {
+        return plan instanceof FilterExec || plan instanceof EvalExec || plan instanceof ProjectExec || plan instanceof RegexExtractExec;
+    }
+
+    /**
+     * Whether a <em>pre-resolution</em> partition hint may cross {@code plan} — the listing layer's stricter counterpart
+     * to {@link #rowPreserving(LogicalPlan)}.
+     *
+     * <p>It must satisfy everything {@code rowPreserving} does, and one thing more: every column the node introduces has
+     * to be knowable <em>by name</em>, because before resolution a name is all a hint has. That rules out
+     * {@link Streaming} as the test. {@link Enrich} is the counterexample that forces this: it is {@code Streaming} and a
+     * {@link GeneratingPlan}, but until the analyzer loads the policy its {@code enrichFields} are empty unless the query
+     * spelled out a {@code WITH} clause. So {@code FROM ds | ENRICH policy ON k | WHERE year == 615}, with a policy that
+     * contributes a {@code year} field, would look like it shadows nothing and would prune folders by the path's year.
+     * {@code COMPLETION}, {@code RERANK} and {@code INSIST} are {@code Streaming} for the same reason and just as opaque.
+     *
+     * <p>So this is an explicit allowlist of nodes whose name changes are fully visible in the parsed tree, and it fails
+     * closed: an unrecognized node stops the hint, the glob is not rewritten, and the folders are listed. That costs a
+     * wider listing. Getting it wrong costs the user rows.
+     */
+    static boolean hintTransparent(LogicalPlan plan) {
+        return plan instanceof Filter
+            || plan instanceof OrderBy
+            || plan instanceof Eval          // its aliases carry names even unresolved
+            || plan instanceof RegexExtract  // DISSECT, GROK — extracted names come from the parser
+            || plan instanceof Rename
+            || plan instanceof Project       // column selection; KEEP extends Project
+            || plan instanceof Drop;
+    }
+
+    /**
+     * The column names {@code plan} introduces or redefines, which therefore no longer mean what the storage path means.
+     * {@code EVAL year = id % 10000} turns {@code year} into a row-derived value with nothing to do with the
+     * {@code year=2024/} folder the row came from, so a {@code WHERE year == 615} above it must not prune a single folder.
+     *
+     * <p>Only the listing layer needs this. Once a plan is resolved, names stop being identity —
+     * {@link SplitDiscoveryPhase} binds conjuncts by {@code NameId}, which is strictly stronger and needs none of it.
+     * Before resolution there are no ids, so shadowing has to be spotted structurally.
+     *
+     * <p>For {@link Rename} the <em>new</em> name is the dangerous one: {@code RENAME id AS year} makes {@code year}
+     * row-derived. The old name disappearing is harmless — a filter still referencing it fails analysis, which is an
+     * error, never a wrong row.
+     */
+    static Set<String> shadowedNames(LogicalPlan plan) {
+        if (plan instanceof GeneratingPlan<?> generating) {
+            return generating.generatedAttributes().stream().map(Attribute::name).collect(Collectors.toSet());
+        }
+        if (plan instanceof Rename rename) {
+            return rename.renamings().stream().map(Alias::name).collect(Collectors.toSet());
+        }
+        return Set.of();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/PartitionPruningRule.java
@@ -20,13 +20,8 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Rename;
 import org.elasticsearch.xpack.esql.plan.logical.Streaming;
-import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
-import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
-import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
-import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
-import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
-import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.plan.physical.RowCountPreserving;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -70,26 +65,18 @@ final class PartitionPruningRule {
     }
 
     /**
-     * The physical twin of {@link #rowPreserving(LogicalPlan)} — same rule, other tree. There is no physical
-     * {@code Streaming} marker to lean on, so the row-preserving execs are named explicitly. Each corresponds to a
-     * {@code Streaming} logical node: {@link FilterExec}, {@link EvalExec}, {@link ProjectExec} (the lowered form of
-     * {@code Keep}/{@code Drop}/{@code Rename}/{@code Insist}), {@link RegexExtractExec} ({@code DISSECT}/{@code GROK}),
-     * and {@link EnrichExec}. An order node is deliberately absent: a sort lowers to {@link TopNExec}, which carries a
-     * limit and so is cardinality-sensitive.
+     * The physical twin of {@link #rowPreserving(LogicalPlan)} — same rule, other tree. Where the logical side leans on
+     * the existing {@link Streaming} marker, the physical side has its own marker, {@link RowCountPreserving}, carried by
+     * every exec that maps rows one-to-one ({@code FilterExec}, {@code EvalExec}, {@code ProjectExec} — the lowered form
+     * of {@code Keep}/{@code Drop}/{@code Rename}/{@code Insist} — {@code RegexExtractExec} for {@code DISSECT}/{@code
+     * GROK}, and {@code EnrichExec}). A cardinality-sensitive exec such as {@code LimitExec} or {@code TopNExec} does not
+     * carry it, so the seed stops there.
      *
-     * <p>This is an allowlist rather than a marker interface on purpose. It fails closed — an exec that is not listed
-     * stops the seed, which costs a wider scan but can never invent an answer. A marker would invert that: it would
-     * pressure every new node to be classified, and a node wrongly marked row-preserving is a wrong result. For a
-     * correctness gate the explicit, conservative list is the safer shape. If a new row-preserving exec is added and
-     * not listed here, the only cost is that pruning stops crossing it — a missed optimization, caught by a perf
-     * regression, not by wrong rows.
+     * <p>The marker is opt-in and fails closed: an exec without it is treated as cardinality-sensitive, so a new
+     * row-preserving node that forgets the marker forfeits an optimization across itself, never correctness.
      */
     static boolean rowPreserving(PhysicalPlan plan) {
-        return plan instanceof FilterExec
-            || plan instanceof EvalExec
-            || plan instanceof ProjectExec
-            || plan instanceof RegexExtractExec
-            || plan instanceof EnrichExec;
+        return plan instanceof RowCountPreserving;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -9,17 +9,28 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryResult;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
+import org.elasticsearch.xpack.esql.plan.logical.Streaming;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 
 import java.util.ArrayList;
@@ -36,15 +47,114 @@ import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.split
  * <p>Filter expressions from {@link FilterExec} ancestors are collected per-source so that
  * each {@link ExternalSourceExec} only receives filters from its own ancestor chain, not
  * from unrelated branches of the plan tree.
+ *
+ * <p><b>Two trees, one rule.</b> Which filters guard a given {@link ExternalSourceExec} is decided here for both shapes
+ * the relation can arrive in: the physical plan (walked by {@code resolveRecursive}, collecting {@link FilterExec}) and
+ * a fragment's logical plan (walked by {@link #guardedRelations}, collecting {@link Filter}). Both exist because a
+ * {@code FROM <dataset>} lowers through a {@code FragmentExec} whose body is still a {@link LogicalPlan}; they are kept
+ * adjacent so the rule cannot drift apart between them, which is exactly how partition pruning silently died in
+ * #143696 — the fragment path was added without the filter ever being re-threaded.
+ *
+ * <p>This decides which files are <em>read</em>. It is not the only place a partition filter is consulted:
+ * {@code PartitionFilterHintExtractor} extracts hints far earlier, pre-resolution, for {@code GlobExpander} to skip
+ * <em>listing</em> whole folders. That layer has its own copy of this problem and does not share these guards — see its
+ * javadoc. Nothing here can compensate for a file that was never listed.
  */
 public final class SplitDiscoveryPhase {
 
     private SplitDiscoveryPhase() {}
 
     /**
-     * Post-prune "scanned" accounting collected while resolving splits, surfaced at the root of the
-     * query profile. The counts reflect what survived coordinator-side pruning and is handed to the
-     * runtime, before any later split coalescing.
+     * An {@link ExternalRelation} found inside a fragment, paired with the conjuncts of the {@link Filter} ancestors
+     * that guard it — the seed for its partition pruning. Empty {@code filters} means the relation is unfiltered and
+     * every file must be read.
+     */
+    public record GuardedRelation(ExternalRelation relation, List<Expression> filters) {
+        public GuardedRelation {
+            filters = List.copyOf(filters);
+        }
+    }
+
+    /**
+     * Pairs every {@link ExternalRelation} in a fragment's logical plan with the AND-split conjuncts of the
+     * {@link Filter} ancestors above it.
+     *
+     * <p>Split discovery lowers each relation to a standalone {@link ExternalSourceExec} via
+     * {@code ExternalRelation.toPhysicalExec()}, which drops the surrounding plan — and with it the {@code Filter} that
+     * was sitting above the relation. Recovering the conjuncts here, before that lowering, is what lets partition
+     * pruning see the predicate at all; without it {@code FileSplitProvider.matchesPartitionFilters} runs on an empty
+     * filter set and every partition folder is read (elastic/elasticsearch#153618).
+     *
+     * <p>The conjuncts are <em>candidates</em>, not commands: {@link #resolveExternalSource} binds each one to the
+     * relation's own output by {@code NameId} before it may prune, so a filter over a downstream-generated column that
+     * merely shares a partition column's name cannot mis-prune.
+     */
+    public static List<GuardedRelation> guardedRelations(LogicalPlan fragment) {
+        List<GuardedRelation> guarded = new ArrayList<>();
+        collectGuardedRelations(fragment, List.of(), guarded);
+        return guarded;
+    }
+
+    private static void collectGuardedRelations(LogicalPlan plan, List<Expression> ancestorFilters, List<GuardedRelation> guarded) {
+        if (plan instanceof ExternalRelation external) {
+            guarded.add(new GuardedRelation(external, ancestorFilters));
+            return;
+        }
+
+        List<Expression> filtersForChildren = rowPreserving(plan) ? ancestorFilters : List.of();
+        if (plan instanceof Filter filter) {
+            List<Expression> extended = new ArrayList<>(filtersForChildren);
+            extended.addAll(splitAnd(filter.condition()));
+            filtersForChildren = List.copyOf(extended);
+        }
+
+        for (LogicalPlan child : plan.children()) {
+            collectGuardedRelations(child, filtersForChildren, guarded);
+        }
+    }
+
+    /**
+     * Whether a filter sitting <em>above</em> {@code plan} may still be used to prune the source files beneath it.
+     *
+     * <p>The reasoning that licenses pruning is: if no row of a file can satisfy the filter, the file cannot
+     * contribute to the result, so skipping it changes nothing. That holds only while every node between the filter
+     * and the source leaves the row count alone. The moment a node <em>selects</em> rows by cardinality, it breaks:
+     * {@code FROM ds | SORT id | LIMIT 4 | WHERE year == 2025} must take four rows and filter them <em>afterwards</em>
+     * — pruning the non-2025 files first would refill the {@code LIMIT} window from the surviving files and return
+     * rows the query never asked for. The same goes for {@code SAMPLE}, {@code STATS}, {@code MV_EXPAND} and joins.
+     *
+     * <p>{@link Streaming} already means exactly "does not add or remove rows", so it carries the rule for us and keeps
+     * carrying it as commands are added. Two nodes qualify without being {@code Streaming}: {@link Filter}, which only
+     * ever removes rows (pruning yet more of them below is still sound), and {@link OrderBy}, which reorders but never
+     * drops. Everything else — anything that could change how many rows reach the top — fails closed to "do not prune":
+     * a full scan, never an invented answer. Value provenance is a separate concern, enforced independently by the
+     * {@code NameId} binding in {@link #resolveExternalSource}.
+     *
+     * <p>Today no unsafe shape actually reaches this walk, so the guard is defence in depth rather than a live fix.
+     * That is not because of anything this class controls: it holds only because the optimizer never pushes a filter
+     * below a limit, nor a limit below a filter, so the two never end up stacked inside one fragment. The guard is here
+     * because that is an invariant of code far away, and #143696 is precisely the story of such an invariant quietly
+     * changing underneath partition pruning.
+     *
+     * @see #rowPreserving(PhysicalPlan) the same rule over the physical tree — the two must agree
+     */
+    private static boolean rowPreserving(LogicalPlan plan) {
+        return plan instanceof Streaming || plan instanceof Filter || plan instanceof OrderBy;
+    }
+
+    /**
+     * The physical-tree twin of {@link #rowPreserving(LogicalPlan)}; see there for why this is an allowlist. Note the
+     * absence of an order-by node: ES|QL lowers a sort to {@link TopNExec}, which carries a limit and therefore
+     * <em>is</em> cardinality-sensitive.
+     */
+    private static boolean rowPreserving(PhysicalPlan plan) {
+        return plan instanceof FilterExec || plan instanceof EvalExec || plan instanceof ProjectExec || plan instanceof RegexExtractExec;
+    }
+
+    /**
+     * Scan accounting collected while resolving splits, surfaced at the root of the query profile. The
+     * counts reflect what survived coordinator-side pruning and is handed to the runtime, before any later
+     * split coalescing.
      *
      * @param plan          the split-enriched physical plan
      * @param filesScanned  distinct files contributing splits (file-based sources only; {@code 0} otherwise)
@@ -99,8 +209,33 @@ public final class SplitDiscoveryPhase {
         int maxRecordBytes,
         BooleanSupplier isCancelled
     ) {
+        return resolveExternalSplitsWithStats(plan, sourceFactories, maxRecordBytes, isCancelled, List.of());
+    }
+
+    /**
+     * Like {@link #resolveExternalSplitsWithStats(PhysicalPlan, Map, int, BooleanSupplier)}, but seeds the recursive
+     * walk with {@code seedFilters} — conjuncts that guard this sub-plan from <em>above</em> and so cannot be recovered
+     * from the tree itself, as produced by {@link #guardedRelations}.
+     *
+     * <p>Needed because since #143696 every {@code FROM <dataset>} is wrapped in a {@code FragmentExec}: the coordinator
+     * physical-plan walk never reaches a top-level {@link ExternalSourceExec}, discovery runs on the fragment path, and
+     * the relation arrives there stripped of its {@code Filter} ancestor. Without the seed, partition pruning was dead
+     * on <em>every</em> production query — single-node included, not only distributed ones
+     * (elastic/elasticsearch#153618).
+     *
+     * <p>The seed is not blindly trusted: {@link #resolveExternalSource} binds each conjunct to the relation's output by
+     * {@link NameId} before it may prune, so a filter over a downstream-generated column that merely shares a partition
+     * column's name cannot mis-prune.
+     */
+    public static Result resolveExternalSplitsWithStats(
+        PhysicalPlan plan,
+        Map<String, ExternalSourceFactory> sourceFactories,
+        int maxRecordBytes,
+        BooleanSupplier isCancelled,
+        List<Expression> seedFilters
+    ) {
         ScanStats stats = new ScanStats();
-        PhysicalPlan resolved = resolveRecursive(plan, List.of(), sourceFactories, maxRecordBytes, stats, isCancelled);
+        PhysicalPlan resolved = resolveRecursive(plan, seedFilters, sourceFactories, maxRecordBytes, stats, isCancelled);
         return new Result(resolved, stats.filesScanned, stats.splitsScanned, stats.bytesScanned);
     }
 
@@ -116,9 +251,9 @@ public final class SplitDiscoveryPhase {
             return resolveExternalSource(exec, ancestorFilters, sourceFactories, maxRecordBytes, stats, isCancelled);
         }
 
-        List<Expression> filtersForChildren = ancestorFilters;
+        List<Expression> filtersForChildren = rowPreserving(plan) ? ancestorFilters : List.of();
         if (plan instanceof FilterExec filterExec) {
-            List<Expression> extended = new ArrayList<>(ancestorFilters);
+            List<Expression> extended = new ArrayList<>(filtersForChildren);
             for (Expression conjunction : splitAnd(filterExec.condition())) {
                 extended.add(conjunction);
             }
@@ -172,13 +307,21 @@ public final class SplitDiscoveryPhase {
         }
         ExternalSchema querySchema = new ExternalSchema(queryDataAttributes);
 
+        // Bind filter hints to the relation's output by NameId, not by name. A downstream EVAL/DISSECT/GROK/ENRICH can
+        // introduce an attribute that SHARES A NAME with a partition column (e.g. `EVAL year = ...`) whose filter
+        // `PushDownAndCombineFilters` may leave above the generating node and thus in ancestorFilters. Pruning by the
+        // path partition value for such a row-derived column produces silently wrong answers. Keeping only conjuncts
+        // whose every attribute reference resolves by id into exec.output() drops those shadowing filters; the split
+        // provider's per-file matcher then sees only genuine partition/data-column predicates. See #153618.
+        List<Expression> boundFilters = filtersBoundToOutput(ancestorFilters, exec.output());
+
         SplitDiscoveryContext context = new SplitDiscoveryContext(
             null,
             fileList != null ? fileList : FileList.UNRESOLVED,
             exec.schemaMap(),
             exec.config(),
             partitionInfo,
-            ancestorFilters,
+            boundFilters,
             querySchema,
             exec.unifiedSchema(),
             maxRecordBytes,
@@ -212,5 +355,26 @@ public final class SplitDiscoveryPhase {
             }
         }
         return exec.withSplits(splits);
+    }
+
+    /**
+     * Retains only those conjuncts whose every referenced attribute resolves by {@link NameId} into {@code output}.
+     * {@link AttributeSet} keys on the attribute id (semantic equality), so a conjunct referencing an attribute that
+     * merely shares a name with an output column — but was produced by a downstream {@code EVAL}/{@code DISSECT}/etc.
+     * with a distinct id — is dropped. A conjunct that references an attribute genuinely in the relation's output
+     * (a partition column or a data column) is kept.
+     */
+    private static List<Expression> filtersBoundToOutput(List<Expression> filters, List<Attribute> output) {
+        if (filters.isEmpty()) {
+            return filters;
+        }
+        AttributeSet outputSet = AttributeSet.of(output);
+        List<Expression> bound = new ArrayList<>(filters.size());
+        for (Expression filter : filters) {
+            if (outputSet.containsAll(filter.references())) {
+                bound.add(filter);
+            }
+        }
+        return bound;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -22,15 +22,9 @@ import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
 import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
-import org.elasticsearch.xpack.esql.plan.logical.Streaming;
-import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
-import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
-import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
-import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 
 import java.util.ArrayList;
@@ -101,7 +95,7 @@ public final class SplitDiscoveryPhase {
             return;
         }
 
-        List<Expression> filtersForChildren = rowPreserving(plan) ? ancestorFilters : List.of();
+        List<Expression> filtersForChildren = PartitionPruningRule.rowPreserving(plan) ? ancestorFilters : List.of();
         if (plan instanceof Filter filter) {
             List<Expression> extended = new ArrayList<>(filtersForChildren);
             extended.addAll(splitAnd(filter.condition()));
@@ -111,44 +105,6 @@ public final class SplitDiscoveryPhase {
         for (LogicalPlan child : plan.children()) {
             collectGuardedRelations(child, filtersForChildren, guarded);
         }
-    }
-
-    /**
-     * Whether a filter sitting <em>above</em> {@code plan} may still be used to prune the source files beneath it.
-     *
-     * <p>The reasoning that licenses pruning is: if no row of a file can satisfy the filter, the file cannot
-     * contribute to the result, so skipping it changes nothing. That holds only while every node between the filter
-     * and the source leaves the row count alone. The moment a node <em>selects</em> rows by cardinality, it breaks:
-     * {@code FROM ds | SORT id | LIMIT 4 | WHERE year == 2025} must take four rows and filter them <em>afterwards</em>
-     * — pruning the non-2025 files first would refill the {@code LIMIT} window from the surviving files and return
-     * rows the query never asked for. The same goes for {@code SAMPLE}, {@code STATS}, {@code MV_EXPAND} and joins.
-     *
-     * <p>{@link Streaming} already means exactly "does not add or remove rows", so it carries the rule for us and keeps
-     * carrying it as commands are added. Two nodes qualify without being {@code Streaming}: {@link Filter}, which only
-     * ever removes rows (pruning yet more of them below is still sound), and {@link OrderBy}, which reorders but never
-     * drops. Everything else — anything that could change how many rows reach the top — fails closed to "do not prune":
-     * a full scan, never an invented answer. Value provenance is a separate concern, enforced independently by the
-     * {@code NameId} binding in {@link #resolveExternalSource}.
-     *
-     * <p>Today no unsafe shape actually reaches this walk, so the guard is defence in depth rather than a live fix.
-     * That is not because of anything this class controls: it holds only because the optimizer never pushes a filter
-     * below a limit, nor a limit below a filter, so the two never end up stacked inside one fragment. The guard is here
-     * because that is an invariant of code far away, and #143696 is precisely the story of such an invariant quietly
-     * changing underneath partition pruning.
-     *
-     * @see #rowPreserving(PhysicalPlan) the same rule over the physical tree — the two must agree
-     */
-    private static boolean rowPreserving(LogicalPlan plan) {
-        return plan instanceof Streaming || plan instanceof Filter || plan instanceof OrderBy;
-    }
-
-    /**
-     * The physical-tree twin of {@link #rowPreserving(LogicalPlan)}; see there for why this is an allowlist. Note the
-     * absence of an order-by node: ES|QL lowers a sort to {@link TopNExec}, which carries a limit and therefore
-     * <em>is</em> cardinality-sensitive.
-     */
-    private static boolean rowPreserving(PhysicalPlan plan) {
-        return plan instanceof FilterExec || plan instanceof EvalExec || plan instanceof ProjectExec || plan instanceof RegexExtractExec;
     }
 
     /**
@@ -251,7 +207,7 @@ public final class SplitDiscoveryPhase {
             return resolveExternalSource(exec, ancestorFilters, sourceFactories, maxRecordBytes, stats, isCancelled);
         }
 
-        List<Expression> filtersForChildren = rowPreserving(plan) ? ancestorFilters : List.of();
+        List<Expression> filtersForChildren = PartitionPruningRule.rowPreserving(plan) ? ancestorFilters : List.of();
         if (plan instanceof FilterExec filterExec) {
             List<Expression> extended = new ArrayList<>(filtersForChildren);
             for (Expression conjunction : splitAnd(filterExec.condition())) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -50,9 +50,10 @@ import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.split
  * #143696 — the fragment path was added without the filter ever being re-threaded.
  *
  * <p>This decides which files are <em>read</em>. It is not the only place a partition filter is consulted:
- * {@code PartitionFilterHintExtractor} extracts hints far earlier, pre-resolution, for {@code GlobExpander} to skip
- * <em>listing</em> whole folders. That layer has its own copy of this problem and does not share these guards — see its
- * javadoc. Nothing here can compensate for a file that was never listed.
+ * {@link PartitionFilterHintExtractor} runs far earlier, pre-resolution, and lets {@code GlobExpander} skip
+ * <em>listing</em> whole folders. Nothing here can compensate for a file that was never listed, so both layers obey the
+ * rules in {@link PartitionPruningRule} — with the pre-resolution layer held to a stricter one, since it has only names
+ * to go on where this side binds by {@code NameId}.
  */
 public final class SplitDiscoveryPhase {
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -45,15 +45,16 @@ import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.split
  * <p><b>Two trees, one rule.</b> Which filters guard a given {@link ExternalSourceExec} is decided here for both shapes
  * the relation can arrive in: the physical plan (walked by {@code resolveRecursive}, collecting {@link FilterExec}) and
  * a fragment's logical plan (walked by {@link #guardedRelations}, collecting {@link Filter}). Both exist because a
- * {@code FROM <dataset>} lowers through a {@code FragmentExec} whose body is still a {@link LogicalPlan}; they are kept
- * adjacent so the rule cannot drift apart between them, which is exactly how partition pruning silently died in
- * #143696 — the fragment path was added without the filter ever being re-threaded.
+ * {@code FROM <dataset>} lowers through a {@code FragmentExec} whose body is still a {@link LogicalPlan}. Keeping the two
+ * walks adjacent, sharing one rule, is what stops them drifting apart: a filter recovered on one path and not the other
+ * would prune inconsistently, and on the fragment path the relation arrives stripped of the {@code Filter} that stood
+ * above it, so the conjuncts have to be recovered here or the matcher never sees the predicate at all.
  *
  * <p>This decides which files are <em>read</em>. It is not the only place a partition filter is consulted:
- * {@link PartitionFilterHintExtractor} runs far earlier, pre-resolution, and lets {@code GlobExpander} skip
- * <em>listing</em> whole folders. Nothing here can compensate for a file that was never listed, so both layers obey the
- * rules in {@link PartitionPruningRule} — with the pre-resolution layer held to a stricter one, since it has only names
- * to go on where this side binds by {@code NameId}.
+ * {@link PartitionFilterHintExtractor} runs earlier, pre-resolution, and lets {@code GlobExpander} skip <em>listing</em>
+ * whole folders. Nothing here can compensate for a file that was never listed, so both layers obey the rules in
+ * {@link PartitionPruningRule} — the pre-resolution layer held to a stricter one, since it has only names to go on where
+ * this side binds by {@code NameId}.
  */
 public final class SplitDiscoveryPhase {
 
@@ -77,8 +78,8 @@ public final class SplitDiscoveryPhase {
      * <p>Split discovery lowers each relation to a standalone {@link ExternalSourceExec} via
      * {@code ExternalRelation.toPhysicalExec()}, which drops the surrounding plan — and with it the {@code Filter} that
      * was sitting above the relation. Recovering the conjuncts here, before that lowering, is what lets partition
-     * pruning see the predicate at all; without it {@code FileSplitProvider.matchesPartitionFilters} runs on an empty
-     * filter set and every partition folder is read (elastic/elasticsearch#153618).
+     * pruning see the predicate at all; without them {@code FileSplitProvider.matchesPartitionFilters} runs on an empty
+     * filter set and every partition folder is read.
      *
      * <p>The conjuncts are <em>candidates</em>, not commands: {@link #resolveExternalSource} binds each one to the
      * relation's own output by {@code NameId} before it may prune, so a filter over a downstream-generated column that
@@ -174,11 +175,10 @@ public final class SplitDiscoveryPhase {
      * walk with {@code seedFilters} — conjuncts that guard this sub-plan from <em>above</em> and so cannot be recovered
      * from the tree itself, as produced by {@link #guardedRelations}.
      *
-     * <p>Needed because since #143696 every {@code FROM <dataset>} is wrapped in a {@code FragmentExec}: the coordinator
-     * physical-plan walk never reaches a top-level {@link ExternalSourceExec}, discovery runs on the fragment path, and
-     * the relation arrives there stripped of its {@code Filter} ancestor. Without the seed, partition pruning was dead
-     * on <em>every</em> production query — single-node included, not only distributed ones
-     * (elastic/elasticsearch#153618).
+     * <p>Needed because every {@code FROM <dataset>} is wrapped in a {@code FragmentExec}: the coordinator physical-plan
+     * walk never reaches a top-level {@link ExternalSourceExec}, discovery runs on the fragment path, and the relation
+     * arrives there stripped of its {@code Filter} ancestor. Without the seed, partition pruning would not fire on any
+     * production query — single-node included, not only distributed ones.
      *
      * <p>The seed is not blindly trusted: {@link #resolveExternalSource} binds each conjunct to the relation's output by
      * {@link NameId} before it may prune, so a filter over a downstream-generated column that merely shares a partition
@@ -269,7 +269,7 @@ public final class SplitDiscoveryPhase {
         // `PushDownAndCombineFilters` may leave above the generating node and thus in ancestorFilters. Pruning by the
         // path partition value for such a row-derived column produces silently wrong answers. Keeping only conjuncts
         // whose every attribute reference resolves by id into exec.output() drops those shadowing filters; the split
-        // provider's per-file matcher then sees only genuine partition/data-column predicates. See #153618.
+        // provider's per-file matcher then sees only genuine partition/data-column predicates.
         List<Expression> boundFilters = filtersBoundToOutput(ancestorFilters, exec.output());
 
         SplitDiscoveryContext context = new SplitDiscoveryContext(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public class EnrichExec extends UnaryExec implements EstimatesRowSize, ExecutesOn {
+public class EnrichExec extends UnaryExec implements EstimatesRowSize, ExecutesOn, RowCountPreserving {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "EnrichExec",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EvalExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EvalExec.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public class EvalExec extends UnaryExec implements EstimatesRowSize {
+public class EvalExec extends UnaryExec implements EstimatesRowSize, RowCountPreserving {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "EvalExec",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FilterExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FilterExec.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import java.io.IOException;
 import java.util.Objects;
 
-public class FilterExec extends UnaryExec {
+public class FilterExec extends UnaryExec implements RowCountPreserving {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "FilterExec",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ProjectExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ProjectExec.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class ProjectExec extends UnaryExec {  // TODO implement EstimatesRowSize *somehow*
+public class ProjectExec extends UnaryExec implements RowCountPreserving {  // TODO implement EstimatesRowSize *somehow*
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "ProjectExec",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RegexExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RegexExtractExec.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public abstract class RegexExtractExec extends UnaryExec implements EstimatesRowSize {
+public abstract class RegexExtractExec extends UnaryExec implements EstimatesRowSize, RowCountPreserving {
 
     protected final Expression inputExpression;
     protected final List<Attribute> extractedFields;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RowCountPreserving.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RowCountPreserving.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+/**
+ * Marks a physical exec that maps its child's rows one-to-one — it may add or drop <em>columns</em>, and reorder rows,
+ * but it never changes how <em>many</em> rows flow through. It is the physical-tree counterpart of the logical
+ * {@link org.elasticsearch.xpack.esql.plan.logical.Streaming} marker.
+ *
+ * <p>The distinction is what lets a filter above such a node be pushed <em>below</em> it: if the row count is
+ * untouched, a predicate that excludes a source can be applied at the source instead, changing nothing about the
+ * result. A node that selects rows by cardinality — a {@code LIMIT}, {@code TOP N}, {@code STATS}, {@code SAMPLE},
+ * {@code MV_EXPAND}, a join — must <em>not</em> carry this marker: pushing a filter past it changes which rows survive.
+ *
+ * <p>Currently consulted only by partition-pruning seed propagation during split discovery
+ * ({@code PartitionPruningRule#rowPreserving(PhysicalPlan)}). It is deliberately opt-in and fails closed: an exec
+ * without the marker is treated as cardinality-sensitive, so forgetting it costs a missed optimization, never a wrong
+ * result. Add it only to a node you are certain preserves row count.
+ */
+public interface RowCountPreserving {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -279,7 +279,6 @@ public class ComputeService {
      * Adds the post-prune external scan accounting to the query profile. The counts are captured
      * before split coalescing, so {@code splits_scanned} reflects the pre-coalesce discovered split
      * count rather than the smaller post-coalesce count.
-     *
      */
     private static void recordExternalScanStats(EsqlExecutionInfo execInfo, SplitDiscoveryPhase.Result result) {
         if (execInfo != null && result.splitsScanned() > 0) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -519,7 +519,7 @@ public class ComputeService {
         plan.forEachDown(FragmentExec.class, fragment -> {
             // Each relation is discovered with the Filter conjuncts that guard it inside the fragment. Lowering a
             // relation to a standalone ExternalSourceExec drops the surrounding plan, so those conjuncts have to be
-            // recovered before the lowering or partition pruning never sees the predicate at all (#153618).
+            // recovered before the lowering or partition pruning never sees the predicate at all.
             for (SplitDiscoveryPhase.GuardedRelation guarded : SplitDiscoveryPhase.guardedRelations(fragment.fragment())) {
                 SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
                     guarded.relation().toPhysicalExec(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -279,6 +279,7 @@ public class ComputeService {
      * Adds the post-prune external scan accounting to the query profile. The counts are captured
      * before split coalescing, so {@code splits_scanned} reflects the pre-coalesce discovered split
      * count rather than the smaller post-coalesce count.
+     *
      */
     private static void recordExternalScanStats(EsqlExecutionInfo execInfo, SplitDiscoveryPhase.Result result) {
         if (execInfo != null && result.splitsScanned() > 0) {
@@ -517,19 +518,22 @@ public class ComputeService {
             return;
         }
         plan.forEachDown(FragmentExec.class, fragment -> {
-            fragment.fragment().forEachDown(ExternalRelation.class, external -> {
-                ExternalSourceExec tempExec = external.toPhysicalExec();
+            // Each relation is discovered with the Filter conjuncts that guard it inside the fragment. Lowering a
+            // relation to a standalone ExternalSourceExec drops the surrounding plan, so those conjuncts have to be
+            // recovered before the lowering or partition pruning never sees the predicate at all (#153618).
+            for (SplitDiscoveryPhase.GuardedRelation guarded : SplitDiscoveryPhase.guardedRelations(fragment.fragment())) {
                 SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
-                    tempExec,
+                    guarded.relation().toPhysicalExec(),
                     operatorFactoryRegistry.sourceFactories(),
                     maxRecordBytes,
-                    isCancelled
+                    isCancelled,
+                    guarded.filters()
                 );
                 if (result.plan() instanceof ExternalSourceExec withSplits) {
                     splits.addAll(withSplits.splits());
                 }
                 recordExternalScanStats(execInfo, result);
-            });
+            }
         });
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -2276,6 +2276,61 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals(3, provider.discoverSplits(ctx).splits().size());
     }
 
+    // -- the matcher may only ever fail to prune; these pin the cases where it used to prune a matching file --
+
+    /**
+     * Integral partition values must be compared as longs, not doubles. Above 2^53 a double cannot separate adjacent
+     * longs, so {@code 9007199254740992 == 9007199254740993} came out TRUE, {@code !=} came out FALSE, and a file
+     * whose every row matches the filter was pruned away. A LONG partition column holding epoch-micros or snowflake
+     * ids reaches this range routinely.
+     */
+    public void testLargeLongPartitionValuesAreNotCollapsedByDoublePrecision() {
+        Map<String, Object> values = Map.of("ts", 9007199254740992L);
+        Literal adjacent = new Literal(SRC, 9007199254740993L, DataType.LONG);
+
+        assertEquals(Boolean.FALSE, FileSplitProvider.evaluateFilter(new Equals(SRC, fieldAttr("ts"), adjacent), values));
+        assertTrue(
+            "ts != <adjacent long> is TRUE, so the file must be kept — pruning it drops every matching row",
+            FileSplitProvider.matchesPartitionFilters(values, List.of(new NotEquals(SRC, fieldAttr("ts"), adjacent)))
+        );
+        assertTrue(
+            "ts < <adjacent long> is TRUE, so the file must be kept",
+            FileSplitProvider.matchesPartitionFilters(values, List.of(new LessThan(SRC, fieldAttr("ts"), adjacent)))
+        );
+    }
+
+    /**
+     * Keyword ranges must order by UTF-8 bytes, the way ES|QL orders keywords. {@link String#compareTo} orders by
+     * UTF-16 code units, which puts a supplementary-plane character (its leading surrogate, 0xD83D) <em>below</em>
+     * a private-use char like U+E000 — the opposite of the engine's answer. The file would be pruned while its rows
+     * satisfy the predicate.
+     */
+    public void testKeywordRangeUsesUtf8ByteOrderNotUtf16() {
+        Map<String, Object> values = Map.of("region", "\uD83D\uDE00"); // U+1F600 GRINNING FACE, above the BMP
+        Literal privateUse = new Literal(SRC, new BytesRef("\uE000"), DataType.KEYWORD); // U+E000, top of the BMP
+
+        assertEquals(
+            "U+1F600 > U+E000 by code point, so the row matches and the file must be kept",
+            Boolean.TRUE,
+            FileSplitProvider.evaluateFilter(new GreaterThan(SRC, fieldAttr("region"), privateUse), values)
+        );
+    }
+
+    /**
+     * A literal on the left of an asymmetric operator keeps its side. Applying the comparator with the column first
+     * would evaluate {@code year > 2024} for {@code 2024 > year} — the exact inverse, pruning precisely the files
+     * that match. {@code LiteralsOnTheRight} normalizes this away upstream, so the matcher is never handed this shape
+     * today; it must still not be wrong if it is.
+     */
+    public void testLiteralOnTheLeftKeepsOperandOrder() {
+        Map<String, Object> values = Map.of("year", 2020);
+
+        // 2024 > year -> 2024 > 2020 -> TRUE (the file matches, and must be kept)
+        assertEquals(Boolean.TRUE, FileSplitProvider.evaluateFilter(new GreaterThan(SRC, intLiteral(2024), fieldAttr("year")), values));
+        // 2024 < year -> 2024 < 2020 -> FALSE (the file cannot match, and may be pruned)
+        assertEquals(Boolean.FALSE, FileSplitProvider.evaluateFilter(new LessThan(SRC, intLiteral(2024), fieldAttr("year")), values));
+    }
+
     // -- helpers --
 
     private static final Source SRC = Source.EMPTY;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractorTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Drop;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Rename;
@@ -335,6 +336,50 @@ public class PartitionFilterHintExtractorTests extends ESTestCase {
         List<PartitionFilterHint> hints = PartitionFilterHintExtractor.extract(plan).get(PATH);
         assertNotNull("DROP must not stop a partition hint", hints);
         assertEquals("year", hints.get(0).columnName());
+    }
+
+    // -- One listing serves every occurrence of a path, so a folder may be skipped only if EVERY occurrence excludes it --
+
+    /**
+     * {@code FORK} reaches the same relation from two branches, and both are served by one listing. A folder excluded
+     * by one branch's filter may still be needed by the other, so an unfiltered branch has to veto the rewrite
+     * outright — otherwise it silently loses the folders the other branch pruned away.
+     */
+    public void testForkUnfilteredBranchVetoesTheRewrite() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan guarded = new Filter(SRC, rel, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+        LogicalPlan fork = new Fork(SRC, List.of(guarded, rel), List.of());
+
+        assertTrue(
+            "one branch's filter must not narrow a listing the other branch reads unfiltered",
+            PartitionFilterHintExtractor.extract(fork).isEmpty()
+        );
+    }
+
+    /** Both branches exclude the same folders, so the listing may safely skip them. */
+    public void testForkAgreeingBranchesKeepTheCommonHint() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan left = new Filter(SRC, rel, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+        LogicalPlan right = new Filter(SRC, rel, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+        LogicalPlan fork = new Fork(SRC, List.of(left, right), List.of());
+
+        List<PartitionFilterHint> hints = PartitionFilterHintExtractor.extract(fork).get(PATH);
+        assertNotNull("both branches want only year=2025, so the rest may be skipped", hints);
+        assertEquals(1, hints.size());
+        assertEquals("year", hints.get(0).columnName());
+    }
+
+    /** Branches wanting different years between them need every folder, so nothing may be skipped. */
+    public void testForkDisagreeingBranchesKeepNoHint() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan left = new Filter(SRC, rel, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+        LogicalPlan right = new Filter(SRC, rel, new Equals(SRC, unresolved("year"), intLiteral(2024)));
+        LogicalPlan fork = new Fork(SRC, List.of(left, right), List.of());
+
+        assertTrue(
+            "the branches need different folders, so neither may narrow the shared listing",
+            PartitionFilterHintExtractor.extract(fork).isEmpty()
+        );
     }
 
     private static final String PATH = "s3://bucket/data/*.parquet";

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/PartitionFilterHintExtractorTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
@@ -24,8 +25,14 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.Drop;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Rename;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
 
 import java.util.List;
@@ -212,6 +219,128 @@ public class PartitionFilterHintExtractorTests extends ESTestCase {
         assertEquals(1, hints.size());
         assertNotNull(hints.get("s3://bucket/a/*.parquet"));
         assertNull(hints.get("s3://bucket/b/*.parquet"));
+    }
+
+    // -- A hint rewrites the glob, so folders it excludes are never listed. These pin when it may not be trusted. --
+
+    /**
+     * {@code SORT id | LIMIT 4 | WHERE year == 2025} takes four rows and filters them <em>afterwards</em>. Narrowing
+     * the listing to {@code year=2025/} first would refill the {@code LIMIT} window from the surviving folders and
+     * return rows the query never asked for. No hint may cross a {@code LIMIT}.
+     */
+    public void testLimitBarrierDropsHints() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan limit = new Limit(SRC, intLiteral(4), rel);
+        LogicalPlan plan = new Filter(SRC, limit, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+
+        assertTrue("a filter above a LIMIT must not narrow the listing", PartitionFilterHintExtractor.extract(plan).isEmpty());
+    }
+
+    /** Same rule, a node that collapses rows rather than truncating them. */
+    public void testAggregateBarrierDropsHints() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan stats = new Aggregate(SRC, rel, List.of(), List.of(unresolved("id")));
+        LogicalPlan plan = new Filter(SRC, stats, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+
+        assertTrue("a filter above STATS must not narrow the listing", PartitionFilterHintExtractor.extract(plan).isEmpty());
+    }
+
+    /**
+     * {@code EVAL year = ...} redefines {@code year} as a row value that has nothing to do with the {@code year=2024/}
+     * folder the row came from. Rewriting the glob to {@code year=615/} would list nothing at all.
+     */
+    public void testEvalShadowDropsMatchingHint() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan eval = new Eval(SRC, rel, List.of(new Alias(SRC, "year", unresolved("id"))));
+        LogicalPlan plan = new Filter(SRC, eval, new Equals(SRC, unresolved("year"), intLiteral(615)));
+
+        assertTrue(
+            "a hint on a column an EVAL redefined must not narrow the listing",
+            PartitionFilterHintExtractor.extract(plan).isEmpty()
+        );
+    }
+
+    /** Only the shadowed conjunct is dropped — a genuine partition predicate alongside it still prunes. */
+    public void testEvalShadowKeepsUnrelatedHint() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan eval = new Eval(SRC, rel, List.of(new Alias(SRC, "year", unresolved("id"))));
+        Expression condition = new And(
+            SRC,
+            new Equals(SRC, unresolved("year"), intLiteral(615)),
+            new Equals(SRC, unresolved("month"), intLiteral(6))
+        );
+        LogicalPlan plan = new Filter(SRC, eval, condition);
+
+        List<PartitionFilterHint> hints = PartitionFilterHintExtractor.extract(plan).get(PATH);
+        assertNotNull("the untouched `month` predicate must survive", hints);
+        assertEquals(1, hints.size());
+        assertEquals("month", hints.get(0).columnName());
+    }
+
+    /**
+     * Direction check. Here the {@code WHERE} reads the real partition column and the {@code EVAL} only affects rows
+     * downstream of it, so the hint is still good. Applying shadowing at the relation rather than at the moment the
+     * walk passes the {@code EVAL} would wrongly drop it.
+     */
+    public void testFilterBelowEvalKeepsHint() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan filter = new Filter(SRC, rel, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+        LogicalPlan plan = new Eval(SRC, filter, List.of(new Alias(SRC, "year", intLiteral(9))));
+
+        List<PartitionFilterHint> hints = PartitionFilterHintExtractor.extract(plan).get(PATH);
+        assertNotNull("a filter BELOW the EVAL reads the partition column and must still prune", hints);
+        assertEquals("year", hints.get(0).columnName());
+    }
+
+    /** {@code RENAME id AS year} makes `year` row-derived just as an EVAL would; the new name is the dangerous one. */
+    public void testRenameShadowDropsHint() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan rename = new Rename(SRC, rel, List.of(new Alias(SRC, "year", unresolved("id"))));
+        LogicalPlan plan = new Filter(SRC, rename, new Equals(SRC, unresolved("year"), intLiteral(615)));
+
+        assertTrue("a hint on a RENAMEd column must not narrow the listing", PartitionFilterHintExtractor.extract(plan).isEmpty());
+    }
+
+    /**
+     * {@code ENRICH} is the reason the listing layer cannot reuse the {@code Streaming} marker: it is row-preserving,
+     * but until the analyzer loads the policy its generated fields are unknown, so a policy that contributes a
+     * {@code year} column would shadow the partition column invisibly. It must stop the hint.
+     */
+    public void testEnrichBarrierDropsHints() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan enrich = new Enrich(
+            SRC,
+            rel,
+            Enrich.Mode.ANY,
+            Literal.keyword(SRC, "policy"),
+            unresolved("id"),
+            null,
+            Map.of(),
+            List.of()
+        );
+        LogicalPlan plan = new Filter(SRC, enrich, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+
+        assertTrue(
+            "ENRICH may introduce columns not knowable pre-resolution, so no hint may cross it",
+            PartitionFilterHintExtractor.extract(plan).isEmpty()
+        );
+    }
+
+    /** KEEP/DROP only remove columns; they never redefine one, so the common shapes must keep pruning. */
+    public void testKeepAndDropAreTransparent() {
+        UnresolvedExternalRelation rel = externalRelation(PATH);
+        LogicalPlan drop = new Drop(SRC, rel, List.of(unresolved("unused")));
+        LogicalPlan plan = new Filter(SRC, drop, new Equals(SRC, unresolved("year"), intLiteral(2025)));
+
+        List<PartitionFilterHint> hints = PartitionFilterHintExtractor.extract(plan).get(PATH);
+        assertNotNull("DROP must not stop a partition hint", hints);
+        assertEquals("year", hints.get(0).columnName());
+    }
+
+    private static final String PATH = "s3://bucket/data/*.parquet";
+
+    private static UnresolvedExternalRelation externalRelation(String path) {
+        return new UnresolvedExternalRelation(SRC, Literal.keyword(SRC, path), Map.of());
     }
 
     private static LogicalPlan filterAboveExternal(Expression condition, String path) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -95,9 +95,9 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     }
 
     /**
-     * The fragment path's seed derivation (#153618). A {@code Filter} above an {@code ExternalRelation} inside a
-     * fragment must be recovered as that relation's pruning seed — this is the step whose absence made partition
-     * pruning dead on every query, because lowering the relation to an {@code ExternalSourceExec} discards the
+     * The fragment path's seed derivation. A {@code Filter} above an {@code ExternalRelation} inside a fragment must be
+     * recovered as that relation's pruning seed — without this step there is no pruning at all, because lowering the
+     * relation to an {@code ExternalSourceExec} discards the
      * {@code Filter} that stood above it.
      */
     public void testGuardedRelationsCollectsFilterAncestorsInFragment() {
@@ -238,9 +238,9 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     }
 
     /**
-     * Fragment-path regression (elastic/elasticsearch#153618): when the {@code ExternalSourceExec} is lowered from an
-     * isolated {@code ExternalRelation} — no surviving {@code FilterExec} ancestor — the coordinator must seed the
-     * recursive walk with the fragment's partition-column filter conjuncts, or L1 partition pruning never sees them.
+     * Fragment-path seeding: when the {@code ExternalSourceExec} is lowered from an isolated {@code ExternalRelation}
+     * — no surviving {@code FilterExec} ancestor — the coordinator must seed the recursive walk with the fragment's
+     * partition-column filter conjuncts, or L1 partition pruning never sees them.
      * Asserts the seed overload plumbs {@code seedFilters} through to {@link SplitDiscoveryContext#filterHints()}.
      */
     public void testSeedFiltersReachContextWithoutFilterExec() {
@@ -270,9 +270,9 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     }
 
     /**
-     * Blocker guard (elastic/elasticsearch#153618): a seed conjunct that references an attribute NOT in the relation's
-     * output — e.g. a downstream {@code EVAL year = ...} that shadows the partition column with a fresh {@code NameId} —
-     * must be dropped before pruning, so the split provider never prunes files by the path partition value for a
+     * Shadowing guard: a seed conjunct that references an attribute NOT in the relation's output — e.g. a downstream
+     * {@code EVAL year = ...} that shadows the partition column with a fresh {@code NameId} — must be dropped before
+     * pruning, so the split provider never prunes files by the path partition value for a
      * row-derived column. Binding is by id, not name: a same-named attribute with a different id is not kept.
      */
     public void testSeedFilterOverShadowingAttributeIsDropped() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -20,12 +20,18 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryResult;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
@@ -88,6 +94,120 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         assertEquals(600L, result.bytesScanned());
     }
 
+    /**
+     * The fragment path's seed derivation (#153618). A {@code Filter} above an {@code ExternalRelation} inside a
+     * fragment must be recovered as that relation's pruning seed — this is the step whose absence made partition
+     * pruning dead on every query, because lowering the relation to an {@code ExternalSourceExec} discards the
+     * {@code Filter} that stood above it.
+     */
+    public void testGuardedRelationsCollectsFilterAncestorsInFragment() {
+        ExternalRelation relation = externalRelation();
+        Expression year = new Equals(SRC, relation.output().get(0), new Literal(SRC, 2025, DataType.INTEGER));
+        Expression month = new Equals(SRC, relation.output().get(1), new Literal(SRC, 6, DataType.INTEGER));
+        // Two stacked Filters, as PushDownAndCombineFilters may leave them: both must reach the relation.
+        LogicalPlan fragment = new Filter(SRC, new Filter(SRC, relation, year), month);
+
+        List<SplitDiscoveryPhase.GuardedRelation> guarded = SplitDiscoveryPhase.guardedRelations(fragment);
+
+        assertEquals(1, guarded.size());
+        assertSame(relation, guarded.get(0).relation());
+        assertEquals("both Filter ancestors must seed the relation", 2, guarded.get(0).filters().size());
+        assertTrue(guarded.get(0).filters().containsAll(List.of(year, month)));
+    }
+
+    /** An AND condition is split into its conjuncts, so each can be matched against a partition column on its own. */
+    public void testGuardedRelationsSplitsConjunction() {
+        ExternalRelation relation = externalRelation();
+        Expression year = new Equals(SRC, relation.output().get(0), new Literal(SRC, 2025, DataType.INTEGER));
+        Expression month = new Equals(SRC, relation.output().get(1), new Literal(SRC, 6, DataType.INTEGER));
+        LogicalPlan fragment = new Filter(SRC, relation, new And(SRC, year, month));
+
+        List<SplitDiscoveryPhase.GuardedRelation> guarded = SplitDiscoveryPhase.guardedRelations(fragment);
+
+        assertEquals(1, guarded.size());
+        assertEquals("`a AND b` must arrive as two prunable conjuncts, not one opaque expression", 2, guarded.get(0).filters().size());
+    }
+
+    /**
+     * A filter above a {@code LIMIT} must not become a pruning seed. {@code SORT id | LIMIT 4 | WHERE year == 2025}
+     * takes four rows and filters them afterwards; pruning the non-2025 files first would refill the limit window from
+     * the survivors and return rows the query never asked for. The seed must be dropped at the cardinality-sensitive
+     * node, leaving the relation unguarded (full scan, correct answer).
+     */
+    public void testGuardedRelationsDoesNotSeedPastLimit() {
+        ExternalRelation relation = externalRelation();
+        Expression year = new Equals(SRC, relation.output().get(0), new Literal(SRC, 2025, DataType.INTEGER));
+        LogicalPlan fragment = new Filter(SRC, new Limit(SRC, new Literal(SRC, 4, DataType.INTEGER), relation), year);
+
+        List<SplitDiscoveryPhase.GuardedRelation> guarded = SplitDiscoveryPhase.guardedRelations(fragment);
+
+        assertEquals(1, guarded.size());
+        assertTrue(
+            "a filter above a LIMIT must not prune the source — LIMIT does not commute with WHERE",
+            guarded.get(0).filters().isEmpty()
+        );
+    }
+
+    /** The complement: with the filter <em>below</em> the limit, WHERE genuinely runs first and pruning is sound. */
+    public void testGuardedRelationsSeedsFilterBelowLimit() {
+        ExternalRelation relation = externalRelation();
+        Expression year = new Equals(SRC, relation.output().get(0), new Literal(SRC, 2025, DataType.INTEGER));
+        LogicalPlan fragment = new Limit(SRC, new Literal(SRC, 4, DataType.INTEGER), new Filter(SRC, relation, year));
+
+        List<SplitDiscoveryPhase.GuardedRelation> guarded = SplitDiscoveryPhase.guardedRelations(fragment);
+
+        assertEquals(1, guarded.size());
+        assertEquals("a filter below the LIMIT still prunes", List.of(year), guarded.get(0).filters());
+    }
+
+    /**
+     * The physical twin of {@link #testGuardedRelationsDoesNotSeedPastLimit}: a {@code FilterExec} above a
+     * {@code LimitExec} must not reach the source either. The two walks encode the same rule and have to agree — the
+     * whole reason this bug existed is that a second path was added and the rule was not carried over to it.
+     */
+    public void testFilterExecAboveLimitExecDoesNotReachSource() {
+        FileList fileList = createFileList(2);
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        LimitExec limit = new LimitExec(SRC, exec, new Literal(SRC, 4, DataType.INTEGER), null);
+        Expression year = new Equals(SRC, outputAttr(exec, "year"), new Literal(SRC, 2025, DataType.INTEGER));
+        FilterExec filter = new FilterExec(SRC, limit, year);
+
+        RecordingSplitProvider recorder = new RecordingSplitProvider();
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(recorder));
+
+        SplitDiscoveryPhase.resolveExternalSplits(filter, factories);
+
+        assertTrue(
+            "a filter above a LIMIT must not prune the source on the physical path either",
+            recorder.lastContext.filterHints().isEmpty()
+        );
+    }
+
+    /** An unfiltered relation is guarded by nothing: every file must be read, and no conjunct may be invented. */
+    public void testGuardedRelationsWithoutFilterHasEmptySeed() {
+        ExternalRelation relation = externalRelation();
+
+        List<SplitDiscoveryPhase.GuardedRelation> guarded = SplitDiscoveryPhase.guardedRelations(relation);
+
+        assertEquals(1, guarded.size());
+        assertTrue("no Filter above the relation means no pruning seed", guarded.get(0).filters().isEmpty());
+    }
+
+    /** An ExternalRelation with `year`/`month` output attributes, standing in for a Hive-partitioned dataset. */
+    private static ExternalRelation externalRelation() {
+        List<Attribute> output = List.of(fieldAttr("year", DataType.INTEGER), fieldAttr("month", DataType.INTEGER));
+        SimpleSourceMetadata metadata = new SimpleSourceMetadata(
+            output,
+            "parquet",
+            "s3://bucket/data/*.parquet",
+            null,
+            null,
+            Map.of(),
+            Map.of()
+        );
+        return new ExternalRelation(SRC, "s3://bucket/data/*.parquet", metadata, output, FileList.UNRESOLVED, Map.of());
+    }
+
     public void testScanStatsZeroWhenNoSplitsDiscovered() {
         ExternalSourceExec exec = createExternalSourceExec(FileList.UNRESOLVED, "parquet");
         Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(new FileSplitProvider()));
@@ -106,7 +226,7 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     public void testFilterExecAboveExternalSourceCollectsFilters() {
         FileList fileList = createFileList(2);
         ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
-        Expression condition = new Equals(SRC, fieldAttr("year", DataType.INTEGER), new Literal(SRC, 2024, DataType.INTEGER));
+        Expression condition = new Equals(SRC, outputAttr(exec, "year"), new Literal(SRC, 2024, DataType.INTEGER));
         FilterExec filter = new FilterExec(SRC, exec, condition);
 
         RecordingSplitProvider recorder = new RecordingSplitProvider();
@@ -115,6 +235,68 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         SplitDiscoveryPhase.resolveExternalSplits(filter, factories);
 
         assertEquals(1, recorder.lastContext.filterHints().size());
+    }
+
+    /**
+     * Fragment-path regression (elastic/elasticsearch#153618): when the {@code ExternalSourceExec} is lowered from an
+     * isolated {@code ExternalRelation} — no surviving {@code FilterExec} ancestor — the coordinator must seed the
+     * recursive walk with the fragment's partition-column filter conjuncts, or L1 partition pruning never sees them.
+     * Asserts the seed overload plumbs {@code seedFilters} through to {@link SplitDiscoveryContext#filterHints()}.
+     */
+    public void testSeedFiltersReachContextWithoutFilterExec() {
+        FileList fileList = createFileList(2);
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        // The seed filter references the relation's own `year` output attribute (matching NameId), so the
+        // output-binding guard keeps it.
+        Expression seed = new Equals(SRC, outputAttr(exec, "year"), new Literal(SRC, 2025, DataType.INTEGER));
+
+        RecordingSplitProvider recorder = new RecordingSplitProvider();
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(recorder));
+
+        SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> false,
+            List.of(seed)
+        );
+
+        assertEquals(
+            "seed filter must reach the split-discovery context on the fragment path",
+            1,
+            recorder.lastContext.filterHints().size()
+        );
+        assertSame(seed, recorder.lastContext.filterHints().get(0));
+    }
+
+    /**
+     * Blocker guard (elastic/elasticsearch#153618): a seed conjunct that references an attribute NOT in the relation's
+     * output — e.g. a downstream {@code EVAL year = ...} that shadows the partition column with a fresh {@code NameId} —
+     * must be dropped before pruning, so the split provider never prunes files by the path partition value for a
+     * row-derived column. Binding is by id, not name: a same-named attribute with a different id is not kept.
+     */
+    public void testSeedFilterOverShadowingAttributeIsDropped() {
+        FileList fileList = createFileList(2);
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        // A fresh `year` FieldAttribute — same NAME as the relation's `year` output column, but a distinct NameId,
+        // standing in for a downstream-generated (EVAL/DISSECT/GROK) column. The guard must drop the filter over it.
+        Expression shadowing = new Equals(SRC, fieldAttr("year", DataType.INTEGER), new Literal(SRC, 2025, DataType.INTEGER));
+
+        RecordingSplitProvider recorder = new RecordingSplitProvider();
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(recorder));
+
+        SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+            () -> false,
+            List.of(shadowing)
+        );
+
+        assertTrue(
+            "a filter over a shadowing (non-output) attribute must be dropped, not used to prune",
+            recorder.lastContext.filterHints().isEmpty()
+        );
     }
 
     public void testMultipleExternalSourcesEachGetOwnSplits() {
@@ -174,10 +356,10 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         ExternalSourceExec exec1 = createExternalSourceExec(fileList1, "parquet");
         ExternalSourceExec exec2 = createExternalSourceExec(fileList2, "csv");
 
-        Expression cond1 = new Equals(SRC, fieldAttr("year", DataType.INTEGER), new Literal(SRC, 2024, DataType.INTEGER));
+        Expression cond1 = new Equals(SRC, outputAttr(exec1, "year"), new Literal(SRC, 2024, DataType.INTEGER));
         FilterExec filter1 = new FilterExec(SRC, exec1, cond1);
 
-        Expression cond2 = new Equals(SRC, fieldAttr("month", DataType.INTEGER), new Literal(SRC, 6, DataType.INTEGER));
+        Expression cond2 = new Equals(SRC, outputAttr(exec2, "month"), new Literal(SRC, 6, DataType.INTEGER));
         FilterExec filter2 = new FilterExec(SRC, exec2, cond2);
 
         RecordingSplitProvider recorder1 = new RecordingSplitProvider();
@@ -195,8 +377,8 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     public void testNestedFiltersAccumulateForDescendantSource() {
         FileList fileList = createFileList(2);
         ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
-        Expression cond1 = new Equals(SRC, fieldAttr("year", DataType.INTEGER), new Literal(SRC, 2024, DataType.INTEGER));
-        Expression cond2 = new Equals(SRC, fieldAttr("month", DataType.INTEGER), new Literal(SRC, 6, DataType.INTEGER));
+        Expression cond1 = new Equals(SRC, outputAttr(exec, "year"), new Literal(SRC, 2024, DataType.INTEGER));
+        Expression cond2 = new Equals(SRC, outputAttr(exec, "month"), new Literal(SRC, 6, DataType.INTEGER));
         FilterExec inner = new FilterExec(SRC, exec, cond1);
         FilterExec outer = new FilterExec(SRC, inner, cond2);
 
@@ -266,10 +448,23 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     }
 
     private static ExternalSourceExec createExternalSourceExec(FileList fileList, String sourceType) {
-        List<Attribute> attrs = List.of(fieldAttr("id", DataType.LONG), fieldAttr("name", DataType.KEYWORD));
+        // Output carries a partition-like `year` and a `month` so tests can build a filter over the SAME attribute
+        // instances (matching NameId), which is what the analyzer produces in a real plan and what
+        // SplitDiscoveryPhase's NameId-binding guard requires.
+        List<Attribute> attrs = List.of(
+            fieldAttr("id", DataType.LONG),
+            fieldAttr("name", DataType.KEYWORD),
+            fieldAttr("year", DataType.INTEGER),
+            fieldAttr("month", DataType.INTEGER)
+        );
         return new ExternalSourceExec(SRC, "s3://bucket/data/*.parquet", sourceType, attrs, Map.of(), Map.of(), null, null).withFileList(
             fileList
         );
+    }
+
+    /** The output attribute named {@code name} on {@code exec} — used to build filters whose reference id matches the relation output. */
+    private static Attribute outputAttr(ExternalSourceExec exec, String name) {
+        return exec.output().stream().filter(a -> a.name().equals(name)).findFirst().orElseThrow();
     }
 
     private static Attribute fieldAttr(String name, DataType type) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/RowCountPreservingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/RowCountPreservingTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.test.ESTestCase;
+
+/**
+ * Pins which execs carry {@link RowCountPreserving}. Partition-pruning seed propagation trusts this marker to decide
+ * whether a filter may be pushed past a node ({@code PartitionPruningRule#rowPreserving(PhysicalPlan)}), so marking a
+ * node that actually changes the row count would prune away matching rows. The forgotten-marker direction is caught by
+ * the pruning tests (a full scan is correct, only slow); this test guards the dangerous direction — a
+ * cardinality-changing exec must never carry the marker.
+ */
+public class RowCountPreservingTests extends ESTestCase {
+
+    public void testRowCountPreservingExecsAreMarked() {
+        assertMarked(FilterExec.class);   // only removes rows; a filter below is still sound
+        assertMarked(EvalExec.class);     // adds columns, one row in one row out
+        assertMarked(ProjectExec.class);  // column selection — the lowered form of KEEP/DROP/RENAME/INSIST
+        assertMarked(RegexExtractExec.class);
+        assertMarked(DissectExec.class);  // extends RegexExtractExec
+        assertMarked(GrokExec.class);     // extends RegexExtractExec
+        assertMarked(EnrichExec.class);
+    }
+
+    public void testCardinalityChangingExecsAreNotMarked() {
+        assertNotMarked(LimitExec.class);
+        assertNotMarked(TopNExec.class);
+        assertNotMarked(AggregateExec.class);
+        assertNotMarked(SampleExec.class);
+        assertNotMarked(MvExpandExec.class);
+    }
+
+    private static void assertMarked(Class<? extends PhysicalPlan> exec) {
+        assertTrue(exec.getSimpleName() + " must carry RowCountPreserving", RowCountPreserving.class.isAssignableFrom(exec));
+    }
+
+    private static void assertNotMarked(Class<? extends PhysicalPlan> exec) {
+        assertFalse(
+            exec.getSimpleName() + " changes the row count and must NOT carry RowCountPreserving",
+            RowCountPreserving.class.isAssignableFrom(exec)
+        );
+    }
+}


### PR DESCRIPTION
## What this is about

Filtering a hive-partitioned dataset on a partition column read **every file in every partition folder**. `FROM ds | WHERE year == 2025 | STATS ...` returned the right answer and scanned all 8 folders to get it. Every provider, every format, single-node and distributed alike.

Split discovery lowers each `ExternalRelation` to a standalone `ExternalSourceExec` via `toPhysicalExec()`. That drops the `Filter` sitting above it inside the fragment, so `FileSplitProvider.matchesPartitionFilters` ran with an empty filter set and kept everything. Pruning was introduced in #143114 and stopped working in #143696, which added the fragment path without re-threading the filter — and since #143696 *every* `FROM <dataset>` takes that path, so this was every query.

## What this PR does

A partition filter is consulted in two places, and both were broken. The first commit fixes which listed files are **read**; the second fixes which folders are **listed** at all.

### The read layer

Recovers the `Filter` conjuncts guarding each relation inside a fragment and seeds split discovery with them.

That alone would ship wrong answers. Once the predicate actually reaches the matcher, four latent defects in it become reachable, and each prunes files that contain matching rows:

- **Keyword partitions matched nothing.** Partition values are Java `String`s; ES|QL string literals are `BytesRef`, whose `toString` is a hex dump. `region == "US"` compared `"US"` against `"[55 53]"`, pruned every folder, returned **zero rows**.
- **A generated column shadowed the path.** The seed matched by name, so `EVAL year = <derived> | WHERE year == 615` pruned on the *folder's* year. No folder is 615 — everything pruned, **zero rows**. The seed now binds to the relation's own output by `NameId`.
- **Big integral partition values collapsed.** Numbers compared via `doubleValue()`, and above 2^53 a `double` cannot separate adjacent longs. For an epoch-micros or snowflake-id column, `ts != <neighbour>` came out `false` and pruned a file whose every row matched. Integral values now compare as `long`.
- **Keyword ranges ordered by UTF-16.** `String.compareTo` compares code *units*; the engine orders keywords by UTF-8 bytes. They disagree above the BMP, so a range predicate pruned a matching `region=😀` folder. Ranges now compare `BytesRef` bytes.

A literal on the left of a range (`2024 > year`) also kept the column's operand position, evaluating the exact inverse. `LiteralsOnTheRight` normalizes that shape away today, so it isn't reachable — but the matcher shouldn't depend on an optimizer rule it can't enforce.

### The listing layer

`PartitionFilterHintExtractor` runs much earlier, on the unresolved plan, and rewrites the glob so non-matching folders are never listed. Nothing downstream can recover a file it skipped, so the guards above are worthless without the same guards here — and it had both of the same defects:

- A hint crossed any node, including `LIMIT`. `SORT id | LIMIT 4 | WHERE year == 2025` narrowed the listing first and refilled the limit window from the survivors.
- Hints matched by name with no shadow check, so `EVAL year = id % 10000 | WHERE year == 615` rewrote the glob to `year=615` and listed nothing.

A hint also no longer narrows a listing shared by more than one consumer unless every consumer excludes the folder — `FORK` reaches one relation from two branches, and one branch's filter must not starve the other.

### One rule, two layers

Both rules now live in `PartitionPruningRule` and both layers consult it. They are deliberately **not** the same predicate, and that difference is the point.

A seed may only cross nodes that leave the row count alone. A `WHERE` above a `LIMIT` does not commute with it, and a seed that leaked past would refill the limit window from the surviving files. The read layer expresses this with the existing `Streaming` marker (plus `Filter` and `OrderBy`).

The listing layer cannot use `Streaming`. It runs before resolution, where a name is all a hint has — while the read layer binds by `NameId` and can therefore safely let a conjunct cross a node whose new columns are unknown. `ENRICH` is the counterexample that forces this: it is `Streaming` *and* a `GeneratingPlan`, but until the analyzer loads the policy its `enrichFields` are empty unless the query spelled out a `WITH`. A policy contributing a `year` column would shadow the partition column invisibly. So the listing layer uses a stricter allowlist of nodes whose name changes are visible in the parsed tree, and fails closed: an unknown node stops the hint and the folders get listed.

`ComputeService` no longer carries its own copy of the filter walk. A rule enforced in one walk and forgotten in the other is exactly how this broke.

## Does it work?

`ExternalHivePartitionPruningIT`, CSV and Parquet, over a `year/month/day` tree of 8 single-row files. Every case asserts the **exact surviving rows** against a plain-Java oracle *and* the scanned-file count, on both the projection and the aggregate plan shape. A row count alone cannot tell a dropped row from a never-matching one; a file count alone cannot tell a correct answer from a lucky one.

Single dimension prunes to 4 files, two to 2, the full spec to 1, a non-matching value to 0. A data-column filter prunes nothing. `OR` with a data-column arm prunes nothing, since the un-evaluable arm forces keep-on-null. `IN`, ranges, `!=` and mixed partition/data filters each land where they should.

Every change above is pinned by a test that goes red when it is reverted — including the two a numeric `year/month/day` matrix silently passes (the keyword partition and the shadowed column), which return *wrong rows* rather than slow ones. On the listing side the barrier, shadow and shared-listing guards each go red without them, and the `FORK` veto is red against the union behaviour it replaced. Several tests deliberately stay green either way: they exist to fail if pruning is ever drawn *too wide*.

The matcher stays conservative: `matchesPartitionFilters` keeps a file whenever a conjunct cannot be decided from the path values, so pruning can only ever fail to prune. These fixes are what make that claim true rather than merely intended.

## What this costs, and what it doesn't cover

Where a hint now stops, the glob is not rewritten and the folders are listed. The answer is right; the listing is wider. The shapes that lose it: a filter separated from the relation by `STATS` (even grouping on the partition column — the pre-resolution walk cannot know the filter commutes with the grouping), `MV_EXPAND`, `ENRICH`, `COMPLETION`, `RERANK`, `INSIST`; and `FORK` branches carrying the same predicate written differently (`year == 2025` vs `year IN (2025)` are not the same hint). In each case the read layer still prunes what it opens, so only the listing widens.

That has a sharp edge worth naming: a query that stayed under `esql.external.max_discovered_files` *because* the rewrite narrowed the listing can now fail against that limit — a success turning into an error. It is bounded to datasets registered with a `key=*` glob or a path template; a `**` glob never rewrote in the first place. The trade is deliberate: losing a rewrite costs latency, getting it wrong costs the user rows.

The listing layer is exercised end to end. Every fixture in the repo registered its dataset with a bare recursive glob, which `GlobExpander` never rewrites — it only rewrites a segment spelled `key=*` — so nothing above unit level had ever reached that layer. There is now a fixture registered under a glob that names its partition keys, where a hint really does rewrite the glob and the non-matching folders are never enumerated. Remove the listing guards and its limit-barrier and shadowed-column cases go red while no other test moves, which is also what demonstrates the rewrite is live there and inert everywhere else.

## What's out of scope

Skipping the folder listing as an *optimization* — teaching the glob rewrite to cover more shapes — is separate. This PR only makes the rewrite that already ships stop returning wrong rows.
