### PR TITLE
Enhance note on asynchronous reindexing

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/reindex-indices.md
+++ b/docs/reference/elasticsearch/rest-apis/reindex-indices.md
@@ -91,8 +91,7 @@ POST _reindex
 If the request contains `wait_for_completion=false`, {{es}} performs some preflight checks, launches the request, and returns a `task` ID you can use to [manage](#monitor-reindex-tasks) the operation.
 
 ::::{note}
-For long-running reindexes, prefer asynchronous reindexes. Synchronous reindex keeps a client waiting on the node that received the request and with
-a long-running request this will likely encounter transport-level timeouts.
+For long-running reindexes, prefer asynchronous requests. Synchronous requests keep the client waiting on the node that received the request and with a long-running request this will likely encounter transport-level timeouts. While the reindex will continue (after client timeout) as a task that's managed within the cluster, the client will not receive expected feedback as to ongoing status of completion.
 ::::
 
 ## Reindex multiple indices sequentially [docs-reindex-multiple-sequentially]

--- a/docs/reference/elasticsearch/rest-apis/reindex-indices.md
+++ b/docs/reference/elasticsearch/rest-apis/reindex-indices.md
@@ -90,7 +90,10 @@ POST _reindex
 
 If the request contains `wait_for_completion=false`, {{es}} performs some preflight checks, launches the request, and returns a `task` ID you can use to [manage](#monitor-reindex-tasks) the operation.
 
-For long-running reindexes, prefer asynchronous reindexes. Synchronous reindex keeps a client waiting on the node that received the request and this will time out.
+::::{note}
+For long-running reindexes, prefer asynchronous reindexes. Synchronous reindex keeps a client waiting on the node that received the request and with
+a long-running request this will likely encounter transport-level timeouts.
+::::
 
 ## Reindex multiple indices sequentially [docs-reindex-multiple-sequentially]
 


### PR DESCRIPTION
Clarify the potential for transport-level timeouts during synchronous reindexing, wrap it in a Note block.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
