### PR TITLE
[9.5] Improve flakiness-detection report annotation (#153499)

### DIFF
--- a/.buildkite/scripts/flakiness-detection/analyzer/analyze.test.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/analyze.test.ts
@@ -3,7 +3,18 @@ import { mkdtemp, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join, dirname } from "path";
 
-import { analyzeReports, classifyFailure, StripSystemStreams } from "./analyze.ts";
+import { analyzeReports, classifyFailure, stripSeedSuffix, StripSystemStreams } from "./analyze.ts";
+
+describe("stripSeedSuffix", () => {
+  test("strips a trailing randomized-runner seed suffix", () => {
+    expect(stripSeedSuffix("testFoo {seed=[24918B24CBE01DE3:A940852AB5443E5]}")).toBe("testFoo");
+  });
+
+  test("leaves plain names and non-seed parameterization suffixes intact", () => {
+    expect(stripSeedSuffix("testFoo")).toBe("testFoo");
+    expect(stripSeedSuffix("testFoo {p0=x}")).toBe("testFoo {p0=x}");
+  });
+});
 
 describe("classifyFailure", () => {
   test("classifies AssertionError messages as 'assertion'", () => {
@@ -50,6 +61,33 @@ describe("analyzeReports", () => {
         failures: 1,
         failureKinds: ["assertion"],
       }),
+    ]);
+  });
+
+  test("collapses seeded iterations of a method into one row, keeping failing seeds", async () => {
+    // A randomized `tests.iters` run emits one testcase per seed. All iterations
+    // of a method must aggregate into a single row with real pass/fail counts,
+    // and the seed-bearing name of a failure must survive for reproduction.
+    const root = await mkTmpReports([
+      {
+        path: "server/build/test-results/test/TEST-org.example.SeedTests.xml",
+        body: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.example.SeedTests" tests="2" failures="1" errors="0">
+  <testcase classname="org.example.SeedTests" name="testFlaky {seed=[AAAA:1111]}"/>
+  <testcase classname="org.example.SeedTests" name="testFlaky {seed=[AAAA:2222]}">
+    <failure type="java.lang.AssertionError" message="boom"/>
+  </testcase>
+</testsuite>`,
+      },
+    ]);
+    const report = await analyzeReports([root]);
+    expect(report.perTest).toHaveLength(1);
+    const flaky = report.perTest[0];
+    expect(flaky.method).toBe("testFlaky");
+    expect(flaky.passes).toBe(1);
+    expect(flaky.failures).toBe(1);
+    expect(flaky.exampleFailures).toEqual([
+      { name: "testFlaky {seed=[AAAA:2222]}", message: "boom" },
     ]);
   });
 
@@ -111,10 +149,10 @@ describe("analyzeReports", () => {
     const plain = report.perTest.find((t) => t.method === "testPlain")!;
     const cdata = report.perTest.find((t) => t.method === "testCdata")!;
     expect(plain.failureKinds).toEqual(["assertion"]);
-    expect(plain.exampleMessages[0]).toContain("expected:<1> but was:<2>");
+    expect(plain.exampleFailures[0].message).toContain("expected:<1> but was:<2>");
     expect(cdata.failureKinds).toEqual(["error"]);
-    expect(cdata.exampleMessages[0]).toContain("boom");
-    expect(cdata.exampleMessages[0]).toContain("Foo.bar(Foo.java:42)");
+    expect(cdata.exampleFailures[0].message).toContain("boom");
+    expect(cdata.exampleFailures[0].message).toContain("Foo.bar(Foo.java:42)");
   });
 
   test("keeps memory bounded when a single <failure> body is huge", async () => {
@@ -140,7 +178,7 @@ describe("analyzeReports", () => {
     expect(huge.failureKinds).toEqual(["assertion"]);
     // The cached example message must be truncated, not the original 4 MiB.
     // The cap inside analyze.ts is 16 KiB per failure body.
-    expect(huge.exampleMessages[0].length).toBeLessThanOrEqual(16 * 1024);
+    expect(huge.exampleFailures[0].message.length).toBeLessThanOrEqual(16 * 1024);
   });
 
   test("uses body text when `message` attribute is empty or absent", async () => {
@@ -164,8 +202,8 @@ describe("analyzeReports", () => {
     const report = await analyzeReports([root]);
     const wins = report.perTest.find((t) => t.method === "testWins")!;
     const empty = report.perTest.find((t) => t.method === "testEmptyAttr")!;
-    expect(wins.exampleMessages).toEqual(["attr wins"]);
-    expect(empty.exampleMessages).toEqual(["body text must be used"]);
+    expect(wins.exampleFailures.map((e) => e.message)).toEqual(["attr wins"]);
+    expect(empty.exampleFailures.map((e) => e.message)).toEqual(["body text must be used"]);
   });
 
   test("self-closing <failure message='..'/> still classifies and records", async () => {
@@ -182,7 +220,7 @@ describe("analyzeReports", () => {
     ]);
     const report = await analyzeReports([root]);
     expect(report.totals.realFailures).toBe(1);
-    expect(report.perTest[0].exampleMessages).toEqual(["boom"]);
+    expect(report.perTest[0].exampleFailures.map((e) => e.message)).toEqual(["boom"]);
   });
 
   test("strips huge <system-out>/<system-err> sections before parsing", async () => {
@@ -242,7 +280,7 @@ ${cases}
     expect(report.totals.successfulCases).toBe(1);
     expect(report.totals.realFailures).toBe(1);
     const failing = report.perTest.find((t) => t.method === "testWithFailureAndStdout")!;
-    expect(failing.exampleMessages).toEqual(["boom"]);
+    expect(failing.exampleFailures.map((e) => e.message)).toEqual(["boom"]);
   });
 
   test("does NOT strip a literal '<system-out' embedded inside a CDATA failure body", async () => {
@@ -264,8 +302,8 @@ ${cases}
     ]);
     const report = await analyzeReports([root]);
     expect(report.totals.realFailures).toBe(1);
-    expect(report.perTest[0].exampleMessages[0]).toContain("<system-out>");
-    expect(report.perTest[0].exampleMessages[0]).toContain("leaked into the message");
+    expect(report.perTest[0].exampleFailures[0].message).toContain("<system-out>");
+    expect(report.perTest[0].exampleFailures[0].message).toContain("leaked into the message");
   });
 
   test("rejects on malformed XML rather than swallowing it silently", async () => {

--- a/.buildkite/scripts/flakiness-detection/analyzer/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/analyze.ts
@@ -12,13 +12,21 @@ export interface FailureEntry {
   message: string;
 }
 
+export interface ExampleFailure {
+  // Original JUnit testcase name, including the randomized-runner seed suffix
+  // (e.g. `foo {seed=[A:B]}`). Retained so a collapsed row still carries the
+  // exact seeds needed to reproduce the failure.
+  name: string;
+  message: string;
+}
+
 export interface TestSummary {
   className: string;
   method: string;
   passes: number;
   failures: number;
   failureKinds: FailureKind[];
-  exampleMessages: string[];
+  exampleFailures: ExampleFailure[];
 }
 
 export interface BatchSummary {
@@ -55,6 +63,17 @@ const SKIP_DIRS = new Set([
 // the (max 3) example messages — but bounds the worst case when a single
 // stack trace runs to multiple megabytes.
 const MAX_FAILURE_TEXT_BYTES = 16 * 1024;
+
+// Elasticsearch's randomized runner bakes a distinct per-iteration seed into
+// each testcase name (`method {seed=[<classSeed>:<methodSeed>]}`), so every
+// `-Dtests.iters` iteration would otherwise key to a separate row. Strip that
+// suffix so all iterations of a method aggregate into one row with real
+// pass/fail counts; the original seed-bearing name is preserved in
+// `ExampleFailure.name` for reproduction. Non-seed parameterization suffixes
+// (e.g. `{p0=x}`) are left intact.
+export function stripSeedSuffix(name: string): string {
+  return name.replace(/ \{seed=\[[0-9A-Fa-f:]+\]\}$/, "");
+}
 
 export function classifyFailure(f: FailureEntry): FailureKind {
   const msg = f.message ?? "";
@@ -109,6 +128,9 @@ interface PendingFailure {
 
 interface CurrentCase {
   entry: TestSummary;
+  // Original testcase name (with seed suffix); the row's `entry.method` has the
+  // seed stripped, but the raw name is recorded on failing examples for repro.
+  rawName: string;
   // First `<failure>` or `<error>` child of the testcase wins; subsequent ones
   // are ignored. Text/CDATA chunks append to `pending.text` while inside the
   // corresponding element body (gated by `insideFailureBody`).
@@ -127,7 +149,7 @@ function ensureEntry(state: AggregateState, className: string, method: string): 
       passes: 0,
       failures: 0,
       failureKinds: [],
-      exampleMessages: [],
+      exampleFailures: [],
     };
     state.perTestMap.set(key, entry);
   }
@@ -281,8 +303,10 @@ function streamParseReport(file: string, state: AggregateState): Promise<BatchSu
       const attrs = node.attributes as Record<string, string>;
 
       if (tag === "testcase") {
+        const rawName = attrs.name ?? "";
         curCase = {
-          entry: ensureEntry(state, attrs.classname ?? "", attrs.name ?? ""),
+          entry: ensureEntry(state, attrs.classname ?? "", stripSeedSuffix(rawName)),
+          rawName,
           pending: null,
           insideFailureBody: false,
           skipped: false,
@@ -343,10 +367,10 @@ function streamParseReport(file: string, state: AggregateState): Promise<BatchSu
             curCase.entry.failures += 1;
             curCase.entry.failureKinds.push(kind);
             if (
-              curCase.entry.exampleMessages.length < 3 &&
-              !curCase.entry.exampleMessages.includes(message)
+              curCase.entry.exampleFailures.length < 3 &&
+              !curCase.entry.exampleFailures.some((e) => e.name === curCase!.rawName && e.message === message)
             ) {
-              curCase.entry.exampleMessages.push(message);
+              curCase.entry.exampleFailures.push({ name: curCase.rawName, message });
             }
             batchFailed += 1;
           }

--- a/.buildkite/scripts/flakiness-detection/analyzer/render.test.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/render.test.ts
@@ -1,15 +1,70 @@
 import { describe, expect, test } from "vitest";
+import type { TestSummary } from "./analyze.ts";
 import { renderMarkdown, severity } from "./render.ts";
 
 describe("renderMarkdown / severity", () => {
   test("renders the failures table when there are real failures", () => {
     const md = renderMarkdown({
       batches: [],
-      perTest: [{ className: "X", method: "y", passes: 0, failures: 1, failureKinds: ["assertion"], exampleMessages: ["boom"] }],
+      perTest: [{
+        className: "X",
+        method: "y",
+        passes: 0,
+        failures: 1,
+        failureKinds: ["assertion"],
+        exampleFailures: [{ name: "y {seed=[A:B]}", message: "boom" }],
+      }],
       totals: { iterations: 1, realFailures: 1, suiteTimeoutMarkers: 0, successfulCases: 0 },
     });
     expect(md).toContain("Failures by test");
     expect(md).toContain("boom");
+    // The seed-bearing name is preserved in the example line for reproduction.
+    expect(md).toContain("`X.y {seed=[A:B]}`: boom");
+  });
+
+  test("summarizes the Kinds column as counts, omitting x1 for singletons", () => {
+    const md = renderMarkdown({
+      batches: [],
+      perTest: [{
+        className: "X",
+        method: "y",
+        passes: 0,
+        failures: 6,
+        failureKinds: ["error", "error", "error", "assertion", "assertion", "other"],
+        exampleFailures: [{ name: "y", message: "boom" }],
+      }],
+      totals: { iterations: 6, realFailures: 6, suiteTimeoutMarkers: 0, successfulCases: 0 },
+    });
+    expect(md).toContain("| error x3, assertion x2, other |");
+  });
+
+  test("bounds a mass-failure report and lists the most-flaky tests first", () => {
+    // Simulate many distinct failing methods (the case seed-grouping cannot
+    // collapse) with long messages, to prove the annotation stays postable.
+    const perTest: TestSummary[] = Array.from({ length: 500 }, (_, i) => ({
+      className: "org.example.MassTests",
+      method: `testFail${i}`,
+      passes: 0,
+      failures: (i % 7) + 1,
+      failureKinds: ["error"],
+      exampleFailures: [{ name: `testFail${i}`, message: "E".repeat(5000) }],
+    }));
+    const md = renderMarkdown({
+      batches: [],
+      perTest,
+      totals: { iterations: 500, realFailures: 500, suiteTimeoutMarkers: 0, successfulCases: 0 },
+    });
+
+    // Comfortably under Buildkite's ~1 MiB annotation limit.
+    expect(md.length).toBeLessThan(900_000);
+    // Row count is capped and the truncation note is present.
+    expect(md).toContain("of 500 failing tests");
+    // Highest-failures rows survive: some method with failures=7 must appear,
+    // and the table must not blow past the row cap (100 rows + header lines).
+    const rowCount = md.split("\n").filter((l) => l.startsWith("| org.example.MassTests |")).length;
+    expect(rowCount).toBeLessThanOrEqual(100);
+    // Individual example messages are truncated, not emitted at full 5000 chars.
+    expect(md).not.toContain("E".repeat(5000));
   });
 
   test("severity reflects the worst signal", () => {

--- a/.buildkite/scripts/flakiness-detection/analyzer/render.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/render.ts
@@ -1,4 +1,26 @@
-import type { FlakinessReport } from "./analyze.ts";
+import type { FailureKind, FlakinessReport } from "./analyze.ts";
+
+// Buildkite rejects annotation bodies larger than ~1 MiB.
+const MAX_FAILING_ROWS = 100;
+const MAX_EXAMPLE_MESSAGES = 25;
+const MAX_MESSAGE_CHARS = 400;
+const MAX_ANNOTATION_BYTES = 900_000;
+const TRUNCATION_MARKER = "\n\n_Annotation truncated to stay under the Buildkite size limit._";
+
+function truncateMessage(msg: string): string {
+  return msg.length <= MAX_MESSAGE_CHARS ? msg : `${msg.slice(0, MAX_MESSAGE_CHARS)}…`;
+}
+
+// Collapse the per-occurrence failure-kind list into counts, preserving
+// first-seen order, e.g. ["error","error","assertion"] -> "error x2, assertion".
+// The " xN" suffix is omitted for singletons.
+function summarizeKinds(kinds: FailureKind[]): string {
+  const counts = new Map<FailureKind, number>();
+  for (const k of kinds) {
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([k, n]) => (n > 1 ? `${k} x${n}` : k)).join(", ");
+}
 
 export function renderMarkdown(report: FlakinessReport): string {
   const { totals } = report;
@@ -11,26 +33,49 @@ export function renderMarkdown(report: FlakinessReport): string {
   lines.push(`- Suite-timeout markers (informational): ${totals.suiteTimeoutMarkers}`);
   lines.push("");
 
-  const failing = report.perTest.filter((t) => t.failures > 0);
+  // Most-flaky first, so truncation drops the least-failing tests.
+  const failing = report.perTest.filter((t) => t.failures > 0).sort((a, b) => b.failures - a.failures);
   if (failing.length > 0) {
+    const shownRows = failing.slice(0, MAX_FAILING_ROWS);
+
     lines.push("### Failures by test");
     lines.push("| Class | Method | Pass | Fail | Kinds |");
     lines.push("| --- | --- | ---: | ---: | --- |");
-    for (const t of failing) {
-      lines.push(`| ${t.className} | ${t.method} | ${t.passes} | ${t.failures} | ${t.failureKinds.join(", ")} |`);
+    for (const t of shownRows) {
+      lines.push(`| ${t.className} | ${t.method} | ${t.passes} | ${t.failures} | ${summarizeKinds(t.failureKinds)} |`);
+    }
+    if (failing.length > shownRows.length) {
+      lines.push("");
+      lines.push(
+        `_Showing ${shownRows.length} of ${failing.length} failing tests; full data in the flakiness-outcomes.json artifact and job logs._`
+      );
     }
     lines.push("");
 
     lines.push("### Example failure messages");
-    for (const t of failing) {
-      for (const msg of t.exampleMessages) {
-        lines.push(`- \`${t.className}.${t.method}\`: ${msg}`);
+    let shownMessages = 0;
+    let omittedMessages = 0;
+    for (const t of shownRows) {
+      for (const ex of t.exampleFailures) {
+        if (shownMessages >= MAX_EXAMPLE_MESSAGES) {
+          omittedMessages += 1;
+          continue;
+        }
+        lines.push(`- \`${t.className}.${ex.name}\`: ${truncateMessage(ex.message)}`);
+        shownMessages += 1;
       }
+    }
+    if (omittedMessages > 0) {
+      lines.push("");
+      lines.push(`_${omittedMessages} further example message(s) omitted; see job logs._`);
     }
   } else {
     lines.push("_No real failures recorded._");
   }
-  return lines.join("\n");
+
+  const body = lines.join("\n");
+  if (body.length <= MAX_ANNOTATION_BYTES) return body;
+  return body.slice(0, MAX_ANNOTATION_BYTES - TRUNCATION_MARKER.length) + TRUNCATION_MARKER;
 }
 
 export function severity(report: FlakinessReport): "error" | "warning" | "success" {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Improve flakiness-detection report annotation (#153499)