### PR TITLE
Backport partial snapshot change to 8.19

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStep.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotNameAlreadyInUseException;
+import org.elasticsearch.snapshots.SnapshotState;
 
 import java.util.Objects;
 
@@ -106,6 +107,7 @@ public class CreateSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         // complete
         request.waitForCompletion(true);
         request.includeGlobalState(false);
+        request.partial(true);
 
         getClient().admin().cluster().createSnapshot(request, listener.map(response -> {
             logger.debug(
@@ -116,25 +118,34 @@ public class CreateSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             );
             final SnapshotInfo snapInfo = response.getSnapshotInfo();
 
-            // Check that there are no failed shards, since the request may not entirely
-            // fail, but may still have failures (such as in the case of an aborted snapshot)
-            if (snapInfo.failedShards() == 0) {
+            if (snapshotCompletedSuccessfully(snapInfo, indexName)) {
                 return true;
             } else {
                 logger.warn(
                     Strings.format(
-                        "failed to create snapshot [%s:%s] for policy [%s] and index [%s]: %s of %s shards failed",
+                        "snapshot [%s:%s] for policy [%s] and index [%s] did not complete successfully: "
+                            + "state [%s], successful shards [%s], failed shards [%s] of [%s], indices %s",
                         snapshotRepository,
                         snapshotName,
                         policyName,
                         indexName,
+                        snapInfo.state(),
+                        snapInfo.successfulShards(),
                         snapInfo.failedShards(),
-                        snapInfo.totalShards()
+                        snapInfo.totalShards(),
+                        snapInfo.indices()
                     )
                 );
                 return false;
             }
         }));
+    }
+
+    static boolean snapshotCompletedSuccessfully(SnapshotInfo snapshotInfo, String indexName) {
+        return snapshotInfo.state() == SnapshotState.SUCCESS
+            && snapshotInfo.failedShards() == 0
+            && snapshotInfo.successfulShards() > 0
+            && snapshotInfo.indices().contains(indexName);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
@@ -338,10 +338,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
 
     private SnapshotInfo snapshotInfo(SnapshotState state, List<String> indices, int failedShards, int successfulShards) {
         return new SnapshotInfo(
-            new Snapshot(
-                randomAlphaOfLength(10),
-                new SnapshotId(randomAlphaOfLength(10), randomAlphaOfLength(10))
-            ),
+            new Snapshot(randomAlphaOfLength(10), new SnapshotId(randomAlphaOfLength(10), randomAlphaOfLength(10))),
             indices,
             List.of(),
             List.of(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
@@ -11,18 +11,24 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSnapshotAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotNameAlreadyInUseException;
+import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
@@ -139,6 +145,94 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
     }
 
+    public void testFailedSnapshotMovesToIncompleteStep() {
+        String indexName = randomAlphaOfLength(10);
+        String policyName = "test-ilm-policy";
+        String snapshotName = indexName + "-" + policyName;
+        String repository = "repository";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(
+                LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
+                Map.of("snapshot_name", snapshotName, "snapshot_repository", repository)
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ClusterState clusterState = ClusterState.builder(emptyClusterState())
+            .metadata(Metadata.builder().put(indexMetadata, true).build())
+            .build();
+
+        try (var threadPool = createThreadPool()) {
+            NoOpClient client = new NoOpClient(threadPool) {
+                @Override
+                @SuppressWarnings("unchecked")
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertThat(action, is(TransportCreateSnapshotAction.TYPE));
+                    assertTrue(request instanceof CreateSnapshotRequest);
+                    listener.onResponse(
+                        (Response) new CreateSnapshotResponse(snapshotInfo(SnapshotState.FAILED, List.of(indexName), 1, 0))
+                    );
+                }
+            };
+            StepKey nextKeyOnComplete = randomStepKey();
+            StepKey nextKeyOnIncomplete = randomStepKey();
+            CreateSnapshotStep step = new CreateSnapshotStep(randomStepKey(), nextKeyOnComplete, nextKeyOnIncomplete, client);
+
+            step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
+
+            assertThat(step.getNextStepKey(), is(nextKeyOnIncomplete));
+        }
+    }
+
+    public void testEmptySnapshotMovesToIncompleteStep() {
+        String indexName = randomAlphaOfLength(10);
+        String policyName = "test-ilm-policy";
+        String snapshotName = indexName + "-" + policyName;
+        String repository = "repository";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(
+                LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
+                Map.of("snapshot_name", snapshotName, "snapshot_repository", repository)
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ClusterState clusterState = ClusterState.builder(emptyClusterState())
+            .metadata(Metadata.builder().put(indexMetadata, true).build())
+            .build();
+
+        try (var threadPool = createThreadPool()) {
+            NoOpClient client = new NoOpClient(threadPool) {
+                @Override
+                @SuppressWarnings("unchecked")
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertThat(action, is(TransportCreateSnapshotAction.TYPE));
+                    assertTrue(request instanceof CreateSnapshotRequest);
+                    listener.onResponse(
+                        (Response) new CreateSnapshotResponse(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 0, 0))
+                    );
+                }
+            };
+            StepKey nextKeyOnComplete = randomStepKey();
+            StepKey nextKeyOnIncomplete = randomStepKey();
+            CreateSnapshotStep step = new CreateSnapshotStep(randomStepKey(), nextKeyOnComplete, nextKeyOnIncomplete, client);
+
+            step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
+
+            assertThat(step.getNextStepKey(), is(nextKeyOnIncomplete));
+        }
+    }
+
     public void testNextStepKey() {
         String indexName = randomAlphaOfLength(10);
         String policyName = "test-ilm-policy";
@@ -217,6 +311,54 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
     }
 
+    public void testSnapshotCompletedSuccessfullyRequiresCompleteTargetSnapshot() {
+        String indexName = randomAlphaOfLength(10);
+
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 0, 1), indexName),
+            is(true)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.FAILED, List.of(indexName), 0, 1), indexName),
+            is(false)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(), 0, 1), indexName),
+            is(false)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 0, 0), indexName),
+            is(false)
+        );
+        assertThat(
+            CreateSnapshotStep.snapshotCompletedSuccessfully(snapshotInfo(SnapshotState.SUCCESS, List.of(indexName), 1, 0), indexName),
+            is(false)
+        );
+    }
+
+    private SnapshotInfo snapshotInfo(SnapshotState state, List<String> indices, int failedShards, int successfulShards) {
+        return new SnapshotInfo(
+            new Snapshot(
+                randomAlphaOfLength(10),
+                new SnapshotId(randomAlphaOfLength(10), randomAlphaOfLength(10))
+            ),
+            indices,
+            List.of(),
+            List.of(),
+            state == SnapshotState.FAILED ? "simulated failure" : null,
+            IndexVersion.current(),
+            0L,
+            0L,
+            successfulShards + failedShards,
+            successfulShards,
+            List.of(),
+            false,
+            null,
+            state,
+            Map.of()
+        );
+    }
+
     private NoOpClient getCreateSnapshotRequestAssertingClient(
         ThreadPool threadPool,
         String expectedRepoName,
@@ -247,6 +389,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
                     createSnapshotRequest.includeGlobalState(),
                     is(false)
                 );
+                assertThat("ILM generated snapshots should use partial snapshots", createSnapshotRequest.partial(), is(true));
             }
         };
     }


### PR DESCRIPTION
This is a partial backport of https://github.com/elastic/elasticsearch/pull/153774 to 8.19 as this branch does not have the DLM Frozen Tier feature so it just backports the ILM related changes (also modified due to the lack of multi project on this branch)