### PR TITLE
ESQL: separate the external dataset-aggregate cache; drop the schema TTL

### DIFF
--- a/docs/changelog/153785.yaml
+++ b/docs/changelog/153785.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153785
+summary: "[ESQLDS] Separate the external dataset-aggregate cache so warm dataset COUNT stops decaying under per-file eviction"
+type: bug

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvStripeStatsCaptureTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvStripeStatsCaptureTests.java
@@ -559,7 +559,6 @@ public class CsvStripeStatsCaptureTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(settings)) {
@@ -1359,7 +1358,6 @@ public class CsvStripeStatsCaptureTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(settings)) {

--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/FlightStorageProvider.java
@@ -70,6 +70,15 @@ public final class FlightStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        // Arrow Flight objects have no last-modified timestamp (FlightStorageObject reports null), so there is
+        // no stable per-file identity to invalidate a schema/stats cache entry on. Bypass caching entirely
+        // rather than cache under an unknowable version. This matters more now that the identity-keyed caches
+        // no longer have a TTL: a null-mtime entry would otherwise be stale forever, not just for the TTL.
+        return false;
+    }
+
+    @Override
     public void close() {
         // Short-lived Flight clients are opened per operation; nothing to close.
     }

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedFormatSpecIT.java
@@ -9,14 +9,11 @@ package org.elasticsearch.xpack.esql.qa.ndjson;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
-import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
-import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.Build;
 import org.elasticsearch.test.AzureReactorThreadFilter;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
-import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 
 import java.io.IOException;
 import java.util.List;
@@ -25,10 +22,7 @@ import java.util.Set;
 /**
  * Parameterized integration tests for compressed NDJSON files (.ndjson.gz, .ndjson.zst, .ndjson.zstd, .ndjson.bz2, .ndjson.bz).
  * Each csv-spec test is run against every configured storage backend (S3, HTTP, LOCAL, GCS) and compression format.
- * Each csv-spec test is run against every configured storage backend and compression format.
- * This class runs four csv-spec files and exceeds {@link EsqlSpecTestCase}'s 10-minute suite budget.
  */
-@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class NdJsonCompressedFormatSpecIT extends AbstractNdJsonExternalSpecTestCase {
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonStripeStatsCaptureTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonStripeStatsCaptureTests.java
@@ -455,7 +455,6 @@ public class NdJsonStripeStatsCaptureTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(settings)) {
@@ -545,7 +544,6 @@ public class NdJsonStripeStatsCaptureTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(settings)) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -120,7 +120,7 @@ public class ExternalSourceCacheService implements Closeable {
      * Entry-count cap for the file-metadata cache. Unlike the schema and listing caches (byte-weighted,
      * variable-size values), a {@link FileMetadata} is two {@code long}s behind a small path key, so the
      * cache is bounded by count rather than bytes — no per-entry byte weigher. 100k tiny entries is a few
-     * tens of MB worst case, and, being hard-TTL-bounded by the schema TTL, the live set is normally far
+     * tens of MB worst case, and, being TTL-bounded by the listing TTL, the live set is normally far
      * smaller. Kept a constant rather than a cluster setting: no workload has needed to tune it, and a
      * public setting is a permanent support surface — it can be promoted to a setting later if a real need
      * appears.
@@ -667,7 +667,7 @@ public class ExternalSourceCacheService implements Closeable {
         // is the only path-agnostic enumeration the Cache exposes that is safe against concurrent LRU
         // mutation (keys()/values() walk the lock-free LRU list). The sweep is O(cache) for a multi-path
         // reconcile, but that is the price of capturing each sibling's pre-eviction entry before the first
-        // commit's put() prunes the expired ones.
+        // commit's put() prunes the LRU tail under weight pressure.
         Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> byPath = new HashMap<>();
         schemaCache.forEach((key, entry) -> {
             if (paths.contains(key.canonicalPath())) {
@@ -681,14 +681,14 @@ public class ExternalSourceCacheService implements Closeable {
      * Collects every schema-cache entry a contribution for {@code (path, mtimeMillis, fingerprint)}
      * applies to: every live match, plus — per KEY, for keys the live sweep no longer has — the
      * pre-reconcile {@code fallback} snapshot (see {@link #snapshotEntriesByPath}), the case where a
-     * sibling path's earlier commit swept this path's expired entry out of the cache before its stats
+     * sibling path's earlier commit weight-evicted this path's entry out of the cache before its stats
      * could be applied. The recovery is per key, not all-or-nothing on the live sweep: the same
      * {@code (path, mtime, fingerprint)} can live under several keys (endpoint/region are key
      * components but not fingerprint inputs), and a partial sweep evicting one twin must not forfeit
      * its delta just because another twin survived. A live entry always wins over its snapshot
      * version (it may carry a concurrent commit's enrichment). A fallback entry passes the same
-     * mtime + fingerprint predicate as a live one, and re-putting it re-inserts the entry with a
-     * fresh write time — the same revive a live expired match already gets. Must run holding the
+     * mtime + fingerprint predicate as a live one, and re-putting it re-inserts the entry — the same
+     * revive a live match already gets. Must run holding the
      * per-path {@link #stripeCommitLocks} lock; callers mutate and re-put the returned entries after
      * this method returns.
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -40,20 +40,31 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongFunction;
 
 /**
- * Coordinator-only, in-memory cache service for external source metadata.
- * Maintains two independent caches:
+ * Coordinator-only, in-memory cache service for external source metadata. Maintains three independent
+ * caches, each with its own weight budget:
  * <ul>
- *   <li>Schema cache (20% of budget, 5m TTL) — shared across users</li>
- *   <li>Listing cache (80% of budget, 30s TTL) — isolated by credential hash</li>
+ *   <li>Per-file schema cache (~20%) — schema + the per-file {@code _stats.*} overlay, keyed by
+ *       {@code (path, mtime, config)}. No time expiry: a changed file has a new mtime, hence a new key.</li>
+ *   <li>Dataset-aggregate cache (~2%) — the memoized whole-dataset row count, keyed by the file-set
+ *       fingerprint. No time expiry; kept separate so per-file churn cannot evict it.</li>
+ *   <li>Listing cache (~78%, 30s TTL) — the file set under a prefix, isolated by credential hash. This is
+ *       the only cache with a TTL: it discovers file identity and has no per-file key to invalidate on.</li>
  * </ul>
- * Uses hard TTL via {@code setExpireAfterWrite} for the initial implementation.
- * Lazy TTL with ETag revalidation is deferred to a follow-up PR.
+ * The identity-keyed caches are bounded by weight + LRU, never by a clock — a timer would only discard
+ * still-valid, expensively harvested entries.
  */
 public class ExternalSourceCacheService implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(ExternalSourceCacheService.class);
 
     private final Cache<SchemaCacheKey, SchemaCacheEntry> schemaCache;
+    /**
+     * The memoized whole-dataset row-count aggregate, keyed by file-set fingerprint. Tiny per entry but
+     * expensive to rebuild (a full cold scan), so it gets its OWN cache: sharing the per-file budget let
+     * per-file churn evict it and the warm dataset {@code COUNT} decayed mid-use. No time expiry — the
+     * fingerprint is a correct-or-miss identity key; only weight/LRU reclaims it.
+     */
+    private final Cache<SchemaCacheKey, SchemaCacheEntry> datasetAggregateCache;
     private final Cache<ListingCacheKey, FileList> listingCache;
     private final long maxTotalBytes;
     private volatile boolean enabled;
@@ -95,22 +106,19 @@ public class ExternalSourceCacheService implements Closeable {
      * per-resolve and fulfillment is per-reconcile, both rare, so a plain lock never contends.
      * Deliberately NOT a {@link CacheBuilder} cache: that offers a count bound or a weight bound but not
      * both at once, has no fulfill-then-remove semantics (a promise is consumed exactly once, not
-     * evicted), and its {@code expireAfterWrite} TTL is the wrong clock — the promise horizon must be
-     * decoupled from the schema TTL (see {@link #PENDING_DATASET_AGGREGATE_TTL_NANOS}).
+     * evicted), and its {@code expireAfterWrite} would be the wrong clock for a register-before /
+     * fulfill-after horizon (see {@link #PENDING_DATASET_AGGREGATE_TTL_NANOS}).
      */
     private static final int MAX_PENDING_DATASET_AGGREGATES = 64;
     private static final int MAX_PENDING_TOTAL_PATHS = 65_536;
     private final LinkedHashMap<SchemaCacheKey, PendingDatasetAggregate> pendingDatasetAggregates = new LinkedHashMap<>();
 
     /**
-     * Pending-descriptor expiry horizon. Deliberately a FIXED constant DECOUPLED from the schema TTL:
-     * the promise is registered at resolve time (before the scan) and fulfilled at reconcile time
-     * (after the scan), so it must comfortably outlive the longest realistic cold scan — a schema-TTL
-     * horizon (5m default) would expire the promise of exactly the multi-minute scans this mechanism
-     * exists for, before their own reconcile could fulfill it. A stale promise costs nothing: the
-     * registry is tiny and doubly bounded, and fulfillment re-validates every path's mtime and config
-     * fingerprint, so correctness never depends on this horizon. (Fulfillment writes a FRESH cache
-     * entry whose own TTL starts at write time — the promise's age does not leak into the entry's.)
+     * Pending-descriptor expiry horizon: a FIXED constant, long enough to comfortably outlive the longest
+     * realistic cold scan (the promise is registered at resolve time, before the scan, and fulfilled at
+     * reconcile time, after it). A stale promise costs nothing: the registry is tiny and doubly bounded,
+     * and fulfillment re-validates every path's mtime and config fingerprint, so correctness never depends
+     * on this horizon. It is only a heap-safety bound on abandoned promises (a query that failed mid-scan).
      */
     private static final long PENDING_DATASET_AGGREGATE_TTL_NANOS = TimeUnit.HOURS.toNanos(1);
 
@@ -123,15 +131,26 @@ public class ExternalSourceCacheService implements Closeable {
         this.maxTotalBytes = totalBudget.getBytes();
         this.enabled = ExternalSourceCacheSettings.CACHE_ENABLED.get(settings);
 
-        TimeValue schemaTtl = ExternalSourceCacheSettings.SCHEMA_TTL.get(settings);
         TimeValue listingTtl = ExternalSourceCacheSettings.LISTING_TTL.get(settings);
 
-        long schemaBudget = maxTotalBytes / 5; // 20%
-        long listingBudget = maxTotalBytes - schemaBudget; // 80%
+        // Per-file schema stays at its established 20%; the dataset-aggregate cache gets a small dedicated
+        // slice carved from listing (each dataset entry is a single row count — kilobytes suffice — so its
+        // exact size barely matters; what matters is that it is ITS OWN slice, immune to per-file churn).
+        long schemaBudget = maxTotalBytes / 5;               // 20%
+        long datasetAggregateBudget = maxTotalBytes / 50;    // 2%
+        long listingBudget = maxTotalBytes - schemaBudget - datasetAggregateBudget; // ~78%
 
+        // No setExpireAfterWrite on schemaCache or datasetAggregateCache: both are identity-keyed (per-file by
+        // mtime, dataset by file-set fingerprint), so a changed input already misses. A timer would only
+        // discard still-valid, expensively harvested entries on a clock. Only the listing cache keeps a TTL —
+        // it discovers file identity and has no per-file key to invalidate on.
         this.schemaCache = CacheBuilder.<SchemaCacheKey, SchemaCacheEntry>builder()
             .setMaximumWeight(schemaBudget)
-            .setExpireAfterWrite(schemaTtl)
+            .weigher((key, value) -> value.estimatedBytes())
+            .build();
+
+        this.datasetAggregateCache = CacheBuilder.<SchemaCacheKey, SchemaCacheEntry>builder()
+            .setMaximumWeight(datasetAggregateBudget)
             .weigher((key, value) -> value.estimatedBytes())
             .build();
 
@@ -142,11 +161,11 @@ public class ExternalSourceCacheService implements Closeable {
             .build();
 
         logger.info(
-            "External source cache initialized: total=[{}], schema=[{}], listing=[{}], schemaTTL=[{}], listingTTL=[{}]",
+            "External source cache initialized: total=[{}], schema=[{}], datasetAggregate=[{}], listing=[{}], listingTTL=[{}]",
             totalBudget,
             ByteSizeValue.ofBytes(schemaBudget),
+            ByteSizeValue.ofBytes(datasetAggregateBudget),
             ByteSizeValue.ofBytes(listingBudget),
-            schemaTtl,
             listingTtl
         );
     }
@@ -189,10 +208,8 @@ public class ExternalSourceCacheService implements Closeable {
      * {@link SchemaCacheKey#forDatasetAggregate}), or {@code null} on a miss. The map carries only
      * dataset-INDEPENDENT-of-declaration keys — today just {@code _stats.row_count} — never per-column
      * stats, so serving it can never leak a wrongly-normalized MIN/MAX (those keep re-scanning until the
-     * per-file rail serves them). A found entry is re-put to refresh the {@code expireAfterWrite} clock
-     * and LRU position: the entry is the warm path's single survival dependency, so a hot dataset must not
-     * decay mid-use while its per-file siblings churn (same revive the per-file reconcile applies to
-     * recovered entries). Does NOT touch the hit/miss counters — those are resolver-driven at the serve
+     * per-file rail serves them). It lives in the dedicated {@link #datasetAggregateCache}, so per-file churn
+     * can no longer evict it. Does NOT touch the hit/miss counters — those are resolver-driven at the serve
      * decision (see {@link #recordDatasetAggregateHit} / {@link #recordDatasetAggregateMiss}).
      */
     @Nullable
@@ -200,22 +217,20 @@ public class ExternalSourceCacheService implements Closeable {
         if (enabled == false || key == null) {
             return null;
         }
-        SchemaCacheEntry entry = schemaCache.get(key);
+        // Cache.get() already promotes the entry to the LRU head, so a hot dataset stays resident; no re-put
+        // is needed (there is no expireAfterWrite clock to refresh — the dataset cache has no TTL).
+        SchemaCacheEntry entry = datasetAggregateCache.get(key);
         if (entry == null || entry.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT) instanceof Number == false) {
             return null;
         }
-        // No hit/miss counting here: every resolve prefetches (including healthy warm resolves whose
-        // per-file merge will succeed and never need the aggregate), so a get-side counter would count
-        // non-events. The resolver counts a hit/miss only when the fallback was actually needed — see
-        // recordDatasetAggregateHit / recordDatasetAggregateMiss.
-        schemaCache.put(key, entry); // refresh write-time TTL + LRU recency
         return entry.safeMetadata();
     }
 
     /**
-     * Stores the dataset-level row-count aggregate for one resolved file set. The entry is a synthetic
-     * {@link SchemaCacheEntry} (no columns; {@code safeMetadata} = the row count) so all existing schema
-     * cache plumbing — weigher, TTL, enable/disable, clearAll, usage stats — applies unchanged.
+     * Stores the dataset-level row-count aggregate for one resolved file set into the dedicated
+     * {@link #datasetAggregateCache}. The entry is a synthetic {@link SchemaCacheEntry} (no columns;
+     * {@code safeMetadata} = the row count) so the common cache plumbing — weigher, enable/disable,
+     * clearAll, usage stats — applies unchanged; only the store (and its budget, no-TTL policy) differs.
      */
     public void putDatasetAggregate(SchemaCacheKey key, long rowCount, String sourceType, String location) {
         if (enabled == false || key == null || rowCount < 0) {
@@ -232,7 +247,7 @@ public class ExternalSourceCacheService implements Closeable {
             Map.of(),
             System.currentTimeMillis()
         );
-        schemaCache.put(key, entry);
+        datasetAggregateCache.put(key, entry);
     }
 
     /**
@@ -356,13 +371,13 @@ public class ExternalSourceCacheService implements Closeable {
         if (enabled == false || contributionsPerFile == null || contributionsPerFile.isEmpty()) {
             return;
         }
-        // Snapshot the glob's entries BEFORE any commit writes: the first put() sweeps TTL-expired
-        // entries, evicting files #2..N's entries before their deltas apply. See snapshotEntriesByPath.
+        // Snapshot the glob's entries BEFORE any commit writes: under weight pressure the first put() can
+        // LRU-evict files #2..N's entries before their deltas apply. See snapshotEntriesByPath.
         Map<String, List<Map.Entry<SchemaCacheKey, SchemaCacheEntry>>> preCommitSnapshot = snapshotEntriesByPath(
             contributionsPerFile.keySet()
         );
         // LinkedHashMap, not HashMap: commit whole-file entries in the caller's contribution order so the
-        // reconcile (and which sibling a capacity/TTL sweep hits during a commit) is deterministic rather
+        // reconcile (and which sibling a capacity sweep hits during a commit) is deterministic rather
         // than dependent on path hashCode. Final per-entry state is order-independent (each path keys a
         // distinct entry; a swept sibling is recovered per key), so this only pins reproducibility.
         Map<String, Map<String, Object>> merged = new LinkedHashMap<>(contributionsPerFile.size());
@@ -588,12 +603,10 @@ public class ExternalSourceCacheService implements Closeable {
 
     /**
      * Snapshots, per contribution path, every schema-cache entry whose canonical path matches — taken
-     * BEFORE a reconcile's first commit write. A cold scan longer than the schema TTL reconciles into a
-     * cache whose entries for the scanned glob have ALL expired: expired entries are still forEach-visible
-     * (expiry evicts lazily), but the first {@code schemaCache.put()} prunes them from the LRU tail, so
-     * file #1's commit would evict files #2..N's entries before their deltas apply — the deltas match
-     * nothing, the all-or-nothing multi-file fold goes incomplete, and the warm aggregate re-scans the
-     * whole source.
+     * BEFORE a reconcile's first commit write. Under weight pressure (a many-file glob whose entries do not
+     * all fit the schema budget), the first {@code schemaCache.put()} prunes the LRU tail, so file #1's
+     * commit can evict files #2..N's entries before their deltas apply — the deltas then match nothing, the
+     * all-or-nothing multi-file fold goes incomplete, and the warm aggregate re-scans the whole source.
      * <p>
      * Only ever consulted (via {@link #collectMatchingEntries}'s {@code fallback}) to recover a SIBLING's
      * swept entry, so it is worth building only for a multi-path reconcile. A single-path reconcile has no
@@ -1241,7 +1254,7 @@ public class ExternalSourceCacheService implements Closeable {
     /**
      * Snapshot-aware body of {@link #reconcileSourceStats}. {@code preCommitSnapshot} is the pre-reconcile
      * per-path entry snapshot (see {@link #snapshotEntriesByPath}), consulted only when the live cache
-     * has no match — the sibling-commit expiry-sweep case described there. Same discipline as
+     * has no match — the sibling-commit weight-sweep case described there. Same discipline as
      * {@link #applyStripeDelta}.
      */
     private void reconcileSourceStats(
@@ -1315,6 +1328,7 @@ public class ExternalSourceCacheService implements Closeable {
 
     public void clearAll() {
         schemaCache.invalidateAll();
+        datasetAggregateCache.invalidateAll();
         listingCache.invalidateAll();
         synchronized (pendingDatasetAggregates) {
             pendingDatasetAggregates.clear();
@@ -1336,6 +1350,8 @@ public class ExternalSourceCacheService implements Closeable {
         stats.put("listing_cache.misses", listingCache.stats().getMisses());
         stats.put("listing_cache.evictions", listingCache.stats().getEvictions());
 
+        stats.put("dataset_aggregate_cache.count", datasetAggregateCache.count());
+        stats.put("dataset_aggregate_cache.evictions", datasetAggregateCache.stats().getEvictions());
         stats.put("dataset_aggregate.hits", datasetAggregateHits.sum());
         stats.put("dataset_aggregate.misses", datasetAggregateMisses.sum());
         synchronized (pendingDatasetAggregates) {
@@ -1354,6 +1370,11 @@ public class ExternalSourceCacheService implements Closeable {
     // Visible for testing
     Cache<SchemaCacheKey, SchemaCacheEntry> schemaCache() {
         return schemaCache;
+    }
+
+    // Visible for testing
+    Cache<SchemaCacheKey, SchemaCacheEntry> datasetAggregateCache() {
+        return datasetAggregateCache;
     }
 
     // Visible for testing

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -157,8 +157,9 @@ public class ExternalSourceCacheService implements Closeable {
 
         // No setExpireAfterWrite on schemaCache or datasetAggregateCache: both are identity-keyed (per-file by
         // mtime, dataset by file-set fingerprint), so a changed input already misses. A timer would only
-        // discard still-valid, expensively harvested entries on a clock. Only the listing cache keeps a TTL —
-        // it discovers file identity and has no per-file key to invalidate on.
+        // discard still-valid, expensively harvested entries on a clock. The two discovery caches below
+        // (listing and file-metadata) DO keep the listing TTL — they hold current file identity with no
+        // per-file key to invalidate on, so they must refresh on a clock.
         this.schemaCache = CacheBuilder.<SchemaCacheKey, SchemaCacheEntry>builder()
             .setMaximumWeight(schemaBudget)
             .weigher((key, value) -> value.estimatedBytes())

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheSettings.java
@@ -38,12 +38,23 @@ public final class ExternalSourceCacheSettings {
         Setting.Property.NodeScope
     );
 
+    /**
+     * Deprecated no-op. The schema (per-file) and dataset-aggregate caches are invalidated by identity
+     * (mtime / file-set fingerprint in the key) and bounded by CACHE_SIZE + LRU, never by a clock — see
+     * {@link ExternalSourceCacheService}. This setting formerly capped the schema cache with a hard TTL;
+     * it is retained, registered, and ignored so a node that carries it in {@code elasticsearch.yml} from
+     * an earlier version still starts (removing a released node setting would fail startup). It is wired to
+     * nothing and emits a deprecation warning when set.
+     */
     public static final Setting<TimeValue> SCHEMA_TTL = Setting.positiveTimeSetting(
         "esql.source.cache.schema.ttl",
         TimeValue.timeValueMinutes(5),
+        Setting.Property.DeprecatedWarning,
         Setting.Property.NodeScope
     );
 
+    // Only the listing cache carries a time-based refresh: it discovers file identity and has no per-file
+    // key to invalidate on. The schema and dataset-aggregate caches invalidate by identity, not by a clock.
     public static final Setting<TimeValue> LISTING_TTL = Setting.positiveTimeSetting(
         "esql.source.cache.listing.ttl",
         TimeValue.timeValueSeconds(30),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -2299,8 +2299,8 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
     /**
      * A warm single-file resolve must be zero-I/O: the file-metadata cache holds {length, mtime} within
-     * the schema TTL, so the second resolve reuses the cached metadata and issues no object probe. This
-     * is the amortization lever removing the per-query warm-path metadata probe.
+     * the file-metadata TTL, so the second resolve reuses the cached metadata and issues no object probe.
+     * This is the amortization lever removing the per-query warm-path metadata probe.
      */
     public void testSingleFileMetadataCacheEliminatesWarmProbe() throws Exception {
         List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
@@ -2312,7 +2312,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -2344,9 +2343,9 @@ public class ExternalSourceResolverTests extends ESTestCase {
     }
 
     /**
-     * The file-metadata cache is bounded by a hard {@code expireAfterWrite} TTL (the schema TTL), so once
-     * the entry expires the next resolve must re-probe the object — mtime is a version token, not a
-     * second freshness clock, and staleness is bounded by TTL alone.
+     * The file-metadata cache is bounded by a hard {@code expireAfterWrite} TTL (the listing TTL, since it
+     * is freshness-discovery like listing), so once the entry expires the next resolve must re-probe the
+     * object — mtime is a version token, not a second freshness clock, and staleness is bounded by the TTL.
      */
     public void testSingleFileMetadataCacheReprobesAfterTtlExpiry() throws Exception {
         List<Attribute> schema = List.of(attr("id", DataType.INTEGER));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -807,7 +807,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         return Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
     }
@@ -1281,7 +1280,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings cacheSettings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -1341,7 +1339,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings cacheSettings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -1965,7 +1962,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -2020,7 +2016,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings cacheSettings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -2272,7 +2267,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -2313,7 +2307,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", false)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -2346,7 +2339,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", false)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 
@@ -2381,7 +2373,6 @@ public class ExternalSourceResolverTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", "5m")
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -41,15 +41,9 @@ import static org.hamcrest.Matchers.lessThan;
 public class ExternalSourceCacheServiceTests extends ESTestCase {
 
     private static Settings defaultSettings() {
-        return schemaTtlSettings("5m");
-    }
-
-    /** {@link #defaultSettings()} with a chosen schema TTL — shrunk by the expiry-sweep tests. */
-    private static Settings schemaTtlSettings(String schemaTtl) {
         return Settings.builder()
             .put("esql.source.cache.size", "10mb")
             .put("esql.source.cache.enabled", true)
-            .put("esql.source.cache.schema.ttl", schemaTtl)
             .put("esql.source.cache.listing.ttl", "30s")
             .build();
     }
@@ -573,157 +567,6 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
                 untouched.safeMetadata()
             );
         }
-    }
-
-    /**
-     * Regression test for the scale mechanism behind the ndjson warm-COUNT loss seen at ClickBench-100M scale:
-     * a cold multi-file scan LONGER than the schema TTL (multi-minute external scans vs the 5m default)
-     * reconciles into a cache whose entries for the scanned glob have ALL expired. Expired entries are
-     * still forEach-visible, but the first commit's {@code put()} prunes every expired entry from the
-     * LRU tail; pre-fix, files #2..N's deltas then matched nothing and were silently dropped — the
-     * multi-file whole-source fold is all-or-nothing, so the warm {@code COUNT(*)} re-scanned the
-     * entire source. Single-file sources self-healed (no sibling entry to sweep), which is exactly the
-     * bench signature: every 1file cell short-circuited even at cold ≫ TTL while multi-file cells with
-     * cold > TTL full-re-scanned. The TTL here is shrunk so the seeded entries are expired by reconcile
-     * time, standing in for "the scan outlived the TTL".
-     */
-    public void testMultiFileStripeCommitSurvivesSchemaTtlExpiry() throws Exception {
-        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("500ms"))) {
-            long mtime = 1000L;
-            String pathA = "s3://bucket/data/hits_00.ndjson";
-            String pathB = "s3://bucket/data/hits_01.ndjson";
-            SchemaCacheKey keyA = SchemaCacheKey.build(pathA, mtime, ".ndjson", Map.of("format", "ndjson"));
-            SchemaCacheKey keyB = SchemaCacheKey.build(pathB, mtime, ".ndjson", Map.of("format", "ndjson"));
-            seedSchemaCache(service, keyA, pathA, "fp");
-            seedSchemaCache(service, keyB, pathB, "fp");
-
-            // Let both entries expire (but remain physically cached — expiry evicts lazily), exactly
-            // the state a scan longer than the TTL leaves behind at reconcile time.
-            Thread.sleep(1200);
-
-            Map<String, List<Map<String, Object>>> contributions = new LinkedHashMap<>();
-            contributions.put(pathA, List.of(stripeFragment(mtime, "fp", 100L, 1024L, 0, 0, 100, true, true, true)));
-            contributions.put(pathB, List.of(stripeFragment(mtime, "fp", 200L, 1024L, 0, 0, 100, true, true, true)));
-            service.reconcileSourceStatsFromContributions(contributions);
-
-            // BOTH files must retain their committed row counts: losing either forfeits the whole
-            // source's warm COUNT(*) (aggregateFileStatistics is all-or-nothing across the glob).
-            assertEquals("first-committed file must keep its stats", 100L, schemaRowCount(service, pathA));
-            assertEquals("sibling file's delta must survive the expiry sweep", 200L, schemaRowCount(service, pathB));
-        }
-    }
-
-    /** Whole-file-contribution twin of {@link #testMultiFileStripeCommitSurvivesSchemaTtlExpiry}. */
-    public void testMultiFileWholeFileCommitSurvivesSchemaTtlExpiry() throws Exception {
-        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("500ms"))) {
-            long mtime = 1000L;
-            String pathA = "s3://bucket/data/hits_00.csv";
-            String pathB = "s3://bucket/data/hits_01.csv";
-            SchemaCacheKey keyA = SchemaCacheKey.build(pathA, mtime, ".csv", Map.of("format", "csv"));
-            SchemaCacheKey keyB = SchemaCacheKey.build(pathB, mtime, ".csv", Map.of("format", "csv"));
-            seedSchemaCache(service, keyA, pathA, "fp");
-            seedSchemaCache(service, keyB, pathB, "fp");
-
-            Thread.sleep(1200);
-
-            Map<String, List<Map<String, Object>>> contributions = new LinkedHashMap<>();
-            contributions.put(pathA, List.of(wholeFileStats(mtime, "fp", 100L)));
-            contributions.put(pathB, List.of(wholeFileStats(mtime, "fp", 200L)));
-            service.reconcileSourceStatsFromContributions(contributions);
-
-            assertEquals("first-committed file must keep its stats", 100L, schemaRowCount(service, pathA));
-            assertEquals("sibling file's whole-file stats must survive the expiry sweep", 200L, schemaRowCount(service, pathB));
-        }
-    }
-
-    /**
-     * A single-file reconcile whose sole entry has expired must still commit its stats. There is no sibling
-     * to sweep, so the pre-write snapshot is never consulted — the lone path's live sweep finds the
-     * expired-but-still-visible entry and revives it — and {@link ExternalSourceCacheService#snapshotEntriesByPath}
-     * skips the whole-cache forEach entirely. This guards that the skip is behavior-preserving for the common
-     * single-file case (the one that would otherwise pay a doubled full-cache scan).
-     */
-    public void testSingleFileStripeCommitSurvivesSchemaTtlExpiry() throws Exception {
-        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("500ms"))) {
-            long mtime = 1000L;
-            String path = "s3://bucket/data/hits_00.ndjson";
-            SchemaCacheKey key = SchemaCacheKey.build(path, mtime, ".ndjson", Map.of("format", "ndjson"));
-            seedSchemaCache(service, key, path, "fp");
-
-            // Let the entry expire (but remain physically cached — expiry evicts lazily).
-            Thread.sleep(1200);
-
-            service.reconcileSourceStatsFromContributions(
-                Map.of(path, List.of(stripeFragment(mtime, "fp", 100L, 1024L, 0, 0, 100, true, true, true)))
-            );
-
-            assertEquals("single-file stats must survive the expiry, snapshot-skip notwithstanding", 100L, schemaRowCount(service, path));
-        }
-    }
-
-    /**
-     * The same {@code (path, mtime, fingerprint)} can live under SEVERAL cache keys — endpoint/region are
-     * {@link SchemaCacheKey} components but not config-fingerprint inputs — and a commit applies its delta to
-     * every one of them. A sibling path's earlier commit can sweep ONE twin (the older, expired one) while the
-     * other is still live; the snapshot recovery must be per key, not all-or-nothing on the live sweep, or the
-     * swept twin's delta is silently lost. Staggered seeding makes the sweep partial deterministically: the
-     * first twin outlives the TTL by reconcile time, the second does not. (If a CI stall expires the second
-     * twin too, both are recovered from the snapshot and the test still passes — it degrades to the
-     * all-swept case rather than false-failing. The one stall that WOULD false-fail is between the two
-     * seeds: a second seed landing past the first twin's TTL sweeps the first twin at seed time, before
-     * any snapshot exists to recover it from. The 3s TTL keeps that window a &gt;2.3s stall inside a
-     * two-statement gap.)
-     */
-    public void testPartialTwinSweepRecoversSweptTwinEntry() throws Exception {
-        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("3s"))) {
-            long mtime = 1000L;
-            String pathA = "s3://bucket/data/hits_00.csv";
-            String pathB = "s3://bucket/data/hits_01.csv";
-            SchemaCacheKey keyA = SchemaCacheKey.build(pathA, mtime, ".csv", Map.of("format", "csv"));
-            SchemaCacheKey twinB1 = SchemaCacheKey.build(pathB, mtime, ".csv", Map.of("format", "csv", "endpoint", "https://e1"));
-            SchemaCacheKey twinB2 = SchemaCacheKey.build(pathB, mtime, ".csv", Map.of("format", "csv", "endpoint", "https://e2"));
-            seedSchemaCache(service, keyA, pathA, "fp");
-            seedSchemaCache(service, twinB1, pathB, "fp");
-            Thread.sleep(700);
-            seedSchemaCache(service, twinB2, pathB, "fp"); // still inside the TTL: seeding must not sweep the first twin
-            Thread.sleep(2500); // now twinB1 and keyA have expired; twinB2 has not
-
-            // Order matters and is honored: pathA must commit before pathB so pathA's put sweeps the expired
-            // twinB1 from the LRU tail BEFORE pathB is collected (that is the partial sweep under test). The
-            // reconcile commits whole-file entries in this LinkedHashMap's insertion order (see the
-            // LinkedHashMap in reconcileSourceStatsFromContributions), so pathA-before-pathB is deterministic
-            // here, not a filename-hashCode accident.
-            Map<String, List<Map<String, Object>>> contributions = new LinkedHashMap<>();
-            contributions.put(pathA, List.of(wholeFileStats(mtime, "fp", 100L)));
-            contributions.put(pathB, List.of(wholeFileStats(mtime, "fp", 200L)));
-            service.reconcileSourceStatsFromContributions(contributions);
-
-            assertEquals("first-committed file must keep its stats", 100L, schemaRowCount(service, keyA));
-            assertEquals("live twin must receive the delta", 200L, schemaRowCount(service, twinB2));
-            assertEquals("twin swept by the sibling commit must be recovered per key", 200L, schemaRowCount(service, twinB1));
-        }
-    }
-
-    /** The committed row count of {@code path}'s entry, read expiry-blind via forEach (get() would hide expired entries). */
-    private static Object schemaRowCount(ExternalSourceCacheService service, String path) {
-        AtomicReference<Object> found = new AtomicReference<>();
-        service.schemaCache().forEach((k, e) -> {
-            if (path.equals(k.canonicalPath())) {
-                found.set(e.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
-            }
-        });
-        return found.get();
-    }
-
-    /** Key-precise variant of {@link #schemaRowCount(ExternalSourceCacheService, String)} for paths cached under twin keys. */
-    private static Object schemaRowCount(ExternalSourceCacheService service, SchemaCacheKey key) {
-        AtomicReference<Object> found = new AtomicReference<>();
-        service.schemaCache().forEach((k, e) -> {
-            if (key.equals(k)) {
-                found.set(e.safeMetadata().get(SourceStatisticsSerializer.STATS_ROW_COUNT));
-            }
-        });
-        return found.get();
     }
 
     public void testReconcileSingleCompleteStripe() throws Exception {
@@ -1693,6 +1536,59 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         }
     }
 
+    /**
+     * The headline fix, red on the shared-cache parent: a dataset aggregate lives in its OWN cache, so
+     * churning the per-file schema cache far past its budget cannot evict it. On the parent both populations
+     * shared one budget, so this churn evicted the aggregate and the warm dataset COUNT re-scanned.
+     */
+    public void testDatasetAggregateSurvivesPerFileCacheEviction() throws Exception {
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "512kb") // small: a burst of per-file entries overflows the schema slice
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(settings)) {
+            SchemaCacheKey dsKey = datasetKey();
+            service.putDatasetAggregate(dsKey, 42L, "csv", "s3://bucket/data/*.csv");
+            assertNotNull("aggregate present right after put", service.getDatasetAggregate(dsKey));
+            assertEquals(1, service.usageStats().get("dataset_aggregate_cache.count"));
+
+            // Churn the per-file schema cache far past its budget.
+            for (int i = 0; i < 3000; i++) {
+                SchemaCacheKey k = SchemaCacheKey.build("s3://bucket/data/file" + i + ".csv", 1000L + i, ".csv", Map.of("format", "csv"));
+                service.getOrComputeSchema(k, kk -> testSchemaEntry());
+            }
+            // The per-file cache evicted heavily; the dataset aggregate, in its own store, is untouched.
+            assertThat("per-file cache must have evicted under the churn", service.schemaCache().count(), lessThan(3000));
+            Map<String, Object> served = service.getDatasetAggregate(dsKey);
+            assertNotNull("dataset aggregate must survive per-file churn — it has its own cache", served);
+            assertEquals(42L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        }
+    }
+
+    /**
+     * B1: {@code esql.source.cache.schema.ttl} shipped in released versions, so it must stay REGISTERED — a
+     * node carrying it in {@code elasticsearch.yml} would fail startup on an unregistered setting. It is now
+     * a deprecated no-op: wired to nothing, ignored.
+     */
+    public void testDeprecatedSchemaTtlSettingStaysRegisteredAndInert() throws Exception {
+        assertTrue(
+            "schema.ttl must stay registered (deprecated no-op) so upgrades don't fail startup",
+            ExternalSourceCacheSettings.settings().stream().anyMatch(s -> s.getKey().equals("esql.source.cache.schema.ttl"))
+        );
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m") // carried over from an earlier version
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(settings)) {
+            SchemaCacheKey key = SchemaCacheKey.build("s3://bucket/f.parquet", 1000L, ".parquet", Map.of());
+            service.getOrComputeSchema(key, k -> testSchemaEntry());
+            assertEquals(1, service.usageStats().get("schema_cache.count"));
+        }
+    }
+
     public void testPendingDatasetAggregateRefusedWhenSingleGlobExceedsPathBudget() {
         // A single glob whose file count exceeds the whole registry's path budget is refused up front
         // (safe-miss) — never registered, so it cannot pin the heap. Observable via the pending gauge.
@@ -1962,29 +1858,25 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         }
     }
 
-    public void testPendingDatasetAggregateOutlivesSchemaTtl() throws Exception {
-        // The promise is registered BEFORE the scan and fulfilled AFTER it, so its expiry horizon must
-        // be decoupled from the schema TTL: with a promise horizon tied to the schema TTL, a scan
-        // longer than the TTL (the motivating 20-minute ClickBench cell vs the 5m default) would expire
-        // its OWN promise before its own reconcile — making the whole mechanism inert exactly where it
-        // matters. Shrink the schema TTL far below the register→fulfill gap and prove fulfillment
-        // still materializes the aggregate.
-        try (ExternalSourceCacheService service = new ExternalSourceCacheService(schemaTtlSettings("50ms"))) {
+    public void testPendingDatasetAggregateFulfilledAcrossSlowScan() throws Exception {
+        // The promise is registered BEFORE the scan and fulfilled AFTER it. Its horizon is a fixed,
+        // cache-independent constant (PENDING_DATASET_AGGREGATE_TTL_NANOS), so a scan that spans a long
+        // gap still fulfills. (This survives the removal of the schema TTL: the caches no longer expire on
+        // a clock at all, and the dataset aggregate lands in its own dedicated store.)
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
             String pathA = "s3://bucket/data/a.csv";
             String pathB = "s3://bucket/data/b.csv";
             SchemaCacheKey key = datasetKey();
             service.registerPendingDatasetAggregate(key, Map.of(pathA, 1000L, pathB, 2000L), 2, "fp", "csv", "slow-scan-glob");
 
-            Thread.sleep(200); // the "cold scan": several schema TTLs long
+            Thread.sleep(200); // stand in for a multi-minute cold scan between register and fulfill
 
             service.reconcileSourceStatsFromContributions(
                 Map.of(pathA, List.of(wholeFileStats(1000L, "fp", 100L)), pathB, List.of(wholeFileStats(2000L, "fp", 200L)))
             );
 
-            // Read immediately: the entry was written by the reconcile just above (its own TTL starts
-            // at write), so only the PROMISE's age is under test here.
             Map<String, Object> served = service.getDatasetAggregate(key);
-            assertNotNull("a promise must outlive a scan longer than the schema TTL", served);
+            assertNotNull("a promise must be fulfilled after a slow scan", served);
             assertEquals(300L, served.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
         }
     }


### PR DESCRIPTION
## What this is about

`FROM <dataset> | STATS COUNT/MIN/MAX` is served warm from memoized stats in the coordinator's
external-source cache. The fulfilled **dataset-level aggregate** (the whole-dataset row count) shared
one cache — one budget, one LRU, one TTL — with the weight-heavy **per-file** schema+stats entries.
A dataset aggregate is tiny (a single row count) but expensive to rebuild (a full cold scan of the
whole set); the per-file entries are large. So per-file churn kept evicting the precious dataset
aggregate, and the warm dataset `COUNT` decayed mid-use and silently re-scanned. It worked halfway.

## What this PR does

- **Gives fulfilled dataset aggregates their own cache**, keyed by the file-set fingerprint. Its slice
  is small (~2% of the external-cache budget) — a dataset entry is a single row count, so kilobytes
  suffice — and it's carved from the listing budget, so per-file stays at its established 20%. Per-file
  churn can no longer evict the aggregate.
- **Drops the `expireAfterWrite` TTL** on both identity-keyed caches. Per-file entries are keyed by
  mtime, dataset aggregates by the file-set fingerprint — a changed input already misses by identity,
  so the timer only discarded still-valid, expensively harvested entries on a clock. The
  `esql.source.cache.schema.ttl` setting stays **registered as a deprecated no-op** so a node carrying
  it from an earlier version still starts (no upgrade break). The listing cache keeps its TTL: it
  discovers file identity and has no per-file key to invalidate on.
- **`FlightStorageProvider` declares `supportsStableMetadata() == false`.** Flight reports a null
  last-modified, so with no TTL a Flight entry would be stale forever; opting out at the
  `isCacheable` gate bypasses caching for Flight entirely.

## Does it work?

New tests: `testDatasetAggregateSurvivesPerFileCacheEviction` — verified **red on `main`** (the shared
cache evicts the aggregate under per-file churn) and green here — plus coverage that the deprecated
`schema.ttl` setting stays registered and inert. Locally green: the `datasources` + `plugin` suites,
`FlightStorageProviderTests`, `:x-pack:plugin:esql:precommit` clean.

## What's in the diff

The dataset-aggregate `get`/`put` retarget to the new store; the 3-way budget split; the setting kept
as a deprecated no-op; the Flight one-liner; stale TTL comments corrected. The per-file
snapshot/twin-recovery machinery is **untouched** — it guards the per-file capacity sweep, which the
split does not affect. Four tests that forced eviction *via* the schema TTL are removed (that scenario
no longer exists); re-establishing capacity-forced coverage of the recovery is a follow-up.

**Interaction with #153715 (single-file metadata cache), which merged into main first:** that PR's
`fileMetadataCache` was bounded by the schema TTL. Since this PR removes the schema TTL, its
`expireAfterWrite` is re-homed to the **listing TTL** — the file-metadata cache is freshness-discovery
(it holds a file's current `{length, mtime}`), so with the schema cache no longer time-expiring it
becomes the single-file freshness gate and belongs on the same 30s discovery cadence as listing. Its
reprobe test is updated to drive expiry via `listing.ttl`. Default single-file metadata freshness
tightens from 5m to 30s.

## What's out of scope (follow-up)

- Separating per-file schema from the per-file stats overlay (one entry today), revisiting the
  recovery machinery + capacity-forced test coverage, listing-cache revalidation, re-deriving the
  budget split, and a defensive "don't cache on null mtime" guard for the other providers.
- No new cache-drop API: operators already drop the caches by toggling the dynamic
  `esql.source.cache.enabled` setting off (which clears them) and on again.
