### PR TITLE
Avoid caching maxOrd in scorer suppliers

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/BFloat16VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/BFloat16VectorScorerSupplier.java
@@ -30,7 +30,6 @@ public abstract class BFloat16VectorScorerSupplier implements RandomVectorScorer
 
     final int dims;
     final int vectorByteSize;
-    final int maxOrd;
     final IndexInput input;
     final FloatVectorValues values;
     final FixedSizeScratch firstScratch;
@@ -43,13 +42,12 @@ public abstract class BFloat16VectorScorerSupplier implements RandomVectorScorer
         this.values = values;
         this.dims = values.dimension();
         this.vectorByteSize = values.getVectorByteLength();
-        this.maxOrd = values.size();
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord > maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorerSupplier.java
@@ -30,7 +30,6 @@ public abstract sealed class Float32VectorScorerSupplier implements RandomVector
 
     final int dims;
     final int vectorByteSize;
-    final int maxOrd;
     final IndexInput input;
     final FloatVectorValues values;
     final FixedSizeScratch firstScratch;
@@ -43,13 +42,12 @@ public abstract sealed class Float32VectorScorerSupplier implements RandomVector
         this.values = values;
         this.dims = values.dimension();
         this.vectorByteSize = dims * Float.BYTES;
-        this.maxOrd = values.size();
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord > maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4Corrections.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4Corrections.java
@@ -11,12 +11,7 @@ package org.elasticsearch.simdvec.internal;
 
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorScorer;
 import org.apache.lucene.util.VectorUtil;
-import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.elasticsearch.simdvec.VectorSimilarityType;
-
-import java.io.IOException;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 
 /**
  * Shared correction formulas for int4 packed-nibble scoring. Used by both the
@@ -30,30 +25,18 @@ final class Int4Corrections {
     @FunctionalInterface
     interface SingleCorrection {
         float apply(
-            QuantizedByteVectorValues values,
             int dims,
             float rawScore,
-            int ord,
+            float docLower,
+            float docUpper,
+            float docAdditional,
+            int docComponentSum,
+            float centroidDP,
             float qLower,
             float qUpper,
             float qAdditional,
             int qComponentSum
-        ) throws IOException;
-    }
-
-    @FunctionalInterface
-    interface BulkCorrection {
-        float apply(
-            QuantizedByteVectorValues values,
-            int dims,
-            MemorySegment scores,
-            MemorySegment ordinals,
-            int numNodes,
-            float qLower,
-            float qUpper,
-            float qAdditional,
-            int qComponentSum
-        ) throws IOException;
+        );
     }
 
     static SingleCorrection singleCorrectionFor(VectorSimilarityType type) {
@@ -64,160 +47,71 @@ final class Int4Corrections {
         };
     }
 
-    static BulkCorrection bulkCorrectionFor(VectorSimilarityType type) {
-        return switch (type) {
-            case COSINE, DOT_PRODUCT -> Int4Corrections::dotProductBulk;
-            case EUCLIDEAN -> Int4Corrections::euclideanBulk;
-            case MAXIMUM_INNER_PRODUCT -> Int4Corrections::maxInnerProductBulk;
-        };
-    }
-
     private Int4Corrections() {}
 
     static float dotProduct(
-        QuantizedByteVectorValues values,
         int dims,
         float rawScore,
-        int ord,
+        float docLower,
+        float docUpper,
+        float docAdditional,
+        int docComponentSum,
+        float centroidDP,
         float queryLower,
         float queryUpper,
         float queryAdditional,
         int queryComponentSum
-    ) throws IOException {
-        var ct = values.getCorrectiveTerms(ord);
-        float ax = ct.lowerInterval();
-        float lx = (ct.upperInterval() - ax) * LIMIT_SCALE;
+    ) {
+        float ax = docLower;
+        float lx = (docUpper - ax) * LIMIT_SCALE;
         float ay = queryLower;
         float ly = (queryUpper - ay) * LIMIT_SCALE;
-        float score = ax * ay * dims + ay * lx * ct.quantizedComponentSum() + ax * ly * queryComponentSum + lx * ly * rawScore;
-        score += queryAdditional + ct.additionalCorrection() - values.getCentroidDP();
+        float score = ax * ay * dims + ay * lx * docComponentSum + ax * ly * queryComponentSum + lx * ly * rawScore;
+        score += queryAdditional + docAdditional - centroidDP;
         return VectorUtil.normalizeToUnitInterval(Math.clamp(score, -1, 1));
     }
 
-    static float dotProductBulk(
-        QuantizedByteVectorValues values,
-        int dims,
-        MemorySegment scoreSeg,
-        MemorySegment ordinalsSeg,
-        int numNodes,
-        float queryLower,
-        float queryUpper,
-        float queryAdditional,
-        int queryComponentSum
-    ) throws IOException {
-        float ay = queryLower;
-        float ly = (queryUpper - ay) * LIMIT_SCALE;
-        float max = Float.NEGATIVE_INFINITY;
-        for (int i = 0; i < numNodes; i++) {
-            float raw = scoreSeg.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-            int nodeOrd = ordinalsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
-            var ct = values.getCorrectiveTerms(nodeOrd);
-            float ax = ct.lowerInterval();
-            float lx = (ct.upperInterval() - ax) * LIMIT_SCALE;
-            float score = ax * ay * dims + ay * lx * ct.quantizedComponentSum() + ax * ly * queryComponentSum + lx * ly * raw;
-            score += queryAdditional + ct.additionalCorrection() - values.getCentroidDP();
-            float normalized = VectorUtil.normalizeToUnitInterval(Math.clamp(score, -1, 1));
-            scoreSeg.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
-            max = Math.max(max, normalized);
-        }
-        return max;
-    }
-
     static float euclidean(
-        QuantizedByteVectorValues values,
         int dims,
         float rawScore,
-        int ord,
+        float docLower,
+        float docUpper,
+        float docAdditional,
+        int docComponentSum,
+        float centroidDP,
         float queryLower,
         float queryUpper,
         float queryAdditional,
         int queryComponentSum
-    ) throws IOException {
-        var ct = values.getCorrectiveTerms(ord);
-        float ax = ct.lowerInterval();
-        float lx = (ct.upperInterval() - ax) * LIMIT_SCALE;
+    ) {
+        float ax = docLower;
+        float lx = (docUpper - ax) * LIMIT_SCALE;
         float ay = queryLower;
         float ly = (queryUpper - ay) * LIMIT_SCALE;
-        float score = ax * ay * dims + ay * lx * ct.quantizedComponentSum() + ax * ly * queryComponentSum + lx * ly * rawScore;
-        score = queryAdditional + ct.additionalCorrection() - 2 * score;
+        float score = ax * ay * dims + ay * lx * docComponentSum + ax * ly * queryComponentSum + lx * ly * rawScore;
+        score = queryAdditional + docAdditional - 2 * score;
         return VectorUtil.normalizeDistanceToUnitInterval(Math.max(score, 0f));
     }
 
-    static float euclideanBulk(
-        QuantizedByteVectorValues values,
-        int dims,
-        MemorySegment scoreSeg,
-        MemorySegment ordinalsSeg,
-        int numNodes,
-        float queryLower,
-        float queryUpper,
-        float queryAdditional,
-        int queryComponentSum
-    ) throws IOException {
-        float ay = queryLower;
-        float ly = (queryUpper - ay) * LIMIT_SCALE;
-        float max = Float.NEGATIVE_INFINITY;
-        for (int i = 0; i < numNodes; i++) {
-            float raw = scoreSeg.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-            int nodeOrd = ordinalsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
-            var ct = values.getCorrectiveTerms(nodeOrd);
-            float ax = ct.lowerInterval();
-            float lx = (ct.upperInterval() - ax) * LIMIT_SCALE;
-            float score = ax * ay * dims + ay * lx * ct.quantizedComponentSum() + ax * ly * queryComponentSum + lx * ly * raw;
-            score = queryAdditional + ct.additionalCorrection() - 2 * score;
-            float normalized = VectorUtil.normalizeDistanceToUnitInterval(Math.max(score, 0f));
-            scoreSeg.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
-            max = Math.max(max, normalized);
-        }
-        return max;
-    }
-
     static float maxInnerProduct(
-        QuantizedByteVectorValues values,
         int dims,
         float rawScore,
-        int ord,
+        float docLower,
+        float docUpper,
+        float docAdditional,
+        int docComponentSum,
+        float centroidDP,
         float queryLower,
         float queryUpper,
         float queryAdditional,
         int queryComponentSum
-    ) throws IOException {
-        var ct = values.getCorrectiveTerms(ord);
-        float ax = ct.lowerInterval();
-        float lx = (ct.upperInterval() - ax) * LIMIT_SCALE;
+    ) {
+        float ax = docLower;
+        float lx = (docUpper - ax) * LIMIT_SCALE;
         float ay = queryLower;
         float ly = (queryUpper - ay) * LIMIT_SCALE;
-        float score = ax * ay * dims + ay * lx * ct.quantizedComponentSum() + ax * ly * queryComponentSum + lx * ly * rawScore;
-        score += queryAdditional + ct.additionalCorrection() - values.getCentroidDP();
+        float score = ax * ay * dims + ay * lx * docComponentSum + ax * ly * queryComponentSum + lx * ly * rawScore;
+        score += queryAdditional + docAdditional - centroidDP;
         return VectorUtil.scaleMaxInnerProductScore(score);
-    }
-
-    static float maxInnerProductBulk(
-        QuantizedByteVectorValues values,
-        int dims,
-        MemorySegment scoreSeg,
-        MemorySegment ordinalsSeg,
-        int numNodes,
-        float queryLower,
-        float queryUpper,
-        float queryAdditional,
-        int queryComponentSum
-    ) throws IOException {
-        float ay = queryLower;
-        float ly = (queryUpper - ay) * LIMIT_SCALE;
-        float max = Float.NEGATIVE_INFINITY;
-        for (int i = 0; i < numNodes; i++) {
-            float raw = scoreSeg.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-            int nodeOrd = ordinalsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
-            var ct = values.getCorrectiveTerms(nodeOrd);
-            float ax = ct.lowerInterval();
-            float lx = (ct.upperInterval() - ax) * LIMIT_SCALE;
-            float score = ax * ay * dims + ay * lx * ct.quantizedComponentSum() + ax * ly * queryComponentSum + lx * ly * raw;
-            score += queryAdditional + ct.additionalCorrection() - values.getCentroidDP();
-            float normalizedScore = VectorUtil.scaleMaxInnerProductScore(score);
-            scoreSeg.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalizedScore);
-            max = Math.max(max, normalizedScore);
-        }
-        return max;
     }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
@@ -19,9 +19,12 @@ import org.elasticsearch.nativeaccess.VectorSimilarityFunctions;
 import org.elasticsearch.simdvec.IndexInputUtils;
 import org.elasticsearch.simdvec.MemorySegmentAccessInputAccess;
 import org.elasticsearch.simdvec.VectorSimilarityType;
+import org.elasticsearch.simdvec.internal.vectorization.ScoreCorrections;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.Optional;
 
 /**
@@ -35,6 +38,10 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
     private static final VectorSimilarityFunctions DISTANCE_FUNCS = NativeAccess.instance()
         .getVectorSimilarityFunctions()
         .orElseThrow(AssertionError::new);
+
+    // Size of the corrections trailer that follows each packed vector in the codec's per-vector
+    // record: 3 floats (lowerInterval, upperInterval, additionalCorrection) + 1 int (quantizedComponentSum).
+    static final int CORRECTIONS_BYTES = 3 * Float.BYTES + Integer.BYTES;
 
     private final ScorerImpl scorerImpl;
     private final QueryContext query;
@@ -94,16 +101,23 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
         IndexInputUtils.checkInputType(input);
         int dims = values.dimension();
         int packedDims = dims / 2;
-        long vectorPitch = packedDims + 3L * Float.BYTES + Integer.BYTES;
+        int vectorPitch = packedDims + CORRECTIONS_BYTES;
+        float centroidDP;
+        try {
+            centroidDP = values.getCentroidDP();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
 
         this.scorerImpl = new ScorerImpl(
             input,
-            values,
+            values.size(),
             dims,
             packedDims,
             vectorPitch,
-            Int4Corrections.singleCorrectionFor(similarityType),
-            Int4Corrections.bulkCorrectionFor(similarityType)
+            similarityType.function(),
+            centroidDP,
+            Int4Corrections.singleCorrectionFor(similarityType)
         );
         this.query = new QueryContext(
             lowerInterval,
@@ -132,53 +146,57 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
      */
     static class ScorerImpl {
         private final IndexInput input;
-        private final QuantizedByteVectorValues values;
+        private final int maxOrd;
         private final int dims;
         private final int packedDims;
-        private final long vectorPitch;
+        private final int vectorPitch;
+        private final VectorSimilarityFunction similarityFunction;
+        private final float centroidDP;
         private final Int4Corrections.SingleCorrection correction;
-        private final Int4Corrections.BulkCorrection bulkCorrection;
-        private byte[] scratch;
+        private final FixedSizeScratch scratch;
         private final AddressesScratch addrsScratch = new AddressesScratch();
         private final OffsetsScratch offsetsScratch = new OffsetsScratch();
 
         ScorerImpl(
             IndexInput input,
-            QuantizedByteVectorValues values,
+            int maxOrd,
             int dims,
             int packedDims,
-            long vectorPitch,
-            Int4Corrections.SingleCorrection correction,
-            Int4Corrections.BulkCorrection bulkCorrection
+            int vectorPitch,
+            VectorSimilarityFunction similarityFunction,
+            float centroidDP,
+            Int4Corrections.SingleCorrection correction
         ) {
             this.input = input;
-            this.values = values;
+            this.maxOrd = maxOrd;
             this.dims = dims;
             this.packedDims = packedDims;
             this.vectorPitch = vectorPitch;
+            this.similarityFunction = similarityFunction;
+            this.centroidDP = centroidDP;
             this.correction = correction;
-            this.bulkCorrection = bulkCorrection;
+            this.scratch = new FixedSizeScratch(vectorPitch);
         }
 
         void checkOrdinal(int ord) {
-            if (ord < 0 || ord >= values.size()) {
+            if (ord < 0 || ord >= maxOrd) {
                 throw new IllegalArgumentException("illegal ordinal: " + ord);
             }
         }
 
-        private byte[] getScratch(int len) {
-            if (scratch == null || scratch.length < len) {
-                scratch = new byte[len];
-            }
-            return scratch;
-        }
-
-        private float applyCorrections(float rawScore, int ord, QueryContext query) throws IOException {
+        private float applyCorrections(float rawScore, MemorySegment correctionsSlice, QueryContext query) {
+            float docLower = correctionsSlice.get(ValueLayout.JAVA_FLOAT_UNALIGNED, 0);
+            float docUpper = correctionsSlice.get(ValueLayout.JAVA_FLOAT_UNALIGNED, Float.BYTES);
+            float docAdditional = correctionsSlice.get(ValueLayout.JAVA_FLOAT_UNALIGNED, 2L * Float.BYTES);
+            int docComponentSum = correctionsSlice.get(ValueLayout.JAVA_INT_UNALIGNED, 3L * Float.BYTES);
             return correction.apply(
-                values,
                 dims,
                 rawScore,
-                ord,
+                docLower,
+                docUpper,
+                docAdditional,
+                docComponentSum,
+                centroidDP,
                 query.lowerInterval(),
                 query.upperInterval(),
                 query.additionalCorrection(),
@@ -186,18 +204,23 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
             );
         }
 
-        private float applyCorrectionsBulk(MemorySegment scores, MemorySegment ordinals, int numNodes, QueryContext query)
-            throws IOException {
-            return bulkCorrection.apply(
-                values,
-                dims,
-                scores,
-                ordinals,
+        private float applyCorrectionsBulk(MemorySegment scores, MemorySegment addrs, int numNodes, QueryContext query) {
+            return ScoreCorrections.nativeBbqApplyCorrectionsBulk(
+                similarityFunction,
+                addrs,
                 numNodes,
+                packedDims,
+                vectorPitch,
+                dims,
                 query.lowerInterval(),
                 query.upperInterval(),
+                query.quantizedComponentSum(),
                 query.additionalCorrection(),
-                query.quantizedComponentSum()
+                Int4Corrections.LIMIT_SCALE,
+                Int4Corrections.LIMIT_SCALE,
+                centroidDP,
+                true,
+                scores
             );
         }
 
@@ -205,9 +228,9 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
             checkOrdinal(node);
             long nodeOffset = (long) node * vectorPitch;
             input.seek(nodeOffset);
-            return IndexInputUtils.withSlice(input, packedDims, this::getScratch, packedTarget -> {
-                int rawScore = DISTANCE_FUNCS.dotProductI4(query.unpackedQuery(), packedTarget, packedDims);
-                return applyCorrections(rawScore, node, query);
+            return IndexInputUtils.withSlice(input, vectorPitch, scratch::getScratch, seg -> {
+                int rawScore = DISTANCE_FUNCS.dotProductI4(query.unpackedQuery(), seg.asSlice(0, packedDims), packedDims);
+                return applyCorrections(rawScore, seg.asSlice(packedDims, CORRECTIONS_BYTES), query);
             });
         }
 
@@ -219,26 +242,19 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
             for (int i = 0; i < numNodes; i++) {
                 offsets[i] = (long) ordinals[i] * vectorPitch;
             }
+            float[] maxScore = new float[] { Float.NEGATIVE_INFINITY };
             MemorySegment scoresSeg = MemorySegment.ofArray(scores);
-            boolean resolved = IndexInputUtils.withSliceAddresses(
-                input,
-                offsets,
-                packedDims,
-                numNodes,
-                addrsScratch::get,
-                addrs -> DISTANCE_FUNCS.dotProductI4BulkSparse(addrs, query.unpackedQuery(), packedDims, numNodes, scoresSeg)
-            );
-            if (resolved) {
-                return applyCorrectionsBulk(scoresSeg, MemorySegment.ofArray(ordinals), numNodes, query);
+            boolean resolved = IndexInputUtils.withSliceAddresses(input, offsets, vectorPitch, numNodes, addrsScratch::get, addrs -> {
+                DISTANCE_FUNCS.dotProductI4BulkSparse(addrs, query.unpackedQuery(), packedDims, numNodes, scoresSeg);
+                maxScore[0] = applyCorrectionsBulk(scoresSeg, addrs, numNodes, query);
+            });
+            if (resolved == false) {
+                for (int i = 0; i < numNodes; i++) {
+                    scores[i] = scoreWithQuery(query, ordinals[i]);
+                    maxScore[0] = Math.max(maxScore[0], scores[i]);
+                }
             }
-
-            // fallback to sequential scoring
-            float max = Float.NEGATIVE_INFINITY;
-            for (int i = 0; i < numNodes; i++) {
-                scores[i] = scoreWithQuery(query, ordinals[i]);
-                max = Math.max(max, scores[i]);
-            }
-            return max;
+            return maxScore[0];
         }
     }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
@@ -111,7 +111,7 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
 
         this.scorerImpl = new ScorerImpl(
             input,
-            values.size(),
+            values,
             dims,
             packedDims,
             vectorPitch,
@@ -146,7 +146,7 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
      */
     static class ScorerImpl {
         private final IndexInput input;
-        private final int maxOrd;
+        private final QuantizedByteVectorValues values;
         private final int dims;
         private final int packedDims;
         private final int vectorPitch;
@@ -159,7 +159,7 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
 
         ScorerImpl(
             IndexInput input,
-            int maxOrd,
+            QuantizedByteVectorValues values,
             int dims,
             int packedDims,
             int vectorPitch,
@@ -168,7 +168,7 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
             Int4Corrections.SingleCorrection correction
         ) {
             this.input = input;
-            this.maxOrd = maxOrd;
+            this.values = values;
             this.dims = dims;
             this.packedDims = packedDims;
             this.vectorPitch = vectorPitch;
@@ -179,7 +179,7 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
         }
 
         void checkOrdinal(int ord) {
-            if (ord < 0 || ord >= maxOrd) {
+            if (ord < 0 || ord >= values.size()) {
                 throw new IllegalArgumentException("illegal ordinal: " + ord);
             }
         }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorerSupplier.java
@@ -55,7 +55,7 @@ public final class Int4VectorScorerSupplier implements RandomVectorScorerSupplie
         }
         this.scorerImpl = new Int4VectorScorer.ScorerImpl(
             input,
-            values.size(),
+            values,
             dims,
             packedDims,
             vectorPitch,

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorerSupplier.java
@@ -17,6 +17,7 @@ import org.elasticsearch.simdvec.IndexInputUtils;
 import org.elasticsearch.simdvec.VectorSimilarityType;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -32,7 +33,7 @@ public final class Int4VectorScorerSupplier implements RandomVectorScorerSupplie
     private final QuantizedByteVectorValues values;
     private final VectorSimilarityType similarityType;
     private final int packedDims;
-    private final long vectorPitch;
+    private final int vectorPitch;
     private final Int4VectorScorer.ScorerImpl scorerImpl;
     private final MemorySegment unpackedQuerySegment;
 
@@ -44,16 +45,23 @@ public final class Int4VectorScorerSupplier implements RandomVectorScorerSupplie
         this.values = values;
         this.similarityType = similarityType;
         this.packedDims = dims / 2;
-        this.vectorPitch = packedDims + 3L * Float.BYTES + Integer.BYTES;
+        this.vectorPitch = packedDims + Int4VectorScorer.CORRECTIONS_BYTES;
         this.unpackedQuerySegment = Arena.ofAuto().allocate(dims, 32);
+        float centroidDP;
+        try {
+            centroidDP = values.getCentroidDP();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         this.scorerImpl = new Int4VectorScorer.ScorerImpl(
             input,
-            values,
+            values.size(),
             dims,
             packedDims,
             vectorPitch,
-            Int4Corrections.singleCorrectionFor(similarityType),
-            Int4Corrections.bulkCorrectionFor(similarityType)
+            similarityType.function(),
+            centroidDP,
+            Int4Corrections.singleCorrectionFor(similarityType)
         );
     }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorerSupplier.java
@@ -29,7 +29,6 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
         .orElseThrow(AssertionError::new);
 
     final int dims;
-    final int maxOrd;
     final float scoreCorrectionConstant;
     final IndexInput input;
     final LegacyQuantizedByteVectorValues values; // to support ordToDoc/getAcceptOrds
@@ -44,7 +43,6 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
         this.input = input;
         this.values = values;
         this.dims = values.dimension();
-        this.maxOrd = values.size();
         this.scoreCorrectionConstant = scoreCorrectionConstant;
         this.vectorDataBytes = dims;
         this.vectorTotalBytes = vectorDataBytes + Float.BYTES;
@@ -53,7 +51,7 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7uOSQVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7uOSQVectorScorerSupplier.java
@@ -44,7 +44,6 @@ public abstract sealed class Int7uOSQVectorScorerSupplier implements RandomVecto
     protected final IndexInput input;
     protected final QuantizedByteVectorValues values;
     protected final int dims;
-    protected final int maxOrd;
     protected final int vectorPitch;
     final FixedSizeScratch firstScratch;
     final FixedSizeScratch secondScratch;
@@ -55,7 +54,6 @@ public abstract sealed class Int7uOSQVectorScorerSupplier implements RandomVecto
         this.input = input;
         this.values = values;
         this.dims = values.dimension();
-        this.maxOrd = values.size();
         this.vectorPitch = dims + CORRECTIONS_BYTES;
         // Scratches are sized to the full per-vector record (vector + corrections), so that the same
         // backing slice can be used for both the dot product (first dims bytes) and the corrections
@@ -89,7 +87,7 @@ public abstract sealed class Int7uOSQVectorScorerSupplier implements RandomVecto
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorerSupplier.java
@@ -30,7 +30,6 @@ public abstract sealed class Int8VectorScorerSupplier implements RandomVectorSco
         .orElseThrow(AssertionError::new);
 
     final int dims;
-    final int maxOrd;
     /**
      * The length in bytes of one vector. For this scorer, it matches the pitch (the distance in memory between 2 vectors, when laid
      * out consecutively) and the total vector size (no padding, no extra fields).
@@ -48,13 +47,12 @@ public abstract sealed class Int8VectorScorerSupplier implements RandomVectorSco
         this.values = values;
         this.dims = values.dimension();
         this.vectorByteSize = values.getVectorByteLength();
-        this.maxOrd = values.size();
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }


### PR DESCRIPTION
Vector scorer suppliers cached `maxOrd = values.size()` at construction time, but during flush the supplier is created before all vectors are written, so `values.size()` grows as vectors are added. The cached value would reject valid ordinals passed by `HnswGraphBuilder.addGraphNode`.
This PR fixes the issue by removing the cached `maxOrd` field and using `values.size()` in `checkOrdinal` across all five supplier classes.
It also fixes an off-by-one in `Float32VectorScorerSupplier` and `BFloat16VectorScorerSupplier` (`>` instead of `>=`).