### PR TITLE
[ESQL] Fix Parquet MAP column footer-stats crash

### DIFF
--- a/docs/changelog/153809.yaml
+++ b/docs/changelog/153809.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153809
+summary: Fix Parquet MAP column footer-stats crash
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -1064,6 +1064,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             for (ColumnChunkMetaData col : rowGroup.getColumns()) {
                 String[] path = col.getPath().toArray();
                 ColumnDescriptor desc = parquetSchema.getColumnDescription(path);
+                if (desc != null && isMapDescendedLeaf(parquetSchema, path)) {
+                    // A MAP's key and value leaves collapse to the same logical name (both stop at the
+                    // enclosing MAP group) and are heterogeneously typed, so folding their footer stats into
+                    // one entry throws in the min/max merge. A MAP is UNSUPPORTED downstream and its stats are
+                    // never consumed, so skip every map-descended leaf entirely. See isMapDescendedLeaf.
+                    continue;
+                }
                 if (desc != null && desc.getMaxRepetitionLevel() > 0 && isTopLevelListLeaf(parquetSchema, path)) {
                     // Top-level list column: its leaf null_count/min/max are element-level and don't
                     // answer row-level COUNT / IS NOT NULL. Publish only a size marker under the attribute
@@ -1078,10 +1085,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 }
                 // Key non-top-level leaves on the flattener's logical leaf name so the stats bind to the
                 // same attribute name the planner uses (a struct-nested list leaf answers.text.list.element
-                // is surfaced as answers.text). NB: a MAP's key and value leaves share this name (both stop
-                // at the enclosing MAP group), so their stats merge into one entry here. That is harmless
-                // while MAP is UNSUPPORTED downstream and never projected; revisit if MAP columns become
-                // readable.
+                // is surfaced as answers.text). MAP leaves are excluded above (isMapDescendedLeaf) because
+                // their key and value share this name yet are heterogeneously typed, which would fold into one
+                // entry and throw in the min/max merge.
                 String colName = desc != null ? logicalLeafName(parquetSchema, path) : col.getPath().toDotString();
                 colSizes.merge(colName, new long[] { col.getTotalUncompressedSize() }, (a, b) -> {
                     a[0] += b[0];
@@ -1349,6 +1355,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         for (ColumnChunkMetaData col : rowGroup.getColumns()) {
             String[] path = col.getPath().toArray();
             ColumnDescriptor desc = parquetSchema.getColumnDescription(path);
+            if (desc != null && isMapDescendedLeaf(parquetSchema, path)) {
+                // Skip map-descended leaves: a MAP's key/value collapse to one heterogeneously typed logical
+                // name that put() here would silently record as wrong value-over-key stats, and a MAP is
+                // UNSUPPORTED downstream so the stats are never consumed. Mirrors extractStatistics.
+                continue;
+            }
             if (desc != null && desc.getMaxRepetitionLevel() > 0 && isTopLevelListLeaf(parquetSchema, path)) {
                 // Top-level list column: size marker only under the attribute name (path[0]); the unknown
                 // null_count makes COUNT decline the footer fast path and scan. Mirrors extractStatistics.
@@ -1363,8 +1375,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             // Publish non-top-level leaves under the flattener's logical leaf name (which stops at an
             // enclosing LIST/MAP) so a COUNT/MIN/MAX(answers.text) lookup resolves. The raw leaf path
             // "answers.text.list.element" would never be found by the planner's attribute name.
-            // See extractStatistics for the logical-name keying rationale and the MAP key/value
-            // stat-merge assumption (harmless while MAP is UNSUPPORTED).
+            // See extractStatistics for the logical-name keying rationale; MAP leaves are skipped above
+            // (isMapDescendedLeaf) since their key/value would collapse to one heterogeneously typed name.
             String colName = desc != null ? logicalLeafName(parquetSchema, path) : col.getPath().toDotString();
             stats.put(SourceStatisticsSerializer.columnSizeBytesKey(colName), col.getTotalUncompressedSize());
             Statistics colStats = col.getStatistics();
@@ -1416,6 +1428,20 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     static int compareStatExtremum(Comparable a, Comparable b) {
         if (a instanceof String && b instanceof String) {
             return SourceStatisticsSerializer.compareKeywordUtf8(a, b);
+        }
+        // Last-resort net: heterogeneously typed extrema (e.g. a MAP key String against a value Long) must not
+        // cross-cast into a raw ClassCastException. The statistics producers already skip map-descended leaves
+        // (isMapDescendedLeaf), so in production only same-type extrema reach here — a mismatch means a fold
+        // regression upstream. Fail loudly under -ea (tests/CI) to catch it, and fall back to a safe 0 in
+        // production rather than crashing on the cross-cast.
+        if (a.getClass() != b.getClass()) {
+            assert false
+                : "heterogeneous stat extrema ["
+                    + a.getClass()
+                    + "] vs ["
+                    + b.getClass()
+                    + "]; map-descended leaves must be skipped upstream";
+            return 0;
         }
         return a.compareTo(b);
     }
@@ -2257,6 +2283,35 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
      */
     private static boolean isRepeatedLeaf(ColumnDescriptor desc) {
         return desc != null && desc.getMaxRepetitionLevel() > 0;
+    }
+
+    /**
+     * Whether the leaf reached by {@code descriptorPath} sits under a {@code MAP} group at any depth.
+     * <p>
+     * A Parquet {@code MAP<K,V>} has two physical leaves ({@code m.key_value.key}, {@code m.key_value.value})
+     * that {@link #logicalLeafName} collapses to the same enclosing-MAP dotted name. Their footer statistics
+     * are therefore heterogeneously typed (e.g. a keyword key and a long value) yet fold into a single entry
+     * keyed on that shared name — comparing a {@code String} key extremum against a {@code Long} value extremum
+     * throws {@link ClassCastException} in the min/max merge. A {@code MAP} group also resolves to
+     * {@link DataType#UNSUPPORTED} downstream, so these stats are never consumed. Collecting them is both
+     * pointless and harmful, so the statistics producers skip every map-descended leaf. Driven off the
+     * schema's {@code MAP} logical annotation (like {@link #logicalLeafName}), it covers homogeneous maps and
+     * every nested variant ({@code struct<map>}, {@code map<string,list>}, {@code map<string,struct>}) at any
+     * depth.
+     */
+    private static boolean isMapDescendedLeaf(GroupType schema, String[] descriptorPath) {
+        Type current = schema;
+        for (String segment : descriptorPath) {
+            // The descriptor path is always resolvable within the schema it came from, so every
+            // intermediate node is a group and getType() never throws here.
+            Type child = current.asGroupType().getType(segment);
+            if (child.isPrimitive() == false
+                && child.asGroupType().getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.MapLogicalTypeAnnotation) {
+                return true;
+            }
+            current = child;
+        }
+        return false;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -30,6 +30,7 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
@@ -294,6 +295,353 @@ public class ParquetFormatReaderTests extends ESTestCase {
         // The flat struct leaf still publishes normally with a concrete null count.
         assertTrue(cols.containsKey("s.a"));
         assertEquals(OptionalLong.of(0L), cols.get("s.a").nullCount());
+    }
+
+    /**
+     * Regression for the Parquet MAP footer-stats crash: a {@code MAP<K,V>} has two physical leaves
+     * ({@code m.key_value.key}, {@code m.key_value.value}) that the flattener collapses to one logical
+     * name {@code m}. Folding their heterogeneously typed footer stats (String key vs Long value) into
+     * one entry threw {@link ClassCastException} in the min/max merge, surfacing as an HTTP 500 before
+     * type resolution — so even {@code STATS COUNT(*)} failed. {@code isMapDescendedLeaf} now skips
+     * every map-descended leaf, so metadata resolves, the map surfaces as {@code UNSUPPORTED} (never
+     * published as a stat), and the sibling scalar keeps its concrete stats.
+     */
+    public void testMapColumnDoesNotCrashAndPublishesNoMapStats() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              required int64 id;
+              optional group m (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional int64 value;
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 5; r++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) r);
+                Group m = g.addGroup("m");
+                m.addGroup("key_value").append("key", "k" + r).append("value", (long) (r * 10));
+                m.addGroup("key_value").append("key", "j" + r).append("value", (long) (r * 10 + 1));
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+
+        // The map column is surfaced but UNSUPPORTED downstream.
+        Attribute mapAttr = metadata.schema().stream().filter(a -> a.name().equals("m")).findFirst().orElseThrow();
+        assertEquals(DataType.UNSUPPORTED, mapAttr.dataType());
+
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        // No folded key/value stats are published under the map's logical name.
+        assertFalse("no stats must be published for the map column", cols.containsKey("m"));
+        // The sibling scalar keeps concrete stats — the footer fast path is preserved for it.
+        assertTrue(cols.containsKey("id"));
+        assertEquals(OptionalLong.of(0L), cols.get("id").nullCount());
+        assertEquals(Optional.of(0L), cols.get("id").minValue());
+        assertEquals(Optional.of(4L), cols.get("id").maxValue());
+    }
+
+    /**
+     * Reversed key/value ordering ({@code map<int,string>}): the fold is still heterogeneous (Long key
+     * vs String value). Metadata must resolve without a 500 and publish no map stats.
+     */
+    public void testMapColumnReversedKeyValueDoesNotCrash() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              required int64 id;
+              optional group m (MAP) {
+                repeated group key_value {
+                  required int64 key;
+                  optional binary value (UTF8);
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 3; r++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) r);
+                g.addGroup("m").addGroup("key_value").append("key", (long) r).append("value", "v" + r);
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        assertFalse(cols.containsKey("m"));
+        assertTrue(cols.containsKey("id"));
+    }
+
+    /**
+     * A third value type ({@code map<string,double>}) folds a String key extremum against a Double
+     * value extremum. Metadata must resolve and publish no map stats.
+     */
+    public void testMapColumnDoubleValueDoesNotCrash() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              required int64 id;
+              optional group m (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional double value;
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 3; r++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) r);
+                g.addGroup("m").addGroup("key_value").append("key", "k" + r).append("value", r + 0.5);
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        assertFalse(cols.containsKey("m"));
+        assertTrue(cols.containsKey("id"));
+    }
+
+    /**
+     * A MAP nested inside a STRUCT ({@code struct<map<string,int>>}): the skip must reach map leaves at
+     * any depth. Metadata resolves, no {@code s.m} stats are published, and the sibling struct leaf
+     * {@code s.a} keeps its concrete stats.
+     */
+    public void testStructNestedMapDoesNotCrash() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              optional group s {
+                required int64 a;
+                optional group m (MAP) {
+                  repeated group key_value {
+                    required binary key (UTF8);
+                    optional int32 value;
+                  }
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 3; r++) {
+                Group g = factory.newGroup();
+                Group s = g.addGroup("s");
+                s.add("a", (long) r);
+                s.addGroup("m").addGroup("key_value").append("key", "k" + r).append("value", r);
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        assertFalse("no stats for the nested map", cols.containsKey("s.m"));
+        assertTrue(cols.containsKey("s.a"));
+        assertEquals(OptionalLong.of(0L), cols.get("s.a").nullCount());
+    }
+
+    /**
+     * A MAP whose value is a LIST ({@code map<string,list<int>>}): a nested-collection variant that must
+     * also resolve without a 500 and publish no map stats.
+     */
+    public void testMapWithListValueDoesNotCrash() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              required int64 id;
+              optional group m (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional group value (LIST) {
+                    repeated group list {
+                      optional int32 element;
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 3; r++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) r);
+                Group kv = g.addGroup("m").addGroup("key_value");
+                kv.append("key", "k" + r);
+                Group value = kv.addGroup("value");
+                value.addGroup("list").append("element", r);
+                value.addGroup("list").append("element", r + 1);
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        assertFalse(cols.containsKey("m"));
+        assertTrue(cols.containsKey("id"));
+    }
+
+    /**
+     * A homogeneous {@code map<string,string>} does not throw (both leaves compare as String), so the
+     * {@code metadata()} path is uninteresting — a MAP is UNSUPPORTED there and dropped by the publish
+     * filter regardless of the fix. The path this case actually corrupts is the split/row-group stats
+     * ({@link ParquetFormatReader#discoverSplitRanges} &rarr; {@code buildRowGroupStats}), which has no
+     * UNSUPPORTED filter: before the skip it {@code put} the value leaf's min/max over the key leaf's
+     * under the folded name {@code m}, serializing wrong per-split stats. Assert those keys are absent so
+     * this is a genuine regression guard (RED before the fix). The sibling scalar keeps its min/max.
+     */
+    public void testHomogeneousMapPublishesNoFoldedSplitStat() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              required int64 id;
+              optional group m (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional binary value (UTF8);
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 3; r++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) r);
+                g.addGroup("m").addGroup("key_value").append("key", "k" + r).append("value", "v" + r);
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(createStorageObject(parquetData));
+        assertEquals(1, ranges.size());
+        Map<String, Object> stats = ranges.getFirst().statistics();
+        // No folded key/value stats are serialized for the map under any of its stat keys.
+        assertNull("no folded map min in split stats", stats.get("_stats.columns.m.min"));
+        assertNull("no folded map max in split stats", stats.get("_stats.columns.m.max"));
+        assertNull("no folded map null_count in split stats", stats.get("_stats.columns.m.null_count"));
+        assertNull("no folded map size in split stats", stats.get("_stats.columns.m.size_bytes"));
+        // The sibling scalar still publishes its real per-split stats.
+        assertEquals(0L, stats.get("_stats.columns.id.min"));
+        assertEquals(2L, stats.get("_stats.columns.id.max"));
+    }
+
+    /**
+     * Control against a regression on the working LIST path: a repeated (struct-nested) {@code list<int>}
+     * leaf must still read and keep its element-spanning min/max (only its null count is unknown, per
+     * #1055). Guards against the map skip accidentally widening to non-map repeated leaves. A top-level
+     * list publishes only a size marker (no min/max, per #1056), so a struct-nested list is used here to
+     * exercise the min/max-preserving branch.
+     */
+    public void testListControlKeepsMinMax() throws Exception {
+        Type blist = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("blist");
+        Type structS = Types.optionalGroup().required(PrimitiveType.PrimitiveTypeName.INT64).named("a").addField(blist).named("s");
+        MessageType schema = new MessageType("test_schema", structS);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 5; r++) {
+                Group g = factory.newGroup();
+                Group s = g.addGroup("s");
+                s.add("a", (long) r);
+                Group list = s.addGroup("blist");
+                list.addGroup("list").append("element", r * 10);
+                list.addGroup("list").append("element", r * 10 + 1);
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        assertTrue("nested list column must still be registered", cols.containsKey("s.blist"));
+        assertEquals("nested list null count must be unknown", OptionalLong.empty(), cols.get("s.blist").nullCount());
+        assertEquals("list min spans every element", Optional.of(0), cols.get("s.blist").minValue());
+        assertEquals("list max spans every element", Optional.of(41), cols.get("s.blist").maxValue());
+    }
+
+    /**
+     * {@link ParquetFormatReader#compareStatExtremum} must never surface a raw {@link ClassCastException}
+     * for heterogeneously typed extrema (the shape a MAP fold would have produced). Reaching it with a
+     * mismatched pair is an upstream regression, so it fails loudly under {@code -ea} (tests run with
+     * assertions enabled) via {@link AssertionError}; in production it returns a safe {@code 0} instead of
+     * crashing. Same-typed extrema keep their natural ordering.
+     */
+    public void testCompareStatExtremumHeterogeneousAsserts() {
+        expectThrows(AssertionError.class, () -> ParquetFormatReader.compareStatExtremum("a", 1L));
+        expectThrows(AssertionError.class, () -> ParquetFormatReader.compareStatExtremum(1L, "a"));
+        assertTrue(ParquetFormatReader.compareStatExtremum(1L, 2L) < 0);
+        assertTrue(ParquetFormatReader.compareStatExtremum(2L, 1L) > 0);
+        assertEquals(0, ParquetFormatReader.compareStatExtremum(1L, 1L));
+        assertTrue(ParquetFormatReader.compareStatExtremum("a", "b") < 0);
+    }
+
+    /**
+     * Reverse nesting ({@code list<map<string,int64>>}): a MAP reached through an enclosing LIST rather
+     * than being the outermost group. This exercises the ordering of the {@code isMapDescendedLeaf} check
+     * ahead of the top-level-list-leaf branch — the map leaves must be skipped (not mis-keyed as a
+     * top-level list size marker), metadata must resolve, and no stats are published for the list-of-map
+     * column while the sibling scalar keeps its stats.
+     */
+    public void testTopLevelListOfMapDoesNotCrash() throws Exception {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test_schema {
+              required int64 id;
+              optional group ml (LIST) {
+                repeated group list {
+                  optional group element (MAP) {
+                    repeated group key_value {
+                      required binary key (UTF8);
+                      optional int64 value;
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> rows = new ArrayList<>();
+            for (int r = 0; r < 3; r++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) r);
+                Group element = g.addGroup("ml").addGroup("list").addGroup("element");
+                element.addGroup("key_value").append("key", "k" + r).append("value", (long) (r * 10));
+                rows.add(g);
+            }
+            return rows;
+        });
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(createStorageObject(parquetData));
+        Map<String, SourceStatistics.ColumnStatistics> cols = metadata.statistics().get().columnStatistics().get();
+        assertFalse("no stats for the list-of-map column", cols.containsKey("ml"));
+        assertTrue(cols.containsKey("id"));
+        assertEquals(OptionalLong.of(0L), cols.get("id").nullCount());
     }
 
     /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetMapColumnIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetMapColumnIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end regression for the Parquet MAP footer-stats crash. A Parquet {@code MAP<K,V>} has two
+ * physical leaves ({@code m.key_value.key}, {@code m.key_value.value}) that the flattener collapses to
+ * the same logical name; folding their heterogeneously typed footer stats into one entry threw a
+ * {@link ClassCastException} in metadata extraction, surfacing as an HTTP 500 before type resolution —
+ * so even {@code STATS COUNT(*)} over a file containing a MAP column failed. This test writes a file
+ * with a MAP column alongside a scalar and a LIST control and asserts the queries succeed.
+ */
+public class ExternalParquetMapColumnIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    public void testCountStarOverMapColumnDoesNotCrash() throws Exception {
+        int totalRows = 200;
+        Path parquetFile = writeMapParquetFile(totalRows);
+        try {
+            String dataset = registerDataset("map_column", StoragePath.fileUri(parquetFile), Map.of());
+
+            // COUNT(*): before the fix this failed with a 500 during metadata extraction of the MAP leaves.
+            try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | STATS c = COUNT(*)"))) {
+                List<? extends ColumnInfo> columns = response.columns();
+                assertThat(columns.size(), equalTo(1));
+                assertThat(columns.get(0).name(), equalTo("c"));
+                List<List<Object>> rows = getValuesList(response);
+                assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo((long) totalRows));
+            }
+
+            // The sibling scalar column still reads.
+            try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | KEEP id | STATS mx = MAX(id)"))) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo((long) (totalRows - 1)));
+            }
+
+            // The LIST control column still reads.
+            try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | STATS c = COUNT(tags)"))) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo((long) totalRows));
+            }
+        } finally {
+            Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    private Path writeMapParquetFile(int rowCount) throws IOException {
+        MessageType schema = MessageTypeParser.parseMessageType("""
+            message test {
+              required int64 id;
+              optional group m (MAP) {
+                repeated group key_value {
+                  required binary key (UTF8);
+                  optional int64 value;
+                }
+              }
+              optional group tags (LIST) {
+                repeated group list {
+                  optional binary element (UTF8);
+                }
+              }
+            }
+            """);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                Group m = g.addGroup("m");
+                m.addGroup("key_value").append("key", "k" + i).append("value", (long) (i * 10));
+                m.addGroup("key_value").append("key", "j" + i).append("value", (long) (i * 10 + 1));
+                Group tags = g.addGroup("tags");
+                tags.addGroup("list").append("element", "t" + i);
+                writer.write(g);
+            }
+        }
+
+        Path tempFile = createTempDir().resolve("map_column_test.parquet");
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
+    }
+}


### PR DESCRIPTION
A Parquet `MAP<K,V>` has two physical leaves (key, value) that the schema flattener collapses to one logical name. Folding their heterogeneously typed footer stats threw a `ClassCastException` during metadata extraction, surfacing as an HTTP 500 before type resolution, so even `STATS COUNT(*)` over a file with a MAP column failed.

Skip every map-descended leaf when collecting footer statistics (both the metadata and split/row-group paths); a MAP is UNSUPPORTED downstream so its stats are never consumed. Adds a last-resort guard in `compareStatExtremum` against mismatched-type extrema.