### PR TITLE
[9.5] ESQL: Fix unmapped fields optimized incorrectly bug on empty mappings (#153137)

### DIFF
--- a/docs/changelog/153137.yaml
+++ b/docs/changelog/153137.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 141990
+pr: 153137
+summary: Fix unmapped fields optimized incorrectly bug on empty mappings
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -137,6 +137,7 @@ public class CsvTestsDataLoader {
         new TestDataset("sample_data").withIndex("cloned_sample_data"),
         new TestDataset("partial_mapping_sample_data"),
         new TestDataset("partial_mapping_mv_sample_data", "mapping-partial_mapping_sample_data.json", "partial_mapping_mv_sample_data.csv"),
+        new TestDataset("no_mapping_date_extract_fields", "mapping-no_mapping_sample_data.json", "date_extract_fields.csv"),
         new TestDataset(
             "partial_mapping_mv_no_source_sample_data",
             "mapping-partial_mapping_no_source_sample_data.json",

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load.csv-spec
@@ -592,6 +592,51 @@ FROM partial_mapping_sample_data
 2024-10-23T12:15:03.360Z | Connected to 10.1.0.3! | Disconnected from 10.1.0.3
 ;
 
+// Reproducer for #141990: replacing an unmapped field from an empty mapping with an EVAL expression should not drop source loading.
+replaceUnmappedFieldFromEmptyMapping
+required_capability: optional_fields_v5
+required_capability: optional_fields_fix_unmapped_load_empty_mapping_no_fields
+
+SET unmapped_fields="load"\;
+FROM no_mapping_date_extract_fields
+| EVAL date_string = date_string::date
+;
+
+date_string:date
+2023-02-01T00:00:00.000Z
+2023-02-02T00:00:00.000Z
+2023-02-03T00:00:00.000Z
+2023-02-04T00:00:00.000Z
+;
+
+aggregateUnmappedFieldFromEmptyMapping
+required_capability: optional_fields_v5
+required_capability: optional_fields_fix_unmapped_load_empty_mapping_no_fields
+
+SET unmapped_fields="load"\;
+FROM no_mapping_date_extract_fields
+| STATS max_date = MAX(date_string::date)
+;
+
+max_date:date
+2023-02-04T00:00:00.000Z
+;
+
+dropReplacedUnmappedFieldFromEmptyMapping
+required_capability: optional_fields_v5
+required_capability: optional_fields_fix_unmapped_load_empty_mapping_no_fields
+
+SET unmapped_fields="load"\;
+FROM no_mapping_date_extract_fields
+| EVAL date_string = date_string::date
+| DROP date_string
+| STATS count = COUNT(*)
+;
+
+count:long
+4
+;
+
 fieldUnmappedInSourceButExcludedSingleIndex
 required_capability: optional_fields_v5
 required_capability: source_field_mapping

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -274,6 +274,12 @@ public class EsqlCapabilities {
         OPTIONAL_FIELDS_FIX_UNMAPPED_LOAD_CONVERT_FUNCTION,
 
         /**
+         * Fix for {@code <no-fields>} leaking into plans when {@code unmapped_fields="load"} loads fields from an empty mapping.
+         * See https://github.com/elastic/elasticsearch/issues/141990.
+         */
+        OPTIONAL_FIELDS_FIX_UNMAPPED_LOAD_EMPTY_MAPPING_NO_FIELDS,
+
+        /**
          * Fix for LOOKUP JOIN and ENRICH failing when the match field has NULL type from unmapped field nullification.
          * See https://github.com/elastic/elasticsearch/issues/141827
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/ResolveUnmapped.java
@@ -81,7 +81,14 @@ public class ResolveUnmapped extends AnalyzerRules.ParameterizedAnalyzerRule<Log
     private static final Literal NULLIFIED = Literal.NULL;
 
     private static EsRelation withAdditionalAttributesUnlessLookup(EsRelation esr, List<? extends Attribute> fields) {
-        return esr.indexMode() == IndexMode.LOOKUP ? esr : esr.withAdditionalAttributes(fields);
+        if (esr.indexMode() == IndexMode.LOOKUP || fields.isEmpty()) {
+            return esr;
+        }
+        // Once real fields are added to an empty-mapping relation, the no-fields marker must not remain in the output.
+        if (esr.output().equals(Analyzer.NO_FIELDS)) {
+            return esr.withAttributes(new ArrayList<>(fields));
+        }
+        return esr.withAdditionalAttributes(fields);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedGoldenTests.java
@@ -128,6 +128,13 @@ public class AnalyzerUnmappedGoldenTests extends UnmappedGoldenTestCase {
             """);
     }
 
+    public void testEvalReplacesUnmappedFieldFromEmptyMapping() throws Exception {
+        runTestsLoadOnly("""
+            FROM no_mapping_date_extract_fields
+            | EVAL date_string = date_string::date
+            """, STAGES);
+    }
+
     public void testMultipleEval() throws Exception {
         runTests("""
             FROM employees

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testEvalReplacesUnmappedFieldFromEmptyMapping/load/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testEvalReplacesUnmappedFieldFromEmptyMapping/load/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Eval[[TODATETIME(date_string{f(PotentiallyUnmappedKeywordEsField)}#0) AS date_string#1]]
+  \_EsRelation[no_mapping_date_extract_fields][date_string{f(PotentiallyUnmappedKeywordEsField)}#0]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testEvalReplacesUnmappedFieldFromEmptyMapping/load/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testEvalReplacesUnmappedFieldFromEmptyMapping/load/query.esql
@@ -1,0 +1,2 @@
+SET unmapped_fields="load"; FROM no_mapping_date_extract_fields
+| EVAL date_string = date_string::date


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: Fix unmapped fields optimized incorrectly bug on empty mappings (#153137)