### PR TITLE
[8.19] Fix under-count in LuceneCountOperator (#151822)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -105,7 +105,7 @@ public class LuceneCountOperator extends LuceneOperator {
 
     @Override
     public boolean isFinished() {
-        return doneCollecting || remainingDocs == 0;
+        return doneCollecting || remainingDocs <= 0;
     }
 
     @Override
@@ -115,23 +115,15 @@ public class LuceneCountOperator extends LuceneOperator {
 
     @Override
     protected Page getCheckedOutput() throws IOException {
-        if (isFinished()) {
-            assert remainingDocs <= 0 : remainingDocs;
-            return null;
-        }
         long start = System.nanoTime();
         try {
             final LuceneScorer scorer = getCurrentOrLoadNextScorer();
-            // no scorer means no more docs
-            if (scorer == null) {
-                remainingDocs = 0;
-            } else {
+            if (scorer != null && remainingDocs > 0) {
                 if (scorer.tags().isEmpty() == false) {
                     throw new UnsupportedOperationException("tags not supported by " + getClass());
                 }
                 Weight weight = scorer.weight();
                 var leafReaderContext = scorer.leafReaderContext();
-                // see org.apache.lucene.search.TotalHitCountCollector
                 int leafCount = weight.count(leafReaderContext);
                 if (leafCount != -1) {
                     var count = Math.min(leafCount, remainingDocs);
@@ -139,15 +131,12 @@ public class LuceneCountOperator extends LuceneOperator {
                     remainingDocs -= count;
                     scorer.markAsDone();
                 } else {
-                    // could not apply shortcut, trigger the search
-                    // TODO: avoid iterating all documents in multiple calls to make cancellation more responsive.
                     scorer.scoreNextRange(leafCollector, leafReaderContext.reader().getLiveDocs(), remainingDocs);
                 }
             }
 
-            Page page = null;
-            // emit only one page
-            if (remainingDocs <= 0 && pagesEmitted == 0) {
+            if (isFinished() && pagesEmitted == 0) {
+                Page page = null;
                 LongBlock count = null;
                 BooleanBlock seen = null;
                 try {
@@ -159,11 +148,12 @@ public class LuceneCountOperator extends LuceneOperator {
                         Releasables.closeExpectNoException(count, seen);
                     }
                 }
+                return page;
             }
-            return page;
         } finally {
             processingNanos += System.nanoTime() - start;
         }
+        return null;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMinMaxOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneMinMaxOperator.java
@@ -81,7 +81,7 @@ final class LuceneMinMaxOperator extends LuceneOperator {
 
     @Override
     public boolean isFinished() {
-        return doneCollecting || remainingDocs == 0;
+        return doneCollecting || remainingDocs <= 0;
     }
 
     @Override
@@ -91,17 +91,11 @@ final class LuceneMinMaxOperator extends LuceneOperator {
 
     @Override
     public Page getCheckedOutput() throws IOException {
-        if (isFinished()) {
-            assert remainingDocs <= 0 : remainingDocs;
-            return null;
-        }
         final long start = System.nanoTime();
         try {
             final LuceneScorer scorer = getCurrentOrLoadNextScorer();
             // no scorer means no more docs
-            if (scorer == null) {
-                remainingDocs = 0;
-            } else {
+            if (scorer != null) {
                 if (scorer.tags().isEmpty() == false) {
                     throw new UnsupportedOperationException("tags not supported by " + getClass());
                 }
@@ -153,7 +147,7 @@ final class LuceneMinMaxOperator extends LuceneOperator {
 
             Page page = null;
             // emit only one page
-            if (remainingDocs <= 0 && pagesEmitted == 0) {
+            if (isFinished() && pagesEmitted == 0) {
                 Block result = null;
                 BooleanBlock seen = null;
                 try {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -152,6 +152,9 @@ public abstract class LuceneOperator extends SourceOperator {
     public void close() {}
 
     LuceneScorer getCurrentOrLoadNextScorer() {
+        if (doneCollecting) {
+            return null;
+        }
         while (currentScorer == null || currentScorer.isDone()) {
             if (currentSlice == null || sliceIndex >= currentSlice.numLeaves()) {
                 sliceIndex = 0;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix under-count in LuceneCountOperator (#151822)](https://github.com/elastic/elasticsearch/pull/151822)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)