### PR TITLE
Fix cluster state deadlock in reshard coordination test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -322,9 +322,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
   method: testDatafeedWithCcsRemoteUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/150541
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
-  method: testSearchWhenCoordinatorSeesSplitFirst
-  issue: https://github.com/elastic/elasticsearch/issues/150621
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=ml/data_frame_analytics_crud/Test put classification given max_trees is greater than 2k}
   issue: https://github.com/elastic/elasticsearch/issues/150629

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -1116,10 +1116,10 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // block split application on stale search node
         final CountDownLatch completedSearch = new CountDownLatch(1);
         final var searchClusterService = internalCluster().getInstance(ClusterService.class, searchNode);
-        // Register an applier that blocks the search node from committing the SPLIT cluster state.
+        // Register an applier that blocks the search node from committing the SPLIT cluster state
         searchClusterService.addStateApplier(event -> {
             final var indexMetadata = event.state().getMetadata().findIndex(index).orElse(null);
-            if (idxMeta != null) {
+            if (indexMetadata != null) {
                 final var resharding = indexMetadata.getReshardingMetadata();
                 if (resharding != null
                     && resharding.getSplit() != null

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequest;
 import org.elasticsearch.action.admin.cluster.allocation.TransportClusterAllocationExplainAction;
@@ -80,7 +79,6 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.support.BlobMetadata;
@@ -1118,24 +1116,17 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         // block split application on stale search node
         final CountDownLatch completedSearch = new CountDownLatch(1);
         final var searchClusterService = internalCluster().getInstance(ClusterService.class, searchNode);
-        final MockTransportService indexNodeTransportService = MockTransportService.getInstance(indexNode);
-        indexNodeTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            if (TransportUpdateSplitTargetShardStateAction.TYPE.name().equals(action)) {
-                TransportRequest actualRequest = MasterNodeRequestHelper.unwrapTermOverride(request);
-
-                if (actualRequest instanceof SplitStateRequest splitStateRequest) {
-                    try {
-                        if (splitStateRequest.getNewTargetShardState() == IndexReshardingState.Split.TargetShardState.SPLIT) {
-                            // wait for search shard cluster block to be in place before releasing SPLIT
-                            searchClusterService.getClusterApplierService()
-                                .runOnApplierThread("get", Priority.IMMEDIATE, state -> safeAwait(completedSearch), ActionListener.noop());
-                        }
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
+        // Register an applier that blocks the search node from committing the SPLIT cluster state.
+        searchClusterService.addStateApplier(event -> {
+            final var indexMetadata = event.state().getMetadata().findIndex(index).orElse(null);
+            if (idxMeta != null) {
+                final var resharding = indexMetadata.getReshardingMetadata();
+                if (resharding != null
+                    && resharding.getSplit() != null
+                    && resharding.getSplit().getTargetShardState(1) == IndexReshardingState.Split.TargetShardState.SPLIT) {
+                    safeAwait(completedSearch);
                 }
             }
-            connection.sendRequest(requestId, action, request, options);
         });
 
         // reshard up to split attempt


### PR DESCRIPTION
Given 2 cluster states, v23 and v24
 - v23 updates the search shards to `STARTED`
 - v24 updates target shard to `SPLIT`

This test can deadlock if:
 - Index node applies cluster state v23
 - Target shard state machine transitions to `SearchShardsOnline`
 - Index node sends `SplitStateRequest` to update target to `SPLIT`
 - As added by the test, this triggers the search node to run `runOnApplierThread` to block on `completedSearch` latch, this can bypass v23 in the queue since it's `Priority.IMMEDIATE`
 - Search node can't apply v23 since the applier is blocked
 - Index node awaits cluster state v24 (in the test)
 - Master can't update state to v24 since the search node has not acked v23
 - Timeout

The fix is to just have the search node block the applier for v24

Resolves #150621