### PR TITLE
[9.4] Fix under-count in LuceneCountOperator (#151822)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneCountOperator.java
@@ -22,7 +22,6 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.lucene.ShardContext;
-import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.RefCounted;
@@ -101,7 +100,7 @@ public class LuceneCountOperator extends LuceneOperator {
 
     @Override
     public boolean isFinished() {
-        return doneCollecting || remainingDocs == 0;
+        return doneCollecting || remainingDocs <= 0;
     }
 
     @Override
@@ -111,36 +110,19 @@ public class LuceneCountOperator extends LuceneOperator {
 
     @Override
     protected Page getCheckedOutput() throws IOException {
-        if (isFinished()) {
-            assert remainingDocs <= 0 : remainingDocs;
-            return null;
-        }
         long start = System.nanoTime();
         try {
-            while (remainingDocs > 0) {
-                final LuceneScorer scorer = getCurrentOrLoadNextScorer();
-                if (scorer == null) {
-                    remainingDocs = 0;
-                } else {
-                    count(scorer);
-                }
-
-                // Check if the query has been cancelled.
-                driverContext.checkForEarlyTermination();
-                // Even if this should almost never happen, we want to update the driver status even when a query runs "forever".
-                if (System.nanoTime() - start > Driver.DEFAULT_STATUS_INTERVAL.getNanos()) {
-                    break;
-                }
+            final LuceneScorer scorer = getCurrentOrLoadNextScorer();
+            if (scorer != null && remainingDocs > 0) {
+                count(scorer);
             }
-
-            if (remainingDocs <= 0) {
+            if (isFinished()) {
                 return buildResult();
-            } else {
-                return null;
             }
         } finally {
             processingNanos += System.nanoTime() - start;
         }
+        return null;
     }
 
     private void count(LuceneScorer scorer) throws IOException {
@@ -161,14 +143,18 @@ public class LuceneCountOperator extends LuceneOperator {
     }
 
     private Page buildResult() {
-        return switch (tagsToState.size()) {
-            case 0 -> null;
-            case 1 -> {
-                Map.Entry<List<Object>, PerTagsState> e = tagsToState.entrySet().iterator().next();
-                yield buildConstantBlocksResult(e.getKey(), e.getValue());
-            }
-            default -> buildNonConstantBlocksResult();
-        };
+        try {
+            return switch (tagsToState.size()) {
+                case 0 -> null;
+                case 1 -> {
+                    Map.Entry<List<Object>, PerTagsState> e = tagsToState.entrySet().iterator().next();
+                    yield buildConstantBlocksResult(e.getKey(), e.getValue());
+                }
+                default -> buildNonConstantBlocksResult();
+            };
+        } finally {
+            tagsToState.clear();
+        }
     }
 
     private Page buildConstantBlocksResult(List<Object> tags, PerTagsState state) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneMinMaxOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneMinMaxOperator.java
@@ -84,7 +84,7 @@ final class LuceneMinMaxOperator extends LuceneOperator {
 
     @Override
     public boolean isFinished() {
-        return doneCollecting || remainingDocs == 0;
+        return doneCollecting || remainingDocs <= 0;
     }
 
     @Override
@@ -94,17 +94,11 @@ final class LuceneMinMaxOperator extends LuceneOperator {
 
     @Override
     public Page getCheckedOutput() throws IOException {
-        if (isFinished()) {
-            assert remainingDocs <= 0 : remainingDocs;
-            return null;
-        }
         final long start = System.nanoTime();
         try {
             final LuceneScorer scorer = getCurrentOrLoadNextScorer();
             // no scorer means no more docs
-            if (scorer == null) {
-                remainingDocs = 0;
-            } else {
+            if (scorer != null) {
                 if (scorer.tags().isEmpty() == false) {
                     throw new UnsupportedOperationException("tags not supported by " + getClass());
                 }
@@ -156,7 +150,7 @@ final class LuceneMinMaxOperator extends LuceneOperator {
 
             Page page = null;
             // emit only one page
-            if (remainingDocs <= 0 && pagesEmitted == 0) {
+            if (isFinished() && pagesEmitted == 0) {
                 Block result = null;
                 BooleanBlock seen = null;
                 try {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneOperator.java
@@ -195,6 +195,9 @@ public abstract class LuceneOperator extends SourceOperator {
     protected void additionalClose() { /* Override this method to add any additional cleanup logic if needed */ }
 
     LuceneScorer getCurrentOrLoadNextScorer() {
+        if (doneCollecting) {
+            return null;
+        }
         for (;;) {
             SubscribableListener<Void> sliceBlocked = null;
             while (currentScorer == null || currentScorer.isDone()) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix under-count in LuceneCountOperator (#151822)](https://github.com/elastic/elasticsearch/pull/151822)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)