### PR TITLE
[9.4] Fix ExchangeServiceTests (#150947)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -248,9 +248,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.checkpoint.TransformGetCheckpointIT
   method: testGetCheckpointTimeoutExceeded
   issue: https://github.com/elastic/elasticsearch/issues/150934
-- class: org.elasticsearch.compute.operator.exchange.ExchangeServiceTests
-  method: testBasic
-  issue: https://github.com/elastic/elasticsearch/issues/153347
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -159,7 +159,7 @@ public class ExchangeServiceTests extends ESTestCase {
         assertBusy(() -> assertTrue(sink2.waitForWriting().listener().isDone()));
         sink2.finish();
         assertTrue(sink2.isFinished());
-        assertTrue(source.isFinished());
+        assertBusy(() -> assertTrue(source.isFinished()));
         source.finish();
         ESTestCase.terminate(threadPool);
         for (Page page : pages) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix ExchangeServiceTests (#150947)](https://github.com/elastic/elasticsearch/pull/150947)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)