### PR TITLE
Backport AsyncSearchActionIT fix to 9.4

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -254,18 +254,6 @@ tests:
 - class: org.elasticsearch.repositories.SnapshotMetricsIT
   method: testSnapshotAPMMetrics
   issue: https://github.com/elastic/elasticsearch/issues/153595
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testDeleteCleanupIndex
-  issue: https://github.com/elastic/elasticsearch/issues/153658
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testRestartAfterCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/153659
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testInvalidId
-  issue: https://github.com/elastic/elasticsearch/issues/153660
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testCleanupOnFailure
-  issue: https://github.com/elastic/elasticsearch/issues/153662
 
 # Examples:
 #

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -154,8 +154,14 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         ensureAllSearchContextsReleased();
 
         internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {});
-        unpauseMaintenanceService();
+        // The restarted node gets a new, unpaused maintenance service that the pre-restart pause did
+        // not cover. It can dispatch a DeleteByQueryRequest to a still-INITIALIZING shard, registering
+        // an async waitForSearchReady callback that opens a reader context only after the shard starts.
+        // Wait for shards to start, then pause and drain any such in-flight contexts before unpausing.
         ensureYellow(ASYNC_RESULTS_INDEX, indexName);
+        pauseMaintenanceService();
+        ensureAllSearchContextsReleased();
+        unpauseMaintenanceService();
     }
 
     protected AsyncSearchResponse submitAsyncSearch(SubmitAsyncSearchRequest request) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/152406 to 9.4

Closes https://github.com/elastic/elasticsearch/issues/153658
Closes https://github.com/elastic/elasticsearch/issues/153659
Closes https://github.com/elastic/elasticsearch/issues/153660
Closes https://github.com/elastic/elasticsearch/issues/153662
