### PR TITLE
ESQL: match_phrase works on runtime text expressions

### DIFF
--- a/docs/changelog/153745.yaml
+++ b/docs/changelog/153745.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153745
+summary: Match_phrase works on runtime text expressions
+type: enhancement

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -1789,7 +1789,7 @@ a:unsigned_long
 matchOperatorFunctionOnLhsConcatKeyword
 skip_flattened_rewrite: concat_rejects_flattened_fields
 required_capability: match_operator_colon
-required_capability: match_runtime_search
+required_capability: fn_match_runtime_filter
 required_capability: match_operator_lhs_expression
 
 FROM employees
@@ -1803,7 +1803,7 @@ emp_no:integer | first_name:keyword | last_name:keyword
 
 matchOperatorFunctionOnLhsNestedFunctionCalls
 required_capability: match_operator_colon
-required_capability: match_runtime_search
+required_capability: fn_match_runtime_filter
 required_capability: match_operator_lhs_expression
 
 FROM books
@@ -1821,7 +1821,7 @@ book_no:keyword | title:text
 
 matchOperatorFunctionOnLhsConstantFolded
 required_capability: match_operator_colon
-required_capability: match_runtime_search
+required_capability: fn_match_runtime_filter
 required_capability: match_operator_lhs_expression
 
 ROW a = "test"
@@ -1834,7 +1834,7 @@ test
 
 matchOperatorFunctionOnLhsFromRow
 required_capability: match_operator_colon
-required_capability: match_runtime_search
+required_capability: fn_match_runtime_filter
 required_capability: match_operator_lhs_expression
 
 ROW a = "Anneke", b = "Preusig"

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
@@ -698,3 +698,115 @@ from all_types
 constant_keyword-foo:keyword | keyword:keyword
 foo                          | key2
 ;
+
+###############################################
+# Tests for MATCH_PHRASE on runtime text expressions (not index-mapped fields)
+#
+
+matchPhraseOnRuntimeText
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match_phrase(content, "Lord of the Rings")
+| SORT book_no
+| LIMIT 3
+| KEEP book_no, title
+;
+
+book_no:keyword | title:text
+1463            | Realms of Tolkien: Images of Middle-earth
+2675            | The Lord of the Rings - Boxed Set
+2714            | Return of the King Being the Third Part of The Lord of the Rings
+;
+
+matchPhraseOnRuntimeTextOrderMatters
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match_phrase(content, "Rings the of Lord")
+| KEEP book_no
+;
+
+book_no:keyword
+;
+
+matchPhraseOnRuntimeTextAndIndexedField
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+FROM books
+| EVAL content = to_text(concat(title, " ", description))
+| WHERE match_phrase(content, "Lord of the Rings") OR match_phrase(author, "William Faulkner")
+| SORT book_no
+| LIMIT 5
+| KEEP book_no
+;
+
+book_no:keyword
+1463
+2675
+2713
+2714
+2883
+;
+
+matchPhraseOnTextWithRow
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+ROW content = to_text(["This is a brown fox", "This is a brown dog", "The fox is brown"])
+| MV_EXPAND content
+| WHERE match_phrase(content, "brown fox")
+| SORT content
+;
+
+content:text
+This is a brown fox
+;
+
+matchPhraseOnTextWithRowAndNullValues
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
+| MV_EXPAND content
+| EVAL content = to_text(case(content == "This is a brown fox", null, content))
+| WHERE match_phrase(content, "brown dog")
+| SORT content
+;
+
+content:text
+This is a brown dog
+;
+
+matchPhraseOnTextWithRowAndMultiValues
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
+| MV_EXPAND content
+| EVAL content = to_text(mv_append(content, "wholly unrelated"))
+| WHERE match_phrase(content, "brown dog")
+| SORT content
+;
+
+content:text
+[This is a brown dog, wholly unrelated]
+;
+
+matchPhraseOnRuntimeTextDoesNotSpanMultipleValues
+required_capability: match_phrase_function
+required_capability: match_phrase_runtime_search
+
+// mv_append returns keyword, so wrap it in to_text to stay on the runtime text path
+ROW content = to_text(mv_append("ends with brown", "fox starts"))
+| WHERE match_phrase(content, "brown fox")
+| KEEP content
+;
+
+content:text
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-phrase-function.csv-spec
@@ -705,7 +705,7 @@ foo                          | key2
 
 matchPhraseOnRuntimeText
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 FROM books
 | EVAL content = to_text(concat(title, " ", description))
@@ -723,7 +723,7 @@ book_no:keyword | title:text
 
 matchPhraseOnRuntimeTextOrderMatters
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 FROM books
 | EVAL content = to_text(concat(title, " ", description))
@@ -736,7 +736,7 @@ book_no:keyword
 
 matchPhraseOnRuntimeTextAndIndexedField
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 FROM books
 | EVAL content = to_text(concat(title, " ", description))
@@ -756,7 +756,7 @@ book_no:keyword
 
 matchPhraseOnTextWithRow
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 ROW content = to_text(["This is a brown fox", "This is a brown dog", "The fox is brown"])
 | MV_EXPAND content
@@ -770,7 +770,7 @@ This is a brown fox
 
 matchPhraseOnTextWithRowAndNullValues
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
 | MV_EXPAND content
@@ -785,7 +785,7 @@ This is a brown dog
 
 matchPhraseOnTextWithRowAndMultiValues
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 ROW content = ["This is a brown fox", "This is a brown dog", "This dog is really brown"]
 | MV_EXPAND content
@@ -800,7 +800,7 @@ content:text
 
 matchPhraseOnRuntimeTextDoesNotSpanMultipleValues
 required_capability: match_phrase_function
-required_capability: match_phrase_runtime_search
+required_capability: fn_match_phrase_runtime_filter
 
 // mv_append returns keyword, so wrap it in to_text to stay on the runtime text path
 ROW content = to_text(mv_append("ends with brown", "fox starts"))

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.plugin;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -26,6 +27,14 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     @Before
     public void setupIndex() {
         createAndPopulateIndex(this::ensureYellow);
+    }
+
+    /**
+     * Runtime match_phrase is gated behind a snapshot-only capability; in release builds the queries these tests
+     * run are rejected by the verifier instead.
+     */
+    private static void assumeRuntimeMatchPhraseEnabled() {
+        assumeTrue("requires runtime match_phrase", EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled());
     }
 
     public void testSimpleWhereMatchPhrase() {
@@ -323,6 +332,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseAfterMvExpand() {
+        assumeRuntimeMatchPhraseEnabled();
         // After MV_EXPAND on the searched field, the expanded attribute is no longer a direct index field, so
         // runtime search takes over: the MV_EXPAND restriction is bypassed and the phrase is evaluated per row.
         var query = """
@@ -341,6 +351,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseAfterMvExpandWithIntermediateCommands() {
+        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | MV_EXPAND content
@@ -400,6 +411,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     // ---- runtime match_phrase: searching text expressions that are not index-mapped fields ----
 
     public void testSimpleWhereRuntimeMatchPhrase() {
+        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | WHERE match_phrase(to_text(concat(content, " extra")), "brown fox")
@@ -415,6 +427,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testRuntimeMatchPhraseOrderMatters() {
+        assumeRuntimeMatchPhraseEnabled();
         // Both tokens exist in ids 1 and 6, but never adjacent in this order, so a runtime phrase matches nothing.
         var query = """
             FROM test
@@ -431,6 +444,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereRuntimeMatchPhraseEvalTextColumn() {
+        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | EVAL text_content = content
@@ -447,6 +461,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereRuntimeMatchPhraseWithRow() {
+        assumeRuntimeMatchPhraseEnabled();
         var query = """
             ROW content = to_text("a brown fox")
             | WHERE match_phrase(content, "brown fox")
@@ -460,6 +475,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testSimpleWhereRuntimeMatchPhraseWithScore() {
+        assumeRuntimeMatchPhraseEnabled();
         // Runtime match_phrase does not contribute to the score, so matching rows keep a 0.0 score.
         var query = """
             FROM test METADATA _score
@@ -476,6 +492,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseRuntimeEvalWithOptionsThrowsError() {
+        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | EVAL new_content = to_text(concat(content, " extra"))
@@ -490,6 +507,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseRuntimeRowWithOptionsThrowsError() {
+        assumeRuntimeMatchPhraseEnabled();
         var query = """
             ROW content = to_text("a brown fox")
             | WHERE match_phrase(content, "brown fox", {"analyzer": "standard"})

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -323,33 +323,53 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseAfterMvExpand() {
+        // After MV_EXPAND on the searched field, the expanded attribute is no longer a direct index field, so
+        // runtime search takes over: the MV_EXPAND restriction is bypassed and the phrase is evaluated per row.
         var query = """
             FROM test
             | MV_EXPAND content
             | WHERE match_phrase(content, "brown fox")
+            | KEEP id
+            | SORT id
             """;
 
-        var error = expectThrows(VerificationException.class, () -> run(query));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after MV_EXPAND"));
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1), List.of(6)));
+        }
     }
 
     public void testMatchPhraseAfterMvExpandWithIntermediateCommands() {
-        var error = expectThrows(VerificationException.class, () -> run("""
+        var query = """
             FROM test
             | MV_EXPAND content
             | EVAL upper_content = to_upper(content)
             | WHERE match_phrase(content, "brown fox")
-            """));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after MV_EXPAND"));
+            | KEEP id
+            | SORT id
+            """;
 
-        error = expectThrows(VerificationException.class, () -> run("""
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1), List.of(6)));
+        }
+
+        query = """
             FROM test
             | MV_EXPAND content
             | SORT id
             | KEEP id, content
             | WHERE match_phrase(content, "brown fox")
-            """));
-        assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after MV_EXPAND"));
+            | KEEP id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1), List.of(6)));
+        }
     }
 
     public void testWhereFalseBeforeInlineStatsWithMatchPhrase() {
@@ -375,6 +395,110 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
 
         var error = expectThrows(VerificationException.class, () -> run(query));
         assertThat(error.getMessage(), containsString("[MatchPhrase] function cannot be used after INLINE"));
+    }
+
+    // ---- runtime match_phrase: searching text expressions that are not index-mapped fields ----
+
+    public void testSimpleWhereRuntimeMatchPhrase() {
+        var query = """
+            FROM test
+            | WHERE match_phrase(to_text(concat(content, " extra")), "brown fox")
+            | KEEP id
+            | SORT id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1), List.of(6)));
+        }
+    }
+
+    public void testRuntimeMatchPhraseOrderMatters() {
+        // Both tokens exist in ids 1 and 6, but never adjacent in this order, so a runtime phrase matches nothing.
+        var query = """
+            FROM test
+            | WHERE match_phrase(to_text(concat(content, " extra")), "fox brown")
+            | KEEP id
+            | SORT id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), Collections.emptyList());
+        }
+    }
+
+    public void testWhereRuntimeMatchPhraseEvalTextColumn() {
+        var query = """
+            FROM test
+            | EVAL text_content = content
+            | WHERE match_phrase(text_content, "brown fox")
+            | KEEP id
+            | SORT id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id"));
+            assertColumnTypes(resp.columns(), List.of("integer"));
+            assertValues(resp.values(), List.of(List.of(1), List.of(6)));
+        }
+    }
+
+    public void testWhereRuntimeMatchPhraseWithRow() {
+        var query = """
+            ROW content = to_text("a brown fox")
+            | WHERE match_phrase(content, "brown fox")
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("content"));
+            assertColumnTypes(resp.columns(), List.of("text"));
+            assertValues(resp.values(), List.of(List.of("a brown fox")));
+        }
+    }
+
+    public void testSimpleWhereRuntimeMatchPhraseWithScore() {
+        // Runtime match_phrase does not contribute to the score, so matching rows keep a 0.0 score.
+        var query = """
+            FROM test METADATA _score
+            | WHERE match_phrase(to_text(concat(content, " extra")), "brown fox")
+            | KEEP id, _score
+            | SORT id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_score"));
+            assertColumnTypes(resp.columns(), List.of("integer", "double"));
+            assertValues(resp.values(), List.of(List.of(1, 0.0), List.of(6, 0.0)));
+        }
+    }
+
+    public void testMatchPhraseRuntimeEvalWithOptionsThrowsError() {
+        var query = """
+            FROM test
+            | EVAL new_content = to_text(concat(content, " extra"))
+            | WHERE match_phrase(new_content, "brown fox", {"slop": 5})
+            | KEEP new_content
+            """;
+        var error = expectThrows(VerificationException.class, () -> run(query));
+        assertThat(
+            error.getMessage(),
+            containsString("Options are not supported for [MATCH_PHRASE] function call on non-index-mapped field [new_content]")
+        );
+    }
+
+    public void testMatchPhraseRuntimeRowWithOptionsThrowsError() {
+        var query = """
+            ROW content = to_text("a brown fox")
+            | WHERE match_phrase(content, "brown fox", {"analyzer": "standard"})
+            """;
+        var error = expectThrows(VerificationException.class, () -> run(query));
+        assertThat(
+            error.getMessage(),
+            containsString("Options are not supported for [MATCH_PHRASE] function call on non-index-mapped field [content]")
+        );
     }
 
     public void testMatchPhraseWithLookupJoin() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql.plugin;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhrase;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -34,7 +34,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
      * run are rejected by the verifier instead.
      */
     private static void assumeRuntimeMatchPhraseEnabled() {
-        assumeTrue("requires runtime match_phrase", EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled());
+        assumeTrue("requires runtime match_phrase", MatchPhrase.runtimeSearchEnabled());
     }
 
     public void testSimpleWhereMatchPhrase() {

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearchTextEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearchTextEvaluator.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 import java.io.IOException;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Set;
 import java.util.function.Function;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.BytesRef;
@@ -23,17 +22,17 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link Match}.
+ * {@link ExpressionEvaluator} implementation for {@link RuntimeSearch}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class MatchTextEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(MatchTextEvaluator.class);
+public final class RuntimeSearchTextEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RuntimeSearchTextEvaluator.class);
 
   private final Source source;
 
   private final ExpressionEvaluator fieldBlock;
 
-  private final Set<BytesRef> queryTerms;
+  private final RuntimeSearch.TokenStreamMatcher matcher;
 
   private final Analyzer analyzer;
 
@@ -43,11 +42,12 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public MatchTextEvaluator(Source source, ExpressionEvaluator fieldBlock, Set<BytesRef> queryTerms,
-      Analyzer analyzer, BytesRef scratch, DriverContext driverContext) {
+  public RuntimeSearchTextEvaluator(Source source, ExpressionEvaluator fieldBlock,
+      RuntimeSearch.TokenStreamMatcher matcher, Analyzer analyzer, BytesRef scratch,
+      DriverContext driverContext) {
     this.source = source;
     this.fieldBlock = fieldBlock;
-    this.queryTerms = queryTerms;
+    this.matcher = matcher;
     this.analyzer = analyzer;
     this.scratch = scratch;
     this.driverContext = driverContext;
@@ -71,7 +71,7 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
     try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
         try {
-          result.appendBoolean(Match.processText(p, fieldBlockBlock, this.queryTerms, this.analyzer, this.scratch));
+          result.appendBoolean(RuntimeSearch.processText(p, fieldBlockBlock, this.matcher, this.analyzer, this.scratch));
         } catch (IOException e) {
           warnings().registerException(e);
           result.appendNull();
@@ -83,7 +83,7 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "MatchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", queryTerms=" + queryTerms + ", analyzer=" + analyzer + "]";
+    return "RuntimeSearchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", matcher=" + matcher + ", analyzer=" + analyzer + "]";
   }
 
   @Override
@@ -103,29 +103,30 @@ public final class MatchTextEvaluator implements ExpressionEvaluator {
 
     private final ExpressionEvaluator.Factory fieldBlock;
 
-    private final Set<BytesRef> queryTerms;
+    private final RuntimeSearch.TokenStreamMatcher matcher;
 
     private final Analyzer analyzer;
 
     private final Function<DriverContext, BytesRef> scratch;
 
-    public Factory(Source source, ExpressionEvaluator.Factory fieldBlock, Set<BytesRef> queryTerms,
-        Analyzer analyzer, Function<DriverContext, BytesRef> scratch) {
+    public Factory(Source source, ExpressionEvaluator.Factory fieldBlock,
+        RuntimeSearch.TokenStreamMatcher matcher, Analyzer analyzer,
+        Function<DriverContext, BytesRef> scratch) {
       this.source = source;
       this.fieldBlock = fieldBlock;
-      this.queryTerms = queryTerms;
+      this.matcher = matcher;
       this.analyzer = analyzer;
       this.scratch = scratch;
     }
 
     @Override
-    public MatchTextEvaluator get(DriverContext context) {
-      return new MatchTextEvaluator(source, fieldBlock.get(context), queryTerms, analyzer, scratch.apply(context), context);
+    public RuntimeSearchTextEvaluator get(DriverContext context) {
+      return new RuntimeSearchTextEvaluator(source, fieldBlock.get(context), matcher, analyzer, scratch.apply(context), context);
     }
 
     @Override
     public String toString() {
-      return "MatchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", queryTerms=" + queryTerms + ", analyzer=" + analyzer + "]";
+      return "RuntimeSearchTextEvaluator[" + "fieldBlock=" + fieldBlock + ", matcher=" + matcher + ", analyzer=" + analyzer + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3123,16 +3123,6 @@ public class EsqlCapabilities {
         APPROXIMATION_FIX_MIN_SOURCE_ROW_COUNT,
 
         /**
-         * Match function and match operator support for runtime expressions, not just ES mapped fields.
-         */
-        MATCH_RUNTIME_SEARCH,
-
-        /**
-         * MATCH_PHRASE function support for runtime text expressions, not just ES mapped fields.
-         */
-        MATCH_PHRASE_RUNTIME_SEARCH(Build.current().isSnapshot()),
-
-        /**
          * Support for expressions (function calls, inline casts) on the LHS of the match operator (:).
          * Requires the grammar change introduced in the same release.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3128,6 +3128,11 @@ public class EsqlCapabilities {
         MATCH_RUNTIME_SEARCH,
 
         /**
+         * MATCH_PHRASE function support for runtime text expressions, not just ES mapped fields.
+         */
+        MATCH_PHRASE_RUNTIME_SEARCH(Build.current().isSnapshot()),
+
+        /**
          * Support for expressions (function calls, inline casts) on the LHS of the match operator (:).
          * Requires the grammar change introduced in the same release.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -1164,6 +1164,9 @@ public class EsqlFunctionRegistry {
             for (String sub : def.capabilities()) {
                 capabilities.add(name + "_" + sub, enabled);
             }
+            for (String sub : def.snapshotCapabilities()) {
+                capabilities.add(name + "_" + sub, enabled && Build.current().isSnapshot());
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionDefinition.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/FunctionDefinition.java
@@ -41,6 +41,7 @@ public class FunctionDefinition {
     private final BiConsumer<Source, List<Expression>> validate;
     private final FunctionBuilder builder;
     private final List<String> subCapabilities;
+    private final List<String> snapshotSubCapabilities;
 
     private FunctionDefinition(
         String name,
@@ -48,7 +49,8 @@ public class FunctionDefinition {
         Class<? extends Function> clazz,
         BiConsumer<Source, List<Expression>> validate,
         FunctionBuilder builder,
-        List<String> subCapabilities
+        List<String> subCapabilities,
+        List<String> snapshotSubCapabilities
     ) {
         this.name = name;
         this.aliases = aliases;
@@ -56,6 +58,7 @@ public class FunctionDefinition {
         this.validate = validate;
         this.builder = builder;
         this.subCapabilities = subCapabilities;
+        this.snapshotSubCapabilities = snapshotSubCapabilities;
     }
 
     public String name() {
@@ -86,6 +89,10 @@ public class FunctionDefinition {
         return subCapabilities;
     }
 
+    public List<String> snapshotCapabilities() {
+        return snapshotSubCapabilities;
+    }
+
     @Override
     public String toString() {
         return format(null, "{}({})", name, aliases.isEmpty() ? "" : aliases.size() == 1 ? aliases.get(0) : aliases);
@@ -99,6 +106,7 @@ public class FunctionDefinition {
         private BiConsumer<Source, List<Expression>> validate;
         private FunctionDefinition.FunctionBuilder builder;
         private List<String> capabilities = List.of();
+        private List<String> snapshotCapabilities = List.of();
 
         Builder(Class<T> function) {
             this.function = function;
@@ -121,10 +129,21 @@ public class FunctionDefinition {
         }
 
         /**
+         * Like {@link #capabilities}, but the resulting capability is only enabled in snapshot builds, even when
+         * the function itself is released. Use it for function features that are still under development: gate the
+         * new behavior on {@link org.elasticsearch.Build#isSnapshot()} and gate its tests on the capability. When
+         * the feature is released, move the name to {@link #capabilities} and remove the behavior gate.
+         */
+        public Builder<T> snapshotCapabilities(String... capabilities) {
+            this.snapshotCapabilities = List.of(capabilities);
+            return this;
+        }
+
+        /**
          * Build the {@link FunctionDefinition} with the given primary name and optional aliases.
          */
         public FunctionDefinition name(String name, String... aliases) {
-            return new FunctionDefinition(name, List.of(aliases), function, validate, builder, capabilities);
+            return new FunctionDefinition(name, List.of(aliases), function, validate, builder, capabilities, snapshotCapabilities);
         }
 
         /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -603,6 +603,13 @@ public abstract class FullTextFunction extends Function
         return new LuceneQueryScoreEvaluator.Factory(toShardConfigs(toScorer.shardContexts()));
     }
 
+    @Override
+    public boolean contributesToScore() {
+        // Runtime search is evaluated per row rather than through a Lucene query, and does not contribute to the
+        // score (yet).
+        return isRuntimeSearch() == false;
+    }
+
     private IndexedByShardId<ShardConfig> toShardConfigs(IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> contexts) {
         return contexts.map(sc -> new ShardConfig(sc.toQuery(evaluatorQueryBuilder()), sc.searcher()));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -7,10 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,7 +20,6 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -62,7 +57,6 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -147,7 +141,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
         entry(PREFIX_LENGTH_FIELD.getPreferredName(), INTEGER),
         entry(ZERO_TERMS_QUERY_FIELD.getPreferredName(), KEYWORD)
     );
-    private static final String CONTENT_FIELD = "content_field";
 
     @FunctionInfo(
         returnType = "boolean",
@@ -489,20 +482,7 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
 
         // Text fields keep analyzer-based matching; every other type compares the query value against the field block directly.
         if (field.dataType() == TEXT) {
-            // TODO: use the analyzer specified in the options, for now we use the standard analyzer.
-            Analyzer analyzer = new StandardAnalyzer();
-            Set<BytesRef> queryTerms;
-            try {
-                queryTerms = queryTerms(analyzer);
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to tokenize query string: " + e.getMessage(), e);
-            }
-            // TODO: use the `zero_terms_query` option, for now we use `none`.
-            if (queryTerms.isEmpty()) {
-                return ConstantEvaluators.CONSTANT_FALSE_FACTORY;
-            }
-
-            return new MatchTextEvaluator.Factory(source(), toEvaluator.apply(field()), queryTerms, analyzer, context -> new BytesRef());
+            return runtimeTextEvaluator(toEvaluator, terms -> new RuntimeSearch.AnyTermMatcher(Set.copyOf(terms)));
         }
 
         Object queryValue = queryAsRuntimeSearchValue(field.dataType(), query().dataType(), Foldables.queryAsObject(query(), sourceText()));
@@ -578,59 +558,6 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
         };
     }
 
-    private Set<BytesRef> queryTerms(Analyzer analyzer) throws IOException {
-        Set<BytesRef> queryTerms = new HashSet<>();
-
-        try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, queryAsObject().toString())) {
-            stream.reset();
-            TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
-            while (stream.incrementToken()) {
-                queryTerms.add(BytesRef.deepCopyOf(term.getBytesRef()));
-            }
-            stream.end();
-        }
-        return queryTerms;
-    }
-
-    @Evaluator(extraName = "Text", warnExceptions = { IOException.class }, allNullsIsNull = false)
-    static boolean processText(
-        @Position int position,
-        BytesRefBlock fieldBlock,
-        @Fixed Set<BytesRef> queryTerms,
-        @Fixed Analyzer analyzer,
-        @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRef scratch
-    ) throws IOException {
-        if (fieldBlock == null) {
-            return false;
-        }
-
-        final var valueCount = fieldBlock.getValueCount(position);
-        final var startIndex = fieldBlock.getFirstValueIndex(position);
-
-        for (int valueIndex = startIndex; valueIndex < startIndex + valueCount; valueIndex++) {
-            boolean foundMatch = false;
-            scratch = fieldBlock.getBytesRef(valueIndex, scratch);
-            // Because we use the standard analyzer and options cannot be specified, we can look for matches in the analyzed token stream.
-            // Once we accept options, we might need to take a different execution path and use a Lucene MemoryIndex.
-            try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, scratch.utf8ToString())) {
-                stream.reset();
-                TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
-                // TODO: Use the operator specified in the query options. For now, we use OR, meaning we stop as soon as we find a match.
-                while (stream.incrementToken()) {
-                    if (queryTerms.contains(term.getBytesRef())) {
-                        foundMatch = true;
-                        break;
-                    }
-                }
-                stream.end();
-            }
-            if (foundMatch) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     @Evaluator(extraName = "BytesRef", allNullsIsNull = false)
     static boolean processBytesRef(
         @Position int position,
@@ -676,14 +603,5 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
             return false;
         }
         return fieldBlock.hasValue(position, query);
-    }
-
-    @Override
-    public boolean contributesToScore() {
-        if (isRuntimeSearch()) {
-            return false;
-        }
-
-        return super.contributesToScore();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
@@ -10,7 +10,11 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.common.Failure;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
@@ -30,6 +34,7 @@ import org.elasticsearch.xpack.esql.expression.function.Options;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.querydsl.query.MatchPhraseQuery;
 
@@ -236,4 +241,47 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
         return new MatchPhraseQuery(source(), fieldName, queryAsObject(), matchPhraseQueryOptions());
     }
 
+    @Override
+    protected boolean isRuntimeSearch() {
+        // Runtime match_phrase is under development (snapshot builds only) and currently supports only text
+        // expressions.
+        // TODO keyword expressions still require an index-mapped field.
+        return EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()
+            && fieldAsFieldAttribute() == null
+            && (field.dataType() == TEXT || field.dataType() == NULL);
+    }
+
+    @Override
+    public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        if (fieldAsFieldAttribute() == null) {
+            return Translatable.NO;
+        }
+        return super.translatable(pushdownPredicates);
+    }
+
+    @Override
+    protected void fieldVerifier(LogicalPlan plan, FullTextFunction function, Expression field, Failures failures) {
+        super.fieldVerifier(plan, function, field, failures);
+        if (isRuntimeSearch() == false) {
+            return;
+        }
+        if (options() != null) {
+            failures.add(
+                Failure.fail(
+                    field,
+                    "Options are not supported for [MATCH_PHRASE] function call on non-index-mapped field [" + field.sourceText() + "]"
+                )
+            );
+        }
+    }
+
+    @Override
+    public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        if (false == isRuntimeSearch()) {
+            // we push down match_phrase to the shards as a Lucene query.
+            return super.toEvaluator(toEvaluator);
+        }
+
+        return runtimeTextEvaluator(toEvaluator, RuntimeSearch.PhraseMatcher::new);
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.common.Failure;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
@@ -68,6 +68,8 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
     );
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(MatchPhrase.class)
         .ternary(MatchPhrase::new)
+        // in-development runtime search support; move to capabilities(...) when released
+        .snapshotCapabilities("runtime_filter")
         .name("match_phrase");
     public static final Set<DataType> FIELD_DATA_TYPES = Set.of(KEYWORD, TEXT, NULL);
     public static final Set<DataType> QUERY_DATA_TYPES = Set.of(KEYWORD, TEXT);
@@ -241,14 +243,20 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
         return new MatchPhraseQuery(source(), fieldName, queryAsObject(), matchPhraseQueryOptions());
     }
 
+    /**
+     * Runtime search on non-index-mapped expressions is under development and enabled in snapshot builds only,
+     * advertised through the snapshot-only {@code fn_match_phrase_runtime_filter} function capability declared on
+     * {@link #DEFINITION}.
+     */
+    public static boolean runtimeSearchEnabled() {
+        return Build.current().isSnapshot();
+    }
+
     @Override
     protected boolean isRuntimeSearch() {
-        // Runtime match_phrase is under development (snapshot builds only) and currently supports only text
-        // expressions.
+        // Runtime match_phrase currently supports only text expressions.
         // TODO keyword expressions still require an index-mapped field.
-        return EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()
-            && fieldAsFieldAttribute() == null
-            && (field.dataType() == TEXT || field.dataType() == NULL);
+        return runtimeSearchEnabled() && fieldAsFieldAttribute() == null && (field.dataType() == TEXT || field.dataType() == NULL);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearch.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.ann.Position;
+import org.elasticsearch.compute.data.BytesRefBlock;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.compute.ann.Fixed.Scope.THREAD_LOCAL;
+
+/**
+ * Runtime (per-row) evaluation of full-text functions on {@code text} expressions that are not index-mapped fields,
+ * where there is no Lucene index to query. Instead, each value is analyzed on the fly and the resulting token stream
+ * is matched directly against the analyzed query terms.
+ * <p>
+ * The block-level walking (multivalue any-value semantics, null handling, per-thread scratch) is shared here through
+ * a single {@code Text} evaluator; what differs between functions is only how a single value's token stream is
+ * matched, expressed as a {@link TokenStreamMatcher} ({@link AnyTermMatcher} for {@code match},
+ * {@link PhraseMatcher} for {@code match_phrase}).
+ */
+public final class RuntimeSearch {
+
+    private static final String CONTENT_FIELD = "content_field";
+
+    private RuntimeSearch() {}
+
+    /**
+     * Decides whether a single value's token stream matches the query. The stream is already reset; implementations
+     * consume it (typically through {@link TermToBytesRefAttribute}) and must not close it.
+     */
+    public interface TokenStreamMatcher {
+        boolean matches(TokenStream stream) throws IOException;
+    }
+
+    /**
+     * Matches when any analyzed token equals any of the query terms — the OR semantics of runtime {@code match}.
+     */
+    public record AnyTermMatcher(Set<BytesRef> queryTerms) implements TokenStreamMatcher {
+        @Override
+        public boolean matches(TokenStream stream) throws IOException {
+            TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+            // TODO: Use the operator specified in the query options. For now, we use OR, meaning we stop as soon as
+            // we find a match.
+            while (stream.incrementToken()) {
+                if (queryTerms.contains(term.getBytesRef())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Matches when all query terms appear in order at consecutive token positions (slop 0) — the semantics of
+     * runtime {@code match_phrase}.
+     */
+    public record PhraseMatcher(List<BytesRef> queryTerms) implements TokenStreamMatcher {
+        @Override
+        public boolean matches(TokenStream stream) throws IOException {
+            TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+            PositionIncrementAttribute positionIncrement = stream.addAttribute(PositionIncrementAttribute.class);
+            // matched[k] being true means the first k + 1 query terms matched a run of tokens at consecutive
+            // positions, ending at the previous token (prev) or at the current one (curr).
+            boolean[] prev = new boolean[queryTerms.size()];
+            boolean[] curr = new boolean[queryTerms.size()];
+            while (stream.incrementToken()) {
+                if (positionIncrement.getPositionIncrement() != 1) {
+                    // A position gap (or a stacked token) breaks adjacency: with slop 0 a phrase only matches
+                    // tokens at consecutive positions.
+                    Arrays.fill(prev, false);
+                }
+                BytesRef token = term.getBytesRef();
+                for (int k = queryTerms.size() - 1; k > 0; k--) {
+                    curr[k] = prev[k - 1] && token.equals(queryTerms.get(k));
+                }
+                curr[0] = token.equals(queryTerms.get(0));
+                if (curr[queryTerms.size() - 1]) {
+                    return true;
+                }
+                boolean[] swap = prev;
+                prev = curr;
+                curr = swap;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Analyzes the given query string into the ordered list of its terms. With the standard analyzer (the only one
+     * supported for now) tokens are emitted at consecutive positions, so the order of the list is enough to describe
+     * a phrase; query-side position gaps cannot happen.
+     */
+    static List<BytesRef> analyzeTerms(Analyzer analyzer, String query) throws IOException {
+        List<BytesRef> terms = new ArrayList<>();
+
+        try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, query)) {
+            stream.reset();
+            TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+            while (stream.incrementToken()) {
+                terms.add(BytesRef.deepCopyOf(term.getBytesRef()));
+            }
+            stream.end();
+        }
+        return terms;
+    }
+
+    @Evaluator(extraName = "Text", warnExceptions = { IOException.class }, allNullsIsNull = false)
+    static boolean processText(
+        @Position int position,
+        BytesRefBlock fieldBlock,
+        @Fixed TokenStreamMatcher matcher,
+        @Fixed Analyzer analyzer,
+        @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRef scratch
+    ) throws IOException {
+        if (fieldBlock == null) {
+            return false;
+        }
+
+        final var valueCount = fieldBlock.getValueCount(position);
+        final var startIndex = fieldBlock.getFirstValueIndex(position);
+
+        for (int valueIndex = startIndex; valueIndex < startIndex + valueCount; valueIndex++) {
+            boolean foundMatch;
+            scratch = fieldBlock.getBytesRef(valueIndex, scratch);
+            // Because we use the standard analyzer and options cannot be specified, the analyzed token stream can be
+            // matched directly. Once we accept options (analyzer, slop), we might need a different execution path,
+            // e.g. a Lucene MemoryIndex.
+            try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, scratch.utf8ToString())) {
+                stream.reset();
+                foundMatch = matcher.matches(stream);
+                stream.end();
+            }
+            if (foundMatch) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearch.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.xpack.esql.core.util.ByteMatchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -88,9 +89,9 @@ public final class RuntimeSearch {
                 }
                 BytesRef token = term.getBytesRef();
                 for (int k = queryTerms.size() - 1; k > 0; k--) {
-                    curr[k] = prev[k - 1] && token.equals(queryTerms.get(k));
+                    curr[k] = prev[k - 1] && ByteMatchers.equals(token, queryTerms.get(k));
                 }
-                curr[0] = token.equals(queryTerms.get(0));
+                curr[0] = ByteMatchers.equals(token, queryTerms.get(0));
                 if (curr[queryTerms.size() - 1]) {
                     return true;
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
@@ -7,7 +7,11 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.PostOptimizationPlanVerificationAware;
@@ -25,12 +29,14 @@ import org.elasticsearch.xpack.esql.expression.function.Options;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNotNull;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
@@ -153,6 +159,38 @@ public abstract class SingleFieldFullTextFunction extends FullTextFunction
      */
     protected FieldAttribute fieldAsFieldAttribute() {
         return fieldAsFieldAttribute(field);
+    }
+
+    /**
+     * Builds the runtime-search evaluator for a {@code text} field: the query string is analyzed once into its
+     * terms, and each row's value is then analyzed and matched by the {@link RuntimeSearch.TokenStreamMatcher} the
+     * given function builds from those terms. How the terms must match (any term, consecutive phrase, ...) is the
+     * only thing that differs between the full-text functions supporting runtime search.
+     */
+    protected ExpressionEvaluator.Factory runtimeTextEvaluator(
+        ToEvaluator toEvaluator,
+        Function<List<BytesRef>, RuntimeSearch.TokenStreamMatcher> matcherBuilder
+    ) {
+        // TODO: use the analyzer specified in the options, for now we use the standard analyzer.
+        Analyzer analyzer = new StandardAnalyzer();
+        List<BytesRef> queryTerms;
+        try {
+            queryTerms = RuntimeSearch.analyzeTerms(analyzer, queryAsObject().toString());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to tokenize query string: " + e.getMessage(), e);
+        }
+        // TODO: use the `zero_terms_query` option, for now we use `none`.
+        if (queryTerms.isEmpty()) {
+            return ConstantEvaluators.CONSTANT_FALSE_FACTORY;
+        }
+
+        return new RuntimeSearchTextEvaluator.Factory(
+            source(),
+            toEvaluator.apply(field()),
+            matcherBuilder.apply(queryTerms),
+            analyzer,
+            context -> new BytesRef()
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2378,10 +2378,12 @@ public class VerifierTests extends ESTestCase {
      * adds for fields sourced from an {@code ExternalRelation}. Regression guard for over-broadening that clause.
      */
     public void testFullTextFunctionsRejectEvalColumnsMessageOmitsFederatedClauseOnRealIndex() throws Exception {
+        // Uses KNN because it is the only field-based full-text function left without runtime search support; if
+        // that lands too, this guard needs another way to trigger the "not a field from an index mapping" failure.
         fullText().error(
-            "from test | eval name = title | where match_phrase(name, \"Meditation\")",
+            "from test | eval v = vector | where knn(v, [1, 2, 3])",
             allOf(
-                containsString("[MatchPhrase] function cannot operate on [name], which is not a field from an index mapping"),
+                containsString("[KNN] function cannot operate on [v], which is not a field from an index mapping"),
                 not(containsString("federated"))
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1955,7 +1955,7 @@ public class VerifierTests extends ESTestCase {
             "MatchPhrase",
             "function",
             "match_phrase(title, \"Meditation\")",
-            EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()
+            MatchPhrase.runtimeSearchEnabled()
         );
 
         checkFieldBasedFunctionNotAllowedAfterCommands("KNN", "function", "knn(vector, [1, 2, 3])", false);
@@ -2370,7 +2370,7 @@ public class VerifierTests extends ESTestCase {
         fullText().query("from test | eval name = title | where match(name, \"Meditation\")");
         fullText().query("from test | eval name = title | where name : \"Meditation\"");
         // match_phrase supports runtime search (snapshot-only for now) on text EVAL columns
-        if (EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()) {
+        if (MatchPhrase.runtimeSearchEnabled()) {
             fullText().query("from test | eval name = title | where match_phrase(name, \"Meditation\")");
         } else {
             fullText().error(
@@ -2406,7 +2406,7 @@ public class VerifierTests extends ESTestCase {
         fullText().query("from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match(y, \"Meditation\")");
 
         // MATCH_PHRASE supports runtime search (snapshot-only for now) on renamed text expressions
-        if (EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()) {
+        if (MatchPhrase.runtimeSearchEnabled()) {
             fullText().query("from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")");
         } else {
             fullText().error(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1948,16 +1948,17 @@ public class VerifierTests extends ESTestCase {
 
         checkFieldBasedFunctionNotAllowedAfterCommands(":", "operator", "title : \"Meditation\"", true);
 
-        // MATCH_PHRASE supports runtime search on text expressions only; substring/concat produce keyword,
-        // so these non-indexed columns are still rejected until keyword runtime support lands.
+        // MATCH_PHRASE supports runtime search (snapshot-only for now) on text expressions only; substring/concat
+        // produce keyword, so these non-indexed columns are still rejected until keyword runtime support lands.
         checkFieldBasedWithNonIndexedColumn("MatchPhrase", "match_phrase(text, \"cat\")", "function");
-        checkFieldBasedFunctionNotAllowedAfterCommands("MatchPhrase", "function", "match_phrase(title, \"Meditation\")", true);
+        checkFieldBasedFunctionNotAllowedAfterCommands(
+            "MatchPhrase",
+            "function",
+            "match_phrase(title, \"Meditation\")",
+            EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()
+        );
 
         checkFieldBasedFunctionNotAllowedAfterCommands("KNN", "function", "knn(vector, [1, 2, 3])", false);
-    }
-
-    private void checkFieldBasedFunctionNotAllowedAfterCommands(String functionName, String functionType, String functionInvocation) {
-        checkFieldBasedFunctionNotAllowedAfterCommands(functionName, functionType, functionInvocation, false);
     }
 
     private void checkFieldBasedFunctionNotAllowedAfterCommands(
@@ -2368,8 +2369,15 @@ public class VerifierTests extends ESTestCase {
         // match and : support runtime search and can operate on EVAL columns
         fullText().query("from test | eval name = title | where match(name, \"Meditation\")");
         fullText().query("from test | eval name = title | where name : \"Meditation\"");
-        // match_phrase supports runtime search on text EVAL columns
-        fullText().query("from test | eval name = title | where match_phrase(name, \"Meditation\")");
+        // match_phrase supports runtime search (snapshot-only for now) on text EVAL columns
+        if (EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()) {
+            fullText().query("from test | eval name = title | where match_phrase(name, \"Meditation\")");
+        } else {
+            fullText().error(
+                "from test | eval name = title | where match_phrase(name, \"Meditation\")",
+                containsString("[MatchPhrase] function cannot operate on [name], which is not a field from an index mapping")
+            );
+        }
     }
 
     /**
@@ -2397,8 +2405,15 @@ public class VerifierTests extends ESTestCase {
         fullText().query("from test | dissect title \"%{extracted}\" | rename extracted as x | where match(x, \"Meditation\")");
         fullText().query("from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match(y, \"Meditation\")");
 
-        // MATCH_PHRASE supports runtime search on renamed text expressions
-        fullText().query("from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")");
+        // MATCH_PHRASE supports runtime search (snapshot-only for now) on renamed text expressions
+        if (EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled()) {
+            fullText().query("from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")");
+        } else {
+            fullText().error(
+                "from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")",
+                containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
+            );
+        }
 
         // MATCH_PHRASE runtime search does not support keyword expressions yet (concat, grok, dissect and
         // substring all produce keyword), so these still require a field from an index mapping

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1948,8 +1948,10 @@ public class VerifierTests extends ESTestCase {
 
         checkFieldBasedFunctionNotAllowedAfterCommands(":", "operator", "title : \"Meditation\"", true);
 
+        // MATCH_PHRASE supports runtime search on text expressions only; substring/concat produce keyword,
+        // so these non-indexed columns are still rejected until keyword runtime support lands.
         checkFieldBasedWithNonIndexedColumn("MatchPhrase", "match_phrase(text, \"cat\")", "function");
-        checkFieldBasedFunctionNotAllowedAfterCommands("MatchPhrase", "function", "match_phrase(title, \"Meditation\")", false);
+        checkFieldBasedFunctionNotAllowedAfterCommands("MatchPhrase", "function", "match_phrase(title, \"Meditation\")", true);
 
         checkFieldBasedFunctionNotAllowedAfterCommands("KNN", "function", "knn(vector, [1, 2, 3])", false);
     }
@@ -2366,11 +2368,8 @@ public class VerifierTests extends ESTestCase {
         // match and : support runtime search and can operate on EVAL columns
         fullText().query("from test | eval name = title | where match(name, \"Meditation\")");
         fullText().query("from test | eval name = title | where name : \"Meditation\"");
-        // match_phrase still requires an index field
-        fullText().error(
-            "from test | eval name = title | where match_phrase(name, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [name], which is not a field from an index mapping")
-        );
+        // match_phrase supports runtime search on text EVAL columns
+        fullText().query("from test | eval name = title | where match_phrase(name, \"Meditation\")");
     }
 
     /**
@@ -2396,14 +2395,14 @@ public class VerifierTests extends ESTestCase {
         fullText().query("from test | dissect title \"%{extracted}\" | rename extracted as x | where match(x, \"Meditation\")");
         fullText().query("from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match(y, \"Meditation\")");
 
-        // MATCH_PHRASE still requires an argument that is a field from an index mapping
+        // MATCH_PHRASE supports runtime search on renamed text expressions
+        fullText().query("from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")");
+
+        // MATCH_PHRASE runtime search does not support keyword expressions yet (concat, grok, dissect and
+        // substring all produce keyword), so these still require a field from an index mapping
         fullText().error(
             "from test | eval text = concat(title, body) | rename text as content | where match_phrase(content, \"Meditation\")",
             containsString("[MatchPhrase] function cannot operate on [content], which is not a field from an index mapping")
-        );
-        fullText().error(
-            "from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")",
-            containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
         );
         fullText().error(
             "from test | grok body \"%{WORD:extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/AbstractRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/AbstractRuntimeSearchEvaluatorTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.junit.After;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Shared harness for end-to-end execution tests of runtime full-text functions, where the field is not a
+ * Lucene-mapped index field. Subclasses build the actual runtime evaluators for their function and run them over
+ * real {@link Block}s built from a breaking block factory, so {@link #allMemoryReleased()} verifies nothing leaks.
+ */
+public abstract class AbstractRuntimeSearchEvaluatorTests extends ESTestCase {
+
+    private final List<CircuitBreaker> breakers = Collections.synchronizedList(new ArrayList<>());
+
+    @After
+    public void allMemoryReleased() {
+        for (CircuitBreaker breaker : breakers) {
+            assertThat(breaker.getUsed(), equalTo(0L));
+        }
+    }
+
+    /** A field evaluator that simply hands back the block at channel 0 of the page. */
+    private static final ExpressionEvaluator.Factory FIELD_AT_0 = context -> new ExpressionEvaluator() {
+        @Override
+        public Block eval(Page page) {
+            Block block = page.getBlock(0);
+            block.incRef();
+            return block;
+        }
+
+        @Override
+        public long baseRamBytesUsed() {
+            return 0;
+        }
+
+        @Override
+        public void close() {}
+    };
+
+    protected static EvaluatorMapper.ToEvaluator toEvaluator() {
+        return new EvaluatorMapper.ToEvaluator() {
+            @Override
+            public ExpressionEvaluator.Factory apply(Expression expression) {
+                return FIELD_AT_0;
+            }
+
+            @Override
+            public FoldContext foldCtx() {
+                return FoldContext.small();
+            }
+        };
+    }
+
+    protected DriverContext driverContext() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        breakers.add(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST));
+        return new DriverContext(bigArrays, BlockFactory.builder(bigArrays).build(), null);
+    }
+
+    /**
+     * Builds the runtime evaluator for the given full-text function and runs it over a single field block, returning
+     * the per-position boolean results ({@code null} only if a position could not be evaluated).
+     */
+    protected Boolean[] evaluate(FullTextFunction function, Function<BlockFactory, Block> fieldBuilder) {
+        DriverContext context = driverContext();
+        Block fieldBlock = fieldBuilder.apply(context.blockFactory());
+        ExpressionEvaluator.Factory factory = function.toEvaluator(toEvaluator());
+        try (ExpressionEvaluator evaluator = factory.get(context)) {
+            Page page = new Page(fieldBlock);
+            try (BooleanBlock result = (BooleanBlock) evaluator.eval(page)) {
+                Boolean[] out = new Boolean[result.getPositionCount()];
+                for (int p = 0; p < out.length; p++) {
+                    out[p] = result.isNull(p) ? null : result.getBoolean(result.getFirstValueIndex(p));
+                }
+                return out;
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    protected static Block bytesRefBlock(BlockFactory factory, Consumer<BytesRefBlock.Builder> build) {
+        try (BytesRefBlock.Builder builder = factory.newBytesRefBlockBuilder(4)) {
+            build.accept(builder);
+            return builder.build();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.expression.ConstantEvaluators;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * End-to-end execution tests for runtime {@code match_phrase}, where the field is not a Lucene-mapped index field.
+ * Unlike {@link MatchPhraseTests}, which only checks type resolution and serialization, this builds the actual
+ * runtime evaluators and runs them over real {@link Block}s.
+ * <p>
+ * This first chunk of runtime {@code match_phrase} only supports {@code text} expressions (the {@code to_text(...)}
+ * case). Unlike runtime {@code match}, which succeeds when <em>any</em> analyzed query token appears in the value,
+ * a phrase only matches when all query tokens appear <em>in order and in consecutive positions</em> (slop 0).
+ * Multivalue (any-value match) and null/missing positions are exercised too.
+ */
+public class MatchPhraseRuntimeSearchEvaluatorTests extends AbstractRuntimeSearchEvaluatorTests {
+
+    private static MatchPhrase runtimeMatchPhrase(String queryValue) {
+        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "field", TEXT);
+        Literal query = new Literal(Source.EMPTY, new BytesRef(queryValue), KEYWORD);
+        MatchPhrase matchPhrase = new MatchPhrase(Source.EMPTY, field, query, null);
+        assertTrue("expected a runtime search, not a pushed-down query", matchPhrase.isRuntimeSearch());
+        return matchPhrase;
+    }
+
+    private Boolean[] evaluatePhrase(String query, String... values) {
+        return evaluate(runtimeMatchPhrase(query), factory -> bytesRefBlock(factory, builder -> {
+            for (String value : values) {
+                builder.appendBytesRef(new BytesRef(value));
+            }
+        }));
+    }
+
+    public void testPhraseMatchesConsecutiveTokens() {
+        Boolean[] result = evaluatePhrase(
+            "brown fox",
+            "This is a brown fox",
+            "This is a brown dog",
+            "The quick brown fox jumps over the lazy dog"
+        );
+        assertArrayEquals(new Boolean[] { true, false, true }, result);
+    }
+
+    public void testPhraseOrderMatters() {
+        // Unlike runtime match, both tokens being present is not enough: they must appear in query order.
+        Boolean[] result = evaluatePhrase("fox brown", "This is a brown fox", "fox is brown");
+        assertArrayEquals(new Boolean[] { false, false }, result);
+    }
+
+    public void testPhraseRequiresAdjacentPositions() {
+        // Slop is 0: intervening tokens break the phrase.
+        Boolean[] result = evaluatePhrase("brown fox", "brown quick fox", "brown fox");
+        assertArrayEquals(new Boolean[] { false, true }, result);
+    }
+
+    public void testPhraseIsAnalyzed() {
+        // The standard analyzer lowercases and strips punctuation, keeping positions consecutive.
+        Boolean[] result = evaluatePhrase("brown fox", "a Brown FOX!", "One brown, fox again");
+        assertArrayEquals(new Boolean[] { true, true }, result);
+    }
+
+    public void testSingleTermPhrase() {
+        // A single-term phrase degrades to simple (analyzed) term presence.
+        Boolean[] result = evaluatePhrase("fox", "This is a brown fox", "The cat sat on the mat");
+        assertArrayEquals(new Boolean[] { true, false }, result);
+    }
+
+    public void testLongerPhrase() {
+        Boolean[] result = evaluatePhrase(
+            "quick brown fox jumps",
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox sleeps"
+        );
+        assertArrayEquals(new Boolean[] { true, false }, result);
+    }
+
+    public void testPhraseWithRepeatedTokens() {
+        Boolean[] result = evaluatePhrase("dog dog", "dog dog", "dog brown dog", "dog");
+        assertArrayEquals(new Boolean[] { true, false, false }, result);
+    }
+
+    public void testPhraseMatchesAtValueBoundaries() {
+        // Phrase at the very start and very end of the value.
+        Boolean[] result = evaluatePhrase("brown fox", "brown fox runs", "he saw a brown fox");
+        assertArrayEquals(new Boolean[] { true, true }, result);
+    }
+
+    public void testMultiValueAndNull() {
+        // Matches if any single value in the position matches; the phrase cannot span values; nulls never match.
+        Boolean[] result = evaluate(runtimeMatchPhrase("brown fox"), factory -> bytesRefBlock(factory, builder -> {
+            builder.beginPositionEntry();
+            builder.appendBytesRef(new BytesRef("white cat"));
+            builder.appendBytesRef(new BytesRef("a brown fox"));
+            builder.endPositionEntry();
+            builder.beginPositionEntry();
+            builder.appendBytesRef(new BytesRef("this is brown"));
+            builder.appendBytesRef(new BytesRef("fox and more"));
+            builder.endPositionEntry();
+            builder.appendNull();
+        }));
+        assertArrayEquals(new Boolean[] { true, false, false }, result);
+    }
+
+    public void testValuesThatAnalyzeToZeroTerms() {
+        Boolean[] result = evaluatePhrase("brown fox", "! !", "");
+        assertArrayEquals(new Boolean[] { false, false }, result);
+    }
+
+    public void testQueryWithZeroTermsUsesConstantBlock() {
+        // The default zero_terms_query is "none", so a query that analyzes to no tokens matches nothing.
+        MatchPhrase matchPhrase = runtimeMatchPhrase("! ! !");
+        assertThat(matchPhrase.toEvaluator(toEvaluator()), instanceOf(ConstantEvaluators.CONSTANT_FALSE_FACTORY.getClass()));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
@@ -10,9 +10,11 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.junit.Before;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
@@ -29,6 +31,12 @@ import static org.hamcrest.Matchers.instanceOf;
  * Multivalue (any-value match) and null/missing positions are exercised too.
  */
 public class MatchPhraseRuntimeSearchEvaluatorTests extends AbstractRuntimeSearchEvaluatorTests {
+
+    @Before
+    public void assumeRuntimeMatchPhraseEnabled() {
+        // Runtime match_phrase is gated behind a snapshot-only capability; there is nothing to test in release builds.
+        assumeTrue("requires runtime match_phrase", EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled());
+    }
 
     private static MatchPhrase runtimeMatchPhrase(String queryValue) {
         ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "field", TEXT);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.function.fulltext;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -35,7 +34,7 @@ public class MatchPhraseRuntimeSearchEvaluatorTests extends AbstractRuntimeSearc
     @Before
     public void assumeRuntimeMatchPhraseEnabled() {
         // Runtime match_phrase is gated behind a snapshot-only capability; there is nothing to test in release builds.
-        assumeTrue("requires runtime match_phrase", EsqlCapabilities.Cap.MATCH_PHRASE_RUNTIME_SEARCH.isEnabled());
+        assumeTrue("requires runtime match_phrase", MatchPhrase.runtimeSearchEnabled());
     }
 
     private static MatchPhrase runtimeMatchPhrase(String queryValue) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchRuntimeSearchEvaluatorTests.java
@@ -8,34 +8,16 @@
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.MockBigArrays;
-import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
-import org.junit.After;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
@@ -43,7 +25,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 /**
@@ -55,54 +36,7 @@ import static org.hamcrest.Matchers.instanceOf;
  * {@code to_text(...)} case), and exact value matching on every other type. Multivalue (any-value match), null/missing
  * positions, and the thread-safety of the shared per-thread scratch {@link BytesRef} are exercised too.
  */
-public class MatchRuntimeSearchEvaluatorTests extends ESTestCase {
-
-    private final List<CircuitBreaker> breakers = Collections.synchronizedList(new ArrayList<>());
-
-    @After
-    public void allMemoryReleased() {
-        for (CircuitBreaker breaker : breakers) {
-            assertThat(breaker.getUsed(), equalTo(0L));
-        }
-    }
-
-    /** A field evaluator that simply hands back the block at channel 0 of the page. */
-    private static final ExpressionEvaluator.Factory FIELD_AT_0 = context -> new ExpressionEvaluator() {
-        @Override
-        public Block eval(Page page) {
-            Block block = page.getBlock(0);
-            block.incRef();
-            return block;
-        }
-
-        @Override
-        public long baseRamBytesUsed() {
-            return 0;
-        }
-
-        @Override
-        public void close() {}
-    };
-
-    private static EvaluatorMapper.ToEvaluator toEvaluator() {
-        return new EvaluatorMapper.ToEvaluator() {
-            @Override
-            public ExpressionEvaluator.Factory apply(Expression expression) {
-                return FIELD_AT_0;
-            }
-
-            @Override
-            public FoldContext foldCtx() {
-                return FoldContext.small();
-            }
-        };
-    }
-
-    private DriverContext driverContext() {
-        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
-        breakers.add(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST));
-        return new DriverContext(bigArrays, BlockFactory.builder(bigArrays).build(), null);
-    }
+public class MatchRuntimeSearchEvaluatorTests extends AbstractRuntimeSearchEvaluatorTests {
 
     private static Match runtimeMatch(DataType fieldType, Object queryValue, DataType queryType) {
         ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "field", fieldType);
@@ -110,36 +44,6 @@ public class MatchRuntimeSearchEvaluatorTests extends ESTestCase {
         Match match = new Match(Source.EMPTY, field, query, null);
         assertTrue("expected a runtime search, not a pushed-down query", match.isRuntimeSearch());
         return match;
-    }
-
-    /**
-     * Builds the runtime evaluator for {@code match} and runs it over a single field block (built from the breaking
-     * block factory so {@link #allMemoryReleased()} verifies nothing leaks), returning the per-position boolean
-     * results ({@code null} only if a position could not be evaluated, which never happens for these inputs).
-     */
-    private Boolean[] evaluate(Match match, Function<BlockFactory, Block> fieldBuilder) {
-        DriverContext context = driverContext();
-        Block fieldBlock = fieldBuilder.apply(context.blockFactory());
-        ExpressionEvaluator.Factory factory = match.toEvaluator(toEvaluator());
-        try (ExpressionEvaluator evaluator = factory.get(context)) {
-            Page page = new Page(fieldBlock);
-            try (BooleanBlock result = (BooleanBlock) evaluator.eval(page)) {
-                Boolean[] out = new Boolean[result.getPositionCount()];
-                for (int p = 0; p < out.length; p++) {
-                    out[p] = result.isNull(p) ? null : result.getBoolean(result.getFirstValueIndex(p));
-                }
-                return out;
-            } finally {
-                page.releaseBlocks();
-            }
-        }
-    }
-
-    private static Block bytesRefBlock(BlockFactory factory, Consumer<BytesRefBlock.Builder> build) {
-        try (BytesRefBlock.Builder builder = factory.newBytesRefBlockBuilder(4)) {
-            build.accept(builder);
-            return builder.build();
-        }
     }
 
     // ---- text: analyzed full-text matching (the to_text case) ----


### PR DESCRIPTION
Add support for `match_phrase` on runtime expressions.  The phrase is evaluated per row by analyzing the value and requiring all query terms to appear in order at consecutive token positions (slop 0, standard analyzer, no options, no score contribution).  These limitations will be addressed in folow-up work.
