### PR TITLE
ESQL: Fix PushQueriesIT [9.5]

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -237,7 +237,7 @@ public class PushQueriesIT extends ESRestTestCase {
     }
 
     public void testCaseInsensitiveEquality() throws IOException {
-        String value = "a".repeat(between(0, 256));
+        String value = "a".repeat(between(1, 256));
         String esqlQuery = """
             FROM test
             | WHERE TO_LOWER(test) == "%value"


### PR DESCRIPTION
Backport of #153527 to 9.5. It matches on query descriptions which doesn't work for empty string. We just skip empty string in the test.
