### PR TITLE
[9.5] [Gradle] Use binary distro for gradle wrapper (#153802)

### DIFF
--- a/build-tools-internal/gradle/wrapper/gradle-wrapper.properties
+++ b/build-tools-internal/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=61ba77b3ff7167e60962763eb4bae79db7120c189b9544358d0ade3c1e712a83
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/build.gradle
+++ b/build.gradle
@@ -494,7 +494,7 @@ tasks.register("branchConsistency") {
 }
 
 tasks.named("wrapper").configure {
-  distributionType = 'ALL'
+  distributionType = 'BIN'
   def minimumGradleVersionFile = project.file('build-tools-internal/src/main/resources/minimumGradleVersion')
   doLast {
     // copy wrapper properties file to build-tools-internal to allow seamless idea integration

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=61ba77b3ff7167e60962763eb4bae79db7120c189b9544358d0ade3c1e712a83
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/plugins/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=61ba77b3ff7167e60962763eb4bae79db7120c189b9544358d0ade3c1e712a83
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Gradle] Use binary distro for gradle wrapper (#153802)