### PR TITLE
[9.4] Apply search timeout to the DFS phase query rewrite (#153479)

### DIFF
--- a/docs/changelog/153479.yaml
+++ b/docs/changelog/153479.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 153479
+summary: Apply search timeout to the DFS phase query rewrite
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchTimeoutIT.java
@@ -393,6 +393,32 @@ public class SearchTimeoutIT extends ESIntegTestCase {
         assertEquals(RestStatus.TOO_MANY_REQUESTS.getStatus(), ex.status().getStatus());
     }
 
+    public void testDfsRewriteTimeoutWithPartialResults() {
+        SearchRequestBuilder searchRequestBuilder = prepareSearch("test").setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+            .setTimeout(new TimeValue(10, TimeUnit.SECONDS))
+            .setQuery(new RewriteTimeoutQuery());
+        ElasticsearchAssertions.assertResponse(searchRequestBuilder, searchResponse -> {
+            assertThat(searchResponse.isTimedOut(), equalTo(true));
+            assertEquals(0, searchResponse.getShardFailures().length);
+            assertEquals(0, searchResponse.getFailedShards());
+            assertThat(searchResponse.getSuccessfulShards(), greaterThan(0));
+            assertEquals(searchResponse.getSuccessfulShards(), searchResponse.getTotalShards());
+            assertEquals(0, searchResponse.getHits().getTotalHits().value());
+            assertEquals(0, searchResponse.getHits().getHits().length);
+        });
+    }
+
+    public void testPartialResultsIntolerantDfsRewriteTimeout() {
+        ElasticsearchException ex = expectThrows(
+            ElasticsearchException.class,
+            prepareSearch("test").setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                .setTimeout(new TimeValue(10, TimeUnit.SECONDS))
+                .setQuery(new RewriteTimeoutQuery())
+                .setAllowPartialSearchResults(false)
+        );
+        assertEquals(RestStatus.TOO_MANY_REQUESTS.getStatus(), ex.status().getStatus());
+    }
+
     public static final class SearchTimeoutPlugin extends Plugin implements SearchPlugin {
         @Override
         public List<QuerySpec<?>> getQueries() {

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -41,6 +41,7 @@ import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +60,12 @@ public class DfsPhase {
 
     public static void execute(SearchContext context) {
         try {
-            collectStatistics(context);
-            executeKnnVectorQuery(context);
+            final Runnable timeoutRunnable = QueryPhase.getTimeoutCheck(context);
+            collectStatistics(context, timeoutRunnable);
+
+            if (context.dfsResult().searchTimedOut() == false) {
+                executeKnnVectorQuery(context, timeoutRunnable);
+            }
 
             if (context.getProfilers() != null) {
                 context.dfsResult().profileResult(context.getProfilers().getDfsProfiler().buildDfsPhaseResults());
@@ -72,7 +77,7 @@ public class DfsPhase {
         }
     }
 
-    private static void collectStatistics(SearchContext context) throws IOException {
+    private static void collectStatistics(SearchContext context, Runnable timeoutRunnable) throws IOException {
         final DfsProfiler profiler = context.getProfilers() == null ? null : context.getProfilers().getDfsProfiler();
 
         Map<String, CollectionStatistics> fieldStatistics = new HashMap<>();
@@ -122,6 +127,10 @@ public class DfsPhase {
             profiler.start();
         }
 
+        if (timeoutRunnable != null) {
+            context.searcher().addQueryCancellation(timeoutRunnable);
+        }
+
         try {
             Timer timer = maybeStartTimer(profiler, DfsTimingType.CREATE_WEIGHT);
             try {
@@ -152,9 +161,20 @@ public class DfsPhase {
                     }
                 }
             }
+
+            if (context.searcher().timeExceeded()) {
+                finalizeStatisticsAsTimedOut(context);
+                return;
+            }
+        } catch (ContextIndexSearcher.TimeExceededException e) {
+            finalizeStatisticsAsTimedOut(context);
+            return;
         } finally {
             if (profiler != null) {
                 profiler.stop();
+            }
+            if (timeoutRunnable != null) {
+                context.searcher().removeQueryCancellation(timeoutRunnable);
             }
         }
 
@@ -179,9 +199,21 @@ public class DfsPhase {
             return profiler.startTimer(dtt);
         }
         return null;
-    };
+    }
 
-    static void executeKnnVectorQuery(SearchContext context) throws IOException {
+    private static void finalizeStatisticsAsTimedOut(SearchContext context) {
+        context.dfsResult().termsStatistics(new Term[0], new TermStatistics[0]).fieldStatistics(Collections.emptyMap()).maxDoc(0);
+        handleDfsTimeout(context);
+    }
+
+    private static void handleDfsTimeout(SearchContext context) {
+        if (context.request().allowPartialSearchResults() == false) {
+            throw new SearchTimeoutException(context.shardTarget(), "Time exceeded");
+        }
+        context.dfsResult().searchTimedOut(true);
+    }
+
+    static void executeKnnVectorQuery(SearchContext context, Runnable timeoutRunnable) throws IOException {
         SearchSourceBuilder source = context.request().source();
         if (source == null || source.knnSearch().isEmpty()) {
             return;
@@ -204,7 +236,6 @@ public class DfsPhase {
         var opsListener = context.indexShard().getSearchOperationListener();
         opsListener.onPreQueryPhase(context);
 
-        final Runnable timeoutRunnable = QueryPhase.getTimeoutCheck(context);
         if (timeoutRunnable != null) {
             context.searcher().addQueryCancellation(timeoutRunnable);
         }
@@ -225,10 +256,7 @@ public class DfsPhase {
             opsListener = null;
         } catch (ContextIndexSearcher.TimeExceededException e) {
             context.dfsResult().knnResults(List.of());
-            if (context.request().allowPartialSearchResults() == false) {
-                throw new SearchTimeoutException(context.shardTarget(), "Time exceeded");
-            }
-            context.dfsResult().searchTimedOut(true);
+            handleDfsTimeout(context);
             opsListener.onQueryPhase(context, System.nanoTime() - beforeQueryTime);
             opsListener = null;
             return;

--- a/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTests.java
@@ -163,7 +163,7 @@ public class DfsPhaseTests extends IndexShardTestCase {
                     );
                 context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
                 context.parsedQuery(new ParsedQuery(query));
-                executeKnnVectorQuery(context);
+                executeKnnVectorQuery(context, null);
                 assertTrue(queryCount.get() > 0);
                 assertTrue(queryTime.get() > 0);
                 reader.close();

--- a/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/dfs/DfsPhaseTimeoutTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -241,6 +242,78 @@ public class DfsPhaseTimeoutTests extends IndexShardTestCase {
         }
     }
 
+    public void testCollectStatisticsWithRewriteTimeoutAllowPartial() throws Exception {
+        DfsSearchResult dfsResult = new DfsSearchResult(null, null, null);
+        ContextIndexSearcher cis = newContextSearcher(reader);
+
+        try (TestSearchContext context = new TestSearchContext(createSearchExecutionContext(), indexShard, cis) {
+            @Override
+            public TimeValue timeout() {
+                return TimeValue.ZERO;
+            }
+
+            @Override
+            public DfsSearchResult dfsResult() {
+                return dfsResult;
+            }
+        }) {
+            context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+            context.parsedQuery(new ParsedQuery(new RewriteTimeoutQuery()));
+            context.request().source(new SearchSourceBuilder());
+
+            DfsPhase.execute(context);
+
+            assertTrue(dfsResult.searchTimedOut());
+            assertEquals(0, dfsResult.terms().length);
+            assertEquals(0, dfsResult.termStatistics().length);
+            assertEquals(0, dfsResult.maxDoc());
+        }
+    }
+
+    public void testCollectStatisticsWithRewriteTimeoutDisallowPartial() throws Exception {
+        DfsSearchResult dfsResult = new DfsSearchResult(null, null, null);
+        ContextIndexSearcher cis = newContextSearcher(reader);
+
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.allowPartialSearchResults(false);
+        searchRequest.source(new SearchSourceBuilder());
+        ShardSearchRequest shardRequest = new ShardSearchRequest(
+            OriginalIndices.NONE,
+            searchRequest,
+            indexShard.shardId(),
+            0,
+            1,
+            AliasFilter.EMPTY,
+            1.0f,
+            System.currentTimeMillis(),
+            null
+        );
+
+        try (TestSearchContext context = new TestSearchContext(createSearchExecutionContext(), indexShard, cis) {
+            @Override
+            public ShardSearchRequest request() {
+                return shardRequest;
+            }
+
+            @Override
+            public TimeValue timeout() {
+                return TimeValue.ZERO;
+            }
+
+            @Override
+            public DfsSearchResult dfsResult() {
+                return dfsResult;
+            }
+        }) {
+            context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+            context.parsedQuery(new ParsedQuery(new RewriteTimeoutQuery()));
+
+            SearchTimeoutException ex = expectThrows(SearchTimeoutException.class, () -> DfsPhase.execute(context));
+            assertThat(ex.status(), equalTo(RestStatus.TOO_MANY_REQUESTS));
+            assertTrue(ex.isTimeout());
+        }
+    }
+
     private SearchExecutionContext createSearchExecutionContext() {
         IndexMetadata indexMetadata = IndexMetadata.builder("index")
             .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()))
@@ -284,6 +357,34 @@ public class DfsPhaseTimeoutTests extends IndexShardTestCase {
             LuceneTestCase.MAYBE_CACHE_POLICY,
             true
         );
+    }
+
+    private static final class RewriteTimeoutQuery extends Query {
+        @Override
+        public Query rewrite(IndexSearcher searcher) {
+            ((ContextIndexSearcher) searcher).throwTimeExceededException();
+            throw new AssertionError("should have thrown TimeExceededException");
+        }
+
+        @Override
+        public String toString(String field) {
+            return "rewrite timeout query";
+        }
+
+        @Override
+        public void visit(QueryVisitor visitor) {
+            visitor.visitLeaf(this);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return sameClassAs(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return classHash();
+        }
     }
 
     private static ContextIndexSearcher newThrowingOnFirstSearchSearcher(IndexReader reader) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Apply search timeout to the DFS phase query rewrite (#153479)