### PR TITLE
[ESQL] Bypass permits for storage metadata ops

### DIFF
--- a/docs/changelog/153686.yaml
+++ b/docs/changelog/153686.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153686
+summary: Bypass permits for storage metadata ops
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
@@ -63,34 +63,25 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         }
     }
 
+    // Metadata ops (length/lastModified/exists) are deliberately exempt from permit acquisition.
+    // The permit is pure throughput control with no correctness role; these are cheap, short-lived
+    // HEAD/stat calls whose fan-out is already bounded by the caller thread pool and
+    // ExternalSourceResolver.MAX_PARALLEL_METADATA_READS. Parking them behind long-lived stream
+    // permits (streams hold their permit for their whole minutes-long lifetime) starved SEARCH
+    // threads — see #1151. Byte-transfer ops (newStream/readBytes) stay permit-governed.
     @Override
     public long length() throws IOException {
-        acquirePermit();
-        try {
-            return delegate.length();
-        } finally {
-            limiter.release();
-        }
+        return delegate.length();
     }
 
     @Override
     public Instant lastModified() throws IOException {
-        acquirePermit();
-        try {
-            return delegate.lastModified();
-        } finally {
-            limiter.release();
-        }
+        return delegate.lastModified();
     }
 
     @Override
     public boolean exists() throws IOException {
-        acquirePermit();
-        try {
-            return delegate.exists();
-        } finally {
-            limiter.release();
-        }
+        return delegate.exists();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObject.java
@@ -67,34 +67,25 @@ class QueryBudgetedStorageObject implements StorageObject {
         }
     }
 
+    // Metadata ops (length/lastModified/exists) are deliberately exempt from permit acquisition.
+    // The permit is pure throughput control with no correctness role; these are cheap, short-lived
+    // HEAD/stat calls whose fan-out is already bounded by the caller thread pool and
+    // ExternalSourceResolver.MAX_PARALLEL_METADATA_READS. Parking them behind long-lived stream
+    // permits (streams hold their permit for their whole minutes-long lifetime) starved SEARCH
+    // threads — see #1151. Byte-transfer ops (newStream/readBytes) stay permit-governed.
     @Override
     public long length() throws IOException {
-        acquirePermit();
-        try {
-            return delegate.length();
-        } finally {
-            budget.release();
-        }
+        return delegate.length();
     }
 
     @Override
     public Instant lastModified() throws IOException {
-        acquirePermit();
-        try {
-            return delegate.lastModified();
-        } finally {
-            budget.release();
-        }
+        return delegate.lastModified();
     }
 
     @Override
     public boolean exists() throws IOException {
-        acquirePermit();
-        try {
-            return delegate.exists();
-        } finally {
-            budget.release();
-        }
+        return delegate.exists();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -94,7 +95,7 @@ public class ConcurrencyLimitedStorageObjectTests extends ESTestCase {
         assertEquals(3, limiter.availablePermits());
     }
 
-    public void testLengthReleasesPermit() throws Exception {
+    public void testLengthBypassesPermit() throws Exception {
         ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);
         StorageObject delegate = mock(StorageObject.class);
         when(delegate.length()).thenReturn(42L);
@@ -102,6 +103,34 @@ public class ConcurrencyLimitedStorageObjectTests extends ESTestCase {
         ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
         assertEquals(42L, obj.length());
         assertEquals(3, limiter.availablePermits());
+    }
+
+    /**
+     * Starvation regression for #1151: metadata ops (length/lastModified/exists) must not acquire the
+     * concurrency permit. With a single permit already held by an open stream, a permit-taking metadata
+     * call would block forever (single-threaded here, so it would deadlock/time out). It must instead
+     * return immediately without touching the permit count.
+     */
+    public void testMetadataOpsBypassPermitWhileStreamHoldsOnlyPermit() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+        when(delegate.length()).thenReturn(42L);
+        when(delegate.lastModified()).thenReturn(Instant.ofEpochMilli(123L));
+        when(delegate.exists()).thenReturn(true);
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        InputStream stream = obj.newStream();
+        assertEquals(0, limiter.availablePermits());
+
+        assertEquals(42L, obj.length());
+        assertEquals(Instant.ofEpochMilli(123L), obj.lastModified());
+        assertTrue(obj.exists());
+        assertEquals("metadata ops must not take the held stream's permit", 0, limiter.availablePermits());
+
+        stream.close();
+        assertEquals(1, limiter.availablePermits());
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObjectTests.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,13 +93,41 @@ public class QueryBudgetedStorageObjectTests extends ESTestCase {
         assertEquals(0, budget.inFlight());
     }
 
-    public void testLengthReleasesBudget() throws Exception {
+    public void testLengthBypassesBudget() throws Exception {
         QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
         StorageObject delegate = mock(StorageObject.class);
         when(delegate.length()).thenReturn(42L);
 
         QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
         assertEquals(42L, obj.length());
+        assertEquals(0, budget.inFlight());
+    }
+
+    /**
+     * Starvation regression for #1151: metadata ops (length/lastModified/exists) must not acquire a
+     * budget permit. With a single-permit budget already fully consumed by an open stream, a
+     * permit-taking metadata call would block forever (single-threaded here, so it would
+     * deadlock/time out). It must instead return immediately without changing the in-flight count.
+     */
+    public void testMetadataOpsBypassBudgetWhileStreamHoldsOnlyPermit() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(1, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+        when(delegate.length()).thenReturn(42L);
+        when(delegate.lastModified()).thenReturn(Instant.ofEpochMilli(123L));
+        when(delegate.exists()).thenReturn(true);
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        InputStream stream = obj.newStream();
+        assertEquals(1, budget.inFlight());
+
+        assertEquals(42L, obj.length());
+        assertEquals(Instant.ofEpochMilli(123L), obj.lastModified());
+        assertTrue(obj.exists());
+        assertEquals("metadata ops must not consume the held stream's budget slot", 1, budget.inFlight());
+
+        stream.close();
         assertEquals(0, budget.inFlight());
     }
 


### PR DESCRIPTION
Metadata ops (length/lastModified/exists) took the same permit as data streams, which hold it for their whole minutes-long lifetime. Under load this parked metadata HEAD/stat calls behind held stream permits, starving the dedicated esql_external_io discovery/read pool (and stalling the esql_worker drivers waiting on it).