### PR TITLE
[9.5] ESQL: ConvertFunction.isNoop refactor (#153819)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -3103,9 +3103,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     // example, an expression like multiTypeEsField(synthetic=false, date_nanos)::date_nanos::datetime is rewritten to
                     // multiTypeEsField(synthetic=true, date_nanos)::datetime, the implicit casting is overwritten by explicit casting and
                     // the multiTypeEsField is not casted to datetime directly.
-                    // TODO: clean-up once we can detect that a convert function is a no-op.
-                    // See https://github.com/elastic/elasticsearch/issues/150376
-                    if (convertExpression.dataType() == fa.field().getDataType()
+                    if (convert.isNoop()
                         && (unionTypeEsField.getUnmappedConversionExpression() == null || convert.supportedTypes().contains(KEYWORD))) {
                         return createIfDoesNotAlreadyExist(fa, fa.field(), unionFieldAttributes);
                     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ConvertFunction.java
@@ -25,4 +25,18 @@ public interface ConvertFunction {
      * The types that {@link #field()} can have.
      */
     Set<DataType> supportedTypes();
+
+    /**
+     * The type this function converts to.
+     */
+    DataType dataType();
+
+    /**
+     * Whether converting a value of {@code field().dataType()} using this function leaves it unchanged, so the cast can be dropped. By
+     * default, this holds when the {@code field().dataType()} already has the output type. Widening conversions (e.g., {@code half_float}
+     * to {@code double}) are not no-ops even though they share a representation, since the declared type changes.
+     */
+    default boolean isNoop() {
+        return field().dataType() == dataType();
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java
@@ -115,6 +115,12 @@ public class FromAggregateMetricDouble extends EsqlScalarFunction implements Con
     }
 
     @Override
+    public boolean isNoop() {
+        // Extracts a single subfield, so it never passes its input through unchanged.
+        return false;
+    }
+
+    @Override
     public Expression replaceChildren(List<Expression> newChildren) {
         return new FromAggregateMetricDouble(source(), newChildren.get(0), newChildren.get(1));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java
@@ -108,6 +108,12 @@ public class ToDegrees extends AbstractConvertFunction implements EvaluatorMappe
         return DOUBLE;
     }
 
+    @Override
+    public boolean isNoop() {
+        // Computes even when the input is already double, so it's never a no-op.
+        return false;
+    }
+
     @ConvertEvaluator(warnExceptions = { ArithmeticException.class })
     static double process(double deg) {
         return NumericUtils.asFiniteNumber(Math.toDegrees(deg));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java
@@ -104,6 +104,12 @@ public class ToRadians extends AbstractConvertFunction implements EvaluatorMappe
         return DOUBLE;
     }
 
+    @Override
+    public boolean isNoop() {
+        // Computes even when the input is already double, so it's never a no-op.
+        return false;
+    }
+
     @ConvertEvaluator
     static double process(double deg) {
         return Math.toRadians(deg);


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: ConvertFunction.isNoop refactor (#153819)