### PR TITLE
[9.5] Fix remote write with audit request bodies (#153581)

### DIFF
--- a/docs/changelog/153581.yaml
+++ b/docs/changelog/153581.yaml
@@ -1,0 +1,6 @@
+area: Network
+issues:
+ - 152713
+pr: 153581
+summary: Fix remote write with audit request bodies
+type: bug

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -116,7 +116,11 @@ public abstract class BaseRestHandler implements RestHandler {
                 throw new IllegalArgumentException(unrecognized(request, unconsumedParams, candidateParams, "parameter"));
             }
 
-            if (request.hasContent() && (request.isContentConsumed() == false && request.isFullContent())) {
+            // Chunk consumers may defer reading until accept(), including when an interceptor has already aggregated the stream.
+            if (request.hasContent()
+                && request.isContentConsumed() == false
+                && request.isFullContent()
+                && action instanceof RequestBodyChunkConsumer == false) {
                 throw new IllegalArgumentException(
                     "request [" + request.method() + " " + request.path() + "] does not support having a body"
                 );
@@ -213,6 +217,12 @@ public abstract class BaseRestHandler implements RestHandler {
         default void close() {}
     }
 
+    /**
+     * A channel consumer that processes a streamed request body incrementally.
+     * <p>
+     * A REST interceptor may aggregate the stream before request preparation. In that case, the handler must either return a different
+     * consumer for the full body or arrange for this consumer to process the full body when it is accepted.
+     */
     public interface RequestBodyChunkConsumer extends RestChannelConsumer {
 
         /**

--- a/server/src/main/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregator.java
+++ b/server/src/main/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregator.java
@@ -21,11 +21,12 @@ import java.util.ArrayList;
 import java.util.Objects;
 
 /**
- * Accumulates a streamed HTTP request body while tracking memory usage via {@link IndexingPressure}.
+ * Accumulates an HTTP request body while tracking memory usage via {@link IndexingPressure}.
  * <p>
  * This is intended for indexing-related REST endpoints that receive opaque request bodies (e.g. protobuf)
  * which must be fully accumulated before processing. It provides backpressure by reserving memory
  * up front and rejecting oversized requests with a 413 status.
+ * The body may already be fully aggregated by a REST interceptor before it reaches this consumer.
  * <p>
  * When {@link #accept(RestChannel)} is called, the aggregator reserves memory via
  * {@link IndexingPressure#markCoordinatingOperationStarted}. If the reservation fails
@@ -40,7 +41,7 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
 
     /**
      * Transforms the accumulated request body before it is handed to the {@link CompletionHandler}.
-     * Implementations must release the input reference when they produce new output.
+     * Implementations must not release the input reference; the caller retains ownership.
      */
     @FunctionalInterface
     public interface BodyPostProcessor {
@@ -51,10 +52,10 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
          * Post-processes the accumulated request body (e.g. decompression).
          *
          * @param body The accumulated raw body to process.
-         *             Unless the post-processor returns the same reference, it is responsible for closing it.
-         *             The caller must not use this reference after this method returns.
+         *             The caller remains responsible for closing this reference.
          * @param maxSize The maximum permitted size for the result.
-         * @return The post-processed body. Must not exceed {@code maxSize}. The caller is responsible for closing the returned reference.
+         * @return The post-processed body. Must not exceed {@code maxSize}. If it differs from {@code body}, it must remain valid after
+         *         {@code body} is closed. The caller is responsible for closing the returned reference.
          * @throws IOException on processing failure
          */
         ReleasableBytesReference process(ReleasableBytesReference body, long maxSize) throws IOException;
@@ -117,7 +118,12 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
             completionHandler.onFailure(channel, e);
             return;
         }
-        request.contentStream().next();
+        if (request.isFullContent()) {
+            // A REST interceptor can aggregate the body before this consumer handles it.
+            handleChunk(channel, request.content().retain(), true);
+        } else {
+            request.contentStream().next();
+        }
     }
 
     @Override
@@ -149,12 +155,17 @@ public class IndexingPressureAwareContentAggregator implements BaseRestHandler.R
             }
             chunks = null;
 
+            ReleasableBytesReference processedBody;
             try {
-                fullBody = bodyPostProcessor.process(fullBody, maxRequestSize);
+                processedBody = bodyPostProcessor.process(fullBody, maxRequestSize);
             } catch (Exception e) {
                 closeOnFailure(channel, e, fullBody);
                 return;
             }
+            if (processedBody != fullBody) {
+                fullBody.close();
+            }
+            fullBody = processedBody;
             accumulatedSize = fullBody.length();
             if (failIfAboveLimit(channel, fullBody)) {
                 return;

--- a/server/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -39,6 +39,13 @@ public interface RestHandler {
         return true;
     }
 
+    /**
+     * Whether this handler supports consuming the request body as a stream.
+     * <p>
+     * Handlers that return {@code false} receive a fully aggregated body. When this method returns {@code true}, a REST interceptor may
+     * still aggregate the stream before it reaches the handler. Such handlers must therefore support receiving either a streamed or full
+     * body, by branching during request preparation or by using a consumer that handles both representations.
+     */
     default boolean supportsContentStream() {
         return false;
     }

--- a/server/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
 import org.elasticsearch.test.ESTestCase;
@@ -322,6 +323,39 @@ public class BaseRestHandlerTests extends ESTestCase {
         }
     }
 
+    public void testChunkConsumerCanConsumeFullBodyAfterPreparation() throws Exception {
+        try (XContentBuilder builder = JsonXContent.contentBuilder().startObject().endObject()) {
+            final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+                new BytesArray(builder.toString()),
+                XContentType.JSON
+            ).build();
+            final var restChannelConsumer = new TestRequestBodyChunkConsumer(request);
+            final BaseRestHandler handler = new BaseRestHandler() {
+                @Override
+                protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+                    assertSame(request, restRequest);
+                    return restChannelConsumer;
+                }
+
+                @Override
+                public String getName() {
+                    return "test_chunk_consumer_with_full_body";
+                }
+
+                @Override
+                public List<Route> routes() {
+                    return Collections.emptyList();
+                }
+            };
+
+            final RestChannel channel = new FakeRestChannel(request, randomBoolean());
+            handler.handleRequest(request, channel, mockClient);
+            assertTrue(request.isContentConsumed());
+            assertTrue(restChannelConsumer.executed);
+            assertTrue(restChannelConsumer.closed);
+        }
+    }
+
     public void testUnconsumedNoBody() throws Exception {
         final var restChannelConsumer = new TestRestChannelConsumer();
         final BaseRestHandler handler = new BaseRestHandler() {
@@ -380,6 +414,26 @@ public class BaseRestHandlerTests extends ESTestCase {
             assertThat(e, hasToString(containsString("request [GET /] does not support having a body")));
             assertFalse(restChannelConsumer.executed);
             assertTrue(restChannelConsumer.closed);
+        }
+    }
+
+    private static class TestRequestBodyChunkConsumer extends TestRestChannelConsumer implements BaseRestHandler.RequestBodyChunkConsumer {
+
+        private final RestRequest request;
+
+        private TestRequestBodyChunkConsumer(RestRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public void accept(RestChannel restChannel) {
+            request.content();
+            super.accept(restChannel);
+        }
+
+        @Override
+        public void handleChunk(RestChannel channel, ReleasableBytesReference chunk, boolean isLast) {
+            fail("full body should not be handled as a chunk");
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/IndexingPressureAwareContentAggregatorTests.java
@@ -63,6 +63,21 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
         assertEquals(0, indexingPressure.stats().getCurrentCoordinatingBytes());
     }
 
+    public void testFullyAggregatedContent() throws Exception {
+        long maxSize = 1024;
+        var content = new BytesArray(randomByteArrayOfLength(64));
+        var request = newFullContentRequest(content);
+        channel = new FakeRestChannel(request, true);
+        aggregator = newAggregator(request, maxSize, IndexingPressureAwareContentAggregator.BodyPostProcessor.NOOP);
+
+        aggregator.accept(channel);
+
+        assertThat(contentRef.get(), equalBytes(content));
+        assertEquals(content.length(), indexingPressure.stats().getCurrentCoordinatingBytes());
+        pressureRef.get().close();
+        assertEquals(0, indexingPressure.stats().getCurrentCoordinatingBytes());
+    }
+
     public void testMultiChunkAggregation() {
         int chunkSize = between(1, 256);
         int nChunks = between(2, 20);
@@ -233,10 +248,7 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
         int expandedSize = 200;
         byte[] expanded = randomByteArrayOfLength(expandedSize);
 
-        initAggregator(maxSize, (body, max) -> {
-            body.close();
-            return new ReleasableBytesReference(new BytesArray(expanded), () -> {});
-        });
+        initAggregator(maxSize, (body, max) -> new ReleasableBytesReference(new BytesArray(expanded), () -> {}));
 
         assertEquals(maxSize, indexingPressure.stats().getCurrentCoordinatingBytes());
 
@@ -245,6 +257,7 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
 
         assertNotNull(contentRef.get());
         assertEquals(expandedSize, contentRef.get().length());
+        assertFalse(chunk.hasReferences());
         assertEquals(expandedSize, indexingPressure.stats().getCurrentCoordinatingBytes());
 
         pressureRef.get().close();
@@ -257,15 +270,13 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
         int expandedSize = 200;
         byte[] expanded = randomByteArrayOfLength(expandedSize);
 
-        initAggregator(maxSize, (body, max) -> {
-            body.close();
-            return new ReleasableBytesReference(new BytesArray(expanded), () -> {});
-        });
+        initAggregator(maxSize, (body, max) -> new ReleasableBytesReference(new BytesArray(expanded), () -> {}));
 
         var chunk = randomReleasableBytesReference(compressedSize);
         stream.sendNext(chunk, true);
 
         assertTooLargeRejected();
+        assertFalse(chunk.hasReferences());
     }
 
     public void testPostProcessorThrowsReleasesResources() {
@@ -291,6 +302,16 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
         return RestRequest.request(parserConfig(), httpRequest, new FakeRestRequest.FakeHttpChannel(null));
     }
 
+    private RestRequest newFullContentRequest(BytesArray content) {
+        var httpRequest = new FakeRestRequest.FakeHttpRequest(
+            RestRequest.Method.POST,
+            "/",
+            content,
+            Map.of("Content-Type", List.of("application/x-protobuf"))
+        );
+        return RestRequest.request(parserConfig(), httpRequest, new FakeRestRequest.FakeHttpChannel(null));
+    }
+
     private void assertTooLargeRejected() {
         assertNull(contentRef.get());
         assertNotNull(channel.capturedResponse());
@@ -305,7 +326,31 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
     private void initAggregator(long maxSize, IndexingPressureAwareContentAggregator.BodyPostProcessor postProcessor) {
         var request = newStreamedRequest(stream);
         channel = new FakeRestChannel(request, true);
-        aggregator = new IndexingPressureAwareContentAggregator(
+        aggregator = newAggregator(request, maxSize, postProcessor);
+        stream.setHandler(new HttpBody.ChunkHandler() {
+            @Override
+            public void onNext(ReleasableBytesReference chunk, boolean isLast) {
+                aggregator.handleChunk(channel, chunk, isLast);
+            }
+
+            @Override
+            public void close() {
+                aggregator.streamClose();
+            }
+        });
+        try {
+            aggregator.accept(channel);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private IndexingPressureAwareContentAggregator newAggregator(
+        RestRequest request,
+        long maxSize,
+        IndexingPressureAwareContentAggregator.BodyPostProcessor postProcessor
+    ) {
+        return new IndexingPressureAwareContentAggregator(
             request,
             indexingPressure,
             maxSize,
@@ -323,22 +368,6 @@ public class IndexingPressureAwareContentAggregatorTests extends ESTestCase {
             },
             postProcessor
         );
-        stream.setHandler(new HttpBody.ChunkHandler() {
-            @Override
-            public void onNext(ReleasableBytesReference chunk, boolean isLast) {
-                aggregator.handleChunk(channel, chunk, isLast);
-            }
-
-            @Override
-            public void close() {
-                aggregator.streamClose();
-            }
-        });
-        try {
-            aggregator.accept(channel);
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
     }
 
 }

--- a/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusRemoteWriteRestIT.java
+++ b/x-pack/plugin/prometheus/src/javaRestTest/java/org/elasticsearch/xpack/prometheus/PrometheusRemoteWriteRestIT.java
@@ -40,6 +40,28 @@ public class PrometheusRemoteWriteRestIT extends AbstractPrometheusRestIT {
         sendEmptyBodyAndAssertSuccess("/_prometheus/metrics/myapp/production/api/v1/write");
     }
 
+    public void testRemoteWriteEndpointWithAuditRequestBodyLogging() throws Exception {
+        enableAuditRequestBodyLogging();
+        sendAndAssertSuccess(simpleWriteRequest("audit_logged_metric"));
+    }
+
+    public void testRemoteWriteEndpointWithAuditRequestBodyLoggingRejectsOversizedSnappyBody() throws Exception {
+        enableAuditRequestBodyLogging();
+        Request request = new Request("POST", "/_prometheus/api/v1/write");
+        // Snappy preamble declaring Integer.MAX_VALUE bytes, exceeding the configured request limit.
+        request.setEntity(
+            new ByteArrayEntity(
+                new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x07 },
+                ContentType.create("application/x-protobuf")
+            )
+        );
+        request.setOptions(request.getOptions().toBuilder().addHeader(HttpHeaders.CONTENT_ENCODING, "snappy").build());
+        addWriteAuth(request);
+
+        ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(413));
+    }
+
     public void testRemoteWriteIndexesGaugeMetric() throws Exception {
         long timestamp = System.currentTimeMillis();
         String metricName = "test_gauge_metric";
@@ -283,6 +305,19 @@ public class PrometheusRemoteWriteRestIT extends AbstractPrometheusRestIT {
             builder.addSamples(s);
         }
         return builder.build();
+    }
+
+    private void enableAuditRequestBodyLogging() throws IOException {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("""
+            {
+              "persistent": {
+                "xpack.security.audit.enabled": true,
+                "xpack.security.audit.logfile.events.emit_request_body": true
+              }
+            }
+            """);
+        client().performRequest(request);
     }
 
     private void sendAndAssertSuccess(RemoteWrite.WriteRequest writeRequest) throws IOException {

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/SnappyBlockDecoder.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/SnappyBlockDecoder.java
@@ -67,9 +67,7 @@ public final class SnappyBlockDecoder implements IndexingPressureAwareContentAgg
 
     @Override
     public ReleasableBytesReference process(ReleasableBytesReference body, long maxSize) throws IOException {
-        try (body) {
-            return decode(body.streamInput(), maxSize);
-        }
+        return decode(body.streamInput(), maxSize);
     }
 
     private ReleasableBytesReference decode(StreamInput in, long maxSize) throws IOException {

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteRestActionTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteRestActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpBody;
@@ -101,6 +102,85 @@ public class PrometheusRemoteWriteRestActionTests extends ESTestCase {
             assertThat(response.contentType(), equalTo(RestResponse.TEXT_CONTENT_TYPE));
             assertThat(response.content().utf8ToString(), containsString("request body too large"));
         }
+    }
+
+    public void testFullContentOversizedSnappyBodyReturns413() throws Exception {
+        // The Snappy preamble declares 101 uncompressed bytes, exceeding the 100-byte request limit.
+        var content = new ReleasableBytesReference(new BytesArray(new byte[] { 101 }), () -> {});
+        var httpRequest = new FakeRestRequest.FakeHttpRequest(
+            RestRequest.Method.POST,
+            "/_prometheus/api/v1/write",
+            Map.of("Content-Type", List.of("application/x-protobuf"), "Content-Encoding", List.of("snappy")),
+            new HttpBody.ByteRefHttpBody(content)
+        ) {
+            private boolean released;
+
+            @Override
+            public void release() {
+                if (released == false) {
+                    released = true;
+                    body().close();
+                }
+            }
+        };
+        var request = RestRequest.request(parserConfig(), httpRequest, new FakeRestRequest.FakeHttpChannel(null));
+        var channel = new FakeRestChannel(request, true);
+        var action = new PrometheusRemoteWriteRestAction(indexingPressure, 100, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+
+        action.handleRequest(request, channel, client);
+
+        try (var response = channel.capturedResponse()) {
+            assertNotNull(response);
+            assertThat(response.status(), equalTo(RestStatus.REQUEST_ENTITY_TOO_LARGE));
+        }
+        assertFalse(content.hasReferences());
+    }
+
+    public void testFullContentSuccessfulSnappyWrite() throws Exception {
+        byte[] uncompressed = randomByteArrayOfLength(64);
+        var content = new ReleasableBytesReference(new BytesArray(SnappyBlockDecoderTests.snappyEncode(uncompressed)), () -> {});
+        var httpRequest = new FakeRestRequest.FakeHttpRequest(
+            RestRequest.Method.POST,
+            "/_prometheus/api/v1/write",
+            Map.of("Content-Type", List.of("application/x-protobuf"), "Content-Encoding", List.of("snappy")),
+            new HttpBody.ByteRefHttpBody(content)
+        ) {
+            private boolean released;
+
+            @Override
+            public void release() {
+                if (released == false) {
+                    released = true;
+                    body().close();
+                }
+            }
+        };
+        var request = RestRequest.request(parserConfig(), httpRequest, new FakeRestRequest.FakeHttpChannel(null));
+        var channel = new FakeRestChannel(request, true);
+        var action = new PrometheusRemoteWriteRestAction(indexingPressure, 1024, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        client = new NoOpNodeClient(threadPool) {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> actionType,
+                Request req,
+                ActionListener<Response> listener
+            ) {
+                assertThat(actionType, equalTo(PrometheusRemoteWriteTransportAction.TYPE));
+                var remoteWriteRequest = (PrometheusRemoteWriteTransportAction.RemoteWriteRequest) req;
+                assertArrayEquals(uncompressed, BytesReference.toBytes(remoteWriteRequest.remoteWriteRequest));
+                remoteWriteRequest.close();
+                listener.onResponse((Response) new PrometheusRemoteWriteTransportAction.RemoteWriteResponse());
+            }
+        };
+
+        action.handleRequest(request, channel, client);
+
+        try (var response = channel.capturedResponse()) {
+            assertNotNull(response);
+            assertThat(response.status(), equalTo(RestStatus.NO_CONTENT));
+        }
+        assertFalse(content.hasReferences());
     }
 
     public void testSuccessfulWriteWithoutSnappy() {

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/SnappyBlockDecoderTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/SnappyBlockDecoderTests.java
@@ -42,7 +42,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         byte[] original = randomByteArrayOfLength(between(1, 1000));
         byte[] compressed = snappyEncode(original);
 
-        try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), original.length)) {
+        try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), original.length)) {
             assertEquals(original.length, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
@@ -51,7 +51,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
     public void testDecodeEmpty() throws IOException {
         // Snappy block: preamble = 0 (empty)
         byte[] compressed = new byte[] { 0 };
-        try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), 1024)) {
+        try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), 1024)) {
             assertEquals(0, result.length());
         }
     }
@@ -63,7 +63,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         int maxSize = between(1, length - 1);
 
         var ex = expectThrows(Exception.class, () -> {
-            try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), maxSize)) {
+            try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), maxSize)) {
                 fail("expected exception for input of length " + length + " with maxSize " + maxSize);
             }
         });
@@ -82,27 +82,39 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         // Compressed should be smaller due to repetition
         assertTrue("expected compression, got " + compressed.length + " >= " + original.length, compressed.length < original.length);
 
-        try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), original.length)) {
+        try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), original.length)) {
             assertEquals(original.length, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
     }
 
-    public void testDecodeReleasesInput() throws IOException {
+    public void testDecodeLeavesInputOpenOnSuccess() throws IOException {
         byte[] original = randomByteArrayOfLength(64);
         byte[] compressed = snappyEncode(original);
         var input = new ReleasableBytesReference(new BytesArray(compressed), () -> {});
 
         try (var result = decoder.process(input, 1024)) {
-            assertFalse("input should be released after process()", input.hasReferences());
+            assertTrue("caller should release input after successful decoding", input.hasReferences());
+            input.close();
+            assertFalse(input.hasReferences());
         }
+    }
+
+    public void testDecodeLeavesInputOpenOnFailure() {
+        var input = releasable(new byte[] { 10, (byte) 0xFF });
+
+        expectThrows(IOException.class, () -> decoder.process(input, 1024));
+
+        assertTrue("caller should release input after a decoding failure", input.hasReferences());
+        input.close();
+        assertFalse(input.hasReferences());
     }
 
     public void testDecodeMalformedInput() {
         // Preamble says 10 bytes uncompressed, then a COPY_4_BYTE_OFFSET tag with insufficient data
         byte[] garbage = new byte[] { 10, (byte) 0xFF };
         expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(garbage), () -> {}), 1024)) {
+            try (var result = decode(new ReleasableBytesReference(new BytesArray(garbage), () -> {}), 1024)) {
                 fail("expected IOException for malformed input");
             }
         });
@@ -110,7 +122,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
     public void testDecodeEmptyInput() {
         expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(new ReleasableBytesReference(BytesArray.EMPTY, () -> {}), 1024)) {
+            try (var result = decode(new ReleasableBytesReference(BytesArray.EMPTY, () -> {}), 1024)) {
                 fail("expected IOException for empty input");
             }
         });
@@ -120,7 +132,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         for (int size : new int[] { 1, 15, 16, 60, 61, 255, 256, 4096, 16384 }) {
             byte[] original = randomByteArrayOfLength(size);
             byte[] compressed = snappyEncode(original);
-            try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), size)) {
+            try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), size)) {
                 assertEquals(size, result.length());
                 assertArrayEquals("failed for size " + size, original, BytesReference.toBytes(result));
             }
@@ -137,7 +149,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         }
         byte[] compressed = snappyEncode(original);
         assertTrue("expected compression", compressed.length < original.length);
-        try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), size)) {
+        try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), size)) {
             assertEquals(size, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
@@ -148,7 +160,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         int size = 32 * 1024 + between(1, 1000);
         byte[] original = randomByteArrayOfLength(size);
         byte[] compressed = snappyEncode(original);
-        try (var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), size)) {
+        try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), size)) {
             assertEquals(size, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
@@ -169,9 +181,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
             System.arraycopy(pattern, 0, original, prefixLen + i * pattern.length, pattern.length);
         }
         byte[] compressed = snappyEncode(original);
-        try (
-            var result = decoder.process(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), totalSize + between(0, 1024))
-        ) {
+        try (var result = decode(new ReleasableBytesReference(new BytesArray(compressed), () -> {}), totalSize + between(0, 1024))) {
             assertEquals(totalSize, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
@@ -191,7 +201,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
             new BytesArray(compressed, split2, compressed.length - split2)
         );
 
-        try (var result = decoder.process(new ReleasableBytesReference(composite, () -> {}), original.length + between(0, 1024))) {
+        try (var result = decode(new ReleasableBytesReference(composite, () -> {}), original.length + between(0, 1024))) {
             assertEquals(original.length, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
@@ -222,7 +232,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         System.arraycopy(literal, 0, expected, literalLen, copyLength);
 
         byte[] compressed = buf.toByteArray();
-        try (var result = decoder.process(releasable(compressed), total)) {
+        try (var result = decode(releasable(compressed), total)) {
             assertEquals(total, result.length());
             assertArrayEquals(expected, BytesReference.toBytes(result));
         }
@@ -239,7 +249,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         byte[] compressed = snappyEncode(original);
         assertTrue("expected compression", compressed.length < original.length);
 
-        try (var result = decoder.process(releasable(compressed), size)) {
+        try (var result = decode(releasable(compressed), size)) {
             assertEquals(size, result.length());
             byte[] decoded = BytesReference.toBytes(result);
             for (int i = 0; i < size; i++) {
@@ -285,7 +295,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         buf.write(data);
 
         byte[] compressed = buf.toByteArray();
-        try (var result = decoder.process(releasable(compressed), length)) {
+        try (var result = decode(releasable(compressed), length)) {
             assertEquals(length, result.length());
             assertArrayEquals(data, BytesReference.toBytes(result));
         }
@@ -295,7 +305,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         // 5-byte varint that decodes to -1 (0xFFFFFFFF), triggering the negative length check
         byte[] overflow = new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x0F };
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(overflow), Long.MAX_VALUE)) {
+            try (var result = decode(releasable(overflow), Long.MAX_VALUE)) {
                 fail("should not reach here");
             }
         });
@@ -306,7 +316,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         // 5 continuation bytes → shift reaches 35, exceeding the 32-bit limit
         byte[] tooLarge = new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00 };
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(tooLarge), Long.MAX_VALUE)) {
+            try (var result = decode(releasable(tooLarge), Long.MAX_VALUE)) {
                 fail("should not reach here");
             }
         });
@@ -334,7 +344,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
         byte[] compressed = buf.toByteArray();
         expectThrows(IOException.class, () -> {
-            try (var result = trackingDecoder.process(releasable(compressed), 40000)) {
+            try (var result = decode(trackingDecoder, releasable(compressed), 40000)) {
                 fail("expected IOException for truncated stream");
             }
         });
@@ -350,7 +360,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
         byte[] compressed = buf.toByteArray();
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(compressed), 1024)) {
+            try (var result = decode(releasable(compressed), 1024)) {
                 fail();
             }
         });
@@ -369,7 +379,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
         byte[] compressed = buf.toByteArray();
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(compressed), 1024)) {
+            try (var result = decode(releasable(compressed), 1024)) {
                 fail();
             }
         });
@@ -397,7 +407,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
         byte[] compressed = buf.toByteArray();
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(compressed), 1024)) {
+            try (var result = decode(releasable(compressed), 1024)) {
                 fail();
             }
         });
@@ -416,7 +426,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
         byte[] compressed = buf.toByteArray();
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(compressed), 10)) {
+            try (var result = decode(releasable(compressed), 10)) {
                 fail("expected IOException for zero copy offset");
             }
         });
@@ -434,7 +444,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
 
         byte[] compressed = buf.toByteArray();
         var ex = expectThrows(IOException.class, () -> {
-            try (var result = decoder.process(releasable(compressed), 10)) {
+            try (var result = decode(releasable(compressed), 10)) {
                 fail("expected IOException for offset exceeding written bytes");
             }
         });
@@ -445,7 +455,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         // Varint byte 0x80 has continuation bit set but no following byte.
         // The partial value is 0, so the decoder treats it as an empty block.
         byte[] truncated = new byte[] { (byte) 0x80 };
-        try (var result = decoder.process(releasable(truncated), 1024)) {
+        try (var result = decode(releasable(truncated), 1024)) {
             assertEquals(0, result.length());
         }
     }
@@ -462,7 +472,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
             withTrailing[i] = randomByte();
         }
 
-        try (var result = decoder.process(releasable(withTrailing), original.length)) {
+        try (var result = decode(releasable(withTrailing), original.length)) {
             assertEquals(original.length, result.length());
             assertArrayEquals(original, BytesReference.toBytes(result));
         }
@@ -498,7 +508,7 @@ public class SnappyBlockDecoderTests extends ESTestCase {
             }
         }
 
-        try (var decoded = decoder.process(compressed.moveToBytesReference(), uncompressed.length + between(0, 1024))) {
+        try (var decoded = decode(compressed.moveToBytesReference(), uncompressed.length + between(0, 1024))) {
             assertThat(decoded, equalBytes(new BytesArray(uncompressed)));
         }
     }
@@ -542,6 +552,17 @@ public class SnappyBlockDecoderTests extends ESTestCase {
         } else {
             out.write(0x01 | (length - 4 << 2) | (((offset >> 8) & 0x07) << 5));
             out.write(offset & 0xFF);
+        }
+    }
+
+    private ReleasableBytesReference decode(ReleasableBytesReference input, long maxSize) throws IOException {
+        return decode(decoder, input, maxSize);
+    }
+
+    private static ReleasableBytesReference decode(SnappyBlockDecoder decoder, ReleasableBytesReference input, long maxSize)
+        throws IOException {
+        try (input) {
+            return decoder.process(input, maxSize);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix remote write with audit request bodies (#153581)