### PR TITLE
Test now sets a less verbose log level

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -574,7 +574,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertEquals("Unknown level constant [BOOM].", e.getMessage());
 
         try {
-            final Settings.Builder testSettings = Settings.builder().put("logger.test", "DEBUG").put("logger._root", "debug");
+            final Settings.Builder testSettings = Settings.builder().put("logger.test", "ERROR").put("logger._root", "error");
             ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings(
                 TEST_REQUEST_TIMEOUT,
                 TEST_REQUEST_TIMEOUT
@@ -582,8 +582,8 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             consumer.accept(testSettings, updateBuilder);
 
             updateBuilder.get();
-            assertEquals(Level.DEBUG, LogManager.getLogger("test").getLevel());
-            assertEquals(Level.DEBUG, LogManager.getRootLogger().getLevel());
+            assertEquals(Level.ERROR, LogManager.getLogger("test").getLevel());
+            assertEquals(Level.ERROR, LogManager.getRootLogger().getLevel());
         } finally {
             ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings(
                 TEST_REQUEST_TIMEOUT,


### PR DESCRIPTION
The test intermittently failed teardown on Windows CI with a commit_state request stuck in-flight for ~1.5 minutes.
Changing the edited level to be ERROR rather than DEBUG so there is less synchronous work to be wrapped up in the test timeframe.
The test is just testing settings upgrade so the actual log level is not important.

Closes: #153562 