### PR TITLE
Avoid caching maxOrd in scorer suppliers

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/BFloat16VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/BFloat16VectorScorerSupplier.java
@@ -30,7 +30,6 @@ public abstract class BFloat16VectorScorerSupplier implements RandomVectorScorer
 
     final int dims;
     final int vectorByteSize;
-    final int maxOrd;
     final IndexInput input;
     final FloatVectorValues values;
     final FixedSizeScratch firstScratch;
@@ -43,13 +42,12 @@ public abstract class BFloat16VectorScorerSupplier implements RandomVectorScorer
         this.values = values;
         this.dims = values.dimension();
         this.vectorByteSize = values.getVectorByteLength();
-        this.maxOrd = values.size();
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord > maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorerSupplier.java
@@ -30,7 +30,6 @@ public abstract sealed class Float32VectorScorerSupplier implements RandomVector
 
     final int dims;
     final int vectorByteSize;
-    final int maxOrd;
     final IndexInput input;
     final FloatVectorValues values;
     final FixedSizeScratch firstScratch;
@@ -43,13 +42,12 @@ public abstract sealed class Float32VectorScorerSupplier implements RandomVector
         this.values = values;
         this.dims = values.dimension();
         this.vectorByteSize = dims * Float.BYTES;
-        this.maxOrd = values.size();
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord > maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorerSupplier.java
@@ -29,7 +29,6 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
         .orElseThrow(AssertionError::new);
 
     final int dims;
-    final int maxOrd;
     final float scoreCorrectionConstant;
     final IndexInput input;
     final LegacyQuantizedByteVectorValues values; // to support ordToDoc/getAcceptOrds
@@ -44,7 +43,6 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
         this.input = input;
         this.values = values;
         this.dims = values.dimension();
-        this.maxOrd = values.size();
         this.scoreCorrectionConstant = scoreCorrectionConstant;
         this.vectorDataBytes = dims;
         this.vectorTotalBytes = vectorDataBytes + Float.BYTES;
@@ -53,7 +51,7 @@ public abstract sealed class Int7SQVectorScorerSupplier implements RandomVectorS
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7uOSQVectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7uOSQVectorScorerSupplier.java
@@ -44,7 +44,6 @@ public abstract sealed class Int7uOSQVectorScorerSupplier implements RandomVecto
     protected final IndexInput input;
     protected final QuantizedByteVectorValues values;
     protected final int dims;
-    protected final int maxOrd;
     protected final int vectorPitch;
     final FixedSizeScratch firstScratch;
     final FixedSizeScratch secondScratch;
@@ -55,7 +54,6 @@ public abstract sealed class Int7uOSQVectorScorerSupplier implements RandomVecto
         this.input = input;
         this.values = values;
         this.dims = values.dimension();
-        this.maxOrd = values.size();
         this.vectorPitch = dims + CORRECTIONS_BYTES;
         // Scratches are sized to the full per-vector record (vector + corrections), so that the same
         // backing slice can be used for both the dot product (first dims bytes) and the corrections
@@ -89,7 +87,7 @@ public abstract sealed class Int7uOSQVectorScorerSupplier implements RandomVecto
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorerSupplier.java
@@ -30,7 +30,6 @@ public abstract sealed class Int8VectorScorerSupplier implements RandomVectorSco
         .orElseThrow(AssertionError::new);
 
     final int dims;
-    final int maxOrd;
     /**
      * The length in bytes of one vector. For this scorer, it matches the pitch (the distance in memory between 2 vectors, when laid
      * out consecutively) and the total vector size (no padding, no extra fields).
@@ -48,13 +47,12 @@ public abstract sealed class Int8VectorScorerSupplier implements RandomVectorSco
         this.values = values;
         this.dims = values.dimension();
         this.vectorByteSize = values.getVectorByteLength();
-        this.maxOrd = values.size();
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord >= values.size()) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }


### PR DESCRIPTION
Vector scorer suppliers cached `maxOrd = values.size()` at construction time, but during flush the supplier is created before all vectors are written, so `values.size()` grows as vectors are added. The cached value would reject valid ordinals passed by `HnswGraphBuilder.addGraphNode`.
This PR fixes the issue by removing the cached `maxOrd` field and using `values.size()` in `checkOrdinal` across all five supplier classes.
It also fixes an off-by-one in `Float32VectorScorerSupplier` and `BFloat16VectorScorerSupplier` (`>` instead of `>=`).