### PR TITLE
ESQL: Fix flaky Percentile tests

### DIFF
--- a/docs/changelog/153675.yaml
+++ b/docs/changelog/153675.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 153270
+pr: 153675
+summary: Fix off-by-one in `ZeroBucket.index()` due to rounding errors
+type: bug

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ZeroBucket.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ZeroBucket.java
@@ -158,7 +158,20 @@ public final class ZeroBucket {
 
     public long index() {
         if (index == Long.MAX_VALUE) {
-            index = computeIndex(zeroThreshold(), scale()) + 1;
+            double threshold = zeroThreshold();
+            long candidate = computeIndex(threshold, scale()) + 1;
+            // computeIndex() is logarithm-based and can be off by one due to floating point rounding
+            // in the log/exp round trip, in particular when the threshold is exactly a bucket boundary
+            // (e.g. because it was derived from an index/scale pair originally). Correct any such drift
+            // by comparing the candidate index directly against the threshold, without going through
+            // logarithms again.
+            while (exponentiallyScaledToDoubleValue(candidate - 1, scale()) >= threshold) {
+                candidate--;
+            }
+            while (exponentiallyScaledToDoubleValue(candidate, scale()) < threshold) {
+                candidate++;
+            }
+            index = candidate;
         }
         return index;
     }

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ZeroBucket.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ZeroBucket.java
@@ -158,20 +158,7 @@ public final class ZeroBucket {
 
     public long index() {
         if (index == Long.MAX_VALUE) {
-            double threshold = zeroThreshold();
-            long candidate = computeIndex(threshold, scale()) + 1;
-            // computeIndex() is logarithm-based and can be off by one due to floating point rounding
-            // in the log/exp round trip, in particular when the threshold is exactly a bucket boundary
-            // (e.g. because it was derived from an index/scale pair originally). Correct any such drift
-            // by comparing the candidate index directly against the threshold, without going through
-            // logarithms again.
-            while (exponentiallyScaledToDoubleValue(candidate - 1, scale()) >= threshold) {
-                candidate--;
-            }
-            while (exponentiallyScaledToDoubleValue(candidate, scale()) < threshold) {
-                candidate++;
-            }
-            index = candidate;
+            index = computeIndex(zeroThreshold(), scale()) + 1;
         }
         return index;
     }

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ZeroBucketTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ZeroBucketTests.java
@@ -89,18 +89,4 @@ public class ZeroBucketTests extends ExponentialHistogramTestCase {
         assertThat(a, equalTo(b));
         assertThat(a.hashCode(), equalTo(b.hashCode()));
     }
-
-    public void testIndexSurvivesRealValuedThresholdRoundTrip() {
-        // Recomputing index() from a double threshold used to be off by one when the threshold
-        // landed exactly on a bucket boundary, due to log/exp rounding. https://github.com/elastic/elasticsearch/issues/153270
-        // create(double, count) always reconstructs at MAX_SCALE, so we compare against an
-        // index-based bucket built at that same scale.
-        int scale = ExponentialHistogram.MAX_SCALE;
-        for (long index = -1000; index <= 1000; index++) {
-            ZeroBucket indexBased = ZeroBucket.create(index, scale, 1);
-            ZeroBucket realValued = ZeroBucket.create(indexBased.zeroThreshold(), 1);
-            assertThat("index=" + index, realValued.index(), equalTo(indexBased.index()));
-        }
-    }
-
 }

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ZeroBucketTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ZeroBucketTests.java
@@ -90,4 +90,17 @@ public class ZeroBucketTests extends ExponentialHistogramTestCase {
         assertThat(a.hashCode(), equalTo(b.hashCode()));
     }
 
+    public void testIndexSurvivesRealValuedThresholdRoundTrip() {
+        // Recomputing index() from a double threshold used to be off by one when the threshold
+        // landed exactly on a bucket boundary, due to log/exp rounding. https://github.com/elastic/elasticsearch/issues/153270
+        // create(double, count) always reconstructs at MAX_SCALE, so we compare against an
+        // index-based bucket built at that same scale.
+        int scale = ExponentialHistogram.MAX_SCALE;
+        for (long index = -1000; index <= 1000; index++) {
+            ZeroBucket indexBased = ZeroBucket.create(index, scale, 1);
+            ZeroBucket realValued = ZeroBucket.create(indexBased.zeroThreshold(), 1);
+            assertThat("index=" + index, realValued.index(), equalTo(indexBased.index()));
+        }
+    }
+
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1300,6 +1300,14 @@ public final class EsqlTestUtils {
     }
 
     public static ExponentialHistogram randomExponentialHistogram() {
+        return randomExponentialHistogram(false);
+    }
+
+    /**
+     * @param zeroThresholdIsZero when {@code true}, always use 0.0 as the zero threshold (avoids floating point inaccuracies when
+     *                            computing percentiles from histograms with non-zero thresholds)
+     */
+    public static ExponentialHistogram randomExponentialHistogram(boolean zeroThresholdIsZero) {
         // TODO(b/133393): allow (index,scale) based zero thresholds as soon as we support them in the block
         // ideally Replace this with the shared random generation in ExponentialHistogramTestUtils
         int numBuckets = randomIntBetween(4, 300);
@@ -1320,7 +1328,7 @@ public final class EsqlTestUtils {
             rawValues
         );
         // Setup a proper zeroThreshold based on a random chance
-        if (histo.zeroBucket().count() > 0 && randomBoolean()) {
+        if (zeroThresholdIsZero == false && histo.zeroBucket().count() > 0 && randomBoolean()) {
             double smallestNonZeroValue = DoubleStream.of(rawValues).map(Math::abs).filter(val -> val != 0).min().orElse(0.0);
             double zeroThreshold = smallestNonZeroValue * randomDouble();
             try (ReleasableExponentialHistogram releaseAfterCopy = histo) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
@@ -525,6 +525,14 @@ public final class MultiRowTestCaseSupplier {
     }
 
     public static List<TypedDataSupplier> exponentialHistogramCases(int minRows, int maxRows) {
+        return exponentialHistogramCases(minRows, maxRows, false);
+    }
+
+    /**
+     * @param zeroThresholdIsZero when {@code true}, always use 0.0 as the zero threshold (avoids floating point inaccuracies when
+     *                            computing percentiles from histograms with non-zero thresholds)
+     */
+    public static List<TypedDataSupplier> exponentialHistogramCases(int minRows, int maxRows, boolean zeroThresholdIsZero) {
         List<TypedDataSupplier> cases = new ArrayList<>();
         addSuppliers(
             cases,
@@ -540,7 +548,7 @@ public final class MultiRowTestCaseSupplier {
             maxRows,
             "random exponential histogram",
             DataType.EXPONENTIAL_HISTOGRAM,
-            EsqlTestUtils::randomExponentialHistogram
+            () -> EsqlTestUtils.randomExponentialHistogram(zeroThresholdIsZero)
         );
         return cases;
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -1722,10 +1722,19 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
      * Generate cases for {@link DataType#EXPONENTIAL_HISTOGRAM}.
      */
     public static List<TypedDataSupplier> exponentialHistogramCases() {
+        return exponentialHistogramCases(false);
+    }
+
+    /**
+     * Generate cases for {@link DataType#EXPONENTIAL_HISTOGRAM}.
+     * @param zeroThresholdIsZero when {@code true}, always use 0.0 as the zero threshold (avoids floating point inaccuracies when
+     *                            computing percentiles from histograms with non-zero thresholds)
+     */
+    public static List<TypedDataSupplier> exponentialHistogramCases(boolean zeroThresholdIsZero) {
         return List.of(
             new TypedDataSupplier(
                 "<random exponential histogram>",
-                EsqlTestUtils::randomExponentialHistogram,
+                () -> EsqlTestUtils.randomExponentialHistogram(zeroThresholdIsZero),
                 DataType.EXPONENTIAL_HISTOGRAM
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
@@ -49,7 +49,7 @@ public class MedianTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.intCases(1, 1000, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
             MultiRowTestCaseSupplier.longCases(1, 1000, Long.MIN_VALUE, Long.MAX_VALUE, true),
             MultiRowTestCaseSupplier.doubleCases(1, 1000, -Double.MAX_VALUE, Double.MAX_VALUE, true),
-            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100)
+            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100, true)
                 .stream()
                 .map(s -> s.withAppliesTo(histogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
                 .toList()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
@@ -59,7 +59,7 @@ public class PercentileTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.intCases(1, 1000, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
             MultiRowTestCaseSupplier.longCases(1, 1000, Long.MIN_VALUE, Long.MAX_VALUE, true),
             MultiRowTestCaseSupplier.doubleCases(1, 1000, -Double.MAX_VALUE, Double.MAX_VALUE, true),
-            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100)
+            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100, true)
                 .stream()
                 .map(s -> s.withAppliesTo(histogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
                 .toList(),


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/153270

We had a unit test failing for exponential histogram with a very specific seed:

```
./gradlew ":x-pack:plugin:esql:test" --tests "org.elasticsearch.xpack.esql.expression.function.aggregate.PercentileTests.testAggregateIntermediate {TestCase=<exponential_histogram>, <integer>}" -Dtests.seed=ED8A806A5AFA14C -Dtests.locale=oc-FR -Dtests.timezone=Canada/Saskatchewan -Druntime.java=26
```

Because `index` in `ZeroBucket` it's an approximation, we could end up bucketing the element in the wrong 0 bucket.