### PR TITLE
[9.5] ILM & DLM should create snapshots with `partial: true` [#153643] (#153774)

### DIFF
--- a/docs/changelog/153774.yaml
+++ b/docs/changelog/153774.yaml
@@ -1,0 +1,6 @@
+area: ILM
+issues:
+ - 153643
+pr: 153774
+summary: "ILM & DLM create snapshots with `partial: true` to prevent blocking cluster recovery actions"
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStep.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotNameAlreadyInUseException;
+import org.elasticsearch.snapshots.SnapshotState;
 
 import java.util.Objects;
 
@@ -110,6 +111,7 @@ public class CreateSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         // complete
         request.waitForCompletion(true);
         request.includeGlobalState(false);
+        request.partial(true);
 
         getClient(projectId).admin().cluster().createSnapshot(request, listener.map(response -> {
             logger.debug(
@@ -120,25 +122,34 @@ public class CreateSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             );
             final SnapshotInfo snapInfo = response.getSnapshotInfo();
 
-            // Check that there are no failed shards, since the request may not entirely
-            // fail, but may still have failures (such as in the case of an aborted snapshot)
-            if (snapInfo.failedShards() == 0) {
+            if (snapshotCompletedSuccessfully(snapInfo, forceMergedIndexName)) {
                 return true;
             } else {
                 logger.warn(
                     Strings.format(
-                        "failed to create snapshot [%s:%s] for policy [%s] and index [%s]: %s of %s shards failed",
+                        "snapshot [%s:%s] for policy [%s] and index [%s] did not complete successfully: "
+                            + "state [%s], successful shards [%s], failed shards [%s] of [%s], indices %s",
                         snapshotRepository,
                         snapshotName,
                         policyName,
                         forceMergedIndexName,
+                        snapInfo.state(),
+                        snapInfo.successfulShards(),
                         snapInfo.failedShards(),
-                        snapInfo.totalShards()
+                        snapInfo.totalShards(),
+                        snapInfo.indices()
                     )
                 );
                 return false;
             }
         }));
+    }
+
+    static boolean snapshotCompletedSuccessfully(SnapshotInfo snapshotInfo, String indexName) {
+        return snapshotInfo.state() == SnapshotState.SUCCESS
+            && snapshotInfo.failedShards() == 0
+            && snapshotInfo.successfulShards() > 0
+            && snapshotInfo.indices().contains(indexName);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSnapshotAction;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -19,12 +20,17 @@ import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotNameAlreadyInUseException;
+import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
@@ -135,6 +141,90 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
     }
 
+    public void testFailedSnapshotMovesToIncompleteStep() {
+        String indexName = randomAlphaOfLength(10);
+        String policyName = "test-ilm-policy";
+        String snapshotName = indexName + "-" + policyName;
+        String repository = "repository";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(
+                LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
+                Map.of("snapshot_name", snapshotName, "snapshot_repository", repository)
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
+
+        try (var threadPool = createThreadPool()) {
+            NoOpClient client = new NoOpClient(threadPool, TestProjectResolvers.usingRequestHeader(threadPool.getThreadContext())) {
+                @Override
+                @SuppressWarnings("unchecked")
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertThat(action, is(TransportCreateSnapshotAction.TYPE));
+                    assertTrue(request instanceof CreateSnapshotRequest);
+                    listener.onResponse(
+                        (Response) new CreateSnapshotResponse(snapshotInfo(SnapshotState.FAILED, List.of(indexName), 1, 0))
+                    );
+                }
+            };
+            StepKey nextKeyOnComplete = randomStepKey();
+            StepKey nextKeyOnIncomplete = randomStepKey();
+            CreateSnapshotStep step = new CreateSnapshotStep(randomStepKey(), nextKeyOnComplete, nextKeyOnIncomplete, client);
+
+            step.performAction(indexMetadata, state, null, ActionListener.noop());
+
+            assertThat(step.getNextStepKey(), is(nextKeyOnIncomplete));
+        }
+    }
+
+    public void testEmptySnapshotMovesToIncompleteStep() {
+        String indexName = randomAlphaOfLength(10);
+        String policyName = "test-ilm-policy";
+        String snapshotName = indexName + "-" + policyName;
+        String repository = "repository";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(
+                LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
+                Map.of("snapshot_name", snapshotName, "snapshot_repository", repository)
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ProjectState state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
+
+        try (var threadPool = createThreadPool()) {
+            NoOpClient client = new NoOpClient(threadPool, TestProjectResolvers.usingRequestHeader(threadPool.getThreadContext())) {
+                @Override
+                @SuppressWarnings("unchecked")
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertThat(action, is(TransportCreateSnapshotAction.TYPE));
+                    assertTrue(request instanceof CreateSnapshotRequest);
+                    listener.onResponse(
+                        (Response) new CreateSnapshotResponse(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 0, 0))
+                    );
+                }
+            };
+            StepKey nextKeyOnComplete = randomStepKey();
+            StepKey nextKeyOnIncomplete = randomStepKey();
+            CreateSnapshotStep step = new CreateSnapshotStep(randomStepKey(), nextKeyOnComplete, nextKeyOnIncomplete, client);
+
+            step.performAction(indexMetadata, state, null, ActionListener.noop());
+
+            assertThat(step.getNextStepKey(), is(nextKeyOnIncomplete));
+        }
+    }
+
     public void testNextStepKey() {
         String indexName = randomAlphaOfLength(10);
         String policyName = "test-ilm-policy";
@@ -211,6 +301,55 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
     }
 
+    public void testSnapshotCompletedSuccessfullyRequiresCompleteTargetSnapshot() {
+        String indexName = randomAlphaOfLength(10);
+
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 0, 1), indexName),
+            is(true)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.FAILED, List.of(indexName), 0, 1), indexName),
+            is(false)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(), 0, 1), indexName),
+            is(false)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 0, 0), indexName),
+            is(false)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 1, 0), indexName),
+            is(false)
+        );
+    }
+
+    private SnapshotInfo snapshotInfo(SnapshotState state, List<String> indices, int failedShards, int successfulShards) {
+        return new SnapshotInfo(
+            new Snapshot(
+                randomProjectIdOrDefault(),
+                randomAlphaOfLength(10),
+                new SnapshotId(randomAlphaOfLength(10), randomAlphaOfLength(10))
+            ),
+            indices,
+            List.of(),
+            List.of(),
+            state == SnapshotState.FAILED ? "simulated failure" : null,
+            IndexVersion.current(),
+            0L,
+            0L,
+            successfulShards + failedShards,
+            successfulShards,
+            List.of(),
+            false,
+            null,
+            state,
+            Map.of()
+        );
+    }
+
     private NoOpClient getCreateSnapshotRequestAssertingClient(
         ThreadPool threadPool,
         String expectedRepoName,
@@ -241,6 +380,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
                     createSnapshotRequest.includeGlobalState(),
                     is(false)
                 );
+                assertThat("ILM generated snapshots should use partial snapshots", createSnapshotRequest.partial(), is(true));
             }
         };
     }

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
@@ -960,15 +960,18 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
             return;
         }
 
-        if (existingSnapshot.state() == SnapshotState.SUCCESS && existingSnapshot.failedShards() == 0) {
+        if (snapshotCompletedSuccessfully(existingSnapshot, indexName)) {
             logger.info("DLM found valid snapshot [{}] for index [{}]", snapshotName, indexName);
         } else {
             logger.info(
-                "DLM found invalid orphaned snapshot [{}] for index [{}] (state [{}], failed shards [{}]), deleting and recreating",
+                "DLM found invalid orphaned snapshot [{}] for index [{}] "
+                    + "(state [{}], successful shards [{}], failed shards [{}], indices {}), deleting and recreating",
                 snapshotName,
                 indexName,
                 existingSnapshot.state(),
-                existingSnapshot.failedShards()
+                existingSnapshot.successfulShards(),
+                existingSnapshot.failedShards(),
+                existingSnapshot.indices()
             );
             deleteSnapshotIfExists(repositoryName, snapshotName, indexName);
             createSnapshot(indexName, repositoryName, snapshotName);
@@ -1111,7 +1114,7 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
             throw new ElasticsearchException("DLM snapshot [{}] for index [{}] did not return snapshot info", snapshotName, indexName);
         }
 
-        if (snapshotInfo.state() == SnapshotState.SUCCESS && snapshotInfo.failedShards() == 0) {
+        if (snapshotCompletedSuccessfully(snapshotInfo, indexName)) {
             logger.info("DLM successfully created snapshot [{}] for index [{}]", snapshotName, indexName);
             return;
         }
@@ -1121,22 +1124,34 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
         String reason = snapshotInfo.reason();
         if (Strings.hasText(reason)) {
             throw new ElasticsearchException(
-                "DLM snapshot [{}] for index [{}] finished with [{}] failed shards, state [{}], reason [{}]",
+                "DLM snapshot [{}] for index [{}] finished with [{}] successful shards and [{}] failed shards, "
+                    + "state [{}], indices {}, reason [{}]",
                 snapshotName,
                 indexName,
+                snapshotInfo.successfulShards(),
                 failedShards,
                 state,
+                snapshotInfo.indices(),
                 reason
             );
         } else {
             throw new ElasticsearchException(
-                "DLM snapshot [{}] for index [{}] finished with [{}] failed shards, state [{}]",
+                "DLM snapshot [{}] for index [{}] finished with [{}] successful shards and [{}] failed shards, state [{}], indices {}",
                 snapshotName,
                 indexName,
+                snapshotInfo.successfulShards(),
                 failedShards,
-                state
+                state,
+                snapshotInfo.indices()
             );
         }
+    }
+
+    private static boolean snapshotCompletedSuccessfully(SnapshotInfo snapshotInfo, String indexName) {
+        return snapshotInfo.state() == SnapshotState.SUCCESS
+            && snapshotInfo.failedShards() == 0
+            && snapshotInfo.successfulShards() > 0
+            && snapshotInfo.indices().contains(indexName);
     }
 
     /**
@@ -1160,6 +1175,7 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
         request.indices(indexName);
         request.waitForCompletion(true);
         request.includeGlobalState(false);
+        request.partial(true);
         request.userMetadata(Map.of(DLM_CREATED_METADATA_KEY, true));
         return request;
     }

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenSnapshotTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenSnapshotTests.java
@@ -274,15 +274,25 @@ public class DLMConvertToFrozenSnapshotTests extends ESTestCase {
     }
 
     private SnapshotInfo createSnapshotInfo(SnapshotState state, int failedShards) {
+        int totalShards = Math.max(1, failedShards);
+        return createSnapshotInfo(state, List.of(indexName), totalShards, totalShards - failedShards, failedShards);
+    }
+
+    private SnapshotInfo createSnapshotInfo(
+        SnapshotState state,
+        List<String> indices,
+        int totalShards,
+        int successfulShards,
+        int failedShards
+    ) {
         String snapshotName = DLMConvertToFrozen.snapshotName(indexName);
         List<SnapshotShardFailure> shardFailures = new ArrayList<>();
         for (int i = 0; i < failedShards; i++) {
             shardFailures.add(new SnapshotShardFailure(null, new ShardId(indexName, randomAlphaOfLength(10), i), "test failure"));
         }
-        int totalShards = Math.max(1, failedShards);
         return new SnapshotInfo(
             new Snapshot(projectId, REPO_NAME, new SnapshotId(snapshotName, randomAlphaOfLength(10))),
-            List.of(indexName),
+            indices,
             List.of(),
             List.of(),
             state == SnapshotState.FAILED ? "simulated failure" : null,
@@ -290,7 +300,7 @@ public class DLMConvertToFrozenSnapshotTests extends ESTestCase {
             clock.millis(),
             clock.millis(),
             totalShards,
-            totalShards - failedShards,
+            successfulShards,
             shardFailures,
             false,
             null,
@@ -321,6 +331,7 @@ public class DLMConvertToFrozenSnapshotTests extends ESTestCase {
         assertThat(request.indices(), is(new String[] { expectedIndex }));
         assertThat(request.includeGlobalState(), is(false));
         assertThat(request.waitForCompletion(), is(true));
+        assertThat(request.partial(), is(true));
     }
 
     private GetSnapshotsResponse emptyGetSnapshotsResponse() {
@@ -355,6 +366,24 @@ public class DLMConvertToFrozenSnapshotTests extends ESTestCase {
             () -> DLMConvertToFrozen.checkSnapshotInfoSuccess(indexName, "snap", info)
         );
         assertThat(e.getMessage(), containsString("FAILED"));
+    }
+
+    public void testCheckSnapshotInfoSuccess_failsWhenSnapshotDoesNotContainTargetIndex() {
+        SnapshotInfo info = createSnapshotInfo(SnapshotState.SUCCESS, List.of(randomAlphaOfLength(10)), 1, 1, 0);
+        ElasticsearchException e = expectThrows(
+            ElasticsearchException.class,
+            () -> DLMConvertToFrozen.checkSnapshotInfoSuccess(indexName, "snap", info)
+        );
+        assertThat(e.getMessage(), containsString("indices"));
+    }
+
+    public void testCheckSnapshotInfoSuccess_failsWithoutSuccessfulShards() {
+        SnapshotInfo info = createSnapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 1, 0, 0);
+        ElasticsearchException e = expectThrows(
+            ElasticsearchException.class,
+            () -> DLMConvertToFrozen.checkSnapshotInfoSuccess(indexName, "snap", info)
+        );
+        assertThat(e.getMessage(), containsString("successful shards"));
     }
 
     public void testCheckSnapshotInfoSuccess_failsWithNull() {
@@ -580,6 +609,22 @@ public class DLMConvertToFrozenSnapshotTests extends ESTestCase {
         converter.checkForOrphanedSnapshotAndStart(indexName, REPO_NAME, snapshotName);
 
         assertGetSnapshotsRequest(REPO_NAME, snapshotName);
+        assertDeleteSnapshotRequest(REPO_NAME, snapshotName);
+        assertCreateSnapshotRequest(REPO_NAME, snapshotName, indexName);
+    }
+
+    public void testCheckForOrphanedSnapshot_withoutTargetIndex_deletesAndRecreates() throws InterruptedException {
+        ProjectState projectState = createProjectState();
+        setClusterState(projectState);
+        SnapshotInfo incompleteSnapshot = createSnapshotInfo(SnapshotState.SUCCESS, List.of(randomAlphaOfLength(10)), 1, 1, 0);
+        mockGetSnapshotsResponse.set(getSnapshotsResponseWith(incompleteSnapshot));
+        mockDeleteSnapshotResponse.set(AcknowledgedResponse.TRUE);
+        mockCreateSnapshotResponse.set(createSuccessfulSnapshotResponse());
+
+        DLMConvertToFrozen converter = createConverter();
+        String snapshotName = DLMConvertToFrozen.snapshotName(indexName);
+        converter.checkForOrphanedSnapshotAndStart(indexName, REPO_NAME, snapshotName);
+
         assertDeleteSnapshotRequest(REPO_NAME, snapshotName);
         assertCreateSnapshotRequest(REPO_NAME, snapshotName, indexName);
     }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ILM & DLM should create snapshots with `partial: true` [#153643] (#153774)