### PR TITLE
Refactor WatcherService lifecycle transitions

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -540,7 +540,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
 
         final WatcherLifeCycleService watcherLifeCycleService = new WatcherLifeCycleService(clusterService, watcherService);
 
-        listener = new WatcherIndexingListener(watchParser, getClock(), watcherService, watcherLifeCycleService.getState());
+        listener = new WatcherIndexingListener(watchParser, getClock(), watcherService, watcherService::getState);
         clusterService.addListener(listener);
 
         logger.info("Watcher initialized components at {}", WatcherDateTimeUtils.dateTimeFormatter.formatMillis(getClock().millis()));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.watcher;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
@@ -25,17 +23,12 @@ import org.elasticsearch.core.NotMultiProjectCapable;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
-import org.elasticsearch.xpack.core.watcher.WatcherState;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.watcher.watch.WatchStoreUtils;
 
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
@@ -43,12 +36,8 @@ import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
 
 public class WatcherLifeCycleService implements ClusterStateListener {
 
-    private static final Logger logger = LogManager.getLogger(WatcherLifeCycleService.class);
-    private final AtomicReference<WatcherState> state = new AtomicReference<>(WatcherState.STARTED);
-    private final AtomicReference<List<ShardRouting>> previousShardRoutings = new AtomicReference<>(Collections.emptyList());
     private volatile boolean shutDown = false; // indicates that the node has been shutdown and we should never start watcher after this.
     private final WatcherService watcherService;
-    private final EnumSet<WatcherState> stopStates = EnumSet.of(WatcherState.STOPPED, WatcherState.STOPPING);
 
     WatcherLifeCycleService(ClusterService clusterService, WatcherService watcherService) {
         this.watcherService = watcherService;
@@ -63,14 +52,9 @@ public class WatcherLifeCycleService implements ClusterStateListener {
         });
     }
 
-    synchronized void shutDown() {
-        this.state.set(WatcherState.STOPPING);
+    void shutDown() {
         shutDown = true;
-        clearAllocationIds();
-        watcherService.shutDown(() -> {
-            this.state.set(WatcherState.STOPPED);
-            logger.info("watcher has stopped and shutdown");
-        });
+        watcherService.setDesiredShutdown();
     }
 
     /**
@@ -83,7 +67,6 @@ public class WatcherLifeCycleService implements ClusterStateListener {
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) || shutDown) {
-            clearAllocationIds();
             // wait until the gateway has recovered from disk, otherwise we think may not have .watches and
             // a .triggered_watches index, but they may not have been restored from the cluster state on disk
             return;
@@ -100,35 +83,14 @@ public class WatcherLifeCycleService implements ClusterStateListener {
         }
 
         boolean isWatcherStoppedManually = isWatcherStoppedManually(event.state());
-        boolean isStoppedOrStopping = stopStates.contains(this.state.get());
-        // if this is not a data node, we need to start it ourselves possibly
-        if (event.state().nodes().getLocalNode().canContainData() == false && isWatcherStoppedManually == false && isStoppedOrStopping) {
-            this.state.set(WatcherState.STARTING);
-            watcherService.start(
-                event.state(),
-                () -> this.state.set(WatcherState.STARTED),
-                (exception -> this.state.set(WatcherState.STOPPED))
-            );
+        // Non-data nodes have no shard routing fingerprint, but may still need Watcher running for manual execution.
+        if (event.state().nodes().getLocalNode().canContainData() == false && isWatcherStoppedManually == false) {
+            watcherService.setDesiredRunning(event.state(), List.of(), "starting");
             return;
         }
 
         if (isWatcherStoppedManually) {
-            if (this.state.get() == WatcherState.STARTED) {
-                clearAllocationIds();
-                boolean stopping = this.state.compareAndSet(WatcherState.STARTED, WatcherState.STOPPING);
-                if (stopping) {
-                    // waiting to set state to stopped until after all currently running watches are finished
-                    watcherService.stop("watcher manually marked to shutdown by cluster state update", () -> {
-                        // only transition from stopping -> stopped (which may not be the case if restarted quickly)
-                        boolean stopped = state.compareAndSet(WatcherState.STOPPING, WatcherState.STOPPED);
-                        if (stopped) {
-                            logger.info("watcher has stopped");
-                        } else {
-                            logger.info("watcher has not been stopped. not currently in a stopping state, current state [{}]", state.get());
-                        }
-                    });
-                }
-            }
+            watcherService.setDesiredStopped("watcher manually marked to shutdown by cluster state update");
             return;
         }
 
@@ -147,13 +109,13 @@ public class WatcherLifeCycleService implements ClusterStateListener {
 
         String watchIndex = watcherIndexMetadata.getIndex().getName();
         List<ShardRouting> localShards = routingNode.shardsWithState(watchIndex, RELOCATING, STARTED).toList();
-        // no local shards, empty out watcher and dont waste resources!
+        // no local shards, empty out watcher and don't waste resources!
         if (localShards.isEmpty()) {
             pauseExecution("no local watcher shards found");
             return;
         }
 
-        // also check if non local shards have changed, as loosing a shard on a
+        // also check if non-local shards have changed, as losing a shard on a
         // remote node or adding a replica on a remote node needs to trigger a reload too
         Set<ShardId> localShardIds = localShards.stream().map(ShardRouting::shardId).collect(Collectors.toSet());
 
@@ -167,42 +129,15 @@ public class WatcherLifeCycleService implements ClusterStateListener {
             .sorted(Comparator.comparing(ShardRouting::hashCode))
             .toList();
 
-        if (previousShardRoutings.get().equals(localAffectedShardRoutings) == false) {
-            if (watcherService.validate(event.state())) {
-                previousShardRoutings.set(localAffectedShardRoutings);
-                if (state.get() == WatcherState.STARTED) {
-                    watcherService.reload(event.state(), "new local watcher shard allocation ids", (exception) -> {
-                        clearAllocationIds(); // will cause reload again
-                    });
-                } else if (isStoppedOrStopping) {
-                    this.state.set(WatcherState.STARTING);
-                    watcherService.start(event.state(), () -> this.state.set(WatcherState.STARTED), (exception) -> {
-                        clearAllocationIds();
-                        this.state.set(WatcherState.STOPPED);
-                    });
-                } else if (state.get() == WatcherState.STARTING) {
-                    // A routing change arrived while watcher is still starting up (reloadInner is in
-                    // flight). Re-invoke start() with the current cluster state so that
-                    // processedClusterStateVersion is bumped: the stale reloadInner will fail its
-                    // version guard and exit early, and a new one with the correct shard-allocation
-                    // partition (shardCount/idx for hostsWatch) will be submitted in its place.
-                    watcherService.start(event.state(), () -> this.state.set(WatcherState.STARTED), (exception) -> {
-                        clearAllocationIds();
-                        this.state.set(WatcherState.STOPPED);
-                    });
-                }
-            } else {
-                clearAllocationIds();
-                this.state.set(WatcherState.STOPPED);
-            }
+        if (watcherService.validate(event.state())) {
+            watcherService.setDesiredRunning(event.state(), localAffectedShardRoutings, "watcher shard allocation changed");
+        } else {
+            watcherService.setDesiredStopped("watcher failed validation");
         }
     }
 
     private void pauseExecution(String reason) {
-        if (clearAllocationIds()) {
-            watcherService.pauseExecution(reason);
-        }
-        this.state.set(WatcherState.STARTED);
+        watcherService.setDesiredPaused(reason);
     }
 
     /**
@@ -212,23 +147,5 @@ public class WatcherLifeCycleService implements ClusterStateListener {
     private static boolean isWatcherStoppedManually(ClusterState state) {
         WatcherMetadata watcherMetadata = state.getMetadata().getProject(ProjectId.DEFAULT).custom(WatcherMetadata.TYPE);
         return watcherMetadata != null && watcherMetadata.manuallyStopped();
-    }
-
-    /**
-     * clear out current allocation ids if not already happened
-     * @return true, if existing allocation ids were cleaned out, false otherwise
-     */
-    private boolean clearAllocationIds() {
-        List<ShardRouting> previousIds = previousShardRoutings.getAndSet(Collections.emptyList());
-        return previousIds.isEmpty() == false;
-    }
-
-    // for testing purposes only
-    List<ShardRouting> shardRoutings() {
-        return previousShardRoutings.get();
-    }
-
-    public Supplier<WatcherState> getState() {
-        return () -> state.get();
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
@@ -180,6 +180,16 @@ public class WatcherLifeCycleService implements ClusterStateListener {
                         clearAllocationIds();
                         this.state.set(WatcherState.STOPPED);
                     });
+                } else if (state.get() == WatcherState.STARTING) {
+                    // A routing change arrived while watcher is still starting up (reloadInner is in
+                    // flight). Re-invoke start() with the current cluster state so that
+                    // processedClusterStateVersion is bumped: the stale reloadInner will fail its
+                    // version guard and exit early, and a new one with the correct shard-allocation
+                    // partition (shardCount/idx for hostsWatch) will be submitted in its place.
+                    watcherService.start(event.state(), () -> this.state.set(WatcherState.STARTED), (exception) -> {
+                        clearAllocationIds();
+                        this.state.set(WatcherState.STOPPED);
+                    });
                 }
             } else {
                 clearAllocationIds();
@@ -204,7 +214,6 @@ public class WatcherLifeCycleService implements ClusterStateListener {
         return watcherMetadata != null && watcherMetadata.manuallyStopped();
     }
 
-    /**
     /**
      * clear out current allocation ids if not already happened
      * @return true, if existing allocation ids were cleaned out, false otherwise

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -197,8 +197,9 @@ public class WatcherService implements WatcherEventConsumer {
 
     /** Requests terminal shutdown and then drains the lifecycle executor. */
     void setDesiredShutdown() {
-        setDesiredState(new Shutdown());
-        stopExecutor();
+        if (setDesiredState(new Shutdown())) {
+            stopExecutor();
+        }
     }
 
     void stopExecutor() {
@@ -360,12 +361,17 @@ public class WatcherService implements WatcherEventConsumer {
         return ReconcileResult.COMPLETE;
     }
 
-    private void setDesiredState(DesiredState newState) {
-        if (newState.equals(desiredState.get())) {
-            return;
+    private boolean setDesiredState(DesiredState newState) {
+        while (true) {
+            final DesiredState currentState = desiredState.get();
+            if (currentState instanceof Shutdown || newState.equals(currentState)) {
+                return false;
+            }
+            if (desiredState.compareAndSet(currentState, newState)) {
+                scheduleReconciliation();
+                return true;
+            }
         }
-        desiredState.set(newState);
-        scheduleReconciliation();
     }
 
     private void scheduleReconciliation() {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -580,11 +580,13 @@ public class WatcherService implements WatcherEventConsumer {
      * @param newState The new state to transition to
      */
     private void validateTransitionAndApplyNewState(WatcherState newState) {
-        assert newState == state.get() || switch (newState) {
-            case STARTED -> WatcherState.STARTING == state.get();
+        assert switch (newState) {
+            case STARTED -> WatcherState.STARTING == state.get() || WatcherState.STARTED == state.get();
             case STOPPED -> WatcherState.STOPPING == state.get();
-            case STOPPING -> WatcherState.STARTED == state.get() || WatcherState.STARTING == state.get();
-            case STARTING -> WatcherState.STOPPED == state.get();
+            case STOPPING -> WatcherState.STARTED == state.get()
+                || WatcherState.STARTING == state.get()
+                || WatcherState.STOPPING == state.get();
+            case STARTING -> WatcherState.STOPPED == state.get() || WatcherState.STARTING == state.get();
         } : "Unexpected transition from state " + state.get() + " to state " + newState;
         state.set(newState);
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -223,7 +223,7 @@ public class WatcherService implements WatcherEventConsumer {
         assert ThreadPool.assertCurrentThreadPool(LIFECYCLE_THREADPOOL_NAME)
             : "reconcile must run on the single threaded [" + LIFECYCLE_THREADPOOL_NAME + "] thread pool";
         DesiredState reconciledState = null;
-        ReconcileResult result = ReconcileResult.COMPLETE;
+        ReconcileResult result;
         try {
             while (true) {
                 reconciledState = desiredState.get();
@@ -258,7 +258,7 @@ public class WatcherService implements WatcherEventConsumer {
             return ReconcileResult.COMPLETE;
         }
         if (starting) {
-            state.set(WatcherState.STARTING);
+            validateTransitionAndApplyNewState(WatcherState.STARTING);
         } else {
             final boolean hasValidWatcherTemplates = WatcherIndexTemplateRegistry.validate(running.clusterState());
             if (hasValidWatcherTemplates == false) {
@@ -289,13 +289,13 @@ public class WatcherService implements WatcherEventConsumer {
                 executionService.executeTriggeredWatches(triggeredWatches);
             }
             appliedShardRoutings = running.affectedShardRoutings();
-            state.set(WatcherState.STARTED);
+            validateTransitionAndApplyNewState(WatcherState.STARTED);
             logger.debug("watch service has been reloaded, reason [{}]", running.reason());
         } catch (Exception e) {
             logger.error(starting ? "error starting watcher" : "error reloading watcher", e);
             if (desiredState.get() == running) {
                 if (starting) {
-                    state.set(WatcherState.STOPPED);
+                    validateTransitionAndApplyNewState(WatcherState.STOPPED);
                 }
                 desiredState.compareAndSet(running, null);
             }
@@ -310,7 +310,7 @@ public class WatcherService implements WatcherEventConsumer {
         triggerService.pauseExecution();
         final int cancelledTaskCount = executionService.pause(() -> {});
         appliedShardRoutings = null;
-        state.set(WatcherState.STARTED);
+        validateTransitionAndApplyNewState(WatcherState.STARTED);
         logger.info("paused watch execution, reason [{}], cancelled [{}] queued tasks", paused.reason(), cancelledTaskCount);
         return ReconcileResult.COMPLETE;
     }
@@ -323,7 +323,7 @@ public class WatcherService implements WatcherEventConsumer {
         if (state.get() == WatcherState.STOPPING) {
             return ReconcileResult.WAITING_FOR_STOP;
         }
-        state.set(WatcherState.STOPPING);
+        validateTransitionAndApplyNewState(WatcherState.STOPPING);
         logger.info("stopping watch service, reason [{}]", stopped.reason());
         triggerService.pauseExecution();
         executionService.pause(() -> notifyStopComplete(stopped));
@@ -350,12 +350,12 @@ public class WatcherService implements WatcherEventConsumer {
     }
 
     private ReconcileResult reconcileShutdown() {
-        state.set(WatcherState.STOPPING);
+        validateTransitionAndApplyNewState(WatcherState.STOPPING);
         appliedShardRoutings = null;
         logger.info("stopping watch service, reason [shutdown initiated]");
         triggerService.stop();
         executionService.pause(() -> {
-            state.set(WatcherState.STOPPED);
+            validateTransitionAndApplyNewState(WatcherState.STOPPED);
             logger.info("watcher has stopped and shutdown");
         });
         return ReconcileResult.COMPLETE;
@@ -574,4 +574,18 @@ public class WatcherService implements WatcherEventConsumer {
         };
     }
 
+    /**
+     * Validate state transition when assertions are enabled, and apply the new state
+     *
+     * @param newState The new state to transition to
+     */
+    private void validateTransitionAndApplyNewState(WatcherState newState) {
+        assert newState == state.get() || switch (newState) {
+            case STARTED -> WatcherState.STARTING == state.get();
+            case STOPPED -> WatcherState.STOPPING == state.get();
+            case STOPPING -> WatcherState.STARTED == state.get() || WatcherState.STARTING == state.get();
+            case STARTING -> WatcherState.STOPPED == state.get();
+        } : "Unexpected transition from state " + state.get() + " to state " + newState;
+        state.set(newState);
+    }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -56,7 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
@@ -79,9 +80,28 @@ public class WatcherService implements WatcherEventConsumer {
     private final WatchParser parser;
     private final Client client;
     private final TimeValue defaultSearchTimeout;
-    private final AtomicLong processedClusterStateVersion = new AtomicLong(0);
     private final ExecutorService executor;
     private final Map<String, Watch> pendingWatches = new HashMap<>();
+    private final AtomicReference<WatcherState> state = new AtomicReference<>(WatcherState.STARTED);
+    private final AtomicReference<DesiredState> desiredState = new AtomicReference<>();
+    private final AtomicBoolean reconciliationScheduled = new AtomicBoolean();
+    private List<ShardRouting> appliedShardRoutings;
+
+    /** The latest lifecycle outcome requested by {@link WatcherLifeCycleService}. */
+    private sealed interface DesiredState permits Running, Paused, Stopped, Shutdown {}
+
+    private record Running(ClusterState clusterState, List<ShardRouting> affectedShardRoutings, String reason) implements DesiredState {}
+
+    private record Paused(String reason) implements DesiredState {}
+
+    private record Stopped(String reason) implements DesiredState {}
+
+    private record Shutdown() implements DesiredState {}
+
+    private enum ReconcileResult {
+        COMPLETE,
+        WAITING_FOR_STOP
+    }
 
     WatcherService(
         Settings settings,
@@ -170,29 +190,14 @@ public class WatcherService implements WatcherEventConsumer {
         }
     }
 
-    /**
-     * Stops the watcher service and marks its services as paused. Callers should set the Watcher state to {@link WatcherState#STOPPING}
-     * prior to calling this method.
-     *
-     * @param stoppedListener The listener that will set Watcher state to: {@link WatcherState#STOPPED}, may not be {@code null}
-     */
-    public void stop(String reason, Runnable stoppedListener) {
-        assert stoppedListener != null;
-        logger.info("stopping watch service, reason [{}]", reason);
-        executionService.pause(stoppedListener);
-        triggerService.pauseExecution();
+    /** Requests that Watcher stop after its current executions finish. */
+    void setDesiredStopped(String reason) {
+        setDesiredState(new Stopped(reason));
     }
 
-    /**
-     * shuts down the trigger service as well to make sure there are no lingering threads
-     *
-     * @param stoppedListener The listener that will set Watcher state to: {@link WatcherState#STOPPED}, may not be {@code null}
-     */
-    void shutDown(Runnable stoppedListener) {
-        assert stoppedListener != null;
-        logger.info("stopping watch service, reason [shutdown initiated]");
-        executionService.pause(stoppedListener);
-        triggerService.stop();
+    /** Requests terminal shutdown and then drains the lifecycle executor. */
+    void setDesiredShutdown() {
+        setDesiredState(new Shutdown());
         stopExecutor();
     }
 
@@ -200,112 +205,186 @@ public class WatcherService implements WatcherEventConsumer {
         ThreadPool.terminate(executor, 10L, TimeUnit.SECONDS);
     }
 
-    /**
-     * Reload the watcher service, does not switch the state from stopped to started, just keep going
-     * @param state cluster state, which is needed to find out about local shards
-     */
-    void reload(ClusterState state, String reason, Consumer<Exception> exceptionConsumer) {
-        boolean hasValidWatcherTemplates = WatcherIndexTemplateRegistry.validate(state);
-        if (hasValidWatcherTemplates == false) {
-            logger.warn("missing watcher index templates");
+    /** Requests that Watcher run using the routing information in {@code state}. */
+    void setDesiredRunning(ClusterState state, List<ShardRouting> affectedShardRoutings, String reason) {
+        final DesiredState currentDesiredState = desiredState.get();
+        if (currentDesiredState instanceof Running running && running.affectedShardRoutings().equals(affectedShardRoutings)) {
+            return;
         }
-        // this method contains the only async code block, being called by the cluster state listener
-        // the reason for this is that loading the watches is done in a sync manner and thus cannot be done on the cluster state listener
-        // thread
-        //
-        // this method itself is called by the cluster state listener, so will never be called in parallel
-        // setting the cluster state version allows us to know if the async method has been overtaken by another async method
-        // this is unlikely, but can happen, if the thread pool schedules two of those runnables at the same time
-        // by checking the cluster state version before and after loading the watches we can potentially just exit without applying the
-        // changes
-        processedClusterStateVersion.set(state.getVersion());
-
-        triggerService.pauseExecution();
-        int cancelledTaskCount = executionService.clearExecutionsAndQueue(() -> {});
-        logger.info("reloading watcher, reason [{}], cancelled [{}] queued tasks", reason, cancelledTaskCount);
-
-        executor.execute(wrapWatcherService(() -> reloadInner(state, reason, false), e -> {
-            logger.error("error reloading watcher", e);
-            exceptionConsumer.accept(e);
-        }));
+        setDesiredState(new Running(state, List.copyOf(affectedShardRoutings), reason));
     }
 
     /**
-     * start the watcher service, load watches in the background
-     *
-     * @param state                     the current cluster state
-     * @param postWatchesLoadedCallback the callback to be triggered, when watches where loaded successfully
+     * Reconciles the current Watcher state with the latest requested state. All mutations of the trigger and execution services made
+     * during start, reload, pause, and stop are serialized on the lifecycle executor.
      */
-    public void start(ClusterState state, Runnable postWatchesLoadedCallback, Consumer<Exception> exceptionConsumer) {
-        executionService.unPause();
-        processedClusterStateVersion.set(state.getVersion());
-        executor.execute(wrapWatcherService(() -> {
-            if (reloadInner(state, "starting", true)) {
-                postWatchesLoadedCallback.run();
-            }
-        }, e -> {
-            logger.error("error starting watcher", e);
-            exceptionConsumer.accept(e);
-        }));
-    }
-
-    /**
-     * reload watches and start scheduling them
-     *
-     * @param state                 the current cluster state
-     * @param reason                the reason for reloading, will be logged
-     * @param loadTriggeredWatches  should triggered watches be loaded in this run, not needed for reloading, only for starting
-     * @return                      true if no other loading of a newer cluster state happened in parallel, false otherwise
-     */
-    private boolean reloadInner(ClusterState state, String reason, boolean loadTriggeredWatches) {
+    private void reconcile() {
         assert ThreadPool.assertCurrentThreadPool(LIFECYCLE_THREADPOOL_NAME)
-            : "reloadInner must run on the single threaded [" + LIFECYCLE_THREADPOOL_NAME + "] thread pool";
-        // exit early if another thread has come in between
-        if (processedClusterStateVersion.get() != state.getVersion()) {
-            logger.debug(
-                "watch service has not been reloaded for state [{}], another reload for state [{}] in progress",
-                state.getVersion(),
-                processedClusterStateVersion.get()
-            );
-            return false;
+            : "reconcile must run on the single threaded [" + LIFECYCLE_THREADPOOL_NAME + "] thread pool";
+        DesiredState reconciledState = null;
+        ReconcileResult result = ReconcileResult.COMPLETE;
+        try {
+            while (true) {
+                reconciledState = desiredState.get();
+                if (reconciledState == null) {
+                    return;
+                }
+                result = switch (reconciledState) {
+                    case Running running -> reconcileRunning(running);
+                    case Paused paused -> reconcilePaused(paused);
+                    case Stopped stopped -> reconcileStopped(stopped);
+                    case Shutdown ignored -> reconcileShutdown();
+                };
+                if (result == ReconcileResult.WAITING_FOR_STOP || desiredState.get() == reconciledState) {
+                    return;
+                }
+            }
+        } finally {
+            reconciliationScheduled.set(false);
+            if (desiredState.get() != reconciledState) {
+                scheduleReconciliation();
+            }
+        }
+    }
+
+    private ReconcileResult reconcileRunning(Running running) {
+        if (state.get() == WatcherState.STOPPING) {
+            return ReconcileResult.WAITING_FOR_STOP;
         }
 
-        Collection<Watch> watches = loadWatches(state);
-        Collection<TriggeredWatch> triggeredWatches = Collections.emptyList();
-        if (loadTriggeredWatches) {
-            triggeredWatches = triggeredWatchStore.findTriggeredWatches(watches, state);
+        final boolean starting = state.get() != WatcherState.STARTED;
+        if (starting == false && running.affectedShardRoutings().equals(appliedShardRoutings)) {
+            return ReconcileResult.COMPLETE;
+        }
+        if (starting) {
+            state.set(WatcherState.STARTING);
+        } else {
+            final boolean hasValidWatcherTemplates = WatcherIndexTemplateRegistry.validate(running.clusterState());
+            if (hasValidWatcherTemplates == false) {
+                logger.warn("missing watcher index templates");
+            }
+            triggerService.pauseExecution();
+            final int cancelledTaskCount = executionService.clearExecutionsAndQueue(() -> {});
+            logger.info("reloading watcher, reason [{}], cancelled [{}] queued tasks", running.reason(), cancelledTaskCount);
         }
 
-        // if we had another state coming in the meantime, we will not start the trigger engines with these watches, but wait
-        // until the others are loaded also this is the place where we pause the trigger service execution and clear the current
-        // execution service, so that we make sure that existing executions finish, but no new ones are executed
-        if (processedClusterStateVersion.get() == state.getVersion()) {
+        try {
+            final Collection<Watch> watches = loadWatches(running.clusterState());
+            final Collection<TriggeredWatch> triggeredWatches;
+            if (starting && desiredState.get() == running) {
+                triggeredWatches = triggeredWatchStore.findTriggeredWatches(watches, running.clusterState());
+            } else {
+                triggeredWatches = Collections.emptyList();
+            }
+
+            if (desiredState.get() != running) {
+                return ReconcileResult.COMPLETE;
+            }
+
             executionService.unPause();
             triggerService.start(watches);
-            addPendingWatches(state);
+            addPendingWatches(running.clusterState());
             if (triggeredWatches.isEmpty() == false) {
                 executionService.executeTriggeredWatches(triggeredWatches);
             }
-            logger.debug("watch service has been reloaded, reason [{}]", reason);
-            return true;
-        } else {
-            logger.debug(
-                "watch service has not been reloaded for state [{}], another reload for state [{}] in progress",
-                state.getVersion(),
-                processedClusterStateVersion.get()
-            );
-            return false;
+            appliedShardRoutings = running.affectedShardRoutings();
+            state.set(WatcherState.STARTED);
+            logger.debug("watch service has been reloaded, reason [{}]", running.reason());
+        } catch (Exception e) {
+            logger.error(starting ? "error starting watcher" : "error reloading watcher", e);
+            if (desiredState.get() == running) {
+                if (starting) {
+                    state.set(WatcherState.STOPPED);
+                }
+                desiredState.compareAndSet(running, null);
+            }
+        }
+        return ReconcileResult.COMPLETE;
+    }
+
+    private ReconcileResult reconcilePaused(Paused paused) {
+        if (state.get() == WatcherState.STOPPING) {
+            return ReconcileResult.WAITING_FOR_STOP;
+        }
+        triggerService.pauseExecution();
+        final int cancelledTaskCount = executionService.pause(() -> {});
+        appliedShardRoutings = null;
+        state.set(WatcherState.STARTED);
+        logger.info("paused watch execution, reason [{}], cancelled [{}] queued tasks", paused.reason(), cancelledTaskCount);
+        return ReconcileResult.COMPLETE;
+    }
+
+    private ReconcileResult reconcileStopped(Stopped stopped) {
+        appliedShardRoutings = null;
+        if (state.get() == WatcherState.STOPPED) {
+            return ReconcileResult.COMPLETE;
+        }
+        if (state.get() == WatcherState.STOPPING) {
+            return ReconcileResult.WAITING_FOR_STOP;
+        }
+        state.set(WatcherState.STOPPING);
+        logger.info("stopping watch service, reason [{}]", stopped.reason());
+        triggerService.pauseExecution();
+        executionService.pause(() -> notifyStopComplete(stopped));
+        return ReconcileResult.WAITING_FOR_STOP;
+    }
+
+    private void notifyStopComplete(Stopped stopped) {
+        try {
+            executor.execute(wrapWatcherService(() -> completeStop(stopped), e -> logger.error("error stopping watcher", e)));
+        } catch (RuntimeException e) {
+            if (executor.isShutdown() == false) {
+                throw e;
+            }
+            logger.debug("watcher lifecycle executor shut down before stop completion was processed");
         }
     }
 
-    /**
-     * Stop execution of watches on this node, do not try to reload anything, but still allow
-     * manual watch execution, i.e. via the execute watch API
-     */
-    public void pauseExecution(String reason) {
-        triggerService.pauseExecution();
-        int cancelledTaskCount = executionService.pause(() -> {});
-        logger.info("paused watch execution, reason [{}], cancelled [{}] queued tasks", reason, cancelledTaskCount);
+    private void completeStop(Stopped stopped) {
+        state.compareAndSet(WatcherState.STOPPING, WatcherState.STOPPED);
+        logger.info("watcher has stopped");
+        if (desiredState.get() != stopped) {
+            scheduleReconciliation();
+        }
+    }
+
+    private ReconcileResult reconcileShutdown() {
+        state.set(WatcherState.STOPPING);
+        appliedShardRoutings = null;
+        logger.info("stopping watch service, reason [shutdown initiated]");
+        triggerService.stop();
+        executionService.pause(() -> {
+            state.set(WatcherState.STOPPED);
+            logger.info("watcher has stopped and shutdown");
+        });
+        return ReconcileResult.COMPLETE;
+    }
+
+    private void setDesiredState(DesiredState newState) {
+        if (newState.equals(desiredState.get())) {
+            return;
+        }
+        desiredState.set(newState);
+        scheduleReconciliation();
+    }
+
+    private void scheduleReconciliation() {
+        if (reconciliationScheduled.compareAndSet(false, true)) {
+            executor.execute(wrapWatcherService(this::reconcile, e -> {
+                reconciliationScheduled.set(false);
+                logger.error("error reconciling watcher lifecycle", e);
+            }));
+        }
+    }
+
+    /** Requests that scheduled execution pause while manual execution remains available. */
+    void setDesiredPaused(String reason) {
+        setDesiredState(new Paused(reason));
+    }
+
+    /** Returns Watcher's reconciled lifecycle state. */
+    public WatcherState getState() {
+        return state.get();
     }
 
     /**

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsAction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsAction;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsRequest;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsResponse;
-import org.elasticsearch.xpack.watcher.WatcherLifeCycleService;
+import org.elasticsearch.xpack.watcher.WatcherService;
 import org.elasticsearch.xpack.watcher.execution.ExecutionService;
 import org.elasticsearch.xpack.watcher.trigger.TriggerService;
 
@@ -42,7 +42,7 @@ public class TransportWatcherStatsAction extends TransportNodesAction<
 
     private final ExecutionService executionService;
     private final TriggerService triggerService;
-    private final WatcherLifeCycleService lifeCycleService;
+    private final WatcherService watcherService;
     private final ProjectResolver projectResolver;
 
     @Inject
@@ -51,7 +51,7 @@ public class TransportWatcherStatsAction extends TransportNodesAction<
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        WatcherLifeCycleService lifeCycleService,
+        WatcherService watcherService,
         ExecutionService executionService,
         TriggerService triggerService,
         ProjectResolver projectResolver
@@ -64,7 +64,7 @@ public class TransportWatcherStatsAction extends TransportNodesAction<
             WatcherStatsRequest.Node::new,
             threadPool.executor(ThreadPool.Names.MANAGEMENT)
         );
-        this.lifeCycleService = lifeCycleService;
+        this.watcherService = watcherService;
         this.executionService = executionService;
         this.triggerService = triggerService;
         this.projectResolver = projectResolver;
@@ -92,7 +92,7 @@ public class TransportWatcherStatsAction extends TransportNodesAction<
     @Override
     protected WatcherStatsResponse.Node nodeOperation(WatcherStatsRequest.Node request, Task task) {
         WatcherStatsResponse.Node statsResponse = new WatcherStatsResponse.Node(clusterService.localNode());
-        statsResponse.setWatcherState(lifeCycleService.getState().get());
+        statsResponse.setWatcherState(watcherService.getState());
         statsResponse.setThreadPoolQueueSize(executionService.executionThreadPoolQueueSize());
         statsResponse.setThreadPoolMaxSize(executionService.executionThreadPoolMaxSize());
         if (request.includeCurrentWatches()) {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -271,6 +271,80 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         assertThat(lifeCycleService.getState().get(), equalTo(WatcherState.STARTED));
     }
 
+    public void testRoutingChangeWhileStartingTriggersStart() {
+        /*
+         * Regression test for a race where a replica shard transitions to STARTED while watcher
+         * is mid-start (state=STARTING, reloadInner in flight). Without handling this case the
+         * stale reloadInner completes with shardCount=1, causing every node to schedule all
+         * watches and producing an alternating throttled/executed history pattern.
+         *
+         * The STARTING state is reached here via validate() returning false on the first
+         * cluster-changed event (e.g. index not yet ready), which drives state to STOPPED; the
+         * next event with the same routing but validate()=true then transitions STOPPED→STARTING.
+         */
+        Index watchIndex = new Index(Watch.INDEX, "uuid");
+        ShardId shardId = new ShardId(watchIndex, 0);
+        DiscoveryNodes nodes = new DiscoveryNodes.Builder().masterNodeId("node_1")
+            .localNodeId("node_1")
+            .add(newNode("node_1"))
+            .add(newNode("node_2"))
+            .build();
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(Watch.INDEX)
+            .settings(settings(IndexVersion.current()).put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), 6))
+            .numberOfShards(1)
+            .numberOfReplicas(1);
+        ProjectMetadata metadata = ProjectMetadata.builder(projectId)
+            .put(IndexTemplateMetadata.builder(HISTORY_TEMPLATE_NAME).patterns(randomIndexPatterns()))
+            .put(indexMetadataBuilder)
+            .build();
+
+        // CS_S: only the primary on the local node (replica not yet allocated)
+        IndexRoutingTable primaryOnly = IndexRoutingTable.builder(watchIndex)
+            .addShard(TestShardRouting.newShardRouting(shardId, "node_1", true, STARTED))
+            .build();
+        ClusterState csWithPrimary = ClusterState.builder(new ClusterName("my-cluster"))
+            .nodes(nodes)
+            .putRoutingTable(projectId, RoutingTable.builder().add(primaryOnly).build())
+            .putProjectMetadata(metadata)
+            .build();
+
+        // CS_3: primary on node_1, replica now STARTED on node_2
+        IndexRoutingTable primaryAndReplica = IndexRoutingTable.builder(watchIndex)
+            .addShard(TestShardRouting.newShardRouting(shardId, "node_1", true, STARTED))
+            .addShard(TestShardRouting.newShardRouting(shardId, "node_2", false, STARTED))
+            .build();
+        ClusterState csWithReplica = ClusterState.builder(new ClusterName("my-cluster"))
+            .nodes(nodes)
+            .putRoutingTable(projectId, RoutingTable.builder().add(primaryAndReplica).build())
+            .putProjectMetadata(metadata)
+            .build();
+
+        ClusterState emptyState = ClusterState.builder(new ClusterName("my-cluster")).nodes(nodes).putProjectMetadata(metadata).build();
+
+        // Step 1: validate() returns false (e.g. index not ready) → state driven to STOPPED
+        // This is to put the lifecycle service in STOPPED state, the bug is in the transition from STOPPED to STARTED
+        when(watcherService.validate(csWithPrimary)).thenReturn(false);
+        lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithPrimary, emptyState));
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STOPPED));
+
+        // Step 2: same routing, validate() now returns true → STOPPED→STARTING, start(CS_S).
+        // The success callback is intentionally not invoked, simulating an in-flight reloadInner.
+        when(watcherService.validate(csWithPrimary)).thenReturn(true);
+        lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithPrimary, emptyState));
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTING));
+        verify(watcherService, times(1)).start(eq(csWithPrimary), any(), any());
+
+        // Step 3: replica becomes STARTED while reloadInner(CS_S) is still in flight.
+        // localAffectedShardRoutings changes from [primary] to [primary, replica], so the routing
+        // differs. The fix must call start(CS_3) to bump processedClusterStateVersion so the
+        // stale reloadInner exits early and a new one uses the correct shardCount=2.
+        reset(watcherService);
+        when(watcherService.validate(csWithReplica)).thenReturn(true);
+        lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithReplica, csWithPrimary));
+        verify(watcherService, times(1)).start(eq(csWithReplica), any(), any());
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTING));
+    }
+
     public void testReloadWithIdenticalRoutingTable() {
         /*
          * This tests that the identical routing table causes reload only once.

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.watcher;
 
-import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -36,18 +35,13 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
-import org.elasticsearch.xpack.core.watcher.WatcherState;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.junit.Before;
-import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -56,9 +50,8 @@ import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateRegistryField.HISTORY_TEMPLATE_NAME;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -110,11 +103,11 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
 
         when(watcherService.validate(clusterState)).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, previousClusterState));
-        verifyNoMoreInteractions(watcherService);
+        verify(watcherService).setDesiredPaused("no watcher index found");
 
-        // Trying to start a second time, but that should have no effect.
+        // Re-publishing the same intent is harmless; WatcherService coalesces it.
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, previousClusterState));
-        verifyNoMoreInteractions(watcherService);
+        verify(watcherService, times(2)).setDesiredPaused("no watcher index found");
     }
 
     public void testStartWithStateNotRecoveredBlock() {
@@ -144,8 +137,8 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         when(watcherService.validate(clusterState)).thenReturn(true);
 
         lifeCycleService.shutDown();
-        verify(watcherService, never()).stop(anyString(), any());
-        verify(watcherService, times(1)).shutDown(any());
+        verify(watcherService, never()).setDesiredStopped(anyString());
+        verify(watcherService).setDesiredShutdown();
 
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
@@ -187,91 +180,22 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .build();
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("foo", stoppedClusterState, clusterState));
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(watcherService, times(1)).stop(eq("watcher manually marked to shutdown by cluster state update"), captor.capture());
-        assertEquals(WatcherState.STOPPING, lifeCycleService.getState().get());
-        captor.getValue().run();
-        assertEquals(WatcherState.STOPPED, lifeCycleService.getState().get());
+        verify(watcherService).setDesiredStopped("watcher manually marked to shutdown by cluster state update");
 
         // Starting via cluster state update, as the watcher metadata block is removed/set to true
         reset(watcherService);
         when(watcherService.validate(clusterState)).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, stoppedClusterState));
-        verify(watcherService, times(1)).start(eq(clusterState), any(), any());
+        verify(watcherService).setDesiredRunning(eq(clusterState), anyList(), anyString());
 
-        // no change, keep going
+        // The lifecycle service republishes intent; WatcherService deduplicates the unchanged routing fingerprint.
         reset(watcherService);
-        lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
-        verifyNoMoreInteractions(watcherService);
-    }
-
-    @SuppressWarnings("unchecked")
-    public void testExceptionOnStart() {
-        /*
-         * This tests that if watcher fails to start because of some exception (for example a timeout while refreshing indices) that it
-         * will fail gracefully, and will start the next time there is a cluster change event if there is no exception that time.
-         */
-        Index index = new Index(Watch.INDEX, "uuid");
-        IndexRoutingTable.Builder indexRoutingTableBuilder = IndexRoutingTable.builder(index);
-        indexRoutingTableBuilder.addShard(
-            TestShardRouting.newShardRouting(new ShardId(index, 0), "node_1", true, ShardRoutingState.STARTED)
-        );
-        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(Watch.INDEX)
-            .settings(settings(IndexVersion.current()).put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), 6)) // the internal index format,
-                                                                                                            // required
-            .numberOfShards(1)
-            .numberOfReplicas(0);
-        ProjectMetadata.Builder metadataBuilder = ProjectMetadata.builder(projectId)
-            .put(indexMetadataBuilder)
-            .put(IndexTemplateMetadata.builder(HISTORY_TEMPLATE_NAME).patterns(randomIndexPatterns()));
-        if (randomBoolean()) {
-            metadataBuilder.putCustom(WatcherMetadata.TYPE, new WatcherMetadata(false));
-        }
-        ProjectMetadata metadata = metadataBuilder.build();
-        IndexRoutingTable indexRoutingTable = indexRoutingTableBuilder.build();
-        ClusterState clusterState = ClusterState.builder(new ClusterName("my-cluster"))
-            .nodes(new DiscoveryNodes.Builder().masterNodeId("node_1").localNodeId("node_1").add(newNode("node_1")))
-            .putRoutingTable(projectId, RoutingTable.builder().add(indexRoutingTable).build())
-            .putProjectMetadata(metadata)
-            .build();
-
-        // mark watcher manually as stopped
-        ClusterState stoppedClusterState = ClusterState.builder(new ClusterName("my-cluster"))
-            .nodes(new DiscoveryNodes.Builder().masterNodeId("node_1").localNodeId("node_1").add(newNode("node_1")))
-            .putRoutingTable(projectId, RoutingTable.builder().add(indexRoutingTable).build())
-            .putProjectMetadata(ProjectMetadata.builder(metadata).putCustom(WatcherMetadata.TYPE, new WatcherMetadata(true)).build())
-            .build();
-
-        lifeCycleService.clusterChanged(new ClusterChangedEvent("foo", stoppedClusterState, clusterState));
-        assertThat(lifeCycleService.getState().get(), equalTo(WatcherState.STOPPING));
-
-        // Now attempt to start watcher with a simulated TimeoutException. Should be stopped
         when(watcherService.validate(clusterState)).thenReturn(true);
-        AtomicBoolean exceptionHit = new AtomicBoolean(false);
-        doAnswer(invocation -> {
-            Consumer<Exception> exceptionConsumer = invocation.getArgument(2);
-            exceptionConsumer.accept(new ElasticsearchTimeoutException(new TimeoutException("Artificial timeout")));
-            exceptionHit.set(true);
-            return null;
-        }).when(watcherService).start(any(), any(), any(Consumer.class));
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
-        assertTrue("Expected simulated timeout not hit", exceptionHit.get());
-        assertThat(lifeCycleService.getState().get(), equalTo(WatcherState.STOPPED));
-
-        // And now attempt to start watcher with no exception. It should start up.
-        AtomicBoolean runnableCalled = new AtomicBoolean(false);
-        doAnswer(invocation -> {
-            Runnable runnable = invocation.getArgument(1);
-            runnable.run();
-            runnableCalled.set(true);
-            return null;
-        }).when(watcherService).start(any(), any(Runnable.class), any());
-        lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterState, clusterState));
-        assertTrue("Runnable not called", runnableCalled.get());
-        assertThat(lifeCycleService.getState().get(), equalTo(WatcherState.STARTED));
+        verify(watcherService).setDesiredRunning(eq(clusterState), anyList(), anyString());
     }
 
-    public void testRoutingChangeWhileStartingTriggersStart() {
+    public void testRoutingChangeWhileStartingRequestsLatestState() {
         /*
          * Regression test for a race where a replica shard transitions to STARTED while watcher
          * is mid-start (state=STARTING, reloadInner in flight). Without handling this case the
@@ -321,33 +245,28 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
 
         ClusterState emptyState = ClusterState.builder(new ClusterName("my-cluster")).nodes(nodes).putProjectMetadata(metadata).build();
 
-        // Step 1: validate() returns false (e.g. index not ready) → state driven to STOPPED
-        // This is to put the lifecycle service in STOPPED state, the bug is in the transition from STOPPED to STARTED
+        // Step 1: validation rejects the initial routing.
         when(watcherService.validate(csWithPrimary)).thenReturn(false);
         lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithPrimary, emptyState));
-        assertThat(lifeCycleService.getState().get(), is(WatcherState.STOPPED));
+        verify(watcherService).setDesiredStopped("watcher failed validation");
 
-        // Step 2: same routing, validate() now returns true → STOPPED→STARTING, start(CS_S).
-        // The success callback is intentionally not invoked, simulating an in-flight reloadInner.
+        // Step 2: the same routing becomes valid and is published as the desired running state.
+        reset(watcherService);
         when(watcherService.validate(csWithPrimary)).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithPrimary, emptyState));
-        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTING));
-        verify(watcherService, times(1)).start(eq(csWithPrimary), any(), any());
+        verify(watcherService).setDesiredRunning(eq(csWithPrimary), anyList(), anyString());
 
-        // Step 3: replica becomes STARTED while reloadInner(CS_S) is still in flight.
-        // localAffectedShardRoutings changes from [primary] to [primary, replica], so the routing
-        // differs. The fix must call start(CS_3) to bump processedClusterStateVersion so the
-        // stale reloadInner exits early and a new one uses the correct shardCount=2.
+        // Step 3: replica becomes STARTED while startup for CS_S is still in flight. Publish the
+        // latest state; WatcherService's reconciler is responsible for coalescing both requests.
         reset(watcherService);
         when(watcherService.validate(csWithReplica)).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithReplica, csWithPrimary));
-        verify(watcherService, times(1)).start(eq(csWithReplica), any(), any());
-        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTING));
+        verify(watcherService).setDesiredRunning(eq(csWithReplica), anyList(), eq("watcher shard allocation changed"));
     }
 
-    public void testReloadWithIdenticalRoutingTable() {
+    public void testPublishesRunningIntentWithIdenticalRoutingTable() {
         /*
-         * This tests that the identical routing table causes reload only once.
+         * WatcherService owns routing-fingerprint deduplication, so the lifecycle service publishes every valid intent.
          */
         startWatcher();
 
@@ -359,38 +278,8 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             when(watcherService.validate(event.state())).thenReturn(true);
             lifeCycleService.clusterChanged(event);
         }
-        // reload should occur on the first event
-        verify(watcherService).reload(eq(events[0].state()), anyString(), any());
-        // but it shouldn't on the second event unless routing table changes
-        verify(watcherService, never()).reload(eq(events[1].state()), anyString(), any());
-    }
-
-    public void testReloadWithIdenticalRoutingTableAfterException() {
-        /*
-         * This tests that even the identical routing table causes reload again if some exception (for example a timeout while loading
-         * watches) interrupted the previous one.
-         */
-        startWatcher();
-
-        ClusterChangedEvent[] events = masterChangeScenario();
-        assertThat(events[1].previousState(), equalTo(events[0].state()));
-        assertFalse(events[1].routingTableChanged());
-
-        // simulate exception on the first event
-        doAnswer(invocation -> {
-            Consumer<Exception> exceptionConsumer = invocation.getArgument(2);
-            exceptionConsumer.accept(new ElasticsearchTimeoutException(new TimeoutException("Artificial timeout")));
-            return null;
-        }).when(watcherService).reload(eq(events[0].state()), anyString(), any());
-
-        for (ClusterChangedEvent event : events) {
-            when(watcherService.validate(event.state())).thenReturn(true);
-            lifeCycleService.clusterChanged(event);
-        }
-        // reload should occur on the first event but it fails
-        verify(watcherService).reload(eq(events[0].state()), anyString(), any());
-        // reload should occur again on the second event because the previous one failed
-        verify(watcherService).reload(eq(events[1].state()), anyString(), any());
+        verify(watcherService).setDesiredRunning(eq(events[0].state()), anyList(), anyString());
+        verify(watcherService).setDesiredRunning(eq(events[1].state()), anyList(), anyString());
     }
 
     private ClusterChangedEvent[] masterChangeScenario() {
@@ -471,24 +360,24 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .putProjectMetadata(ProjectMetadata.builder(projectId).put(indexMetadata, false))
             .build();
 
-        // set current allocation ids
+        // Publish the routing fingerprint for the local shard.
         when(watcherService.validate(eq(clusterStateWithLocalShards))).thenReturn(true);
         when(watcherService.validate(eq(clusterStateWithoutLocalShards))).thenReturn(false);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithLocalShards, clusterStateWithoutLocalShards));
-        verify(watcherService, times(1)).reload(eq(clusterStateWithLocalShards), eq("new local watcher shard allocation ids"), any());
+        verify(watcherService).setDesiredRunning(eq(clusterStateWithLocalShards), anyList(), eq("watcher shard allocation changed"));
         verify(watcherService, times(1)).validate(eq(clusterStateWithLocalShards));
         verifyNoMoreInteractions(watcherService);
 
         // no more local shards, lets pause execution
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutLocalShards, clusterStateWithLocalShards));
-        verify(watcherService, times(1)).pauseExecution(eq("no local watcher shards found"));
+        verify(watcherService).setDesiredPaused("no local watcher shards found");
         verifyNoMoreInteractions(watcherService);
 
-        // no further invocations should happen if the cluster state does not change in regard to local shards
+        // The lifecycle service publishes intent for every relevant cluster state; WatcherService coalesces duplicates.
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutLocalShards, clusterStateWithoutLocalShards));
-        verifyNoMoreInteractions(watcherService);
+        verify(watcherService).setDesiredPaused("no local watcher shards found");
     }
 
     public void testReplicaWasAddedOrRemoved() {
@@ -554,12 +443,12 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
 
         when(watcherService.validate(eq(firstEvent.state()))).thenReturn(true);
         lifeCycleService.clusterChanged(firstEvent);
-        verify(watcherService).reload(eq(firstEvent.state()), anyString(), any());
+        verify(watcherService).setDesiredRunning(eq(firstEvent.state()), anyList(), anyString());
 
         reset(watcherService);
         when(watcherService.validate(eq(secondEvent.state()))).thenReturn(true);
         lifeCycleService.clusterChanged(secondEvent);
-        verify(watcherService).reload(eq(secondEvent.state()), anyString(), any());
+        verify(watcherService).setDesiredRunning(eq(secondEvent.state()), anyList(), anyString());
     }
 
     // make sure that cluster state changes can be processed on nodes that do not hold data
@@ -598,11 +487,10 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .build();
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", currentState, previousState));
-        verify(watcherService, times(0)).pauseExecution(any());
-        verify(watcherService, times(0)).reload(any(), any(), any());
+        verify(watcherService).setDesiredRunning(currentState, List.of(), "starting");
     }
 
-    public void testThatMissingWatcherIndexMetadataOnlyResetsOnce() {
+    public void testMissingWatcherIndexPublishesPausedIntent() {
         Index watchIndex = new Index(Watch.INDEX, "foo");
         ShardId shardId = new ShardId(watchIndex, 0);
         IndexRoutingTable watchRoutingTable = IndexRoutingTable.builder(watchIndex)
@@ -624,17 +512,17 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         when(watcherService.validate(eq(clusterStateWithWatcherIndex))).thenReturn(true);
         when(watcherService.validate(eq(clusterStateWithoutWatcherIndex))).thenReturn(false);
 
-        // first add the shard allocation ids, by going from empty cs to CS with watcher index
+        // First publish a running intent by going from an empty state to one with the watcher index.
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithWatcherIndex, clusterStateWithoutWatcherIndex));
-        verify(watcherService).reload(eq(clusterStateWithWatcherIndex), anyString(), any());
+        verify(watcherService).setDesiredRunning(eq(clusterStateWithWatcherIndex), anyList(), anyString());
 
-        // now remove watches index, and ensure that pausing is only called once, no matter how often called (i.e. each CS update)
+        // Now remove the watches index. Repeated intent is coalesced inside WatcherService.
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutWatcherIndex, clusterStateWithWatcherIndex));
-        verify(watcherService, times(1)).pauseExecution(any());
+        verify(watcherService).setDesiredPaused(anyString());
 
         reset(watcherService);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", clusterStateWithoutWatcherIndex, clusterStateWithWatcherIndex));
-        verifyNoMoreInteractions(watcherService);
+        verify(watcherService).setDesiredPaused(anyString());
     }
 
     public void testWatcherServiceDoesNotStartIfIndexTemplatesAreMissing() throws Exception {
@@ -649,7 +537,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         when(watcherService.validate(eq(state))).thenReturn(true);
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", state, state));
-        verify(watcherService, times(0)).start(any(ClusterState.class), any(), any());
+        verify(watcherService, times(0)).setDesiredRunning(any(ClusterState.class), anyList(), anyString());
     }
 
     public void testWatcherStopsWhenMasterNodeIsMissing() {
@@ -658,7 +546,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         DiscoveryNodes nodes = new DiscoveryNodes.Builder().localNodeId("node_1").add(newNode("node_1")).build();
         ClusterState state = ClusterState.builder(new ClusterName("my-cluster")).nodes(nodes).build();
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", state, state));
-        verify(watcherService, times(1)).pauseExecution(eq("no master node"));
+        verify(watcherService).setDesiredPaused("no master node");
     }
 
     public void testWatcherStopsOnClusterLevelBlock() {
@@ -668,7 +556,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         ClusterBlocks clusterBlocks = ClusterBlocks.builder().addGlobalBlock(NoMasterBlockService.NO_MASTER_BLOCK_WRITES).build();
         ClusterState state = ClusterState.builder(new ClusterName("my-cluster")).nodes(nodes).blocks(clusterBlocks).build();
         lifeCycleService.clusterChanged(new ClusterChangedEvent("any", state, state));
-        verify(watcherService, times(1)).pauseExecution(eq("write level cluster block"));
+        verify(watcherService).setDesiredPaused("write level cluster block");
     }
 
     public void testMasterOnlyNodeCanStart() {
@@ -682,7 +570,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .build();
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("test", state, state));
-        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTED));
+        verify(watcherService).setDesiredRunning(state, List.of(), "starting");
     }
 
     public void testDataNodeWithoutDataCanStart() {
@@ -695,7 +583,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .build();
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("test", state, state));
-        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTED));
+        verify(watcherService).setDesiredPaused("no watcher index found");
     }
 
     // this emulates a node outage somewhere in the cluster that carried a watcher shard
@@ -743,7 +631,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             .putProjectMetadata(ProjectMetadata.builder(projectId).put(indexMetadata, false))
             .build();
 
-        // initialize the previous state, so all the allocation ids are loaded
+        // Publish both states; WatcherService decides whether their routing fingerprints require work.
         when(watcherService.validate(any())).thenReturn(true);
         lifeCycleService.clusterChanged(new ClusterChangedEvent("whatever", previousState, currentState));
 
@@ -751,7 +639,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         when(watcherService.validate(any())).thenReturn(true);
         ClusterChangedEvent event = new ClusterChangedEvent("whatever", currentState, previousState);
         lifeCycleService.clusterChanged(event);
-        verify(watcherService).reload(eq(event.state()), anyString(), any());
+        verify(watcherService).setDesiredRunning(eq(event.state()), anyList(), anyString());
     }
 
     private void startWatcher() {
@@ -782,9 +670,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         when(watcherService.validate(state)).thenReturn(true);
 
         lifeCycleService.clusterChanged(new ClusterChangedEvent("foo", state, emptyState));
-        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTED));
-        verify(watcherService, times(1)).reload(eq(state), anyString(), any());
-        assertThat(lifeCycleService.shardRoutings(), hasSize(1));
+        verify(watcherService).setDesiredRunning(eq(state), anyList(), anyString());
 
         // reset the mock, the user has to mock everything themselves again
         reset(watcherService);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.NotMultiProjectCapable;
@@ -75,13 +76,9 @@ import org.mockito.ArgumentCaptor;
 import java.time.Clock;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -307,15 +304,15 @@ public class WatcherServiceTests extends ESTestCase {
         final TriggerService triggerService = mock(TriggerService.class);
         final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, taskQueue);
         doAnswer(invocation -> {
             invocation.<Runnable>getArgument(0).run();
             return 0;
         }).when(executionService).pause(any());
         service.setDesiredStopped("test setup");
-        executor.runNext();
-        executor.runNext();
+        taskQueue.runRandomTask();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPED));
 
         final ClusterState firstState = ClusterState.builder(new ClusterName("_name")).version(1).build();
@@ -325,8 +322,9 @@ public class WatcherServiceTests extends ESTestCase {
         service.setDesiredRunning(firstState, List.of(firstRouting), "starting");
         service.setDesiredRunning(latestState, List.of(latestRouting), "starting");
 
-        assertThat(executor.tasks, hasSize(1));
-        executor.runNext();
+        assertTrue(taskQueue.hasRunnableTasks());
+        taskQueue.runRandomTask();
+        assertFalse(taskQueue.hasRunnableTasks());
 
         assertThat(service.getState(), is(WatcherState.STARTED));
         verify(triggeredWatchStore).findTriggeredWatches(List.of(), latestState);
@@ -336,44 +334,44 @@ public class WatcherServiceTests extends ESTestCase {
 
     public void testReconcilerIgnoresUnchangedRoutingWhileRunning() {
         final TriggerService triggerService = mock(TriggerService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
         final WatcherService service = createWatcherService(
             triggerService,
             mock(TriggeredWatchStore.class),
             mock(ExecutionService.class),
-            executor
+            taskQueue
         );
         final ShardRouting routing = newRouting("node-1");
 
         service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).version(1).build(), List.of(routing), "initial routing");
-        executor.runNext();
+        taskQueue.runRandomTask();
         verify(triggerService).start(List.of());
         clearInvocations(triggerService);
 
         service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).version(2).build(), List.of(routing), "unchanged routing");
 
-        assertThat(executor.tasks, hasSize(0));
+        assertFalse(taskQueue.hasRunnableTasks());
         verifyNoMoreInteractions(triggerService);
     }
 
     public void testReconcilerReloadsUnchangedRoutingAfterPause() {
         final TriggerService triggerService = mock(TriggerService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
         final WatcherService service = createWatcherService(
             triggerService,
             mock(TriggeredWatchStore.class),
             mock(ExecutionService.class),
-            executor
+            taskQueue
         );
         final ShardRouting routing = newRouting("node-1");
         final ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
 
         service.setDesiredRunning(clusterState, List.of(routing), "initial routing");
-        executor.runNext();
+        taskQueue.runRandomTask();
         service.setDesiredPaused("test pause");
-        executor.runNext();
+        taskQueue.runRandomTask();
         service.setDesiredRunning(clusterState, List.of(routing), "resume");
-        executor.runNext();
+        taskQueue.runRandomTask();
 
         verify(triggerService, times(2)).start(List.of());
     }
@@ -382,15 +380,15 @@ public class WatcherServiceTests extends ESTestCase {
         final TriggerService triggerService = mock(TriggerService.class);
         final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, taskQueue);
         doAnswer(invocation -> {
             invocation.<Runnable>getArgument(0).run();
             return 0;
         }).when(executionService).pause(any());
         service.setDesiredStopped("test setup");
-        executor.runNext();
-        executor.runNext();
+        taskQueue.runRandomTask();
+        taskQueue.runRandomTask();
 
         final ClusterState firstState = ClusterState.builder(new ClusterName("_name")).version(1).build();
         final ClusterState latestState = ClusterState.builder(new ClusterName("_name")).version(2).build();
@@ -403,7 +401,7 @@ public class WatcherServiceTests extends ESTestCase {
         }).when(triggeredWatchStore).findTriggeredWatches(any(), any());
 
         service.setDesiredRunning(firstState, List.of(newRouting("node-1")), "starting");
-        executor.runNext();
+        taskQueue.runRandomTask();
 
         assertThat(service.getState(), is(WatcherState.STARTED));
         verify(triggerService).start(List.of());
@@ -415,15 +413,15 @@ public class WatcherServiceTests extends ESTestCase {
         final TriggerService triggerService = mock(TriggerService.class);
         final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, taskQueue);
         doAnswer(invocation -> {
             invocation.<Runnable>getArgument(0).run();
             return 0;
         }).when(executionService).pause(any());
         service.setDesiredStopped("test setup");
-        executor.runNext();
-        executor.runNext();
+        taskQueue.runRandomTask();
+        taskQueue.runRandomTask();
 
         final ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
         doAnswer(invocation -> {
@@ -432,8 +430,8 @@ public class WatcherServiceTests extends ESTestCase {
         }).when(triggeredWatchStore).findTriggeredWatches(any(), eq(clusterState));
 
         service.setDesiredRunning(clusterState, List.of(), "starting");
-        executor.runNext();
-        executor.runNext();
+        taskQueue.runRandomTask();
+        taskQueue.runRandomTask();
 
         assertThat(service.getState(), is(WatcherState.STOPPED));
         verify(triggerService, never()).start(any());
@@ -444,8 +442,8 @@ public class WatcherServiceTests extends ESTestCase {
         final TriggerService triggerService = mock(TriggerService.class);
         final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, taskQueue);
         final AtomicReference<Runnable> stopCompletion = new AtomicReference<>();
         doAnswer(invocation -> {
             stopCompletion.set(invocation.getArgument(0));
@@ -453,17 +451,17 @@ public class WatcherServiceTests extends ESTestCase {
         }).when(executionService).pause(any());
 
         service.setDesiredStopped("manual stop");
-        executor.runNext();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPING));
 
         final ClusterState latestState = ClusterState.builder(new ClusterName("_name")).build();
         service.setDesiredRunning(latestState, List.of(), "manual restart");
-        executor.runNext();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPING));
 
         stopCompletion.get().run();
-        executor.runNext();
-        executor.runNext();
+        taskQueue.runRandomTask();
+        taskQueue.runRandomTask();
 
         assertThat(service.getState(), is(WatcherState.STARTED));
         verify(triggerService).start(List.of());
@@ -474,8 +472,8 @@ public class WatcherServiceTests extends ESTestCase {
         final TriggerService triggerService = mock(TriggerService.class);
         final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, taskQueue);
         doAnswer(invocation -> {
             invocation.<Runnable>getArgument(0).run();
             return 0;
@@ -483,7 +481,7 @@ public class WatcherServiceTests extends ESTestCase {
 
         service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).build(), List.of(), "starting");
         service.setDesiredShutdown();
-        executor.runNext();
+        taskQueue.runRandomTask();
 
         assertThat(service.getState(), is(WatcherState.STOPPED));
         verify(triggerService).stop();
@@ -494,15 +492,15 @@ public class WatcherServiceTests extends ESTestCase {
     public void testShutdownIsTerminal() {
         final TriggerService triggerService = mock(TriggerService.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, mock(TriggeredWatchStore.class), executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, mock(TriggeredWatchStore.class), executionService, taskQueue);
         doAnswer(invocation -> {
             invocation.<Runnable>getArgument(0).run();
             return 0;
         }).when(executionService).pause(any());
 
         service.setDesiredShutdown();
-        executor.runNext();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPED));
         clearInvocations(triggerService, executionService);
 
@@ -510,7 +508,7 @@ public class WatcherServiceTests extends ESTestCase {
         service.setDesiredPaused("too late");
         service.setDesiredStopped("too late");
 
-        assertThat(executor.tasks, hasSize(0));
+        assertFalse(taskQueue.hasRunnableTasks());
         assertThat(service.getState(), is(WatcherState.STOPPED));
         verifyNoMoreInteractions(triggerService, executionService);
     }
@@ -518,8 +516,8 @@ public class WatcherServiceTests extends ESTestCase {
     public void testReconcilerShutdownSupersedesInProgressStop() {
         final TriggerService triggerService = mock(TriggerService.class);
         final ExecutionService executionService = mock(ExecutionService.class);
-        final QueuedExecutorService executor = new QueuedExecutorService();
-        final WatcherService service = createWatcherService(triggerService, mock(TriggeredWatchStore.class), executionService, executor);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final WatcherService service = createWatcherService(triggerService, mock(TriggeredWatchStore.class), executionService, taskQueue);
         final AtomicReference<Runnable> stopCompletion = new AtomicReference<>();
         doAnswer(invocation -> {
             final Runnable completion = invocation.getArgument(0);
@@ -530,16 +528,16 @@ public class WatcherServiceTests extends ESTestCase {
         }).when(executionService).pause(any());
 
         service.setDesiredStopped("manual stop");
-        executor.runNext();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPING));
 
         service.setDesiredShutdown();
-        executor.runNext();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPED));
         verify(triggerService).stop();
 
         stopCompletion.get().run();
-        executor.runNext();
+        taskQueue.runRandomTask();
         assertThat(service.getState(), is(WatcherState.STOPPED));
     }
 
@@ -859,7 +857,7 @@ public class WatcherServiceTests extends ESTestCase {
         TriggerService triggerService,
         TriggeredWatchStore triggeredWatchStore,
         ExecutionService executionService,
-        QueuedExecutorService executor
+        DeterministicTaskQueue taskQueue
     ) {
         return new WatcherService(
             Settings.EMPTY,
@@ -868,53 +866,11 @@ public class WatcherServiceTests extends ESTestCase {
             executionService,
             mock(WatchParser.class),
             client,
-            executor
+            taskQueue.getThreadPool().generic()
         ) {
             @Override
             void stopExecutor() {}
         };
-    }
-
-    private static class QueuedExecutorService extends AbstractExecutorService {
-        private final Queue<Runnable> tasks = new ArrayDeque<>();
-        private boolean shutdown;
-
-        @Override
-        public void shutdown() {
-            shutdown = true;
-        }
-
-        @Override
-        public List<Runnable> shutdownNow() {
-            shutdown = true;
-            final List<Runnable> queuedTasks = List.copyOf(tasks);
-            tasks.clear();
-            return queuedTasks;
-        }
-
-        @Override
-        public boolean isShutdown() {
-            return shutdown;
-        }
-
-        @Override
-        public boolean isTerminated() {
-            return shutdown && tasks.isEmpty();
-        }
-
-        @Override
-        public boolean awaitTermination(long timeout, TimeUnit unit) {
-            return isTerminated();
-        }
-
-        @Override
-        public void execute(Runnable command) {
-            tasks.add(command);
-        }
-
-        private void runNext() {
-            tasks.remove().run();
-        }
     }
 
     private static ScheduleTriggerEngineMock newEngineMock() {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.Murmur3HashFunction;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.settings.Settings;
@@ -51,12 +52,14 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.watcher.WatcherState;
 import org.elasticsearch.xpack.core.watcher.input.ExecutableInput;
 import org.elasticsearch.xpack.core.watcher.trigger.Trigger;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.core.watcher.watch.WatchStatus;
 import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.execution.ExecutionService;
+import org.elasticsearch.xpack.watcher.execution.TriggeredWatch;
 import org.elasticsearch.xpack.watcher.execution.TriggeredWatchStore;
 import org.elasticsearch.xpack.watcher.input.none.ExecutableNoneInput;
 import org.elasticsearch.xpack.watcher.trigger.ScheduleTriggerEngineMock;
@@ -72,10 +75,15 @@ import org.mockito.ArgumentCaptor;
 import java.time.Clock;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.aMapWithSize;
@@ -89,10 +97,13 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class WatcherServiceTests extends ESTestCase {
@@ -243,7 +254,7 @@ public class WatcherServiceTests extends ESTestCase {
             return null;
         }).when(client).execute(eq(TransportClearScrollAction.TYPE), any(ClearScrollRequest.class), anyActionListener());
 
-        service.start(clusterState, () -> {}, exception -> {});
+        service.setDesiredRunning(clusterState, List.of(), "starting");
 
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(triggerService).start(captor.capture());
@@ -252,16 +263,16 @@ public class WatcherServiceTests extends ESTestCase {
         assertThat(watches, hasSize(activeWatchCount));
     }
 
-    public void testExceptionHandling() {
+    public void testFailedReloadCanBeRetried() {
         /*
-         * This tests that if the WatcherService throws an exception while refreshing indices that the exception is handled by the
-         * exception consumer rather than being propagated higher in the stack.
+         * A failed reload must not mark its routing fingerprint as applied or prevent a later cluster-state update from retrying it.
          */
         TriggerService triggerService = mock(TriggerService.class);
         TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
         ExecutionService executionService = mock(ExecutionService.class);
         WatchParser parser = mock(WatchParser.class);
         final ElasticsearchTimeoutException exception = new ElasticsearchTimeoutException(new TimeoutException("Artifical timeout"));
+        final AtomicInteger attempts = new AtomicInteger();
         WatcherService service = new WatcherService(
             Settings.EMPTY,
             triggerService,
@@ -273,6 +284,7 @@ public class WatcherServiceTests extends ESTestCase {
         ) {
             @Override
             void refreshWatches(IndexMetadata indexMetadata) {
+                attempts.incrementAndGet();
                 throw exception;
             }
         };
@@ -284,9 +296,227 @@ public class WatcherServiceTests extends ESTestCase {
         csBuilder.putProjectMetadata(metadataBuilder);
         ClusterState clusterState = csBuilder.build();
 
-        AtomicReference<Exception> exceptionReference = new AtomicReference<>();
-        service.start(clusterState, () -> { fail("Excepted an exception"); }, exceptionReference::set);
-        assertThat(exceptionReference.get(), equalTo(exception));
+        service.setDesiredRunning(clusterState, List.of(), "starting");
+        service.setDesiredRunning(clusterState, List.of(), "retrying");
+
+        assertThat(attempts.get(), is(2));
+        assertThat(service.getState(), is(WatcherState.STARTED));
+    }
+
+    public void testReconcilerCoalescesStartupToLatestState() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return 0;
+        }).when(executionService).pause(any());
+        service.setDesiredStopped("test setup");
+        executor.runNext();
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPED));
+
+        final ClusterState firstState = ClusterState.builder(new ClusterName("_name")).version(1).build();
+        final ClusterState latestState = ClusterState.builder(new ClusterName("_name")).version(2).build();
+        final ShardRouting firstRouting = newRouting("node-1");
+        final ShardRouting latestRouting = newRouting("node-2");
+        service.setDesiredRunning(firstState, List.of(firstRouting), "starting");
+        service.setDesiredRunning(latestState, List.of(latestRouting), "starting");
+
+        assertThat(executor.tasks, hasSize(1));
+        executor.runNext();
+
+        assertThat(service.getState(), is(WatcherState.STARTED));
+        verify(triggeredWatchStore).findTriggeredWatches(List.of(), latestState);
+        verify(triggeredWatchStore, never()).findTriggeredWatches(List.of(), firstState);
+        verify(triggerService).start(List.of());
+    }
+
+    public void testReconcilerIgnoresUnchangedRoutingWhileRunning() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(
+            triggerService,
+            mock(TriggeredWatchStore.class),
+            mock(ExecutionService.class),
+            executor
+        );
+        final ShardRouting routing = newRouting("node-1");
+
+        service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).version(1).build(), List.of(routing), "initial routing");
+        executor.runNext();
+        verify(triggerService).start(List.of());
+        clearInvocations(triggerService);
+
+        service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).version(2).build(), List.of(routing), "unchanged routing");
+
+        assertThat(executor.tasks, hasSize(0));
+        verifyNoMoreInteractions(triggerService);
+    }
+
+    public void testReconcilerReloadsUnchangedRoutingAfterPause() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(
+            triggerService,
+            mock(TriggeredWatchStore.class),
+            mock(ExecutionService.class),
+            executor
+        );
+        final ShardRouting routing = newRouting("node-1");
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
+
+        service.setDesiredRunning(clusterState, List.of(routing), "initial routing");
+        executor.runNext();
+        service.setDesiredPaused("test pause");
+        executor.runNext();
+        service.setDesiredRunning(clusterState, List.of(routing), "resume");
+        executor.runNext();
+
+        verify(triggerService, times(2)).start(List.of());
+    }
+
+    public void testReconcilerDiscardsStartupSupersededDuringRecovery() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return 0;
+        }).when(executionService).pause(any());
+        service.setDesiredStopped("test setup");
+        executor.runNext();
+        executor.runNext();
+
+        final ClusterState firstState = ClusterState.builder(new ClusterName("_name")).version(1).build();
+        final ClusterState latestState = ClusterState.builder(new ClusterName("_name")).version(2).build();
+        final TriggeredWatch triggeredWatch = mock(TriggeredWatch.class);
+        doAnswer(invocation -> {
+            if (invocation.getArgument(1) == firstState) {
+                service.setDesiredRunning(latestState, List.of(newRouting("node-2")), "routing changed");
+            }
+            return List.of(triggeredWatch);
+        }).when(triggeredWatchStore).findTriggeredWatches(any(), any());
+
+        service.setDesiredRunning(firstState, List.of(newRouting("node-1")), "starting");
+        executor.runNext();
+
+        assertThat(service.getState(), is(WatcherState.STARTED));
+        verify(triggerService).start(List.of());
+        verify(executionService).executeTriggeredWatches(List.of(triggeredWatch));
+        verify(triggeredWatchStore, times(2)).findTriggeredWatches(any(), any());
+    }
+
+    public void testReconcilerStopSupersedesStartup() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return 0;
+        }).when(executionService).pause(any());
+        service.setDesiredStopped("test setup");
+        executor.runNext();
+        executor.runNext();
+
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
+        doAnswer(invocation -> {
+            service.setDesiredStopped("superseding stop");
+            return List.of();
+        }).when(triggeredWatchStore).findTriggeredWatches(any(), eq(clusterState));
+
+        service.setDesiredRunning(clusterState, List.of(), "starting");
+        executor.runNext();
+        executor.runNext();
+
+        assertThat(service.getState(), is(WatcherState.STOPPED));
+        verify(triggerService, never()).start(any());
+        verify(executionService, never()).unPause();
+    }
+
+    public void testReconcilerRestartsAfterStopCompletes() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        final AtomicReference<Runnable> stopCompletion = new AtomicReference<>();
+        doAnswer(invocation -> {
+            stopCompletion.set(invocation.getArgument(0));
+            return 0;
+        }).when(executionService).pause(any());
+
+        service.setDesiredStopped("manual stop");
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPING));
+
+        final ClusterState latestState = ClusterState.builder(new ClusterName("_name")).build();
+        service.setDesiredRunning(latestState, List.of(), "manual restart");
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPING));
+
+        stopCompletion.get().run();
+        executor.runNext();
+        executor.runNext();
+
+        assertThat(service.getState(), is(WatcherState.STARTED));
+        verify(triggerService).start(List.of());
+        verify(triggeredWatchStore).findTriggeredWatches(List.of(), latestState);
+    }
+
+    public void testReconcilerShutdownSupersedesQueuedStartup() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final TriggeredWatchStore triggeredWatchStore = mock(TriggeredWatchStore.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, triggeredWatchStore, executionService, executor);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return 0;
+        }).when(executionService).pause(any());
+
+        service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).build(), List.of(), "starting");
+        service.setDesiredShutdown();
+        executor.runNext();
+
+        assertThat(service.getState(), is(WatcherState.STOPPED));
+        verify(triggerService).stop();
+        verify(triggerService, never()).start(any());
+        verify(triggeredWatchStore, never()).findTriggeredWatches(any(), any());
+    }
+
+    public void testReconcilerShutdownSupersedesInProgressStop() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, mock(TriggeredWatchStore.class), executionService, executor);
+        final AtomicReference<Runnable> stopCompletion = new AtomicReference<>();
+        doAnswer(invocation -> {
+            final Runnable completion = invocation.getArgument(0);
+            if (stopCompletion.compareAndSet(null, completion) == false) {
+                completion.run();
+            }
+            return 0;
+        }).when(executionService).pause(any());
+
+        service.setDesiredStopped("manual stop");
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPING));
+
+        service.setDesiredShutdown();
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPED));
+        verify(triggerService).stop();
+
+        stopCompletion.get().run();
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPED));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -324,7 +554,7 @@ public class WatcherServiceTests extends ESTestCase {
             void stopExecutor() {}
         };
 
-        service.pauseExecution("pausing");
+        service.setDesiredPaused("pausing");
         assertThat(triggerService.count(), is(0L));
         verify(triggerEngine).pauseExecution();
     }
@@ -350,7 +580,7 @@ public class WatcherServiceTests extends ESTestCase {
         ClusterState.Builder csBuilder = new ClusterState.Builder(new ClusterName("_name"));
         csBuilder.metadata(Metadata.builder());
 
-        service.reload(csBuilder.build(), "whatever", exception -> {});
+        service.setDesiredRunning(csBuilder.build(), List.of(), "whatever");
         verify(executionService).clearExecutionsAndQueue(any());
         verify(executionService, never()).pause(any());
         verify(triggerService).pauseExecution();
@@ -380,7 +610,7 @@ public class WatcherServiceTests extends ESTestCase {
         // simulate exception in WatcherService's private loadWatches()
         when(project.getIndicesLookup()).thenThrow(RuntimeException.class);
 
-        service.reload(csBuilder.metadata(metadata).build(), "whatever", exception -> {});
+        service.setDesiredRunning(csBuilder.metadata(metadata).build(), List.of(), "whatever");
         verify(triggerService).pauseExecution();
         verify(triggerService, never()).start(any());
     }
@@ -601,8 +831,74 @@ public class WatcherServiceTests extends ESTestCase {
         };
     }
 
+    private WatcherService createWatcherService(
+        TriggerService triggerService,
+        TriggeredWatchStore triggeredWatchStore,
+        ExecutionService executionService,
+        QueuedExecutorService executor
+    ) {
+        return new WatcherService(
+            Settings.EMPTY,
+            triggerService,
+            triggeredWatchStore,
+            executionService,
+            mock(WatchParser.class),
+            client,
+            executor
+        ) {
+            @Override
+            void stopExecutor() {}
+        };
+    }
+
+    private static class QueuedExecutorService extends AbstractExecutorService {
+        private final Queue<Runnable> tasks = new ArrayDeque<>();
+        private boolean shutdown;
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            final List<Runnable> queuedTasks = List.copyOf(tasks);
+            tasks.clear();
+            return queuedTasks;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown && tasks.isEmpty();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return isTerminated();
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            tasks.add(command);
+        }
+
+        private void runNext() {
+            tasks.remove().run();
+        }
+    }
+
     private static ScheduleTriggerEngineMock newEngineMock() {
         return new ScheduleTriggerEngineMock(new ScheduleRegistry(Collections.emptySet()), Clock.systemUTC());
+    }
+
+    private static ShardRouting newRouting(String nodeId) {
+        return TestShardRouting.newShardRouting(new ShardId(new Index(Watch.INDEX, "uuid"), 0), nodeId, true, ShardRoutingState.STARTED);
     }
 
     private ClusterState singleShardLocalState() {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -491,6 +491,30 @@ public class WatcherServiceTests extends ESTestCase {
         verify(triggeredWatchStore, never()).findTriggeredWatches(any(), any());
     }
 
+    public void testShutdownIsTerminal() {
+        final TriggerService triggerService = mock(TriggerService.class);
+        final ExecutionService executionService = mock(ExecutionService.class);
+        final QueuedExecutorService executor = new QueuedExecutorService();
+        final WatcherService service = createWatcherService(triggerService, mock(TriggeredWatchStore.class), executionService, executor);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return 0;
+        }).when(executionService).pause(any());
+
+        service.setDesiredShutdown();
+        executor.runNext();
+        assertThat(service.getState(), is(WatcherState.STOPPED));
+        clearInvocations(triggerService, executionService);
+
+        service.setDesiredRunning(ClusterState.builder(new ClusterName("_name")).build(), List.of(), "too late");
+        service.setDesiredPaused("too late");
+        service.setDesiredStopped("too late");
+
+        assertThat(executor.tasks, hasSize(0));
+        assertThat(service.getState(), is(WatcherState.STOPPED));
+        verifyNoMoreInteractions(triggerService, executionService);
+    }
+
     public void testReconcilerShutdownSupersedesInProgressStop() {
         final TriggerService triggerService = mock(TriggerService.class);
         final ExecutionService executionService = mock(ExecutionService.class);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.xpack.core.watcher.WatcherState;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsRequest;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsResponse;
-import org.elasticsearch.xpack.watcher.WatcherLifeCycleService;
+import org.elasticsearch.xpack.watcher.WatcherService;
 import org.elasticsearch.xpack.watcher.execution.ExecutionService;
 import org.elasticsearch.xpack.watcher.trigger.TriggerService;
 import org.junit.After;
@@ -69,8 +69,8 @@ public class TransportWatcherStatsActionTests extends ESTestCase {
         when(clusterState.getMetadata()).thenReturn(metadata);
         when(clusterState.metadata()).thenReturn(metadata);
 
-        WatcherLifeCycleService watcherLifeCycleService = mock(WatcherLifeCycleService.class);
-        when(watcherLifeCycleService.getState()).thenReturn(() -> WatcherState.STARTED);
+        WatcherService watcherService = mock(WatcherService.class);
+        when(watcherService.getState()).thenReturn(WatcherState.STARTED);
 
         ExecutionService executionService = mock(ExecutionService.class);
         when(executionService.executionThreadPoolQueueSize()).thenReturn(100L);
@@ -95,7 +95,7 @@ public class TransportWatcherStatsActionTests extends ESTestCase {
             clusterService,
             threadPool,
             new ActionFilters(Collections.emptySet()),
-            watcherLifeCycleService,
+            watcherService,
             executionService,
             triggerService,
             TestProjectResolvers.singleProject(projectId)


### PR DESCRIPTION
This formalises the way the watcher service transitions between states.

It simplifies the `WatcherLifeCycleService` so that it just translates cluster state updates into desired states for the `WatcherService`, and the `WatcherService` itself reconciles the desired state with its current state.

This allows us to more reliably manage state upon transitions between states.