### PR TITLE
[9.4] ES|QL: Fix timezone flaky test cases (#153493)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -223,8 +224,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Linear
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -234,8 +235,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -245,8 +246,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -256,8 +257,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -267,8 +268,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -280,8 +281,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Exponential
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -291,8 +292,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -302,8 +303,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -313,8 +314,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -324,8 +325,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -337,8 +338,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Gaussian
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -348,8 +349,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -359,8 +360,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -370,8 +371,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -381,8 +382,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -394,8 +395,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datetime Defaults
         testCaseSuppliers.addAll(
             datetimeTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 null,
                 null,
@@ -410,8 +411,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos Linear
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -421,8 +422,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -432,8 +433,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -443,8 +444,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -454,8 +455,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -467,8 +468,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos Exponential
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -478,8 +479,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -489,8 +490,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -500,8 +501,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -511,8 +512,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -524,8 +525,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos Gaussian
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -535,8 +536,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2020, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -546,8 +547,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -557,8 +558,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1970, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -568,8 +569,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         );
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(1900, 12, 12, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 Duration.ofDays(10),
                 0.33,
@@ -581,8 +582,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         // Datenanos default
         testCaseSuppliers.addAll(
             dateNanosTestCase(
-                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                LocalDateTime.of(2025, 8, 20, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                LocalDateTime.of(2000, 1, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 Duration.ofDays(10000),
                 null,
                 null,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/RangeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/RangeTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 
@@ -210,7 +210,7 @@ public class RangeTests extends ESTestCase {
                 (Boolean) test[4],
                 l(test[5], (DataType) test[6]),
                 (Boolean) test[7],
-                ZoneId.systemDefault()
+                ZoneOffset.UTC
             );
             assertEquals(
                 "failed on test " + i + ": " + Arrays.toString(test),


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ES|QL: Fix timezone flaky test cases (#153493)