### PR TITLE
Fix DimensionValuesByteRefGroupingAggregatorFunctionTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -331,9 +331,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchDuringRollingRestartIT
   method: testSearchesSurviveRollingRestart
   issue: https://github.com/elastic/elasticsearch/issues/151828
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValuesByteRefGroupingAggregatorFunctionTests
-  method: testSimple
-  issue: https://github.com/elastic/elasticsearch/issues/152128
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=search.highlight/30_max_analyzed_offset/Plain highlighter on a field WITH OFFSETS exceeding index.highlight.max_analyzed_offset should FAIL}
   issue: https://github.com/elastic/elasticsearch/issues/152367

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
@@ -47,6 +47,7 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
         Map<Integer, List<BytesRef>> expectedValues = new HashMap<>();
         int prefixBlocks = between(0, 2);
         int suffixBlocks = between(0, 2);
+        int nextGroupId = 0;
         for (int i = 0; i < numPages; i++) {
             int positions = between(1, 100);
             try (
@@ -70,7 +71,7 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
                         }
                         valuesBuilder.endPositionEntry();
                     }
-                    int group = between(0, 1000);
+                    int group = randomBoolean() ? nextGroupId++ : randomIntBetween(0, nextGroupId);
                     groups.appendInt(group);
                     expectedValues.putIfAbsent(group, values);
                 }


### PR DESCRIPTION
The groupIds are generated randomly in the test - they should be generated as if by BlockHash instead.

Closes #152128