### PR TITLE
Backport #153542 to 9.5: ESQL: Fix first()/last() crashing on unresolved

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -1593,3 +1593,17 @@ max:double | max2:double | cluster:keyword | pod:keyword | b:datetime
 5.625      | 5.625       | prod            | two         | 2024-05-10T00:15:00.000Z
 8.625      | 10.125      | qa              | two         | 2024-05-10T00:15:00.000Z
 ;
+
+firstAndLastWithNullSort
+required_capability: ts_command_v0
+required_capability: fix_agg_first_last_foldables_in_sort_field
+TS k8s
+| STATS x = first(network.bytes_in, null), y = last(network.bytes_in, null) BY pod
+| SORT pod
+;
+
+x:long | y:long | pod:keyword
+278    | 206    | one
+585    | 972    | three
+799    | 913    | two
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/InsertDefaultInnerTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/InsertDefaultInnerTimeSeriesAggregate.java
@@ -67,6 +67,13 @@ public class InsertDefaultInnerTimeSeriesAggregate extends Rule<LogicalPlan, Log
         if (aggregate.origin() == TimeSeriesAggregate.Origin.PROMQL_COMMAND) {
             return aggregate;
         }
+        if (aggregate.timestamp() == null || aggregate.timestamp().resolved() == false) {
+            /*
+             * Timestamp was dropped before the function. Leave the aggregate untouched so the Verifier can
+             * report a proper resolution failure
+             */
+            return aggregate;
+        }
         Holder<Boolean> changed = new Holder<>(false);
         List<NamedExpression> newAggregates = aggregate.aggregates().stream().map(agg -> {
             // The actual aggregation functions in aggregates will be aliases, while the groupings in aggregates will be Attributes

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/First.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/First.java
@@ -59,7 +59,11 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isTyp
 
 public class First extends AggregateFunction implements ToAggregator {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "First", First::readFrom);
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(First.class).binary(First::new).name("first");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(First.class)
+        .binary(First::new)
+        // Fix a crash when the sort argument is a foldable/null value and @timestamp has been dropped from a TS query's output.
+        .capabilities("fix_null_sort_dropped_timestamp")
+        .name("first");
 
     private final Expression sort;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Last.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Last.java
@@ -59,7 +59,11 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isTyp
 
 public class Last extends AggregateFunction implements ToAggregator {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Last", Last::readFrom);
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Last.class).binary(Last::new).name("last");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Last.class)
+        .binary(Last::new)
+        // Fix a crash when the sort argument is a foldable/null value and @timestamp has been dropped from a TS query's output.
+        .capabilities("fix_null_sort_dropped_timestamp")
+        .name("last");
 
     private final Expression sort;
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
+import org.elasticsearch.xpack.esql.core.expression.UnresolvedTimestamp;
 import org.elasticsearch.xpack.esql.core.expression.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePatternList;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPatternList;
@@ -2794,6 +2795,26 @@ public class AnalyzerTests extends ESTestCase {
 
         var limit = as(plan, Limit.class);
         assertThat(limit.child(), not(instanceOf(OrderBy.class)));
+    }
+
+    public void testFirstWithNullSortAndDroppedTimestampFailsGracefully() {
+        // Dropping @timestamp before the STATS command makes the implicit timestamp sort parameter of first()/last()
+        // unresolvable; this must surface as a normal resolution failure rather than an internal exception (#153487).
+        tsdb().error(
+            "TS test | KEEP network.connections, host | STATS x = first(network.connections, null) by host",
+            containsString(UnresolvedTimestamp.UNRESOLVED_SUFFIX)
+        );
+    }
+
+    public void testFirstWithNullSortAndTimestampPresent() {
+        // When @timestamp is still resolvable, first()/last() with a null sort should resolve without error.
+        var plan = tsdb().query("TS test | STATS x = first(network.connections, null) by host");
+        assertTrue(plan.resolved());
+    }
+
+    public void testNonTimeSeriesFirstWithNullSort() {
+        var plan = basic().query("FROM test | STATS x = first(last_name, null) by first_name");
+        assertTrue(plan.resolved());
     }
 
     public void testNoImplicitTimestampSortForNotTsQuery() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -910,6 +910,45 @@ error on rename timestamp:
   - match: { error.reason: '/(verification_exception:\ )?Found\ 1\ problem\nline\ 3:13:\ \[rate\(k8s.pod.network.tx\)\]\ requires\ the\ \[@timestamp\]\ field,\ which\ was\ either\ not\ present\ in\ the\ source\ index,\ or\ has\ been\ dropped\ or\ renamed/' }
 
 ---
+first/last with null sort and dropped timestamp fails cleanly:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ ts_command_v0, fn_first_fix_null_sort_dropped_timestamp, fn_last_fix_null_sort_dropped_timestamp ]
+      reason: "TS specific check"
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      catch: bad_request
+      esql.query:
+        body:
+          query: |
+            TS test
+            | KEEP k8s.pod.ip, k8s.pod.name
+            | STATS x = first(k8s.pod.ip, null) BY k8s.pod.name
+
+  - match: { error.type: "verification_exception" }
+  - match: { error.reason: '/requires\ the\ \[@timestamp\]\ field,\ which\ was\ either\ not\ present\ in\ the\ source\ index,\ or\ has\ been\ dropped\ or\ renamed/' }
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      catch: bad_request
+      esql.query:
+        body:
+          query: |
+            TS test
+            | KEEP k8s.pod.ip, k8s.pod.name
+            | STATS x = last(k8s.pod.ip, null) BY k8s.pod.name
+
+  - match: { error.type: "verification_exception" }
+  - match: { error.reason: '/requires\ the\ \[@timestamp\]\ field,\ which\ was\ either\ not\ present\ in\ the\ source\ index,\ or\ has\ been\ dropped\ or\ renamed/' }
+
+---
 Stats with partial submetrics for aggregate metric double with average as default:
   - requires:
       test_runner_features: [capabilities]


### PR DESCRIPTION
Backport of #153542 to 9.5.

Prevents crashing on queries like:
```
TS test
| KEEP network.connections, host
| STATS x = FIRST(network.connections, null) BY host
```

Closes #153487.