### PR TITLE
[9.3] fix deprecated fields in tests (#153637)

### DIFF
--- a/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
@@ -33,8 +33,8 @@
                                 "filter": {
                                   "range": {
                                     "@timestamp" : {
-                                      "from": "{{ctx.trigger.scheduled_time}}||-5m",
-                                      "to": "{{ctx.trigger.triggered_time}}"
+                                      "gte": "{{ctx.trigger.scheduled_time}}||-5m",
+                                      "lte": "{{ctx.trigger.triggered_time}}"
                                     }
                                   }
                                 }
@@ -157,8 +157,8 @@
                                 "filter": {
                                   "range": {
                                     "@timestamp" : {
-                                      "from": "{{ctx.trigger.scheduled_time}}||-5m",
-                                      "to": "{{ctx.trigger.triggered_time}}"
+                                      "gte": "{{ctx.trigger.scheduled_time}}||-5m",
+                                      "lte": "{{ctx.trigger.triggered_time}}"
                                     }
                                   }
                                 }

--- a/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/painless/30_inline_watch.yml
+++ b/x-pack/plugin/watcher/src/yamlRestTest/resources/rest-api-spec/test/painless/30_inline_watch.yml
@@ -39,8 +39,8 @@
                           "filter": {
                             "range": {
                               "@timestamp" : {
-                                "from": "{{ctx.trigger.scheduled_time}}||-5m",
-                                "to": "{{ctx.trigger.triggered_time}}"
+                                "gte": "{{ctx.trigger.scheduled_time}}||-5m",
+                                "lte": "{{ctx.trigger.triggered_time}}"
                               }
                             }
                           }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix deprecated fields in tests (#153637)](https://github.com/elastic/elasticsearch/pull/153637)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)