### PR TITLE
[9.5] [ESQL] cache single-file metadata, skip warm probe (#153715)

### DIFF
--- a/docs/changelog/153715.yaml
+++ b/docs/changelog/153715.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153715
+summary: "Cache single-file metadata, skip warm probe"
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -26,6 +26,8 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalStats;
+import org.elasticsearch.xpack.esql.datasources.cache.FileMetadata;
+import org.elasticsearch.xpack.esql.datasources.cache.FileMetadataCacheKey;
 import org.elasticsearch.xpack.esql.datasources.cache.ListingCacheKey;
 import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheEntry;
 import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheKey;
@@ -564,26 +566,25 @@ public class ExternalSourceResolver {
         }
 
         ExternalSourceMetadata extMetadata;
-        StorageObject object;
+        StorageEntry storageEntry;
         if (isCacheable(provider)) {
-            // Stat the file first (cheap HEAD/stat) to get mtime for the cache key.
-            // Null mtime (e.g. gRPC/Flight, GCS/Azure fixtures) falls back to EPOCH so the
-            // cache key is stable; providers that never report trustworthy mtime should
-            // eventually return supportsStableMetadata() == false to bypass caching entirely.
-            object = provider.newObject(storagePath);
-            Instant lastMod = object.lastModified();
-            long mtime = lastMod != null ? lastMod.toEpochMilli() : Instant.EPOCH.toEpochMilli();
+            // Warm path is zero-I/O: the file-metadata cache holds {length, mtime} within the schema TTL, so a warm
+            // single-file resolve never touches a live object (fileMetadataOf). mtime is the cache key's version token;
+            // length + mtime rebuild the singleton FileList.
+            FileMetadata meta = fileMetadataOf(storagePath, provider, config);
             String formatType = detectFormatType(storagePath);
-            SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtime, formatType, config);
+            SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), meta.mtimeMillis(), formatType, config);
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
                 return SchemaCacheEntry.from(resolveSingleSource(path, config));
             });
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
+            storageEntry = new StorageEntry(storagePath, meta.length(), Instant.ofEpochMilli(meta.mtimeMillis()));
         } else {
             SourceMetadata metadata = resolveSingleSource(path, config);
             extMetadata = wrapAsExternalSourceMetadata(metadata, config, declaredReadSpecOf(declaredMapping));
-            object = provider.newObject(storagePath);
+            StorageObject object = provider.newObject(storagePath);
+            storageEntry = new StorageEntry(storagePath, object.length(), object.lastModified());
         }
 
         // Capture the raw file schema: schemaMap describes the physical schema each reader actually
@@ -592,10 +593,7 @@ public class ExternalSourceResolver {
         // shim that injects them into the relation's metadataFields). See ResolveExternalRelations.
         List<Attribute> fileSchema = extMetadata.schema();
 
-        FileList singletonList = GlobExpander.fileListOf(
-            List.of(new StorageEntry(storagePath, object.length(), object.lastModified())),
-            path
-        );
+        FileList singletonList = GlobExpander.fileListOf(List.of(storageEntry), path);
         // Single-file: degenerate case of the general flow — one-entry schemaMap, identity mapping.
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = singleEntrySchemaMap(storagePath, fileSchema);
         listener.onResponse(new ExternalSourceResolution.ResolvedSource(extMetadata, singletonList, schemaMap));
@@ -923,6 +921,35 @@ public class ExternalSourceResolver {
      */
     private boolean isCacheable(StorageProvider provider) {
         return cacheService != null && cacheService.isEnabled() && provider.supportsStableMetadata();
+    }
+
+    /**
+     * The single file's {@link FileMetadata} ({@code {length, mtime}}), shared by both single-file rails (inferred
+     * {@link #resolveSingleFileSource} and strict {@link #resolveStrictSingleFile}). A cacheable provider serves it
+     * from the file-metadata cache within the schema TTL, so a warm resolve is zero-I/O; a miss — or a non-cacheable
+     * provider — probes the live object exactly once via {@link #probeFileMetadata(StoragePath, StorageProvider)}. The
+     * mtime is the version token that rebuilds the {@link SchemaCacheKey}; length + mtime rebuild the singleton
+     * {@code StorageEntry}.
+     */
+    private FileMetadata fileMetadataOf(StoragePath storagePath, StorageProvider provider, Map<String, Object> config) throws Exception {
+        if (isCacheable(provider)) {
+            FileMetadataCacheKey metaKey = FileMetadataCacheKey.build(storagePath.toString(), config);
+            return cacheService.getOrComputeFileMetadata(metaKey, k -> probeFileMetadata(storagePath, provider));
+        }
+        return probeFileMetadata(storagePath, provider);
+    }
+
+    /**
+     * One live object probe: a cheap HEAD/stat that on S3 is a single {@code bytes=-1} GET serving both length and
+     * mtime. Null mtime (e.g. gRPC/Flight, GCS/Azure fixtures) falls back to EPOCH so the derived cache key is stable;
+     * providers that never report a trustworthy mtime should return {@code supportsStableMetadata() == false} to bypass
+     * caching entirely.
+     */
+    private static FileMetadata probeFileMetadata(StoragePath storagePath, StorageProvider provider) throws Exception {
+        StorageObject probe = provider.newObject(storagePath);
+        Instant lastMod = probe.lastModified();
+        long mtime = lastMod != null ? lastMod.toEpochMilli() : Instant.EPOCH.toEpochMilli();
+        return new FileMetadata(probe.length(), mtime);
     }
 
     private StorageProvider resolveProvider(StoragePath storagePath, Map<String, Object> config) {
@@ -2126,7 +2153,11 @@ public class ExternalSourceResolver {
         Map<String, Object> config,
         DatasetMapping declaredMapping
     ) throws Exception {
-        StorageObject object = provider.newObject(storagePath);
+        // Same warm-probe amortization as the inferred single-file rail (resolveSingleFileSource): a cacheable
+        // provider serves {length, mtime} from the file-metadata cache within the schema TTL, so a warm strict
+        // resolve never probes the live object; a miss (or a non-cacheable provider) probes exactly once. Strict
+        // resolution reads no file body, so length + mtime are the only per-query object metadata it needs.
+        FileMetadata meta = fileMetadataOf(storagePath, provider, config);
         // Declared mapping is the whole schema, in LOGICAL names; a `path` rename is applied at the reader, so the
         // operator (and file schema) work purely in logical names.
         List<Attribute> logicalSchema = DeclaredSchemaResolver.declaredAttributes(declaredMapping);
@@ -2139,8 +2170,7 @@ public class ExternalSourceResolver {
         // Cheap no-I/O guard first (no partitions on a single file), then the columnar coercibility check which reads
         // this file's footer (cached when the provider is).
         rejectDeclaredMappingViolations(null, declaredMapping);
-        Instant singleMtime = object.lastModified();
-        long mtimeMillis = singleMtime != null ? singleMtime.toEpochMilli() : Instant.EPOCH.toEpochMilli();
+        long mtimeMillis = meta.mtimeMillis();
         rejectStrictColumnarUncoercibleTypes(sourceType, provider, storagePath, mtimeMillis, config, declaredMapping);
         ExternalSourceMetadata extMetadata = strictSingleFileMetadata(
             path,
@@ -2153,7 +2183,7 @@ public class ExternalSourceResolver {
             mtimeMillis
         );
         FileList singletonList = GlobExpander.fileListOf(
-            List.of(new StorageEntry(storagePath, object.length(), object.lastModified())),
+            List.of(new StorageEntry(storagePath, meta.length(), Instant.ofEpochMilli(meta.mtimeMillis()))),
             path
         );
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaMap = singleEntrySchemaMap(storagePath, logicalSchema);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/EndpointRegion.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/EndpointRegion.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import java.util.Map;
+
+/**
+ * The object-identity dimensions shared by every external-source cache key: the storage {@code endpoint}
+ * and {@code region} pulled from the WITH config. The same canonical path on a different endpoint (or
+ * region) resolves to a different physical object, so both participate in key identity. Extracted so
+ * {@link SchemaCacheKey}, {@link FileMetadataCacheKey}, and {@link ListingCacheKey} read them identically
+ * and cannot drift on these dimensions.
+ */
+record EndpointRegion(String endpoint, String region) {
+    static EndpointRegion of(Map<String, Object> config) {
+        String endpoint = config != null ? String.valueOf(config.getOrDefault("endpoint", "")) : "";
+        String region = config != null ? String.valueOf(config.getOrDefault("region", "")) : "";
+        return new EndpointRegion(endpoint, region);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheService.java
@@ -41,9 +41,10 @@ import java.util.function.LongFunction;
 
 /**
  * Coordinator-only, in-memory cache service for external source metadata.
- * Maintains two independent caches:
+ * Maintains three independent caches:
  * <ul>
  *   <li>Schema cache (20% of budget, 5m TTL) — shared across users</li>
+ *   <li>File-metadata cache (count-bounded, schema TTL) — {@code {length, mtime}} per path, shared across users</li>
  *   <li>Listing cache (80% of budget, 30s TTL) — isolated by credential hash</li>
  * </ul>
  * Uses hard TTL via {@code setExpireAfterWrite} for the initial implementation.
@@ -54,6 +55,7 @@ public class ExternalSourceCacheService implements Closeable {
     private static final Logger logger = LogManager.getLogger(ExternalSourceCacheService.class);
 
     private final Cache<SchemaCacheKey, SchemaCacheEntry> schemaCache;
+    private final Cache<FileMetadataCacheKey, FileMetadata> fileMetadataCache;
     private final Cache<ListingCacheKey, FileList> listingCache;
     private final long maxTotalBytes;
     private volatile boolean enabled;
@@ -100,6 +102,17 @@ public class ExternalSourceCacheService implements Closeable {
      */
     private static final int MAX_PENDING_DATASET_AGGREGATES = 64;
     private static final int MAX_PENDING_TOTAL_PATHS = 65_536;
+
+    /**
+     * Entry-count cap for the file-metadata cache. Unlike the schema and listing caches (byte-weighted,
+     * variable-size values), a {@link FileMetadata} is two {@code long}s behind a small path key, so the
+     * cache is bounded by count rather than bytes — no per-entry byte weigher. 100k tiny entries is a few
+     * tens of MB worst case, and, being hard-TTL-bounded by the schema TTL, the live set is normally far
+     * smaller. Kept a constant rather than a cluster setting: no workload has needed to tune it, and a
+     * public setting is a permanent support surface — it can be promoted to a setting later if a real need
+     * appears.
+     */
+    private static final int FILE_METADATA_CACHE_MAX_ENTRIES = 100_000;
     private final LinkedHashMap<SchemaCacheKey, PendingDatasetAggregate> pendingDatasetAggregates = new LinkedHashMap<>();
 
     /**
@@ -135,6 +148,14 @@ public class ExternalSourceCacheService implements Closeable {
             .weigher((key, value) -> value.estimatedBytes())
             .build();
 
+        // Shares the schema TTL: the metadata entry is the version token that rebuilds the schema key, so
+        // its freshness horizon must match the schema entry it gates. No byte weigher — entries are tiny and
+        // fixed-size, so the cache is bounded by a generous entry count instead of the byte budget.
+        this.fileMetadataCache = CacheBuilder.<FileMetadataCacheKey, FileMetadata>builder()
+            .setMaximumWeight(FILE_METADATA_CACHE_MAX_ENTRIES)
+            .setExpireAfterWrite(schemaTtl)
+            .build();
+
         this.listingCache = CacheBuilder.<ListingCacheKey, FileList>builder()
             .setMaximumWeight(listingBudget)
             .setExpireAfterWrite(listingTtl)
@@ -142,10 +163,12 @@ public class ExternalSourceCacheService implements Closeable {
             .build();
 
         logger.info(
-            "External source cache initialized: total=[{}], schema=[{}], listing=[{}], schemaTTL=[{}], listingTTL=[{}]",
+            "External source cache initialized: total=[{}], schema=[{}], listing=[{}], fileMetadataMaxEntries=[{}], "
+                + "schemaTTL=[{}], listingTTL=[{}]",
             totalBudget,
             ByteSizeValue.ofBytes(schemaBudget),
             ByteSizeValue.ofBytes(listingBudget),
+            FILE_METADATA_CACHE_MAX_ENTRIES,
             schemaTtl,
             listingTtl
         );
@@ -160,6 +183,21 @@ public class ExternalSourceCacheService implements Closeable {
             return loader.load(key);
         }
         return schemaCache.computeIfAbsent(key, loader);
+    }
+
+    /**
+     * Returns cached {@link FileMetadata} or computes it via the loader. The loader — a single object
+     * probe (mtime + length), on S3 one {@code bytes=-1} GET — is only invoked on a miss. When the cache
+     * is disabled, the loader is called directly (bypassing the cache), so the probe still happens every
+     * query. Mirrors {@link #getOrComputeSchema}: this is the amortization lever that removes the
+     * per-query warm-path metadata probe for single-file sources.
+     */
+    public FileMetadata getOrComputeFileMetadata(FileMetadataCacheKey key, CacheLoader<FileMetadataCacheKey, FileMetadata> loader)
+        throws Exception {
+        if (enabled == false) {
+            return loader.load(key);
+        }
+        return fileMetadataCache.computeIfAbsent(key, loader);
     }
 
     /**
@@ -1315,6 +1353,7 @@ public class ExternalSourceCacheService implements Closeable {
 
     public void clearAll() {
         schemaCache.invalidateAll();
+        fileMetadataCache.invalidateAll();
         listingCache.invalidateAll();
         synchronized (pendingDatasetAggregates) {
             pendingDatasetAggregates.clear();
@@ -1330,6 +1369,11 @@ public class ExternalSourceCacheService implements Closeable {
         stats.put("schema_cache.hits", schemaCache.stats().getHits());
         stats.put("schema_cache.misses", schemaCache.stats().getMisses());
         stats.put("schema_cache.evictions", schemaCache.stats().getEvictions());
+
+        stats.put("file_metadata_cache.count", fileMetadataCache.count());
+        stats.put("file_metadata_cache.hits", fileMetadataCache.stats().getHits());
+        stats.put("file_metadata_cache.misses", fileMetadataCache.stats().getMisses());
+        stats.put("file_metadata_cache.evictions", fileMetadataCache.stats().getEvictions());
 
         stats.put("listing_cache.count", listingCache.count());
         stats.put("listing_cache.hits", listingCache.stats().getHits());
@@ -1354,6 +1398,11 @@ public class ExternalSourceCacheService implements Closeable {
     // Visible for testing
     Cache<SchemaCacheKey, SchemaCacheEntry> schemaCache() {
         return schemaCache;
+    }
+
+    // Visible for testing
+    Cache<FileMetadataCacheKey, FileMetadata> fileMetadataCache() {
+        return fileMetadataCache;
     }
 
     // Visible for testing

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FileMetadata.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FileMetadata.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+/**
+ * A single object's cheap physical metadata: byte {@code length} and last-modified epoch millis.
+ * mtime is stored purely as the version token that rebuilds the {@link SchemaCacheKey} and populates
+ * the resolved {@code StorageEntry}; staleness is bounded by the file-metadata cache's hard TTL alone,
+ * never by mtime acting as a second freshness clock. {@code length} is cached alongside because the
+ * warm single-file resolve rebuilds its singleton file list from both, so caching mtime without length
+ * would still force the per-query object probe.
+ * <p>
+ * Consequence of caching the version token: a file overwritten in place is not observed until its
+ * {@link FileMetadataCacheKey} entry expires (the schema TTL, 5m default) — a warm hit serves the
+ * prior length/mtime and its schema/stats. Bounded staleness traded for the removed per-query probe.
+ */
+public record FileMetadata(long length, long mtimeMillis) {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FileMetadataCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FileMetadataCacheKey.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import java.util.Map;
+
+/**
+ * Key for a cached {@link FileMetadata}. Deliberately credential-INDEPENDENT (endpoint + region only,
+ * no access key / token) so the entry is shared across users exactly like the schema cache — the same
+ * canonical path on the same endpoint/region resolves to the same object regardless of who asks. The
+ * same canonical path on a different endpoint resolves to a different object, so endpoint and region
+ * are part of the identity.
+ */
+public record FileMetadataCacheKey(String canonicalPath, String endpoint, String region) {
+    public static FileMetadataCacheKey build(String canonicalPath, Map<String, Object> config) {
+        EndpointRegion location = EndpointRegion.of(config);
+        return new FileMetadataCacheKey(canonicalPath, location.endpoint(), location.region());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ListingCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ListingCacheKey.java
@@ -40,10 +40,9 @@ public record ListingCacheKey(
     );
 
     public static ListingCacheKey build(String scheme, String bucket, String prefixAndGlob, Map<String, Object> config) {
-        String endpoint = config != null ? String.valueOf(config.getOrDefault("endpoint", "")) : "";
-        String region = config != null ? String.valueOf(config.getOrDefault("region", "")) : "";
+        EndpointRegion location = EndpointRegion.of(config);
         long[] hash = computeCredentialHash(config);
-        return new ListingCacheKey(scheme, bucket, prefixAndGlob, endpoint, region, hash[0], hash[1]);
+        return new ListingCacheKey(scheme, bucket, prefixAndGlob, location.endpoint(), location.region(), hash[0], hash[1]);
     }
 
     static long[] computeCredentialHash(Map<String, Object> config) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheKey.java
@@ -97,10 +97,17 @@ public record SchemaCacheKey(
     );
 
     public static SchemaCacheKey build(String canonicalPath, long mtime, String formatType, Map<String, Object> config) {
-        String endpoint = config != null ? String.valueOf(config.getOrDefault("endpoint", "")) : "";
-        String region = config != null ? String.valueOf(config.getOrDefault("region", "")) : "";
+        EndpointRegion location = EndpointRegion.of(config);
         String formatConfig = buildFormatConfig(config);
-        return new SchemaCacheKey(canonicalPath, mtime, formatType != null ? formatType : "", formatConfig, endpoint, region, null);
+        return new SchemaCacheKey(
+            canonicalPath,
+            mtime,
+            formatType != null ? formatType : "",
+            formatConfig,
+            location.endpoint(),
+            location.region(),
+            null
+        );
     }
 
     /**
@@ -146,10 +153,17 @@ public record SchemaCacheKey(
         // fileSetFingerprint (isDatasetAggregate() vs the collision defense). Require the fingerprint here
         // so a marker-suffixed key with a null fingerprint is never representable and the two agree.
         Objects.requireNonNull(fingerprint, "dataset aggregate key requires a non-null file-set fingerprint");
-        String endpoint = config != null ? String.valueOf(config.getOrDefault("endpoint", "")) : "";
-        String region = config != null ? String.valueOf(config.getOrDefault("region", "")) : "";
+        EndpointRegion location = EndpointRegion.of(config);
         String formatType = (sourceType == null ? "" : sourceType) + DATASET_AGGREGATE_MARKER;
-        return new SchemaCacheKey(pattern == null ? "" : pattern, 0L, formatType, buildFormatConfig(config), endpoint, region, fingerprint);
+        return new SchemaCacheKey(
+            pattern == null ? "" : pattern,
+            0L,
+            formatType,
+            buildFormatConfig(config),
+            location.endpoint(),
+            location.region(),
+            fingerprint
+        );
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -2303,6 +2303,92 @@ public class ExternalSourceResolverTests extends ESTestCase {
         }
     }
 
+    /**
+     * A warm single-file resolve must be zero-I/O: the file-metadata cache holds {length, mtime} within
+     * the schema TTL, so the second resolve reuses the cached metadata and issues no object probe. This
+     * is the amortization lever removing the per-query warm-path metadata probe.
+     */
+    public void testSingleFileMetadataCacheEliminatesWarmProbe() throws Exception {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/single.parquet", schema);
+
+        CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of(), schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+            PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f1);
+            assertNotNull(f1.actionGet().resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals("cold resolve probes the object exactly once", 1, countingProvider.metadataProbeCount.get());
+
+            Map<String, Object> stats1 = cacheService.usageStats();
+            assertEquals(1L, stats1.get("file_metadata_cache.misses"));
+            assertEquals(0L, stats1.get("file_metadata_cache.hits"));
+            assertEquals(1, stats1.get("file_metadata_cache.count"));
+
+            PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f2);
+            ExternalSourceResolution res2 = f2.actionGet();
+            assertNotNull(res2.resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals(1, res2.resolvedSource("s3://bucket/data/single.parquet").fileList().fileCount());
+            assertEquals("warm resolve issues zero additional probes", 1, countingProvider.metadataProbeCount.get());
+
+            Map<String, Object> stats2 = cacheService.usageStats();
+            assertEquals(1L, stats2.get("file_metadata_cache.misses"));
+            assertEquals(1L, stats2.get("file_metadata_cache.hits"));
+            assertEquals(1, stats2.get("file_metadata_cache.count"));
+        }
+    }
+
+    /**
+     * The file-metadata cache is bounded by a hard {@code expireAfterWrite} TTL (the schema TTL), so once
+     * the entry expires the next resolve must re-probe the object — mtime is a version token, not a
+     * second freshness clock, and staleness is bounded by TTL alone.
+     */
+    public void testSingleFileMetadataCacheReprobesAfterTtlExpiry() throws Exception {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/single.parquet", schema);
+
+        CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of(), schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "500ms")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+            PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f1);
+            assertNotNull(f1.actionGet().resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals(1, countingProvider.metadataProbeCount.get());
+
+            // Let the entry expire (it remains lazily cached but is TTL-dead), then resolve again.
+            Thread.sleep(1200);
+
+            PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f2);
+            assertNotNull(f2.actionGet().resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals("expired metadata entry must be re-probed", 2, countingProvider.metadataProbeCount.get());
+
+            Map<String, Object> stats = cacheService.usageStats();
+            assertEquals(2L, stats.get("file_metadata_cache.misses"));
+        }
+    }
+
     public void testSingleFileCacheDisabledBypassesCache() throws Exception {
         List<Attribute> schema = List.of(attr("val", DataType.LONG));
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
@@ -2331,6 +2417,12 @@ public class ExternalSourceResolverTests extends ESTestCase {
             assertEquals("schema cache should have no entries when disabled", 0, stats.get("schema_cache.count"));
             assertEquals("schema cache should have no hits when disabled", 0L, stats.get("schema_cache.hits"));
             assertEquals("schema cache should have no misses when disabled", 0L, stats.get("schema_cache.misses"));
+            assertEquals("file-metadata cache should have no entries when disabled", 0, stats.get("file_metadata_cache.count"));
+            assertEquals(
+                "disabled cache must not eliminate the probe — one probe per resolve",
+                3,
+                countingProvider.metadataProbeCount.get()
+            );
         }
     }
 
@@ -3428,25 +3520,38 @@ public class ExternalSourceResolverTests extends ESTestCase {
     private static class StubStorageProvider implements StorageProvider {
         private final Map<String, List<StorageEntry>> listingsByPrefix;
         private final Map<String, List<Attribute>> schemasByPath;
+        // Non-null only when the wrapping provider wants to count metadata probes: it is passed to every
+        // object so an object.lastModified() call (the single-file metadata probe) increments it.
+        @Nullable
+        private final AtomicInteger probeCount;
 
         StubStorageProvider(Map<String, List<StorageEntry>> listingsByPrefix, Map<String, List<Attribute>> schemasByPath) {
+            this(listingsByPrefix, schemasByPath, null);
+        }
+
+        StubStorageProvider(
+            Map<String, List<StorageEntry>> listingsByPrefix,
+            Map<String, List<Attribute>> schemasByPath,
+            @Nullable AtomicInteger probeCount
+        ) {
             this.listingsByPrefix = listingsByPrefix;
             this.schemasByPath = schemasByPath;
+            this.probeCount = probeCount;
         }
 
         @Override
         public StorageObject newObject(StoragePath path) {
-            return new StubStorageObject(path);
+            return new StubStorageObject(path, 0, probeCount);
         }
 
         @Override
         public StorageObject newObject(StoragePath path, long length) {
-            return new StubStorageObject(path, length);
+            return new StubStorageObject(path, length, probeCount);
         }
 
         @Override
         public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
-            return new StubStorageObject(path, length);
+            return new StubStorageObject(path, length, probeCount);
         }
 
         @Override
@@ -3491,14 +3596,21 @@ public class ExternalSourceResolverTests extends ESTestCase {
     private static class StubStorageObject implements StorageObject {
         private final StoragePath path;
         private final long length;
+        @Nullable
+        private final AtomicInteger probeCount;
 
         StubStorageObject(StoragePath path) {
-            this(path, 0);
+            this(path, 0, null);
         }
 
         StubStorageObject(StoragePath path, long length) {
+            this(path, length, null);
+        }
+
+        StubStorageObject(StoragePath path, long length, @Nullable AtomicInteger probeCount) {
             this.path = path;
             this.length = length;
+            this.probeCount = probeCount;
         }
 
         @Override
@@ -3518,6 +3630,11 @@ public class ExternalSourceResolverTests extends ESTestCase {
 
         @Override
         public Instant lastModified() {
+            // The single-file metadata probe is the one caller of lastModified() in the cacheable flow, so
+            // counting it here isolates the probe from the schema-resolution object creation.
+            if (probeCount != null) {
+                probeCount.incrementAndGet();
+            }
             return Instant.EPOCH;
         }
 
@@ -3539,10 +3656,15 @@ public class ExternalSourceResolverTests extends ESTestCase {
     private static class CountingStorageProvider implements StorageProvider {
         final AtomicInteger listCallCount = new AtomicInteger();
         final AtomicInteger schemaCallCount = new AtomicInteger();
+        // Counts the single-file metadata probe. Incremented by the object's lastModified() (the one caller
+        // of it in the cacheable flow), so it isolates the metadata probe from the schema-resolution object
+        // creation that also calls newObject. The warm-path file-metadata cache drives it to exactly one
+        // probe across repeated resolves.
+        final AtomicInteger metadataProbeCount = new AtomicInteger();
         private final StubStorageProvider delegate;
 
         CountingStorageProvider(Map<String, List<StorageEntry>> listingsByPrefix, Map<String, List<Attribute>> schemasByPath) {
-            this.delegate = new StubStorageProvider(listingsByPrefix, schemasByPath);
+            this.delegate = new StubStorageProvider(listingsByPrefix, schemasByPath, metadataProbeCount);
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -276,6 +276,116 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         }
     }
 
+    public void testFileMetadataHitMiss() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            AtomicInteger loaderCalls = new AtomicInteger();
+            FileMetadataCacheKey key = FileMetadataCacheKey.build("s3://bucket/data/file.parquet", Map.of());
+
+            FileMetadata meta1 = service.getOrComputeFileMetadata(key, k -> {
+                loaderCalls.incrementAndGet();
+                return new FileMetadata(4096L, 1000L);
+            });
+            assertEquals(4096L, meta1.length());
+            assertEquals(1000L, meta1.mtimeMillis());
+            assertEquals(1, loaderCalls.get());
+
+            FileMetadata meta2 = service.getOrComputeFileMetadata(key, k -> {
+                loaderCalls.incrementAndGet();
+                return new FileMetadata(9999L, 2000L);
+            });
+            assertSame(meta1, meta2);
+            assertEquals("warm hit must not invoke the loader", 1, loaderCalls.get());
+
+            Map<String, Object> stats = service.usageStats();
+            assertEquals(1, stats.get("file_metadata_cache.count"));
+            assertEquals(1L, stats.get("file_metadata_cache.misses"));
+            assertEquals(1L, stats.get("file_metadata_cache.hits"));
+        }
+    }
+
+    public void testFileMetadataDisabledBypassesCache() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            service.setEnabled(false);
+            AtomicInteger loaderCalls = new AtomicInteger();
+            FileMetadataCacheKey key = FileMetadataCacheKey.build("s3://bucket/data/file.parquet", Map.of());
+
+            service.getOrComputeFileMetadata(key, k -> {
+                loaderCalls.incrementAndGet();
+                return new FileMetadata(1L, 1L);
+            });
+            service.getOrComputeFileMetadata(key, k -> {
+                loaderCalls.incrementAndGet();
+                return new FileMetadata(1L, 1L);
+            });
+            assertEquals("disabled cache calls the loader every time", 2, loaderCalls.get());
+            assertEquals(0, service.usageStats().get("file_metadata_cache.count"));
+        }
+    }
+
+    public void testFileMetadataDifferentEndpointSeparateEntries() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            AtomicInteger loaderCalls = new AtomicInteger();
+            FileMetadataCacheKey key1 = FileMetadataCacheKey.build(
+                "s3://bucket/data/file.parquet",
+                Map.of("endpoint", "us-east-1.amazonaws.com")
+            );
+            FileMetadataCacheKey key2 = FileMetadataCacheKey.build(
+                "s3://bucket/data/file.parquet",
+                Map.of("endpoint", "eu-west-1.amazonaws.com")
+            );
+            assertNotEquals(key1, key2);
+
+            service.getOrComputeFileMetadata(key1, k -> {
+                loaderCalls.incrementAndGet();
+                return new FileMetadata(1L, 1L);
+            });
+            service.getOrComputeFileMetadata(key2, k -> {
+                loaderCalls.incrementAndGet();
+                return new FileMetadata(2L, 2L);
+            });
+            assertEquals(2, loaderCalls.get());
+        }
+    }
+
+    public void testFileMetadataCredentialIndependentKey() {
+        // The file-metadata key is credential-independent so entries are shared across users, exactly
+        // like the schema cache — only endpoint/region participate in identity.
+        FileMetadataCacheKey withCredA = FileMetadataCacheKey.build(
+            "s3://bucket/data/file.parquet",
+            Map.of("access_key", "userA", "endpoint", "e", "region", "r")
+        );
+        FileMetadataCacheKey withCredB = FileMetadataCacheKey.build(
+            "s3://bucket/data/file.parquet",
+            Map.of("access_key", "userB", "endpoint", "e", "region", "r")
+        );
+        assertEquals(withCredA, withCredB);
+    }
+
+    public void testClearAllEmptiesFileMetadataCache() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            FileMetadataCacheKey key = FileMetadataCacheKey.build("s3://bucket/data/file.parquet", Map.of());
+            service.getOrComputeFileMetadata(key, k -> new FileMetadata(1L, 1L));
+            assertEquals(1, service.usageStats().get("file_metadata_cache.count"));
+
+            service.clearAll();
+            assertEquals(0, service.usageStats().get("file_metadata_cache.count"));
+        }
+    }
+
+    public void testUsageStatsExposesFileMetadataCacheKeys() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            Map<String, Object> stats = service.usageStats();
+            assertTrue(stats.containsKey("file_metadata_cache.count"));
+            assertTrue(stats.containsKey("file_metadata_cache.hits"));
+            assertTrue(stats.containsKey("file_metadata_cache.misses"));
+            assertTrue(stats.containsKey("file_metadata_cache.evictions"));
+            assertEquals(0, stats.get("file_metadata_cache.count"));
+            assertEquals(0L, stats.get("file_metadata_cache.hits"));
+            assertEquals(0L, stats.get("file_metadata_cache.misses"));
+            assertEquals(0L, stats.get("file_metadata_cache.evictions"));
+        }
+    }
+
     public void testSchemaCacheEntryNameIdSafety() {
         SchemaCacheEntry entry = testSchemaEntry();
         List<Attribute> attrs1 = entry.toAttributes();


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ESQL] cache single-file metadata, skip warm probe (#153715)