### PR TITLE
ES|QL: make date_nanos declarable for external datasets

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -5825,10 +5825,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private Object tryParseDateNanos(String value, int columnIndex) {
             // Mirrors tryParseDatetime exactly, one rail down: a column with a declared `format` parses strictly with
             // that ES DateFormatter, overriding the epoch shortcut and the file-level datetime_format, for THIS column
-            // only. Both rails go through EsqlDataTypeConverter.dateNanosToLong, so the declared and file-level formats
-            // agree with each other. No cross-format claim here, unlike tryParseDatetime: the columnar readers' string
-            // -> date_nanos coercion (DeclaredTypeCoercions.scalarCoercer) still uses the no-format overload, and NDJSON
-            // has no date_nanos support at all.
+            // only. Every rail goes through EsqlDataTypeConverter.dateNanosToLong — the SAME string -> date_nanos
+            // conversion the columnar declared coercion (DeclaredTypeCoercions.scalarCoercer, which threads the
+            // declared format) and the NDJSON decode arm use — so identical bytes with an identical declared format
+            // yield the same instant across every format. A bare numeric cell is epoch NANOS: the declared type names
+            // the numeric unit (datetime = millis, date_nanos = nanos; see DeclaredTypeCoercions).
             if (columnIndex >= 0
                 && declaredFormatters != null
                 && columnIndex < declaredFormatters.length

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -8191,6 +8191,8 @@ public class CsvFormatReaderTests extends ESTestCase {
             "true",
             DataType.DATETIME,
             "2020-01-01T00:00:00.000Z",
+            DataType.DATE_NANOS,
+            "2020-01-01T00:00:00.000Z",
             DataType.UNSIGNED_LONG,
             "18446744073709551615",
             DataType.IP,

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -1667,6 +1667,7 @@ public class NdJsonPageDecoder implements Closeable {
                 case UNSIGNED_LONG -> decodeUnsignedLongValue(parser, token, inArray);
                 case DOUBLE -> decodeDoubleValue(parser, token, inArray);
                 case DATETIME -> decodeDatetimeValue(parser, token, inArray);
+                case DATE_NANOS -> decodeDateNanosValue(parser, token, inArray);
                 case KEYWORD, TEXT -> {
                     var chars = CharBuffer.wrap(parser.getTextCharacters(), parser.getTextOffset(), parser.getTextLength());
                     ((BytesRefBlock.Builder) blockBuilder).appendBytesRef(toScratchBytesRef(chars));
@@ -1856,6 +1857,60 @@ public class NdJsonPageDecoder implements Closeable {
             } else {
                 // a boolean, or a fractional number, in a datetime column: unsupported cross-kind drift
                 crossKindDrift(parser, inArray, DataType.DATETIME);
+            }
+        }
+
+        /**
+         * The {@code date_nanos} twin of {@link #decodeDatetimeValue}, one rail down — mirroring
+         * {@code CsvFormatReader.tryParseDateNanos} exactly:
+         * <ul>
+         *   <li>a declared {@code format} is authoritative and OVERRIDES the numeric-epoch shortcut, exactly as
+         *       the datetime arm above (declared formatters win over token kind);</li>
+         *   <li>a numeric token without one is epoch <b>nanoseconds</b> — the declared type names the numeric
+         *       unit ({@code datetime} = millis, {@code date_nanos} = nanos; see {@code DeclaredTypeCoercions}).
+         *       A negative epoch has no {@code date_nanos} representation, so it fails the cell through the
+         *       error policy rather than ever emitting a negative nanos long;</li>
+         *   <li>a string token without one parses with the file-level {@link #datetimeFormatter} — the same
+         *       rail the datetime arm and CSV use ({@code strict_date_optional_time} by default, which parses
+         *       nanosecond fractions) — but through {@code dateNanosToLong} so the instant lands in nanos.</li>
+         * </ul>
+         * Every parse arm goes through {@link EsqlDataTypeConverter#dateNanosToLong}, the SAME string -&gt;
+         * date_nanos conversion the columnar declared coercion and CSV use, so identical bytes with an
+         * identical declared format yield the same instant across every format. A boolean or a fractional
+         * number is an unsupported cross-kind drift, matching the datetime arm.
+         */
+        private void decodeDateNanosValue(JsonParser parser, JsonToken token, boolean inArray) throws IOException {
+            if (declaredFormatter != null && (token == JsonToken.VALUE_STRING || token == JsonToken.VALUE_NUMBER_INT)) {
+                try {
+                    ((LongBlock.Builder) blockBuilder).appendLong(
+                        EsqlDataTypeConverter.dateNanosToLong(parser.getValueAsString(), declaredFormatter)
+                    );
+                } catch (IllegalArgumentException | InvalidArgumentException | DateTimeException e) {
+                    coercionFailure(blockBuilder, parser, inArray, DataType.DATE_NANOS);
+                }
+            } else if (token == JsonToken.VALUE_NUMBER_INT) {
+                try {
+                    long nanos = parser.getLongValue();
+                    if (nanos < 0) {
+                        // pre-epoch: no date_nanos representation — per-cell failure, never a negative nanos long
+                        coercionFailure(blockBuilder, parser, inArray, DataType.DATE_NANOS);
+                    } else {
+                        ((LongBlock.Builder) blockBuilder).appendLong(nanos);
+                    }
+                } catch (InputCoercionException e) {
+                    coercionFailure(blockBuilder, parser, inArray, DataType.DATE_NANOS); // beyond-long epoch: a real value error
+                }
+            } else if (token == JsonToken.VALUE_STRING) {
+                try {
+                    ((LongBlock.Builder) blockBuilder).appendLong(
+                        EsqlDataTypeConverter.dateNanosToLong(parser.getValueAsString(), datetimeFormatter)
+                    );
+                } catch (IllegalArgumentException | InvalidArgumentException | DateTimeException e) {
+                    coercionFailure(blockBuilder, parser, inArray, DataType.DATE_NANOS);
+                }
+            } else {
+                // a boolean, or a fractional number, in a date_nanos column: unsupported cross-kind drift
+                crossKindDrift(parser, inArray, DataType.DATE_NANOS);
             }
         }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.esql.datasources.DeclaredSchemaValidator;
 import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
+import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import org.hamcrest.Matchers;
 import org.junit.After;
 
@@ -550,6 +551,88 @@ public class NdJsonPageDecoderTests extends ESTestCase {
         }
     }
 
+    // --- declared date_nanos reads ---
+
+    /**
+     * An ISO string in a declared date_nanos column parses through the file-level formatter rail
+     * (strict_date_optional_time by default) into dateNanosToLong — and sub-millisecond digits SURVIVE:
+     * strict_date_optional_time parses fractions to nanosecond resolution, so the default rail does not
+     * truncate the very precision the type exists for.
+     */
+    public void testDeclaredDateNanosIsoStringKeepsNanoPrecision() throws IOException {
+        String ndjson = "{\"v\":\"2024-01-15T12:34:56.123456789Z\"}\n";
+        try (Page page = decodeOneColumn(ndjson, DataType.DATE_NANOS, ErrorPolicy.STRICT)) {
+            LongBlock block = page.getBlock(0);
+            assertEquals(EsqlDataTypeConverter.dateNanosToLong("2024-01-15T12:34:56.123456789Z"), block.getLong(0));
+        }
+    }
+
+    /**
+     * A numeric token in a declared date_nanos column is epoch NANOSECONDS — the declared type names the
+     * numeric unit (datetime = millis, date_nanos = nanos) — matching the CSV numeric rail and the columnar
+     * whole-number identity coercion. NOT the mapper-ingest millis reading.
+     */
+    public void testDeclaredDateNanosNumericTokenIsEpochNanos() throws IOException {
+        long nanos = 1_700_000_000_123_456_789L;
+        try (Page page = decodeOneColumn("{\"v\":" + nanos + "}\n", DataType.DATE_NANOS, ErrorPolicy.STRICT)) {
+            LongBlock block = page.getBlock(0);
+            assertEquals("identity epoch-nanos reinterpret, no scaling", nanos, block.getLong(0));
+        }
+    }
+
+    /**
+     * A declared `format` is authoritative and OVERRIDES the numeric-epoch shortcut, exactly as the datetime
+     * arm does: a column declared {date_nanos, format:"yyyyMMdd"} reads the token 20260101 as 2026-01-01, NOT
+     * as an epoch-nanos number.
+     */
+    public void testDeclaredDateNanosFormatOverridesNumericShortcut() throws IOException {
+        String ndjson = "{\"ts\":20260101}\n";
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                null, // file-level formatter unused; the column carries its own declared format
+                List.of(attribute("ts", DataType.DATE_NANOS)),
+                null,
+                10,
+                blockFactory,
+                ErrorPolicy.STRICT,
+                "test://declared-date-nanos",
+                new NdJsonReaderCounters(),
+                Map.of("ts", "yyyyMMdd")
+            )
+        ) {
+            try (Page page = decoder.decodePage()) {
+                assertNotNull(page);
+                assertEquals(EsqlDataTypeConverter.dateNanosToLong("2026-01-01T00:00:00Z"), ((LongBlock) page.getBlock(0)).getLong(0));
+            }
+        }
+    }
+
+    /**
+     * A negative epoch has no date_nanos representation: never a negative nanos long — the cell fails through
+     * the error policy (null_field nulls + warns; fail_fast fails the read).
+     */
+    public void testDeclaredDateNanosNegativeEpochIsPerCellFailure() throws IOException {
+        try (Page page = decodeOneColumn("{\"v\":-1}\n{\"v\":5}\n", DataType.DATE_NANOS, ErrorPolicy.PERMISSIVE)) {
+            LongBlock block = page.getBlock(0);
+            assertTrue("negative epoch nulls the cell", block.isNull(0));
+            assertEquals("the good cell still decodes", 5L, block.getLong(block.getFirstValueIndex(1)));
+        }
+        drainWarnings();
+        expectThrows(EsqlIllegalArgumentException.class, () -> decodeOneColumn("{\"v\":-1}\n", DataType.DATE_NANOS, ErrorPolicy.STRICT));
+    }
+
+    /** A boolean or a fractional number in a date_nanos column is an unsupported cross-kind drift, matching datetime. */
+    public void testDeclaredDateNanosCrossKindDrift() throws IOException {
+        try (Page page = decodeOneColumn("{\"v\":true}\n{\"v\":1.5}\n{\"v\":7}\n", DataType.DATE_NANOS, ErrorPolicy.PERMISSIVE)) {
+            LongBlock block = page.getBlock(0);
+            assertTrue("boolean in a date_nanos column nulls the cell", block.isNull(0));
+            assertTrue("fractional number in a date_nanos column nulls the cell", block.isNull(1));
+            assertEquals(7L, block.getLong(block.getFirstValueIndex(2)));
+        }
+        drainWarnings();
+    }
+
     /**
      * Reads the response-header warnings emitted on the test thread and clears them so the parent
      * {@code ensureNoWarnings} post-check passes. Returns the unwrapped warning messages.
@@ -716,6 +799,8 @@ public class NdJsonPageDecoderTests extends ESTestCase {
             DataType.BOOLEAN,
             "true",
             DataType.DATETIME,
+            "\"2020-01-01T00:00:00.000Z\"",
+            DataType.DATE_NANOS,
             "\"2020-01-01T00:00:00.000Z\"",
             DataType.UNSIGNED_LONG,
             "18446744073709551615",

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -91,6 +91,55 @@ final class ParquetColumnDecoding {
     }
 
     /**
+     * The nanoseconds-per-stored-tick divisor for pushing an epoch-nanoseconds ({@code DATE_NANOS}) filter
+     * literal against a physical column's raw footer statistics, or {@code null} when the raw statistics are
+     * not expressible as epoch-nanoseconds and the predicate must NOT be pushed (a wrongly-pruned row group is
+     * never read — RECHECK guards false positives, not rows that were never decoded).
+     * <p>
+     * Now that {@code date_nanos} is declarable, a {@code DATE_NANOS} predicate can sit over ANY physical column
+     * a declared read admits — not only the inferred {@code TIMESTAMP(MICROS|NANOS)} shapes this used to assume.
+     * So this is an explicit ALLOW-list over what is provably pushable, not a decline-list of known-bad
+     * annotations (a decline-list is exactly what would miss the next TIME-like case):
+     * <ul>
+     *   <li>{@code TIMESTAMP(NANOS)} &rarr; 1 (identity);</li>
+     *   <li>{@code TIMESTAMP(MICROS)} &rarr; {@link #NANOS_PER_MICRO};</li>
+     *   <li>{@code TIMESTAMP(MILLIS)} &rarr; {@link #NANOS_PER_MILLI} — a declared {@code date_nanos} over a
+     *       millis column rides the {@code DATETIME -> DATE_NANOS} coercion, so every decoded value is exactly
+     *       {@code t x 1_000_000} (or null, which no filter matches);</li>
+     *   <li>no annotation on a signed {@code INT64} &rarr; 1 — the declared-read unit convention's identity
+     *       case: a raw whole number declared {@code date_nanos} IS epoch-nanos, so raw stats equal scan
+     *       values bit-for-bit;</li>
+     *   <li><b>everything else declines</b>: {@code TIME} (nanos-of-day, not an epoch — and {@code TIME(MICROS)}
+     *       additionally scales x1_000 at decode while its stats stay raw), unsigned {@code INT64} (sign-wrap
+     *       ordering), {@code DECIMAL}, non-{@code INT64} primitives, and any annotation this method has never
+     *       heard of.</li>
+     * </ul>
+     * Lives here, next to the decode transforms it summarizes, for the same no-drift reason as
+     * {@link #integralDecodeScalesRelativeToRawStats}. Consulted by both {@code
+     * ParquetPushedExpressions.buildDateNanosPredicate} and {@code translateDateNanosIn} so the comparison and
+     * {@code IN} paths cannot disagree; the same built predicate also drives page-level pruning
+     * ({@code ColumnIndexRowRangesComputer}), which is therefore guarded by the same divisor.
+     */
+    @Nullable
+    static Long dateNanosPushdownDivisor(PrimitiveType primitiveType) {
+        if (primitiveType.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
+            return null;
+        }
+        LogicalTypeAnnotation logical = primitiveType.getLogicalTypeAnnotation();
+        if (logical == null) {
+            return 1L;
+        }
+        if (logical instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return switch (ts.getUnit()) {
+                case NANOS -> 1L;
+                case MICROS -> NANOS_PER_MICRO;
+                case MILLIS -> NANOS_PER_MILLI;
+            };
+        }
+        return null;
+    }
+
+    /**
      * Whether decoding a physical column with logical annotation {@code annotation} into an ESQL integral value
      * ({@code long}/{@code integer}) applies a scaling factor that the raw parquet footer statistics do NOT carry, so
      * a raw integral predicate pushed against those stats would mis-prune. This is the ground truth for the pushdown

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -697,13 +697,16 @@ final class ParquetPushedExpressions {
     }
 
     /**
-     * Builds a predicate for an ESQL {@code DATE_NANOS} column, whose query literal is epoch-nanoseconds. A
-     * {@code DATE_NANOS} column is only ever INFERRED from a physical {@code TIMESTAMP(MICROS)} (×1_000 to nanos) or
-     * {@code TIMESTAMP(NANOS)} (identity) column — {@code date_nanos} is not a declarable type, and {@code
-     * TIMESTAMP(MILLIS)} infers to {@code datetime} — so the nanosecond bound is converted to microseconds (or left
-     * as nanos), rounded outward via {@link #boundToPhysicalUnit} so the pushed predicate is never stricter than the
-     * true nanosecond predicate. Safe because temporal pushdown is always RECHECK (see
-     * {@link ParquetFilterPushdownSupport#isFullyEvaluable}), so {@code FilterExec} re-applies the exact semantics.
+     * Builds a predicate for an ESQL {@code DATE_NANOS} column, whose query literal is epoch-nanoseconds. Since
+     * {@code date_nanos} became declarable, this column can sit over any physical INT64 a declared read admits —
+     * not only the inferred {@code TIMESTAMP(MICROS|NANOS)} shapes — so the divisor comes from the explicit
+     * allow-list {@link ParquetColumnDecoding#dateNanosPushdownDivisor} (timestamps in all three units plus the
+     * un-annotated signed INT64 identity case; everything else — TIME, unsigned, unknown — declines rather than
+     * pushing a raw-unit predicate that silently prunes matching row groups). The nanosecond bound is converted
+     * to the stored unit, rounded outward via {@link #boundToPhysicalUnit} so the pushed predicate is never
+     * stricter than the true nanosecond predicate. Safe because temporal pushdown is always RECHECK (see
+     * {@link ParquetFilterPushdownSupport#isFullyEvaluable}), so {@code FilterExec} re-applies the exact
+     * semantics — while a decline merely loses pruning, never rows.
      */
     private static FilterPredicate buildDateNanosPredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
@@ -711,12 +714,14 @@ final class ParquetPushedExpressions {
             return null;
         }
         if (value == null) {
+            // IS NULL / IS NOT NULL reason over null counts only — unit-independent, so no divisor gate.
             return orderedPredicate(FilterApi.longColumn(columnName), null, op);
         }
+        Long divisor = ParquetColumnDecoding.dateNanosPushdownDivisor(ptype);
+        if (divisor == null) {
+            return null;
+        }
         long nanos = ((Number) value).longValue();
-        long divisor = ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation())
-            ? ParquetColumnDecoding.NANOS_PER_MICRO
-            : 1L;
         Long bound = boundToPhysicalUnit(nanos, op, divisor);
         return bound == null ? null : orderedPredicate(FilterApi.longColumn(columnName), bound, op);
     }
@@ -874,29 +879,35 @@ final class ParquetPushedExpressions {
     }
 
     /**
-     * {@code IN} counterpart to {@link #buildDateNanosPredicate}. The query literals are epoch-nanoseconds. For a
-     * physical {@code NANOS} column each value is pushed exactly. For a {@code MICROS} column, an element can only
-     * equal a stored value when it is an exact multiple of 1_000 ns; non-multiples are dropped (they can never match,
-     * so omitting them keeps the pushed set a correct subset). If every element is dropped, no predicate is pushed and
+     * {@code IN} counterpart to {@link #buildDateNanosPredicate}. The query literals are epoch-nanoseconds. The
+     * divisor comes from the same {@link ParquetColumnDecoding#dateNanosPushdownDivisor} allow-list, so the two
+     * {@code DATE_NANOS} push paths cannot disagree: an identity column (NANOS, or the un-annotated signed INT64
+     * a declared {@code date_nanos} reads as raw epoch-nanos) pushes each value exactly; a scaled column (MICROS,
+     * MILLIS) can only match an element that is an exact multiple of the stored tick — non-multiples are dropped
+     * (they can never match, so omitting them keeps the pushed set a correct subset); an un-pushable physical
+     * (TIME, unsigned INT64, unknown) declines entirely. If every element is dropped, no predicate is pushed and
      * the scan + recheck yields the (empty) result.
      */
     private static FilterPredicate translateDateNanosIn(String columnName, List<Object> rawValues, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
-        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
+        if (ptype == null) {
             return null;
         }
-        // A DATE_NANOS column is only ever inferred from TIMESTAMP(MICROS) (÷1_000) or TIMESTAMP(NANOS) (identity).
-        if (ParquetColumnDecoding.isMicrosTimestamp(ptype.getLogicalTypeAnnotation()) == false) {
+        Long divisor = ParquetColumnDecoding.dateNanosPushdownDivisor(ptype);
+        if (divisor == null) {
+            return null;
+        }
+        if (divisor == 1L) {
             return inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
         }
-        List<Object> micros = new ArrayList<>();
+        List<Object> ticks = new ArrayList<>();
         for (Object v : rawValues) {
             long nanos = ((Number) v).longValue();
-            if (nanos % ParquetColumnDecoding.NANOS_PER_MICRO == 0) {
-                micros.add(nanos / ParquetColumnDecoding.NANOS_PER_MICRO);
+            if (nanos % divisor == 0) {
+                ticks.add(nanos / divisor);
             }
         }
-        return micros.isEmpty() ? null : inPredicate(FilterApi.longColumn(columnName), micros, v -> (Long) v);
+        return ticks.isEmpty() ? null : inPredicate(FilterApi.longColumn(columnName), ticks, v -> (Long) v);
     }
 
     private static <T extends Comparable<T>, C extends Operators.Column<T> & Operators.SupportsEqNotEq> FilterPredicate inPredicate(

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -446,6 +446,131 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         assertThat(repr, containsString(String.valueOf(nanos2 / 1_000)));
     }
 
+    // --- Declared DATE_NANOS over other physical units (newly reachable: date_nanos is declarable) ---
+
+    /**
+     * A column DECLARED {@code date_nanos} over a physical {@code TIMESTAMP(MILLIS)} column decodes each stored
+     * milli as {@code t x 1_000_000} nanos (the {@code DATETIME -> DATE_NANOS} coercion), so the raw footer
+     * statistics are 10^6 smaller than the query literal. Without the unit allow-list the divisor fell through
+     * to 1 and the raw NANOS literal was pushed against MILLIS stats: {@code WHERE ts > <instant>} pruned every
+     * row group and returned silently empty results — pruning is unrecoverable, RECHECK only re-filters rows
+     * that were read. The guard pushes the bound converted to the stored milli unit, rounded outward.
+     */
+    public void testDeclaredDateNanosOverTimestampMillisPushesMillisBound() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts")
+            .named("test");
+
+        long nanos = 1_700_000_000_123_456_789L; // not a milli tick: GT must floor to the stored unit
+        long expectedMillis = Math.floorDiv(nanos, 1_000_000L);
+        Expression expr = new GreaterThan(Source.EMPTY, attr("ts", DataType.DATE_NANOS), lit(nanos, DataType.DATE_NANOS), null);
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull("declared date_nanos over TIMESTAMP(MILLIS) pushes the millis-converted bound", fp);
+        assertThat(fp.toString(), containsString(String.valueOf(expectedMillis)));
+        // The load-bearing red-without-the-guard assertion: the raw nanos literal must never reach the footer.
+        assertThat(fp.toString(), not(containsString(String.valueOf(nanos))));
+    }
+
+    /** The Range path (both bounds) rides buildDateNanosPredicate and must convert both bounds to millis. */
+    public void testDeclaredDateNanosRangeOverTimestampMillisConvertsBothBounds() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts")
+            .named("test");
+
+        long lowerNanos = 1_700_000_000_000_000_000L; // exact milli ticks: GTE/LTE stay exact
+        long upperNanos = 1_700_000_100_000_000_000L;
+        Expression range = new Range(
+            Source.EMPTY,
+            attr("ts", DataType.DATE_NANOS),
+            lit(lowerNanos, DataType.DATE_NANOS),
+            true,
+            lit(upperNanos, DataType.DATE_NANOS),
+            true,
+            ZoneOffset.UTC
+        );
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(range)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(lowerNanos / 1_000_000L)));
+        assertThat(fp.toString(), containsString(String.valueOf(upperNanos / 1_000_000L)));
+        // RED without the guard: the raw nanos bounds would appear verbatim.
+        assertThat(fp.toString(), not(containsString(String.valueOf(lowerNanos))));
+        assertThat(fp.toString(), not(containsString(String.valueOf(upperNanos))));
+    }
+
+    /**
+     * The IN path has the same unit hazard: elements convert to the stored milli unit; an element that is not
+     * an exact milli tick can never match a stored value and is dropped from the pushed set (a correct subset).
+     */
+    public void testDeclaredDateNanosInOverTimestampMillisConvertsAndDropsNonTicks() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+            .named("ts")
+            .named("test");
+
+        long tick = 1_700_000_000_123_000_000L;    // exact milli tick -> pushed as 1_700_000_000_123
+        long nonTick = 1_700_000_000_123_456_789L; // no stored milli equals it -> dropped
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("ts", DataType.DATE_NANOS),
+            List.of(lit(tick, DataType.DATE_NANOS), lit(nonTick, DataType.DATE_NANOS))
+        );
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString(String.valueOf(tick / 1_000_000L)));
+        // RED without the guard: both raw nanos values were pushed verbatim against millis stats.
+        assertThat(fp.toString(), not(containsString(String.valueOf(tick))));
+        assertThat(fp.toString(), not(containsString(String.valueOf(nonTick))));
+    }
+
+    /**
+     * A physical {@code TIME(MICROS)} column maps to LONG at inference, so a declared {@code date_nanos} over
+     * it is reachable once {@code supports(LONG, DATE_NANOS)} holds. TIME is nanos-of-day, not an epoch — and
+     * {@code isMicrosTimestamp} tests the Timestamp annotation, so before the allow-list a Time annotation fell
+     * through to divisor 1 while the scan separately scales x1_000: a guaranteed mis-prune. Both the comparison
+     * and the IN path must decline.
+     */
+    public void testDeclaredDateNanosOverTimeColumnDeclinesPushdown() {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .as(LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .named("t")
+            .named("test");
+
+        Expression cmp = new GreaterThan(Source.EMPTY, attr("t", DataType.DATE_NANOS), lit(43_200_000_000_000L, DataType.DATE_NANOS), null);
+        assertNull("date_nanos over TIME(MICROS) must not push", new ParquetPushedExpressions(List.of(cmp)).toFilterPredicate(schema));
+
+        Expression inExpr = new In(Source.EMPTY, attr("t", DataType.DATE_NANOS), List.of(lit(43_200_000_000_000L, DataType.DATE_NANOS)));
+        assertNull(
+            "date_nanos IN over TIME(MICROS) must not push",
+            new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema)
+        );
+    }
+
+    /**
+     * The allow-list's identity case and its unsigned decline: an un-annotated signed INT64 declared
+     * {@code date_nanos} is the unit convention's identity read (raw stats == scan values bit-for-bit), so it
+     * pushes with divisor 1 — declining it would be a needless lost-pruning cost; an unsigned INT64
+     * ({@code intType(64, false)}) decodes sign-wrapped and must decline.
+     */
+    public void testDeclaredDateNanosOverPlainInt64PushesIdentityAndUnsignedDeclines() {
+        long nanos = 1_700_000_000_123_456_789L;
+        MessageType plain = Types.buildMessage().required(INT64).named("n").named("test");
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(eq("n", DataType.DATE_NANOS, nanos))).toFilterPredicate(plain);
+        assertNotNull("un-annotated signed INT64 is the identity case and must push", fp);
+        assertThat(fp.toString(), containsString(String.valueOf(nanos)));
+
+        MessageType unsigned = Types.buildMessage().required(INT64).as(LogicalTypeAnnotation.intType(64, false)).named("n").named("test");
+        assertNull(
+            "date_nanos over unsigned INT64 must not push",
+            new ParquetPushedExpressions(List.of(eq("n", DataType.DATE_NANOS, nanos))).toFilterPredicate(unsigned)
+        );
+    }
+
     // --- DATE (INT32) ---
 
     public void testToFilterPredicateDateInt32() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -385,6 +385,68 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         }
     }
 
+    public void testStrictDeclaredDateNanosReadsWholeNumberAsEpochNanos() throws Exception {
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+
+        // The headline user story: a lake column holding a raw epoch-nanoseconds whole number can now be pinned to
+        // date_nanos. Inference would have produced LONG (a bare number carries no unit), so declaring the column is
+        // the only way to present it at its real precision — and the declared type is what names the unit: under
+        // `date_nanos` the number IS epoch-nanos (under `datetime` it would be epoch-millis).
+        Path nanosFixture = createTempDir().resolve("events.csv");
+        Files.writeString(
+            nanosFixture,
+            String.join(
+                "\n",
+                "id,event_time",
+                "1,1700000000123456789",
+                "2,1700000000000000000",
+                // sub-millisecond digits survive: the whole point of the type
+                "3,1700000000999999999"
+            ) + "\n"
+        );
+
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("id", new DatasetFieldMapping("integer", null));
+        properties.put("event_time", new DatasetFieldMapping("date_nanos", null));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, properties));
+
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "events_nanos",
+                    "local_ds",
+                    nanosFixture.toUri().toString(),
+                    null,
+                    new HashMap<>(Map.of("format", "csv")),
+                    mapping
+                )
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM events_nanos | SORT id | LIMIT 10"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(2));
+            assertThat(columns.get(1).name(), equalTo("event_time"));
+            assertThat(
+                "the column presents as date_nanos, not the long inference would have given",
+                response.columns().get(1).type().typeName(),
+                equalTo("date_nanos")
+            );
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(3));
+            // Rendered at nanosecond precision — the identity epoch-nanos reinterpret, no rescaling. (The renderer
+            // trims trailing zeros, so a whole-second instant shows as .000Z; the sub-millisecond digits below are
+            // the ones that would have been lost had the number been read as epoch-millis.)
+            assertThat(rows.get(0).get(1).toString(), equalTo("2023-11-14T22:13:20.123456789Z"));
+            assertThat(rows.get(1).get(1).toString(), equalTo("2023-11-14T22:13:20.000Z"));
+            assertThat(rows.get(2).get(1).toString(), equalTo("2023-11-14T22:13:20.999999999Z"));
+        }
+    }
+
     public void testNonStrictDeclaredSchemaOverridesDeclaredColumnsAndKeepsInferredRest() throws Exception {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
@@ -139,9 +139,7 @@ public final class DeclaredSchemaValidator {
         }
         DataType resolved = DataType.fromNameOrAlias(type);
         if (resolved != DataType.DATETIME && resolved != DataType.DATE_NANOS) {
-            throw new IllegalArgumentException(
-                "[format] on column [" + column + "] is only supported on [date] and [date_nanos] columns"
-            );
+            throw new IllegalArgumentException("[format] on column [" + column + "] is only supported on [date] and [date_nanos] columns");
         }
         try {
             DateFormatter.forPattern(format);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidator.java
@@ -44,6 +44,9 @@ public final class DeclaredSchemaValidator {
      * ES|QL types the external readers (CSV/NDJSON/Parquet/ORC) can currently produce, hence the declarable set.
      * {@code ip} is produced by parsing a string column (the mapper-style coercion in
      * {@code DeclaredTypeCoercions}: CSV parses it directly, Parquet/ORC coerce a physical string column);
+     * {@code date_nanos} reads a whole-number source as epoch-nanoseconds — the declared type names the numeric
+     * unit ({@code datetime} = millis, {@code date_nanos} = nanos; see {@code DeclaredTypeCoercions}) — and a
+     * string source parses with the column's declared {@code format} (else ISO nanos);
      * per-format narrowing stays deferred to read time like the rest of the set (see the class Javadoc).
      */
     static final Set<DataType> DECLARABLE_TYPES = Set.of(
@@ -54,6 +57,7 @@ public final class DeclaredSchemaValidator {
         DataType.DOUBLE,
         DataType.BOOLEAN,
         DataType.DATETIME,
+        DataType.DATE_NANOS,
         DataType.UNSIGNED_LONG,
         DataType.IP
     );
@@ -122,9 +126,10 @@ public final class DeclaredSchemaValidator {
 
     /**
      * A declared {@code format} is a date-parse pattern, so it is only accepted on a column whose type resolves to
-     * {@code datetime} ({@code date_nanos} is not a declarable type). The pattern is validated here with the ES
-     * {@link DateFormatter#forPattern} — the same class the text readers use to parse a <b>declared</b> date column
-     * (CSV/TSV via a per-column {@code DateFormatter}, NDJSON likewise), so a bad pattern fails the PUT rather than the
+     * {@code datetime} or {@code date_nanos}. The pattern is validated here with the ES
+     * {@link DateFormatter#forPattern} — the same class the readers use to parse a <b>declared</b> date column
+     * (CSV/TSV via a per-column {@code DateFormatter}, NDJSON likewise, the columnar string coercion through
+     * {@code DeclaredTypeCoercions}), so a bad pattern fails the PUT rather than the
      * first query and a PUT-accepted pattern is read-parseable. (The readers' <em>file-level</em> {@code datetime_format}
      * on CSV uses a JDK formatter; that is a separate, unaffected path.)
      */
@@ -132,8 +137,11 @@ public final class DeclaredSchemaValidator {
         if (format == null) {
             return;
         }
-        if (DataType.fromNameOrAlias(type) != DataType.DATETIME) {
-            throw new IllegalArgumentException("[format] on column [" + column + "] is only supported on [date] columns");
+        DataType resolved = DataType.fromNameOrAlias(type);
+        if (resolved != DataType.DATETIME && resolved != DataType.DATE_NANOS) {
+            throw new IllegalArgumentException(
+                "[format] on column [" + column + "] is only supported on [date] and [date_nanos] columns"
+            );
         }
         try {
             DateFormatter.forPattern(format);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -401,9 +401,7 @@ public final class DeclaredTypeCoercions {
                     yield v -> {
                         long nanos = ((Number) v).longValue();
                         if (nanos < 0) {
-                            throw new IllegalArgumentException(
-                                "Value [" + v + "] is out of range for a date_nanos epoch-nanoseconds read"
-                            );
+                            throw new IllegalArgumentException("Value [" + v + "] is out of range for a date_nanos epoch-nanoseconds read");
                         }
                         return nanos;
                     };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -86,10 +86,20 @@ import java.util.function.IntFunction;
  *       column's declared {@code format} (else the ISO default), whole-number sources
  *       reinterpret as epoch milliseconds (the {@code epoch_millis} half of the default date
  *       format);</li>
- *   <li><b>{@code date_nanos}</b>: string sources parse ISO, {@code datetime} sources widen
- *       millis&rarr;nanos (what an epoch-millis token ingests to in a {@code date_nanos} field;
- *       out-of-nanos-range instants fail per value). Plain whole numbers stay out — a raw long
- *       is ambiguous between a millis and a nanos payload;</li>
+ *   <li><b>{@code date_nanos}</b>: string sources parse via the column's declared {@code format}
+ *       (else the ISO nanos default), {@code datetime} sources widen millis&rarr;nanos (what an
+ *       epoch-millis token ingests to in a {@code date_nanos} field; out-of-nanos-range instants
+ *       fail per value), and whole-number sources reinterpret as epoch <b>nanoseconds</b> — the
+ *       declared type names the numeric unit ({@code datetime} = millis above, {@code date_nanos}
+ *       = nanos here), matching the shipped CSV inline-schema numeric read. This deliberately
+ *       diverges from mapper ingest, whose default date format reads a numeric token into a
+ *       {@code date_nanos} field as epoch-<i>millis</i>: under a millis reading a raw nanos
+ *       payload — the one raw-int64 timestamp shape with no other declarable expression — would be
+ *       silently misread, and the identity reading keeps footer stats, filter pushdown, and scan
+ *       values bit-identical for a raw column. The composition rule with a declared {@code format}:
+ *       the format, when present, is the authoritative parse dialect; when absent, the declared
+ *       type names the numeric unit. A negative epoch has no {@code date_nanos} representation
+ *       (the {@code TO_DATE_NANOS} range rule) and fails per value — never a negative nanos long;</li>
  *   <li><b>{@code ip}</b>: string sources only, parsed with the same underlying primitive the ip
  *       mapper delegates to ({@code InetAddresses} parse + the 16-byte doc-values encoding).</li>
  * </ul>
@@ -167,10 +177,16 @@ public final class DeclaredTypeCoercions {
             // Epoch-millis reinterpret for whole numbers; a nanos payload is NOT millis, so
             // date_nanos sources don't reinterpret into datetime.
             case DATETIME -> fromString || from == DataType.INTEGER || from == DataType.LONG || from == DataType.UNSIGNED_LONG;
-            // String parse, or the millis->nanos widen an epoch-millis token gets when ingested
-            // into a date_nanos field (also the cross-file DATETIME + DATE_NANOS unification).
-            // Plain whole numbers stay out: a raw long is ambiguous between millis and nanos.
-            case DATE_NANOS -> fromString || from == DataType.DATETIME;
+            // String parse, the millis->nanos widen an epoch-millis token gets when ingested into
+            // a date_nanos field (also the cross-file DATETIME + DATE_NANOS unification), or the
+            // whole-number epoch-NANOS reinterpret: the declared type names the numeric unit
+            // (datetime = millis above, date_nanos = nanos), matching the CSV inline-schema numeric
+            // read — see the class Javadoc for the deliberate divergence from mapper ingest.
+            case DATE_NANOS -> fromString
+                || from == DataType.DATETIME
+                || from == DataType.INTEGER
+                || from == DataType.LONG
+                || from == DataType.UNSIGNED_LONG;
             case IP -> fromString;
             default -> false;
         };
@@ -373,6 +389,24 @@ public final class DeclaredTypeCoercions {
                     // on pre-epoch and post-2262 instants — the same range rule as TO_DATE_NANOS —
                     // so an unrepresentable instant nulls the cell instead of silently overflowing.
                     yield v -> DateUtils.toNanoSeconds((Long) v);
+                }
+                if (from == DataType.INTEGER || from == DataType.LONG || from == DataType.UNSIGNED_LONG) {
+                    // Whole-number source: identity epoch-NANOS reinterpret — the declared type names the
+                    // unit (see the class Javadoc for the deliberate divergence from mapper ingest). A
+                    // negative epoch has no date_nanos representation (the TO_DATE_NANOS range rule), so it
+                    // fails per value through onCoercionFailure rather than ever emitting a negative nanos
+                    // long. An unsigned_long source arrives from valueReader as the true Number
+                    // (unsignedLongAsNumber), so a magnitude >= 2^63 longValue()s with bit 63 set — negative
+                    // — and the same domain check rejects it; a wrapped positive cannot leak.
+                    yield v -> {
+                        long nanos = ((Number) v).longValue();
+                        if (nanos < 0) {
+                            throw new IllegalArgumentException(
+                                "Value [" + v + "] is out of range for a date_nanos epoch-nanoseconds read"
+                            );
+                        }
+                        return nanos;
+                    };
                 }
                 throw new IllegalArgumentException(
                     "cannot coerce from [" + from.typeName() + "] to [" + to.typeName() + "]; supports() must gate castBlock callers"

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DeclaredSchemaValidatorTests.java
@@ -43,6 +43,24 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
         DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props))); // no throw
     }
 
+    public void testFormatOnDateNanosColumnAcceptedAtPut() {
+        // `format` is accepted on date_nanos exactly as on date: the declared pattern is the string-parse dialect.
+        // (The numeric-epoch read stays format-free — there the declared type itself names the unit.)
+        Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
+        props.put("ts", DatasetFieldMapping.withFormat("date_nanos", null, "yyyy-MM-dd HH:mm:ss.SSSSSSSSS"));
+        DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props))); // no throw
+    }
+
+    public void testInvalidFormatPatternOnDateNanosRejectedAtPut() {
+        Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
+        props.put("ts", DatasetFieldMapping.withFormat("date_nanos", null, "not-a-valid-pattern-{{{"));
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props)))
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("invalid [format]"));
+    }
+
     public void testFormatOnNonDateColumnRejected() {
         // `format` is a date-parse pattern, so it is only meaningful on a date column.
         Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
@@ -51,7 +69,10 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> DeclaredSchemaValidator.validate(new DatasetMapping(new Mappings(Dynamic.TRUE, props)))
         );
-        assertTrue(e.getMessage(), e.getMessage().contains("[format] on column [name] is only supported on [date] columns"));
+        assertTrue(
+            e.getMessage(),
+            e.getMessage().contains("[format] on column [name] is only supported on [date] and [date_nanos] columns")
+        );
     }
 
     public void testInvalidFormatPatternRejectedAtPut() {
@@ -116,7 +137,9 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
                     "g",
                     "unsigned_long",
                     "h",
-                    "ip"
+                    "ip",
+                    "i",
+                    "date_nanos"
                 ),
                 null
             )
@@ -129,7 +152,7 @@ public class DeclaredSchemaValidatorTests extends ESTestCase {
     }
 
     public void testUnsupportedTypeRejected() {
-        for (String bad : new String[] { "geo_point", "date_nanos", "binary", "short", "float", "version", "not_a_type" }) {
+        for (String bad : new String[] { "geo_point", "binary", "short", "float", "version", "not_a_type" }) {
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
                 () -> DeclaredSchemaValidator.validate(mapping(Dynamic.TRUE, props("col", bad), null))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIteratorTests.java
@@ -270,7 +270,11 @@ public class SchemaAdaptingIteratorTests extends ESTestCase {
 
     public void testMemoryCleanupOnFailure() {
         List<Attribute> unified = List.of(attr("a", DataType.INTEGER), attr("b", DataType.LONG));
-        ColumnMapping mapping = new ColumnMapping(new int[] { 0, 1 }, new DataType[] { null, DataType.DATE_NANOS });
+        // VERSION is the cast target because this test only needs *a* failing cast: it pins that the blocks built
+        // before the failure are released, not any particular pair's support status. VERSION is not a declarable
+        // type and has no coercion arm, so it cannot drift into the supported set and quietly stop failing — which
+        // is exactly what happened to the INTEGER -> DATE_NANOS pair this used to rely on.
+        ColumnMapping mapping = new ColumnMapping(new int[] { 0, 1 }, new DataType[] { null, DataType.VERSION });
 
         IntBlock intBlock1 = blockFactory.newConstantIntBlockWith(1, 2);
         IntBlock intBlock2 = blockFactory.newConstantIntBlockWith(2, 2);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
@@ -103,10 +103,15 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
             case LONG, INTEGER, DOUBLE, UNSIGNED_LONG -> fromString || fromWhole || from == DataType.DOUBLE;
             case BOOLEAN -> fromString; // number->boolean does not ingest
             case DATETIME -> fromString || from == DataType.INTEGER || from == DataType.LONG || from == DataType.UNSIGNED_LONG;
-            // string parse, or the millis->nanos widen a date_nanos field runs on an epoch-millis
-            // token at ingest (also cross-file DATETIME + DATE_NANOS unification); a raw long stays
-            // out — ambiguous between millis and nanos
-            case DATE_NANOS -> fromString || from == DataType.DATETIME;
+            // string parse, the millis->nanos widen a date_nanos field runs on an epoch-millis
+            // token at ingest (also cross-file DATETIME + DATE_NANOS unification), or the
+            // whole-number epoch-NANOS identity reinterpret — the declared type names the unit
+            // (datetime = millis, date_nanos = nanos), the deliberate mapper-ingest divergence
+            case DATE_NANOS -> fromString
+                || from == DataType.DATETIME
+                || from == DataType.INTEGER
+                || from == DataType.LONG
+                || from == DataType.UNSIGNED_LONG;
             case IP -> fromString;
             default -> false;
         };
@@ -701,6 +706,126 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
                 assertThat(((LongBlock) cast).getLong(0), equalTo(EsqlDataTypeConverter.dateNanosToLong("2024-01-15T12:34:56.123456789Z")));
             }
         }
+    }
+
+    /**
+     * A whole-number source declared {@code date_nanos} is an identity epoch-NANOS reinterpret — the declared
+     * type names the numeric unit (datetime = millis, date_nanos = nanos), matching the shipped CSV
+     * inline-schema numeric read and keeping footer stats, pushdown, and scan values bit-identical for a raw
+     * column. NOT the mapper-ingest millis reading — see the class Javadoc's deliberate divergence.
+     */
+    public void testCastWholeNumberToDateNanosIsIdentityNanos() {
+        long nanos = 1_700_000_000_123_456_789L;
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { 0L, nanos }, 2).asBlock();
+            Block cast = castStrict(src, DataType.LONG, DataType.DATE_NANOS)
+        ) {
+            LongBlock out = (LongBlock) cast;
+            assertEquals(0L, out.getLong(out.getFirstValueIndex(0)));
+            assertEquals("identity reinterpret, no scaling", nanos, out.getLong(out.getFirstValueIndex(1)));
+        }
+        try (
+            Block src = blockFactory.newIntArrayVector(new int[] { 42 }, 1).asBlock();
+            Block cast = castStrict(src, DataType.INTEGER, DataType.DATE_NANOS)
+        ) {
+            assertEquals(42L, ((LongBlock) cast).getLong(0));
+        }
+    }
+
+    /**
+     * A negative epoch has no {@code date_nanos} representation (the {@code TO_DATE_NANOS} range rule): the
+     * lenient read nulls the cell and warns — never a negative nanos long — and the strict read fails.
+     */
+    public void testCastNegativeWholeNumberToDateNanosFailsPerValue() {
+        List<String> warnings = new ArrayList<>();
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { -1L, 5L }, 2).asBlock();
+            Block cast = DeclaredTypeCoercions.castBlock(
+                src,
+                DataType.LONG,
+                DataType.DATE_NANOS,
+                null,
+                blockFactory,
+                "ts",
+                capturing(warnings)
+            )
+        ) {
+            assertTrue("negative epoch nulls the cell", cast.isNull(0));
+            LongBlock out = (LongBlock) cast;
+            assertEquals("the good cell still decodes", 5L, out.getLong(out.getFirstValueIndex(1)));
+        }
+        assertThat(warnings, hasSize(1));
+        assertThat(warnings.get(0), containsString("declared type [date_nanos]"));
+        try (Block src = blockFactory.newLongArrayVector(new long[] { -1L }, 1).asBlock()) {
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> DeclaredTypeCoercions.castBlock(src, DataType.LONG, DataType.DATE_NANOS, null, blockFactory, null, null).close()
+            );
+        }
+    }
+
+    /**
+     * An {@code unsigned_long} source decodes through valueReader's sign-flip decode to the true Number, so a
+     * magnitude &ge; 2^63 arrives as a BigInteger whose longValue() is negative and the non-negative domain
+     * check rejects it per value — a wrapped positive cannot leak. In-domain magnitudes pass identically.
+     */
+    public void testCastUnsignedLongToDateNanosRejectsAboveSignedRangePerValue() {
+        long inRange = NumericUtils.asLongUnsigned(BigInteger.valueOf(1_700_000_000_123_456_789L));
+        long aboveSigned = NumericUtils.asLongUnsigned(new BigInteger("9223372036854775808")); // 2^63
+        List<String> warnings = new ArrayList<>();
+        try (
+            Block src = blockFactory.newLongArrayVector(new long[] { inRange, aboveSigned }, 2).asBlock();
+            Block cast = DeclaredTypeCoercions.castBlock(
+                src,
+                DataType.UNSIGNED_LONG,
+                DataType.DATE_NANOS,
+                null,
+                blockFactory,
+                "ts",
+                capturing(warnings)
+            )
+        ) {
+            LongBlock out = (LongBlock) cast;
+            assertEquals(1_700_000_000_123_456_789L, out.getLong(out.getFirstValueIndex(0)));
+            assertTrue("2^63 has no date_nanos representation — per-value failure, not a wrap", cast.isNull(1));
+        }
+        assertThat(warnings, hasSize(1));
+    }
+
+    /** Multi-value positions coerce element-by-element; a failing element nulls the whole position (bulk semantics). */
+    public void testCastLongToDateNanosMultiValue() {
+        List<String> warnings = new ArrayList<>();
+        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(2)) {
+            builder.beginPositionEntry();
+            builder.appendLong(1L);
+            builder.appendLong(2L);
+            builder.endPositionEntry();
+            builder.beginPositionEntry();
+            builder.appendLong(3L);
+            builder.appendLong(-1L);
+            builder.endPositionEntry();
+            try (Block source = builder.build()) {
+                try (
+                    Block cast = DeclaredTypeCoercions.castBlock(
+                        source,
+                        DataType.LONG,
+                        DataType.DATE_NANOS,
+                        null,
+                        blockFactory,
+                        "ts",
+                        capturing(warnings)
+                    )
+                ) {
+                    LongBlock out = (LongBlock) cast;
+                    assertThat(out.getValueCount(0), equalTo(2));
+                    int first = out.getFirstValueIndex(0);
+                    assertEquals(1L, out.getLong(first));
+                    assertEquals(2L, out.getLong(first + 1));
+                    assertTrue("bulk semantics null the whole position on a negative element", cast.isNull(1));
+                }
+            }
+        }
+        assertThat(warnings, hasSize(1));
     }
 
     // ---- per-cell bulk leniency ----

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_dataset.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/220_dataset.yml
@@ -211,7 +211,7 @@ setup:
               g: { type: geo_point }
 
   - do:
-      catch: /\[format\] on column \[msg\] is only supported on \[date\] columns/
+      catch: /\[format\] on column \[msg\] is only supported on \[date\] and \[date_nanos\] columns/
       esql.put_dataset:
         name: ds
         body:
@@ -220,6 +220,22 @@ setup:
           mappings:
             properties:
               msg: { type: keyword, format: "yyyy-MM-dd" }
+
+  # date_nanos IS declarable and accepts a `format` (the string-parse dialect), so the pattern is validated the
+  # same way it is on a date column — a bad one fails the PUT rather than the first query. Only the rejection is
+  # asserted here: every PUT in this file is deliberately a rejection, so that `cluster-state-visibility` can
+  # assert the esql_dataset custom is absent. Acceptance of `{type: date_nanos}` is covered by
+  # DeclaredSchemaValidatorTests and end-to-end by FromDatasetIT (real PUT + real read).
+  - do:
+      catch: /invalid \[format\] \[not-a-pattern-\{\{\{\] on column \[ts\]/
+      esql.put_dataset:
+        name: ds_bad_nanos_format
+        body:
+          data_source: parent
+          resource: "s3://x/*.csv"
+          mappings:
+            properties:
+              ts: { type: date_nanos, format: "not-a-pattern-{{{" }
 
   - do:
       esql.delete_data_source:


### PR DESCRIPTION
## What this is about

A Parquet file written by Spark stores its timestamps as `TIMESTAMP(MICROS)`. We read that column at full precision already — it infers as `date_nanos`, scans natively, harvests stats, pushes filters. What you cannot do is *say so*: `date_nanos` was missing from the declarable set, so

```
PUT _query/dataset/events
{ "mappings": { "properties": { "ts": { "type": "date_nanos" } } } }
→ unsupported declared type [date_nanos] for column [ts]
```

Under `dynamic: false` the declaration **is** the schema, so a column you cannot declare is a column you cannot have. The lake file we already read correctly was a strict-mode dead end.

## What this PR does

Makes `date_nanos` declarable, and admits whole-number sources into it.

A raw whole number read into a column declared `date_nanos` is an identity epoch-nanoseconds reinterpret. **The declared type names the numeric unit**: `datetime` means the number is millis, `date_nanos` means it is nanos. No new syntax, no new formatter, no new mapping field — and it is what CSV's inline schema already shipped, so the declared path now agrees with the live one instead of contradicting it.

A declared `format` composes with that rule rather than fighting it: when present it is the authoritative parse dialect for string sources; when absent, the type names the unit. The numeric arm stays format-free.

This deliberately diverges from mapper ingest, which reads a numeric token into a `date_nanos` field as epoch-*millis*. Under a millis reading, a raw nanos payload — the one raw-int64 timestamp shape with no other declarable expression — is silently misread. The identity reading also keeps footer stats, pushdown, and scan values bit-identical for a raw column. A negative epoch has no `date_nanos` representation and fails per value through the error policy; it never emits a negative nanos long.

NDJSON had no `date_nanos` decode arm at all. It has one now, mirroring its datetime twin and CSV's rail.

## The bug this unlocked

Both parquet `date_nanos` push paths assumed the type was *only ever inferred*, which bounded the physical column to `TIMESTAMP(MICROS|NANOS)`. `buildDateNanosPredicate` said so in its javadoc, in as many words: *"`date_nanos` is not a declarable type"*. Anything else fell through to divisor 1.

Declaring `date_nanos` falsifies that. Over a physical `TIMESTAMP(MILLIS)` column — already a supported pair, since millis infers to `datetime` and `datetime → date_nanos` coerces — a nanos literal gets pushed against millis row-group statistics. That is a 10⁶ error: `WHERE ts > <instant>` prunes every row group and returns **silently empty results**. Pruning is unrecoverable. RECHECK re-filters rows that were read; it cannot recover a row group that was never decoded. `TIME`-annotated INT64 is the same hazard by a different door — it infers to `long`, and `isMicrosTimestamp` tests the *Timestamp* annotation, so a Time annotation fell through to divisor 1 while the scan separately scales ×1000.

Both sites now take their divisor from one allow-list: timestamps in all three units, plus the un-annotated signed INT64 identity case. TIME, unsigned INT64, and anything unknown decline instead of pushing. A decline costs pruning, never rows. The same predicate drives page-level pruning, so that surface is guarded by the same divisor.

It is an allow-list, not a deny-list, precisely because TIME is what a deny-list misses.

## Does it work?

`FromDatasetIT` declares a raw epoch-nanos column `date_nanos` over a strict dataset and reads it end to end: `1700000000123456789` renders `2023-11-14T22:13:20.123456789Z`. The sub-millisecond digits survive — the precision that would have been lost under a millis reading.

The five pushdown fixtures were written first and **confirmed red before the guard existed**, then green after. That red is the evidence the guard is load-bearing and not decoration.

Full `:x-pack:plugin:esql:test` is green (595,648 tests) except `SchemaAdaptingIteratorTests.testMemoryCleanupOnFailure`, which fails identically on an untouched `main` — verified by running it on a clean checkout.

## What's in the diff

```mermaid
graph TD
    PUT["PUT dataset — mappings"] --> V["DeclaredSchemaValidator<br/>DECLARABLE_TYPES += date_nanos<br/>format accepted on it"]
    V --> S["DeclaredTypeCoercions.supports<br/>date_nanos ← whole numbers"]
    S --> C["scalarCoercer<br/>identity epoch-nanos + non-negative check"]
    C --> R{"read path"}
    R -->|"parquet TIMESTAMP micros/nanos"| N["native — identity, untouched"]
    R -->|"parquet raw INT64 / millis"| CB["castBlock"]
    R -->|"NDJSON"| ND["decodeDateNanosValue — new"]
    R -->|"CSV/TSV"| CSV["already shipped"]
    C --> P["ParquetColumnDecoding<br/>dateNanosPushdownDivisor — allow-list"]
    P --> BP["buildDateNanosPredicate"]
    P --> IN["translateDateNanosIn"]
    BP --> PR["row-group + page pruning"]
    IN --> PR
```

The coercion core and the declarability switch are one-liners each. The weight is in the NDJSON arm, the pushdown allow-list, and the tests.

## What's out of scope

ORC infers `TIMESTAMP → DATETIME` and cannot produce `date_nanos` today, so a declared `date_nanos` over ORC rides the `datetime → date_nanos` coercion: instants correct to the millisecond, sub-millisecond zero, and pre-epoch instants null+warn. Loud, not silent. Native ORC nanos would retype every existing ORC dataset's timestamp columns — a different blast radius and a different change.

An *unannotated* raw int64 in epoch-**micros** stays inexpressible: there is no `epoch_micros` formatter and the convention says nanos. Annotated micros columns — actual Spark output — are `date_nanos` natively, so this is a corner.

Closes elastic/esql-planning#1287
