### PR TITLE
[9.3] Stabilize DatafeedJobsIT timing stats after datafeed delete (#145169)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -41,12 +41,14 @@ import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.utils.Intervals;
@@ -63,6 +65,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.createDatafeed;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.createDatafeedBuilder;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.createScheduledJob;
@@ -247,6 +250,19 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         CheckedRunnable<Exception> openAndRunJob = () -> {
             openJob(job.getId());
             assertBusy(() -> assertEquals(getJobStats(job.getId()).get(0).getState(), JobState.OPENED));
+
+            // After deleting a datafeed, timing stats are removed asynchronously; on multi-node clusters a
+            // subsequent putDatafeed can briefly observe stale search_count from the replica. Wait until
+            // the timing stats document is gone before asserting via GetDatafeedsStats.
+            assertBusy(() -> {
+                client().admin().indices().prepareRefresh(AnomalyDetectorsIndex.jobResultsAliasedName(job.getId())).get();
+                assertResponse(
+                    prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(job.getId())).setQuery(
+                        QueryBuilders.idsQuery().addIds(DatafeedTimingStats.documentId(job.getId()))
+                    ).setSize(0).setTrackTotalHits(true),
+                    response -> assertThat(response.getHits().getTotalHits().value(), equalTo(0L))
+                );
+            }, 30, TimeUnit.SECONDS);
 
             putDatafeed(datafeedConfig);
             // Datafeed did not do anything yet, hence search_count is equal to 0.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Stabilize DatafeedJobsIT timing stats after datafeed delete (#145169)](https://github.com/elastic/elasticsearch/pull/145169)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)