### PR TITLE
ES|QL: relax hive-partition IT node-count assertion for pruning

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractHivePartitionParityIT.java
@@ -164,9 +164,9 @@ public abstract class AbstractHivePartitionParityIT extends AbstractExternalData
         request.profile(true);
         try (var response = run(request)) {
             assertThat(
-                "external scan must distribute across >= 2 data nodes for [" + query + "]",
+                "external scan must run on >= 1 data node for [" + query + "]",
                 externalScanNodeNames(response).size(),
-                greaterThanOrEqualTo(2)
+                greaterThanOrEqualTo(1)
             );
             // Tag each cell name:type=value so the diff catches a column-TYPE regression (a partition column
             // surfacing as a different type than the file-resident twin), not just a value regression.

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionFilterPushdownIT.java
@@ -65,9 +65,9 @@ public class ExternalParquetHivePartitionFilterPushdownIT extends AbstractExtern
         request.profile(true);
         try (var response = run(request)) {
             assertThat(
-                "external scan must distribute across >= 2 data nodes to exercise the UNRESOLVED-FileList path",
+                "external scan must run on >= 1 data node to exercise the UNRESOLVED-FileList path",
                 externalScanNodeNames(response).size(),
-                greaterThanOrEqualTo(2)
+                greaterThanOrEqualTo(1)
             );
             return getValuesList(response);
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
@@ -106,9 +106,9 @@ public class ExternalParquetHivePartitionNullValueIT extends AbstractExternalDat
         request.profile(true);
         try (var response = run(request)) {
             assertThat(
-                "external scan must distribute across >= 2 data nodes",
+                "external scan must run on >= 1 data node",
                 externalScanNodeNames(response).size(),
-                greaterThanOrEqualTo(2)
+                greaterThanOrEqualTo(1)
             );
             return new QueryResult(getValuesList(response), response.columns().stream().map(c -> c.name()).toList());
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionNullValueIT.java
@@ -105,11 +105,7 @@ public class ExternalParquetHivePartitionNullValueIT extends AbstractExternalDat
         request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
         request.profile(true);
         try (var response = run(request)) {
-            assertThat(
-                "external scan must run on >= 1 data node",
-                externalScanNodeNames(response).size(),
-                greaterThanOrEqualTo(1)
-            );
+            assertThat("external scan must run on >= 1 data node", externalScanNodeNames(response).size(), greaterThanOrEqualTo(1));
             return new QueryResult(getValuesList(response), response.columns().stream().map(c -> c.name()).toList());
         }
     }


### PR DESCRIPTION
The hive-partition external ITs assert the external scan distributes across `>= 2` data nodes. That only held while partition pruning was broken: an unfiltered scan hit every partition file, so the splits spread across nodes. Since #153640 made pruning work, a filtered query prunes to the matching partition — often one file, one node — and the `>= 2` assertion fails.

These tests were added after #153640's branch point, so #153640's CI never ran them; the squash merge landed the pruning change on a main that already had them, and the two first ran together on the 9.5 backport.

Relaxes the node-count assertion to `>= 1` in `AbstractHivePartitionParityIT` (covers the CSV/TSV/NDJSON/Parquet parity ITs), `ExternalParquetHivePartitionFilterPushdownIT`, and `ExternalParquetHivePartitionNullValueIT`. The row-count and parity assertions — the actual correctness checks — are unchanged. Validated by running all six classes with the failing seed `E9FED5AFF3C609DC`.
