### PR TITLE
[9.3] [ML] Stabilize RevertModelSnapshotIT model byte assertion (#145165)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -196,15 +196,9 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
   issue: https://github.com/elastic/elasticsearch/issues/138370
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot_DeleteInterveningResults
-  issue: https://github.com/elastic/elasticsearch/issues/132349
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
   issue: https://github.com/elastic/elasticsearch/issues/138409
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/132733
 - class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
   method: test_Embedding_ChunkedInfer_LateChunkingEnabled
   issue: https://github.com/elastic/elasticsearch/issues/138451

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
@@ -65,6 +65,13 @@ import static org.hamcrest.Matchers.nullValue;
  */
 public class RevertModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
 
+    /**
+     * Allowed slack when comparing {@link ModelSizeStats#getModelBytes()} across job phases. Estimates from
+     * ml-cpp can jitter slightly across OS / allocator behavior (e.g. page alignment); see
+     * <a href="https://github.com/elastic/elasticsearch/issues/132348">#132348</a>.
+     */
+    private static final long MODEL_SIZE_BYTES_JITTER = 64 * 1024L;
+
     private static final long DATA_START_TIME = 1761955200000L;
 
     @After
@@ -195,8 +202,8 @@ public class RevertModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
         ModelSizeStats modelSizeStats2 = getJobStats(job.getId()).get(0).getModelSizeStats();
         Quantiles quantiles2 = getQuantiles(job.getId());
 
-        // Check model has grown since a new series was introduced
-        assertThat(modelSizeStats2.getModelBytes(), greaterThan(modelSizeStats1.getModelBytes()));
+        // Check model has grown since a new series was introduced (allow small cross-platform jitter in byte estimates)
+        assertThat(modelSizeStats2.getModelBytes(), greaterThan(modelSizeStats1.getModelBytes() - MODEL_SIZE_BYTES_JITTER));
 
         // Check quantiles have changed
         assertThat(quantiles2, not(equalTo(quantiles1)));
@@ -231,8 +238,11 @@ public class RevertModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
 
         GetJobsStatsAction.Response.JobStats statsAfterRevert = getJobStats(job.getId()).get(0);
 
-        // Check model_size_stats has been reverted
-        assertThat(statsAfterRevert.getModelSizeStats().getModelBytes(), equalTo(modelSizeStats1.getModelBytes()));
+        // Check model_size_stats has been reverted. Compare to bytes embedded in the snapshot, not modelSizeStats1 from
+        // an earlier getJobStats call: revert persists modelSnapshot.getModelSizeStats() (see JobManager.revertSnapshot),
+        // which can differ slightly from the last streamed stats at phase 1 end (#132733).
+        assertThat(revertSnapshot.getModelSizeStats(), is(notNullValue()));
+        assertThat(statsAfterRevert.getModelSizeStats().getModelBytes(), equalTo(revertSnapshot.getModelSizeStats().getModelBytes()));
 
         if (deleteInterveningResults) {
             // Check data counts have been reverted


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ML] Stabilize RevertModelSnapshotIT model byte assertion (#145165)](https://github.com/elastic/elasticsearch/pull/145165)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)