### PR TITLE
ESQL: Logs for failing test

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/EsqlRefCountingListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/EsqlRefCountingListener.java
@@ -11,6 +11,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.compute.operator.FailureCollector;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 
 /**
  * Similar to {@link org.elasticsearch.action.support.RefCountingListener},
@@ -18,6 +20,8 @@ import org.elasticsearch.core.Releasable;
  * @see FailureCollector
  */
 public final class EsqlRefCountingListener implements Releasable {
+    private static final Logger logger = LogManager.getLogger(EsqlRefCountingListener.class);
+
     private final FailureCollector failureCollector;
     private final RefCountingRunnable refs;
 
@@ -25,6 +29,7 @@ public final class EsqlRefCountingListener implements Releasable {
         this.failureCollector = new FailureCollector();
         this.refs = new RefCountingRunnable(() -> {
             Exception error = failureCollector.getFailure();
+            logger.debug("all refs released [success={}]", error == null);
             if (error != null) {
                 delegate.onFailure(error);
             } else {
@@ -43,6 +48,7 @@ public final class EsqlRefCountingListener implements Releasable {
 
     @Override
     public void close() {
+        logger.trace("releasing initial ref");
         refs.close();
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -46,6 +46,7 @@ import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportRequest;
@@ -133,6 +134,10 @@ import static org.hamcrest.Matchers.hasSize;
  * Test data is loaded lazily in order to facilitate faster startup when running/debugging individual test cases.
  */
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
+@TestLogging(
+    value = "org.elasticsearch.compute.EsqlRefCountingListener:TRACE",
+    reason = "capture ref-counting completion timing to diagnose the silent hang in #153394"
+)
 public class CsvIT extends ESTestCase {
 
     private static final Logger logger = LogManager.getLogger(CsvIT.class);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.esql;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import com.sun.management.HotSpotDiagnosticMXBean;
 
 import org.apache.lucene.tests.util.TimeUnits;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -95,6 +97,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -380,7 +383,7 @@ public class CsvIT extends ESTestCase {
         var listener = new ResponseListener(cluster.getInstance(TransportService.class).getThreadPool());
         cluster.client().execute(EsqlQueryAction.INSTANCE, request, listener);
         // Using a longer timeout here as test infrastructure might populate data lazily while request is in progress.
-        try (var response = listener.actionGet(5, TimeUnit.MINUTES)) {
+        try (EsqlQueryResponse response = listener.actionGet(5, TimeUnit.MINUTES)) {
             assertFalse("response must not be partial: " + response.getExecutionInfo(), response.isPartial());
             ExpectedResults expected = indexLoadStrategy.transformExpectedResults(
                 groupName + "." + testName,
@@ -412,6 +415,9 @@ public class CsvIT extends ESTestCase {
             testCase.assertWarnings(false).assertWarnings(warnings, null);
             CsvAssert.assertDocumentsFound(testCase.expectedDocumentsFound, response.documentsFound());
         } catch (Throwable t) {
+            if (t instanceof ElasticsearchTimeoutException) {
+                dumpHeapOnTimeout();
+            }
             t.setStackTrace(prependSpec(t.getStackTrace()));
             throw t;
         }
@@ -732,6 +738,16 @@ public class CsvIT extends ESTestCase {
         Path geoIpDir = configDir.resolve("ingest-geoip");
         Files.createDirectories(geoIpDir);
         GeoIpTestUtils.copyDefaultDatabases(geoIpDir);
+    }
+
+    private static void dumpHeapOnTimeout() {
+        try {
+            String path = System.getProperty("java.io.tmpdir") + "/esql-hang-" + System.currentTimeMillis() + ".hprof";
+            ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class).dumpHeap(path, true);
+            logger.warn("Query timed out; heap dump written to [{}]", path);
+        } catch (Exception e) {
+            logger.warn("Query timed out; failed to dump heap", e);
+        }
     }
 
     private static class ResponseListener extends PlainActionFuture<EsqlQueryResponse> {


### PR DESCRIPTION
Adds extra logs to help figure out #153394. And causes a heap dump on timeout of the test for the same reason - it'll help figure out the failure when it recurs.
