### PR TITLE
[8.19] Migrate eql mixed cluster tests to junit rule based test-cluster framework (#149258)

### DIFF
--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -11,7 +11,6 @@ import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
-apply plugin: 'elasticsearch.bc-upgrade-test'
 
 dependencies {
     javaRestTestImplementation project(':x-pack:qa')

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -1,9 +1,17 @@
-apply plugin: 'elasticsearch.legacy-java-rest-test'
-apply plugin: 'elasticsearch.bwc-test'
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
 
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.bwc-test'
+apply plugin: 'elasticsearch.bc-upgrade-test'
 
 dependencies {
     javaRestTestImplementation project(':x-pack:qa')
@@ -11,47 +19,19 @@ dependencies {
     javaRestTestImplementation project(path: xpackModule('eql'), configuration: 'default')
 }
 
-tasks.named("javaRestTest").configure { enabled = false }
-
 buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.0") &&
         v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
-    def cluster = testClusters.register(baseName) {
-        versions = [bwcVersion.toString(), project.version]
-        numberOfNodes = 3
-        testDistribution = 'DEFAULT'
-        setting 'xpack.security.enabled', 'false'
-        setting 'xpack.watcher.enabled', 'false'
-        setting 'xpack.ml.enabled', 'false'
-        setting 'xpack.eql.enabled', 'true'
-        setting 'xpack.license.self_generated.type', 'trial'
-        // for debugging purposes
-        // setting 'logger.org.elasticsearch.xpack.eql.plugin.TransportEqlSearchAction', 'TRACE'
-    }
-
-    tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-        useCluster cluster
-        mustRunAfter("precommit")
-        classpath = sourceSets.javaRestTest.runtimeClasspath
-        testClassesDirs = sourceSets.javaRestTest.output.classesDirs
-        def socketsProvider1 = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
-        def socketsProvider2 = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
-        doFirst {
-            // Getting the endpoints causes a wait for the cluster
-            println "Endpoints are: ${-> socketsProvider1.get()}"
-            println "Upgrading one node to create a mixed cluster"
-            getRegistry().get().nextNodeToNextVersion(cluster)
-            println "Upgrade complete, endpoints are: ${-> socketsProvider2.get()} }"
-        }
-        nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
-        nonInputProperties.systemProperty('tests.clustername', baseName)
-        systemProperty 'tests.bwc_nodes_version', bwcVersion.toString().replace('-SNAPSHOT', '')
-        systemProperty 'tests.new_nodes_version', project.version.toString().replace('-SNAPSHOT', '')
-
-        def bwcEnabled = project.bwc_tests_enabled
-        onlyIf("BWC tests disabled") { bwcEnabled }
+    tasks.register("v${bwcVersion}#javaRestTest", StandaloneRestIntegTestTask) {
+        usesBwcDistribution(bwcVersion)
+        systemProperty("tests.old_cluster_version", bwcVersion)
+        maxParallelForks = 1
     }
 
     tasks.register(bwcTaskName(bwcVersion)) {
-        dependsOn "${baseName}#mixedClusterTest"
+        dependsOn "v${bwcVersion}#javaRestTest"
     }
+}
+
+tasks.named("javaRestTest") {
+    enabled = false
 }

--- a/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/Clusters.java
+++ b/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/Clusters.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.eql.qa.mixed_node;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
+
+import java.util.stream.IntStream;
+
+public class Clusters {
+
+    private static final String OLD_CLUSTER_VERSION_STRING = System.getProperty("tests.old_cluster_version");
+
+    /**
+     * The old cluster version with -SNAPSHOT suffix stripped (for version comparison).
+     */
+    static final String OLD_CLUSTER_VERSION = OLD_CLUSTER_VERSION_STRING.replace("-SNAPSHOT", "");
+
+    static HttpHost[] oldNodeAddresses(ElasticsearchCluster cluster) {
+        return nodeAddresses(cluster, 0, 1);
+    }
+
+    static HttpHost[] newNodeAddresses(ElasticsearchCluster cluster) {
+        return nodeAddresses(cluster, 2);
+    }
+
+    private static HttpHost[] nodeAddresses(ElasticsearchCluster cluster, int... indices) {
+        return IntStream.of(indices).mapToObj(i -> HttpHost.create(cluster.getHttpAddress(i))).toArray(HttpHost[]::new);
+    }
+
+    /**
+     * Creates a mixed-version cluster with 3 nodes: 2 old version nodes (indices 0, 1) and 1 current version node (index 2).
+     * Mirrors the original testClusters setup of numberOfNodes=3 with one node upgraded to current.
+     * Note: xpack.eql.enabled is intentionally omitted — it is deprecated since 7.9.2 and always enabled.
+     */
+    public static ElasticsearchCluster mixedVersionCluster() {
+        boolean isDetachedVersion = System.getProperty("tests.bwc.refspec.main") != null;
+        return ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .withNode(node -> node.version(OLD_CLUSTER_VERSION_STRING, isDetachedVersion)) // index 0: old
+            .withNode(node -> node.version(OLD_CLUSTER_VERSION_STRING, isDetachedVersion)) // index 1: old
+            .withNode(node -> node.version(Version.CURRENT)) // index 2: new
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.watcher.enabled", "false")
+            .setting("xpack.ml.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial")
+            .build();
+    }
+}

--- a/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/Clusters.java
+++ b/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/Clusters.java
@@ -41,11 +41,10 @@ public class Clusters {
      * Note: xpack.eql.enabled is intentionally omitted — it is deprecated since 7.9.2 and always enabled.
      */
     public static ElasticsearchCluster mixedVersionCluster() {
-        boolean isDetachedVersion = System.getProperty("tests.bwc.refspec.main") != null;
         return ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            .withNode(node -> node.version(OLD_CLUSTER_VERSION_STRING, isDetachedVersion)) // index 0: old
-            .withNode(node -> node.version(OLD_CLUSTER_VERSION_STRING, isDetachedVersion)) // index 1: old
+            .withNode(node -> node.version(OLD_CLUSTER_VERSION_STRING)) // index 0: old
+            .withNode(node -> node.version(OLD_CLUSTER_VERSION_STRING)) // index 1: old
             .withNode(node -> node.version(Version.CURRENT)) // index 2: new
             .setting("xpack.security.enabled", "false")
             .setting("xpack.watcher.enabled", "false")

--- a/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
+++ b/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.eql.qa.mixed_node;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -18,6 +17,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.NotEqualMessageBuilder;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.eql.expression.function.EqlFunctionRegistry;
@@ -284,8 +284,7 @@ public class EqlSearchIT extends ESRestTestCase {
             Request request = new Request("POST", index + "/_eql/search?" + filterPath);
             StringBuilder payload = new StringBuilder("{\"query\":\"" + event + " where true\",\"size\":15");
             // Older versions don't support this option
-            if (nodesList.stream()
-                .allMatch(x -> x.transportVersion() != null && x.transportVersion().supports(TransportVersions.V_8_18_0))) {
+            if (Version.fromString(Clusters.OLD_CLUSTER_VERSION).onOrAfter("8.18.0")) {
                 if (randomBoolean()) {
                     payload.append(", \"allow_partial_search_results\": " + randomBoolean());
                 }
@@ -311,8 +310,7 @@ public class EqlSearchIT extends ESRestTestCase {
 
             StringBuilder payload = new StringBuilder("{\"query\":\"" + query + "\",\"filter\":" + filter);
             // Older versions don't support this option
-            if (nodesList.stream()
-                .allMatch(x -> x.transportVersion() != null && x.transportVersion().supports(TransportVersions.V_8_18_0))) {
+            if (Version.fromString(Clusters.OLD_CLUSTER_VERSION).onOrAfter("8.18.0")) {
                 if (randomBoolean()) {
                     payload.append(", \"allow_partial_search_results\": " + randomBoolean());
                 }

--- a/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
+++ b/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.eql.qa.mixed_node;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.http.HttpHost;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.Request;
@@ -14,14 +16,15 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.NotEqualMessageBuilder;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.eql.expression.function.EqlFunctionRegistry;
-import org.elasticsearch.xpack.ql.TestNode;
-import org.elasticsearch.xpack.ql.TestNodes;
 import org.elasticsearch.xpack.ql.expression.function.FunctionDefinition;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,7 +41,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableList;
-import static org.elasticsearch.xpack.ql.TestUtils.buildNodeAndVersions;
 import static org.elasticsearch.xpack.ql.TestUtils.readResource;
 
 /**
@@ -46,25 +48,30 @@ import static org.elasticsearch.xpack.ql.TestUtils.readResource;
  * The test is against a three-node cluster where one node is upgraded, the other two are on the old version.
  *
  */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class EqlSearchIT extends ESRestTestCase {
 
-    private static final String BWC_NODES_VERSION = System.getProperty("tests.bwc_nodes_version");
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.mixedVersionCluster();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     private static final String index = "test_eql_mixed_versions";
     private static int numShards;
     private static int numReplicas = 1;
     private static int numDocs;
-    private static TestNodes nodes;
-    private static List<TestNode> newNodes;
-    private static List<TestNode> bwcNodes;
+    private static HttpHost[] newNodeHosts;
+    private static HttpHost[] bwcNodeHosts;
 
     @Before
     public void createIndex() throws IOException {
-        nodes = buildNodeAndVersions(client(), BWC_NODES_VERSION);
-        numShards = nodes.size();
+        numShards = 3;
         numDocs = randomIntBetween(numShards, 15);
-        newNodes = new ArrayList<>(nodes.getNewNodes());
-        bwcNodes = new ArrayList<>(nodes.getBWCNodes());
+        newNodeHosts = Clusters.newNodeAddresses(cluster);
+        bwcNodeHosts = Clusters.oldNodeAddresses(cluster);
 
         String mappings = readResource(EqlSearchIT.class.getResourceAsStream("/eql_mapping.json"));
         createIndex(index, indexSettings(numShards, numReplicas).build(), mappings);
@@ -78,19 +85,19 @@ public class EqlSearchIT extends ESRestTestCase {
     }
 
     public void testEventsWithRequestToOldNodes() throws Exception {
-        assertEventsQueryOnNodes(bwcNodes);
+        assertEventsQueryOnNodes(bwcNodeHosts);
     }
 
     public void testEventsWithRequestToUpgradedNodes() throws Exception {
-        assertEventsQueryOnNodes(newNodes);
+        assertEventsQueryOnNodes(newNodeHosts);
     }
 
     public void testSequencesWithRequestToOldNodes() throws Exception {
-        assertSequncesQueryOnNodes(bwcNodes);
+        assertSequncesQueryOnNodes(bwcNodeHosts);
     }
 
     public void testSequencesWithRequestToUpgradedNodes() throws Exception {
-        assertSequncesQueryOnNodes(newNodes);
+        assertSequncesQueryOnNodes(newNodeHosts);
     }
 
     /**
@@ -111,9 +118,7 @@ public class EqlSearchIT extends ESRestTestCase {
             .collect(Collectors.toSet());
         // each function has a query and query results associated to it
         Set<String> testedFunctions = new HashSet<>();
-        try (
-            RestClient client = buildClient(restClientSettings(), newNodes.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
-        ) {
+        try (RestClient client = buildClient(restClientSettings(), newNodeHosts)) {
             // filter only the relevant bits of the response
             String filterPath = "filter_path=hits.events._id";
             Request request = new Request("POST", index + "/_eql/search?" + filterPath);
@@ -269,12 +274,10 @@ public class EqlSearchIT extends ESRestTestCase {
         assertTrue(testedFunctions.containsAll(availableFunctions));
     }
 
-    private void assertEventsQueryOnNodes(List<TestNode> nodesList) throws Exception {
+    private void assertEventsQueryOnNodes(HttpHost[] nodeHosts) throws Exception {
         final String event = randomEvent();
         Map<String, Object> expectedResponse = prepareEventsTestData(event);
-        try (
-            RestClient client = buildClient(restClientSettings(), nodesList.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
-        ) {
+        try (RestClient client = buildClient(restClientSettings(), nodeHosts)) {
             // filter only the relevant bits of the response
             String filterPath = "filter_path=hits.events._source.@timestamp,hits.events._source.event_type,hits.events._source.sequence";
 
@@ -296,11 +299,9 @@ public class EqlSearchIT extends ESRestTestCase {
         }
     }
 
-    private void assertSequncesQueryOnNodes(List<TestNode> nodesList) throws Exception {
+    private void assertSequncesQueryOnNodes(HttpHost[] nodeHosts) throws Exception {
         Map<String, Object> expectedResponse = prepareSequencesTestData();
-        try (
-            RestClient client = buildClient(restClientSettings(), nodesList.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
-        ) {
+        try (RestClient client = buildClient(restClientSettings(), nodeHosts)) {
             String filterPath = "filter_path=hits.sequences.join_keys,hits.sequences.events._id,hits.sequences.events._source";
             String query = "sequence by `sequence` with maxspan=100ms [success where true] by correlation_success1, correlation_success2 "
                 + "[failure where true] by correlation_failure1, correlation_failure2";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate eql mixed cluster tests to junit rule based test-cluster framework (#149258)](https://github.com/elastic/elasticsearch/pull/149258)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)