### PR TITLE
[9.5] [ESQLDS] Speedup Utf8Sanitizer for ascii-only strings (#153530)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Utf8Sanitizer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Utf8Sanitizer.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.ByteUtils;
 
 import java.util.Arrays;
 
@@ -35,13 +36,35 @@ public final class Utf8Sanitizer {
     /** {@code U+FFFD} REPLACEMENT CHARACTER encoded as UTF-8. */
     private static final byte[] REPLACEMENT = { (byte) 0xEF, (byte) 0xBF, (byte) 0xBD };
 
+    /** Mask selecting the high bit of every byte in a {@code long}; a zero result means all-ASCII. */
+    private static final long ASCII_MASK = 0x8080808080808080L;
+
+    /**
+     * Advances {@code i} past a maximal run of all-ASCII 8-byte words, stopping at the first word
+     * containing a non-ASCII byte or at {@code wordEnd} (the exclusive bound past which an 8-byte read
+     * would cross {@code end}). Returns {@code i} unchanged when no full ASCII word starts at {@code i}.
+     */
+    private static int skipAsciiWords(byte[] bytes, int i, int wordEnd) {
+        while (i < wordEnd && (((long) ByteUtils.LITTLE_ENDIAN_LONG.get(bytes, i)) & ASCII_MASK) == 0) {
+            i += Long.BYTES;
+        }
+        return i;
+    }
+
     /**
      * Allocation-free scan reporting whether {@code [off, off+len)} is well-formed UTF-8.
      */
     public static boolean isWellFormed(byte[] bytes, int off, int len) {
         int i = off;
         int end = off + len;
+        // ASCII-dominant columns (the common case) are skipped a word at a time instead of byte at a time;
+        // any non-ASCII byte in the word falls through to the scalar path below.
+        int wordEnd = end - Long.BYTES + 1;
         while (i < end) {
+            i = skipAsciiWords(bytes, i, wordEnd);
+            if (i >= end) {
+                break;
+            }
             int b0 = bytes[i] & 0xFF;
             if (b0 < 0x80) {
                 // ASCII
@@ -132,7 +155,20 @@ public final class Utf8Sanitizer {
         int outLen = 0;
         int i = off;
         int end = off + len;
+        int wordEnd = end - Long.BYTES + 1;
         while (i < end) {
+            // Bulk-copy runs of ASCII words instead of re-deriving a 1-byte sequence length per byte.
+            int runEnd = skipAsciiWords(bytes, i, wordEnd);
+            if (runEnd > i) {
+                int runLen = runEnd - i;
+                out = ensureCapacity(out, outLen + runLen);
+                System.arraycopy(bytes, i, out, outLen, runLen);
+                outLen += runLen;
+                if (runEnd >= end) {
+                    break;
+                }
+                i = runEnd;
+            }
             int consumed = sequenceLength(bytes, i, end);
             if (consumed > 0) {
                 out = ensureCapacity(out, outLen + consumed);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/Utf8SanitizerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/Utf8SanitizerTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.ESTestCase;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 public class Utf8SanitizerTests extends ESTestCase {
 
@@ -75,6 +76,36 @@ public class Utf8SanitizerTests extends ESTestCase {
             BytesRef out = Utf8Sanitizer.sanitize(new BytesRef(random, 0, random.length));
             assertTrue("sanitized output must be valid UTF-8", Utf8Sanitizer.isWellFormed(out.bytes, out.offset, out.length));
         }
+    }
+
+    public void testLongAsciiRunIsWellFormed() {
+        // Exercises the word-wide fast path over several full 8-byte words plus a partial tail.
+        for (int len : new int[] { 7, 8, 9, 15, 16, 17, 63, 64, 65 }) {
+            byte[] ascii = new byte[len];
+            Arrays.fill(ascii, (byte) 'a');
+            BytesRef in = new BytesRef(ascii);
+            assertTrue("len=" + len, Utf8Sanitizer.isWellFormed(in.bytes, in.offset, in.length));
+            assertSame(in, Utf8Sanitizer.sanitize(in));
+        }
+    }
+
+    public void testMalformedByteAtEveryWordPosition() {
+        // A single ill-formed lead byte is detected (and repaired) no matter where it falls
+        // relative to an 8-byte fast-path word, including exactly on a word boundary.
+        int len = 20;
+        for (int pos = 0; pos < len; pos++) {
+            byte[] bytes = new byte[len];
+            Arrays.fill(bytes, (byte) 'a');
+            bytes[pos] = (byte) 0xFF;
+            byte[] expected = concat(repeat((byte) 'a', pos), FFFD, repeat((byte) 'a', len - pos - 1));
+            assertSanitized(bytes, expected);
+        }
+    }
+
+    private static byte[] repeat(byte b, int count) {
+        byte[] out = new byte[count];
+        Arrays.fill(out, b);
+        return out;
     }
 
     public void testRespectsOffsetAndLength() {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ESQLDS] Speedup Utf8Sanitizer for ascii-only strings (#153530)