### PR TITLE
[9.3] Migrate repository-multi-version to JUnit rule based test clusters (#151777)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,169 @@
+# Elasticsearch
+
+## Toolchain Snapshot
+- **Java**: JDK 25 via `JAVA_HOME`; use the bundled Gradle wrapper (`./gradlew`).
+- **Build tooling**: Gradle composite build with `build-conventions`, `build-tools`, and `build-tools-internal`; Docker is required for some packaging/tests.
+- **OS packages**: Packaging and QA jobs expect ephemeral hosts; do not run packaging suites on your workstation.
+- **Security**: Default dev clusters enable security; use `elastic-admin:elastic-password` or disable with `-Dtests.es.xpack.security.enabled=false`.
+- **Cursor/Copilot rules**: None provided in repo; follow this guide plus CONTRIBUTING.md.
+
+## Build & Run Commands
+- Refer to BUILDING.md, CONTRIBUTING.md & TESTING.asciidoc for comprehensive build/test instructions.
+
+## Verification & Lint Tasks
+- `./gradlew spotlessJavaCheck` / `spotlessApply` (or `:server:spotlessJavaCheck`): enforce formatter profile in `build-conventions/formatterConfig.xml`.
+- `spotlessApply` also prunes unused imports and reorders imports automatically. Run it instead of manually hunting for unused imports after refactoring.
+
+## Project Structure
+The repository is organized into several key directories:
+*   `server`: The core Elasticsearch server.
+*   `modules`: Features shipped with Elasticsearch by default.
+*   `plugins`: Officially supported plugins.
+*   `libs`: Internal libraries used by other parts of the project.
+*   `qa`: Integration and multi-version tests.
+*   `docs`: Project documentation.
+*   `distribution`: Logic for building distribution packages.
+*   `x-pack`: Additional code modules and plugins under Elastic License.
+*   `build-conventions`, `build-tools`, `build-tools-internal`: Gradle build logic. Refer to BUILDING.md for details on how these are structured and used.
+
+## Stateless Elasticsearch
+
+Stateless Elasticsearch is a distribution where shard data is stored in an **object store** (e.g., S3, GCS, Azure) rather than local disk. Nodes carry no durable local state. The cluster distinguishes two node roles: **indexing nodes** (`index` role, write path + translog replication to object store) and **search nodes** (`search` role, read-only via shared blob cache). The `DiscoveryNode.STATELESS_ENABLED_SETTING` gates stateless behavior at runtime.
+
+### Plugin `deploymentTarget`
+
+Plugins can set `deploymentTarget` in `build.gradle`. That value tells the node **whether to load the plugin**: **`STATEFUL_ONLY`** (stateful clusters only), **`STATELESS_ONLY`** (stateless mode on only), or **`ALL`** (always loaded; this is the default when the property is omitted).
+
+### Plugin locations
+
+| Plugin | Gradle path | Purpose |
+|---|---|---|
+| `stateless` | `:x-pack:plugin:stateless` | Core stateless — engines, allocation, cache, object store, recovery |
+| `stateless-sigterm` | `:x-pack:plugin:stateless-sigterm` | Clean SIGTERM shutdown for Kubernetes |
+| `stateless-master-failover` | `:x-pack:plugin:stateless-master-failover` | Master failover behavior |
+| `stateless-no-wait-for-active-shards` | `:x-pack:plugin:stateless-no-wait-for-active-shards` | Suppresses wait-for-active-shards |
+| `stateless-health-shards-availability` | `:x-pack:plugin:stateless-health-shards-availability` | Shard availability health indicators |
+
+**Package**: `org.elasticsearch.xpack.stateless.*` throughout.
+
+### Key subsystems
+
+- **Object store** (`objectstore/`): `ObjectStoreService`, bucket config, GC tasks for stale indices and translogs.
+- **Commits** (`commits/`): `StatelessCommitService` manages shard commits to blob store; `HollowShardsService` manages hollow indexing shards.
+- **Cache & prewarming** (`cache/`): `StatelessSharedBlobCacheService`, online prewarming, `SearchCommitPrefetcher`.
+- **Engines** (`engine/`): `IndexEngine` (write path) and `SearchEngine` (read-only); `TranslogReplicator` replicates translog to object store.
+- **Allocation** (`allocation/`): `StatelessExistingShardsAllocator`, separate balancing weights per tier, heap-usage-aware allocation decisions.
+- **Recovery** (`recovery/`): custom primary relocation and unpromotable shard relocation protocols.
+
+## Testing Cheatsheet
+- Standard suite: `./gradlew test` (respects cached results; add `-Dtests.timestamp=$(date +%s)` to bypass caches when reusing seeds).
+- Single project: `./gradlew :server:test` (or other subproject path).
+- Single class: `./gradlew :server:test --tests org.elasticsearch.package.ClassName`.
+- Single package: `./gradlew :server:test --tests 'org.elasticsearch.package.*'`.
+- Single method / repeated runs: `./gradlew :server:test --tests org.elasticsearch.package.ClassName.methodName -Dtests.iters=N`.
+- Deterministic seed: append `-Dtests.seed=DEADBEEF` (each method uses derived seeds).
+- JVM tuning knobs: `-Dtests.jvms=8`, `-Dtests.heap.size=4G`, `-Dtests.jvm.argline="-verbose:gc"`, `-Dtests.output=always`, etc.
+- Debugging: append `--debug-jvm` to the Gradle test task and attach a debugger on port 5005.
+- CI reproductions: copy the `REPRODUCE WITH` line from CI logs; it includes project path, seed, and JVM flags.
+- Yaml REST tests: `./gradlew ":rest-api-spec:yamlRestTest" --tests "org.elasticsearch.test.rest.ClientYamlTestSuiteIT.test {yaml=<relative_test_file_path>}"`
+- ES|QL CSV tests: `./gradlew ":x-pack:plugin:esql:internalClusterTest" --tests "org.elasticsearch.xpack.esql.CsvIT.*<csv-file>*"` (e.g. `--tests "...CsvIT.*stats_first_last*"`); append `*<test-name>*` to target a single test within the file.
+- Use the Elasticsearch testing framework where possible for unit and yaml tests and be consistent in style with other elasticsearch tests.
+- Use real classes over mocks or stubs for unit tests, unless the real class is complex then either a simplified subclass should be created within the test or, as a last resort, a mock or stub can be used. Unit tests must be as close to real-world scenarios as possible.
+- Ensure mocks or stubs are well-documented and clearly indicate why they were necessary.
+
+### Test Types
+- Unit Tests: Preferred. Extend `ESTestCase`.
+- Single Node: Extend `ESSingleNodeTestCase` (lighter than full integ test).
+- Integration: Extend `ESIntegTestCase`.
+- REST API: Extend `ESRestTestCase` or `ESClientYamlSuiteTestCase`. **YAML based REST tests are preferred** for integration/API testing.
+
+### Distribution selection for external-module tests
+- Prefer the OSS/minimal distribution over `usesDefaultDistribution` whenever possible. `usesDefaultDistribution` packages the full default distribution, which is significantly more expensive to build and run.
+- Only use `usesDefaultDistribution` when the test genuinely requires a feature that is only available in the default distribution and cannot be replicated with a custom cluster configuration that includes just the needed plugins. Always document the reason in the `usesDefaultDistribution(...)` message.
+
+## Dependency Hygiene
+- Never add a dependency without checking for existing alternatives in the repo.
+
+## Entitlement Policy
+- Never add an entitlement speculatively. Each entry in `entitlement-policy.yaml` must have a specific justification — ideally a concrete `NotEntitledException` that was observed, or at minimum a clear explanation of why the library requires that capability. Entitlements are a least-privilege mechanism; granting one "just in case" defeats the purpose.
+- Every use of `ESTestCase.WithoutEntitlements` must be accompanied by a comment explaining why the entitlement failure is spurious in the test context and would not occur in production.
+
+## Formatting & Imports
+- Absolutely no wildcard imports; keep existing import order and avoid reordering untouched lines.
+- In `switch` statements, do not use `default` as a branch for valid or expected options. Enumerate those cases explicitly and reserve `default` for throwing an exception for unexpected values, or an assertion error if this code branch is unreachable.
+
+## Types, Generics, and Suppressions
+- Prefer type-safe constructs; avoid raw types and unchecked casts.
+- If suppressing warnings, scope `@SuppressWarnings` narrowly (ideally a single statement or method).
+- Document non-obvious casts or type assumptions via Javadoc/comments for reviewers.
+
+## Naming Conventions
+- REST handlers typically use the `Rest*Action` pattern; transport-layer handlers mirror them with `Transport*Action` classes.
+- REST classes expose routes via `RestHandler#routes`; when adding endpoints ensure naming matches existing REST/Transport patterns to aid discoverability.
+- Transport `ActionType` strings encode scope (`indices:data/read/...`, `cluster:admin/...`, etc.); align new names with these conventions to integrate with privilege resolution.
+
+## Logging & Error Handling
+- Elasticsearch should prefer its own logger `org.elasticsearch.logging.LogManager` & `org.elasticsearch.logging.Logger`; declare `private static final Logger logger = LogManager.getLogger(Class.class)`.
+- Always use parameterized logging (`logger.debug("operation [{}]", value)`); never build strings via concatenation.
+- Wrap expensive log-message construction in `() -> Strings.format(...)` suppliers when logging at `TRACE`/`DEBUG` to avoid unnecessary work.
+- Log levels:
+  - `TRACE`: highly verbose developer diagnostics; usually read alongside code.
+  - `DEBUG`: detailed production troubleshooting; ensure volume is bounded.
+  - `INFO`: default-enabled operational milestones; prefer factual language.
+  - `WARN`: actionable problems users must investigate; include context and, if needed, exception stack traces.
+  - `ERROR`: reserve for unrecoverable states (e.g., storage health failures); prefer `WARN` otherwise.
+- Only log client-caused exceptions when the cluster admin can act on them; otherwise rely on API responses.
+- Tests can assert logging via `MockLog` for complex flows.
+
+## Javadoc & Comments
+- New packages/classes/public or abstract methods require Javadoc explaining the "why" rather than the implementation details.
+- Avoid documenting trivial getters/setters; focus on behavior, preconditions, or surprises.
+- For tests, Javadoc can describe scenario setup/expectations to aid future contributors.
+- Do not remove existing comments from code unless the code is also being removed or the comment has become incorrect.
+
+## License Headers
+- Default header (outside `x-pack`): Elastic License 2.0, SSPL v1, or AGPL v3—they are already codified at the top of Java files; copy from existing sources.
+- Files under `x-pack` require the Elastic License 2.0-only header; IDEs configured per CONTRIBUTING.md can insert correct text automatically.
+
+## Generated Files
+- Never hand-edit generated files. Instead, edit the source they are generated from and regenerate.
+- ANTLR-generated files can be regenerated by running the `regen` task on the relevant subproject.
+- Other generated files are regenerated by compiling the project.
+
+## Debugging Missing Tests
+
+When expected test methods are absent from results (not failed, not skipped — simply not present in the XML or binary event stream), check `muted-tests.yml` first. The build translates every entry into a Gradle `TestFilter.excludePattern`, which silently drops matching tests before the randomized runner receives them. A muted test fires no `testStarted` event and leaves no trace in `results-generic.bin`.
+   ```bash
+   grep 'ClassName\|methodName' muted-tests.yml
+   ```
+
+### `No tests found for given includes: [**/*$*.class]`
+
+When a test task fails at execution with `No tests found for given includes: [**/*$*.class](exclude rules)`, it usually does **not** mean Gradle failed to detect the test class. The far more common cause is that **every test method in the targeted class is muted** in `muted-tests.yml`. With all methods excluded, the randomized runner enumerates zero runnable tests.
+
+The behavior is environment-dependent: `MutedTestPlugin` calls `filter.setFailOnNoMatchingTests(buildParams.getCi() == false)`. So an all-muted suite **fails locally** (`ci == false`) with this exact message, but **passes silently in CI** (`ci == true`). This is especially misleading when verifying a freshly migrated or renamed test — it looks like a classpath/detection bug, but the test JVM does start (you'll see native-library and `FeatureFlag` log lines), builds any `@ClassRule` cluster *specs*, then exits in a few seconds without starting the cluster because no test method survived the mute filter.
+
+To confirm: `grep ClassName muted-tests.yml`. To verify the migration/test actually runs, temporarily remove the matching mute entries (or run on a host where `ci` is true), then restore them.
+
+## Best Practices for Automation Agents
+- Never edit unrelated files; keep diffs tightly scoped to the task at hand.
+- Prefer Gradle tasks over ad-hoc scripts.
+- When scripting CLI sequences, leverage `gradlew` task.
+- Unrecognized changes: assume other agent; keep going; focus your changes. If it causes issues, stop + ask user.
+- Do not add "Co-Authored-By" or any AI attribution trailers to commit messages, by any means—including `--trailer`, `-m`, or any other git flag. commit messages should adhere to the 50/72 rule: use a maximum of 50 columns for the commit summary
+
+## Methods with Required Javadoc Reading
+If you encounter any of the following methods, you must go and read their javadoc before taking any other actions:
+* `fullyLoadedAnalyzer`
+* `TestAnalyzer.statementError`
+* `TestAnalyzer.error`
+* `forciblyCast`
+
+## Backwards compatibility
+- For changes to a `Writeable` implementation (`writeTo` and constructor from `StreamInput`), add a new `public static final <UNIQUE_DESCRIPTIVE_NAME> = TransportVersion.fromName("<unique_descriptive_name>")` and use it in the new code paths. Confirm the backport branches and then generate a new version file with `./gradlew generateTransportVersion`.
+- Never hand-edit transport version resource files; always use the Gradle tasks. See `docs/internal/Versioning.md` for the full workflow.
+
+Stay aligned with `CONTRIBUTING.md`, `BUILDING.md`, and `TESTING.asciidoc`; this AGENTS guide summarizes—but does not replace—those authoritative docs.
+
+## Documentation
+When building or editing docs, read `docs/AGENTS.md` first.

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -31,7 +31,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":qa:ccs-rolling-upgrade-remote-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":qa:mixed-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":qa:multi-cluster-search");
-        map.put(LegacyRestTestBasePlugin.class, ":qa:repository-multi-version");
         map.put(LegacyRestTestBasePlugin.class, ":qa:rolling-upgrade-legacy");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ent-search");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:mixed-tier-cluster");

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -9,73 +9,20 @@
 
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
-apply plugin: 'elasticsearch.internal-testclusters'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
-apply plugin: 'elasticsearch.standalone-rest-test'
-
 apply plugin: 'elasticsearch.bwc-test'
 
 buildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
-  String oldClusterName = "${baseName}-old"
-  String newClusterName = "${baseName}-new"
-
-  def clusterSettings = { v ->
-    return {
-      version = v
-      numberOfNodes = 2
-      setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-      setting 'xpack.security.enabled', 'false'
-      if (v.equals('8.10.0') || v.equals('8.10.1') || v.equals('8.10.2')  || v.equals('8.10.3')) {
-        // 8.10.x versions contain a bogus assertion that trips when reading repositories touched by newer versions
-        // see https://github.com/elastic/elasticsearch/issues/98454 for details
-        jvmArgs '-da'
-      }
-    }
-  }
-
-  testClusters.register(oldClusterName, clusterSettings(bwcVersion.toString()))
-  testClusters.register(newClusterName, clusterSettings(project.version))
-
-  tasks.register("${baseName}#Step1OldClusterTest", StandaloneRestIntegTestTask) {
-    useCluster testClusters.named(oldClusterName)
-    mustRunAfter("precommit")
-    doFirst {
-      delete("${buildDir}/cluster/shared/repo/${baseName}")
-    }
-    systemProperty 'tests.rest.suite', 'step1'
-  }
-
-  tasks.register("${baseName}#Step2NewClusterTest", StandaloneRestIntegTestTask) {
-    useCluster testClusters.named(newClusterName)
-    dependsOn "${baseName}#Step1OldClusterTest"
-    systemProperty 'tests.rest.suite', 'step2'
-  }
-
-  tasks.register("${baseName}#Step3OldClusterTest", StandaloneRestIntegTestTask) {
-    useCluster testClusters.named(oldClusterName)
-    dependsOn "${baseName}#Step2NewClusterTest"
-    systemProperty 'tests.rest.suite', 'step3'
-  }
-
-  tasks.register("${baseName}#Step4NewClusterTest", StandaloneRestIntegTestTask) {
-    useCluster testClusters.named(newClusterName)
-    dependsOn "${baseName}#Step3OldClusterTest"
-    systemProperty 'tests.rest.suite', 'step4'
-  }
-
-  tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {
-    it.systemProperty 'tests.old_cluster_version', bwcVersion.toString().minus("-SNAPSHOT")
-    it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
-    def clusterName = it.name.contains("Step2") || it.name.contains("Step4") ? "${newClusterName}" : "${oldClusterName}"
-    it.nonInputProperties.systemProperty('tests.rest.cluster', testClusters.named(clusterName).map(c -> c.allHttpSocketURI.join(",")))
-    it.nonInputProperties.systemProperty('tests.clustername', clusterName)
-  }
-
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn tasks.named("${baseName}#Step4NewClusterTest")
+  // The single task per BWC version drives the whole old/new/old/new repository access scenario from one JVM. The two clusters
+  // (old and current version) and the four sequential steps are wired up inside MultiVersionRepositoryAccessIT itself.
+  tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+    usesBwcDistribution(bwcVersion)
+    systemProperty("tests.old_cluster_version", bwcVersion)
   }
 }
 
-tasks.named('testTestingConventions').configure {
-  suffixes = ["IT"]
+tasks.withType(Test).configureEach {
+  // CI doesn't like it when there's multiple clusters running at once
+  maxParallelForks = 1
 }

--- a/qa/repository-multi-version/src/javaRestTest/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/javaRestTest/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -9,6 +9,11 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.TestMethodAndParams;
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
+
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.client.Request;
@@ -19,15 +24,25 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.snapshots.SnapshotsServiceUtils;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,7 +61,14 @@ import static org.hamcrest.Matchers.is;
  *     <li>Run against the old version cluster from the first step: {@link TestStep#STEP3_OLD_CLUSTER}</li>
  *     <li>Run against the current version cluster from the second step: {@link TestStep#STEP4_NEW_CLUSTER}</li>
  * </ul>
+ * <p>
+ * Rather than splitting the four steps across separate Gradle tasks and JVMs (as the legacy {@code testClusters} setup did), the steps are
+ * modelled as ordered test parameters. Two {@link ElasticsearchCluster} rules — one on the old version and one on the current version —
+ * share the same {@code path.repo} directory and run for the duration of the suite. {@link TestCaseOrdering} guarantees that every test
+ * method runs against {@link TestStep#STEP1_OLD_CLUSTER} first, then {@link TestStep#STEP2_NEW_CLUSTER}, and so on, so the repository state
+ * accumulated by earlier steps is observed by later ones.
  */
+@TestCaseOrdering(MultiVersionRepositoryAccessIT.TestStepOrdering.class)
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {
@@ -66,18 +88,100 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
             return name;
         }
 
-        public static TestStep parse(String value) {
-            return switch (value) {
-                case "step1" -> STEP1_OLD_CLUSTER;
-                case "step2" -> STEP2_NEW_CLUSTER;
-                case "step3" -> STEP3_OLD_CLUSTER;
-                case "step4" -> STEP4_NEW_CLUSTER;
-                default -> throw new AssertionError("unknown test step: " + value);
-            };
+        /**
+         * Whether this step runs against the old-version cluster (steps 1 and 3) as opposed to the current-version cluster (steps 2 and 4).
+         */
+        boolean runsAgainstOldCluster() {
+            return this == STEP1_OLD_CLUSTER || this == STEP3_OLD_CLUSTER;
         }
     }
 
-    private static final TestStep TEST_STEP = TestStep.parse(System.getProperty("tests.rest.suite"));
+    /**
+     * Orders test execution so that all methods run against {@link TestStep#STEP1_OLD_CLUSTER} before any run against
+     * {@link TestStep#STEP2_NEW_CLUSTER}, and so on. This preserves the sequential old/new/old/new repository access the legacy
+     * multi-task setup relied on.
+     */
+    public static class TestStepOrdering implements Comparator<TestMethodAndParams> {
+        @Override
+        public int compare(TestMethodAndParams o1, TestMethodAndParams o2) {
+            return Integer.compare(getOrdinal(o1), getOrdinal(o2));
+        }
+
+        private static int getOrdinal(TestMethodAndParams t) {
+            return ((TestStep) t.getInstanceArguments().get(0)).ordinal();
+        }
+    }
+
+    private static final String OLD_CLUSTER_VERSION = System.getProperty("tests.old_cluster_version");
+
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static final ElasticsearchCluster oldCluster = buildCluster(OLD_CLUSTER_VERSION, isOldClusterDetachedVersion());
+
+    private static final ElasticsearchCluster newCluster = buildCluster(Version.CURRENT.toString(), false);
+
+    private static ElasticsearchCluster buildCluster(String version, boolean detachedVersion) {
+        var cluster = ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .version(version, detachedVersion)
+            .nodes(2)
+            .setting("path.repo", () -> repoDirectory.getRoot().getPath())
+            .setting("xpack.security.enabled", "false");
+        // 8.10.x versions contain a bogus assertion that trips when reading repositories touched by newer versions
+        // see https://github.com/elastic/elasticsearch/issues/98454 for details
+        if (version.equals("8.10.0") || version.equals("8.10.1") || version.equals("8.10.2") || version.equals("8.10.3")) {
+            cluster.jvmArg("-da");
+        }
+        return cluster.build();
+    }
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(oldCluster).around(newCluster);
+
+    /**
+     * Tracks which cluster the shared REST client is currently pointing at, so we only tear down and re-create the client when a step
+     * needs the other cluster.
+     */
+    private static Boolean clientUsesOldCluster = null;
+
+    @ParametersFactory(shuffle = false)
+    public static Iterable<Object[]> parameters() {
+        return Arrays.stream(TestStep.values()).map(s -> new Object[] { s }).collect(Collectors.toList());
+    }
+
+    private final TestStep testStep;
+
+    public MultiVersionRepositoryAccessIT(@Name("step") TestStep testStep) {
+        this.testStep = testStep;
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return testStep.runsAgainstOldCluster() ? oldCluster.getHttpAddresses() : newCluster.getHttpAddresses();
+    }
+
+    /**
+     * Repoints the shared REST client at the cluster required by the current step. {@link ESRestTestCase#initClient()} runs first (as a
+     * superclass {@code @Before}) and is a no-op once the client is initialized, so here we explicitly close and re-create the client
+     * whenever the step switches between the old and new cluster.
+     */
+    @Before
+    public void selectClusterForStep() throws IOException {
+        boolean needsOldCluster = testStep.runsAgainstOldCluster();
+        if (clientUsesOldCluster != null && clientUsesOldCluster != needsOldCluster) {
+            closeClients();
+            initClient();
+        }
+        clientUsesOldCluster = needsOldCluster;
+    }
+
+    /**
+     * The repository name must be stable across all four steps so that a repository created in one step is observed by later steps.
+     * {@link #getTestName()} includes the parameterized step suffix (e.g. {@code "testReadOnlyRepo {step=step1}"}), so strip it.
+     */
+    private String getRepoName() {
+        return getTestName().split(" ")[0];
+    }
 
     @Override
     protected boolean preserveSnapshotsUponCompletion() {
@@ -95,42 +199,42 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     }
 
     public void testCreateAndRestoreSnapshot() throws IOException {
-        final String repoName = getTestName();
+        final String repoName = getRepoName();
         try {
             final int shards = 3;
             final String index = "test-index";
             createIndex(index, shards);
             createRepository(repoName, false, true);
-            createSnapshot(repoName, "snapshot-" + TEST_STEP, index);
+            createSnapshot(repoName, "snapshot-" + testStep, index);
             final String snapshotToDeleteName = "snapshot-to-delete";
             // Create a snapshot and delete it right away again to test the impact of each version's cleanup functionality that is run
             // as part of the snapshot delete
             createSnapshot(repoName, snapshotToDeleteName, index);
             final List<Map<String, Object>> snapshotsIncludingToDelete = listSnapshots(repoName);
             // Every step creates one snapshot and we have to add one more for the temporary snapshot
-            assertThat(snapshotsIncludingToDelete, hasSize(TEST_STEP.ordinal() + 1 + 1));
+            assertThat(snapshotsIncludingToDelete, hasSize(testStep.ordinal() + 1 + 1));
             assertThat(
                 snapshotsIncludingToDelete.stream().map(sn -> (String) sn.get("snapshot")).collect(Collectors.toList()),
                 hasItem(snapshotToDeleteName)
             );
             deleteSnapshot(repoName, snapshotToDeleteName);
             final List<Map<String, Object>> snapshots = listSnapshots(repoName);
-            assertThat(snapshots, hasSize(TEST_STEP.ordinal() + 1));
-            switch (TEST_STEP) {
+            assertThat(snapshots, hasSize(testStep.ordinal() + 1));
+            switch (testStep) {
                 case STEP2_NEW_CLUSTER, STEP4_NEW_CLUSTER -> assertSnapshotStatusSuccessful(
                     repoName,
                     snapshots.stream().map(sn -> (String) sn.get("snapshot")).toArray(String[]::new)
                 );
-                case STEP1_OLD_CLUSTER -> assertSnapshotStatusSuccessful(repoName, "snapshot-" + TEST_STEP);
+                case STEP1_OLD_CLUSTER -> assertSnapshotStatusSuccessful(repoName, "snapshot-" + testStep);
                 case STEP3_OLD_CLUSTER -> assertSnapshotStatusSuccessful(
                     repoName,
-                    "snapshot-" + TEST_STEP,
+                    "snapshot-" + testStep,
                     "snapshot-" + TestStep.STEP3_OLD_CLUSTER
                 );
             }
-            if (TEST_STEP == TestStep.STEP3_OLD_CLUSTER) {
+            if (testStep == TestStep.STEP3_OLD_CLUSTER) {
                 ensureSnapshotRestoreWorks(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER, shards, index);
-            } else if (TEST_STEP == TestStep.STEP4_NEW_CLUSTER) {
+            } else if (testStep == TestStep.STEP4_NEW_CLUSTER) {
                 for (TestStep value : TestStep.values()) {
                     ensureSnapshotRestoreWorks(repoName, "snapshot-" + value, shards, index);
                 }
@@ -141,28 +245,28 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     }
 
     public void testReadOnlyRepo() throws IOException {
-        final String repoName = getTestName();
+        final String repoName = getRepoName();
         final int shards = 3;
-        final boolean readOnly = TEST_STEP.ordinal() > 1; // only restore from read-only repo in steps 3 and 4
+        final boolean readOnly = testStep.ordinal() > 1; // only restore from read-only repo in steps 3 and 4
         createRepository(repoName, readOnly, true);
         final String index = "test-index";
         if (readOnly == false) {
             createIndex(index, shards);
-            createSnapshot(repoName, "snapshot-" + TEST_STEP, index);
+            createSnapshot(repoName, "snapshot-" + testStep, index);
         }
         final List<Map<String, Object>> snapshots = listSnapshots(repoName);
-        switch (TEST_STEP) {
+        switch (testStep) {
             case STEP1_OLD_CLUSTER -> assertThat(snapshots, hasSize(1));
             case STEP2_NEW_CLUSTER, STEP4_NEW_CLUSTER, STEP3_OLD_CLUSTER -> assertThat(snapshots, hasSize(2));
         }
-        if (TEST_STEP == TestStep.STEP1_OLD_CLUSTER || TEST_STEP == TestStep.STEP3_OLD_CLUSTER) {
+        if (testStep == TestStep.STEP1_OLD_CLUSTER || testStep == TestStep.STEP3_OLD_CLUSTER) {
             assertSnapshotStatusSuccessful(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER);
         } else {
             assertSnapshotStatusSuccessful(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER, "snapshot-" + TestStep.STEP2_NEW_CLUSTER);
         }
-        if (TEST_STEP == TestStep.STEP3_OLD_CLUSTER) {
+        if (testStep == TestStep.STEP3_OLD_CLUSTER) {
             ensureSnapshotRestoreWorks(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER, shards, index);
-        } else if (TEST_STEP == TestStep.STEP4_NEW_CLUSTER) {
+        } else if (testStep == TestStep.STEP4_NEW_CLUSTER) {
             ensureSnapshotRestoreWorks(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER, shards, index);
             ensureSnapshotRestoreWorks(repoName, "snapshot-" + TestStep.STEP2_NEW_CLUSTER, shards, index);
         }
@@ -174,7 +278,7 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     );
 
     public void testUpgradeMovesRepoToNewMetaVersion() throws IOException {
-        final String repoName = getTestName();
+        final String repoName = getRepoName();
         try {
             final int shards = 3;
             final String index = "test-index";
@@ -183,7 +287,7 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
             // 7.12.0+ will try to load RepositoryData during repo creation if verify is true, which is impossible in case of version
             // incompatibility in the downgrade test step. We verify that it is impossible here and then create the repo using verify=false
             // to check behavior on other operations below.
-            final boolean verify = TEST_STEP != TestStep.STEP3_OLD_CLUSTER
+            final boolean verify = testStep != TestStep.STEP3_OLD_CLUSTER
                 || SnapshotsServiceUtils.includesUUIDs(minNodeVersion)
                 || minNodeVersion.before(IndexVersions.V_7_12_0);
             if (verify == false) {
@@ -191,13 +295,13 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
             }
             createRepository(repoName, false, verify);
             // only create some snapshots in the first two steps
-            if (TEST_STEP == TestStep.STEP1_OLD_CLUSTER || TEST_STEP == TestStep.STEP2_NEW_CLUSTER) {
-                createSnapshot(repoName, "snapshot-" + TEST_STEP, index);
+            if (testStep == TestStep.STEP1_OLD_CLUSTER || testStep == TestStep.STEP2_NEW_CLUSTER) {
+                createSnapshot(repoName, "snapshot-" + testStep, index);
                 final List<Map<String, Object>> snapshots = listSnapshots(repoName);
                 // Every step creates one snapshot
-                assertThat(snapshots, hasSize(TEST_STEP.ordinal() + 1));
+                assertThat(snapshots, hasSize(testStep.ordinal() + 1));
                 assertSnapshotStatusSuccessful(repoName, snapshots.stream().map(sn -> (String) sn.get("snapshot")).toArray(String[]::new));
-                if (TEST_STEP == TestStep.STEP1_OLD_CLUSTER) {
+                if (testStep == TestStep.STEP1_OLD_CLUSTER) {
                     ensureSnapshotRestoreWorks(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER, shards, index);
                 } else {
                     deleteSnapshot(repoName, "snapshot-" + TestStep.STEP1_OLD_CLUSTER);
@@ -210,14 +314,14 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
                 }
             } else {
                 if (SnapshotsServiceUtils.includesUUIDs(minNodeVersion) == false) {
-                    assertThat(TEST_STEP, is(TestStep.STEP3_OLD_CLUSTER));
+                    assertThat(testStep, is(TestStep.STEP3_OLD_CLUSTER));
                     expectThrowsAnyOf(EXPECTED_BWC_EXCEPTIONS, () -> listSnapshots(repoName));
                     expectThrowsAnyOf(EXPECTED_BWC_EXCEPTIONS, () -> deleteSnapshot(repoName, "snapshot-1"));
                     expectThrowsAnyOf(EXPECTED_BWC_EXCEPTIONS, () -> deleteSnapshot(repoName, "snapshot-2"));
                     expectThrowsAnyOf(EXPECTED_BWC_EXCEPTIONS, () -> createSnapshot(repoName, "snapshot-impossible", index));
                 } else {
                     assertThat(listSnapshots(repoName), hasSize(2));
-                    if (TEST_STEP == TestStep.STEP4_NEW_CLUSTER) {
+                    if (testStep == TestStep.STEP4_NEW_CLUSTER) {
                         ensureSnapshotRestoreWorks(repoName, "snapshot-1", shards, index);
                         ensureSnapshotRestoreWorks(repoName, "snapshot-2", shards, index);
                     }
@@ -229,7 +333,7 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
     }
 
     public void testSnapshotCreatedInOldVersionCanBeDeletedInNew() throws IOException {
-        final String repoName = getTestName();
+        final String repoName = getRepoName();
         try {
             final int shards = 3;
             final String index = "test-index";
@@ -237,20 +341,20 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
             final IndexVersion minNodeVersion = minimumIndexVersion();
             // 7.12.0+ will try to load RepositoryData during repo creation if verify is true, which is impossible in case of version
             // incompatibility in the downgrade test step.
-            final boolean verify = TEST_STEP != TestStep.STEP3_OLD_CLUSTER
+            final boolean verify = testStep != TestStep.STEP3_OLD_CLUSTER
                 || SnapshotsServiceUtils.includesUUIDs(minNodeVersion)
                 || minNodeVersion.before(IndexVersions.V_7_12_0);
             createRepository(repoName, false, verify);
 
             // Create snapshots in the first step
-            if (TEST_STEP == TestStep.STEP1_OLD_CLUSTER) {
+            if (testStep == TestStep.STEP1_OLD_CLUSTER) {
                 int numberOfSnapshots = randomIntBetween(5, 10);
                 for (int i = 0; i < numberOfSnapshots; i++) {
                     createSnapshot(repoName, "snapshot-" + i, index);
                 }
                 final List<Map<String, Object>> snapshots = listSnapshots(repoName);
                 assertSnapshotStatusSuccessful(repoName, snapshots.stream().map(sn -> (String) sn.get("snapshot")).toArray(String[]::new));
-            } else if (TEST_STEP == TestStep.STEP2_NEW_CLUSTER) {
+            } else if (testStep == TestStep.STEP2_NEW_CLUSTER) {
                 final List<Map<String, Object>> snapshots = listSnapshots(repoName);
                 List<String> snapshotNames = new ArrayList<>(snapshots.stream().map(sn -> (String) sn.get("snapshot")).toList());
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Migrate repository-multi-version to JUnit rule based test clusters (#151777)](https://github.com/elastic/elasticsearch/pull/151777)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)