### PR TITLE
[8.19] Fix testExchangeSourceContinueOnFailure (#150936)

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -406,7 +406,9 @@ public class ExchangeServiceTests extends ESTestCase {
                 AtomicBoolean sinkFailed = new AtomicBoolean();
                 ActionListener<Void> oneSinkListener = refs.acquire();
                 exchangeSourceHandler.addRemoteSink((allSourcesFinished, listener) -> {
-                    if (fetched.incrementAndGet() > failAfter) {
+                    // Don't simulate failure when allSourcesFinished - the exchange source might have
+                    // already completed, and the failure can be ignored in the completion listener
+                    if (fetched.incrementAndGet() > failAfter && allSourcesFinished == false) {
                         sinkHandler.fetchPageAsync(true, listener.delegateFailure((l, r) -> {
                             failedRequests.incrementAndGet();
                             sinkFailed.set(true);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix testExchangeSourceContinueOnFailure (#150936)](https://github.com/elastic/elasticsearch/pull/150936)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)