### PR TITLE
Reject non-object input when parsing maps

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
@@ -379,7 +379,9 @@ public abstract class AbstractXContentParser implements XContentParser {
      * Skips to the next token if the parser does not yet have a current token (i.e. {@link #currentToken()} returns {@code null}) and then
      * checks it.
      *
-     * @return the first key in the map if a non-empty map start is found
+     * @return the first key in the map if a non-empty map start is found, or {@code null} if the map is empty or the whole document is
+     *         empty
+     * @throws XContentParseException if the current token is anything other than the start of an object
      */
     @Nullable
     private static String findNonEmptyMapStart(XContentParser parser) throws IOException {
@@ -390,7 +392,17 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == XContentParser.Token.START_OBJECT) {
             return parser.nextFieldName();
         }
-        return token == Token.FIELD_NAME ? parser.currentName() : null;
+        if (token == Token.FIELD_NAME) {
+            return parser.currentName();
+        }
+        if (token == null) {
+            // the document is entirely empty, treat it as an empty map like the empty object {}
+            return null;
+        }
+        throw new XContentParseException(
+            parser.getTokenLocation(),
+            "Failed to parse object: expecting " + XContentParser.Token.START_OBJECT + " but got " + token
+        );
     }
 
     // Skips the current parser to the next array start. Assumes that the parser is either positioned before an array field's name token or

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -261,6 +261,39 @@ public class XContentParserTests extends ESTestCase {
         }
     }
 
+    public void testMapOnNonObjectInputFails() throws IOException {
+        for (String source : List.of("123", "12.5", "\"utter nonsense\"", "true", "null", "[\"an\", \"array\"]")) {
+            try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, source))) {
+                XContentParseException e = expectThrows(XContentParseException.class, parser::map);
+                assertThat(e.getMessage(), containsString("Failed to parse object: expecting START_OBJECT but got"));
+            }
+            try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, source))) {
+                expectThrows(XContentParseException.class, parser::mapOrdered);
+            }
+            try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, source))) {
+                expectThrows(XContentParseException.class, parser::mapStrings);
+            }
+        }
+    }
+
+    public void testMapOnEmptyOrObjectInput() throws IOException {
+        try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, ""))) {
+            assertThat(parser.map(), equalTo(emptyMap()));
+        }
+        try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, "{}"))) {
+            assertThat(parser.map(), equalTo(emptyMap()));
+        }
+        try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, "{\"a\": 1}"))) {
+            assertThat(parser.map(), equalTo(Map.of("a", 1)));
+        }
+        // a parser positioned on a field name reads the remaining fields of the current object
+        try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, "{\"a\": 1, \"b\": 2}"))) {
+            assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+            assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+            assertThat(parser.map(), equalTo(Map.of("a", 1, "b", 2)));
+        }
+    }
+
     private Map<String, String> readMapStrings(String source) throws IOException {
         try (XContentParser parser = decorateParser(super.createParser(JsonXContent.jsonXContent, source))) {
             XContentParser.Token token = parser.nextToken();


### PR DESCRIPTION
Sending a bare JSON value (a string, number, boolean, `null` or an array) to an API which expects a map of values in the request body used to be silently treated as if the body was empty. For example, the request from #109522:

    curl 'http://localhost:9200/_snapshot/test-repo/test-snap/_restore' \
      -H 'Content-type: application/json' --data-binary '"utter nonsense"'

would trigger the restore as if no body was sent at all.

This change makes `AbstractXContentParser#findNonEmptyMapStart` reject any input that is not an object with an `XContentParseException` (surfaced as `400 Bad Request` at the REST layer), mirroring how `skipToListStart` already rejects non-array input for lists. An entirely empty document is still treated as an empty map, preserving the previous behaviour.

Note that this makes all callers of `XContentParser#map`, `#mapOrdered`, `#mapStrings` and `#map(Supplier, CheckedFunction)` strict: a JSON `null` or any other non-object token where a map was expected now throws instead of silently yielding an empty map.

Verified locally with `:libs:x-content:test`, `:libs:x-content:spotlessJavaCheck` and `:libs:x-content:precommit`.

Closes #109522
