### PR TITLE
[9.4] Fix flaky t-digest sparse Gaussian median test (#153534)

### DIFF
--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/ComparisonTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/ComparisonTests.java
@@ -126,12 +126,15 @@ public class ComparisonTests extends TDigestTestCase {
             assertEquals(String.valueOf(percentile), expected, hybridDigest.quantile(q), accuracy);
         }
 
-        // The absolute value of median is within [0,5000], which is deemed close enough to 0 compared to the max value.
+        // The true median is ~0, negligible against this distribution's +/-5,000,000 range. Allow 0.01 * the standard
+        // deviation (which is SAMPLE_COUNT here), matching testDenseGaussianDistribution; the previous fixed 5000
+        // (0.005 * standard deviation) was occasionally too tight for the merging/hybrid digests and flaky (#153061).
+        double medianTolerance = SAMPLE_COUNT / 100.0;
         double expectedMedian = Dist.quantile(0.5, samples);
         assertEquals(expectedMedian, sortingDigest.quantile(0.5), 0);
-        assertEquals(expectedMedian, avlTreeDigest.quantile(0.5), 5000);
-        assertEquals(expectedMedian, mergingDigest.quantile(0.5), 5000);
-        assertEquals(expectedMedian, hybridDigest.quantile(0.5), 5000);
+        assertEquals(expectedMedian, avlTreeDigest.quantile(0.5), medianTolerance);
+        assertEquals(expectedMedian, mergingDigest.quantile(0.5), medianTolerance);
+        assertEquals(expectedMedian, hybridDigest.quantile(0.5), medianTolerance);
 
         releaseData();
     }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -230,9 +230,6 @@ tests:
 - class: org.elasticsearch.packaging.test.PackageUpgradeTests
   method: test21CheckUpgradedVersion
   issue: https://github.com/elastic/elasticsearch/issues/152909
-- class: org.elasticsearch.tdigest.ComparisonTests
-  method: testSparseGaussianDistribution
-  issue: https://github.com/elastic/elasticsearch/issues/153061
 - class: org.elasticsearch.test.apmintegration.TracesApmIT
   method: testTraces
   issue: https://github.com/elastic/elasticsearch/issues/153062


### PR DESCRIPTION
Closes #153061.

# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix flaky t-digest sparse Gaussian median test (#153534)](https://github.com/elastic/elasticsearch/pull/153534)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)