### PR TITLE
[9.5] ESQL: Corrects bug with LOOKUP JOIN, empty scopes and security enabled (#153825)

### DIFF
--- a/docs/changelog/153825.yaml
+++ b/docs/changelog/153825.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 153825
+summary: "Corrects bug with LOOKUP JOIN, empty scopes and security enabled"
+type: bug

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -1775,6 +1775,33 @@ public class EsqlSecurityIT extends ESRestTestCase {
         assertThat(resp.getResponse().getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
     }
 
+    public void testLookupJoinWithRequestFilterMatchingNoDocs() throws Exception {
+        assumeTrue(
+            "Requires LOOKUP JOIN capability",
+            hasCapabilities(adminClient(), List.of(EsqlCapabilities.Cap.JOIN_LOOKUP_V12.capabilityName()))
+        );
+        // Regression test: a request-level filter that matches no source documents used to cause the
+        // lookup index field-caps request to be sent with an empty index expression. With security
+        // enabled, IndicesAndAliasesResolver then expanded the empty expression to all authorised
+        // indices (lookup-user1 and lookup-user2 for metadata1_read2), making the lookup join fail
+        // with "Lookup Join requires a single lookup mode index; [...] resolves to multiple indices"
+        // instead of returning an empty result set.
+        // https://github.com/elastic/kibana/issues/277613
+        Request request = new Request("POST", "_query");
+        request.setJsonEntity("""
+            {
+                "query": "FROM index-user2 | LOOKUP JOIN lookup-user2 ON value | KEEP value, org | LIMIT 10",
+                "filter": {"match_none": {}}
+            }
+            """);
+        request.setOptions(runAsUserOptions("metadata1_read2", null));
+        request.addParameter("error_trace", "true");
+        Response resp = client().performRequest(request);
+        assertOK(resp);
+        Map<String, Object> respMap = entityAsMap(resp);
+        assertThat(respMap.get("values"), equalTo(List.of()));
+    }
+
     public void testFromLookupIndexForbidden() throws Exception {
         var resp = expectThrows(ResponseException.class, () -> runESQLCommand("metadata1_read2", "FROM lookup-user1"));
         assertThat(resp.getMessage(), containsString("Unknown index [lookup-user1]"));

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterLookupJoinIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterLookupJoinIT.java
@@ -251,6 +251,53 @@ public class CrossClusterLookupJoinIT extends AbstractCrossClusterTestCase {
         }
     }
 
+    /**
+     * When all remote clusters have skip_unavailable=true and the lookup index is missing on all of them,
+     * each remote cluster is skipped individually inside {@code receiveLookupIndexResolution}.
+     * If the local cluster is also part of the query and holds the lookup index, the query succeeds
+     * with both remotes reported as SKIPPED.
+     * If the query targets only remote clusters (no local source), the lookup field-caps request
+     * returns an invalid resolution before the per-cluster skip logic is reached, so the query
+     * currently fails with a VerificationException (pre-existing limitation).
+     */
+    public void testLookupJoinAllRemoteClustersSkipped() throws IOException {
+        setupClusters(3);
+        populateLookupIndex(LOCAL_CLUSTER, "values_lookup", 10);
+        // lookup index is intentionally absent from both remote clusters
+
+        setSkipUnavailable(REMOTE_CLUSTER_1, true);
+        setSkipUnavailable(REMOTE_CLUSTER_2, true);
+        try {
+            // Local source + both remotes: remote clusters are skipped because the lookup is missing
+            // on them; local cluster succeeds and contributes 10 rows.
+            try (
+                EsqlQueryResponse resp = runQuery(
+                    "FROM logs-*, *:logs-* | EVAL lookup_key = v | LOOKUP JOIN values_lookup ON lookup_key",
+                    randomBoolean()
+                )
+            ) {
+                List<List<Object>> values = getValuesList(resp);
+                assertThat(values, hasSize(10));
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.getCluster(LOCAL_CLUSTER).getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+                assertThat(executionInfo.getCluster(REMOTE_CLUSTER_1).getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+                assertThat(executionInfo.getCluster(REMOTE_CLUSTER_2).getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            }
+
+            // Pure-remote source: lookup field-caps for the qualified remote expressions returns
+            // notFound (no responses) before per-cluster skip logic runs, so both remotes
+            // end up in a VerificationException rather than being skipped cleanly.
+            // FIXME: ideally this should return 0 rows with both remotes SKIPPED.
+            expectThrows(
+                VerificationException.class,
+                containsString("Unknown index [cluster-a:values_lookup,remote-b:values_lookup]"),
+                () -> runQuery("FROM *:logs-* | EVAL lookup_key = v | LOOKUP JOIN values_lookup ON lookup_key", randomBoolean())
+            );
+        } finally {
+            clearSkipUnavailable(3);
+        }
+    }
+
     public void testLookupJoinMissingLocalIndex() throws IOException {
         setupClusters(2);
         populateLookupIndex(REMOTE_CLUSTER_1, "values_lookup", 10);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -1445,13 +1445,23 @@ public class EsqlSession {
             // indices) the resolver's continuation reaches this on the external blob-store pool.
             EsqlPlugin.externalBlobStorePool()
         );
-        // No need to update the minimum transport version in the PreAnalysisResult,
-        // it should already have been determined during the main index resolution.
-        executionInfo.queryProfile().incFieldCapsCalls();
         var lookupIndexScope = EsqlCCSUtils.onlyRunning(
             executionInfo,
             computeLookupJoinIndexScope(plan, localPattern, result.indexResolution())
         );
+        if (lookupIndexScope.isEmpty()) {
+            // The source index returned no contributing clusters (all shards were pruned by the
+            // request-level filter). Skip the lookup field-caps call — sending an empty index
+            // expression would let security expand it to all authorised indices (including
+            // non-lookup ones), causing a spurious error. Return an invalid resolution instead
+            // so that analyzedPlan() throws a VerificationException that analyzeWithRetry can
+            // catch and retry without the filter.
+            listener.onResponse(result.addLookupIndexResolution(localPattern, IndexResolution.notFound(localPattern)));
+            return;
+        }
+        // No need to update the minimum transport version in the PreAnalysisResult,
+        // it should already have been determined during the main index resolution.
+        executionInfo.queryProfile().incFieldCapsCalls();
         indexResolver.resolveLookupIndices(
             EsqlCCSUtils.createQualifiedLookupIndexExpressionFromAvailableClusters(lookupIndexScope, localPattern),
             result.wildcardJoinIndices().contains(localPattern) ? IndexResolver.ALL_FIELDS : result.fieldNames,


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: Corrects bug with LOOKUP JOIN, empty scopes and security enabled (#153825)