### PR TITLE
[9.5] Fix Math.clamp min > max in supplementCentroids (#153584)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -796,9 +796,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.overridingExpressionGroupings}
   issue: https://github.com/elastic/elasticsearch/issues/153690
-- class: org.elasticsearch.index.codec.vectors.diskbbq.es95.ES950DiskBBQVectorsFormatTests
-  method: testOneRepeatedVector
-  issue: https://github.com/elastic/elasticsearch/issues/153568
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsFirstLastIT
   method: test {csv-spec:stats_first_last.Test aggregating on integers from row}
   issue: https://github.com/elastic/elasticsearch/issues/153700

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
@@ -729,7 +729,8 @@ public class HierarchicalKMeans<V> {
 
         Random random = new Random(42L);
         int n = vectors.size();
-        int sampleSize = Math.clamp(needed * 64L, 4096, n);
+        // select a minimum of 4096 vectors (n may be smaller than 4096)
+        int sampleSize = Math.clamp(needed * 64L, Math.min(4096, n), n);
 
         // Reservoir-sample sampleSize vector indices, deterministic with seed 42.
         int[] sample = new int[sampleSize];


### PR DESCRIPTION
Backport #153584 to 9.5

Fixes #153568