### PR TITLE
Flakiness detection: skip abstract base test classes

### DIFF
--- a/.buildkite/pipelines/flakiness-detection-manual.yml
+++ b/.buildkite/pipelines/flakiness-detection-manual.yml
@@ -19,3 +19,7 @@ steps:
       bun .buildkite/scripts/flakiness-detection/entrypoints/manual.ts
     timeout_in_minutes: 10
     soft_fail: false
+    # manual.ts writes this when it skips BWC tests that cannot be re-run via the
+    # bare task; the generated analyze step downloads it and records them as
+    # not_applicable. No-op when the file is absent.
+    artifact_paths: flakiness-skipped.json

--- a/.buildkite/pipelines/pull-request/flakiness-detection.yml
+++ b/.buildkite/pipelines/pull-request/flakiness-detection.yml
@@ -14,3 +14,7 @@ steps:
           node .buildkite/scripts/flakiness-detection/entrypoints/pr.ts
         timeout_in_minutes: 10
         soft_fail: true
+        # pr.ts writes this when it skips BWC tests that cannot be re-run via the
+        # bare task; the generated analyze step downloads it and records them as
+        # not_applicable. No-op when the file is absent.
+        artifact_paths: flakiness-skipped.json

--- a/.buildkite/scripts/flakiness-detection/README.md
+++ b/.buildkite/scripts/flakiness-detection/README.md
@@ -172,9 +172,10 @@ Derived in priority order by `analyzer/outcome.ts` (`deriveOutcome`):
 | --------------- | ------------------------------------------------------------------------------ |
 | `flaky_detected`| `realFailures > 0` (failing test cases, excluding suite-timeout markers)        |
 | `timeout`       | `rc == 124`, or `rc == 137` with duration at/after the inner timeout            |
-| `infra_fail`    | `rc == 137` short run (`oom_killed`), or any other non-zero `rc` with no real failures |
+| `infra_fail`    | `rc == 137` short run (`oom_killed`), a non-zero `rc` with a heap dump (`oom`), or any other non-zero `rc` with no real failures |
 | `hang`          | `rc == 0` but zero recorded test cases                                          |
 | `clean_pass`    | `rc == 0` with recorded cases and no real failures                              |
+| `not_applicable`| assigned upstream (not by `deriveOutcome`) for a test that could not be re-run at all, e.g. a BWC qa project whose bare task is disabled - "nothing to re-run", excluded from the false-failure metric |
 
 `timedOut` is reported alongside `outcome` so the two timeout shapes stay
 distinguishable: a job that times out **with** a real failure is
@@ -182,11 +183,14 @@ distinguishable: a job that times out **with** a real failure is
 positive), while a job that times out with **no** failing run is `timeout`
 (`timedOut=true`) — the false positive we want to drive down.
 
-`infraSubtype` is only ever `oom_killed` (rc 137 + short run, decided without a
-log). Finer infra subtypes (disk-full, etc.) would require the job log, which CI
-cannot read, so they are left unset. Jobs that fail *before* the wrapper runs
-(e.g. a pre-command hook failure) write no status file and so produce no
-payload; the external pipeline records those as `infra_fail` from job state.
+`infraSubtype` is `oom_killed` (rc 137 + short run, the kernel OOM-killer) or
+`oom` (a JVM-heap `OutOfMemoryError`: rc != 0 with a `*/build/heapdump/*.hprof`
+file present, detected by the never-fail wrapper; the analyze step does not read
+the job log). Finer infra subtypes (disk-full, etc.) would require the job log,
+which we currently choose not to read, so they are left unset. Jobs that fail
+*before* the wrapper runs (e.g. a pre-command hook failure) write no status file
+and so produce no payload; the external pipeline records those as `infra_fail`
+from job state.
 
 ## File layout
 

--- a/.buildkite/scripts/flakiness-detection/README.md
+++ b/.buildkite/scripts/flakiness-detection/README.md
@@ -203,6 +203,8 @@ flakiness-detection/
     changed-files.ts     git-diff source
     unmutes.ts           muted-tests.yml diff source
     explicit-list.ts     FQCN list source
+    bwc.ts               BWC-project detection → not_applicable partition
+    abstract.ts          skips abstract base classes (their --tests matches nothing)
   commands.ts            dedupe / collapse / batch / emit RunnableCommand[]
   runners/
     buildkite.ts         RunnableCommand[] → BK YAML + upload (wraps + writes per-job status file)

--- a/.buildkite/scripts/flakiness-detection/README.md
+++ b/.buildkite/scripts/flakiness-detection/README.md
@@ -176,6 +176,7 @@ Derived in priority order by `analyzer/outcome.ts` (`deriveOutcome`):
 | `hang`          | `rc == 0` but zero recorded test cases                                          |
 | `clean_pass`    | `rc == 0` with recorded cases and no real failures                              |
 | `not_applicable`| assigned upstream (not by `deriveOutcome`) for a test that could not be re-run at all, e.g. a BWC qa project whose bare task is disabled - "nothing to re-run", excluded from the false-failure metric |
+| `build_failed`  | assigned upstream when the pre-flight compile gate fails: the PR did not compile, so the re-run batches were skipped. One record stands in for the skipped batches; excluded from the false-failure metric (the PR is already red from its main build) |
 
 `timedOut` is reported alongside `outcome` so the two timeout shapes stay
 distinguishable: a job that times out **with** a real failure is

--- a/.buildkite/scripts/flakiness-detection/analyzer/outcome.test.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/outcome.test.ts
@@ -84,6 +84,28 @@ describe("deriveOutcome", () => {
     });
   });
 
+  test("rc != 0 with a heap dump is an infra fail subtyped oom", () => {
+    expect(deriveOutcome({ rc: 1, durationSec: 30, realFailures: 0, totalCases: 0, timeoutThresholdSec: THRESHOLD, oomDetected: true })).toEqual({
+      outcome: "infra_fail",
+      timedOut: false,
+      infraSubtype: "oom",
+    });
+  });
+
+  test("a real failure still wins over an oom heap dump (flakiness proven)", () => {
+    expect(deriveOutcome({ rc: 1, durationSec: 30, realFailures: 1, totalCases: 5, timeoutThresholdSec: THRESHOLD, oomDetected: true })).toEqual({
+      outcome: "flaky_detected",
+      timedOut: false,
+    });
+  });
+
+  test("oomDetected does not override a clean rc 0 run", () => {
+    expect(deriveOutcome({ rc: 0, durationSec: 30, realFailures: 0, totalCases: 2, timeoutThresholdSec: THRESHOLD, oomDetected: true })).toEqual({
+      outcome: "clean_pass",
+      timedOut: false,
+    });
+  });
+
   test("rc 0 with no recorded cases is a hang", () => {
     expect(deriveOutcome({ rc: 0, durationSec: 30, realFailures: 0, totalCases: 0, timeoutThresholdSec: THRESHOLD })).toEqual({
       outcome: "hang",

--- a/.buildkite/scripts/flakiness-detection/analyzer/outcome.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/outcome.ts
@@ -2,7 +2,7 @@
 // analyze step (which classifies every batch job from its rc + JUnit XML) and
 // its unit tests.
 
-export type FlakinessOutcome = "clean_pass" | "flaky_detected" | "timeout" | "hang" | "infra_fail";
+export type FlakinessOutcome = "clean_pass" | "flaky_detected" | "timeout" | "hang" | "infra_fail" | "not_applicable";
 
 export interface OutcomeInput {
   // Wrapped command's return code (124 = our SIGTERM timeout, 137 = SIGKILL).
@@ -19,6 +19,13 @@ export interface OutcomeInput {
   // minus the never-fail grace) so it tracks config changes; see
   // entrypoints/analyze.ts.
   timeoutThresholdSec: number;
+  // True when the never-fail wrapper found a JVM heap dump (`*/build/heapdump/*.hprof`)
+  // after the run - the signal for a JVM-heap `OutOfMemoryError` in a test worker,
+  // which exits via Gradle with rc=1 (not the SIGKILL rc=137 the kernel OOM-killer
+  // produces). Without this the two OOM shapes are indistinguishable from a plain
+  // build failure, since the analyze step does not read the job log (a choice we
+  // may revisit).
+  oomDetected?: boolean;
 }
 
 export interface DerivedOutcome {
@@ -28,9 +35,11 @@ export interface DerivedOutcome {
   // distinguishes "timed out but flakiness already proven" from a clean
   // `timeout` where no run failed.
   timedOut: boolean;
-  // Only ever "oom_killed" (rc 137 + short run). Every other infra subtype would
-  // need the job log, which CI cannot read, so it is left unset here.
-  infraSubtype?: "oom_killed";
+  // "oom_killed" = kernel OOM-killer SIGKILL (rc 137 + short run). "oom" =
+  // JVM-heap OutOfMemoryError detected from a heap-dump file (rc != 0,
+  // non-SIGKILL). Every other infra subtype would need the job log, which we
+  // currently choose not to read, so it is left unset here.
+  infraSubtype?: "oom_killed" | "oom";
 }
 
 /**
@@ -39,7 +48,7 @@ export interface DerivedOutcome {
  * failure outranks everything, including a concurrent timeout, because that is
  * what matters for the false-positive metric.
  */
-export function deriveOutcome({ rc, durationSec, realFailures, totalCases, timeoutThresholdSec }: OutcomeInput): DerivedOutcome {
+export function deriveOutcome({ rc, durationSec, realFailures, totalCases, timeoutThresholdSec, oomDetected }: OutcomeInput): DerivedOutcome {
   const threshold = timeoutThresholdSec;
   const timedOut = rc === 124 || (rc === 137 && durationSec >= threshold);
 
@@ -55,7 +64,11 @@ export function deriveOutcome({ rc, durationSec, realFailures, totalCases, timeo
       : { outcome: "infra_fail", timedOut: false, infraSubtype: "oom_killed" };
   }
   if (rc !== 0) {
-    return { outcome: "infra_fail", timedOut: false };
+    // A JVM-heap OutOfMemoryError exits here (rc=1, not SIGKILL); the heap-dump
+    // signal lets us subtype it as `oom` instead of a generic infra_fail.
+    return oomDetected
+      ? { outcome: "infra_fail", timedOut: false, infraSubtype: "oom" }
+      : { outcome: "infra_fail", timedOut: false };
   }
   return totalCases === 0 ? { outcome: "hang", timedOut: false } : { outcome: "clean_pass", timedOut: false };
 }

--- a/.buildkite/scripts/flakiness-detection/analyzer/outcome.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/outcome.ts
@@ -2,7 +2,7 @@
 // analyze step (which classifies every batch job from its rc + JUnit XML) and
 // its unit tests.
 
-export type FlakinessOutcome = "clean_pass" | "flaky_detected" | "timeout" | "hang" | "infra_fail" | "not_applicable";
+export type FlakinessOutcome = "clean_pass" | "flaky_detected" | "timeout" | "hang" | "infra_fail" | "not_applicable" | "build_failed";
 
 export interface OutcomeInput {
   // Wrapped command's return code (124 = our SIGTERM timeout, 137 = SIGKILL).

--- a/.buildkite/scripts/flakiness-detection/commands.test.ts
+++ b/.buildkite/scripts/flakiness-detection/commands.test.ts
@@ -5,9 +5,33 @@ import {
   deduplicateYamlRunners,
   generateBatchCommand,
   buildCommands,
+  compileTasksFor,
 } from "./commands.ts";
 import type { ClassifiedTest } from "./domain.ts";
 import { DEFAULT_BATCHING_CONFIG } from "./domain.ts";
+
+describe("compileTasksFor", () => {
+  test("maps each source set to its compile task, de-duplicated per project", () => {
+    const tests: ClassifiedTest[] = [
+      { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "a.ATests" },
+      { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "a.BTests" },
+      { gradleProject: ":server", kind: "internalClusterTest", sourceSet: "internalClusterTest", fqcn: "a.CIT" },
+      { gradleProject: ":x-pack:plugin:ml", kind: "javaRestTest", sourceSet: "javaRestTest", fqcn: "a.DIT" },
+      { gradleProject: ":x-pack:plugin:ml", kind: "yamlRestTestRunner", sourceSet: "yamlRestTest" },
+    ];
+
+    expect(compileTasksFor(tests)).toEqual([
+      ":server:compileTestJava",
+      ":server:compileInternalClusterTestJava",
+      ":x-pack:plugin:ml:compileJavaRestTestJava",
+      ":x-pack:plugin:ml:compileYamlRestTestJava",
+    ]);
+  });
+
+  test("empty for no tests", () => {
+    expect(compileTasksFor([])).toEqual([]);
+  });
+});
 
 describe("collapseYamlSuites", () => {
   test("collapses multiple YAML files in same directory", () => {

--- a/.buildkite/scripts/flakiness-detection/commands.ts
+++ b/.buildkite/scripts/flakiness-detection/commands.ts
@@ -4,6 +4,31 @@ import type { BatchingConfig, ClassifiedTest, RunnableCommand, TestKind } from "
 
 import { KIND_KEYS, KIND_LABELS, KIND_ORDER } from "./domain.ts";
 
+// Maps a source set to the Gradle task that compiles it. Used by the pre-flight
+// compile gate so a PR that does not compile is caught once, up front, instead
+// of failing every re-run batch identically.
+const SOURCE_SET_COMPILE_TASK: Record<string, string> = {
+  test: "compileTestJava",
+  internalClusterTest: "compileInternalClusterTestJava",
+  javaRestTest: "compileJavaRestTestJava",
+  yamlRestTest: "compileYamlRestTestJava",
+};
+
+/**
+ * The unique `:project:compile<SourceSet>Java` tasks covering every runnable
+ * test's source set, e.g. `:server:compileTestJava`. Compiling these transitively
+ * builds their dependencies, so a green result means the batches can at least be
+ * enumerated and started.
+ */
+export function compileTasksFor(tests: ClassifiedTest[]): string[] {
+  const tasks = new Set<string>();
+  for (const t of tests) {
+    const compileTask = SOURCE_SET_COMPILE_TASK[t.sourceSet];
+    if (compileTask) tasks.add(`${t.gradleProject}:${compileTask}`);
+  }
+  return [...tasks];
+}
+
 export function dedupeTests(tests: ClassifiedTest[]): ClassifiedTest[] {
   const seen = new Set<string>();
   const result: ClassifiedTest[] = [];

--- a/.buildkite/scripts/flakiness-detection/detectors/abstract.test.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/abstract.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { isAbstractTestClass } from "./abstract.ts";
+
+describe("isAbstractTestClass", () => {
+  test("true for a public abstract class", () => {
+    const src = "package x;\npublic abstract class AbstractFooTests extends ESTestCase {}";
+    expect(isAbstractTestClass(src, "AbstractFooTests")).toBe(true);
+  });
+
+  test("true for a package-private abstract class", () => {
+    expect(isAbstractTestClass("abstract class FooTests {}", "FooTests")).toBe(true);
+  });
+
+  test("false for a concrete class", () => {
+    const src = "public class FooTests extends ESTestCase {}";
+    expect(isAbstractTestClass(src, "FooTests")).toBe(false);
+  });
+
+  test("false when abstract applies to a different (inner/helper) class", () => {
+    const src = "public class FooTests {\n  abstract class Helper {}\n}";
+    expect(isAbstractTestClass(src, "FooTests")).toBe(false);
+  });
+
+  test("does not confuse an abstract method for an abstract class", () => {
+    const src = "public class FooTests {\n  abstract void doThing();\n}";
+    expect(isAbstractTestClass(src, "FooTests")).toBe(false);
+  });
+
+  test("handles a nested-class name containing regex metacharacters ($)", () => {
+    // A `$` in the name would act as an end-anchor if not escaped, silently
+    // failing the match. `Outer$Inner` really appears as a `class Outer$Inner`?
+    // No - the source declares the inner simple name; we assert the escaped
+    // literal is matched, not treated as an anchor.
+    const src = "public abstract class Outer$Inner extends ESTestCase {}";
+    expect(isAbstractTestClass(src, "Outer$Inner")).toBe(true);
+    // And a concrete same-name class is correctly not matched.
+    expect(isAbstractTestClass("public class Outer$Inner {}", "Outer$Inner")).toBe(false);
+  });
+});

--- a/.buildkite/scripts/flakiness-detection/detectors/abstract.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/abstract.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Reads a repo-relative `.java` file, returning its text or null when it cannot
+// be read. Injected so the detectors stay pure and unit-testable without the
+// filesystem.
+export type JavaSourceReader = (repoRelativePath: string) => string | null;
+
+export function defaultJavaSourceReader(repoRoot: string): JavaSourceReader {
+  return (repoRelativePath) => {
+    try {
+      return readFileSync(join(repoRoot, repoRelativePath), "utf8");
+    } catch {
+      return null;
+    }
+  };
+}
+
+/**
+ * True when the given source declares `<simpleClassName>` as an abstract class.
+ *
+ * Abstract base classes are named to the same `*Tests`/`*IT` conventions that
+ * `SOURCE_SET_PATTERNS` matches (e.g. `AbstractFooTests`), so the detector would
+ * emit `--tests <AbstractFooTests>` - which matches zero runnable tests and,
+ * because `MutedTestPlugin` sets `failOnNoMatchingTests(ci == false)`, passes
+ * silently in CI and is recorded as a `hang`. Skipping abstract classes up front
+ * removes that whole class of silent no-op re-runs.
+ */
+export function isAbstractTestClass(source: string, simpleClassName: string): boolean {
+  // The class declaration, allowing modifiers before `abstract` (e.g.
+  // `public abstract class Foo`). `abstract` sits immediately before `class`.
+  // Escape the class name: a nested-class descriptor can carry a `$`
+  // (`Outer$Inner`), which would otherwise act as a regex end-anchor and make
+  // the match silently fail - re-admitting the abstract class as a `hang`.
+  return new RegExp(`\\babstract\\s+class\\s+${escapeRegExp(simpleClassName)}\\b`).test(source);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/.buildkite/scripts/flakiness-detection/detectors/bwc.test.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/bwc.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import type { ClassifiedTest } from "../domain.ts";
+
+import { isBwcProject, partitionByBwc, type BuildScriptReader } from "./bwc.ts";
+
+// A reader backed by an in-memory map keyed by the project source directory.
+function reader(files: Record<string, string>): BuildScriptReader {
+  return (projectDir) => (projectDir in files ? files[projectDir] : null);
+}
+
+const bwcBuildGradle = `
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.bwc-test'
+
+buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName -> }
+`;
+
+const plainBuildGradle = `
+apply plugin: 'elasticsearch.internal-java-rest-test'
+dependencies { }
+`;
+
+describe("isBwcProject", () => {
+  test("true when build.gradle applies elasticsearch.bwc-test", () => {
+    const read = reader({ "x-pack/plugin/logsdb/qa/rolling-upgrade": bwcBuildGradle });
+    expect(isBwcProject(":x-pack:plugin:logsdb:qa:rolling-upgrade", read)).toBe(true);
+  });
+
+  test("false for a plain project", () => {
+    const read = reader({ "server": plainBuildGradle });
+    expect(isBwcProject(":server", read)).toBe(false);
+  });
+
+  test("false when no build script exists", () => {
+    expect(isBwcProject(":does:not:exist", reader({}))).toBe(false);
+  });
+
+  test("false when the plugin id only appears in a comment or unrelated string", () => {
+    const commented = "// TODO: this is not a elasticsearch.bwc-test project\nString s = \"elasticsearch.bwc-test\"\n";
+    expect(isBwcProject(":server", reader({ server: commented }))).toBe(false);
+  });
+
+  test("true for the Kotlin id(\"...\") application form", () => {
+    const kts = 'plugins {\n  id("elasticsearch.bwc-test")\n}\n';
+    expect(isBwcProject(":qa:kts", reader({ "qa/kts": kts }))).toBe(true);
+  });
+
+  test("maps the :test:external-modules test- rename back to its directory", () => {
+    const read = reader({ "test/external-modules/foo": bwcBuildGradle });
+    expect(isBwcProject(":test:external-modules:test-foo", read)).toBe(true);
+  });
+});
+
+describe("partitionByBwc", () => {
+  test("splits BWC tests into notApplicable and keeps the rest runnable", () => {
+    const tests: ClassifiedTest[] = [
+      { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "org.elasticsearch.FooTests" },
+      { gradleProject: ":x-pack:plugin:logsdb:qa:rolling-upgrade", kind: "javaRestTest", sourceSet: "javaRestTest", fqcn: "org.elasticsearch.BwcIT" },
+    ];
+    const read = reader({
+      "server": plainBuildGradle,
+      "x-pack/plugin/logsdb/qa/rolling-upgrade": bwcBuildGradle,
+    });
+
+    const { runnable, notApplicable } = partitionByBwc(tests, read);
+    expect(runnable).toEqual([tests[0]]);
+    expect(notApplicable).toEqual([tests[1]]);
+  });
+
+  test("reads each project's build script at most once", () => {
+    const reads: string[] = [];
+    const read: BuildScriptReader = (projectDir) => {
+      reads.push(projectDir);
+      return projectDir === "qa/bwc" ? bwcBuildGradle : plainBuildGradle;
+    };
+    const tests: ClassifiedTest[] = [
+      { gradleProject: ":qa:bwc", kind: "javaRestTest", sourceSet: "javaRestTest", fqcn: "a.A" },
+      { gradleProject: ":qa:bwc", kind: "javaRestTest", sourceSet: "javaRestTest", fqcn: "a.B" },
+      { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "a.C" },
+    ];
+
+    const { runnable, notApplicable } = partitionByBwc(tests, read);
+    expect(reads).toEqual(["qa/bwc", "server"]);
+    expect(notApplicable).toHaveLength(2);
+    expect(runnable).toHaveLength(1);
+  });
+});

--- a/.buildkite/scripts/flakiness-detection/detectors/bwc.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/bwc.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import type { ClassifiedTest } from "../domain.ts";
+
+import { toProjectDir } from "../domain.ts";
+
+// A project applies the BWC test plugin when its build script *applies* the
+// `elasticsearch.bwc-test` plugin. On such projects the bare test task
+// (`test` / `javaRestTest` / ...) is disabled by `elasticsearch.bwc-test.gradle`
+// - the tests only run under the version-qualified `v<version>#bwcTest` tasks -
+// so re-running the bare task the detector emits does nothing (0 tests, exit 0),
+// which the analyzer would otherwise record as a `hang`. We therefore treat these
+// as `not_applicable` ("nothing to re-run"). Actually re-running them via the
+// version-qualified tasks is a separate, harder follow-up.
+//
+// Covers the Groovy `apply plugin: '...'` and `id '...'` forms and the Kotlin
+// `id("...")` form.
+const BWC_TEST_PLUGIN_APPLIED = /(?:apply\s+plugin\s*:\s*|id\s*\(?\s*)['"]elasticsearch\.bwc-test['"]/;
+
+// Reads a project's build script, given its source directory (repo-relative).
+// Returns null when no build script is found. Injected so the partition logic
+// stays pure and unit-testable without touching the filesystem.
+export type BuildScriptReader = (projectDir: string) => string | null;
+
+export function defaultBuildScriptReader(repoRoot: string): BuildScriptReader {
+  return (projectDir) => {
+    for (const name of ["build.gradle", "build.gradle.kts"]) {
+      try {
+        return readFileSync(join(repoRoot, projectDir, name), "utf8");
+      } catch {
+        // Try the next candidate name; fall through to null if none exist.
+      }
+    }
+    return null;
+  };
+}
+
+export function isBwcProject(gradleProject: string, read: BuildScriptReader): boolean {
+  const text = read(toProjectDir(gradleProject));
+  return text !== null && BWC_TEST_PLUGIN_APPLIED.test(text);
+}
+
+export interface BwcPartition {
+  // Tests whose bare task actually runs them - fan out to batch jobs as usual.
+  runnable: ClassifiedTest[];
+  // Tests on BWC projects that the bare task cannot run - recorded as
+  // `not_applicable`, never fanned out.
+  notApplicable: ClassifiedTest[];
+}
+
+/**
+ * Splits the detected tests into runnable ones and BWC ones that cannot be
+ * re-run via the bare task. The BWC decision is cached per Gradle project so
+ * each `build.gradle` is read at most once.
+ */
+export function partitionByBwc(tests: ClassifiedTest[], read: BuildScriptReader): BwcPartition {
+  const cache = new Map<string, boolean>();
+  const runnable: ClassifiedTest[] = [];
+  const notApplicable: ClassifiedTest[] = [];
+  for (const t of tests) {
+    let bwc = cache.get(t.gradleProject);
+    if (bwc === undefined) {
+      bwc = isBwcProject(t.gradleProject, read);
+      cache.set(t.gradleProject, bwc);
+    }
+    (bwc ? notApplicable : runnable).push(t);
+  }
+  return { runnable, notApplicable };
+}

--- a/.buildkite/scripts/flakiness-detection/detectors/changed-files.test.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/changed-files.test.ts
@@ -139,4 +139,30 @@ describe("classifyChangedFiles", () => {
     expect(result[0].kind).toBe("test");
     expect(result[1].kind).toBe("javaRestTest");
   });
+
+  test("skips an abstract class whose name matches the *Tests convention (with reader)", () => {
+    const abstractPath = "server/src/test/java/org/elasticsearch/index/codec/AbstractDocValuesFormatTests.java";
+    const concretePath = "server/src/test/java/org/elasticsearch/index/IndexTests.java";
+    const sources: Record<string, string> = {
+      [abstractPath]: "public abstract class AbstractDocValuesFormatTests extends ESTestCase {}",
+      [concretePath]: "public class IndexTests extends ESTestCase {}",
+    };
+
+    const result = classifyChangedFiles([abstractPath, concretePath], (p) => sources[p] ?? null);
+    expect(result).toEqual([
+      {
+        gradleProject: ":server",
+        kind: "test",
+        sourceSet: "test",
+        fqcn: "org.elasticsearch.index.IndexTests",
+      },
+    ]);
+  });
+
+  test("without a reader, an abstract-named-*Tests class is still classified (back-compat)", () => {
+    const result = classifyChangedFiles([
+      "server/src/test/java/org/elasticsearch/index/codec/AbstractDocValuesFormatTests.java",
+    ]);
+    expect(result).toHaveLength(1);
+  });
 });

--- a/.buildkite/scripts/flakiness-detection/detectors/changed-files.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/changed-files.ts
@@ -1,14 +1,25 @@
 import type { ClassifiedTest } from "../domain.ts";
 
 import { SOURCE_SET_PATTERNS, toFqcn, toGradleProject } from "../domain.ts";
+import { isAbstractTestClass, type JavaSourceReader } from "./abstract.ts";
 
-export function classifyChangedFiles(files: string[]): ClassifiedTest[] {
+export function classifyChangedFiles(files: string[], readSource?: JavaSourceReader): ClassifiedTest[] {
   const tests: ClassifiedTest[] = [];
 
   for (const file of files) {
     for (const pattern of SOURCE_SET_PATTERNS) {
       const match = file.match(pattern.regex);
       if (match) {
+        // `match[2]` is the class path for java kinds and the yaml path for
+        // yamlRestTestSuite. Skip abstract base classes (java kinds only): their
+        // `*Tests`/`*IT` name matches but `--tests` on them runs nothing.
+        if (readSource && pattern.kind !== "yamlRestTestSuite") {
+          const source = readSource(file);
+          if (source && isAbstractTestClass(source, match[2].split("/").pop()!)) {
+            break;
+          }
+        }
+
         const test: ClassifiedTest = {
           gradleProject: toGradleProject(match[1]),
           kind: pattern.kind,

--- a/.buildkite/scripts/flakiness-detection/detectors/explicit-list.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/explicit-list.ts
@@ -1,4 +1,5 @@
 import type { ClassifiedTest, TestRef } from "../domain.ts";
+import type { JavaSourceReader } from "./abstract.ts";
 import { locateTest } from "./locator.ts";
 
 export interface UnresolvedSpec {
@@ -24,7 +25,8 @@ export interface ExplicitListResult {
  */
 export function classifyExplicitList(
   specs: string[],
-  repoFiles: string[]
+  repoFiles: string[],
+  readSource?: JavaSourceReader
 ): ExplicitListResult {
   const located: ClassifiedTest[] = [];
   const unlocated: UnresolvedSpec[] = [];
@@ -34,7 +36,7 @@ export function classifyExplicitList(
     if (spec === "") continue;
 
     const ref = parseSpec(spec);
-    const result = locateTest(ref, repoFiles);
+    const result = locateTest(ref, repoFiles, readSource);
     if (result === null) {
       unlocated.push({ spec });
     } else {

--- a/.buildkite/scripts/flakiness-detection/detectors/locator.test.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/locator.test.ts
@@ -97,4 +97,21 @@ describe("locateTest", () => {
       locateTest(ref, ["server/src/main/java/org/elasticsearch/NotATest.java"])
     ).toBeNull();
   });
+
+  test("returns null for an abstract base class when a reader is supplied", () => {
+    const ref: TestRef = { className: "org.elasticsearch.index.IndexTests" };
+    const readSource = () => "public abstract class IndexTests extends ESTestCase {}";
+    expect(locateTest(ref, repoFiles, readSource)).toBeNull();
+  });
+
+  test("still locates a concrete class when a reader is supplied", () => {
+    const ref: TestRef = { className: "org.elasticsearch.index.IndexTests" };
+    const readSource = () => "public class IndexTests extends ESTestCase {}";
+    expect(locateTest(ref, repoFiles, readSource)).toEqual({
+      gradleProject: ":server",
+      kind: "test",
+      sourceSet: "test",
+      fqcn: "org.elasticsearch.index.IndexTests",
+    });
+  });
 });

--- a/.buildkite/scripts/flakiness-detection/detectors/locator.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/locator.ts
@@ -9,6 +9,8 @@ import {
   toGradleProject,
 } from "../domain.ts";
 
+import { isAbstractTestClass, type JavaSourceReader } from "./abstract.ts";
+
 const YAML_METHOD_REGEX = /^test \{yaml=.+\}$/;
 
 /**
@@ -18,12 +20,21 @@ const YAML_METHOD_REGEX = /^test \{yaml=.+\}$/;
  * explicit-list detector (resolving developer-supplied specs).
  *
  * Returns `null` when no source file matches the className — typically because
- * the class was deleted in the same PR.
+ * the class was deleted in the same PR — or, when `readSource` is supplied, when
+ * the class is an abstract base class (its `--tests` filter would match nothing
+ * and pass silently as a hang).
  */
-export function locateTest(ref: TestRef, repoFiles: string[]): ClassifiedTest | null {
+export function locateTest(ref: TestRef, repoFiles: string[], readSource?: JavaSourceReader): ClassifiedTest | null {
   const pathSuffix = ref.className.replace(/\./g, "/") + ".java";
   const candidate = repoFiles.find((f) => f === pathSuffix || f.endsWith("/" + pathSuffix));
   if (candidate === undefined) return null;
+
+  if (readSource) {
+    const source = readSource(candidate);
+    if (source && isAbstractTestClass(source, ref.className.split(".").pop()!)) {
+      return null;
+    }
+  }
 
   for (const pattern of SOURCE_SET_PATTERNS) {
     const match = candidate.match(pattern.regex);

--- a/.buildkite/scripts/flakiness-detection/detectors/unmutes.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/unmutes.ts
@@ -4,6 +4,7 @@ import type {
   ClassifiedTest,
   TestRef,
 } from "../domain.ts";
+import type { JavaSourceReader } from "./abstract.ts";
 import { locateTest } from "./locator.ts";
 
 interface RawMutedTest {
@@ -58,7 +59,8 @@ export interface UnmuteDetectionResult {
 export function findUnmutedTests(
   oldYamlText: string,
   newYamlText: string,
-  repoFiles: string[]
+  repoFiles: string[],
+  readSource?: JavaSourceReader
 ): UnmuteDetectionResult {
   const before = parseMutedEntries(oldYamlText);
   const after = parseMutedEntries(newYamlText);
@@ -67,7 +69,7 @@ export function findUnmutedTests(
   const located: ClassifiedTest[] = [];
   const unlocated: TestRef[] = [];
   for (const entry of unmuted) {
-    const test = locateTest(entry, repoFiles);
+    const test = locateTest(entry, repoFiles, readSource);
     if (test === null) {
       unlocated.push(entry);
     } else {

--- a/.buildkite/scripts/flakiness-detection/domain.ts
+++ b/.buildkite/scripts/flakiness-detection/domain.ts
@@ -77,6 +77,20 @@ export function toFqcn(javaPath: string): string {
   return javaPath.replace(/\//g, ".");
 }
 
+/**
+ * Inverse of {@link toGradleProject}: maps a Gradle project path back to its
+ * source directory (e.g. `:x-pack:plugin:logsdb:qa:rolling-upgrade` ->
+ * `x-pack/plugin/logsdb/qa/rolling-upgrade`), undoing the `:test:external-modules`
+ * `test-` rename. Used to locate a project's `build.gradle` for BWC detection.
+ */
+export function toProjectDir(gradleProject: string): string {
+  const segments = gradleProject.replace(/^:/, "").split(":");
+  if (segments[0] === "test" && segments[1] === "external-modules" && segments.length >= 3 && segments[2].startsWith("test-")) {
+    segments[2] = segments[2].slice("test-".length);
+  }
+  return segments.join("/");
+}
+
 export const KIND_ORDER: TestKind[] = [
   "test",
   "internalClusterTest",

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import type { ClassifiedTest } from "../domain.ts";
+
+import { notApplicablePayload } from "./analyze.ts";
+
+describe("notApplicablePayload", () => {
+  test("maps a skipped BWC javaRestTest to a zeroed not_applicable record", () => {
+    const t: ClassifiedTest = {
+      gradleProject: ":x-pack:plugin:logsdb:qa:rolling-upgrade",
+      kind: "javaRestTest",
+      sourceSet: "javaRestTest",
+      fqcn: "org.elasticsearch.xpack.logsdb.SomeIT",
+    };
+
+    expect(notApplicablePayload(t)).toEqual({
+      jobId: "not-applicable:javaRestTest::x-pack:plugin:logsdb:qa:rolling-upgrade:org.elasticsearch.xpack.logsdb.SomeIT",
+      stepKey: "flakiness-detection:java-rest",
+      kind: "javaRestTest",
+      rc: 0,
+      durationSec: 0,
+      realFailures: 0,
+      suiteTimeouts: 0,
+      totalCases: 0,
+      outcome: "not_applicable",
+      timedOut: false,
+      failingClasses: [],
+      reason: "bwc",
+    });
+  });
+
+  test("uses the full yaml descriptor as the target for a yaml case", () => {
+    const t: ClassifiedTest = {
+      gradleProject: ":qa:mixed",
+      kind: "yamlRestTestCase",
+      sourceSet: "yamlRestTest",
+      fqcn: "org.elasticsearch.SomeYamlIT",
+      yamlTest: "test {yaml=10_basic/Foo}",
+    };
+
+    const payload = notApplicablePayload(t);
+    expect(payload.outcome).toBe("not_applicable");
+    expect(payload.jobId).toContain("org.elasticsearch.SomeYamlIT.test {yaml=10_basic/Foo}");
+    expect(payload.stepKey).toBe("flakiness-detection:yaml-case");
+  });
+});

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { ClassifiedTest } from "../domain.ts";
 
-import { notApplicablePayload } from "./analyze.ts";
+import { buildFailedPayload, notApplicablePayload } from "./analyze.ts";
 
 describe("notApplicablePayload", () => {
   test("maps a skipped BWC javaRestTest to a zeroed not_applicable record", () => {
@@ -42,5 +42,24 @@ describe("notApplicablePayload", () => {
     expect(payload.outcome).toBe("not_applicable");
     expect(payload.jobId).toContain("org.elasticsearch.SomeYamlIT.test {yaml=10_basic/Foo}");
     expect(payload.stepKey).toBe("flakiness-detection:yaml-case");
+  });
+});
+
+describe("buildFailedPayload", () => {
+  test("is a single build_failed record attributed to the precompile gate", () => {
+    expect(buildFailedPayload()).toEqual({
+      jobId: "build-failed:precompile",
+      stepKey: "flakiness-detection:precompile",
+      kind: "",
+      rc: 1,
+      durationSec: 0,
+      realFailures: 0,
+      suiteTimeouts: 0,
+      totalCases: 0,
+      outcome: "build_failed",
+      timedOut: false,
+      failingClasses: [],
+      reason: "compile",
+    });
   });
 });

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "path";
 import { analyzeReports } from "../analyzer/analyze.ts";
 import { deriveOutcome } from "../analyzer/outcome.ts";
 import { renderMarkdown, severity } from "../analyzer/render.ts";
-import { DEFAULT_AGENT_CONFIG } from "../domain.ts";
+import { DEFAULT_AGENT_CONFIG, KIND_KEYS, type ClassifiedTest, type TestKind } from "../domain.ts";
 import { NEVER_FAIL_GRACE_MINUTES } from "../runners/buildkite.ts";
 
 const PROJECT_ROOT = resolve(`${import.meta.dirname}/../../../..`);
@@ -37,6 +37,12 @@ const MAX_FAILING_CLASSES = 50;
 // Keep this filename in sync with FLAKINESS_OUTCOMES_ARTIFACT in runners/buildkite.ts.
 const OUTCOMES_ARTIFACT_FILE = "flakiness-outcomes.json";
 
+// Written by the bootstrap step (entrypoints/pr.ts): tests that could not be
+// re-run (BWC projects). Downloaded next to this script and folded into the
+// outcomes as `not_applicable`. Keep in sync with FLAKINESS_SKIPPED_ARTIFACT in
+// runners/buildkite.ts and entrypoints/pr.ts.
+const SKIPPED_FILE = "flakiness-skipped.json";
+
 // Self-reported by each batch job's never-fail wrapper (runners/buildkite.ts).
 interface JobStatus {
   jobId: string;
@@ -45,6 +51,12 @@ interface JobStatus {
   rc: number;
   durationSec: number;
 }
+
+// A JobStatus plus the raw signals the wrapper reports that are inputs to
+// classification but are not themselves payload fields (the payload's
+// `infraSubtype` comes from deriveOutcome, not the wrapper). Kept separate so it
+// is not spread into the payload.
+type JobStatusWithSignals = JobStatus & { oomDetected: boolean };
 
 // One element of the `data-flakiness` annotation array.
 interface FlakinessPayload extends JobStatus {
@@ -55,16 +67,19 @@ interface FlakinessPayload extends JobStatus {
   timedOut: boolean;
   infraSubtype?: string;
   failingClasses: string[];
+  // Set only on `not_applicable` records: why the test could not be re-run
+  // (currently always "bwc").
+  reason?: string;
 }
 
-async function readJobStatuses(): Promise<JobStatus[]> {
+async function readJobStatuses(): Promise<JobStatusWithSignals[]> {
   let entries;
   try {
     entries = await readdir(STATUS_DIR, { withFileTypes: true });
   } catch {
     return [];
   }
-  const statuses: JobStatus[] = [];
+  const statuses: JobStatusWithSignals[] = [];
   for (const e of entries) {
     if (!e.isFile() || !e.name.endsWith(".json")) continue;
     try {
@@ -76,6 +91,9 @@ async function readJobStatuses(): Promise<JobStatus[]> {
           kind: String(parsed.kind ?? ""),
           rc: Number(parsed.rc ?? 0),
           durationSec: Number(parsed.durationSec ?? 0),
+          // The wrapper reports `infraSubtype: "oom"` when a heap dump was found;
+          // it is a classification input, not a payload field.
+          oomDetected: parsed.infraSubtype === "oom",
         });
       }
     } catch (err) {
@@ -112,7 +130,10 @@ function downloadJobReports(jobId: string): string {
 // job's XML fails, fall back to classifying from rc/duration alone (zero test
 // counts) so a single bad job can never block the whole annotation. The status
 // file's rc is the most important signal anyway.
-async function buildPayload(status: JobStatus): Promise<FlakinessPayload> {
+async function buildPayload(statusWithSignals: JobStatusWithSignals): Promise<FlakinessPayload> {
+  // Split the classification-only signals from the fields that belong in the
+  // payload (spread below).
+  const { oomDetected, ...status } = statusWithSignals;
   let realFailures = 0;
   let suiteTimeouts = 0;
   let totalCases = 0;
@@ -127,7 +148,7 @@ async function buildPayload(status: JobStatus): Promise<FlakinessPayload> {
   } catch (err) {
     console.error(`Failed to analyze reports for job ${status.jobId}; classifying from rc/duration only:`, err);
   }
-  const derived = deriveOutcome({ rc: status.rc, durationSec: status.durationSec, realFailures, totalCases, timeoutThresholdSec: INNER_TIMEOUT_SEC });
+  const derived = deriveOutcome({ rc: status.rc, durationSec: status.durationSec, realFailures, totalCases, timeoutThresholdSec: INNER_TIMEOUT_SEC, oomDetected });
   const payload: FlakinessPayload = {
     ...status,
     realFailures,
@@ -141,6 +162,37 @@ async function buildPayload(status: JobStatus): Promise<FlakinessPayload> {
     payload.infraSubtype = derived.infraSubtype;
   }
   return payload;
+}
+
+// Read the BWC skip list the bootstrap step wrote. Absent = nothing skipped.
+async function readSkippedTests(): Promise<ClassifiedTest[]> {
+  try {
+    const parsed = JSON.parse(await readFile(join(PROJECT_ROOT, SKIPPED_FILE), "utf8"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// A skipped BWC test never ran as a job, so it has no rc/duration/XML. It is
+// recorded as a `not_applicable` payload with zeroed counts and a synthetic
+// jobId so downstream keyed on jobId stays well-formed.
+export function notApplicablePayload(t: ClassifiedTest): FlakinessPayload {
+  const target = t.yamlTest ? `${t.fqcn}.${t.yamlTest}` : (t.fqcn ?? t.suitePath ?? "");
+  return {
+    jobId: `not-applicable:${t.kind}:${t.gradleProject}:${target}`,
+    stepKey: KIND_KEYS[t.kind as TestKind] ?? "",
+    kind: t.kind,
+    rc: 0,
+    durationSec: 0,
+    realFailures: 0,
+    suiteTimeouts: 0,
+    totalCases: 0,
+    outcome: "not_applicable",
+    timedOut: false,
+    failingClasses: [],
+    reason: "bwc",
+  };
 }
 
 function annotate(context: string, style: string, body: string): void {
@@ -169,6 +221,17 @@ async function run(): Promise<void> {
       console.error(`Failed to build payload for job ${status.jobId}:`, err);
     }
   }
+
+  // Fold in the tests the bootstrap step could not re-run (BWC): recorded as
+  // `not_applicable` so they are counted separately from `hang`/`infra_fail`.
+  const skipped = await readSkippedTests();
+  for (const t of skipped) {
+    payloads.push(notApplicablePayload(t));
+  }
+  if (skipped.length > 0) {
+    console.log(`Recorded ${skipped.length} not_applicable (BWC, not re-runnable via the bare task).`);
+  }
+
   if (process.env.CI && payloads.length > 0) {
     // Written at PROJECT_ROOT (the step cwd / checkout root) so the analyze
     // step's `artifact_paths` glob picks it up for upload.

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
@@ -43,6 +43,11 @@ const OUTCOMES_ARTIFACT_FILE = "flakiness-outcomes.json";
 // runners/buildkite.ts and entrypoints/pr.ts.
 const SKIPPED_FILE = "flakiness-skipped.json";
 
+// Written by the pre-flight compile step only when compilation fails; folded in
+// as a single `build_failed` outcome (the skipped batches produce none). Keep in
+// sync with FLAKINESS_PRECOMPILE_ARTIFACT in runners/buildkite.ts.
+const PRECOMPILE_FILE = "flakiness-precompile.json";
+
 // Self-reported by each batch job's never-fail wrapper (runners/buildkite.ts).
 interface JobStatus {
   jobId: string;
@@ -195,6 +200,35 @@ export function notApplicablePayload(t: ClassifiedTest): FlakinessPayload {
   };
 }
 
+// True when the pre-flight compile step left a failure marker.
+async function precompileFailed(): Promise<boolean> {
+  try {
+    const parsed = JSON.parse(await readFile(join(PROJECT_ROOT, PRECOMPILE_FILE), "utf8"));
+    return parsed?.outcome === "build_failed";
+  } catch {
+    return false;
+  }
+}
+
+// A single record standing in for the batches that were skipped because the PR
+// did not compile.
+export function buildFailedPayload(): FlakinessPayload {
+  return {
+    jobId: "build-failed:precompile",
+    stepKey: "flakiness-detection:precompile",
+    kind: "",
+    rc: 1,
+    durationSec: 0,
+    realFailures: 0,
+    suiteTimeouts: 0,
+    totalCases: 0,
+    outcome: "build_failed",
+    timedOut: false,
+    failingClasses: [],
+    reason: "compile",
+  };
+}
+
 function annotate(context: string, style: string, body: string): void {
   try {
     execSync(`buildkite-agent annotate --style "${style}" --context "${context}"`, {
@@ -230,6 +264,14 @@ async function run(): Promise<void> {
   }
   if (skipped.length > 0) {
     console.log(`Recorded ${skipped.length} not_applicable (BWC, not re-runnable via the bare task).`);
+  }
+
+  // If the pre-flight compile gate failed, the batches were skipped and produced
+  // no statuses; record a single `build_failed` so a non-compiling PR does not
+  // read as zero problems.
+  if (await precompileFailed()) {
+    payloads.push(buildFailedPayload());
+    console.log("Recorded build_failed (PR did not compile; re-runs were skipped).");
   }
 
   if (process.env.CI && payloads.length > 0) {

--- a/.buildkite/scripts/flakiness-detection/entrypoints/local.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/local.ts
@@ -2,6 +2,8 @@ import { execSync } from "child_process";
 import { resolve } from "path";
 
 import { classifyExplicitList } from "../detectors/explicit-list.ts";
+import { defaultJavaSourceReader } from "../detectors/abstract.ts";
+import { partitionByBwc, defaultBuildScriptReader } from "../detectors/bwc.ts";
 import { buildCommands } from "../commands.ts";
 import { runLocally } from "../runners/local.ts";
 import { DEFAULT_BATCHING_CONFIG } from "../domain.ts";
@@ -35,11 +37,22 @@ export async function run(): Promise<void> {
   }).toString();
   const repoFiles = repoFilesOutput.split("\n").map((f) => f.trim()).filter((f) => f !== "");
 
-  const { located, unlocated } = classifyExplicitList(specs, repoFiles);
+  const { located, unlocated } = classifyExplicitList(specs, repoFiles, defaultJavaSourceReader(PROJECT_ROOT));
   if (unlocated.length > 0) {
-    console.error(`Could not resolve ${unlocated.length} spec(s):`);
+    console.error(`Could not resolve ${unlocated.length} spec(s) (or they are abstract base classes):`);
     for (const u of unlocated) console.error(`  - ${u.spec}`);
     process.exit(1); // fail-fast (per design)
+  }
+
+  // BWC qa projects can't be re-run via the bare task; drop them with a note so
+  // a local run doesn't silently execute zero tests for them.
+  const { runnable, notApplicable } = partitionByBwc(located, defaultBuildScriptReader(PROJECT_ROOT));
+  for (const t of notApplicable) {
+    console.error(`Skipping BWC test (not re-runnable via the bare task): ${t.gradleProject} ${t.fqcn ?? t.suitePath ?? ""}`);
+  }
+  if (runnable.length === 0) {
+    console.error("No runnable tests after filtering; nothing to do.");
+    process.exit(0);
   }
 
   const baseCfg: typeof DEFAULT_BATCHING_CONFIG = {
@@ -58,7 +71,7 @@ export async function run(): Promise<void> {
     : baseCfg;
 
   const startMs = Date.now();
-  const exitCode = runLocally(buildCommands(located, cfg), PROJECT_ROOT);
+  const exitCode = runLocally(buildCommands(runnable, cfg), PROJECT_ROOT);
   const report = await analyzeReports([PROJECT_ROOT], startMs);
   console.log("\n" + renderMarkdown(report));
   process.exit(exitCode);

--- a/.buildkite/scripts/flakiness-detection/entrypoints/manual.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/manual.ts
@@ -1,12 +1,19 @@
 import { execSync } from "child_process";
 import { resolve } from "path";
+import { writeFileSync } from "fs";
 
 import { classifyExplicitList } from "../detectors/explicit-list.ts";
-import { buildCommands } from "../commands.ts";
+import { defaultJavaSourceReader } from "../detectors/abstract.ts";
+import { partitionByBwc, defaultBuildScriptReader } from "../detectors/bwc.ts";
+import { buildCommands, compileTasksFor } from "../commands.ts";
 import { uploadBuildkitePipeline } from "../runners/buildkite.ts";
 import { DEFAULT_AGENT_CONFIG, DEFAULT_BATCHING_CONFIG } from "../domain.ts";
 
 const PROJECT_ROOT = resolve(`${import.meta.dirname}/../../../..`);
+
+// Keep in sync with FLAKINESS_SKIPPED_ARTIFACT (runners/buildkite.ts) and the
+// manual pipeline's `artifact_paths`.
+const SKIPPED_FILE = "flakiness-skipped.json";
 
 export function run(): void {
   const rawClasses = process.env.FLAKINESS_CLASSES;
@@ -25,9 +32,11 @@ export function run(): void {
   }).toString();
   const repoFiles = repoFilesOutput.split("\n").map((f) => f.trim()).filter((f) => f !== "");
 
-  const { located, unlocated } = classifyExplicitList(specs, repoFiles);
+  // Skip abstract base classes (they match the *Tests/*IT convention but run no
+  // tests) via the source reader, same as the PR flow.
+  const { located, unlocated } = classifyExplicitList(specs, repoFiles, defaultJavaSourceReader(PROJECT_ROOT));
   if (unlocated.length > 0) {
-    console.error(`Could not resolve ${unlocated.length} spec(s) to a source file:`);
+    console.error(`Could not resolve ${unlocated.length} spec(s) to a source file (or they are abstract base classes):`);
     for (const u of unlocated) console.error(`  - ${u.spec}`);
     process.exit(1); // fail-fast on typos
   }
@@ -45,7 +54,24 @@ export function run(): void {
       }
     : DEFAULT_BATCHING_CONFIG;
 
-  uploadBuildkitePipeline(buildCommands(located, cfg), DEFAULT_AGENT_CONFIG);
+  // BWC qa projects disable the bare task, so partition them out (recorded as
+  // not_applicable) rather than fanning out doomed no-op batches.
+  const { runnable, notApplicable } = partitionByBwc(located, defaultBuildScriptReader(PROJECT_ROOT));
+  if (notApplicable.length > 0) {
+    console.log(`Skipping ${notApplicable.length} BWC test(s) - not re-runnable via the bare task (recorded as not_applicable).`);
+    if (process.env.CI) {
+      try {
+        writeFileSync(resolve(PROJECT_ROOT, SKIPPED_FILE), JSON.stringify(notApplicable));
+      } catch (err) {
+        console.error(`Failed to write ${SKIPPED_FILE}:`, err);
+      }
+    }
+  }
+
+  uploadBuildkitePipeline(buildCommands(runnable, cfg), DEFAULT_AGENT_CONFIG, {
+    hasNotApplicable: notApplicable.length > 0,
+    compileTasks: compileTasksFor(runnable),
+  });
 }
 
 if (import.meta.main) run();

--- a/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
@@ -1,12 +1,23 @@
 import { execSync } from "child_process";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
 import { classifyChangedFiles } from "../detectors/changed-files.ts";
+import { partitionByBwc, defaultBuildScriptReader } from "../detectors/bwc.ts";
 import { findUnmutedTests, type UnmuteDetectionResult } from "../detectors/unmutes.ts";
 import { buildCommands, dedupeTests } from "../commands.ts";
 import { uploadBuildkitePipeline } from "../runners/buildkite.ts";
-import { DEFAULT_AGENT_CONFIG, DEFAULT_BATCHING_CONFIG } from "../domain.ts";
+import { DEFAULT_AGENT_CONFIG, DEFAULT_BATCHING_CONFIG, type ClassifiedTest } from "../domain.ts";
+
+// Bootstrap-written list of tests that cannot be re-run (BWC projects). The
+// analyze step downloads and folds it into the outcomes as `not_applicable`.
+// Keep in sync with FLAKINESS_SKIPPED_ARTIFACT in runners/buildkite.ts.
+const SKIPPED_FILE = "flakiness-skipped.json";
+
+function describeTest(t: ClassifiedTest): string {
+  const target = t.yamlTest ? `${t.fqcn}.${t.yamlTest}` : (t.fqcn ?? t.suitePath ?? "(whole source set)");
+  return `${t.gradleProject} [${t.kind}] ${target}`;
+}
 
 const PROJECT_ROOT = resolve(`${import.meta.dirname}/../../../..`);
 
@@ -126,12 +137,32 @@ export function run(): void {
     process.exit(0);
   }
 
-  if (tests.length > 30) {
-    console.log(`Warning: ${tests.length} test files to re-run`);
+  // BWC qa projects disable the bare test task, so the detector's plain
+  // `:project:task` re-runs nothing (0 tests, exit 0). Split those out so they
+  // are recorded as `not_applicable` instead of wasting jobs and polluting the
+  // metric as `hang`s. Running them properly (version-qualified `v<ver>#bwcTest`)
+  // is a separate follow-up.
+  const { runnable, notApplicable } = partitionByBwc(tests, defaultBuildScriptReader(PROJECT_ROOT));
+  if (notApplicable.length > 0) {
+    console.log(`Skipping ${notApplicable.length} BWC test(s) - not re-runnable via the bare task (recorded as not_applicable):`);
+    for (const t of notApplicable) {
+      console.log(`  - ${describeTest(t)}`);
+    }
+    if (process.env.CI) {
+      try {
+        writeFileSync(resolve(PROJECT_ROOT, SKIPPED_FILE), JSON.stringify(notApplicable));
+      } catch (err) {
+        console.error(`Failed to write ${SKIPPED_FILE}:`, err);
+      }
+    }
+  }
+
+  if (runnable.length > 30) {
+    console.log(`Warning: ${runnable.length} test files to re-run`);
     if (process.env.CI) {
       try {
         execSync(
-          `buildkite-agent annotate "Warning: ${tests.length} test files to re-run (${changedTests.length} changed, ${unmuted.located.length} unmuted). This may take a while." --style "warning" --context "flakiness-detection"`,
+          `buildkite-agent annotate "Warning: ${runnable.length} test files to re-run (${changedTests.length} changed, ${unmuted.located.length} unmuted). This may take a while." --style "warning" --context "flakiness-detection"`,
           { cwd: PROJECT_ROOT, stdio: "inherit" }
         );
       } catch {
@@ -141,8 +172,9 @@ export function run(): void {
   }
 
   uploadBuildkitePipeline(
-    buildCommands(tests, DEFAULT_BATCHING_CONFIG),
-    DEFAULT_AGENT_CONFIG
+    buildCommands(runnable, DEFAULT_BATCHING_CONFIG),
+    DEFAULT_AGENT_CONFIG,
+    { hasNotApplicable: notApplicable.length > 0 }
   );
 }
 

--- a/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
@@ -5,7 +5,7 @@ import { resolve } from "path";
 import { classifyChangedFiles } from "../detectors/changed-files.ts";
 import { partitionByBwc, defaultBuildScriptReader } from "../detectors/bwc.ts";
 import { findUnmutedTests, type UnmuteDetectionResult } from "../detectors/unmutes.ts";
-import { buildCommands, dedupeTests } from "../commands.ts";
+import { buildCommands, compileTasksFor, dedupeTests } from "../commands.ts";
 import { uploadBuildkitePipeline } from "../runners/buildkite.ts";
 import { DEFAULT_AGENT_CONFIG, DEFAULT_BATCHING_CONFIG, type ClassifiedTest } from "../domain.ts";
 
@@ -174,7 +174,7 @@ export function run(): void {
   uploadBuildkitePipeline(
     buildCommands(runnable, DEFAULT_BATCHING_CONFIG),
     DEFAULT_AGENT_CONFIG,
-    { hasNotApplicable: notApplicable.length > 0 }
+    { hasNotApplicable: notApplicable.length > 0, compileTasks: compileTasksFor(runnable) }
   );
 }
 

--- a/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
 import { classifyChangedFiles } from "../detectors/changed-files.ts";
+import { defaultJavaSourceReader, type JavaSourceReader } from "../detectors/abstract.ts";
 import { partitionByBwc, defaultBuildScriptReader } from "../detectors/bwc.ts";
 import { findUnmutedTests, type UnmuteDetectionResult } from "../detectors/unmutes.ts";
 import { buildCommands, compileTasksFor, dedupeTests } from "../commands.ts";
@@ -50,7 +51,7 @@ export function resolveMergeBaseTarget(
 // timeout_in_minutes budget.
 const GIT_COMMAND_TIMEOUT_MS = 60_000;
 
-function detectUnmutedTests(mergeBase: string, projectRoot: string): UnmuteDetectionResult {
+function detectUnmutedTests(mergeBase: string, projectRoot: string, readSource: JavaSourceReader): UnmuteDetectionResult {
   console.log(`  Reading muted-tests.yml at ${mergeBase}...`);
   let oldYaml = "";
   try {
@@ -88,7 +89,7 @@ function detectUnmutedTests(mergeBase: string, projectRoot: string): UnmuteDetec
     .filter((f) => f !== "");
   console.log(`  Indexed ${repoFiles.length} tracked files`);
 
-  return findUnmutedTests(oldYaml, newYaml, repoFiles);
+  return findUnmutedTests(oldYaml, newYaml, repoFiles, readSource);
 }
 
 export function run(): void {
@@ -106,11 +107,15 @@ export function run(): void {
   const changedFiles = changedFilesOutput.split("\n").map((f) => f.trim()).filter((f) => f);
   console.log(`Found ${changedFiles.length} changed files`);
 
-  const changedTests = classifyChangedFiles(changedFiles);
+  // Reads working-tree Java sources so the detectors can skip abstract base
+  // classes (whose `*Tests`/`*IT` name matches but which run no tests).
+  const readSource = defaultJavaSourceReader(PROJECT_ROOT);
+
+  const changedTests = classifyChangedFiles(changedFiles, readSource);
   console.log(`Found ${changedTests.length} changed test files`);
 
   console.log("Detecting unmuted tests...");
-  const unmuted = detectUnmutedTests(mergeBase, PROJECT_ROOT);
+  const unmuted = detectUnmutedTests(mergeBase, PROJECT_ROOT, readSource);
   console.log(`Found ${unmuted.located.length} unmuted tests`);
   if (unmuted.unlocated.length > 0) {
     console.log(`Skipping ${unmuted.unlocated.length} unmuted tests whose class files no longer exist:`);

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -106,16 +106,22 @@ describe("toBuildkitePipeline end-to-end", () => {
     const [batch, analyze] = pipeline.steps[0].steps;
 
     // Single-batch step captures the start epoch and writes a per-job status
-    // file tagged with the kind + step key, carrying the runtime rc + duration.
+    // file tagged with the kind + step key, carrying the runtime rc + duration
+    // + OOM subtype (from the heap-dump probe below).
     expect(batch.command).toContain("_fd_start=$(date +%s)");
     expect(batch.command).toContain(
-      'printf \'{"jobId":"%s","stepKey":"%s","kind":"%s","rc":%s,"durationSec":%s}\' "$$BUILDKITE_JOB_ID" "flakiness-detection:unit" "test" "$$rc" "$(( _fd_end - _fd_start ))" > "flakiness-status/status-$$BUILDKITE_JOB_ID.json" || true'
+      'printf \'{"jobId":"%s","stepKey":"%s","kind":"%s","rc":%s,"durationSec":%s,"infraSubtype":"%s"}\' "$$BUILDKITE_JOB_ID" "flakiness-detection:unit" "test" "$$rc" "$(( _fd_end - _fd_start ))" "$$_fd_oom" > "flakiness-status/status-$$BUILDKITE_JOB_ID.json" || true'
     );
+    // OOM is detected from a heap-dump file (TTY-safe), not the log; the probe
+    // stops at the first match.
+    expect(batch.command).toContain("find . -type f -path '*/build/heapdump/*.hprof' -print -quit");
 
-    // The analyze step is not a test batch and must not write a status file.
+    // The analyze step is not a test batch and must not write a status file or
+    // probe for OOM.
     expect(analyze.key).toBe("flakiness-detection:analyze");
     expect(analyze.command).not.toContain("flakiness-status/status-");
     expect(analyze.command).not.toContain("_fd_start=");
+    expect(analyze.command).not.toContain("heapdump");
   });
 
   test("each parallel batch writes a status file with the correct kind", () => {
@@ -253,6 +259,7 @@ describe("toBuildkitePipeline", () => {
     expect(analyze.artifact_paths).toBe("flakiness-outcomes.json");
     expect(analyze.agents).toBeUndefined();
     expect(analyze.command).toContain('buildkite-agent artifact download "flakiness-status/*.json" . || true');
+    expect(analyze.command).toContain('buildkite-agent artifact download "flakiness-skipped.json" . || true');
     expect(analyze.command).toContain("node .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts");
     // Order: download statuses → analyzer.
     const downloadIdx = analyze.command.indexOf("artifact download");
@@ -260,5 +267,21 @@ describe("toBuildkitePipeline", () => {
     expect(downloadIdx).toBeLessThan(analyzerIdx);
     // Analyze step uses timeout_in_minutes: 10, so inner timeout is 8m.
     expect(analyze.command).toContain("timeout --foreground --signal=TERM --kill-after=30s 8m bash");
+  });
+
+  test("emits an analyze-only step when all tests are not_applicable (no batches)", () => {
+    // All detected tests were BWC → zero batch commands, but the analyze step
+    // must still run so the not_applicable records reach the outcomes artifact.
+    const pipeline = toBuildkitePipeline([], DEFAULT_AGENT_CONFIG, { hasNotApplicable: true });
+    const steps = pipeline.steps[0].steps;
+    expect(steps).toHaveLength(1);
+    expect(steps[0].key).toBe("flakiness-detection:analyze");
+    expect(steps[0].depends_on).toEqual([]);
+    expect(steps[0].command).toContain('buildkite-agent artifact download "flakiness-skipped.json" . || true');
+  });
+
+  test("no analyze step when there are neither batches nor not_applicable tests", () => {
+    const pipeline = toBuildkitePipeline([], DEFAULT_AGENT_CONFIG);
+    expect(pipeline.steps[0].steps).toEqual([]);
   });
 });

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -285,3 +285,59 @@ describe("toBuildkitePipeline", () => {
     expect(pipeline.steps[0].steps).toEqual([]);
   });
 });
+
+describe("toBuildkitePipeline compile gate", () => {
+  const cmds: RunnableCommand[] = [
+    { kind: "test", label: "unit tests", key: "flakiness-detection:unit", command: "cmd" },
+  ];
+
+  test("prepends a precompile step the batches hard-depend on", () => {
+    const pipeline = toBuildkitePipeline(cmds, DEFAULT_AGENT_CONFIG, {
+      compileTasks: [":server:compileTestJava", ":x-pack:plugin:ml:compileJavaRestTestJava"],
+    });
+    const steps = pipeline.steps[0].steps;
+
+    // precompile first, then the batch, then analyze.
+    expect(steps.map((s) => s.key)).toEqual([
+      "flakiness-detection:precompile",
+      "flakiness-detection:unit",
+      "flakiness-detection:analyze",
+    ]);
+
+    const [precompile, batch, analyze] = steps;
+    // Compiles the requested tasks via the gradle wrapper and uploads the marker.
+    expect(precompile.command).toContain(
+      ".ci/scripts/run-gradle.sh :server:compileTestJava :x-pack:plugin:ml:compileJavaRestTestJava"
+    );
+    expect(precompile.command).toContain('> "flakiness-precompile.json"');
+    expect(precompile.command).toContain("exit $$rc");
+    expect(precompile.artifact_paths).toBe("flakiness-precompile.json");
+    expect(precompile.agents?.provider).toBe("gcp");
+
+    // Batch hard-depends on the gate (allow_failure false → skipped on failure).
+    expect(batch.depends_on).toEqual([{ step: "flakiness-detection:precompile", allow_failure: false }]);
+
+    // Analyze depends on the gate with allow_failure so it still records
+    // build_failed when the gate fails and the batches are skipped.
+    expect(analyze.depends_on).toContainEqual({ step: "flakiness-detection:precompile", allow_failure: true });
+    expect(analyze.command).toContain('buildkite-agent artifact download "flakiness-precompile.json" . || true');
+  });
+
+  test("no precompile step when compileTasks is empty", () => {
+    const pipeline = toBuildkitePipeline(cmds, DEFAULT_AGENT_CONFIG, { compileTasks: [] });
+    const keys = pipeline.steps[0].steps.map((s) => s.key);
+    expect(keys).not.toContain("flakiness-detection:precompile");
+    expect(pipeline.steps[0].steps[0].depends_on).toBeUndefined();
+  });
+
+  test("no precompile step when there are no batches (all not_applicable)", () => {
+    // Nothing to compile even though compileTasks were computed from a now-empty
+    // runnable set.
+    const pipeline = toBuildkitePipeline([], DEFAULT_AGENT_CONFIG, {
+      hasNotApplicable: true,
+      compileTasks: [":server:compileTestJava"],
+    });
+    const keys = pipeline.steps[0].steps.map((s) => s.key);
+    expect(keys).toEqual(["flakiness-detection:analyze"]);
+  });
+});

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -102,13 +102,24 @@ function wrapNeverFail(
     "fi",
     // Best-effort per-job status file for the analyze step to pick up. `|| true`
     // and the trailing `exit 0` ensure observability can never fail a batch.
-    // `stepKey`/`kind` are build-time constants; `rc`/duration are runtime, so
+    // `stepKey`/`kind` are build-time constants; `rc`/duration/oom are runtime, so
     // they are `$$`-escaped to defer past Buildkite's pipeline-upload pass.
+    //
+    // OOM detection: every ES test JVM runs with `-XX:+HeapDumpOnOutOfMemoryError`
+    // and `-XX:HeapDumpPath=<buildDir>/heapdump` (ElasticsearchTestBasePlugin), so
+    // a `*/build/heapdump/*.hprof` file after the run means a JVM-heap
+    // OutOfMemoryError occurred - which exits via Gradle with rc=1, not the
+    // SIGKILL rc=137 the kernel OOM-killer produces. We detect it from the file
+    // (not the log) to avoid touching the wrapped command's stdout/`--foreground`
+    // plumbing; `-quit` stops at the first match. analyze.ts turns this into the
+    // `oom` infraSubtype.
     ...(emitOutcome
       ? [
           "_fd_end=$(date +%s)",
           "mkdir -p flakiness-status",
-          `printf '{"jobId":"%s","stepKey":"%s","kind":"%s","rc":%s,"durationSec":%s}' "$$BUILDKITE_JOB_ID" "${contextKey}" "${emitOutcome.kind}" "$$rc" "$(( _fd_end - _fd_start ))" > "flakiness-status/status-$$BUILDKITE_JOB_ID.json" || true`,
+          "_fd_oom=\"\"",
+          "if [ -n \"$(find . -type f -path '*/build/heapdump/*.hprof' -print -quit 2>/dev/null)\" ]; then _fd_oom=\"oom\"; fi",
+          `printf '{"jobId":"%s","stepKey":"%s","kind":"%s","rc":%s,"durationSec":%s,"infraSubtype":"%s"}' "$$BUILDKITE_JOB_ID" "${contextKey}" "${emitOutcome.kind}" "$$rc" "$(( _fd_end - _fd_start ))" "$$_fd_oom" > "flakiness-status/status-$$BUILDKITE_JOB_ID.json" || true`,
         ]
       : []),
     "exit 0",
@@ -132,6 +143,12 @@ const FLAKINESS_STATUS_ARTIFACTS = "flakiness-status/*.json";
 // Keep this filename in sync with entrypoints/analyze.ts.
 const FLAKINESS_OUTCOMES_ARTIFACT = "flakiness-outcomes.json";
 
+// Written by the bootstrap step (entrypoints/pr.ts) listing tests that could not
+// be re-run (BWC projects). Downloaded by the analyze step, which folds them into
+// the outcomes artifact as `not_applicable`. Keep in sync with entrypoints/pr.ts
+// and the bootstrap step's `artifact_paths` in pipelines/pull-request/flakiness-detection.yml.
+const FLAKINESS_SKIPPED_ARTIFACT = "flakiness-skipped.json";
+
 interface PipelineGroup {
   group: string;
   steps: PipelineStep[];
@@ -147,7 +164,11 @@ interface Pipeline {
  */
 export function toBuildkitePipeline(
   commands: RunnableCommand[],
-  cfg: AgentConfig
+  cfg: AgentConfig,
+  // When there are BWC (`not_applicable`) tests to report, the analyze step is
+  // emitted even with zero batch steps so those records still reach the outcomes
+  // artifact.
+  opts: { hasNotApplicable?: boolean } = {}
 ): Pipeline {
   const byKey = new Map<string, RunnableCommand[]>();
   for (const c of commands) {
@@ -188,21 +209,23 @@ export function toBuildkitePipeline(
     steps.push(step);
   }
 
-  if (steps.length > 0) {
+  if (steps.length > 0 || opts.hasNotApplicable) {
     const deps = steps.map((s) => ({ step: s.key, allow_failure: true }));
     steps.push({
       label: "flakiness report",
       key: "flakiness-detection:analyze",
-      // Download the per-job status files, then run the analyzer. The analyzer
-      // reads each status file and downloads that job's JUnit XML per job
-      // (`--step <jobId>`) so it can attribute results to a job before
-      // classifying. It writes the structured per-job outcomes to
+      // Download the per-job status files and the skipped-tests list, then run
+      // the analyzer. The analyzer reads each status file and downloads that
+      // job's JUnit XML per job (`--step <jobId>`) so it can attribute results
+      // to a job before classifying, and folds the skipped list in as
+      // `not_applicable`. It writes the structured per-job outcomes to
       // FLAKINESS_OUTCOMES_ARTIFACT, which `artifact_paths` below uploads for the
       // observability pipeline to read. `|| true` tolerates a build with no
-      // status artifacts.
+      // status/skipped artifacts.
       command: wrapNeverFail(
         [
           `buildkite-agent artifact download "${FLAKINESS_STATUS_ARTIFACTS}" . || true`,
+          `buildkite-agent artifact download "${FLAKINESS_SKIPPED_ARTIFACT}" . || true`,
           "node .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts",
         ].join("\n"),
         "flakiness-detection:analyze",
@@ -230,9 +253,10 @@ export function toBuildkitePipeline(
 export function uploadBuildkitePipeline(
   commands: RunnableCommand[],
   cfg: AgentConfig,
-  cwd: string = PROJECT_ROOT
+  opts: { hasNotApplicable?: boolean; cwd?: string } = {}
 ): void {
-  const yaml = stringify(toBuildkitePipeline(commands, cfg));
+  const cwd = opts.cwd ?? PROJECT_ROOT;
+  const yaml = stringify(toBuildkitePipeline(commands, cfg, { hasNotApplicable: opts.hasNotApplicable }));
   console.log("--- Generated pipeline");
   console.log(yaml);
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -149,6 +149,38 @@ const FLAKINESS_OUTCOMES_ARTIFACT = "flakiness-outcomes.json";
 // and the bootstrap step's `artifact_paths` in pipelines/pull-request/flakiness-detection.yml.
 const FLAKINESS_SKIPPED_ARTIFACT = "flakiness-skipped.json";
 
+// Written by the pre-flight compile step (below) only when compilation fails, so
+// the analyze step can record a single `build_failed` outcome instead of the
+// batches (which are skipped) producing none. Keep in sync with entrypoints/analyze.ts.
+const FLAKINESS_PRECOMPILE_ARTIFACT = "flakiness-precompile.json";
+
+// Pre-flight compile gate. A PR that does not compile otherwise fails every
+// re-run batch identically (up to 100x fan-out), which wastes CI and floods the
+// metric with `infra_fail`. This step compiles the affected source sets once;
+// batch steps hard-depend on it (allow_failure: false) so Buildkite skips them
+// when it fails. It is intentionally NOT never-fail wrapped: it must exit
+// non-zero to make Buildkite skip the batches. That turns the step red, but only
+// ever on a PR that genuinely does not compile - which is already red from its
+// main build - so it never introduces a false failure on an otherwise-green PR.
+const PRECOMPILE_KEY = "flakiness-detection:precompile";
+const PRECOMPILE_TIMEOUT_MINUTES = 30;
+
+function precompileCommand(compileTasks: string[]): string {
+  return [
+    "set +e",
+    `.ci/scripts/run-gradle.sh ${compileTasks.join(" ")}`,
+    "rc=$?",
+    // On failure, leave a marker the analyze step folds in as `build_failed`,
+    // and annotate. `$$rc` defers past Buildkite's upload-time interpolation.
+    `if [ "$$rc" -ne 0 ]; then`,
+    `  printf '{"outcome":"build_failed","reason":"compile"}' > "${FLAKINESS_PRECOMPILE_ARTIFACT}" || true`,
+    `  buildkite-agent annotate --style error --context "flakiness-detection-precompile" "Flakiness detection could not compile the affected test source sets, so the re-runs were skipped. This reflects only the flakiness precompile step (see its log for the compile error); it makes no claim about the rest of the build." || true`,
+    "fi",
+    // Propagate the real exit code so dependent batch steps are skipped on failure.
+    "exit $$rc",
+  ].join("\n");
+}
+
 interface PipelineGroup {
   group: string;
   steps: PipelineStep[];
@@ -165,10 +197,11 @@ interface Pipeline {
 export function toBuildkitePipeline(
   commands: RunnableCommand[],
   cfg: AgentConfig,
-  // When there are BWC (`not_applicable`) tests to report, the analyze step is
-  // emitted even with zero batch steps so those records still reach the outcomes
-  // artifact.
-  opts: { hasNotApplicable?: boolean } = {}
+  // `hasNotApplicable`: emit the analyze step even with zero batch steps so BWC
+  // `not_applicable` records still reach the outcomes artifact.
+  // `compileTasks`: when non-empty, prepend a pre-flight compile gate the batch
+  // steps hard-depend on.
+  opts: { hasNotApplicable?: boolean; compileTasks?: string[] } = {}
 ): Pipeline {
   const byKey = new Map<string, RunnableCommand[]>();
   for (const c of commands) {
@@ -176,6 +209,10 @@ export function toBuildkitePipeline(
     if (list) list.push(c);
     else byKey.set(c.key, [c]);
   }
+
+  // Only gate on compile when there are batches to gate. All-BWC builds (no
+  // batches) have nothing to compile.
+  const gateOnCompile = (opts.compileTasks?.length ?? 0) > 0 && byKey.size > 0;
 
   const steps: PipelineStep[] = [];
   for (const [key, batches] of byKey) {
@@ -206,10 +243,32 @@ export function toBuildkitePipeline(
       step.parallelism = batches.length;
       step.env = env;
     }
+
+    // Hard dependency (allow_failure omitted = false) so a compile failure skips
+    // the re-run batches instead of running them all doomed.
+    if (gateOnCompile) {
+      step.depends_on = [{ step: PRECOMPILE_KEY, allow_failure: false }];
+    }
     steps.push(step);
   }
 
+  // Prepend the compile gate ahead of the batch steps it guards.
+  if (gateOnCompile) {
+    steps.unshift({
+      label: "precompile",
+      key: PRECOMPILE_KEY,
+      command: precompileCommand(opts.compileTasks!),
+      timeout_in_minutes: PRECOMPILE_TIMEOUT_MINUTES,
+      agents: { ...cfg.agents },
+      artifact_paths: FLAKINESS_PRECOMPILE_ARTIFACT,
+      retry: NO_AUTO_RETRY,
+    });
+  }
+
   if (steps.length > 0 || opts.hasNotApplicable) {
+    // allow_failure: true so the report still runs when a batch fails, is
+    // skipped (compile gate failed), or the gate itself fails - it must record
+    // the `build_failed`/`not_applicable` outcomes in those cases.
     const deps = steps.map((s) => ({ step: s.key, allow_failure: true }));
     steps.push({
       label: "flakiness report",
@@ -226,6 +285,7 @@ export function toBuildkitePipeline(
         [
           `buildkite-agent artifact download "${FLAKINESS_STATUS_ARTIFACTS}" . || true`,
           `buildkite-agent artifact download "${FLAKINESS_SKIPPED_ARTIFACT}" . || true`,
+          `buildkite-agent artifact download "${FLAKINESS_PRECOMPILE_ARTIFACT}" . || true`,
           "node .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts",
         ].join("\n"),
         "flakiness-detection:analyze",
@@ -253,10 +313,12 @@ export function toBuildkitePipeline(
 export function uploadBuildkitePipeline(
   commands: RunnableCommand[],
   cfg: AgentConfig,
-  opts: { hasNotApplicable?: boolean; cwd?: string } = {}
+  opts: { hasNotApplicable?: boolean; compileTasks?: string[]; cwd?: string } = {}
 ): void {
   const cwd = opts.cwd ?? PROJECT_ROOT;
-  const yaml = stringify(toBuildkitePipeline(commands, cfg, { hasNotApplicable: opts.hasNotApplicable }));
+  const yaml = stringify(
+    toBuildkitePipeline(commands, cfg, { hasNotApplicable: opts.hasNotApplicable, compileTasks: opts.compileTasks })
+  );
   console.log("--- Generated pipeline");
   console.log(yaml);
 


### PR DESCRIPTION
> **Stacked on #153806 (which is stacked on #153803).** This branch includes those PRs' commits; review the top commit ("Flakiness: skip abstract base test classes"). Merge #153803 then #153806 first.

## What

Skips abstract base test classes in the detector, so they are never emitted as `--tests` targets.

## Why

An abstract base class (e.g. `AbstractDocValuesFormatTests`) is named to the same `*Tests`/`*IT` conventions the detector matches, so it was turned into `--tests <AbstractDocValuesFormatTests>` - which matches **zero** runnable tests. Because `MutedTestPlugin` sets `failOnNoMatchingTests(ci == false)`, that run passes silently in CI and the batch is recorded as a `hang`, i.e. the PR's tests were never actually re-run (a silent false-negative for the whole point of the pipeline). This was a confirmed cause of ~30% of the `hang` outcomes.

## How

The detector now reads the working-tree Java source and skips a class declared `abstract`, in both the changed-files and unmute resolution paths. The check is opt-in via an injected `JavaSourceReader`, so the existing pure detector unit tests (which pass only file paths) keep working unchanged; `entrypoints/pr.ts` supplies the real filesystem reader.

Unit tests cover `isAbstractTestClass` (public/package-private/inner-class/abstract-method cases) and the skip behaviour in both `classifyChangedFiles` and `locateTest`.
