### PR TITLE
[9.3] ES|QL: Fix timezone flaky test cases (#153493)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -222,8 +223,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Linear
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -233,8 +234,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -244,8 +245,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -255,8 +256,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -266,8 +267,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -279,8 +280,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Exponential
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -290,8 +291,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -301,8 +302,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -312,8 +313,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -323,8 +324,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -336,8 +337,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Gaussian
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -347,8 +348,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -358,8 +359,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -369,8 +370,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -380,8 +381,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -393,8 +394,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Defaults
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 null,
                 null,
@@ -409,8 +410,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos Linear
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -420,8 +421,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -431,8 +432,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -442,8 +443,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -453,8 +454,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -466,8 +467,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos Exponential
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -477,8 +478,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -488,8 +489,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -499,8 +500,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -510,8 +511,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -523,8 +524,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos Gaussian
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -534,8 +535,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -545,8 +546,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -556,8 +557,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -567,8 +568,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -580,8 +581,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos default
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 null,
                 null,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/RangeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/RangeTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 
@@ -210,7 +210,7 @@ public class RangeTests extends ESTestCase {
                 (Boolean) test[4],
                 l(test[5], (DataType) test[6]),
                 (Boolean) test[7],
-                ZoneId.systemDefault()
+                ZoneOffset.UTC
             );
             assertEquals(
                 "failed on test " + i + ": " + Arrays.toString(test),


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ES|QL: Fix timezone flaky test cases (#153493)