### PR TITLE
[8.19] [ML] Retry datafeed STARTED state write on system reassignment (#151399)

### DIFF
--- a/docs/changelog/151399.yaml
+++ b/docs/changelog/151399.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 151399
+summary: Retry datafeed STARTED state write on system reassignment
+type: bug

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedRetryResilienceIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedRetryResilienceIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.persistent.UpdatePersistentTaskStatusAction;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.test.NodeRoles.onlyRoles;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Integration tests for datafeed retry resilience during system-initiated reassignments.
+ *
+ * <p>Unit tests in {@link org.elasticsearch.xpack.ml.datafeed.DatafeedRunnerTests} cover retry
+ * decision logic; these tests verify end-to-end behavior is unchanged for user starts and that
+ * datafeeds recover after node failure (exercising the reassignment retry path).
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class DatafeedRetryResilienceIT extends BaseMlIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), MockTransportService.TestPlugin.class);
+    }
+
+    public void testNormalDatafeedStartStop_smokeTest() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        ensureStableCluster(1);
+
+        String jobId = "datafeed-retry-resilience-smoke-job";
+        String datafeedId = jobId + "-datafeed";
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+
+        client().admin().indices().prepareCreate("data").setMapping("time", "type=date").get();
+        DatafeedConfig config = createDatafeed(datafeedId, jobId, Collections.singletonList("data"));
+        client().execute(PutDatafeedAction.INSTANCE, new PutDatafeedAction.Request(config)).actionGet();
+
+        ensureYellow();
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+        client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L)).actionGet();
+
+        assertBusy(() -> assertThat(getDatafeedState(datafeedId), equalTo(DatafeedState.STARTED)), 30, TimeUnit.SECONDS);
+
+        client().execute(StopDatafeedAction.INSTANCE, new StopDatafeedAction.Request(datafeedId)).actionGet();
+        client().execute(CloseJobAction.INSTANCE, new CloseJobAction.Request(jobId)).actionGet();
+
+        assertBusy(() -> {
+            GetJobsStatsAction.Response stats = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+                .actionGet();
+            assertThat(stats.getResponse().results().get(0).getState(), equalTo(JobState.CLOSED));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * When the node running a datafeed stops, the datafeed persistent task is reassigned and should
+     * return to {@link DatafeedState#STARTED} on another node (retrying transient failures during the
+     * STARTED state write on reassignment).
+     */
+    public void testDatafeedReopensAfterNodeFailure() throws Exception {
+        internalCluster().ensureAtMostNumDataNodes(0);
+        internalCluster().startMasterOnlyNode();
+        String mlNodeA = internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)));
+        String mlNodeB = internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.ML_ROLE)));
+        ensureStableCluster(3);
+
+        String jobId = "datafeed-retry-resilience-failover-job";
+        String datafeedId = jobId + "-datafeed";
+        Job.Builder job = createJob(jobId, ByteSizeValue.ofMb(2));
+        client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
+
+        client().admin().indices().prepareCreate("data").setMapping("time", "type=date").get();
+        DatafeedConfig config = createDatafeed(datafeedId, jobId, Collections.singletonList("data"));
+        client().execute(PutDatafeedAction.INSTANCE, new PutDatafeedAction.Request(config)).actionGet();
+
+        ensureYellow();
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+        client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L)).actionGet();
+
+        String origNode = awaitJobOpenedAndAssigned(jobId, null);
+        assertNotNull(origNode);
+        assertThat(origNode, anyOf(equalTo(mlNodeA), equalTo(mlNodeB)));
+        String survivingNode = origNode.equals(mlNodeA) ? mlNodeB : mlNodeA;
+        assertBusy(() -> assertThat(getDatafeedState(datafeedId), equalTo(DatafeedState.STARTED)), 30, TimeUnit.SECONDS);
+
+        setMlIndicesDelayedNodeLeftTimeoutToZero();
+        ensureGreen();
+
+        String masterNode = internalCluster().getMasterName();
+        MockTransportService masterTransport = MockTransportService.getInstance(masterNode);
+        AtomicInteger injectedFailures = new AtomicInteger();
+        masterTransport.addRequestHandlingBehavior(UpdatePersistentTaskStatusAction.INSTANCE.name(), (handler, request, channel, task) -> {
+            if (injectedFailures.get() < 2) {
+                injectedFailures.incrementAndGet();
+                channel.sendResponse(new ConnectTransportException(masterTransport.getLocalNode(), "injected transient failure"));
+                return;
+            }
+            handler.messageReceived(request, channel, task);
+        });
+
+        internalCluster().stopNode(origNode);
+        ensureStableCluster(2, survivingNode);
+
+        awaitJobOpenedAndAssigned(jobId, survivingNode);
+        assertBusy(() -> {
+            assertThat(getDatafeedState(datafeedId), equalTo(DatafeedState.STARTED));
+            assertThat("retry path should have hit injected transport failures", injectedFailures.get(), greaterThan(1));
+        }, 2, TimeUnit.MINUTES);
+
+        masterTransport.clearAllRules();
+
+        GetJobsStatsAction.Response jobStats = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+            .actionGet();
+        assertThat(jobStats.getResponse().results().get(0).getState(), equalTo(JobState.OPENED));
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportStartDatafeedAction.java
@@ -536,8 +536,11 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                 datafeedTask.completeOrFailIfRequired(null);
                 return;
             }
+            // DatafeedState has no allocation id: null state means a fresh user start (fail-fast path),
+            // STARTED means the task was already running and this is a system reassignment (retry path).
+            boolean isReassignment = DatafeedState.STARTED.equals(datafeedState);
             switch (datafeedTask.setDatafeedRunner(datafeedRunner)) {
-                case NEITHER -> datafeedRunner.run(datafeedTask, datafeedTask::completeOrFailIfRequired);
+                case NEITHER -> datafeedRunner.run(datafeedTask, isReassignment, datafeedTask::completeOrFailIfRequired);
                 case ISOLATED -> logger.info("[{}] datafeed isolated immediately after reassignment.", params.getDatafeedId());
                 case STOPPED -> {
                     logger.info("[{}] datafeed stopped immediately after reassignment. Marking as completed", params.getDatafeedId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunner.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.RetryableAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -38,6 +39,7 @@ import org.elasticsearch.xpack.ml.action.datafeed.TransportStartDatafeedAction;
 import org.elasticsearch.xpack.ml.action.datafeed.TransportStartDatafeedAction.DatafeedTask.StoppedOrIsolated;
 import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManager;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.utils.MlRecoverableErrorClassifier;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -93,7 +95,7 @@ public class DatafeedRunner {
         clusterService.addListener(taskRunner);
     }
 
-    public void run(TransportStartDatafeedAction.DatafeedTask task, Consumer<Exception> finishHandler) {
+    public void run(TransportStartDatafeedAction.DatafeedTask task, boolean isReassignment, Consumer<Exception> finishHandler) {
         ActionListener<DatafeedJob> datafeedJobHandler = ActionListener.wrap(datafeedJob -> {
             String jobId = datafeedJob.getJobId();
             Holder holder = new Holder(
@@ -107,7 +109,7 @@ public class DatafeedRunner {
                 () -> runningDatafeedsOnThisNode.put(task.getAllocationId(), holder)
             );
             if (stoppedOrIsolated == StoppedOrIsolated.NEITHER) {
-                task.updatePersistentTaskState(DatafeedState.STARTED, new ActionListener<>() {
+                ActionListener<PersistentTask<?>> startedStateListener = new ActionListener<>() {
                     @Override
                     public void onResponse(PersistentTask<?> persistentTask) {
                         taskRunner.runWhenJobIsOpened(task, jobId);
@@ -115,6 +117,16 @@ public class DatafeedRunner {
 
                     @Override
                     public void onFailure(Exception e) {
+                        if (task.getStoppedOrIsolated() != StoppedOrIsolated.NEITHER) {
+                            logger.info(
+                                "[{}] Aborting STARTED state update as datafeed has been {}",
+                                task.getDatafeedId(),
+                                task.getStoppedOrIsolated().toString().toLowerCase(Locale.ROOT)
+                            );
+                            runningDatafeedsOnThisNode.remove(task.getAllocationId());
+                            finishHandler.accept(null);
+                            return;
+                        }
                         if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
                             // The task was stopped in the meantime, no need to do anything
                             logger.info("[{}] Aborting as datafeed has been stopped", task.getDatafeedId());
@@ -124,7 +136,12 @@ public class DatafeedRunner {
                             finishHandler.accept(e);
                         }
                     }
-                });
+                };
+                if (isReassignment) {
+                    createUpdateDatafeedStateRetryableAction(task, startedStateListener).run();
+                } else {
+                    task.updatePersistentTaskState(DatafeedState.STARTED, startedStateListener);
+                }
             } else {
                 logger.info(
                     "[{}] Datafeed has been {} before running",
@@ -691,6 +708,53 @@ public class DatafeedRunner {
                 }
             }
             tasksToRun.retainAll(remainingTasks);
+        }
+    }
+
+    static boolean shouldRetryDatafeedStateUpdate(TransportStartDatafeedAction.DatafeedTask task, Exception e) {
+        return task.getStoppedOrIsolated() == StoppedOrIsolated.NEITHER && MlRecoverableErrorClassifier.isRecoverable(e);
+    }
+
+    UpdateDatafeedStateRetryableAction createUpdateDatafeedStateRetryableAction(
+        TransportStartDatafeedAction.DatafeedTask task,
+        ActionListener<PersistentTask<?>> listener
+    ) {
+        return new UpdateDatafeedStateRetryableAction(task, listener);
+    }
+
+    /**
+     * Retries the {@link DatafeedState#STARTED} persistent-task state write for system-initiated reassignments.
+     *
+     * Uses exponential backoff with:
+     * - Initial delay: 5 seconds
+     * - Max delay: 5 minutes
+     * - Total timeout: from {@link MachineLearning#JOB_OPEN_RETRY_TIMEOUT} (default 60 minutes)
+     */
+    class UpdateDatafeedStateRetryableAction extends RetryableAction<PersistentTask<?>> {
+
+        private final TransportStartDatafeedAction.DatafeedTask task;
+
+        UpdateDatafeedStateRetryableAction(TransportStartDatafeedAction.DatafeedTask task, ActionListener<PersistentTask<?>> listener) {
+            super(
+                logger,
+                threadPool,
+                TimeValue.timeValueSeconds(5),
+                TimeValue.timeValueMinutes(5),
+                clusterService.getClusterSettings().get(MachineLearning.JOB_OPEN_RETRY_TIMEOUT),
+                listener,
+                threadPool.generic()
+            );
+            this.task = Objects.requireNonNull(task);
+        }
+
+        @Override
+        public void tryAction(ActionListener<PersistentTask<?>> listener) {
+            task.updatePersistentTaskState(DatafeedState.STARTED, listener);
+        }
+
+        @Override
+        public boolean shouldRetry(Exception e) {
+            return shouldRetryDatafeedStateUpdate(task, e);
         }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunnerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunnerTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.datafeed;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -17,10 +18,13 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.test.ESTestCase;
@@ -29,6 +33,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -47,10 +52,13 @@ import org.mockito.ArgumentCaptor;
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.ml.job.task.OpenJobPersistentTasksExecutorTests.addJobTask;
@@ -62,6 +70,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -110,6 +119,11 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(cs.build());
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.builder().put(MachineLearning.JOB_OPEN_RETRY_TIMEOUT.getKey(), "60m").build(),
+            Set.of(MachineLearning.JOB_OPEN_RETRY_TIMEOUT)
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         DiscoveryNode dNode = mock(DiscoveryNode.class);
         when(dNode.getName()).thenReturn("this_node_has_a_name");
@@ -165,7 +179,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         when(datafeedJob.runLookBack(0L, 60000L)).thenThrow(new DatafeedJob.EmptyDataCountException(0L, false));
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
         verify(threadPool, never()).schedule(any(), any(), any(Executor.class));
@@ -176,7 +190,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         when(datafeedJob.runLookBack(0L, 60000L)).thenReturn(null);
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
         verify(threadPool, never()).schedule(any(), any(), any(Executor.class));
@@ -186,7 +200,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         when(datafeedJob.runLookBack(0, 60000L)).thenThrow(new DatafeedJob.ExtractionProblemException(0L, new RuntimeException("dummy")));
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         verify(threadPool, times(1)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
         verify(threadPool, never()).schedule(any(), any(), any(Executor.class));
@@ -210,7 +224,7 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, null);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         verify(threadPool, times(11)).schedule(any(), any(), any(Executor.class));
         verify(auditor, times(1)).warning(eq(JOB_ID), anyString());
@@ -224,7 +238,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         StartDatafeedAction.DatafeedParams params = new StartDatafeedAction.DatafeedParams(DATAFEED_ID, 0L);
         DatafeedTask task = TransportStartDatafeedActionTests.createDatafeedTask(1, "type", "action", null, params, datafeedRunner);
         task = spyDatafeedTask(task);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         ArgumentCaptor<DatafeedJob.AnalysisProblemException> analysisProblemCaptor = ArgumentCaptor.forClass(
             DatafeedJob.AnalysisProblemException.class
@@ -245,7 +259,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         StartDatafeedAction.DatafeedParams params = new StartDatafeedAction.DatafeedParams(DATAFEED_ID, 0L);
         DatafeedTask task = TransportStartDatafeedActionTests.createDatafeedTask(1, "type", "action", null, params, datafeedRunner);
         task = spyDatafeedTask(task);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         verify(auditor).error(JOB_ID, "Datafeed is encountering errors submitting data for analysis: non-stopping");
         assertThat(datafeedRunner.isRunning(task), is(true));
@@ -260,7 +274,7 @@ public class DatafeedRunnerTests extends ESTestCase {
         StartDatafeedAction.DatafeedParams params = new StartDatafeedAction.DatafeedParams(DATAFEED_ID, 0L);
         DatafeedTask task = TransportStartDatafeedActionTests.createDatafeedTask(1, "type", "action", null, params, datafeedRunner);
         task = spyDatafeedTask(task);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         verify(threadPool, times(2)).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
         if (cancelled) {
@@ -283,7 +297,7 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         // Verify datafeed has not started running yet as job is still opening
         verify(threadPool, never()).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
@@ -324,7 +338,7 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         // Verify datafeed has not started running yet as job doesn't have an open autodetect communicator
         verify(threadPool, never()).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
@@ -359,7 +373,7 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         // Verify datafeed has not started running yet as job is stale (i.e. even though opened it is part way through relocating)
         verify(threadPool, never()).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
@@ -397,7 +411,7 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         // Verify datafeed has not started running yet as job is still opening
         verify(threadPool, never()).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
@@ -424,7 +438,7 @@ public class DatafeedRunnerTests extends ESTestCase {
 
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         // Verify datafeed has not started running yet as job is still opening
         verify(threadPool, never()).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
@@ -455,12 +469,112 @@ public class DatafeedRunnerTests extends ESTestCase {
         Consumer<Exception> handler = mockConsumer();
         DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
         when(task.getStoppedOrIsolated()).thenReturn(DatafeedTask.StoppedOrIsolated.STOPPED);
-        datafeedRunner.run(task, handler);
+        datafeedRunner.run(task, false, handler);
 
         // Verify datafeed aborted after creating context but before doing anything else
         verify(datafeedContextProvider).buildDatafeedContext(eq(DATAFEED_ID), any());
         verify(datafeedJobBuilder, never()).build(any(), any(), any());
         verify(threadPool, never()).executor(MachineLearning.DATAFEED_THREAD_POOL_NAME);
+    }
+
+    public void testReassignmentShouldUseRetryActionFactory() {
+        DatafeedRunner spyRunner = spy(datafeedRunner);
+        DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
+        DatafeedRunner.UpdateDatafeedStateRetryableAction mockAction = mock(DatafeedRunner.UpdateDatafeedStateRetryableAction.class);
+        doReturn(mockAction).when(spyRunner).createUpdateDatafeedStateRetryableAction(eq(task), any());
+        Consumer<Exception> handler = mockConsumer();
+
+        spyRunner.run(task, true, handler);
+
+        verify(spyRunner).createUpdateDatafeedStateRetryableAction(eq(task), any());
+        verify(mockAction).run();
+        verify(task, never()).updatePersistentTaskState(eq(DatafeedState.STARTED), any());
+    }
+
+    public void testUserStartShouldNotUseRetryActionFactory() {
+        DatafeedRunner spyRunner = spy(datafeedRunner);
+        DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
+        Consumer<Exception> handler = mockConsumer();
+
+        spyRunner.run(task, false, handler);
+
+        verify(spyRunner, never()).createUpdateDatafeedStateRetryableAction(any(), any());
+        verify(task).updatePersistentTaskState(eq(DatafeedState.STARTED), any());
+    }
+
+    public void testRecoverableStateUpdateFailureShouldRetryAndEventuallySucceed() {
+        enableSynchronousRetryScheduling();
+        DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
+        AtomicInteger attempts = new AtomicInteger();
+        doAnswer(invocationOnMock -> {
+            ActionListener<PersistentTask<?>> listener = invocationOnMock.getArgument(1);
+            if (attempts.incrementAndGet() == 1) {
+                listener.onFailure(new MasterNotDiscoveredException());
+            } else {
+                listener.onResponse(mock(PersistentTask.class));
+            }
+            return null;
+        }).when(task).updatePersistentTaskState(any(), any());
+
+        AtomicBoolean succeeded = new AtomicBoolean(false);
+        datafeedRunner.createUpdateDatafeedStateRetryableAction(task, ActionTestUtils.assertNoFailureListener(r -> succeeded.set(true)))
+            .run();
+
+        assertTrue(succeeded.get());
+        assertEquals(2, attempts.get());
+    }
+
+    public void testIrrecoverableStateUpdateFailureShouldFailFast() {
+        enableSynchronousRetryScheduling();
+        DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
+        doAnswer(invocationOnMock -> {
+            ActionListener<PersistentTask<?>> listener = invocationOnMock.getArgument(1);
+            listener.onFailure(new IllegalArgumentException("bad config"));
+            return null;
+        }).when(task).updatePersistentTaskState(any(), any());
+
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        datafeedRunner.createUpdateDatafeedStateRetryableAction(task, ActionTestUtils.assertNoSuccessListener(failure::set)).run();
+
+        assertTrue(failure.get() instanceof IllegalArgumentException);
+        verify(task, times(1)).updatePersistentTaskState(eq(DatafeedState.STARTED), any());
+    }
+
+    public void testStoppedTaskStateUpdateFailureShouldCompleteGracefully() {
+        enableSynchronousRetryScheduling();
+        DatafeedTask task = createDatafeedTask(DATAFEED_ID, 0L, 60000L);
+        when(task.getStoppedOrIsolated()).thenReturn(DatafeedTask.StoppedOrIsolated.NEITHER, DatafeedTask.StoppedOrIsolated.STOPPED);
+        doAnswer(invocationOnMock -> {
+            ActionListener<PersistentTask<?>> listener = invocationOnMock.getArgument(1);
+            listener.onFailure(new MasterNotDiscoveredException());
+            return null;
+        }).when(task).updatePersistentTaskState(any(), any());
+
+        Consumer<Exception> handler = mockConsumer();
+        datafeedRunner.run(task, true, handler);
+
+        verify(task, times(1)).updatePersistentTaskState(eq(DatafeedState.STARTED), any());
+        ArgumentCaptor<Exception> failureCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(handler).accept(failureCaptor.capture());
+        assertNull(failureCaptor.getValue());
+    }
+
+    public void testRecoverableErrorShouldRetryDatafeedStateUpdate() {
+        DatafeedTask task = mock(DatafeedTask.class);
+        when(task.getStoppedOrIsolated()).thenReturn(DatafeedTask.StoppedOrIsolated.NEITHER);
+        assertTrue(DatafeedRunner.shouldRetryDatafeedStateUpdate(task, new MasterNotDiscoveredException()));
+    }
+
+    public void testStoppedTaskShouldNotRetryDatafeedStateUpdate() {
+        DatafeedTask task = mock(DatafeedTask.class);
+        when(task.getStoppedOrIsolated()).thenReturn(DatafeedTask.StoppedOrIsolated.STOPPED);
+        assertFalse(DatafeedRunner.shouldRetryDatafeedStateUpdate(task, new MasterNotDiscoveredException()));
+    }
+
+    public void testResourceNotFoundShouldNotRetryDatafeedStateUpdate() {
+        DatafeedTask task = mock(DatafeedTask.class);
+        when(task.getStoppedOrIsolated()).thenReturn(DatafeedTask.StoppedOrIsolated.NEITHER);
+        assertFalse(DatafeedRunner.shouldRetryDatafeedStateUpdate(task, new org.elasticsearch.ResourceNotFoundException("gone")));
     }
 
     public static DatafeedConfig.Builder createDatafeedConfig(String datafeedId, String jobId) {
@@ -507,6 +621,14 @@ public class DatafeedRunnerTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     private Consumer<Exception> mockConsumer() {
         return mock(Consumer.class);
+    }
+
+    private void enableSynchronousRetryScheduling() {
+        when(threadPool.generic()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        when(threadPool.schedule(any(Runnable.class), any(TimeValue.class), any(Executor.class))).thenAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return mock(Scheduler.Cancellable.class);
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -354,6 +354,11 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
         }
     }
 
+    public static DatafeedState getDatafeedState(String datafeedId) {
+        GetDatafeedsStatsAction.Response.DatafeedStats stats = getDatafeedStats(datafeedId);
+        return stats == null ? null : stats.getDatafeedState();
+    }
+
     public static void deleteAllDatafeeds(Logger logger, Client client) throws Exception {
         final QueryPage<DatafeedConfig> datafeeds = client.execute(
             GetDatafeedsAction.INSTANCE,


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Retry datafeed STARTED state write on system reassignment (#151399)