### PR TITLE
[9.3] [LicenseCheckPlugin] Detect duplicate header (#153810)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/LicenseHeadersTask.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/LicenseHeadersTask.java
@@ -53,6 +53,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -199,6 +200,10 @@ public abstract class LicenseHeadersTask extends DefaultTask {
             return simpleLicenseFamily;
         }).toArray(SimpleLicenseFamily[]::new));
 
+        List<Problem> problems = new ArrayList<>();
+
+        checkForDuplicateHeaders(problems);
+
         File repFile = getReportFile().getAsFile().get();
         ClaimStatistic stats = generateReport(reportConfiguration, repFile);
         boolean unknownLicenses = stats.getNumUnknown() > 0;
@@ -206,7 +211,6 @@ public abstract class LicenseHeadersTask extends DefaultTask {
         if (unknownLicenses || unApprovedLicenses) {
             List<String> unapproved = unapprovedFiles(repFile);
             getLogger().error("The following files contain unapproved license headers:");
-            List<Problem> problems = new ArrayList<>();
             unapproved.forEach(file -> {
                 getLogger().error(file);
                 problems.add(
@@ -222,10 +226,61 @@ public abstract class LicenseHeadersTask extends DefaultTask {
                     )
                 );
             });
+        }
+        if (problems.isEmpty() == false) {
             throw problemReporter.throwing(
                 new GradleException("Check failed. License header problems were found. Full details: " + repFile.getAbsolutePath()),
                 problems
             );
+        }
+    }
+
+    /**
+     * Checks each source file for duplicate license header blocks. Apache RAT only verifies that an approved
+     * license header is present — it does not fail when a file contains more than one header. A file with two
+     * different headers is ambiguous about which license governs it, so we fail explicitly.
+     * <p>
+     * Detection strategy: count occurrences of the block-comment opener pattern
+     * {@code "/*\n * Copyright Elasticsearch B.V."} in each file (after normalising line endings to LF).
+     * Matching against the full opener rather than just the copyright string avoids false positives from
+     * files that legitimately mention the copyright text inside string literals, text blocks, or Javadoc
+     * comments (e.g. code-generators that embed a license header in the strings they emit).
+     */
+    private void checkForDuplicateHeaders(List<Problem> problems) {
+        // The exact prefix of every Elasticsearch license block-comment header.
+        final String HEADER_OPENER = "/*\n * Copyright Elasticsearch B.V.";
+        for (FileCollection dirSet : getSourceFolders().get()) {
+            for (File f : dirSet.getAsFileTree().matching(patternFilterable -> patternFilterable.exclude(getExcludes()))) {
+                String content;
+                try {
+                    // Normalise Windows line endings so the pattern always contains a plain '\n'.
+                    content = Files.readString(f.toPath(), StandardCharsets.UTF_8).replace("\r\n", "\n");
+                } catch (IOException e) {
+                    throw new GradleException("Cannot read " + f + " to check for duplicate license headers", e);
+                }
+                int count = 0;
+                int idx = 0;
+                while ((idx = content.indexOf(HEADER_OPENER, idx)) != -1) {
+                    count++;
+                    idx += 1;
+                }
+                if (count > 1) {
+                    String path = f.getAbsolutePath();
+                    getLogger().error("Duplicate license header in: " + path);
+                    problems.add(
+                        problemReporter.create(
+                            ProblemId.create(
+                                "duplicate-license-header",
+                                "Duplicate license header",
+                                ElasticsearchBuildProblems.LICENSE_HEADERS
+                            ),
+                            spec -> spec.contextualLabel("Duplicate license header in " + path)
+                                .fileLocation(path)
+                                .solution("Remove the duplicate license header block from the file")
+                        )
+                    );
+                }
+            }
         }
     }
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
@@ -59,6 +59,37 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPlugin
         result.task(":licenseHeaders").outcome == TaskOutcome.SUCCESS
     }
 
+    def "detects duplicate license headers in same file"() {
+        given:
+        duplicateHeaderFile()
+
+        when:
+        def result = gradleRunner("licenseHeaders").buildAndFail()
+
+        then:
+        result.task(":licenseHeaders").outcome == TaskOutcome.FAILED
+        assertOutputContains(result.output, "./src/main/java/org/acme/DuplicateHeader.java")
+
+        and: "problems report contains duplicate-license-header problem"
+        assertProblemsReportContains("license-headers")
+        assertProblemsReportContainsProblem("duplicate-license-header")
+    }
+
+    def "detects duplicate license header placed after package declaration"() {
+        given:
+        duplicateHeaderAfterPackageFile()
+
+        when:
+        def result = gradleRunner("licenseHeaders").buildAndFail()
+
+        then:
+        result.task(":licenseHeaders").outcome == TaskOutcome.FAILED
+        assertOutputContains(result.output, "./src/main/java/org/acme/DuplicateHeaderAfterPackage.java")
+
+        and:
+        assertProblemsReportContainsProblem("duplicate-license-header")
+    }
+
     def "supports sspl by convention"() {
         given:
         dualLicensedFile()
@@ -123,6 +154,60 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPlugin
  package ${packageString(sourceFile)};
 
  public class ${sourceFile.getName() - ".java"} {
+ }
+ """
+    }
+
+    /** A file with two Elasticsearch copyright blocks placed consecutively before the package declaration. */
+    private File duplicateHeaderFile() {
+        file("src/main/java/org/acme/DuplicateHeader.java") << """
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+ package org.acme;
+ public class DuplicateHeader {
+ }
+ """
+    }
+
+    /**
+     * A file with an Elastic 2.0 header before the package declaration and a tri-license header
+     * inserted after the package declaration — the exact pattern seen in MatchConfigSerializationTests.
+     */
+    private File duplicateHeaderAfterPackageFile() {
+        file("src/main/java/org/acme/DuplicateHeaderAfterPackage.java") << """
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+ package org.acme;
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+ public class DuplicateHeaderAfterPackage {
  }
  """
     }

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -183,6 +183,46 @@ abstract class AbstractGradleFuncTest extends Specification {
         true
     }
 
+    /**
+     * Parses the Gradle Problems API report and returns the diagnostics as a list of maps.
+     * Each diagnostic has: problemId (list of {name, displayName}), severity, contextualLabel, solutions, locations.
+     */
+    List<Map> problemsReportDiagnostics() {
+        def reportFile = new File(testProjectDir.root, "build/reports/problems/problems-report.html")
+        if (!reportFile.exists()) {
+            return []
+        }
+        def content = reportFile.text
+        def matcher = content =~ /\/\/ begin-report-data\n(.*)\n\/\/ end-report-data/
+        if (!matcher.find()) {
+            return []
+        }
+        def json = new groovy.json.JsonSlurper().parseText(matcher.group(1))
+        return json.diagnostics ?: []
+    }
+
+    /**
+     * Asserts that problems were reported with the given group name in the problem ID hierarchy.
+     */
+    def assertProblemsReportContains(String groupName) {
+        def diagnostics = problemsReportDiagnostics()
+        assert diagnostics.any { diag ->
+            diag.problemId.any { id -> id.name == groupName }
+        } : "Expected problems report to contain group '${groupName}', but found: ${diagnostics.collect { it.problemId*.name }.flatten().unique()}"
+        true
+    }
+
+    /**
+     * Asserts that problems were reported with the given problem name (leaf ID) in the report.
+     */
+    def assertProblemsReportContainsProblem(String problemName) {
+        def diagnostics = problemsReportDiagnostics()
+        assert diagnostics.any { diag ->
+            diag.problemId.last().name == problemName
+        } : "Expected problems report to contain problem '${problemName}', but found: ${diagnostics.collect { it.problemId.last().name }.unique()}"
+        true
+    }
+
     String normalized(String input) {
         return normalizeString(input, testProjectDir.root)
     }

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/RestTriggerOutOfMemoryAction.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/RestTriggerOutOfMemoryAction.java
@@ -7,13 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
 package org.elasticsearch.test.esql.heap_attack;
 
 import org.elasticsearch.client.internal.node.NodeClient;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/MatchConfigSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/MatchConfigSerializationTests.java
@@ -7,15 +7,6 @@
 
 package org.elasticsearch.xpack.esql.enrich;
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
- */
-
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [LicenseCheckPlugin] Detect duplicate header (#153810)