### PR TITLE
Relax unnecessarily strict equality check between segments

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -619,8 +619,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static int dotProductI7uChecked(MemorySegment a, MemorySegment b, int length) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, length, a.byteSize());
+            Objects.checkFromIndexSize(0L, length, b.byteSize());
             return callSingleDistanceInt(dotI7uHandle, a, b, length);
         }
 
@@ -629,8 +629,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static int squareDistanceI7uChecked(MemorySegment a, MemorySegment b, int length) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, length, a.byteSize());
+            Objects.checkFromIndexSize(0L, length, b.byteSize());
             return callSingleDistanceInt(squareI7uHandle, a, b, length);
         }
 
@@ -649,8 +649,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float cosineI8Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize());
+            Objects.checkFromIndexSize(0L, elementCount, b.byteSize());
             return callSingleDistanceFloat(cosI8Handle, a, b, elementCount);
         }
 
@@ -659,8 +659,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float dotProductI8Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize());
+            Objects.checkFromIndexSize(0L, elementCount, b.byteSize());
             return callSingleDistanceFloat(dotI8Handle, a, b, elementCount);
         }
 
@@ -669,8 +669,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float squareDistanceI8Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize());
+            Objects.checkFromIndexSize(0L, elementCount, b.byteSize());
             return callSingleDistanceFloat(squareI8Handle, a, b, elementCount);
         }
 
@@ -679,8 +679,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float dotProductF32Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize() / Float.BYTES);
+            Objects.checkFromIndexSize(0L, elementCount, b.byteSize() / Float.BYTES);
             return callSingleDistanceFloat(dotF32Handle, a, b, elementCount);
         }
 
@@ -689,8 +689,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float squareDistanceF32Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize() / Float.BYTES);
+            Objects.checkFromIndexSize(0L, elementCount, b.byteSize() / Float.BYTES);
             return callSingleDistanceFloat(squareF32Handle, a, b, elementCount);
         }
 
@@ -699,7 +699,6 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float dotProductDBF16QF32Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize() / 2);
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize() / Short.BYTES);
             Objects.checkFromIndexSize(0L, elementCount, b.byteSize() / Float.BYTES);
             return callSingleDistanceFloat(dotDBF16QF32Handle, a, b, elementCount);
@@ -710,7 +709,6 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float dotProductDBF16QBF16Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize() / Short.BYTES);
             Objects.checkFromIndexSize(0L, elementCount, b.byteSize() / Short.BYTES);
             return callSingleDistanceFloat(dotDBF16QBF16Handle, a, b, elementCount);
@@ -721,7 +719,6 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float squareDistanceDBF16QF32Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize() / 2);
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize() / Short.BYTES);
             Objects.checkFromIndexSize(0L, elementCount, b.byteSize() / Float.BYTES);
             return callSingleDistanceFloat(squareDBF16QF32Handle, a, b, elementCount);
@@ -732,7 +729,6 @@ public final class JdkVectorLibrary implements VectorLibrary {
         );
 
         static float squareDistanceDBF16QBF16Checked(MemorySegment a, MemorySegment b, int elementCount) {
-            checkByteSize(a.byteSize(), b.byteSize());
             Objects.checkFromIndexSize(0L, elementCount, a.byteSize() / Short.BYTES);
             Objects.checkFromIndexSize(0L, elementCount, b.byteSize() / Short.BYTES);
             return callSingleDistanceFloat(squareDBF16QBF16Handle, a, b, elementCount);
@@ -796,12 +792,6 @@ public final class JdkVectorLibrary implements VectorLibrary {
             Objects.checkFromIndexSize(0L, (long) length * 4, query.byteSize());
             Objects.checkFromIndexSize(0L, length, a.byteSize());
             return callSingleDistanceLong(dotD2Q4PackedHandle, a, query, length);
-        }
-
-        private static void checkByteSize(long aSize, long bSize) {
-            if (aSize != bSize) {
-                throw new IllegalArgumentException("Dimensions differ: " + aSize + "!=" + bSize);
-            }
         }
 
         private static final MethodHandle dotProductI7uBulk$mh = HANDLES.get(

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBFloat16Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBFloat16Tests.java
@@ -423,10 +423,15 @@ public class JDKVectorLibraryBFloat16Tests extends VectorSimilarityFunctionsTest
             case FLOAT32 -> size * Float.BYTES;
         };
 
-        Exception ex = expectThrows(IAE, () -> similarity(segment.asSlice(0L, aSize), segment.asSlice(0L, bSize + 2), size));
-        assertThat(ex.getMessage(), containsString("Dimensions differ"));
+        // Segments can differ in size and be larger than length: only length bytes are read
+        var aTail = randomIntBetween(0, size) * BFloat16.BYTES;
+        var bTail = randomIntBetween(0, size) * switch (queryType) {
+            case BFLOAT16 -> BFloat16.BYTES;
+            case FLOAT32 -> Float.BYTES;
+        };
+        similarity(segment.asSlice(0L, aSize + aTail), segment.asSlice(0L, bSize + bTail), size);
 
-        ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, aSize), segment.asSlice(bSize, bSize), size + 1));
+        Exception ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, aSize), segment.asSlice(bSize, bSize), size + 1));
         assertThat(ex.getMessage(), containsString("out of bounds for length"));
 
         ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, aSize), segment.asSlice(bSize, bSize), -1));

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryFloat32Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryFloat32Tests.java
@@ -365,10 +365,13 @@ public class JDKVectorLibraryFloat32Tests extends VectorSimilarityFunctionsTests
         assumeTrue(notSupportedMsg(), supported());
         var segment = arena.allocate((long) size * 3 * Float.BYTES);
 
-        Exception ex = expectThrows(IAE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size + 1), size));
-        assertThat(ex.getMessage(), containsString("Dimensions differ"));
+        int elemBytes = size * Float.BYTES;
+        // Segments can differ in size and be larger than length: only length bytes are read
+        var aTail = randomIntBetween(0, size) * Float.BYTES;
+        var bTail = randomIntBetween(0, size) * Float.BYTES;
+        similarity(segment.asSlice(0L, elemBytes + aTail), segment.asSlice(0L, elemBytes + bTail), size);
 
-        ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), size + 1));
+        Exception ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), size + 1));
         assertThat(ex.getMessage(), containsString("out of bounds for length"));
 
         ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), -1));

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt7uTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt7uTests.java
@@ -317,10 +317,12 @@ public class JDKVectorLibraryInt7uTests extends VectorSimilarityFunctionsTests {
         assumeTrue(notSupportedMsg(), supported());
         var segment = arena.allocate((long) size * 3);
 
-        Exception ex = expectThrows(IAE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size + 1), size));
-        assertThat(ex.getMessage(), containsString("Dimensions differ"));
+        // Segments can differ in size and be larger than length: only length bytes are read
+        var aTail = randomIntBetween(0, size);
+        var bTail = randomIntBetween(0, size);
+        similarity(segment.asSlice(0L, size + aTail), segment.asSlice(0L, size + bTail), size);
 
-        ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), size + 1));
+        Exception ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), size + 1));
         assertThat(ex.getMessage(), containsString("out of bounds for length"));
 
         ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), -1));

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt8Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt8Tests.java
@@ -306,10 +306,12 @@ public class JDKVectorLibraryInt8Tests extends VectorSimilarityFunctionsTests {
         assumeTrue(notSupportedMsg(), supported());
         var segment = arena.allocate((long) size * 3);
 
-        Exception ex = expectThrows(IAE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size + 1), size));
-        assertThat(ex.getMessage(), containsString("Dimensions differ"));
+        // Segments can differ in size and be larger than length: only length bytes are read
+        var aTail = randomIntBetween(0, size);
+        var bTail = randomIntBetween(0, size);
+        similarity(segment.asSlice(0L, size + aTail), segment.asSlice(0L, size + bTail), size);
 
-        ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), size + 1));
+        Exception ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), size + 1));
         assertThat(ex.getMessage(), containsString("out of bounds for length"));
 
         ex = expectThrows(IOOBE, () -> similarity(segment.asSlice(0L, size), segment.asSlice(size, size), -1));


### PR DESCRIPTION
In preparation for https://github.com/elastic/elasticsearch/pull/153283, change the check for single scorers to be of equality between segments to individual checks.

Instead of relying on checking the shape of `a` and then checking that `a` and `b` have the same size, the shape of each `a` and `b` is checked separately, which is enough to ensure correctness and makes more sense (and let us avoid un-necessary slicing in some cases).