### PR TITLE
Fix inlinestats double release [backport 9.5]

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ColumnLoadOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ColumnLoadOperator.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
@@ -26,13 +27,14 @@ public class ColumnLoadOperator extends AbstractPageMappingToIteratorOperator {
     }
 
     /**
-     * Factory for {@link ColumnLoadOperator}. It's received {@link Block}s
-     * are never closed, so we need to build them from a non-tracking factory.
+     * Factory for {@link ColumnLoadOperator}. The {@link Block} inside {@link Values}
+     * is never closed by this factory; each operator instance deep-copies it into its
+     * own {@link BlockFactory} on construction.
      */
     public record Factory(Values values, int positionsOrd) implements OperatorFactory {
         @Override
         public Operator get(DriverContext driverContext) {
-            return new ColumnLoadOperator(values, positionsOrd);
+            return new ColumnLoadOperator(new Values(values.name, values.block.deepCopy(driverContext.blockFactory())), positionsOrd);
         }
 
         @Override
@@ -46,18 +48,7 @@ public class ColumnLoadOperator extends AbstractPageMappingToIteratorOperator {
 
     public ColumnLoadOperator(Values values, int positionsOrd) {
         this.positionsOrd = positionsOrd;
-        this.values = clone(values);
-    }
-
-    // FIXME: Since we don't have a thread-safe RefCounted for blocks/vectors, we have to clone the values block to avoid
-    // data races of reference when sharing blocks/vectors across threads. Remove this when we have a thread-safe RefCounted
-    // for blocks/vectors.
-    static Values clone(Values values) {
-        final Block block = values.block;
-        try (var builder = block.elementType().newBlockBuilder(block.getPositionCount(), block.blockFactory())) {
-            builder.copyFrom(block, 0, block.getPositionCount());
-            return new Values(values.name, builder.build());
-        }
+        this.values = values;
     }
 
     /**
@@ -68,14 +59,6 @@ public class ColumnLoadOperator extends AbstractPageMappingToIteratorOperator {
 
     @Override
     protected ReleasableIterator<Page> receive(Page page) {
-        // TODO tracking is complex for values
-        /*
-         * values is likely shared across many threads so tracking it is complex.
-         * Lookup will incRef it on the way in and decrement the ref on the way
-         * out but it's not really clear what the right way to get all that thread
-         * safe is. For now we can ignore this because we're not actually tracking
-         * the memory of the block.
-         */
         return appendBlocks(page, values.block.lookup(page.getBlock(positionsOrd), TARGET_BLOCK_SIZE));
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/RowInTableLookupOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/RowInTableLookupOperator.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.aggregation.table.RowInTableLookup;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
@@ -19,7 +20,67 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Looks up each row of an input {@link Page} in a pre-built table and appends
+ * the matching row index as a new {@link IntBlock}.
+ * <p>
+ *     The table is supplied at construction time as an array of {@link Key}s,
+ *     each holding one key column. Input pages may have more columns than just
+ *     the key columns; {@code blockMapping} selects which blocks in the input
+ *     correspond to each key, in order.
+ * </p>
+ * <p>
+ *     For example, given a lookup table keyed on {@code class} with a
+ *     non-key column {@code meaning}:
+ * </p>
+ * {@snippet lang="txt" :
+ * ┌──────────┬───────────────────────────┐
+ * │ class    │ meaning                   │
+ * ├──────────┼───────────────────────────┤
+ * │ Euclid   │ unpredictable behavior    │
+ * │ Keter    │ extremely hard to contain │
+ * │ Safe     │ safely contained          │
+ * └──────────┴───────────────────────────┘
+ * }
+ * <p>
+ *     The {@link Key} passed to this operator contains only the {@code class}
+ *     column — {@code meaning} is stored separately and fetched by a downstream
+ *     operator using the row index this operator emits. Given an input page:
+ * </p>
+ * {@snippet lang="txt" :
+ * ┌─────┬─────┬──────────┐
+ * │ doc │ ref │ class    │
+ * ├─────┼─────┼──────────┤
+ * │   0 │ 049 │ Euclid   │
+ * │   1 │ 682 │ Keter    │
+ * │   2 │ 179 │ Thaumiel │
+ * └─────┴─────┴──────────┘
+ * }
+ * <p>
+ *     With {@code blockMapping = [2]} ({@code class} at block 2 is the only
+ *     key), the operator produces:
+ * </p>
+ * {@snippet lang="txt" :
+ * ┌─────┬─────┬──────────┬───────────┐
+ * │ doc │ ref │ class    │ row index │
+ * ├─────┼─────┼──────────┼───────────┤
+ * │   0 │ 049 │ Euclid   │         0 │  ← meaning: unpredictable behavior
+ * │   1 │ 682 │ Keter    │         1 │  ← meaning: extremely hard to contain
+ * │   2 │ 179 │ Thaumiel │      null │  ← no match: Thaumiel not in table
+ * └─────┴─────┴──────────┴───────────┘
+ * }
+ * <p>
+ *     The {@link Factory} holds the key {@link Block}s and is shared across
+ *     all drivers. Each driver's constructor deep-copies those blocks into its
+ *     own {@link BlockFactory}, so the factory's blocks are never released by
+ *     this operator.
+ * </p>
+ */
 public class RowInTableLookupOperator extends AbstractPageMappingToIteratorOperator {
+    /**
+     * A single key column of the lookup table: its field name and the block
+     * of values (one value per table row).
+     */
     public record Key(String name, Block block) {
         @Override
         public String toString() {
@@ -36,8 +97,9 @@ public class RowInTableLookupOperator extends AbstractPageMappingToIteratorOpera
     }
 
     /**
-     * Factory for {@link RowInTableLookupOperator}. It's received {@link Block}s
-     * are never closed, so we need to build them from a non-tracking factory.
+     * Factory for {@link RowInTableLookupOperator}. The {@link Block}s inside
+     * the {@link Key}s are never closed by this factory; each operator instance
+     * deep-copies them into its own {@link BlockFactory} on construction.
      */
     public record Factory(Key[] keys, int[] blockMapping) implements Operator.OperatorFactory {
         public Factory {
@@ -67,12 +129,17 @@ public class RowInTableLookupOperator extends AbstractPageMappingToIteratorOpera
         }
         this.blockMapping = blockMapping;
         this.keys = new ArrayList<>(keys.length);
+        // Each driver needs its own copy of the blocks because we return parts of them.
         Block[] blocks = new Block[keys.length];
         for (int k = 0; k < keys.length; k++) {
             this.keys.add(keys[k].name);
-            blocks[k] = keys[k].block;
+            blocks[k] = keys[k].block.deepCopy(blockFactory);
         }
-        this.lookup = RowInTableLookup.build(blockFactory, blocks);
+        try {
+            this.lookup = RowInTableLookup.build(blockFactory, blocks);
+        } finally {
+            Releasables.closeExpectNoException(blocks);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backport of #153171 to 9.5.

Fixes a double release bug with INLINE STATS - specifically it comes because the Lookup join stuff is shared between many threads and they contain a Block.

Closes #152801
Closes #153184
Closes #153123
Closes #152904
Closes #153592