### PR TITLE
[ESQL] Abort external read backoff on hard cancel

### DIFF
--- a/docs/changelog/153641.yaml
+++ b/docs/changelog/153641.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153641
+summary: Abort external read backoff on hard cancel
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -63,6 +63,22 @@ public final class AsyncExternalSourceBuffer {
     private volatile Throwable failure = null;
 
     /**
+     * Set when a live producer is cut by a hard stop — i.e. {@link #finish(boolean) finish(true)} performs the
+     * running→finishing transition (task cancel / async DELETE tearing the operator down, or a LIMIT teardown
+     * closing the source while the producer is still reading). Unlike {@link #noMoreInputs}, this is <em>not</em>
+     * set by async STOP ({@code finish(false)}, which keeps buffered pages for a partial response) nor by natural
+     * EOF (where the producer's own {@code finish(false)} wins the transition, so the driver's later
+     * {@code finish(true)} on close no longer transitions). It is consulted as the ambient
+     * {@link StorageRetryCancellation} signal installed around the runtime producer read so an in-flight storage
+     * retry/throttle backoff aborts promptly instead of sleeping through its budget while the query is already
+     * cancelled. See {@link StorageRetryCancellation} for why STOP must not trip this, and for the
+     * degenerate-query case this does <em>not</em> fix: a read wedged in a genuinely uncancellable operation off
+     * the scoped thread (a parallel-parse worker, a native reader) still unwinds only on its own timeout, so the
+     * driver's completion and final resource release wait for it even though the task is already marked cancelled.
+     */
+    private volatile boolean readCancelled = false;
+
+    /**
      * Per-file captured source metadata contributions, populated by the background reader thread as
      * iterators close. Each path's value is a list of flat {@code _stats.*} maps — one per chunk for
      * parallel parsing, one per split for macro-splits, one for whole-file reads. The coordinator
@@ -409,6 +425,13 @@ public final class AsyncExternalSourceBuffer {
      */
     public boolean finish(boolean drainingPages) {
         boolean transitioned = noMoreInputs.compareAndSet(false, true);
+        // A draining finish that actually made the transition is a hard cut of a still-running producer
+        // (cancel / DELETE / LIMIT teardown), never natural EOF (producer's own finish(false) wins first) nor
+        // STOP (drainingPages == false). Only then arm the read-cancellation signal so an in-flight storage
+        // backoff aborts; see the readCancelled javadoc.
+        if (drainingPages && transitioned) {
+            readCancelled = true;
+        }
         // See the javadoc above for why this must not be gated on `transitioned`.
         if (drainingPages) {
             discardPages();
@@ -441,6 +464,15 @@ public final class AsyncExternalSourceBuffer {
 
     public boolean noMoreInputs() {
         return noMoreInputs.get();
+    }
+
+    /**
+     * Whether a live producer was hard-cut (see {@link #readCancelled}). Used as the ambient
+     * {@link StorageRetryCancellation} signal around the runtime producer read so a parked storage
+     * retry/throttle backoff aborts on cancel rather than sleeping out its budget.
+     */
+    public boolean readCancelled() {
+        return readCancelled;
     }
 
     public int size() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1558,7 +1558,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private void openUnitThenDrain(ProducerState state, ActionListener<Void> completionListener) {
         try {
             executor.execute(ActionRunnable.wrap(completionListener, l -> {
-                if (advanceToNextUnit(state) == false) {
+                // Install the hard-cancel signal as the ambient StorageRetryCancellation scope for the blocking
+                // open probes (length()/computeSegments/reader open) so a parked storage retry/throttle backoff on
+                // the runtime read path aborts on cancel instead of sleeping out its budget. Mirrors the scope the
+                // coordinator installs in ExternalSourceResolver for discovery/resolution footer reads.
+                boolean opened = StorageRetryCancellation.callWithCancellation(state.buffer::readCancelled, () -> advanceToNextUnit(state));
+                if (opened == false) {
                     snapshotBytesRead(state);
                     snapshotFormatReaderStatus(state);
                     l.onResponse(null);
@@ -1587,7 +1592,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      */
     private void drainCurrentUnit(ProducerState state, ActionListener<Void> completionListener) {
         try {
-            DrainResult result = drainHotPath(state, completionListener);
+            // Same StorageRetryCancellation scope as the open phase: the page pulls (tryAdvance/hasNext/next)
+            // drive the storage reads whose retry/throttle backoff must observe a hard cancel here.
+            DrainResult result = StorageRetryCancellation.callWithCancellation(
+                state.buffer::readCancelled,
+                () -> drainHotPath(state, completionListener)
+            );
             switch (result) {
                 case DONE -> {
                     // Buffer finished (externally or by row-limit exhaustion) while an iterator is still open:
@@ -2308,33 +2318,38 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         executor.execute(ActionRunnable.run(failureListener, () -> {
             FormatReader reader = readerWithDynamicThreshold(formatReader);
-            CloseableIterator<Page> pages = openWithParallelism(
-                reader,
-                storageObject,
-                PhysicalNames.translateNames(projectedColumns, renames),
-                errorPolicy,
-                false,
-                true,
-                // Single whole-file read: the file is its own final split, so its trailing segment reaches EOF.
-                true,
-                null,
-                0L,
-                buffer.capturedSourceMetadataSink(),
-                buffer::recordWarning,
-                buffer::recordInformationalWarning
-            );
-            if (pages == null) {
-                FormatReadContext ctx = FormatReadContext.builder()
-                    .projectedColumns(PhysicalNames.translateNames(projectedColumns, renames))
-                    .batchSize(batchSize)
-                    .rowLimit(rowLimit)
-                    .errorPolicy(errorPolicy)
-                    .maxRecordBytes(maxRecordBytes)
-                    .statsColumnScope(statsColumnScope)
-                    .informationalWarningSink(buffer::recordInformationalWarning)
-                    .build();
-                pages = reader.read(storageObject, ctx);
-            }
+            // Install the hard-cancel signal as the ambient StorageRetryCancellation scope for the blocking open,
+            // so a parked storage retry/throttle backoff aborts on cancel rather than sleeping out its budget.
+            CloseableIterator<Page> pages = StorageRetryCancellation.callWithCancellation(buffer::readCancelled, () -> {
+                CloseableIterator<Page> opened = openWithParallelism(
+                    reader,
+                    storageObject,
+                    PhysicalNames.translateNames(projectedColumns, renames),
+                    errorPolicy,
+                    false,
+                    true,
+                    // Single whole-file read: the file is its own final split, so its trailing segment reaches EOF.
+                    true,
+                    null,
+                    0L,
+                    buffer.capturedSourceMetadataSink(),
+                    buffer::recordWarning,
+                    buffer::recordInformationalWarning
+                );
+                if (opened == null) {
+                    FormatReadContext ctx = FormatReadContext.builder()
+                        .projectedColumns(PhysicalNames.translateNames(projectedColumns, renames))
+                        .batchSize(batchSize)
+                        .rowLimit(rowLimit)
+                        .errorPolicy(errorPolicy)
+                        .maxRecordBytes(maxRecordBytes)
+                        .statsColumnScope(statsColumnScope)
+                        .informationalWarningSink(buffer::recordInformationalWarning)
+                        .build();
+                    opened = reader.read(storageObject, ctx);
+                }
+                return opened;
+            });
             pages = applyRowPositionStrategy(reader, pages, projectedColumns);
             pages = StatsCapturingIterator.wrap(pages, buffer.capturedSourceMetadataSink());
             // Wrap with the deferred-extraction encoder (no-op when not enabled), then with the
@@ -2354,6 +2369,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 // Cold-path drain resumes on the consumer pool (esql_worker), not the read/parse pool, so the
                 // drain never competes with parser workers for I/O threads. See runProducerLoop's split.
                 producerExecutor,
+                // Ambient hard-cancel signal so the drain's page-pull backoff aborts on cancel.
+                buffer::readCancelled,
                 // Close the iterator chain and record telemetry BEFORE notifying the buffer:
                 // closing publishes the finalize marker into the capture sink (via
                 // StatsCapturingIterator and the parallel coordinators' finalize hook), and
@@ -2403,6 +2420,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 buffer,
                 // Cold-path drain resumes on the consumer pool (esql_worker); see startSyncWrapperRead / runProducerLoop.
                 producerExecutor,
+                // Ambient hard-cancel signal so the drain's page-pull backoff aborts on cancel.
+                buffer::readCancelled,
                 // See startSyncWrapperRead: close the iterator chain and record telemetry
                 // before notifying the buffer so the finalize marker and the telemetry
                 // counters reach the operator status snapshot before isFinished() flips.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
@@ -64,8 +64,8 @@ public final class ExternalSourceDrainUtils {
 
     /**
      * Overload without an ambient cancellation signal, preserving the pre-existing behaviour for callers
-     * (e.g. connector sources and tests) that do not thread a hard-cancel signal into the drain. Equivalent to
-     * passing a supplier that never reports cancelled: cooperative {@code noMoreInputs} cancellation still applies.
+     * (currently tests) that do not thread a hard-cancel signal into the drain. Equivalent to passing a
+     * supplier that never reports cancelled: cooperative {@code noMoreInputs} cancellation still applies.
      */
     public static void drainPagesAsync(
         CloseableIterator<Page> pages,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 
 import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
 
 /**
  * Utility for draining pages from a {@link CloseableIterator} into an {@link AsyncExternalSourceBuffer}
@@ -44,9 +45,27 @@ public final class ExternalSourceDrainUtils {
      * on the Driver thread. The executor captures and restores thread context
      * at submission time, so no explicit context-preserving wrapper is needed.
      *
-     * <p><b>Cancellation:</b> No timeout. Cancellation comes from
+     * <p><b>Cancellation:</b> No timeout. Cooperative cancellation comes from
      * {@code buffer.finish(true)} setting {@code noMoreInputs}, which causes
-     * {@code waitForSpace()} to return an already-completed listener.
+     * {@code waitForSpace()} to return an already-completed listener and stops the loop at the next page
+     * boundary. To also abort a page pull ({@code hasNext()}/{@code next()}) parked in storage retry/throttle
+     * backoff, {@code readCancelled} is installed as the ambient {@link StorageRetryCancellation} signal around
+     * every drain step (initial and executor-resumed) — mirroring the {@code runProducerLoop} read path.
+     */
+    public static void drainPagesAsync(
+        CloseableIterator<Page> pages,
+        AsyncExternalSourceBuffer buffer,
+        Executor executor,
+        BooleanSupplier readCancelled,
+        ActionListener<Void> listener
+    ) {
+        drainBatch(pages, buffer, executor, readCancelled, listener);
+    }
+
+    /**
+     * Overload without an ambient cancellation signal, preserving the pre-existing behaviour for callers
+     * (e.g. connector sources and tests) that do not thread a hard-cancel signal into the drain. Equivalent to
+     * passing a supplier that never reports cancelled: cooperative {@code noMoreInputs} cancellation still applies.
      */
     public static void drainPagesAsync(
         CloseableIterator<Page> pages,
@@ -54,35 +73,38 @@ public final class ExternalSourceDrainUtils {
         Executor executor,
         ActionListener<Void> listener
     ) {
-        drainBatch(pages, buffer, executor, listener);
+        drainBatch(pages, buffer, executor, () -> false, listener);
     }
 
     private static void drainBatch(
         CloseableIterator<Page> pages,
         AsyncExternalSourceBuffer buffer,
         Executor executor,
+        BooleanSupplier readCancelled,
         ActionListener<Void> listener
     ) {
         try {
-            while (pages.hasNext() && buffer.noMoreInputs() == false) {
-                SubscribableListener<Void> space = buffer.waitForSpace();
-                if (space.isDone()) {
-                    if (buffer.noMoreInputs()) break;
-                    Page page = pages.next();
-                    page.allowPassingToDifferentDriver();
-                    buffer.addPage(page);
-                } else {
-                    space.addListener(ActionListener.wrap(v -> {
-                        try {
-                            executor.execute(() -> drainBatch(pages, buffer, executor, listener));
-                        } catch (Exception e) {
-                            listener.onFailure(e);
-                        }
-                    }, listener::onFailure));
-                    return;
+            StorageRetryCancellation.runWithCancellation(readCancelled, () -> {
+                while (pages.hasNext() && buffer.noMoreInputs() == false) {
+                    SubscribableListener<Void> space = buffer.waitForSpace();
+                    if (space.isDone()) {
+                        if (buffer.noMoreInputs()) break;
+                        Page page = pages.next();
+                        page.allowPassingToDifferentDriver();
+                        buffer.addPage(page);
+                    } else {
+                        space.addListener(ActionListener.wrap(v -> {
+                            try {
+                                executor.execute(() -> drainBatch(pages, buffer, executor, readCancelled, listener));
+                            } catch (Exception e) {
+                                listener.onFailure(e);
+                            }
+                        }, listener::onFailure));
+                        return;
+                    }
                 }
-            }
-            listener.onResponse(null);
+                listener.onResponse(null);
+            });
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
@@ -32,6 +32,11 @@ import java.util.function.BooleanSupplier;
  * to {@code AsyncExternalSourceBuffer.readCancelled()} — a hard cut of a still-running producer (task cancel /
  * async DELETE / LIMIT teardown), but <em>not</em> async STOP, which keeps buffered pages for a partial
  * response and must therefore let an in-flight read complete cooperatively rather than abort it mid-backoff.
+ * This means a STOP arriving while a read is parked in backoff can lag by up to that read's remaining retry
+ * budget before the producer observes {@code noMoreInputs} between pages and exits — sub-second for a transient
+ * backoff, up to the per-attempt throttle ceiling (tens of seconds) for a throttled read. That bounded lag is
+ * an accepted cost of the STOP contract: arming {@code readCancelled} on STOP would abort the read and degrade
+ * a graceful partial-result stop into a hard failure, so STOP deliberately waits the backoff out.
  * Between pages the runtime producer already exits on {@code noMoreInputs}; the runtime scope adds the missing
  * in-read coverage so a page pull parked in retry/throttle backoff aborts promptly on a hard cancel instead of
  * sleeping out its budget (the cause of long-lived post-cancel reads on slow/throttling object stores).

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageRetryCancellation.java
@@ -26,19 +26,39 @@ import java.util.function.BooleanSupplier;
  * around that read via {@link #runWithCancellation}. Nested scopes restore the enclosing supplier on
  * exit; when no scope is active {@link #isCancelled()} returns {@code false}.
  *
- * <p><b>Scope.</b> Scopes are installed only around coordinator-side split-discovery and source-resolution
- * footer reads. Data-node runtime scan reads hit the same backoff with no scope active and are
- * intentionally not covered here: the driver already checks task cancellation between pages, so only the
- * in-read backoff is uncovered on that path. Extending cancellation to the runtime read path is left as a
- * separate, follow-up change.
+ * <p><b>Scope.</b> Scopes are installed around coordinator-side split-discovery and source-resolution footer
+ * reads (see {@code ExternalSourceResolver}) and around the data-node runtime producer read (see
+ * {@code AsyncExternalSourceOperatorFactory} and {@code ExternalSourceDrainUtils}). The runtime scope is keyed
+ * to {@code AsyncExternalSourceBuffer.readCancelled()} — a hard cut of a still-running producer (task cancel /
+ * async DELETE / LIMIT teardown), but <em>not</em> async STOP, which keeps buffered pages for a partial
+ * response and must therefore let an in-flight read complete cooperatively rather than abort it mid-backoff.
+ * Between pages the runtime producer already exits on {@code noMoreInputs}; the runtime scope adds the missing
+ * in-read coverage so a page pull parked in retry/throttle backoff aborts promptly on a hard cancel instead of
+ * sleeping out its budget (the cause of long-lived post-cancel reads on slow/throttling object stores).
  *
  * <p><b>Thread affinity.</b> The signal only reaches a backoff sleep that runs on the same thread the scope
  * was installed on. This holds for every synchronous {@code StorageObject} footer read driven from the
- * discovery / resolution worker. It does NOT reach reads outside that synchronous Java retry layer: the
- * bzip2 parallel block-boundary scan runs chunk reads on a separate executor for large files (the
+ * discovery / resolution worker, and for the runtime open / drain steps that pull pages on the same thread the
+ * scope wraps. It does NOT reach reads outside that synchronous Java retry layer: the bzip2 parallel
+ * block-boundary scan and other parallel-parse workers run chunk reads on separate executor threads (the
  * thread-local does not propagate to those threads), and the parquet-rs reader performs footer I/O in a
  * native runtime that bypasses the Java retry layer entirely. Both fall back to their own, non-cancellable
  * backoff.
+ *
+ * <p><b>Degenerate-query cancellation (what the scope does NOT fix).</b> The scope only shortcuts the Java
+ * retry/throttle <em>backoff sleep</em> — it never interrupts an in-progress socket read or a native read, and
+ * it never reaches a read running on a thread it does not wrap (a parallel-parse worker, a native reader). For a
+ * degenerate query blocked in one of those — e.g. a single stalled object-store connection with no data flowing,
+ * or a native row-group read — a hard cancel behaves as follows: the driver observes the cancel between loop
+ * iterations and throws {@link TaskCancelledException}, and the task is marked cancelled at the task layer, but
+ * the driver's <em>completion</em> (via {@code DriverContext.waitForAsyncActions}) — and therefore the final
+ * response delivery and full resource release (the held storage connection, buffered blocks) — still waits for
+ * that background read to unwind on its own: its socket/read timeout, a native stall timeout, or natural EOF.
+ * In other words, arming {@code readCancelled} converts the common multi-hour case (a producer sleeping out an
+ * object-store retry/throttle backoff) into a prompt abort, but it does not bound a read wedged in a genuinely
+ * uncancellable operation off the scoped thread; that residual case is bounded only by the underlying layer's
+ * own timeout, not by cancellation. Closing that gap needs interrupt-/stream-abort-based cancellation and is a
+ * separate change.
  */
 final class StorageRetryCancellation {
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -503,6 +503,8 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
             "a cancelled read must surface as TaskCancelledException, got " + thrown.get(),
             thrown.get() instanceof TaskCancelledException
         );
+        producer.join(TimeUnit.SECONDS.toMillis(10));
+        assertFalse("the producer thread must have exited", producer.isAlive());
     }
 
     /**
@@ -542,5 +544,7 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
 
         assertTrue("the read completes its own backoff under STOP", done.await(10, TimeUnit.SECONDS));
         assertNull("STOP must not surface the read as a cancellation failure", thrown.get());
+        producer.join(TimeUnit.SECONDS.toMillis(10));
+        assertFalse("the producer thread must have exited", producer.isAlive());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -404,4 +404,50 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         assertTrue("the last line must note suppression", drained.get(drained.size() - 1).contains("further reader warnings suppressed"));
         assertFalse(buffer.isPartial());
     }
+
+    /**
+     * A hard-cutting {@code finish(true)} that wins the running→finishing transition (task cancel / async DELETE /
+     * LIMIT teardown while the producer is still reading) must arm {@link AsyncExternalSourceBuffer#readCancelled()}
+     * so the runtime read's {@code StorageRetryCancellation} scope aborts a parked storage backoff.
+     */
+    public void testFinishTrueArmsReadCancelledWhenTransitioning() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        assertFalse("a fresh buffer is not cancelled", buffer.readCancelled());
+        assertTrue("first finish(true) makes the transition", buffer.finish(true));
+        assertTrue("a transitioning draining finish is a hard cut and must arm read cancellation", buffer.readCancelled());
+    }
+
+    /**
+     * Async STOP is {@code finish(false)}: it keeps buffered pages for a partial response and must NOT arm read
+     * cancellation, otherwise an in-flight read would be aborted mid-backoff and the STOP contract (return what was
+     * already produced) would degrade into a hard failure.
+     */
+    public void testFinishFalseDoesNotArmReadCancelled() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        assertTrue("first finish(false) makes the transition", buffer.finish(false));
+        assertFalse("STOP must not arm read cancellation", buffer.readCancelled());
+    }
+
+    /**
+     * Natural EOF: the producer's own {@code finish(false)} wins the transition, so the driver's later
+     * {@code finish(true)} on operator close no longer transitions and must not be mistaken for a cancel.
+     */
+    public void testNaturalCompletionThenCloseDoesNotArmReadCancelled() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        assertTrue("producer's finish(false) wins the transition at natural EOF", buffer.finish(false));
+        assertFalse("the driver's later close is a no-op transition and must not arm cancellation", buffer.finish(true));
+        assertFalse("natural completion is not a cancel", buffer.readCancelled());
+    }
+
+    /**
+     * A producer that fails on its own (real read error) sets {@code noMoreInputs} via {@link
+     * AsyncExternalSourceBuffer#onFailure}; a subsequent close's {@code finish(true)} then loses the transition, so
+     * read cancellation stays disarmed — there is no other in-flight read to abort.
+     */
+    public void testOnFailureThenCloseDoesNotArmReadCancelled() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        buffer.onFailure(new RuntimeException("boom"));
+        assertFalse("close after a producer failure does not transition", buffer.finish(true));
+        assertFalse("a producer's own failure is not a read cancellation", buffer.readCancelled());
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -16,12 +16,14 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.IsBlockedResult;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonReaderStatus;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -449,5 +451,96 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         buffer.onFailure(new RuntimeException("boom"));
         assertFalse("close after a producer failure does not transition", buffer.finish(true));
         assertFalse("a producer's own failure is not a read cancellation", buffer.readCancelled());
+    }
+
+    /**
+     * End-to-end coverage of the runtime producer read wiring. {@code AsyncExternalSourceOperatorFactory}'s
+     * {@code openUnitThenDrain} / {@code drainCurrentUnit} / {@code startSyncWrapperRead} all install the buffer's
+     * hard-cancel signal as the ambient {@link StorageRetryCancellation} scope exactly this way —
+     * {@code callWithCancellation(buffer::readCancelled, <read>)} — so the read work is what this test reproduces
+     * (the real factory adds only the two-executor producer loop around the same seam). A read parked in
+     * retry/throttle backoff is modeled by {@link StorageRetryCancellation#sleepWithCancellationChecks}. A hard-cut
+     * {@code finish(true)} (task cancel / async DELETE / LIMIT teardown) must arm {@code readCancelled()} so the
+     * scoped backoff aborts promptly with {@link TaskCancelledException} instead of sleeping out its budget — the
+     * long-lived post-cancel read this change fixes. The scope is the only thing that cuts a backoff already
+     * entered; cooperative {@code noMoreInputs} only fires between pulls.
+     */
+    public void testHardCancelAbortsScopedReadBackoff() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        CountDownLatch readParked = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        long backoffMillis = TimeUnit.SECONDS.toMillis(60);
+        long startNanos = System.nanoTime();
+
+        Thread producer = new Thread(() -> {
+            try {
+                // Mirrors the factory: the read runs inside a scope keyed to buffer::readCancelled.
+                StorageRetryCancellation.runWithCancellation(buffer::readCancelled, () -> {
+                    readParked.countDown();
+                    StorageRetryCancellation.sleepWithCancellationChecks(backoffMillis);
+                });
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                done.countDown();
+            }
+        }, "async-buffer-read-backoff-hard-cancel");
+        producer.setDaemon(true);
+        producer.start();
+
+        assertTrue("the read must have parked in backoff", readParked.await(10, TimeUnit.SECONDS));
+        // Hard cut while the producer is parked in backoff.
+        assertTrue("hard cancel wins the running->finishing transition", buffer.finish(true));
+
+        assertTrue("the scoped backoff must abort after a hard cancel", done.await(10, TimeUnit.SECONDS));
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        assertTrue(
+            "abort must not wait out the backoff budget (took " + elapsedMillis + "ms of " + backoffMillis + "ms)",
+            elapsedMillis < backoffMillis / 2
+        );
+        assertTrue(
+            "a cancelled read must surface as TaskCancelledException, got " + thrown.get(),
+            thrown.get() instanceof TaskCancelledException
+        );
+    }
+
+    /**
+     * Companion to {@link #testHardCancelAbortsScopedReadBackoff} proving the runtime scope is keyed to the
+     * hard-cut signal only. Async STOP is {@code finish(false)}: it leaves {@code readCancelled()} disarmed, so the
+     * same scoped read runs its backoff to completion rather than aborting mid-flight. Arming on STOP would turn a
+     * graceful partial-result stop into a {@link TaskCancelledException}; the accepted cost is that STOP waits out
+     * the in-flight backoff (bounded by the retry budget) before the producer exits on {@code noMoreInputs}.
+     */
+    public void testStopDoesNotAbortScopedReadBackoff() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        CountDownLatch readParked = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        // A short real backoff the read is expected to sleep out: STOP must not cut it short.
+        long backoffMillis = 200;
+
+        Thread producer = new Thread(() -> {
+            try {
+                StorageRetryCancellation.runWithCancellation(buffer::readCancelled, () -> {
+                    readParked.countDown();
+                    StorageRetryCancellation.sleepWithCancellationChecks(backoffMillis);
+                });
+            } catch (Throwable t) {
+                thrown.set(t);
+            } finally {
+                done.countDown();
+            }
+        }, "async-buffer-read-backoff-stop");
+        producer.setDaemon(true);
+        producer.start();
+
+        assertTrue("the read must have parked in backoff", readParked.await(10, TimeUnit.SECONDS));
+        // Graceful STOP: keeps buffered pages, must not arm read cancellation.
+        assertTrue("STOP wins the running->finishing transition", buffer.finish(false));
+        assertFalse("STOP must not arm read cancellation", buffer.readCancelled());
+
+        assertTrue("the read completes its own backoff under STOP", done.await(10, TimeUnit.SECONDS));
+        assertNull("STOP must not surface the read as a cancellation failure", thrown.get());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -799,6 +800,99 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         assertNotNull(error.get());
         assertTrue(error.get().getMessage().contains("immediate hasNext failure"));
         assertEquals(0, buffer.size());
+        buffer.finish(true);
+    }
+
+    /**
+     * The drain installs {@code readCancelled} as the ambient {@link StorageRetryCancellation} scope around every
+     * page pull. A pull parked in a storage retry/throttle backoff (modeled here by
+     * {@link StorageRetryCancellation#sleepWithCancellationChecks}) must therefore abort promptly with
+     * {@link TaskCancelledException} when the signal flips — instead of sleeping out the full backoff, which is the
+     * long-lived post-cancel read this change fixes. Cooperative {@code noMoreInputs} cancellation only fires
+     * between pulls, so it cannot cut a pull already inside the backoff; the scope is what closes that gap.
+     */
+    public void testDrainAbortsPagePullBackoffOnCancel() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        CountDownLatch pullStarted = new CountDownLatch(1);
+        long backoffMillis = TimeUnit.SECONDS.toMillis(30);
+
+        CloseableIterator<Page> backoffIterator = new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                pullStarted.countDown();
+                try {
+                    // Mirrors RetryPolicy.execute / RetryableStorageObject.reopenOrThrow parking in backoff.
+                    StorageRetryCancellation.sleepWithCancellationChecks(backoffMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                return false;
+            }
+
+            @Override
+            public Page next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        long startNanos = System.nanoTime();
+        // The first drain step runs synchronously on the caller, so dispatch it to a worker thread — otherwise the
+        // backoff sleep would block this test thread before it can flip the cancel signal.
+        exec.execute(
+            () -> ExternalSourceDrainUtils.drainPagesAsync(
+                backoffIterator,
+                buffer,
+                exec,
+                cancelled::get,
+                ActionListener.wrap(v -> done.countDown(), e -> {
+                    error.set(e);
+                    done.countDown();
+                })
+            )
+        );
+
+        assertTrue("the page pull must have entered the backoff", pullStarted.await(10, TimeUnit.SECONDS));
+        cancelled.set(true);
+        assertTrue("drain must abort after cancel rather than sleeping out the backoff", done.await(10, TimeUnit.SECONDS));
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        assertTrue(
+            "drain aborted well under the " + backoffMillis + "ms backoff (took " + elapsedMillis + "ms)",
+            elapsedMillis < backoffMillis / 2
+        );
+        assertNotNull("a cancelled pull must surface as a failure", error.get());
+        assertTrue("cancel must surface as TaskCancelledException, got " + error.get(), error.get() instanceof TaskCancelledException);
+        buffer.finish(true);
+    }
+
+    /**
+     * Sanity: threading a never-cancelled signal through the drain does not change normal completion — all pages
+     * are drained and success is reported.
+     */
+    public void testDrainWithCancellationSupplierCompletesNormally() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        List<Page> pages = List.of(createTestPage(1, 10), createTestPage(1, 10));
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesAsync(
+            iteratorOf(pages),
+            buffer,
+            exec,
+            () -> false,
+            ActionListener.wrap(v -> latch.countDown(), e -> {
+                error.set(e);
+                latch.countDown();
+            })
+        );
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull("normal drain must not fail", error.get());
+        assertEquals("both pages must be buffered", 2, buffer.size());
         buffer.finish(true);
     }
 


### PR DESCRIPTION
Runtime external-source reads parked in storage retry/throttle backoff ignored hard cancels (task cancel, DELETE, LIMIT teardown), so a cancelled query slept out its retry budget while holding the producer thread, buffer and open stream.

Install the hard-cancel signal (AsyncExternalSourceBuffer.readCancelled, armed only on finish(true) so STOP still returns partial results) as the ambient StorageRetryCancellation scope around the producer read, mirroring discovery/footer reads. Reads wedged off the scoped thread still unwind on their own timeout.