### PR TITLE
[CI] DLMFrozenTransitionDisruptionIT testMasterFailoverDuringCleanup failing [#153174]

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -640,9 +640,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testSourceRelocationAndTargetRestart
   issue: https://github.com/elastic/elasticsearch/issues/153173
-- class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
-  method: testMasterFailoverDuringCleanup
-  issue: https://github.com/elastic/elasticsearch/issues/153174
 - class: org.elasticsearch.packaging.test.PackageUpgradeTests
   method: test12SetupBwcVersion
   issue: https://github.com/elastic/elasticsearch/issues/152819

--- a/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
@@ -697,6 +697,17 @@ public class DLMFrozenTransitionDisruptionIT extends ESIntegTestCase {
      * master node while it is being stopped asynchronously by the disruption thread.
      */
     private void waitForStableCluster(int nodeCount) throws Exception {
+        // The disruption latch fires before the async disruption thread finishes stopping the
+        // node. If we probe cluster health while the node is still shutting down,
+        // ensureStableCluster can route the health request via the dying node's local client,
+        // whose response future is never completed (no transport disconnect fires for in-JVM
+        // client calls, and the node's scheduler that would enforce the request timeout is
+        // gone), hanging the test until the suite timeout. Wait for the disruption to actually
+        // finish first.
+        for (Thread t : disruptionThreadsToJoin) {
+            t.join(TimeUnit.SECONDS.toMillis(60));
+            assertFalse("disruption thread [" + t.getName() + "] did not finish in time", t.isAlive());
+        }
         assertBusy(() -> {
             try {
                 ensureStableCluster(nodeCount);


### PR DESCRIPTION
There's a race condition in the wait for stable cluster block of the disrruption tests:

1. registerDisruptionInterceptor counts down the latch before the async disruption thread starts internalCluster().stopCurrentMasterNode(). The test thread proceeds into waitForStableCluster(5) while the master node is still shutting down
2. ensureStableCluster (test framework, test/framework/.../ESIntegTestCase.java:1982-1995) picks viaNode = randomFrom(internalCluster().getNodeNames()) — the dying master is still in that list — and issues the cluster-health request through that node's in-JVM NodeClient.
3. The node closes underneath the request. A local client call has no transport disconnect to fail the listener, and the dying node's scheduler (which would fire the health request's 30s timeout) is gone. The unbounded PlainActionFuture.get() never returns.
4. assertBusy(..., 60s) cannot help: it only bounds time between probe attempts; it cannot interrupt a probe that never returns. The test thread hangs until the suite timeout.

The fix is to join every thread in disruptionThreadsToJoin with a bounded wait and assert it finished. This ensures the node is dead and no longer a candidate for getting sent the health request before firing off that request.
                                                                                          
Fixes #153174