### PR TITLE
[ML] Fix and unmute TransformTaskFailedStateIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -613,9 +613,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
-- class: org.elasticsearch.xpack.transform.integration.TransformTaskFailedStateIT
-  method: testStartFailedTransform
-  issue: https://github.com/elastic/elasticsearch/issues/153065
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testMultiTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/150101

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
@@ -173,7 +173,7 @@ public class TransformTaskFailedStateIT extends TransformRestTestCase {
 
         stopTransform(transformId, true);
 
-        assertThat(getTransformTasks(), is(empty()));
+        assertBusy(() -> assertThat(getTransformTasks(), is(empty())));
         assertThat(getTransformTasksFromClusterState(transformId), is(empty()));
     }
 


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/153065

There time window between `stopTransform` and `getTransformTasks` is too narrow - the transforms do not have enough time to be deregistered.

`assertBusy` should do the trick, but I'm open to having the discussion whether the `waitForCompletion=true` [parameter](https://github.com/darius-vil/elasticsearch/blob/f893571dfe28b55aa97d18dd13ab6e264cdcefa3/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java#L476) we set should guarantee that this doesn't happen instead