### PR TITLE
Skip seatbelt init when process is already sandboxed

### DIFF
--- a/libs/foreign-library/processor/src/main/java/org/elasticsearch/foreign/processor/ImplClassWriter.java
+++ b/libs/foreign-library/processor/src/main/java/org/elasticsearch/foreign/processor/ImplClassWriter.java
@@ -358,9 +358,17 @@ class ImplClassWriter {
             int marshaledSlot = arenaSlot + 1;
             for (NativeType paramType : paramTypes) {
                 if (paramType == NativeType.STRING) {
+                    var notNull = tryBlock.newLabel();
+                    var end = tryBlock.newLabel();
+                    tryBlock.aload(slot);
+                    tryBlock.ifnonnull(notNull);
+                    tryBlock.getstatic(CD_MemorySegment, "NULL", CD_MemorySegment);
+                    tryBlock.goto_(end);
+                    tryBlock.labelBinding(notNull);
                     tryBlock.aload(arenaSlot);
                     tryBlock.aload(slot);
                     tryBlock.invokestatic(CD_MemorySegmentAdapter, "allocateString", MTD_MemorySegmentAdapter_allocateString);
+                    tryBlock.labelBinding(end);
                     tryBlock.astore(marshaledSlot);
                     marshaledSlot++;
                 }

--- a/libs/foreign-library/processor/src/test/java/org/elasticsearch/foreign/processor/ImplClassWriterTests.java
+++ b/libs/foreign-library/processor/src/test/java/org/elasticsearch/foreign/processor/ImplClassWriterTests.java
@@ -358,7 +358,8 @@ public class ImplClassWriterTests extends ProcessorTestCase {
         byte[] bytes = Files.readAllBytes(classFile);
 
         var cm = ClassFile.of().parse(bytes);
-        boolean hasNullCheck = cm.methods().stream()
+        boolean hasNullCheck = cm.methods()
+            .stream()
             .filter(m -> m.methodName().equalsString("op"))
             .flatMap(m -> m.code().stream())
             .flatMap(ca -> ca.elementStream())

--- a/libs/foreign-library/processor/src/test/java/org/elasticsearch/foreign/processor/ImplClassWriterTests.java
+++ b/libs/foreign-library/processor/src/test/java/org/elasticsearch/foreign/processor/ImplClassWriterTests.java
@@ -11,7 +11,12 @@ package org.elasticsearch.foreign.processor;
 
 import org.elasticsearch.core.SuppressForbidden;
 
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.BranchInstruction;
 import java.lang.invoke.MethodHandle;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Tests that {@link ImplClassWriter} generates correct {@code $Impl} class files.
@@ -325,5 +330,39 @@ public class ImplClassWriterTests extends ProcessorTestCase {
         Class<?> driver = result.loadClass("test.BufDriver");
         Object buf = driver.getMethod("create", short.class).invoke(null, (short) 42);
         assertNotNull("BufDriver.create must return a non-null Buf", buf);
+    }
+
+    /**
+     * A {@code String} parameter passed as {@code null} must not reach
+     * {@code allocateString}, which would throw {@link NullPointerException}. The generated
+     * bytecode must contain an {@code IFNONNULL} guard that routes null strings to
+     * {@code MemorySegment.NULL} instead.
+     */
+    public void testNullStringParamGeneratesNullCheck() throws Exception {
+        String source = """
+            package test;
+            import org.elasticsearch.foreign.LibrarySpecification;
+            import org.elasticsearch.foreign.Function;
+            @LibrarySpecification
+            public interface NullableStringLib {
+                @Function("native_op")
+                int op(String name, int flags);
+            }
+            """;
+
+        CompilationResult result = compile("test.NullableStringLib", source);
+        assertTrue("Expected compilation to succeed but got errors: " + result.errors(), result.success());
+
+        Path classFile = result.outputDir().resolve("test/NullableStringLib$Impl.class");
+        assertTrue("Generated NullableStringLib$Impl.class not found", Files.exists(classFile));
+        byte[] bytes = Files.readAllBytes(classFile);
+
+        var cm = ClassFile.of().parse(bytes);
+        boolean hasNullCheck = cm.methods().stream()
+            .filter(m -> m.methodName().equalsString("op"))
+            .flatMap(m -> m.code().stream())
+            .flatMap(ca -> ca.elementStream())
+            .anyMatch(e -> e instanceof BranchInstruction bi && bi.opcode() == Opcode.IFNONNULL);
+        assertTrue("Generated op body must contain IFNONNULL for null-String guard", hasNullCheck);
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/MacNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/MacNativeAccess.java
@@ -107,6 +107,18 @@ public class MacNativeAccess extends PosixNativeAccess {
     }
 
     private void initMacSandbox() {
+        // macOS PIDs are 32-bit (pid_t); Math.toIntExact guards the implicit assumption
+        int pid = Math.toIntExact(ProcessHandle.current().pid());
+        int sandboxStatus = macLibc.sandbox_check(pid, null, 0);
+        if (sandboxStatus != 0) {
+            if (sandboxStatus < 0) {
+                logger.warn("sandbox_check returned {}; assuming already sandboxed, skipping seatbelt initialization", sandboxStatus);
+            } else {
+                logger.debug("already running inside a macOS sandbox; skipping seatbelt initialization");
+            }
+            return;
+        }
+
         // write rules to a temporary file, which will be passed to sandbox_init()
         Path rules;
         try {

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/MacCLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/MacCLibrary.java
@@ -12,6 +12,7 @@ package org.elasticsearch.nativeaccess.lib;
 import org.elasticsearch.foreign.Function;
 import org.elasticsearch.foreign.LibrarySpecification;
 import org.elasticsearch.foreign.Platform;
+import org.elasticsearch.foreign.Variadic;
 
 import java.lang.foreign.MemorySegment;
 
@@ -24,8 +25,31 @@ import java.lang.foreign.MemorySegment;
 public interface MacCLibrary {
 
     /**
+     * Checks whether the process with the given pid is subject to a sandbox policy.
+     *
+     * <p>Pass {@code null} for {@code operation} and {@code 0} for {@code type} to test
+     * whether any sandbox is active without checking a specific operation. Returns non-zero
+     * if sandboxed, 0 if not sandboxed, -1 on error.
+     *
+     * <p>This function is not part of the public macOS SDK but is considered stable in
+     * practice: Apple has not deprecated it (unlike {@code sandbox_init}), it resolves
+     * directly from the system lookup, and it is relied upon by Chromium
+     * ({@code sandbox/mac/seatbelt.cc}) to detect whether the process is already
+     * sandboxed before attempting further sandbox configuration.
+     *
+     * @see <a href="https://github.com/chromium/chromium/blob/main/sandbox/mac/seatbelt.cc">
+     *      Chromium seatbelt.cc — IsSandboxed()</a>
+     */
+    @Variadic(firstArg = 3)
+    @Function("sandbox_check")
+    int sandbox_check(int pid, String operation, int type);
+
+    /**
      * Initializes the macOS Seatbelt sandbox with the given profile file path and flags.
      * On failure, writes a pointer to an error string into {@code errorbuf}.
+     *
+     * <p>Deprecated by Apple in the macOS SDK, but no replacement exists. Chromium likewise
+     * suppresses the deprecation warning and continues to use this call.
      *
      * @see <a href="x-man-page://3/sandbox_init">sandbox_init(3)</a>
      */
@@ -34,6 +58,8 @@ public interface MacCLibrary {
 
     /**
      * Releases the error string buffer allocated by {@code sandbox_init} on failure.
+     *
+     * <p>Deprecated by Apple alongside {@code sandbox_init}; no replacement exists.
      *
      * @see <a href="x-man-page://3/sandbox_init">sandbox_init(3)</a>
      */


### PR DESCRIPTION
Adds sandbox_check binding to MacCLibrary to detect whether the process
is already running inside a macOS sandbox before attempting seatbelt
initialization. Includes null-string support in ImplClassWriter so the
null operation argument passes MemorySegment.NULL to the native function
rather than throwing NPE.