### PR TITLE
[9.5] ES|QL|DS Surface external-read permit exhaustion as a retryable 503 (#153742)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObjectMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -217,10 +218,21 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         try {
             limiter.acquire();
         } catch (TimeoutException e) {
-            throw new EsRejectedExecutionException("Failed to acquire concurrency permit for cloud API call: " + e.getMessage());
+            // Permit pool exhausted: a node-local admission back-pressure condition, not a client error. Raise it as
+            // the retryable 503-class type the retry layer acts on (RetryableStorageObject -> RetryPolicy.execute
+            // catches ExternalUnavailableException and re-attempts). throttling=false: this is a local semaphore, not
+            // a remote-store 429/503, so it must not feed the per-bucket adaptive backoff or the throttle budget.
+            throw new ExternalUnavailableException(e, "Timed out acquiring cloud API concurrency permit: {}", e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new EsRejectedExecutionException("Interrupted while waiting for concurrency permit: " + e);
+            // Interrupt is a shutdown/cancellation signal, not back-pressure: throw non-retryable so the
+            // retry layer does not loop on an interrupt flag that will fire again immediately. The interrupt
+            // is preserved as the cause so the origin survives in diagnostics (the type has no cause constructor).
+            EsRejectedExecutionException rejected = new EsRejectedExecutionException(
+                "Interrupted while acquiring cloud API concurrency permit"
+            );
+            rejected.initCause(e);
+            throw rejected;
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
@@ -84,14 +86,20 @@ class ConcurrencyLimitedStorageProvider implements StorageProvider {
         delegate.close();
     }
 
-    private void acquirePermit() throws IOException {
+    private void acquirePermit() {
         try {
             limiter.acquire();
         } catch (TimeoutException e) {
-            throw new IOException("Failed to acquire concurrency permit for cloud API call", e);
+            // Permit pool exhausted: a node-local admission back-pressure condition, not a client error. Raise it as
+            // the retryable 503-class type the retry layer acts on (RetryableStorageProvider -> RetryPolicy.execute
+            // catches ExternalUnavailableException and re-attempts). throttling=false: this is a local semaphore, not
+            // a remote-store 429/503, so it must not feed the per-bucket adaptive backoff or the throttle budget.
+            throw new ExternalUnavailableException(e, "Timed out acquiring cloud API concurrency permit: {}", e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IOException("Interrupted while waiting for concurrency permit", e);
+            // Interrupt is a shutdown/cancellation signal, not back-pressure: throw non-retryable so the
+            // retry layer does not loop on an interrupt flag that will fire again immediately.
+            throw new EsRejectedExecutionException("Interrupted while acquiring cloud API concurrency permit");
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -7,12 +7,14 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
 import org.elasticsearch.cluster.metadata.DatasetMapping;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThrottledIterator;
 import org.elasticsearch.core.Nullable;
@@ -36,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.ListingHint;
@@ -481,6 +484,14 @@ public class ExternalSourceResolver {
      * an {@link ElasticsearchException} carrying the path and detail. A footer read can fail <em>because</em> the
      * query was cancelled mid-read and arrive wrapped (e.g. the schema cache wraps loader failures), so the
      * cancellation state is consulted directly rather than matched on the exception type.
+     * <p>
+     * A retryable back-pressure failure (permit exhaustion / remote-store unavailability) reaches here as an
+     * {@link ExternalUnavailableException} (503), but the factory loop always re-wraps a factory failure in an
+     * {@link IllegalArgumentException} (400). So the 503 is recovered from the cause chain <em>before</em> the
+     * {@link IllegalArgumentException} branch and surfaced as a 503, otherwise a transient capacity condition would be
+     * masked as a non-retryable client error and the client's retry path would never engage. An interrupt during permit
+     * acquisition arrives the same way as an {@link EsRejectedExecutionException} (429) and is recovered identically so a
+     * node-level rejection is not masked as a 400.
      */
     private RuntimeException mapResolveFailure(String path, Exception e) {
         if (e instanceof TaskCancelledException tce) {
@@ -490,6 +501,41 @@ public class ExternalSourceResolver {
         if (isCancelled()) {
             LOGGER.debug("External source resolution cancelled for [{}]", path);
             return new TaskCancelledException(RESOLUTION_CANCELLED_MESSAGE);
+        }
+        // A buried 503 (retryable back-pressure) must not be masked as a 400 by the factory loop's IllegalArgumentException
+        // wrapper. unwrap walks the root + cause chain (cycle-guarded), so it catches the 503 raw or wrapped. Re-wrap so
+        // the client message keeps the path context while the 503 status and the throttling flag survive.
+        ExternalUnavailableException unavailable = (ExternalUnavailableException) ExceptionsHelper.unwrap(
+            e,
+            ExternalUnavailableException.class
+        );
+        if (unavailable != null) {
+            recordDiscoveryFailure();
+            LOGGER.warn("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
+            return new ExternalUnavailableException(
+                unavailable.throttling(),
+                unavailable,
+                "Failed to resolve external source [{}]: {}",
+                path,
+                unavailable.getMessage()
+            );
+        }
+        // A permit-acquisition interrupt surfaces as an EsRejectedExecutionException (429). The factory loop wraps it
+        // in an IllegalArgumentException (400), so recover it from the cause chain before the IllegalArgumentException
+        // branch: a node-level rejection must keep its 429 status instead of being masked as a client error. Re-wrap
+        // so the client message keeps the path context while the 429 status survives (the type has no cause constructor).
+        EsRejectedExecutionException rejected = (EsRejectedExecutionException) ExceptionsHelper.unwrap(
+            e,
+            EsRejectedExecutionException.class
+        );
+        if (rejected != null) {
+            recordDiscoveryFailure();
+            LOGGER.warn("Failed to resolve external source [{}]: {}", path, e.getMessage(), e);
+            EsRejectedExecutionException wrapped = new EsRejectedExecutionException(
+                String.format(Locale.ROOT, "Failed to resolve external source [%s]: %s", path, rejected.getMessage())
+            );
+            wrapped.initCause(rejected);
+            return wrapped;
         }
         if (e instanceof IllegalArgumentException || e instanceof UnsupportedOperationException) {
             recordDiscoveryFailure();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
@@ -348,9 +348,10 @@ class RetryPolicy {
     }
 
     private static boolean isTransientSingleCause(Throwable t) {
-        // Typed signal from a storage provider: it classified this fault by type/status (no message sniffing).
-        // Every retryable remote-store status (5xx/429/timeout) is mapped to ExternalUnavailableException at the
-        // provider boundary, so the retry layer keys on the type, not the HTTP status or the message.
+        // Typed signal: a fault was classified by type/status (no message sniffing). Every retryable remote-store
+        // status (5xx/429/timeout) is mapped to ExternalUnavailableException at the provider boundary, and node-local
+        // admission back-pressure (permit exhaustion) is mapped to it at the concurrency-limiter boundary, so the retry
+        // layer keys on the type, not the HTTP status or the message.
         if (t instanceof ExternalUnavailableException) {
             return true;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalException.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalException.java
@@ -23,8 +23,9 @@ import org.elasticsearch.xpack.esql.core.QlException;
  *     read or decode (bad/unsupported input, missing object).</li>
  *     <li>{@link ExternalServerException} &rarr; 500, a bug or broken invariant in our own reading
  *     code.</li>
- *     <li>{@link ExternalUnavailableException} &rarr; 503, a retryable transport failure talking to
- *     the remote store.</li>
+ *     <li>{@link ExternalUnavailableException} &rarr; 503, a retryable back-pressure /
+ *     temporarily-unavailable condition (a remote-store transport failure, or a node-local admission
+ *     condition such as permit exhaustion).</li>
  * </ul>
  * Subtypes extend {@link QlException} (rather than {@code QlClientException}/{@code QlServerException})
  * so they can share this single umbrella while each pinning its own status.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalUnavailableException.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalUnavailableException.java
@@ -10,10 +10,11 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 import org.elasticsearch.rest.RestStatus;
 
 /**
- * A retryable transport failure talking to the remote store backing an external data source — the
- * store returned a 5xx, throttled us, or the connection timed out / was reset. Maps to
- * {@code 503 Service Unavailable}: the read might succeed on retry, so it is neither a permanent
- * client error nor a cluster bug.
+ * The retryable, 503-class carrier for a back-pressure / temporarily-unavailable condition on an
+ * external read. Most commonly a transport failure talking to the remote store (the store returned a
+ * 5xx, throttled us, or the connection timed out / was reset), but also a node-local admission
+ * condition such as storage concurrency permit exhaustion. Maps to {@code 503 Service Unavailable}:
+ * the read might succeed on retry, so it is neither a permanent client error nor a cluster bug.
  * <p>
  * Permanent transport outcomes (object not found, a malformed response) are not raised here; those
  * are client-class and surface as {@link ExternalClientException}.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
@@ -8,13 +8,17 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObjectMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -186,6 +190,60 @@ public class ConcurrencyLimitedStorageObjectTests extends ESTestCase {
 
         ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
         assertSame(snapshot, obj.metrics());
+    }
+
+    /**
+     * Permit exhaustion is a back-pressure condition, so an acquire timeout must surface as the retryable
+     * 503-class {@link ExternalUnavailableException} the retry layer acts on, not a non-retryable client error.
+     * throttling() is false: a node-local semaphore is not a remote-store throttle, so it must not feed the
+     * per-bucket adaptive backoff or the throttle retry budget.
+     */
+    public void testPermitExhaustionThrowsRetryable503() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, 50);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hi".getBytes(StandardCharsets.UTF_8)));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        // Hold the single permit by opening (and not closing) a stream, then force a second permit-taking
+        // acquire (newStream is byte-transfer, so permit-governed) to time out.
+        InputStream held = obj.newStream();
+        try {
+            ExternalUnavailableException thrown = expectThrows(ExternalUnavailableException.class, obj::newStream);
+            assertEquals(RestStatus.SERVICE_UNAVAILABLE, thrown.status());
+            assertFalse("node-local permit exhaustion is not a remote throttle", thrown.throttling());
+            assertTrue("permit exhaustion must be retryable", RetryPolicy.DEFAULT.isRetryable(thrown));
+        } finally {
+            held.close();
+        }
+    }
+
+    /**
+     * An interrupt while waiting for a permit is a shutdown/cancellation signal, not back-pressure. It must surface as a
+     * non-retryable {@link EsRejectedExecutionException} (429) so the storage retry layer does not loop on an interrupt
+     * flag that fires again immediately, while preserving the interrupt as the cause and restoring the thread's
+     * interrupt status for the caller.
+     */
+    public void testPermitAcquireInterruptThrowsNonRetryableRejection() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hi".getBytes(StandardCharsets.UTF_8)));
+
+        ConcurrencyLimitedStorageObject obj = new ConcurrencyLimitedStorageObject(delegate, limiter);
+        // Hold the single permit so the next permit-taking acquire must wait, then set the interrupt flag so
+        // tryAcquire throws immediately (newStream is byte-transfer, so permit-governed).
+        InputStream held = obj.newStream();
+        try {
+            Thread.currentThread().interrupt();
+            EsRejectedExecutionException thrown = expectThrows(EsRejectedExecutionException.class, obj::newStream);
+            assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(thrown));
+            assertFalse("an interrupt is not back-pressure and must not be retried", RetryPolicy.DEFAULT.isRetryable(thrown));
+            assertTrue("the caught interrupt must be preserved as the cause", thrown.getCause() instanceof InterruptedException);
+            assertTrue("the interrupt status must be restored for the caller", Thread.currentThread().isInterrupted());
+        } finally {
+            // Clear the interrupt flag re-set by acquirePermit so it does not leak into later tests.
+            Thread.interrupted();
+            held.close();
+        }
     }
 
     public void testNewStreamReleasesPermitOnDelegateException() throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProviderTests.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
@@ -70,6 +72,46 @@ public class ConcurrencyLimitedStorageProviderTests extends ESTestCase {
         ConcurrencyLimitedStorageProvider provider = new ConcurrencyLimitedStorageProvider(delegate, limiter);
         expectThrows(IOException.class, () -> provider.exists(StoragePath.of("s3://bucket/key")));
         assertEquals(3, limiter.availablePermits());
+    }
+
+    /**
+     * A provider-level permit-acquire timeout (e.g. during listing / exists probes) is back-pressure, so it must
+     * surface as the retryable 503-class {@link ExternalUnavailableException}, not a plain non-retryable IOException.
+     */
+    public void testPermitExhaustionThrowsRetryable503() throws Exception {
+        ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, 50);
+        StorageProvider delegate = mock(StorageProvider.class);
+        StorageIterator emptyIterator = new StorageIterator() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public StorageEntry next() {
+                return null;
+            }
+
+            @Override
+            public void close() {}
+        };
+        when(delegate.listObjects(any(), anyBoolean())).thenReturn(emptyIterator);
+        when(delegate.exists(any())).thenReturn(true);
+
+        ConcurrencyLimitedStorageProvider provider = new ConcurrencyLimitedStorageProvider(delegate, limiter);
+        // Hold the single permit by leaving the list iterator open, then force a second acquire to time out.
+        StorageIterator held = provider.listObjects(StoragePath.of("s3://bucket/prefix"), true);
+        try {
+            ExternalUnavailableException thrown = expectThrows(
+                ExternalUnavailableException.class,
+                () -> provider.exists(StoragePath.of("s3://bucket/key"))
+            );
+            assertEquals(RestStatus.SERVICE_UNAVAILABLE, thrown.status());
+            assertFalse("node-local permit exhaustion is not a remote throttle", thrown.throttling());
+            assertTrue("permit exhaustion must be retryable", RetryPolicy.DEFAULT.isRetryable(thrown));
+        } finally {
+            held.close();
+        }
     }
 
     public void testNewObjectReturnsConcurrencyLimitedObject() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFailuresTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFailuresTests.java
@@ -56,10 +56,12 @@ public class ExternalFailuresTests extends ESTestCase {
     }
 
     public void testRejectedExecutionIsBackpressureNotServerError() {
-        // A saturated thread pool or the storage concurrency guardrail can reject work as an
-        // EsRejectedExecutionException. That is load-shed backpressure (429), not a broken invariant in our
-        // reading code (500): classify must return it unchanged so its self-carried 429 survives, rather than
-        // wrapping it as an ExternalServerException.
+        // A saturated thread pool (or the node shutting down) can reject work as an EsRejectedExecutionException.
+        // That is load-shed backpressure (429), not a broken invariant in our reading code (500): classify must
+        // return it unchanged so its self-carried 429 survives, rather than wrapping it as an ExternalServerException.
+        // Storage concurrency permit exhaustion is a separate case: it is raised as a 503-class
+        // ExternalUnavailableException at the concurrency-limiter boundary so the storage retry layer engages, so it
+        // does not reach classify() as an EsRejectedExecutionException.
         var rejected = new EsRejectedExecutionException("rejected execution while reading external source");
         RuntimeException classified = ExternalFailures.classify(rejected);
         assertSame(rejected, classified);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
@@ -14,11 +15,13 @@ import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.encryption.spi.EncryptionService;
@@ -35,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -74,6 +78,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -1929,6 +1934,135 @@ public class ExternalSourceResolverTests extends ESTestCase {
         assertEquals("validateConfig must fire before resolveMetadata; the format reader must not be reached", 0, readerCallCount.get());
     }
 
+    // ===== Back-pressure / unavailability during resolution =====
+
+    /**
+     * The format spec of an external source exercised by the back-pressure tests: {@code parquet} is a footer
+     * format (in {@link ExternalSourceResolver#FILE_TYPED_FORMATS}, so it takes the file-typed cache-key branch),
+     * while {@code csv} and {@code ndjson} are text formats that take the other branch. The permit-exhaustion fix
+     * lives below the format reader, so all three must behave identically; parametrizing across them guards against
+     * a future format-specific short-circuit in the resolver reintroducing the masking.
+     */
+    private static final List<String[]> BACK_PRESSURE_FORMATS = List.of(
+        new String[] { "parquet", ".parquet" },
+        new String[] { "csv", ".csv" },
+        new String[] { "ndjson", ".ndjson" }
+    );
+
+    /**
+     * A terminal permit-exhaustion / unavailability failure during metadata resolution reaches the resolver as an
+     * {@link ExternalUnavailableException} (503). The factory loop re-wraps every factory failure in an
+     * {@link IllegalArgumentException} (400), so the resolver must recover the buried 503 from the cause chain and
+     * surface it as 503, not a masked 400: otherwise the client's retry / back-pressure path is skipped. Verified
+     * for every format because the fix is format-independent (it sits at the storage layer, below the reader).
+     */
+    public void testMetadataResolutionUnavailabilitySurfacesAs503() {
+        for (String[] format : BACK_PRESSURE_FORMATS) {
+            String formatName = format[0];
+            String path = "s3://bucket/data/file" + format[1];
+            Map<String, List<Attribute>> schemasByPath = Map.of(path, List.of(attr("x", DataType.INTEGER)));
+            ExternalSourceResolver resolver = createResolverWithFailingMetadata(
+                formatName,
+                format[1],
+                schemasByPath,
+                () -> new ExternalUnavailableException("Timed out acquiring cloud API concurrency permit", (Throwable) null),
+                null
+            );
+            PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+            resolver.resolve(List.of(path), Map.of(), future);
+
+            ExternalUnavailableException e = expectThrows(ExternalUnavailableException.class, future::actionGet);
+            assertEquals("format [" + formatName + "] must surface 503", RestStatus.SERVICE_UNAVAILABLE, e.status());
+            assertThat(e.getMessage(), containsString(path));
+        }
+    }
+
+    /**
+     * The schema cache resolves a miss by running the metadata read inside its loader and re-throwing any failure
+     * wrapped in an {@link java.util.concurrent.ExecutionException}. So on the cacheable path the 503 arrives buried
+     * one layer deeper (ExecutionException over the factory's IllegalArgumentException over the
+     * {@link ExternalUnavailableException}); the resolver must still recover it and surface a 503, not a 400 or 500.
+     * Parametrized across formats because footer ({@code parquet}) and text ({@code csv}/{@code ndjson}) formats take
+     * different file-typed cache-key branches on the way to the failing read.
+     */
+    public void testMetadataResolutionUnavailabilitySurfacesAs503ThroughSchemaCache() {
+        for (String[] format : BACK_PRESSURE_FORMATS) {
+            String formatName = format[0];
+            String path = "s3://bucket/data/file" + format[1];
+            Map<String, List<Attribute>> schemasByPath = Map.of(path, List.of(attr("x", DataType.INTEGER)));
+            try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+                ExternalSourceResolver resolver = createResolverWithFailingMetadata(
+                    formatName,
+                    format[1],
+                    schemasByPath,
+                    () -> new ExternalUnavailableException("Timed out acquiring cloud API concurrency permit", (Throwable) null),
+                    cacheService
+                );
+                PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+                resolver.resolve(List.of(path), Map.of(), future);
+
+                ExternalUnavailableException e = expectThrows(ExternalUnavailableException.class, future::actionGet);
+                assertEquals("format [" + formatName + "] must surface 503", RestStatus.SERVICE_UNAVAILABLE, e.status());
+                assertThat(e.getMessage(), containsString(path));
+            }
+        }
+    }
+
+    /**
+     * An interrupt during permit acquisition reaches the resolver as an {@link EsRejectedExecutionException} (429). Like
+     * the 503 case, the factory loop re-wraps it in an {@link IllegalArgumentException} (400), so the resolver must
+     * recover the buried 429 from the cause chain and surface a node-level rejection as 429 rather than a masked 400.
+     * Verified for every format because the recovery is format-independent.
+     */
+    public void testMetadataResolutionInterruptSurfacesAs429() {
+        for (String[] format : BACK_PRESSURE_FORMATS) {
+            String formatName = format[0];
+            String path = "s3://bucket/data/file" + format[1];
+            Map<String, List<Attribute>> schemasByPath = Map.of(path, List.of(attr("x", DataType.INTEGER)));
+            ExternalSourceResolver resolver = createResolverWithFailingMetadata(
+                formatName,
+                format[1],
+                schemasByPath,
+                () -> new EsRejectedExecutionException("Interrupted while acquiring cloud API concurrency permit"),
+                null
+            );
+            PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+            resolver.resolve(List.of(path), Map.of(), future);
+
+            EsRejectedExecutionException e = expectThrows(EsRejectedExecutionException.class, future::actionGet);
+            assertEquals("format [" + formatName + "] must surface 429", RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(e));
+            assertThat(e.getMessage(), containsString(path));
+        }
+    }
+
+    /**
+     * The cacheable path buries the {@link EsRejectedExecutionException} one layer deeper (the schema cache re-throws the
+     * loader failure wrapped in an {@link java.util.concurrent.ExecutionException} over the factory's
+     * {@link IllegalArgumentException}); the resolver must still recover it and surface a 429, not a 400 or 500.
+     */
+    public void testMetadataResolutionInterruptSurfacesAs429ThroughSchemaCache() {
+        for (String[] format : BACK_PRESSURE_FORMATS) {
+            String formatName = format[0];
+            String path = "s3://bucket/data/file" + format[1];
+            Map<String, List<Attribute>> schemasByPath = Map.of(path, List.of(attr("x", DataType.INTEGER)));
+            try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(cacheEnabledSettings())) {
+                ExternalSourceResolver resolver = createResolverWithFailingMetadata(
+                    formatName,
+                    format[1],
+                    schemasByPath,
+                    () -> new EsRejectedExecutionException("Interrupted while acquiring cloud API concurrency permit"),
+                    cacheService
+                );
+                PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+                resolver.resolve(List.of(path), Map.of(), future);
+
+                EsRejectedExecutionException e = expectThrows(EsRejectedExecutionException.class, future::actionGet);
+                assertEquals("format [" + formatName + "] must surface 429", RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(e));
+                assertThat(e.getMessage(), containsString(path));
+            }
+        }
+    }
+
     // ===== Empty resolution =====
 
     public void testEmptyPathListReturnsEmptyResolution() throws Exception {
@@ -2970,6 +3104,89 @@ public class ExternalSourceResolverTests extends ESTestCase {
         );
 
         return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, null, isCancelled);
+    }
+
+    /**
+     * Builds a resolver for a source of the given {@code formatName}/{@code extension} whose format reader throws
+     * {@code failure.get()} from {@code metadata(...)}, modelling a storage read that failed after its retries were
+     * exhausted (e.g. permit exhaustion surfacing as a 503-class {@link ExternalUnavailableException}). Runs on the
+     * DIRECT executor so the resolve completes synchronously. A non-null {@code cacheService} exercises the cacheable
+     * path, where the failure is re-thrown wrapped in an {@link java.util.concurrent.ExecutionException} by the cache
+     * loader.
+     */
+    private ExternalSourceResolver createResolverWithFailingMetadata(
+        String formatName,
+        String extension,
+        Map<String, List<Attribute>> schemasByPath,
+        Supplier<? extends RuntimeException> failure,
+        @Nullable ExternalSourceCacheService cacheService
+    ) {
+        NoConfigFormatReader formatReader = new NoConfigFormatReader() {
+            @Override
+            public RowPositionStrategy rowPositionStrategy() {
+                return PassThroughRowPositionStrategy.INSTANCE;
+            }
+
+            @Override
+            public SourceMetadata metadata(StorageObject object) {
+                throw failure.get();
+            }
+
+            @Override
+            public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String formatName() {
+                return formatName;
+            }
+
+            @Override
+            public List<String> fileExtensions() {
+                return List.of(extension);
+            }
+
+            @Override
+            public void close() {}
+        };
+        StubStorageProvider storageProvider = new StubStorageProvider(Map.of(), schemasByPath);
+
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of(formatName, extension));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", stubStorageProviderFactory(storageProvider));
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of(formatName, (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            new DataSourceCredentials(ENCRYPTION_SERVICE),
+            () -> false
+        );
+
+        return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module, Settings.EMPTY, cacheService);
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
@@ -160,6 +160,40 @@ public class RetryPolicyTests extends ESTestCase {
         assertEquals(3, calls.get());
     }
 
+    public void testExecuteRetriesPermitExhaustionAndSucceeds() throws IOException {
+        // Permit exhaustion surfaces as a 503-class ExternalUnavailableException (throttling=false), which execute()
+        // treats as a transient fault: it catches the exception and re-attempts, succeeding once the permit frees.
+        RetryPolicy policy = new RetryPolicy(3, 1, 10);
+        AtomicInteger calls = new AtomicInteger();
+        StoragePath path = StoragePath.of("s3://bucket/key");
+
+        String result = policy.execute(() -> {
+            if (calls.incrementAndGet() < 3) {
+                throw new ExternalUnavailableException("at admission capacity", (Throwable) null);
+            }
+            return "ok";
+        }, "test", path);
+
+        assertEquals("ok", result);
+        assertEquals(3, calls.get());
+    }
+
+    public void testDecideRetriesPermitExhaustionOnNormalBudgetWithoutRampingBackoff() {
+        // Permit exhaustion is a throttling=false ExternalUnavailableException, so decide() (the shared async/sync
+        // classification point) treats it as a transient, non-throttle fault: it retries on the NORMAL budget, the
+        // higher throttle budget does not apply, and the cross-request adaptive backoff is never fed.
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, () -> 0L);
+        RetryPolicy policy = new RetryPolicy(2, 1, 10, 8, 1, 10, RetryPolicy.NO_BUDGET, null).withAdaptiveBackoff(backoff);
+        ExternalUnavailableException permitExhaustion = new ExternalUnavailableException("at admission capacity", (Throwable) null);
+
+        assertTrue("within the normal budget it must retry", policy.decide(permitExhaustion, 0, System.nanoTime()).retry());
+        assertFalse(
+            "at the normal-budget limit it must give up; the higher throttle budget must not apply",
+            policy.decide(permitExhaustion, 2, System.nanoTime()).retry()
+        );
+        assertEquals("node-local exhaustion must not ramp the adaptive backoff", 1, backoff.currentMultiplier());
+    }
+
     public void testExecuteThrowsAfterMaxRetries() {
         RetryPolicy policy = new RetryPolicy(2, 1, 10);
         AtomicInteger calls = new AtomicInteger();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL|DS Surface external-read permit exhaustion as a retryable 503 (#153742)](https://github.com/elastic/elasticsearch/pull/153742)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)