### PR TITLE
[9.5] ESQL: fix hint-blind listing cache and rewrite-to-empty throw (#153682)

### DIFF
--- a/docs/changelog/153682.yaml
+++ b/docs/changelog/153682.yaml
@@ -1,0 +1,5 @@
+pr: 153682
+summary: Fix hint-blind external-dataset listing cache and rewrite-to-empty throw
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalFileMetadataPruningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalFileMetadataPruningIT.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -112,10 +111,11 @@ public class ExternalFileMetadataPruningIT extends AbstractExternalDataSourceIT 
     }
 
     /**
-     * Variant: filter excludes ALL files → resolver rejects with "no files" error,
-     * proving that the listing-time prune removed all candidates before any read.
+     * Variant: filter excludes ALL files. The metadata hint prunes the listing to nothing, but a filter excluding
+     * every file returns zero rows, not an error — the listing prune is only an optimization and the {@code WHERE}
+     * still runs on the rows, which yields zero.
      */
-    public void testFileModifiedFilterExcludesAllFiles() throws Exception {
+    public void testFileModifiedFilterExcludesAllFilesReturnsZeroRows() throws Exception {
         Path dir = createTempDir();
         Path fileA = writeParquetFile(dir, "a.parquet");
         Path fileB = writeParquetFile(dir, "b.parquet");
@@ -136,10 +136,11 @@ public class ExternalFileMetadataPruningIT extends AbstractExternalDataSourceIT 
             + " | WHERE `_file.modified` > \"2024-01-01T00:00:00.000Z\""
             + " | STATS c = COUNT(*)";
 
-        var request = syncEsqlQueryRequest(query);
-
-        Exception e = expectThrows(Exception.class, () -> { run(request).close(); });
-        assertThat(e.getMessage(), containsString("matched no files"));
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            long count = ((Number) rows.get(0).get(0)).longValue();
+            assertThat("an all-excluding _file.modified filter returns zero rows, not an error", count, equalTo(0L));
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalListingCacheHintIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalListingCacheHintIT.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+
+/**
+ * End-to-end coverage for two listing-layer correctness defects, exercised through real text-format queries
+ * ({@code WHERE} → hint extraction → glob rewrite → node-local listing cache), the chain the unit and resolver tests
+ * inject the middle of. Run against CSV and NDJSON because the listing layer is shared by every text format — the
+ * cache is one {@code ExternalSourceCacheService}, keyed identically whatever the reader.
+ *
+ * <p>Two conditions are load-bearing and easy to get subtly wrong:
+ * <ul>
+ *   <li><b>{@code schema_resolution: first_file_wins}.</b> The default is {@code union_by_name}, whose reconciliation
+ *       path never consults the listing cache. A poisoning test on the default path passes for the wrong reason — it
+ *       never touches the cache at all.</li>
+ *   <li><b>Both queries on one coordinator.</b> The listing cache is a node singleton on the resolving coordinator, so
+ *       the sequence must be pinned to a single node with {@code client(coordinator)} for the second query to hit the
+ *       first's entry.</li>
+ * </ul>
+ *
+ * <p>The glob has the shape {@code <root>/<key>=* / ** / *.<ext>} (without the spaces): the {@code key=*} segment is
+ * what {@code GlobExpander.rewriteSegment} narrows, the double-star is required for {@code LocalStorageProvider} to
+ * recurse, the concrete extension drives format inference, and folder values are left unpadded so the rewrite fires.
+ */
+public class ExternalListingCacheHintIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class, NdJsonDataSourcePlugin.class);
+    }
+
+    /** A text format under test: its file extension and how it materialises a two-column ({@code id,value}) file. */
+    private enum TextFormat {
+        CSV("csv", ".csv") {
+            @Override
+            String render(List<String[]> rows) {
+                StringBuilder sb = new StringBuilder("id,value\n");
+                for (String[] row : rows) {
+                    sb.append(row[0]).append(',').append(row[1]).append('\n');
+                }
+                return sb.toString();
+            }
+        },
+        NDJSON("ndjson", ".ndjson") {
+            @Override
+            String render(List<String[]> rows) {
+                StringBuilder sb = new StringBuilder();
+                for (String[] row : rows) {
+                    sb.append("{\"id\":").append(row[0]).append(",\"value\":\"").append(row[1]).append("\"}\n");
+                }
+                return sb.toString();
+            }
+        };
+
+        private final String tag;
+        private final String ext;
+
+        TextFormat(String tag, String ext) {
+            this.tag = tag;
+            this.ext = ext;
+        }
+
+        abstract String render(List<String[]> rows);
+    }
+
+    /**
+     * The core defect (esql-planning#1174's headline example): a filtered query narrows the listing to a subset of the
+     * files and caches it; keyed only on the path, that subset is then served to a later unfiltered query, which
+     * silently reads fewer files than the dataset holds. Uses a {@code _file.name} filter on a plain glob — that
+     * pruning runs on any multi-file listing, so the defect is not specific to hive-partitioned globs. The listing
+     * cache is only consulted under {@code first_file_wins} (the default {@code union_by_name} never lists through it),
+     * and it is a node singleton, so both queries are pinned to one coordinator.
+     */
+    public void testFilteredThenUnfilteredSeesEveryFile() throws Exception {
+        for (TextFormat format : TextFormat.values()) {
+            Path root = createTempDir().resolve("poison_" + format.tag);
+            writeFile(root, "a", format, List.of(new String[] { "1", "alpha" }, new String[] { "2", "beta" }));
+            writeFile(root, "b", format, List.of(new String[] { "3", "gamma" }, new String[] { "4", "delta" }));
+            writeFile(root, "c", format, List.of(new String[] { "5", "epsilon" }, new String[] { "6", "zeta" }));
+
+            String glob = StoragePath.fileUri(root) + "/*" + format.ext;
+            String dataset = registerDataset("poison_" + format.tag, glob, Map.of("schema_resolution", "first_file_wins"));
+            String coordinator = internalCluster().getNodeNames()[0];
+
+            long filtered = count(
+                coordinator,
+                "FROM " + dataset + " METADATA _file.name | WHERE _file.name == \"a" + format.ext + "\" | STATS c = COUNT(*)"
+            );
+            assertEquals("[" + format + "] the filter keeps only a's rows", 2L, filtered);
+
+            long unfiltered = count(coordinator, "FROM " + dataset + " | STATS c = COUNT(*)");
+            assertEquals("[" + format + "] the unfiltered query must count every file, not the cached subset", 6L, unfiltered);
+        }
+    }
+
+    /**
+     * A filter that rewrites the glob onto a folder that does not exist must return zero rows, not raise "Glob pattern
+     * matched no files". On the local filesystem the missing narrowed prefix throws in {@code listObjects}, so this
+     * exercises the exception arm of the fallback specifically. Runs on the default (reconciliation) resolution, which
+     * reads hive-partitioned rows and routes its listing through the same fallback.
+     */
+    public void testZeroMatchFilterReturnsZeroRowsNotError() throws Exception {
+        for (TextFormat format : TextFormat.values()) {
+            Path root = createTempDir().resolve("zeromatch_" + format.tag);
+            writePartition(root.resolve("year=2024"), format, List.of(new String[] { "1", "alpha" }, new String[] { "2", "beta" }));
+
+            String dataset = registerHivePartitioned("zeromatch_" + format.tag, root, "year", format);
+            String coordinator = internalCluster().getNodeNames()[0];
+
+            long count = count(coordinator, "FROM " + dataset + " | WHERE year == 2099 | STATS c = COUNT(*)");
+            assertEquals("[" + format + "] an excluding filter returns zero rows, not an error", 0L, count);
+        }
+    }
+
+    /**
+     * The trap the fallback exists to avoid: {@code rewriteSegment} spells the value with {@code String.valueOf}, so
+     * {@code WHERE month == 6} narrows the glob to {@code month=6} — but the folder on disk is the zero-padded
+     * {@code month=06}. The rewritten glob matches nothing; without the fallback that is an error (or, if naively
+     * "fixed" to return empty, silent zero rows). It must fall back to the full listing and return the matching rows.
+     */
+    public void testZeroPaddedMonthFolderAgainstUnpaddedPredicate() throws Exception {
+        for (TextFormat format : TextFormat.values()) {
+            Path root = createTempDir().resolve("padded_" + format.tag);
+            writePartition(root.resolve("month=06"), format, List.of(new String[] { "1", "alpha" }, new String[] { "2", "beta" }));
+            writePartition(root.resolve("month=07"), format, List.<String[]>of(new String[] { "3", "gamma" }));
+
+            String dataset = registerHivePartitioned("padded_" + format.tag, root, "month", format);
+            String coordinator = internalCluster().getNodeNames()[0];
+
+            long count = count(coordinator, "FROM " + dataset + " | WHERE month == 6 | STATS c = COUNT(*)");
+            assertEquals("[" + format + "] the zero-padded month=06 folder must still be read", 2L, count);
+        }
+    }
+
+    /**
+     * A comma-separated path where {@code WHERE month == 6} narrows segment A onto a zero-padded {@code month=06}
+     * folder its rewrite misses, while segment B (an unpadded {@code month=6} folder) still matches. Because B keeps
+     * the whole-path listing non-empty, the pre-fix whole-path fallback never fired and A's rows were silently
+     * dropped — the query counted only B's rows. Per-segment fallback recovers A's. (Bug found in human review of
+     * #153682.) Both segments carry the {@code month} partition so it stays a bound column over the union.
+     */
+    public void testCommaPathSegmentRewrittenToEmptyStillCounted() throws Exception {
+        for (TextFormat format : TextFormat.values()) {
+            Path base = createTempDir().resolve("comma_" + format.tag);
+            Path a = base.resolve("a");
+            Path b = base.resolve("b");
+            writePartition(a.resolve("month=06"), format, List.of(new String[] { "1", "alpha" }, new String[] { "2", "beta" }));
+            writePartition(
+                b.resolve("month=6"),
+                format,
+                List.of(new String[] { "3", "gamma" }, new String[] { "4", "delta" }, new String[] { "5", "eps" })
+            );
+
+            @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+            String glob = StoragePath.fileUri(a)
+                + "/month=*/**/*"
+                + format.ext
+                + ","
+                + StoragePath.fileUri(b)
+                + "/month=*/**/*"
+                + format.ext;
+            String dataset = registerDataset("comma_" + format.tag, glob, Map.of("hive_partitioning", true));
+            String coordinator = internalCluster().getNodeNames()[0];
+
+            long count = count(coordinator, "FROM " + dataset + " | WHERE month == 6 | STATS c = COUNT(*)");
+            assertEquals("[" + format + "] segment a's zero-padded month=06 rows must be counted, not dropped", 5L, count);
+        }
+    }
+
+    private String registerHivePartitioned(String name, Path root, String partitionKey, TextFormat format) {
+        // The key=* segment is what the rewrite narrows; ** makes the local provider recurse. Left on the default
+        // union_by_name resolution: this is a fallback (defect 2) test, which fires on the reconciliation path too and
+        // avoids the unrelated first_file_wins + hive-partition virtual-column path.
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/" + partitionKey + "=*/**/*" + format.ext;
+        return registerDataset(name, glob, Map.of("hive_partitioning", true));
+    }
+
+    private long count(String coordinator, String query) {
+        try (EsqlQueryResponse response = client(coordinator).execute(EsqlQueryAction.INSTANCE, syncEsqlQueryRequest(query)).actionGet()) {
+            List<List<Object>> rows = getValuesList(response);
+            return ((Number) rows.get(0).get(0)).longValue();
+        }
+    }
+
+    /** Writes {@code <baseName>.<ext>} directly under {@code dir} — a flat, unpartitioned file. */
+    private static void writeFile(Path dir, String baseName, TextFormat format, List<String[]> rows) throws Exception {
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve(baseName + format.ext), format.render(rows), StandardCharsets.UTF_8);
+    }
+
+    /** Writes {@code data.<ext>} under a Hive partition directory (e.g. {@code year=2024/}). */
+    private static void writePartition(Path partitionDir, TextFormat format, List<String[]> rows) throws Exception {
+        Files.createDirectories(partitionDir);
+        Files.writeString(partitionDir.resolve("data" + format.ext), format.render(rows), StandardCharsets.UTF_8);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -637,9 +637,7 @@ public class ExternalSourceResolver {
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
             int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
             long discoveryStartNanos = System.nanoTime();
-            FileList raw = path.indexOf(',') >= 0
-                ? GlobExpander.expandCommaSeparated(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion)
-                : GlobExpander.expandGlob(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
+            FileList raw = GlobExpander.expand(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
             recordDiscovery(raw, discoveryStartNanos, storagePath.scheme());
             if (raw.fileCount() == 0) {
                 throw new IllegalArgumentException("Glob pattern matched no files: " + path);
@@ -651,11 +649,7 @@ public class ExternalSourceResolver {
         FileList listing;
         long discoveryStartNanos = System.nanoTime();
         if (cacheable) {
-            ListingCacheKey listingKey = ListingCacheKey.build(storagePath.scheme(), storagePath.host(), storagePath.path(), config);
-            listing = cacheService.getOrComputeListing(
-                listingKey,
-                k -> expandAndCompact(path, provider, hints, hivePartitioning, storagePath)
-            );
+            listing = cachedListing(path, storagePath, provider, hints, hivePartitioning, config);
         } else {
             listing = expandAndCompact(path, provider, hints, hivePartitioning, storagePath);
         }
@@ -912,6 +906,31 @@ public class ExternalSourceResolver {
         int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
         int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
         return GlobExpander.expandAndCompact(path, provider, hints, hivePartitioning, storagePath, maxDiscoveredFiles, maxGlobExpansion);
+    }
+
+    /**
+     * Looks up, or computes and caches, the compacted listing for a cacheable provider. The cache-key build and the
+     * compute lambda are kept together on purpose: the discriminator folded into the key must describe exactly the
+     * {@code (path, hints, hivePartitioning)} the lambda expands, or a filtered query's narrowed listing can be
+     * served to a later unfiltered one. Every cacheable resolution rail routes through here so that pairing lives in
+     * one place. See {@link ListingCacheKey}.
+     */
+    private FileList cachedListing(
+        String path,
+        StoragePath storagePath,
+        StorageProvider provider,
+        @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
+        boolean hivePartitioning,
+        Map<String, Object> config
+    ) throws Exception {
+        ListingCacheKey listingKey = ListingCacheKey.build(
+            storagePath.scheme(),
+            storagePath.host(),
+            storagePath.path(),
+            config,
+            GlobExpander.listingCacheDiscriminator(path, hints, hivePartitioning)
+        );
+        return cacheService.getOrComputeListing(listingKey, k -> expandAndCompact(path, provider, hints, hivePartitioning, storagePath));
     }
 
     /**
@@ -2350,13 +2369,9 @@ public class ExternalSourceResolver {
         if (path.indexOf(',') >= 0) {
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
             int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
-            listing = GlobExpander.expandCommaSeparated(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
+            listing = GlobExpander.expand(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
         } else if (isCacheable(provider)) {
-            ListingCacheKey listingKey = ListingCacheKey.build(storagePath.scheme(), storagePath.host(), storagePath.path(), config);
-            listing = cacheService.getOrComputeListing(
-                listingKey,
-                k -> expandAndCompact(path, provider, hints, hivePartitioning, storagePath)
-            );
+            listing = cachedListing(path, storagePath, provider, hints, hivePartitioning, config);
         } else {
             listing = expandAndCompact(path, provider, hints, hivePartitioning, storagePath);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ListingCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ListingCacheKey.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasources.cache;
 
+import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.hash.MurmurHash3;
+import org.elasticsearch.common.util.ByteUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -19,6 +21,24 @@ import java.util.TreeMap;
  * values (NOT the credential keys) for isolation between users with different credentials.
  * Endpoint and region are included because the same bucket on different endpoints
  * contains different objects.
+ *
+ * <p>The {@code listingDiscriminatorH1/H2} are a 128-bit hash of everything about the query that changes which
+ * files the listing contains — the filter hints that narrow it, and the hive-partitioning flag that decides
+ * whether they can. Without it the key would not determine its value: a filtered query would cache a narrowed
+ * listing under the key an unfiltered query then hits, silently serving it fewer files than the dataset holds.
+ * The discriminator string is produced by {@code GlobExpander.listingCacheDiscriminator} (from the same code the
+ * listing itself goes through) and hashed here for the same size reason as the credentials: a filter's
+ * {@code IN}-list can be arbitrarily large, and the cache weighs only the value, so the key must not grow with the
+ * query.
+ *
+ * <p>Unlike the credential hash, the discriminator uses a <b>collision-resistant</b> digest (SHA-256, truncated to
+ * 128 bits). A collision here would serve one filter's narrowed listing to a different filter — a wrong answer. The
+ * credential pre-image is secret, so its hash cannot be collided on purpose and Murmur3 suffices; the discriminator
+ * pre-image is built from the query's own filter literals, so a non-cryptographic hash would let a caller
+ * <i>construct</i> a collision. With SHA-256 truncated to 128 bits, two distinct discriminators collide with
+ * probability 2<sup>-128</sup>, and a cache would need ~2<sup>64</sup> co-resident entries to reach even-odds
+ * birthday risk — negligible, and below the rate of undetected hardware bit-errors every result already passes
+ * through.
  */
 public record ListingCacheKey(
     String scheme,
@@ -27,7 +47,9 @@ public record ListingCacheKey(
     String endpoint,
     String region,
     long credentialHashH1,
-    long credentialHashH2
+    long credentialHashH2,
+    long listingDiscriminatorH1,
+    long listingDiscriminatorH2
 ) {
     private static final Set<String> CREDENTIAL_PARAMS = Set.of(
         "access_key",
@@ -39,10 +61,40 @@ public record ListingCacheKey(
         "token"
     );
 
-    public static ListingCacheKey build(String scheme, String bucket, String prefixAndGlob, Map<String, Object> config) {
+    public static ListingCacheKey build(
+        String scheme,
+        String bucket,
+        String prefixAndGlob,
+        Map<String, Object> config,
+        String listingDiscriminator
+    ) {
         EndpointRegion location = EndpointRegion.of(config);
         long[] hash = computeCredentialHash(config);
-        return new ListingCacheKey(scheme, bucket, prefixAndGlob, location.endpoint(), location.region(), hash[0], hash[1]);
+        long[] discriminatorHash = sha256Truncated(listingDiscriminator);
+        return new ListingCacheKey(
+            scheme,
+            bucket,
+            prefixAndGlob,
+            location.endpoint(),
+            location.region(),
+            hash[0],
+            hash[1],
+            discriminatorHash[0],
+            discriminatorHash[1]
+        );
+    }
+
+    /**
+     * SHA-256 of the discriminator, truncated to its first 128 bits. Collision-resistant because the pre-image is
+     * built from user-supplied filter literals (see the class javadoc). An empty/absent discriminator maps to zero,
+     * which no real discriminator reaches (it always begins with the hive-partitioning flag).
+     */
+    static long[] sha256Truncated(String value) {
+        if (value == null || value.isEmpty()) {
+            return new long[] { 0L, 0L };
+        }
+        byte[] digest = MessageDigests.sha256().digest(value.getBytes(StandardCharsets.UTF_8));
+        return new long[] { ByteUtils.readLongBE(digest, 0), ByteUtils.readLongBE(digest, 8) };
     }
 
     static long[] computeCredentialHash(Map<String, Object> config) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -31,9 +31,13 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Expands glob patterns and comma-separated path lists into resolved {@link FileList} instances.
@@ -91,15 +95,111 @@ public final class GlobExpander {
         int maxDiscoveredFiles,
         int maxGlobExpansion
     ) throws IOException {
-        FileList expanded = path.indexOf(',') >= 0
-            ? doExpandCommaSeparated(path, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion)
-            : doExpandGlob(path, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion);
+        FileList expanded = expand(path, provider, hints, hivePartitioning, maxDiscoveredFiles, maxGlobExpansion);
         if (expanded.isResolved() == false || expanded.fileCount() == 0) {
             return expanded;
         }
         if (expanded instanceof GenericFileList raw) {
             String basePath = storagePath.patternPrefix().toString();
             return FileListCompactor.compact(basePath, raw);
+        }
+        return expanded;
+    }
+
+    /**
+     * Expands a whole path — glob or comma-separated list — applying the filter hints. Each glob (a lone pattern, or
+     * every segment of a comma list) is expanded through {@link #expandGlobWithRewriteFallback}, which recovers the
+     * files a glob rewrite can hide behind a value-spelling mismatch. A comma list is handled per segment so one
+     * segment's rewrite-to-empty cannot be masked by another segment that still matches.
+     */
+    public static FileList expand(
+        String path,
+        StorageProvider provider,
+        @Nullable List<PartitionFilterHint> hints,
+        boolean hivePartitioning,
+        int maxDiscoveredFiles,
+        int maxGlobExpansion
+    ) throws IOException {
+        return path.indexOf(',') >= 0
+            ? doExpandCommaSeparated(path, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion)
+            : expandGlobWithRewriteFallback(path, provider, hints, hivePartitioning, null, null, maxDiscoveredFiles, maxGlobExpansion);
+    }
+
+    /**
+     * Expands a single glob, falling back to the un-rewritten glob if — and only if — a partition rewrite narrowed it
+     * to nothing. Hint-based narrowing is only an optimisation: the query's filter is still evaluated on the rows, so
+     * listing a superset is always correct while listing a subset is a wrong answer.
+     *
+     * <p>Only the glob rewrite ({@link #effectivePattern}/{@link #rewriteSegment}) can hide files: it spells a value
+     * with {@link String#valueOf}, so {@code WHERE month == 6} narrows the glob to {@code month=6} while the Hive
+     * convention writes a zero-padded {@code month=06}. Reporting empty there would be silent zero rows on an ordinary
+     * dataset, so we re-list the un-rewritten glob — keeping the {@code _file.*} filters, which are exact and cannot
+     * hide anything — and let the row filter decide. If the un-rewritten glob is empty too, the pattern genuinely
+     * matches nothing and the caller's "matched no files" error stands. When the rewrite did not change the pattern
+     * there is nothing to disambiguate, so we expand once with no retry.
+     */
+    private static FileList expandGlobWithRewriteFallback(
+        String pattern,
+        StorageProvider provider,
+        @Nullable List<PartitionFilterHint> hints,
+        boolean hivePartitioning,
+        @Nullable PartitionConfig partitionConfig,
+        @Nullable Map<String, Object> config,
+        int maxDiscoveredFiles,
+        int maxGlobExpansion
+    ) throws IOException {
+        if (effectivePattern(pattern, hints, hivePartitioning, partitionConfig).equals(pattern)) {
+            return doExpandGlob(pattern, provider, hints, hivePartitioning, partitionConfig, config, maxDiscoveredFiles, maxGlobExpansion);
+        }
+        // The retry drops the rewrite but keeps the exact _file.* filters, so it can only come back empty when the
+        // un-rewritten glob genuinely matches nothing.
+        List<PartitionFilterHint> fileHintsOnly = fileMetadataHints(hints);
+        FileList expanded;
+        try {
+            expanded = doExpandGlob(
+                pattern,
+                provider,
+                hints,
+                hivePartitioning,
+                partitionConfig,
+                config,
+                maxDiscoveredFiles,
+                maxGlobExpansion
+            );
+        } catch (IOException e) {
+            // The rewritten prefix may name a folder that does not exist; the local filesystem throws where object
+            // stores return empty. Both mean the rewrite, not the dataset, emptied the listing — retry either way.
+            logger.debug(() -> "Rewritten listing of [" + pattern + "] failed; re-listing without the glob rewrite", e);
+            try {
+                return doExpandGlob(
+                    pattern,
+                    provider,
+                    fileHintsOnly,
+                    hivePartitioning,
+                    partitionConfig,
+                    config,
+                    maxDiscoveredFiles,
+                    maxGlobExpansion
+                );
+            } catch (IOException retryFailure) {
+                retryFailure.addSuppressed(e);
+                throw retryFailure;
+            }
+        }
+        if (expanded.isResolved() && expanded.fileCount() == 0) {
+            logger.debug("Rewrite of [{}] narrowed to an empty listing; re-listing without the glob rewrite", pattern);
+            // A full re-list can exceed max_discovered_files and throw, exactly as the un-filtered query would; that
+            // cap error is preserved deliberately — deciding spelling-miss vs genuinely-empty needs the full listing.
+            return doExpandGlob(
+                pattern,
+                provider,
+                fileHintsOnly,
+                hivePartitioning,
+                partitionConfig,
+                config,
+                maxDiscoveredFiles,
+                maxGlobExpansion
+            );
         }
         return expanded;
     }
@@ -201,10 +301,7 @@ public final class GlobExpander {
         Check.notNull(pattern, "pattern cannot be null");
         Check.notNull(provider, "provider cannot be null");
 
-        String effectivePattern = pattern;
-        if (hints != null && hints.isEmpty() == false && hivePartitioning) {
-            effectivePattern = rewriteGlobWithHints(pattern, hints, partitionConfig);
-        }
+        String effectivePattern = effectivePattern(pattern, hints, hivePartitioning, partitionConfig);
 
         StoragePath storagePath = StoragePath.of(effectivePattern);
 
@@ -240,7 +337,7 @@ public final class GlobExpander {
                     checkDiscoveredFilesLimit(matched.size(), maxDiscoveredFiles);
                 }
                 if (hints != null && hints.isEmpty() == false) {
-                    matched = applyFileMetadataFilters(matched, hints);
+                    matched = applyFileFiltersRetainingAnchor(matched, hints);
                 }
                 if (matched.isEmpty()) {
                     return FileList.EMPTY;
@@ -278,7 +375,7 @@ public final class GlobExpander {
         // Apply file metadata filters from WHERE clause hints (e.g., _file.modified > X, _file.size > Y).
         // This prunes files at listing time — before any data is read.
         if (hints != null && hints.isEmpty() == false) {
-            matched = applyFileMetadataFilters(matched, hints);
+            matched = applyFileFiltersRetainingAnchor(matched, hints);
         }
 
         if (matched.isEmpty()) {
@@ -290,6 +387,18 @@ public final class GlobExpander {
         PartitionMetadata partitionMetadata = detectPartitions(matched, hivePartitioning, partitionConfig, config);
 
         return new GenericFileList(matched, pattern, partitionMetadata);
+    }
+
+    /**
+     * Applies the {@code _file.*} filters, but keeps the unfiltered listing when they prune a non-empty listing to
+     * nothing. Those filters are exact, so an all-pruned result is genuinely zero rows — but the resolver needs at
+     * least one file to anchor schema inference, and the split- and row-level filters still yield zero rows from the
+     * retained listing. A partial prune (some files survive) stands untouched; only the all-pruned case is retained,
+     * which also keeps that emptiness out of {@link #expandGlobWithRewriteFallback}'s rewrite-only retry.
+     */
+    private static List<StorageEntry> applyFileFiltersRetainingAnchor(List<StorageEntry> matched, List<PartitionFilterHint> hints) {
+        List<StorageEntry> filtered = applyFileMetadataFilters(matched, hints);
+        return filtered.isEmpty() && matched.isEmpty() == false ? matched : filtered;
     }
 
     static PartitionMetadata detectPartitions(
@@ -370,19 +479,15 @@ public final class GlobExpander {
         Check.notNull(pathList, "pathList cannot be null");
         Check.notNull(provider, "provider cannot be null");
 
-        String[] segments = pathList.split(",");
         List<StorageEntry> allEntries = new ArrayList<>();
 
-        for (String segment : segments) {
-            String trimmed = segment.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-
+        for (String trimmed : commaSegments(pathList)) {
             StoragePath segmentPath = StoragePath.of(trimmed);
             if (segmentPath.isPattern()) {
                 int remainingBudget = maxDiscoveredFiles - allEntries.size();
-                FileList expanded = doExpandGlob(
+                // Per segment, so a segment a rewrite narrows to empty falls back on its own instead of being masked
+                // by another segment that still matches.
+                FileList expanded = expandGlobWithRewriteFallback(
                     trimmed,
                     provider,
                     hints,
@@ -413,6 +518,163 @@ public final class GlobExpander {
         PartitionMetadata partitionMetadata = detectPartitions(allEntries, hivePartitioning, partitionConfig, config);
 
         return new GenericFileList(allEntries, pathList, partitionMetadata);
+    }
+
+    /**
+     * The pattern an expansion will actually list once the hints have narrowed it. The one place that decides
+     * whether a hint reaches the glob at all; {@link #doExpandGlob} and {@link #listingCacheDiscriminator} both
+     * route through it so that the listing cache key cannot drift from the listing it names.
+     */
+    static String effectivePattern(
+        String pattern,
+        @Nullable List<PartitionFilterHint> hints,
+        boolean hivePartitioning,
+        @Nullable PartitionConfig partitionConfig
+    ) {
+        if (hints == null || hints.isEmpty() || hivePartitioning == false) {
+            return pattern;
+        }
+        return rewriteGlobWithHints(pattern, hints, partitionConfig);
+    }
+
+    /**
+     * Everything about a query that determines which files a {@code path} lists: the {@code hivePartitioning} flag,
+     * the effective (post-rewrite) glob pattern, and the {@code _file.*} metadata filters. These are the inputs
+     * {@link #doExpandGlob} consults beyond the storage contents themselves — the rewrite via {@link #effectivePattern}
+     * and the file filters via {@link #applyFileMetadataFilters} — and this value shares those same helpers, so the
+     * listing cache key it feeds cannot drift from the listing it names. Note this binds only the cache key: a new
+     * hint channel added to {@link #doExpandGlob} must be added here by hand, or that channel silently reintroduces
+     * the poisoning bug.
+     *
+     * <p>{@link #encode} is injective — every variable-length piece is length-prefixed, so no user-controlled filter
+     * literal (which may hold any character, including the delimiters) can forge a field boundary and collide two
+     * different filters onto one key. Equal encodings therefore genuinely mean equal listings. A new field added to
+     * this record joins {@code equals} for free but must be added to {@code encode} by hand to stay in the key.
+     */
+    private record ListingIdentity(boolean hivePartitioning, String effectivePattern, List<String> encodedFileHints) {
+
+        static ListingIdentity of(String path, @Nullable List<PartitionFilterHint> hints, boolean hivePartitioning) {
+            return new ListingIdentity(
+                hivePartitioning,
+                effectiveWholePathPattern(path, hints, hivePartitioning),
+                encodedFileMetadataHints(hints)
+            );
+        }
+
+        String encode() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(hivePartitioning ? '1' : '0');
+            appendLengthPrefixed(sb, effectivePattern);
+            sb.append(encodedFileHints.size()).append(':');
+            for (String encodedHint : encodedFileHints) {
+                appendLengthPrefixed(sb, encodedHint);
+            }
+            return sb.toString();
+        }
+    }
+
+    /** Appends {@code <charLength>':'<value>}, an injective framing that no value content can forge a boundary in. */
+    private static void appendLengthPrefixed(StringBuilder sb, String value) {
+        sb.append(value.length()).append(':').append(value);
+    }
+
+    /**
+     * A string that identifies the listing a given set of hints produces for a given path: equal discriminators
+     * guarantee equal listings, so it is safe to key the listing cache on it. See {@link ListingIdentity} for the
+     * inputs it captures and why they are exhaustive; hints that reach none of them (an ordinary data column, say)
+     * leave the discriminator untouched, so an incidentally-filtered query still shares the un-filtered entry.
+     */
+    public static String listingCacheDiscriminator(String path, @Nullable List<PartitionFilterHint> hints, boolean hivePartitioning) {
+        return ListingIdentity.of(path, hints, hivePartitioning).encode();
+    }
+
+    /**
+     * Mirrors {@link #expand}'s glob/comma dispatch: in a comma list only the pattern segments are rewritten, over
+     * the same {@link #commaSegments} decomposition the expansion walks. {@code partitionConfig} is fixed null to
+     * match {@link #expand}'s signature — the production listing paths carry no {@link PartitionConfig} (see
+     * {@link #expandAndCompact}), so neither does the identity that names their result.
+     */
+    private static String effectiveWholePathPattern(String path, @Nullable List<PartitionFilterHint> hints, boolean hive) {
+        if (path.indexOf(',') < 0) {
+            return effectivePattern(path, hints, hive, null);
+        }
+        List<String> segments = commaSegments(path);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            String segment = segments.get(i);
+            sb.append(isPattern(segment) ? effectivePattern(segment, hints, hive, null) : segment);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * The non-empty, trimmed segments of a comma-separated path list. The one decomposition shared by the expansion
+     * ({@link #doExpandCommaSeparated}) and the identity that names its result ({@link #effectiveWholePathPattern}),
+     * so the two cannot disagree on which segments a path has.
+     */
+    private static List<String> commaSegments(String pathList) {
+        String[] raw = pathList.split(",");
+        List<String> segments = new ArrayList<>(raw.length);
+        for (String segment : raw) {
+            String trimmed = segment.trim();
+            if (trimmed.isEmpty() == false) {
+                segments.add(trimmed);
+            }
+        }
+        return segments;
+    }
+
+    /**
+     * Whether a comma-list segment is a glob, matching {@link #doExpandCommaSeparated}'s test. An unparseable
+     * segment is reported as a non-pattern so that building a cache key never fails: the expansion that follows
+     * raises the parse error, exactly as it does today.
+     */
+    private static boolean isPattern(String segment) {
+        try {
+            return StoragePath.of(segment).isPattern();
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /** The hints {@link #applyFileMetadataFilters} acts on, each encoded injectively (length-prefixed) and ordered. */
+    private static List<String> encodedFileMetadataHints(@Nullable List<PartitionFilterHint> hints) {
+        List<PartitionFilterHint> fileHints = fileMetadataHints(hints);
+        if (fileHints.isEmpty()) {
+            return List.of();
+        }
+        List<String> encoded = new ArrayList<>(fileHints.size());
+        for (PartitionFilterHint hint : fileHints) {
+            StringBuilder sb = new StringBuilder();
+            appendLengthPrefixed(sb, hint.columnName());
+            appendLengthPrefixed(sb, hint.operator().name());
+            sb.append(hint.values().size()).append(':');
+            for (Object value : hint.values()) {
+                // The value's type is part of its identity: _file.name == "6" and _file.name == 6 filter differently.
+                appendLengthPrefixed(sb, value == null ? "\0null" : value.getClass().getName());
+                appendLengthPrefixed(sb, value == null ? "\0null" : value.toString());
+            }
+            encoded.add(sb.toString());
+        }
+        Collections.sort(encoded);
+        return encoded;
+    }
+
+    /** The subset of hints that {@link #applyFileMetadataFilters} prunes the listing with. */
+    static List<PartitionFilterHint> fileMetadataHints(@Nullable List<PartitionFilterHint> hints) {
+        if (hints == null || hints.isEmpty()) {
+            return List.of();
+        }
+        List<PartitionFilterHint> fileHints = new ArrayList<>();
+        for (PartitionFilterHint hint : hints) {
+            if (FileMetadataColumns.isFileMetadataColumn(hint.columnName())) {
+                fileHints.add(hint);
+            }
+        }
+        return fileHints;
     }
 
     public static String rewriteGlobWithHints(String pattern, List<PartitionFilterHint> hints) {
@@ -475,14 +737,11 @@ public final class GlobExpander {
             if (hint.isSingleValue()) {
                 segments[segIdx] = escapeGlobMeta(String.valueOf(values.get(0)));
             } else {
-                StringBuilder sb = new StringBuilder("{");
-                for (int v = 0; v < values.size(); v++) {
-                    if (v > 0) {
-                        sb.append(',');
-                    }
-                    sb.append(escapeGlobMeta(String.valueOf(values.get(v))));
+                Set<String> spellings = partitionValueSpellings(values);
+                if (braceExpressible(spellings) == false) {
+                    continue; // leave the wildcard so the full set is listed (superset); the row filter narrows
                 }
-                segments[segIdx] = sb.append('}').toString();
+                segments[segIdx] = brace(spellings);
             }
             changed = true;
         }
@@ -533,13 +792,114 @@ public final class GlobExpander {
             return key + "=" + escapeGlobMeta(String.valueOf(values.get(0)));
         }
 
-        // Multiple values: use glob brace syntax key={v1,v2,...}
-        StringBuilder sb = new StringBuilder(key).append("={");
-        for (int i = 0; i < values.size(); i++) {
-            if (i > 0) {
+        // Multiple values: use glob brace syntax key={v1,v2,...}, each value in every on-disk spelling. If a value
+        // holds a brace delimiter the glob dialect cannot express, leave the wildcard so the full set is listed.
+        Set<String> spellings = partitionValueSpellings(values);
+        if (braceExpressible(spellings) == false) {
+            return segment;
+        }
+        return key + "=" + brace(spellings);
+    }
+
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+    /**
+     * The ASCII characters Hive/Spark percent-escape in a partition folder name ({@code FileUtils.escapePathName} /
+     * {@code ExternalCatalogUtils.escapePathName}): the C0 control range, {@code DEL}, and a fixed punctuation set.
+     * Space, {@code ,} and {@code }} are deliberately NOT escaped by those writers (so {@link #braceExpressible}
+     * still vetoes comma/brace values to a full-glob listing). Non-ASCII passes through literally, matching the writer.
+     */
+    private static final BitSet HIVE_ESCAPE = new BitSet(128);
+    static {
+        for (int c = 0; c < 0x20; c++) {
+            HIVE_ESCAPE.set(c);
+        }
+        HIVE_ESCAPE.set(0x7F);
+        for (char c : new char[] { '"', '#', '%', '\'', '*', '/', ':', '=', '?', '\\', '{', '[', ']', '^' }) {
+            HIVE_ESCAPE.set(c);
+        }
+    }
+
+    /**
+     * The on-disk spellings an {@code IN}-list of partition value can take, so the glob rewrite (which matches folder
+     * names literally) lists every folder the row filter would keep instead of silently dropping some. For each value:
+     * the value itself; its two-digit zero-padded form when a single digit (Hive convention for
+     * {@code month}/{@code day}/{@code hour}, {@code 6 → 06}); and the Hive/Spark percent-escaped form of each
+     * ({@code ns:click → ns%3Aclick}, the everyday shape for string partitions holding {@code :} or {@code /}, e.g.
+     * timestamps). Every spelling only <b>widens</b> the brace, so the listing is always a superset and the row filter
+     * narrows — a wrong spelling can never drop rows, only add a folder that is then filtered out.
+     *
+     * <p>A single {@code EQUALS} value stays a concrete segment (it prefix-narrows the listing; a spelling miss lists
+     * empty and hits the un-rewritten fallback). Remaining gaps — integer-vs-decimal spelling ({@code 6} vs
+     * {@code 6.0}, a typing mismatch better fixed by matching folders by typed value), boolean case, padding wider
+     * than two digits, and mixed-width padding within one column — either hit the empty-listing fallback or are the
+     * value-aware follow-up; they cannot be solved cleanly by widening spellings (e.g. blindly emitting {@code 6.0}
+     * for every integer would list nonsense {@code year=2024.0}).
+     */
+    private static Set<String> partitionValueSpellings(List<Object> values) {
+        Set<String> spellings = new LinkedHashSet<>();
+        for (Object value : values) {
+            for (String variant : valueVariants(String.valueOf(value))) {
+                spellings.add(variant);
+                String escaped = hiveEscape(variant);
+                if (escaped.equals(variant) == false) {
+                    spellings.add(escaped);
+                }
+            }
+        }
+        return spellings;
+    }
+
+    /** A value's unescaped on-disk forms before writer escaping: itself and its 2-zero-padded single-digit form. */
+    private static List<String> valueVariants(String raw) {
+        if (raw.length() == 1 && raw.charAt(0) >= '0' && raw.charAt(0) <= '9') {
+            return List.of(raw, "0" + raw);
+        }
+        return List.of(raw);
+    }
+
+    /** Percent-escapes {@code value} the way Hive/Spark write partition folder names (see {@link #HIVE_ESCAPE}). */
+    private static String hiveEscape(String value) {
+        StringBuilder sb = null;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 128 && HIVE_ESCAPE.get(c)) {
+                if (sb == null) {
+                    sb = new StringBuilder(value.length() + 6).append(value, 0, i);
+                }
+                sb.append('%').append(HEX[(c >> 4) & 0xF]).append(HEX[c & 0xF]);
+            } else if (sb != null) {
+                sb.append(c);
+            }
+        }
+        return sb == null ? value : sb.toString();
+    }
+
+    /**
+     * Whether a set of spellings can be expressed as glob brace alternatives. A value containing {@code ,} or
+     * {@code }} would be mis-split by the brace parser (into separate alternatives, or a truncated brace), turning
+     * one value into several and dropping the folder that literally contains the delimiter — so when any spelling
+     * holds one, the caller must skip the rewrite and list the full glob (a superset) rather than a wrong subset.
+     */
+    private static boolean braceExpressible(Set<String> spellings) {
+        for (String spelling : spellings) {
+            if (spelling.indexOf(',') >= 0 || spelling.indexOf('}') >= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Joins glob-escaped spellings into a brace alternation {@code {a,b,c}}. */
+    private static String brace(Set<String> spellings) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (String spelling : spellings) {
+            if (first == false) {
                 sb.append(',');
             }
-            sb.append(escapeGlobMeta(String.valueOf(values.get(i))));
+            sb.append(escapeGlobMeta(spelling));
+            first = false;
         }
         return sb.append('}').toString();
     }
@@ -561,12 +921,7 @@ public final class GlobExpander {
     }
 
     public static List<StorageEntry> applyFileMetadataFilters(List<StorageEntry> entries, List<PartitionFilterHint> hints) {
-        List<PartitionFilterHint> fileHints = new ArrayList<>();
-        for (PartitionFilterHint hint : hints) {
-            if (FileMetadataColumns.isFileMetadataColumn(hint.columnName())) {
-                fileHints.add(hint);
-            }
-        }
+        List<PartitionFilterHint> fileHints = fileMetadataHints(hints);
         if (fileHints.isEmpty()) {
             return entries;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -2009,6 +2009,131 @@ public class ExternalSourceResolverTests extends ESTestCase {
     }
 
     /**
+     * A filtered query must not poison the listing cache for a later unfiltered one. The filter's hints narrow the
+     * listing to a subset of the files; keyed only on the path, that subset would be served back to a query that
+     * carries no filter, which then silently sees fewer files than the dataset holds. Here the {@code _file.name}
+     * hint on a plain glob prunes the listing to one file; the unfiltered follow-up must still see all three.
+     */
+    public void testListingCacheNotPoisonedByFileMetadataHint() throws Exception {
+        String glob = "s3://bucket/data/*.parquet";
+        Map<String, List<Attribute>> schemas = new HashMap<>();
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+        schemas.put("s3://bucket/data/a.parquet", schema);
+        schemas.put("s3://bucket/data/b.parquet", schema);
+        schemas.put("s3://bucket/data/c.parquet", schema);
+        List<StorageEntry> listing = List.of(
+            entry("s3://bucket/data/a.parquet", 100),
+            entry("s3://bucket/data/b.parquet", 200),
+            entry("s3://bucket/data/c.parquet", 300)
+        );
+        CountingStorageProvider provider = new CountingStorageProvider(Map.of("s3://bucket/data/", listing), schemas);
+
+        var hint = new PartitionFilterHintExtractor.PartitionFilterHint(
+            FileMetadataColumns.NAME,
+            PartitionFilterHintExtractor.Operator.EQUALS,
+            List.of("a.parquet")
+        );
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+            ExternalSourceResolver resolver = createResolverWithCache(provider, schemas, cacheService);
+
+            ExternalSourceResolution filtered = resolveWith(resolver, glob, Map.of(glob, List.of(hint)));
+            assertEquals(1, filtered.resolvedSource(glob).fileList().fileCount());
+
+            ExternalSourceResolution unfiltered = resolveWith(resolver, glob, Map.of());
+            assertEquals(
+                "the unfiltered query must see every file, not the filtered query's cached subset",
+                3,
+                unfiltered.resolvedSource(glob).fileList().fileCount()
+            );
+        }
+    }
+
+    /**
+     * The keyed-glob form of the same defect: {@code WHERE year == 2024} rewrites the glob to a single partition
+     * folder, so the cached listing enumerates only that folder. An unfiltered follow-up must not be served that
+     * narrowed listing.
+     */
+    public void testListingCacheNotPoisonedByPartitionHint() throws Exception {
+        String glob = "s3://bucket/data/year=*/*.parquet";
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+        Map<String, List<Attribute>> schemas = new HashMap<>();
+        schemas.put("s3://bucket/data/year=2024/a.parquet", schema);
+        schemas.put("s3://bucket/data/year=2025/b.parquet", schema);
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put(
+            "s3://bucket/data/",
+            List.of(entry("s3://bucket/data/year=2024/a.parquet", 100), entry("s3://bucket/data/year=2025/b.parquet", 200))
+        );
+        listingsByPrefix.put("s3://bucket/data/year=2024/", List.of(entry("s3://bucket/data/year=2024/a.parquet", 100)));
+        CountingStorageProvider provider = new CountingStorageProvider(listingsByPrefix, schemas);
+
+        var hint = new PartitionFilterHintExtractor.PartitionFilterHint(
+            "year",
+            PartitionFilterHintExtractor.Operator.EQUALS,
+            List.of(2024)
+        );
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+            ExternalSourceResolver resolver = createResolverWithCache(provider, schemas, cacheService);
+
+            ExternalSourceResolution filtered = resolveWith(resolver, glob, Map.of(glob, List.of(hint)));
+            assertEquals(1, filtered.resolvedSource(glob).fileList().fileCount());
+
+            ExternalSourceResolution unfiltered = resolveWith(resolver, glob, Map.of());
+            assertEquals(
+                "the unfiltered query must enumerate every partition, not the filtered query's single folder",
+                2,
+                unfiltered.resolvedSource(glob).fileList().fileCount()
+            );
+        }
+    }
+
+    /**
+     * A filter that rewrites the glob to a folder that does not exist must resolve to the full listing, not raise
+     * "Glob pattern matched no files". The rewrite spells the value literally ({@code year=2099}); the row filter
+     * still runs, so listing the whole dataset is correct and the query returns zero rows on its own. This is also
+     * what protects a zero-padded {@code month=06} folder from a {@code month == 6} predicate.
+     */
+    public void testZeroMatchPartitionFilterResolvesToFullListingNotError() throws Exception {
+        String glob = "s3://bucket/data/year=*/*.parquet";
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+        Map<String, List<Attribute>> schemas = new HashMap<>();
+        schemas.put("s3://bucket/data/year=2024/a.parquet", schema);
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        listingsByPrefix.put("s3://bucket/data/", List.of(entry("s3://bucket/data/year=2024/a.parquet", 100)));
+        // The narrowed prefix s3://bucket/data/year=2099/ is deliberately absent: an object store lists it as empty.
+        CountingStorageProvider provider = new CountingStorageProvider(listingsByPrefix, schemas);
+
+        var hint = new PartitionFilterHintExtractor.PartitionFilterHint(
+            "year",
+            PartitionFilterHintExtractor.Operator.EQUALS,
+            List.of(2099)
+        );
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+            ExternalSourceResolver resolver = createResolverWithCache(provider, schemas, cacheService);
+
+            ExternalSourceResolution resolution = resolveWith(resolver, glob, Map.of(glob, List.of(hint)));
+            assertEquals(1, resolution.resolvedSource(glob).fileList().fileCount());
+        }
+    }
+
+    private ExternalSourceResolution resolveWith(
+        ExternalSourceResolver resolver,
+        String glob,
+        Map<String, List<PartitionFilterHintExtractor.PartitionFilterHint>> filterHints
+    ) {
+        Map<String, Map<String, Object>> pathConfigs = Map.of(
+            glob,
+            new HashMap<>(configFor(FormatReader.SchemaResolution.FIRST_FILE_WINS))
+        );
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of(glob), pathConfigs, filterHints, null, null, future);
+        return future.actionGet();
+    }
+
+    /**
      * Invariant: every schema-resolution mode must consult the schema cache on the per-file
      * resolve. A second resolve of the same glob across the same paths must add zero schema-loader
      * calls. Parameterized over {@link #MULTI_FILE_STRATEGIES} so any new mode inherits the

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobExpanderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobExpanderTests.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -156,6 +157,67 @@ public class GlobExpanderTests extends ESTestCase {
         assertEquals("s3://bucket/year={2023,2024}/*.parquet", rewritten);
     }
 
+    /**
+     * A single-digit IN value must match both its bare and zero-padded folder spelling (6 → month=6 or month=06),
+     * or a query like {@code month IN (6, 11)} silently drops the zero-padded month=06 while month=11 still matches.
+     * Multi-digit values (11, years) are emitted unchanged.
+     */
+    public void testRewriteGlobWithInHintEmitsZeroPaddedSpellings() {
+        var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.IN, 6, 11));
+        String rewritten = GlobExpander.rewriteGlobWithHints("s3://bucket/month=*/*.parquet", hints);
+        assertEquals("s3://bucket/month={6,06,11}/*.parquet", rewritten);
+    }
+
+    /**
+     * An IN value that contains a brace delimiter ({@code ,} or <code>&#125;</code>) cannot be expressed as a glob
+     * brace alternative — the parser would split it and drop the folder that literally contains the delimiter. The
+     * rewrite must be vetoed, leaving the wildcard so the full glob is listed (a superset) and the row filter narrows.
+     */
+    public void testRewriteGlobWithInHintVetoedWhenValueHoldsBraceDelimiter() {
+        var hints = List.of(hint("region", PartitionFilterHintExtractor.Operator.IN, "a,b", "c"));
+        String rewritten = GlobExpander.rewriteGlobWithHints("s3://bucket/region=*/*.parquet", hints);
+        assertEquals("s3://bucket/region=*/*.parquet", rewritten);
+    }
+
+    /**
+     * An IN value with characters Hive/Spark percent-escape in folder names (`:` `/` etc.) must emit both the bare and
+     * escaped spelling — the on-disk folder is `category=ns%3Aclick`, so a rewrite to bare `ns:click` would miss it.
+     */
+    public void testRewriteGlobWithInHintEmitsHiveEscapedSpellings() {
+        var hints = List.of(hint("category", PartitionFilterHintExtractor.Operator.IN, "login", "ns:click"));
+        String rewritten = GlobExpander.rewriteGlobWithHints("s3://bucket/category=*/*.parquet", hints);
+        assertThat(rewritten, containsString("ns:click"));
+        assertThat(rewritten, containsString("ns%3Aclick"));
+        assertThat(rewritten, containsString("login"));
+    }
+
+    /**
+     * End-to-end: an IN over a Hive-escaped partition folder lists it. Folders `category=login/` and the escaped
+     * `category=ns%3Aclick/` (Spark's on-disk spelling of value `ns:click`); `WHERE category IN ("login","ns:click")`
+     * must list both, not silently drop the escaped one. Red before the escape-spelling fix (esql-planning#1176).
+     */
+    public void testInListMatchesHiveEscapedFolder() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of(
+                "s3://bucket/data/",
+                List.of(
+                    entry("s3://bucket/data/category=login/a.parquet", 100),
+                    entry("s3://bucket/data/category=ns%3Aclick/b.parquet", 200)
+                )
+            )
+        );
+
+        var hints = List.of(hint("category", PartitionFilterHintExtractor.Operator.IN, "login", "ns:click"));
+        FileList result = GlobExpander.expand("s3://bucket/data/category=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < result.fileCount(); i++) {
+            paths.add(result.path(i).toString());
+        }
+        assertEquals("the escaped category=ns%3Aclick folder must be listed alongside category=login", 2, result.fileCount());
+        assertTrue(paths.contains("s3://bucket/data/category=ns%3Aclick/b.parquet"));
+    }
+
     public void testRewriteGlobWithRangeHintNoRewrite() {
         var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.GREATER_THAN_OR_EQUAL, 2020));
         String rewritten = GlobExpander.rewriteGlobWithHints("s3://bucket/year=*/*.parquet", hints);
@@ -168,7 +230,8 @@ public class GlobExpanderTests extends ESTestCase {
             hint("month", PartitionFilterHintExtractor.Operator.IN, 1, 2, 3)
         );
         String rewritten = GlobExpander.rewriteGlobWithHints("s3://bucket/year=*/month=*/*.parquet", hints);
-        assertEquals("s3://bucket/year=2024/month={1,2,3}/*.parquet", rewritten);
+        // Single-digit IN values carry their zero-padded spelling too, so month=01/02/03 folders match.
+        assertEquals("s3://bucket/year=2024/month={1,01,2,02,3,03}/*.parquet", rewritten);
     }
 
     public void testRewriteGlobNonWildcardNotRewritten() {
@@ -237,8 +300,8 @@ public class GlobExpanderTests extends ESTestCase {
         var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.IN, 1, 2));
         PartitionConfig config = new PartitionConfig(PartitionConfig.Strategy.TEMPLATE, "{year}/{month}");
         String rewritten = GlobExpander.rewriteGlobWithHints("s3://bucket/*/*/*.parquet", hints, config);
-        // Second wildcard maps to {month} → rewritten to {1,2}
-        assertEquals("s3://bucket/*/{1,2}/*.parquet", rewritten);
+        // Second wildcard maps to {month} → rewritten to {1,01,2,02} so zero-padded folders match too
+        assertEquals("s3://bucket/*/{1,01,2,02}/*.parquet", rewritten);
     }
 
     public void testRewriteGlobWithTemplateRangeHintsNoRewrite() {
@@ -480,7 +543,382 @@ public class GlobExpanderTests extends ESTestCase {
         assertEquals(2, result.fileCount());
     }
 
+    // -- hints that prune the listing to nothing fall back to the un-hinted listing --
+
+    /**
+     * The rewritten glob names a folder that does not exist. Listing a superset of the files is always correct —
+     * the row filter still runs — so the expansion must fall back to the original glob rather than report that the
+     * pattern matched nothing, which the resolver turns into an error.
+     */
+    public void testHintPruningListingToEmptyFallsBackToUnhintedListing() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of("s3://bucket/data/", List.of(entry("s3://bucket/data/year=2024/a.parquet", 100)))
+        );
+
+        var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
+        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertEquals(1, result.fileCount());
+        assertEquals("s3://bucket/data/year=2024/a.parquet", result.path(0).toString());
+    }
+
+    /**
+     * The trap this fix exists to avoid. {@code rewriteSegment} spells the hint's value with {@code String.valueOf},
+     * so {@code WHERE month == 6} narrows the glob to {@code month=6} — but Hive writes a zero-padded {@code month=06}.
+     * Reporting "matched no files" (or empty) there would turn an ordinary dataset into silent zero rows.
+     */
+    public void testZeroPaddedFolderAgainstUnpaddedHintFallsBack() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of("s3://bucket/data/", List.of(entry("s3://bucket/data/month=06/a.parquet", 100)))
+        );
+
+        var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6));
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertEquals("the zero-padded folder must still be listed", 1, result.fileCount());
+        assertEquals("s3://bucket/data/month=06/a.parquet", result.path(0).toString());
+    }
+
+    /**
+     * The local filesystem provider throws when a directory does not exist, where an object store lists the missing
+     * prefix as empty. A hint that narrows the prefix to a folder that was never created must behave the same on both.
+     */
+    public void testHintNarrowedPrefixThatThrowsFallsBackToUnhintedListing() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of("s3://bucket/data/", List.of(entry("s3://bucket/data/year=2024/a.parquet", 100)))
+        );
+        provider.throwOnUnknownPrefix = true;
+
+        var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
+        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertEquals(1, result.fileCount());
+    }
+
+    /**
+     * The {@code _file.*} filters are exact — an all-pruned result is genuinely zero rows, with no spelling to
+     * disambiguate — so an all-pruned listing is retained (the resolver needs an anchor and the row filter still
+     * yields zero rows) rather than re-listed. The listing must not be recomputed a second time.
+     */
+    public void testFileMetadataPruneToEmptyRetainsAnchorWithoutRelisting() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of("s3://bucket/data/", List.of(entry("s3://bucket/data/a.parquet", 100), entry("s3://bucket/data/b.parquet", 200)))
+        );
+
+        var hints = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "nope.parquet"));
+        FileList result = GlobExpander.expand("s3://bucket/data/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertEquals(2, result.fileCount());
+        assertEquals("an exact _file.* prune is retained in one listing pass, not re-listed", 1, provider.listCallCount);
+    }
+
+    /**
+     * A comma segment a rewrite narrows to empty must fall back on its own, not be masked by another segment that
+     * still matches. Without per-segment fallback the {@code a/month=06} files are silently dropped while {@code b/}
+     * keeps the aggregate non-empty.
+     */
+    public void testCommaSegmentRewrittenToEmptyFallsBackForThatSegment() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of(
+                "s3://bucket/a/",
+                List.of(entry("s3://bucket/a/month=06/x.parquet", 100)),
+                "s3://bucket/b/",
+                List.of(entry("s3://bucket/b/y.parquet", 200))
+            )
+        );
+
+        var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6));
+        FileList result = GlobExpander.expand("s3://bucket/a/month=*/*.parquet,s3://bucket/b/*.parquet", provider, hints, true, MAX, MAX);
+
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < result.fileCount(); i++) {
+            paths.add(result.path(i).toString());
+        }
+        assertEquals("the pruned segment's zero-padded file must survive alongside the other segment", 2, result.fileCount());
+        assertTrue(paths.contains("s3://bucket/a/month=06/x.parquet"));
+        assertTrue(paths.contains("s3://bucket/b/y.parquet"));
+    }
+
+    /**
+     * A single glob with an IN-list mixing single- and multi-digit values on a zero-padded partition. `month=11`
+     * matches the rewrite so the listing is non-empty and the empty-fallback never fires; without the zero-padded
+     * spelling in the brace, `month=06` is silently dropped even though the row filter would keep it. (Same wrong-data
+     * class as the human-reviewed comma bug, single-glob form; esql-planning#1176.)
+     */
+    public void testInListMixedDigitValuesMatchZeroPaddedFolders() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of(
+                "s3://bucket/data/",
+                List.of(entry("s3://bucket/data/month=06/a.parquet", 100), entry("s3://bucket/data/month=11/b.parquet", 200))
+            )
+        );
+
+        var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.IN, 6, 11));
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < result.fileCount(); i++) {
+            paths.add(result.path(i).toString());
+        }
+        assertEquals("the zero-padded month=06 must be listed alongside month=11", 2, result.fileCount());
+        assertTrue(paths.contains("s3://bucket/data/month=06/a.parquet"));
+        assertTrue(paths.contains("s3://bucket/data/month=11/b.parquet"));
+    }
+
+    /** The local-filesystem flavor of the per-segment fallback: the rewritten segment prefix throws. */
+    public void testCommaSegmentRewrittenPrefixThatThrowsFallsBack() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of(
+                "s3://bucket/a/",
+                List.of(entry("s3://bucket/a/month=06/x.parquet", 100)),
+                "s3://bucket/b/",
+                List.of(entry("s3://bucket/b/y.parquet", 200))
+            )
+        );
+        provider.throwOnUnknownPrefix = true;
+
+        var hints = List.of(hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6));
+        FileList result = GlobExpander.expand("s3://bucket/a/month=*/*.parquet,s3://bucket/b/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertEquals(2, result.fileCount());
+    }
+
+    /**
+     * The rewrite-channel fallback drops the rewrite but must keep the exact {@code _file.*} filters, or the fallback
+     * over-lists. Here {@code month == 6} empties the rewritten glob; the fallback re-lists {@code month=*} but the
+     * {@code _file.size > 100} filter must still exclude the small file.
+     */
+    public void testRewriteFallbackKeepsFileMetadataFilter() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of(
+                "s3://bucket/data/",
+                List.of(
+                    entry("s3://bucket/data/month=06/big.parquet", 200),
+                    entry("s3://bucket/data/month=06/small.parquet", 10),
+                    entry("s3://bucket/data/month=07/other.parquet", 300)
+                )
+            )
+        );
+
+        var hints = List.of(
+            hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6),
+            hint(FileMetadataColumns.SIZE, PartitionFilterHintExtractor.Operator.GREATER_THAN, 100)
+        );
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < result.fileCount(); i++) {
+            paths.add(result.path(i).toString());
+        }
+        assertEquals("the fallback keeps the size filter, dropping the small file", 2, result.fileCount());
+        assertTrue(paths.contains("s3://bucket/data/month=06/big.parquet"));
+        assertTrue(paths.contains("s3://bucket/data/month=07/other.parquet"));
+    }
+
+    /**
+     * A query whose rewrite AND file filter both exclude everything still leaves an anchor: the rewrite fallback
+     * re-lists {@code month=*}, the exact size filter prunes it to empty, and retention keeps the file so the
+     * resolver never sees zero files (the row filter yields zero rows downstream).
+     */
+    public void testComposedPruneToEmptyRetainsAnchor() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of("s3://bucket/data/", List.of(entry("s3://bucket/data/month=06/small.parquet", 10)))
+        );
+
+        var hints = List.of(
+            hint("month", PartitionFilterHintExtractor.Operator.EQUALS, 6),
+            hint(FileMetadataColumns.SIZE, PartitionFilterHintExtractor.Operator.GREATER_THAN, 1_000_000)
+        );
+        FileList result = GlobExpander.expand("s3://bucket/data/month=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertTrue(result.isResolved());
+        assertEquals(1, result.fileCount());
+        assertEquals("s3://bucket/data/month=06/small.parquet", result.path(0).toString());
+    }
+
+    /** A pattern that genuinely matches nothing still comes back empty — the caller's loud error is preserved. */
+    public void testUnhintedListingAlsoEmptyStaysEmpty() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(Map.of("s3://bucket/data/", List.of()));
+
+        var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
+        FileList result = GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, MAX, MAX);
+
+        assertTrue(result.isResolved());
+        assertEquals(0, result.fileCount());
+    }
+
+    /** A hint that narrows nothing must not trigger a second listing pass. */
+    public void testUnhintedEmptyListingIsNotRetried() throws IOException {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(Map.of("s3://bucket/data/", List.of()));
+
+        FileList result = GlobExpander.expand("s3://bucket/data/*.parquet", provider, null, true, MAX, MAX);
+
+        assertEquals(0, result.fileCount());
+        assertEquals("no hints, so no fallback listing", 1, provider.listCallCount);
+    }
+
+    /**
+     * The rewrite fallback re-lists the full glob to tell a spelling-miss from a genuinely empty partition. If that
+     * full listing exceeds {@code max_discovered_files} the discovery cap fires — the same error the un-filtered
+     * query would raise. That cap error is preserved deliberately; deciding the two cases needs the full listing.
+     */
+    public void testRewriteFallbackBeyondDiscoveryCapKeepsCapError() {
+        PrefixAwareStubProvider provider = new PrefixAwareStubProvider(
+            Map.of(
+                "s3://bucket/data/",
+                List.of(
+                    entry("s3://bucket/data/year=2024/a.parquet", 100),
+                    entry("s3://bucket/data/year=2024/b.parquet", 200),
+                    entry("s3://bucket/data/year=2024/c.parquet", 300)
+                )
+            )
+        );
+
+        var hints = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2099));
+        var e = expectThrows(
+            QlIllegalArgumentException.class,
+            () -> GlobExpander.expand("s3://bucket/data/year=*/*.parquet", provider, hints, true, 2, MAX)
+        );
+        assertThat(e.getMessage(), containsString("discovered too many files"));
+    }
+
+    // -- listing cache discriminator --
+
+    /**
+     * The property the listing cache key rests on: equal discriminators must mean equal listings. Hints reach the
+     * listing through the glob rewrite and the {@code _file.*} filters, and nothing else. This catches a new listing
+     * channel added to the expansion but not the discriminator — <b>only for the hint shapes below</b>, so extend
+     * {@code hintSets} whenever a new channel or hint kind is introduced, or it can slip through.
+     */
+    public void testDiscriminatorDeterminesTheListing() throws IOException {
+        Map<String, List<StorageEntry>> tree = Map.of(
+            "s3://bucket/data/",
+            List.of(entry("s3://bucket/data/year=2024/a.parquet", 100), entry("s3://bucket/data/year=2025/b.parquet", 200)),
+            "s3://bucket/data/year=2024/",
+            List.of(entry("s3://bucket/data/year=2024/a.parquet", 100)),
+            "s3://bucket/data/year=2025/",
+            List.of(entry("s3://bucket/data/year=2025/b.parquet", 200))
+        );
+        String pattern = "s3://bucket/data/year=*/*.parquet";
+
+        List<List<PartitionFilterHintExtractor.PartitionFilterHint>> hintSets = List.of(
+            List.of(),
+            List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024)),
+            List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2025)),
+            List.of(hint("region", PartitionFilterHintExtractor.Operator.EQUALS, "us")),
+            List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "a.parquet")),
+            List.of(hint(FileMetadataColumns.SIZE, PartitionFilterHintExtractor.Operator.GREATER_THAN, 150))
+        );
+
+        Map<String, List<String>> listingByDiscriminator = new HashMap<>();
+        for (var hints : hintSets) {
+            for (boolean hive : List.of(true, false)) {
+                String discriminator = GlobExpander.listingCacheDiscriminator(pattern, hints, hive);
+                List<String> files = new ArrayList<>();
+                FileList expanded = GlobExpander.expand(pattern, new PrefixAwareStubProvider(tree), hints, hive, MAX, MAX);
+                for (int i = 0; i < expanded.fileCount(); i++) {
+                    files.add(expanded.path(i).toString());
+                }
+                List<String> previous = listingByDiscriminator.putIfAbsent(discriminator, files);
+                if (previous != null) {
+                    assertEquals("same discriminator must mean the same listing", previous, files);
+                }
+            }
+        }
+    }
+
+    /**
+     * A hint on an ordinary data column reaches neither channel, so it must leave the discriminator alone —
+     * otherwise every distinct WHERE literal would get its own cache entry and the listing cache would stop
+     * hitting for filtered queries.
+     */
+    public void testDiscriminatorIgnoresHintsThatCannotNarrowTheListing() {
+        String pattern = "s3://bucket/data/*.parquet";
+        String unhinted = GlobExpander.listingCacheDiscriminator(pattern, null, true);
+
+        var dataColumnHint = List.of(hint("user_id", PartitionFilterHintExtractor.Operator.EQUALS, 42));
+        assertEquals(unhinted, GlobExpander.listingCacheDiscriminator(pattern, dataColumnHint, true));
+
+        // A `year=*` segment is absent from this pattern, so even a rewritable hint cannot narrow it.
+        var absentPartitionHint = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
+        assertEquals(unhinted, GlobExpander.listingCacheDiscriminator(pattern, absentPartitionHint, true));
+    }
+
+    /** Every input that changes the listing must change the discriminator. */
+    public void testDiscriminatorSeparatesHintsThatNarrowTheListing() {
+        String keyed = "s3://bucket/data/year=*/*.parquet";
+        String plain = "s3://bucket/data/*.parquet";
+        String unhintedKeyed = GlobExpander.listingCacheDiscriminator(keyed, null, true);
+
+        var year2024 = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
+        var year2025 = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2025));
+        assertNotEquals(unhintedKeyed, GlobExpander.listingCacheDiscriminator(keyed, year2024, true));
+        assertNotEquals(
+            GlobExpander.listingCacheDiscriminator(keyed, year2024, true),
+            GlobExpander.listingCacheDiscriminator(keyed, year2025, true)
+        );
+
+        // hive_partitioning gates the rewrite and selects the partition metadata carried by the cached listing.
+        assertNotEquals(unhintedKeyed, GlobExpander.listingCacheDiscriminator(keyed, null, false));
+
+        var fileName = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "a.parquet"));
+        assertNotEquals(
+            GlobExpander.listingCacheDiscriminator(plain, null, true),
+            GlobExpander.listingCacheDiscriminator(plain, fileName, true)
+        );
+
+        // A value's type is part of its identity: _file.name == "6" and _file.name == 6 do not filter alike.
+        var nameSix = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "6"));
+        var nameSixInt = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, 6));
+        assertNotEquals(
+            GlobExpander.listingCacheDiscriminator(plain, nameSix, true),
+            GlobExpander.listingCacheDiscriminator(plain, nameSixInt, true)
+        );
+    }
+
+    /** In a comma-separated list only the pattern segments are rewritten, so only they may move the discriminator. */
+    public void testDiscriminatorHandlesCommaSeparatedPaths() {
+        String paths = "s3://bucket/a/year=*/*.parquet,s3://bucket/b/plain.parquet";
+        var year2024 = List.of(hint("year", PartitionFilterHintExtractor.Operator.EQUALS, 2024));
+
+        String unhinted = GlobExpander.listingCacheDiscriminator(paths, null, true);
+        String hinted = GlobExpander.listingCacheDiscriminator(paths, year2024, true);
+
+        assertNotEquals(unhinted, hinted);
+        assertThat(hinted, containsString("s3://bucket/a/year=2024/*.parquet"));
+        assertThat(hinted, containsString("s3://bucket/b/plain.parquet"));
+    }
+
+    /**
+     * Filter literals carry arbitrary characters, including whatever delimiters the encoding uses. Two distinct
+     * filters must never encode to the same discriminator — a collision would serve one filter's narrowed listing to
+     * the other. Exercises values holding the control characters a naive separator-joined encoding would break on.
+     */
+    public void testDiscriminatorDoesNotCollideOnValuesContainingDelimiters() {
+        String pattern = "s3://bucket/data/*.parquet";
+
+        // A single value that splices in what would be a second value under separator-joining.
+        var oneSplicedValue = List.of(
+            hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.IN, "a\u0001java.lang.String:b")
+        );
+        var twoValues = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.IN, "a", "b"));
+        assertNotEquals(
+            GlobExpander.listingCacheDiscriminator(pattern, oneSplicedValue, true),
+            GlobExpander.listingCacheDiscriminator(pattern, twoValues, true)
+        );
+
+        // A value carrying the top-level joiner must not fake the pattern/hints boundary.
+        var nullByteValue = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "x\u0000y"));
+        var plainValue = List.of(hint(FileMetadataColumns.NAME, PartitionFilterHintExtractor.Operator.EQUALS, "xy"));
+        assertNotEquals(
+            GlobExpander.listingCacheDiscriminator(pattern, nullByteValue, true),
+            GlobExpander.listingCacheDiscriminator(pattern, plainValue, true)
+        );
+    }
+
     // -- helpers --
+
+    private static final int MAX = Integer.MAX_VALUE;
 
     private static PartitionFilterHintExtractor.PartitionFilterHint hint(
         String column,
@@ -488,6 +926,84 @@ public class GlobExpanderTests extends ESTestCase {
         Object... values
     ) {
         return new PartitionFilterHintExtractor.PartitionFilterHint(column, op, List.of(values));
+    }
+
+    /**
+     * Lists only the entries under the requested prefix, as a real provider does. {@link StubProvider} returns its
+     * whole listing whatever the prefix, which makes a glob narrowed onto a missing folder indistinguishable from an
+     * un-narrowed one — the reason the listing layer's pruning bugs never surfaced in these tests.
+     *
+     * <p>{@code throwOnUnknownPrefix} models {@code LocalStorageProvider}, which throws on a missing directory where
+     * an object store returns an empty listing.
+     */
+    private static class PrefixAwareStubProvider implements StorageProvider {
+        private final Map<String, List<StorageEntry>> listingsByPrefix;
+        boolean throwOnUnknownPrefix = false;
+        int listCallCount = 0;
+
+        PrefixAwareStubProvider(Map<String, List<StorageEntry>> listingsByPrefix) {
+            this.listingsByPrefix = listingsByPrefix;
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new StubStorageObject(path, 0, false);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return new StubStorageObject(path, length, true);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return new StubStorageObject(path, length, true);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) throws IOException {
+            listCallCount++;
+            List<StorageEntry> entries = listingsByPrefix.get(prefix.toString());
+            if (entries == null) {
+                if (throwOnUnknownPrefix) {
+                    throw new IOException("Directory does not exist: " + prefix);
+                }
+                entries = List.of();
+            }
+            List<StorageEntry> snapshot = entries;
+            return new StorageIterator() {
+                private final Iterator<StorageEntry> it = snapshot.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                @Override
+                public StorageEntry next() {
+                    if (it.hasNext() == false) {
+                        throw new NoSuchElementException();
+                    }
+                    return it.next();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return false;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of("s3");
+        }
+
+        @Override
+        public void close() {}
     }
 
     private static StorageEntry entry(String path, long length) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
+import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.SplitStats;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
 public class ExternalSourceCacheServiceTests extends ESTestCase {
@@ -98,7 +100,7 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
     public void testListingHitMiss() throws Exception {
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
             AtomicInteger loaderCalls = new AtomicInteger();
-            ListingCacheKey key = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of());
+            ListingCacheKey key = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), "");
 
             FileList listing1 = service.getOrComputeListing(key, k -> {
                 loaderCalls.incrementAndGet();
@@ -123,8 +125,8 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
             AtomicInteger loaderCalls = new AtomicInteger();
 
-            ListingCacheKey key1 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of("access_key", "userA"));
-            ListingCacheKey key2 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of("access_key", "userB"));
+            ListingCacheKey key1 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of("access_key", "userA"), "");
+            ListingCacheKey key2 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of("access_key", "userB"), "");
             assertNotEquals(key1, key2);
 
             service.getOrComputeListing(key1, k -> {
@@ -143,8 +145,20 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
             AtomicInteger loaderCalls = new AtomicInteger();
 
-            ListingCacheKey key1 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of("endpoint", "us-east-1.amazonaws.com"));
-            ListingCacheKey key2 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of("endpoint", "eu-west-1.amazonaws.com"));
+            ListingCacheKey key1 = ListingCacheKey.build(
+                "s3",
+                "bucket",
+                "/data/*.parquet",
+                Map.of("endpoint", "us-east-1.amazonaws.com"),
+                ""
+            );
+            ListingCacheKey key2 = ListingCacheKey.build(
+                "s3",
+                "bucket",
+                "/data/*.parquet",
+                Map.of("endpoint", "eu-west-1.amazonaws.com"),
+                ""
+            );
             assertNotEquals(key1, key2);
 
             service.getOrComputeListing(key1, k -> {
@@ -157,6 +171,98 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
             });
             assertEquals(2, loaderCalls.get());
         }
+    }
+
+    public void testDifferentListingDiscriminatorSeparatesEntries() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            AtomicInteger loaderCalls = new AtomicInteger();
+
+            // Same scheme/bucket/glob/credentials — the only difference is the filter that narrowed each listing.
+            // Uses the real discriminator so a change to its encoding that broke isolation would fail here too.
+            String glob = "s3://bucket/data/year=*/*.parquet";
+            var hint = new PartitionFilterHintExtractor.PartitionFilterHint(
+                "year",
+                PartitionFilterHintExtractor.Operator.EQUALS,
+                List.of(2024)
+            );
+            ListingCacheKey filtered = ListingCacheKey.build(
+                "s3",
+                "bucket",
+                "/data/year=*/*.parquet",
+                Map.of(),
+                GlobExpander.listingCacheDiscriminator(glob, List.of(hint), true)
+            );
+            ListingCacheKey unfiltered = ListingCacheKey.build(
+                "s3",
+                "bucket",
+                "/data/year=*/*.parquet",
+                Map.of(),
+                GlobExpander.listingCacheDiscriminator(glob, null, true)
+            );
+            assertNotEquals(filtered, unfiltered);
+
+            service.getOrComputeListing(filtered, k -> {
+                loaderCalls.incrementAndGet();
+                return testCompactFileList();
+            });
+            service.getOrComputeListing(unfiltered, k -> {
+                loaderCalls.incrementAndGet();
+                return testCompactFileList();
+            });
+            assertEquals("a differently-filtered listing must not be served from the unfiltered entry", 2, loaderCalls.get());
+        }
+    }
+
+    public void testSameListingDiscriminatorSharesEntry() throws Exception {
+        try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
+            AtomicInteger loaderCalls = new AtomicInteger();
+
+            String discriminator = GlobExpander.listingCacheDiscriminator("s3://bucket/data/*.parquet", null, true);
+            ListingCacheKey key1 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), discriminator);
+            ListingCacheKey key2 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), discriminator);
+            assertEquals(key1, key2);
+
+            service.getOrComputeListing(key1, k -> {
+                loaderCalls.incrementAndGet();
+                return testCompactFileList();
+            });
+            service.getOrComputeListing(key2, k -> {
+                loaderCalls.incrementAndGet();
+                return testCompactFileList();
+            });
+            assertEquals("identical discriminators share one entry", 1, loaderCalls.get());
+        }
+    }
+
+    /**
+     * A filter's {@code IN}-list is unbounded, and the cache weighs only the value, so the discriminator is hashed
+     * into the key rather than stored raw. The key stays fixed-width however large the filter is, while still
+     * separating two different large filters and sharing one entry for identical ones.
+     */
+    public void testLargeDiscriminatorIsHashedNotStoredRaw() throws Exception {
+        StringBuilder longIn = new StringBuilder("s3://bucket/data/year={");
+        for (int i = 0; i < 5000; i++) {
+            if (i > 0) {
+                longIn.append(',');
+            }
+            longIn.append(2000 + i);
+        }
+        String bigGlobA = longIn.append("}/*.parquet").toString();
+        String bigGlobB = bigGlobA.replace("year={2000", "year={1999");
+        assertThat("the discriminator string this test hashes is genuinely large", bigGlobA.length(), greaterThan(20000));
+
+        ListingCacheKey a1 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), bigGlobA);
+        ListingCacheKey a2 = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), bigGlobA);
+        ListingCacheKey b = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), bigGlobB);
+
+        assertEquals("identical large discriminators hash equal", a1, a2);
+        assertNotEquals("different large discriminators do not collide", a1, b);
+
+        // Gate the hashing itself: the key must hold the SHA-256-truncated digest of the discriminator, not the
+        // raw string. Recompute the expected digest independently — this fails if build() ever stored the string.
+        long[] expected = ListingCacheKey.sha256Truncated(bigGlobA);
+        assertEquals("key stores the SHA-256 digest (high 64 bits)", expected[0], a1.listingDiscriminatorH1());
+        assertEquals("key stores the SHA-256 digest (low 64 bits)", expected[1], a1.listingDiscriminatorH2());
     }
 
     public void testDisabledBypassesCache() throws Exception {
@@ -182,7 +288,7 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
             SchemaCacheKey sKey = SchemaCacheKey.build("s3://bucket/file.parquet", 1000L, ".parquet", Map.of());
             service.getOrComputeSchema(sKey, k -> testSchemaEntry());
 
-            ListingCacheKey lKey = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of());
+            ListingCacheKey lKey = ListingCacheKey.build("s3", "bucket", "/data/*.parquet", Map.of(), "");
             service.getOrComputeListing(lKey, k -> testCompactFileList());
 
             Map<String, Object> stats = service.usageStats();
@@ -400,7 +506,7 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
 
     public void testListingCacheStoresHiveFileList() throws Exception {
         try (ExternalSourceCacheService service = new ExternalSourceCacheService(defaultSettings())) {
-            ListingCacheKey key = ListingCacheKey.build("s3", "bucket", "/data/*" + "*/*.parquet", Map.of());
+            ListingCacheKey key = ListingCacheKey.build("s3", "bucket", "/data/*" + "*/*.parquet", Map.of(), "");
             FileList listing = service.getOrComputeListing(key, k -> testCompactHiveFileList());
             assertNotNull(listing.partitionMetadata());
             assertFalse(listing.partitionMetadata().isEmpty());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ESQL: fix hint-blind listing cache and rewrite-to-empty throw (#153682)](https://github.com/elastic/elasticsearch/pull/153682)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)