### PR TITLE
Preserve the sort value format in top_hits cross-shard reduce

### DIFF
--- a/docs/changelog/153870.yaml
+++ b/docs/changelog/153870.yaml
@@ -1,0 +1,6 @@
+pr: 153870
+summary: Preserve the sort value format in the `top_hits` aggregation reduce
+area: Aggregations
+type: bug
+issues:
+ - 144130

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -14,7 +14,6 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
@@ -37,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Results of the {@link TopHitsAggregator}.
@@ -187,13 +187,13 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
             } while (topDocsForShard.scoreDocs[position] != scoreDoc);
             SearchHit hit = aggregations.get(shardIndex).searchHits.getAt(position);
             if (scoreDoc instanceof FieldDoc fieldDoc && fieldDoc.fields != null && fieldDoc.fields.length > 0) {
-                Object[] existingFormatted = hit.getSortValues();
-                boolean hasBytesRef = Arrays.stream(fieldDoc.fields).anyMatch(f -> f instanceof BytesRef);
-                if (hasBytesRef && existingFormatted != null && existingFormatted.length == fieldDoc.fields.length) {
-                    // Preserve the shard's formatted values for BytesRef fields (e.g. version, keyword)
-                    // so we don't format them with RAW, which assumes UTF-8 and fails on version encoding.
+                Object[] shardFormatted = hit.getSortValues();
+                if (shardFormatted != null && shardFormatted.length == fieldDoc.fields.length) {
                     hit.sortValues(
-                        SearchSortValues.fromFormattedAndRaw(buildFormattedSortValues(fieldDoc.fields, existingFormatted), fieldDoc.fields)
+                        SearchSortValues.fromFormattedAndRaw(
+                            reduceFormattedSortValues(fieldDoc.fields, shardFormatted, hit.getRawSortValues()),
+                            fieldDoc.fields
+                        )
                     );
                 } else {
                     DocValueFormat[] formats = new DocValueFormat[fieldDoc.fields.length];
@@ -208,17 +208,18 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
     }
 
     /**
-     * Build formatted sort values: use existing formatted value for BytesRef (e.g. version) fields
-     * to avoid re-formatting with RAW (UTF-8), and use RAW for numeric types.
+     * Rebuild the formatted sort values for a hit chosen during the cross-shard merge.
+     * <p>
+     * When a shard applied a non-RAW format its formatted sort value differs from the raw one (e.g. dates render
+     * as strings, versions and keywords keep their original bytes); reuse that value so the format survives the
+     * reduce. When the shard used RAW (formatted equals raw) format the merged raw value with RAW, which also
+     * reflects any numeric type coercion applied while merging incompatible sort types across shards.
      */
-    private static Object[] buildFormattedSortValues(Object[] rawValues, Object[] existingFormatted) {
-        Object[] formatted = new Object[rawValues.length];
-        for (int i = 0; i < rawValues.length; i++) {
-            if (rawValues[i] instanceof BytesRef && existingFormatted != null && i < existingFormatted.length) {
-                formatted[i] = existingFormatted[i];
-            } else {
-                formatted[i] = DocValueFormat.RAW.formatSortValue(rawValues[i]);
-            }
+    private static Object[] reduceFormattedSortValues(Object[] mergedRawValues, Object[] shardFormatted, Object[] shardRaw) {
+        Object[] formatted = new Object[mergedRawValues.length];
+        for (int i = 0; i < mergedRawValues.length; i++) {
+            boolean shardAppliedFormat = shardRaw != null && i < shardRaw.length && Objects.equals(shardFormatted[i], shardRaw[i]) == false;
+            formatted[i] = shardAppliedFormat ? shardFormatted[i] : DocValueFormat.RAW.formatSortValue(mergedRawValues[i]);
         }
         return formatted;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -23,10 +23,12 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -44,6 +46,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -350,6 +353,45 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         }
     }
 
+    public void testReducePreservesDateSortValueFormat() {
+        AggregationBuilder builder = mock(AggregationBuilder.class);
+        List<SearchHits> topHitsToRelease = new ArrayList<>();
+        AggregationReduceContext reduceContext = InternalAggregationTestCase.mockReduceContext(builder).forFinalReduction(topHitsToRelease);
+
+        // A date sort carries a DateTime format with sort-value formatting enabled (see FieldSortBuilder), so a shard
+        // hit's sort value is already the formatted date string. The reduce path must keep that string rather than
+        // re-formatting the raw epoch millis with RAW, which would surface the raw long instead. Regression: #144130.
+        DocValueFormat dateFormat = DocValueFormat.enableFormatSortValues(
+            new DocValueFormat.DateTime(
+                DateFormatter.forPattern("strict_date_optional_time"),
+                ZoneOffset.UTC,
+                DateFieldMapper.Resolution.MILLISECONDS
+            )
+        );
+        long earlierMillis = 1_600_000_000_000L;
+        long laterMillis = 1_700_000_000_000L;
+
+        InternalTopHits shard0 = createTopHitsWithSortValue("test", SortField.Type.LONG, laterMillis, dateFormat, 2, 0);
+        InternalTopHits shard1 = createTopHitsWithSortValue("test", SortField.Type.LONG, earlierMillis, dateFormat, 2, 1);
+        try {
+            InternalTopHits reduced = (InternalTopHits) InternalAggregationTestCase.reduce(List.of(shard0, shard1), reduceContext);
+            assertNotNull("Reduced result should not be null", reduced);
+            SearchHit[] hits = reduced.getHits().getHits();
+            assertThat("both shard hits should survive the merge", hits.length, equalTo(2));
+            for (SearchHit hit : hits) {
+                Object formatted = hit.getSortValues()[0];
+                Object raw = hit.getRawSortValues()[0];
+                assertThat("raw sort value should stay the epoch millis", raw, instanceOf(Long.class));
+                assertThat("date sort value must stay formatted, not the raw epoch", formatted, instanceOf(String.class));
+                assertThat(formatted, equalTo(dateFormat.format((Long) raw)));
+            }
+            releaseTopHits(topHitsToRelease);
+        } finally {
+            shard0.getHits().decRef();
+            shard1.getHits().decRef();
+        }
+    }
+
     /**
      * Round-trip serialization reads SearchHits with pooled=true so that coordinator can release them.
      * This test ensures deserialized InternalTopHits has pooled hits when they have source, and content equality is preserved.
@@ -406,6 +448,32 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
 
         TopDocsAndMaxScore topDocsAndMaxScore = new TopDocsAndMaxScore(topFieldDocs, 1.0f);
         return new InternalTopHits(name, 0, 1, topDocsAndMaxScore, searchHits, null);
+    }
+
+    private InternalTopHits createTopHitsWithSortValue(
+        String name,
+        SortField.Type type,
+        Object rawSortValue,
+        DocValueFormat format,
+        int size,
+        int shardIndex
+    ) {
+        SortField sortField = new SortField("field", type);
+        FieldDoc fieldDoc = new FieldDoc(0, 1.0f, new Object[] { rawSortValue });
+        TopFieldDocs topFieldDocs = new TopFieldDocs(
+            new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+            new FieldDoc[] { fieldDoc },
+            new SortField[] { sortField }
+        );
+        fieldDoc.shardIndex = shardIndex;
+
+        SearchHit hit = new SearchHit(0, "doc" + shardIndex);
+        hit.score(1.0f);
+        hit.sortValues(new Object[] { rawSortValue }, new DocValueFormat[] { format });
+        SearchHits searchHits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+
+        TopDocsAndMaxScore topDocsAndMaxScore = new TopDocsAndMaxScore(topFieldDocs, 1.0f);
+        return new InternalTopHits(name, 0, size, topDocsAndMaxScore, searchHits, null);
     }
 
     @Override


### PR DESCRIPTION
Since #141919, the `top_hits` aggregation loses the sort `format` during the cross-shard reduce. When rebuilding the merged hits, `InternalTopHits` re-derived the sort values with `DocValueFormat.RAW` for every non-`BytesRef` field, so a date sort key came back as raw epoch millis (e.g. `1700000000000`) instead of the formatted string (e.g. `2023-11-14T22:13:20.000Z`).

Closes #144130 — Kibana's Logs UI is currently blocked on this (elastic/kibana#259214).

### Fix

The shard already formatted its sort values with each field's real `DocValueFormat`, so during reduce we now reuse that formatted value whenever the shard applied a non-RAW format — detected by the formatted value differing from the raw one (dates, `version`, `keyword`). We only fall back to formatting the merged raw value with `RAW` when the shard itself used RAW, which keeps the existing numeric type coercion when merging incompatible sort types across shards. This generalizes the previous `BytesRef`-only special case (version/keyword) to all non-RAW formats.

### Test

`InternalTopHitsTests.testReducePreservesDateSortValueFormat` reduces two shards sorted on a date field (`DocValueFormat.DateTime` with sort-value formatting enabled, as `FieldSortBuilder` sets it up) and asserts every reduced hit keeps the formatted date string with the raw epoch preserved. It fails on `main` (RAW turns it back into a raw `Long`) and passes with this change. The existing `testReduceWithMixedSortFieldTypes` (INT/LONG coercion) still passes.
