### PR TITLE
Disable tls for OTLP exporter

### DIFF
--- a/docs/changelog/153833.yaml
+++ b/docs/changelog/153833.yaml
@@ -1,0 +1,5 @@
+area: Infra/Metrics
+issues: []
+pr: 153833
+summary: Disable tls for OTLP exporter
+type: enhancement

--- a/modules/apm/build.gradle
+++ b/modules/apm/build.gradle
@@ -18,6 +18,7 @@ def otelInstrumentationVersion = '2.26.1-alpha'
 def otelContribDiskBufferingVersion = '1.57.0-alpha'
 
 dependencies {
+  implementation project(":libs:ssl-config")
   implementation "io.opentelemetry:opentelemetry-api:${otelVersion}"
   implementation "io.opentelemetry:opentelemetry-context:${otelVersion}"
   implementation "io.opentelemetry:opentelemetry-sdk:${otelVersion}"

--- a/modules/apm/src/main/java/module-info.java
+++ b/modules/apm/src/main/java/module-info.java
@@ -10,6 +10,7 @@
 module org.elasticsearch.telemetry.apm {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;
+    requires org.elasticsearch.sslconfig;
     requires org.elasticsearch.xcontent;
     requires org.apache.logging.log4j;
     requires org.apache.logging.log4j.core;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -98,6 +98,7 @@ public class APM extends Plugin implements NetworkPlugin, TelemetryPlugin {
             OtelSdkSettings.TELEMETRY_RESOURCE_ATTRIBUTES,
             // Shared OTLP export transport (metrics + traces)
             OtelSdkSettings.TELEMETRY_EXPORT_ENDPOINT,
+            OtelSdkSettings.TELEMETRY_EXPORT_VERIFY_SERVER_CERT,
             OtelSdkSettings.TELEMETRY_EXPORT_INTERVAL,
             OtelSdkSettings.TELEMETRY_EXPORT_SEND_TIMEOUT,
             OtelSdkSettings.TELEMETRY_EXPORT_CONNECT_TIMEOUT,

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplier.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplier.java
@@ -11,6 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.export.otelsdk;
 
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
@@ -24,14 +25,22 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.ssl.TrustEverythingConfig;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.telemetry.apm.internal.APMAgentSettings;
 import org.elasticsearch.telemetry.apm.internal.export.MeterSupplier;
 
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import static org.elasticsearch.telemetry.TelemetryProvider.OTEL_METRICS_ENABLED_SYSTEM_PROPERTY;
 
@@ -81,11 +90,26 @@ public class OtelSdkExportMeterSupplier implements MeterSupplier {
 
         var systemProvider = buildSystemMeterProvider(meterProviderRef::get);
         meterProviderRef.set(systemProvider);
+        var readerExportInterval = registerReaderMetrics(systemProvider);
         var otelSdk = OpenTelemetrySdk.builder().setMeterProvider(systemProvider).build();
 
         // RuntimeTelemetry uses JMX (Java 8+) and JFR (Java 17+) to collect JVM metrics. See https://ela.st/otel-runtime-telemetry
         var runtimeTelemetry = OTelJvmMetricsEnabled() ? RuntimeTelemetry.create(otelSdk) : null;
-        return new OTelMetricsResources(systemProvider, runtimeTelemetry);
+        return new OTelMetricsResources(systemProvider, runtimeTelemetry, readerExportInterval);
+    }
+
+    /**
+     * Registers a gauge reporting the configured metric reader export interval. Paired with the SDK's
+     * {@code otel.sdk.metric_reader.collection.duration}, it lets alerting compute collection overhead as a
+     * fraction of the cycle without hardcoding the interval, so the two stay in sync when the setting changes.
+     */
+    ObservableDoubleGauge registerReaderMetrics(SdkMeterProvider provider) {
+        double intervalSeconds = OtelSdkSettings.TELEMETRY_EXPORT_INTERVAL.get(settings).millis() / 1000.0;
+        return provider.get("elasticsearch")
+            .gaugeBuilder("es.apm.metrics.reader.export_interval")
+            .setDescription("Configured metric reader export interval, for computing collection overhead")
+            .setUnit("s")
+            .buildWithCallback(measurement -> measurement.record(intervalSeconds));
     }
 
     private static boolean OTelJvmMetricsEnabled() {
@@ -140,6 +164,7 @@ public class OtelSdkExportMeterSupplier implements MeterSupplier {
         if (authHeader != null) {
             builder.addHeader("Authorization", authHeader);
         }
+        configureTls(settings, builder::setSslContext);
         return builder.build();
     }
 
@@ -155,6 +180,20 @@ public class OtelSdkExportMeterSupplier implements MeterSupplier {
             }
         }
         return null;
+    }
+
+    static void configureTls(Settings settings, BiConsumer<SSLContext, X509TrustManager> sslContextSetter) {
+        if (OtelSdkSettings.TELEMETRY_EXPORT_VERIFY_SERVER_CERT.get(settings)) {
+            return;
+        }
+        X509ExtendedTrustManager trustAll = TrustEverythingConfig.TRUST_EVERYTHING.createTrustManager();
+        try {
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, new TrustManager[] { trustAll }, null);
+            sslContextSetter.accept(context, trustAll);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     /** Flushes the meter provider. Callers must join the result with an appropriate timeout. */
@@ -192,7 +231,11 @@ public class OtelSdkExportMeterSupplier implements MeterSupplier {
         }
     }
 
-    record OTelMetricsResources(SdkMeterProvider meterProvider, RuntimeTelemetry runtimeTelemetry) implements AutoCloseable {
+    record OTelMetricsResources(
+        SdkMeterProvider meterProvider,
+        RuntimeTelemetry runtimeTelemetry,
+        ObservableDoubleGauge readerExportInterval
+    ) implements AutoCloseable {
 
         OTelMetricsResources {
             Objects.requireNonNull(meterProvider, "meterProvider");
@@ -200,6 +243,9 @@ public class OtelSdkExportMeterSupplier implements MeterSupplier {
 
         @Override
         public void close() {
+            if (readerExportInterval != null) {
+                readerExportInterval.close();
+            }
             if (runtimeTelemetry != null) {
                 runtimeTelemetry.close();
             }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportTracerSupplier.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportTracerSupplier.java
@@ -65,6 +65,7 @@ public class OtelSdkExportTracerSupplier implements TraceSupplier {
         if (authHeader != null) {
             builder.addHeader("Authorization", authHeader);
         }
+        OtelSdkExportMeterSupplier.configureTls(settings, builder::setSslContext);
         OtlpGrpcSpanExporter exporter = builder.build();
 
         BatchSpanProcessor processor = BatchSpanProcessor.builder(exporter)

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettings.java
@@ -50,6 +50,13 @@ public final class OtelSdkSettings {
      * Required when the SDK metrics or trace path is active. */
     public static final Setting<String> TELEMETRY_EXPORT_ENDPOINT = Setting.simpleString("telemetry.export.endpoint", "", NodeScope);
 
+    /** When {@code false}, TLS certificate verification is disabled for the OTLP exporters. */
+    public static final Setting<Boolean> TELEMETRY_EXPORT_VERIFY_SERVER_CERT = Setting.boolSetting(
+        "telemetry.export.verify_server_cert",
+        true,
+        NodeScope
+    );
+
     /**
      * Initial backoff of the shared OTLP retry policy ({@link #OTLP_RETRY_POLICY}).
      * The default allows for fast retry and manageable total timeout.

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplierTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplierTests.java
@@ -115,7 +115,7 @@ public class OtelSdkExportMeterSupplierTests extends ESTestCase {
     public void testSpanProcessorSelfMonitoringMetricsFlowIntoHealthProvider() {
         InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
         SdkMeterProvider meterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
-        var resources = new OtelSdkExportMeterSupplier.OTelMetricsResources(meterProvider, null);
+        var resources = new OtelSdkExportMeterSupplier.OTelMetricsResources(meterProvider, null, null);
         OtelSdkExportMeterSupplier meterSupplier = new OtelSdkExportMeterSupplier(Settings.EMPTY, null, resources);
 
         BatchSpanProcessor processor = BatchSpanProcessor.builder(InMemorySpanExporter.create())
@@ -132,6 +132,25 @@ public class OtelSdkExportMeterSupplierTests extends ESTestCase {
             );
         }
         meterSupplier.close();
+    }
+
+    public void testExportIntervalGaugeReportsConfiguredInterval() {
+        InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+        SdkMeterProvider meterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+        Settings settings = Settings.builder().put(OtelSdkSettings.TELEMETRY_EXPORT_INTERVAL.getKey(), "90s").build();
+        OtelSdkExportMeterSupplier supplier = new OtelSdkExportMeterSupplier(settings, null);
+
+        try (var gauge = supplier.registerReaderMetrics(meterProvider)) {
+            MetricData metric = inMemoryReader.collectAllMetrics()
+                .stream()
+                .filter(m -> m.getName().equals("es.apm.metrics.reader.export_interval"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("es.apm.metrics.reader.export_interval gauge was not emitted"));
+            assertEquals("s", metric.getUnit());
+            double value = metric.getDoubleGaugeData().getPoints().iterator().next().getValue();
+            assertEquals(90.0, value, 0.0);
+        }
+        meterProvider.close();
     }
 
     /** attemptFlushMetrics() after close() must return a successful no-op result. */


### PR DESCRIPTION
The old APM Java agent supported `telemetry.agent.verify_server_cert=false,` which fully disables TLS cert verification when talking to the APM server.
In case someone or something relies on this behaviour, we are introducing it with OTLP exporter.

There is also an unrelated change which add emitting the metric collection interval setting as a metric, to be used in alerts calculation.

elastic/elasticsearch-team#4484