### PR TITLE
[9.5] Remove flaky search in SearchableSnapshotsCanMatchOnCoordinatorIntegTests (#153607)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -805,9 +805,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.blob.SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests
   method: testPeriodicMaintenance
   issue: https://github.com/elastic/elasticsearch/issues/153548
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsCanMatchOnCoordinatorIntegTests
-  method: testLogsDBSearchableSnapshotShardsThatHaveMatchingDataAreNotSkippedOnTheCoordinatingNode
-  issue: https://github.com/elastic/elasticsearch/issues/153564
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.lookupJoinWithExpression [ndjson.bz2/HTTP]}
   issue: https://github.com/elastic/elasticsearch/issues/153744

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.searchablesnapshots;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchShardsGroup;
 import org.elasticsearch.action.search.SearchShardsRequest;
 import org.elasticsearch.action.search.SearchShardsResponse;
@@ -840,20 +839,8 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         SearchRequest request = new SearchRequest().indices(searchableSnapshotIndexWithinSearchRange)
             .source(new SearchSourceBuilder().query(rangeQuery));
 
-        // All shards failed, since all shards are unassigned and the IndexMetadata min/max timestamp
-        // is not available yet
-        expectThrows(SearchPhaseExecutionException.class, () -> {
-            SearchResponse response = client().search(request).actionGet();
-            logger.info(
-                "[TEST DEBUG INFO] Search hits: {} Successful shards: {}, failed shards: {}, skipped shards: {}, total shards: {}",
-                response.getHits().getTotalHits().value(),
-                response.getSuccessfulShards(),
-                response.getFailedShards(),
-                response.getSkippedShards(),
-                response.getTotalShards()
-            );
-            fail("This search call is expected to throw an exception but it did not");
-        });
+        // Deliberately no full search here: against recovering shards it can block on
+        // IndexShard#waitForSearchReady.
 
         // test with SearchShards API
         boolean allowPartialSearchResults = false;


### PR DESCRIPTION
Backport of #153607 to 9.5.

Closes #153564