### PR TITLE
Fix _ignored_source format flip for TSDB indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -266,6 +266,7 @@ public class IndexVersions {
     public static final IndexVersion UPGRADE_TO_LUCENE_10_5_0 = def(9_104_0_00, Version.LUCENE_10_5_0);
     public static final IndexVersion DISK_BBQ_ES950_AUTO_CALIBRATE = def(9_105_0_00, Version.LUCENE_10_5_0);
     public static final IndexVersion TIME_SERIES_ES95_CODEC_DEFAULT = def(9_106_0_00, Version.LUCENE_10_5_0);
+    public static final IndexVersion IGNORED_SOURCE_AS_DOC_VALUES_NO_FF = def(9_107_0_00, Version.LUCENE_10_5_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -611,7 +611,8 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
     public static IgnoredSourceFormat ignoredSourceFormat(IndexSettings indexSettings) {
         IndexVersion indexCreatedVersion = indexSettings.getIndexVersionCreated();
         // we need TSDB doc values format to use binary doc values for ignored source, otherwise the source will be uncompressed
-        if (indexCreatedVersion.onOrAfter(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES) && indexSettings.useTimeSeriesDocValuesFormat()) {
+        if (indexCreatedVersion.onOrAfter(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF)
+            && indexSettings.useTimeSeriesDocValuesFormat()) {
             return IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -611,8 +612,12 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
     public static IgnoredSourceFormat ignoredSourceFormat(IndexSettings indexSettings) {
         IndexVersion indexCreatedVersion = indexSettings.getIndexVersionCreated();
         // we need TSDB doc values format to use binary doc values for ignored source, otherwise the source will be uncompressed
-        if (indexCreatedVersion.onOrAfter(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF)
-            && indexSettings.useTimeSeriesDocValuesFormat()) {
+
+        IndexVersion switchToDocValuesFormatVersion = Build.current().isSnapshot()
+            ? IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES
+            : IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF;
+
+        if (indexCreatedVersion.onOrAfter(switchToDocValuesFormatVersion) && indexSettings.useTimeSeriesDocValuesFormat()) {
             return IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -2655,7 +2655,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         assertEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
             IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES, tsdbDocValuesFormatEnabled)
+                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF, tsdbDocValuesFormatEnabled)
             )
         );
 
@@ -2663,7 +2663,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         assertNotEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
             IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES, tsdbDocValuesFormatDisabled)
+                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF, tsdbDocValuesFormatDisabled)
             )
         );
 
@@ -2672,7 +2672,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
             IgnoredSourceFieldMapper.ignoredSourceFormat(
                 createIndexSettings(
-                    IndexVersionUtils.getPreviousVersion(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES),
+                    IndexVersionUtils.getPreviousVersion(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF),
                     tsdbDocValuesFormatEnabled
                 )
             )

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -10,11 +10,13 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DirectoryReader;
+import org.elasticsearch.Build;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.test.WildcardFieldMaskingReader;
@@ -2652,29 +2654,25 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             .build();
 
         // with TSDB doc values format enabled and matching index version, the doc values ignored source format should be used
+        IndexVersion switchToDocValuesFormatVersion = Build.current().isSnapshot()
+            ? IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES
+            : IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF;
         assertEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
-            IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF, tsdbDocValuesFormatEnabled)
-            )
+            IgnoredSourceFieldMapper.ignoredSourceFormat(createIndexSettings(switchToDocValuesFormatVersion, tsdbDocValuesFormatEnabled))
         );
 
         // index version alone is not enough, TSDB doc values setting must also be enabled.
         assertNotEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
-            IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF, tsdbDocValuesFormatDisabled)
-            )
+            IgnoredSourceFieldMapper.ignoredSourceFormat(createIndexSettings(switchToDocValuesFormatVersion, tsdbDocValuesFormatDisabled))
         );
 
         // TSDB doc values format is not enough, the index version must also match
         assertNotEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
             IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(
-                    IndexVersionUtils.getPreviousVersion(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF),
-                    tsdbDocValuesFormatEnabled
-                )
+                createIndexSettings(IndexVersionUtils.getPreviousVersion(switchToDocValuesFormatVersion), tsdbDocValuesFormatEnabled)
             )
         );
     }


### PR DESCRIPTION
#152481 removed the `ignored_source_as_doc_values` feature flag check from `IgnoredSourceFieldMapper#ignoredSourceFormat` without bumping the gating index version (`IGNORED_SOURCE_AS_DOC_VALUES`).

The flag was disabled by default on release builds, so existing TSDB indices created at or after `IGNORED_SOURCE_AS_DOC_VALUES` had written `_ignored_source` using the stored-field `COALESCED_SINGLE_IGNORED_SOURCE` format. After the flag removal, the same indices resolved to `DOC_VALUES_IGNORED_SOURCE`. Since the on-disk format must not change over the lifetime of an index, searches began failing with:

```
java.lang.IllegalStateException: unexpected docvalues type NONE for field '_ignored_source' (expected=BINARY). Re-index with correct docvalues type.
```

This gates the doc values format on a new index version (`IGNORED_SOURCE_AS_DOC_VALUES_NO_FF`) so only indices created after this change use it; indices created in the flag-removal window keep the stored-field format they were written with.

Closes #153901