### PR TITLE
[9.5] [ML] Guard CPS project_routing CredentialTransitionsTests with ML_CROSS_PROJECT flag (#152879)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -520,12 +520,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.xpack.ml.datafeed.CredentialTransitionsTests
-  method: testValidateSearchBeforeMintWhenProbeReturnsNoMatchingProjectShouldDeferToRuntime
-  issue: https://github.com/elastic/elasticsearch/issues/152130
-- class: org.elasticsearch.xpack.ml.datafeed.CredentialTransitionsTests
-  method: testValidateSearchBeforeMintWhenProbeReturnsNoMatchingProjectForQualifiedIndexShouldFail
-  issue: https://github.com/elastic/elasticsearch/issues/152131
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingStatsSparklineIT
   method: test {csv-spec:stats_sparkline.sparklineWithWeightedAvg}
   issue: https://github.com/elastic/elasticsearch/issues/152159

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.security.cloud.CloudCredential;
 import org.elasticsearch.xpack.core.security.cloud.CloudCredentialManager;
+import org.elasticsearch.xpack.core.security.cloud.CloudCredentialsExtension;
 import org.elasticsearch.xpack.core.security.cloud.InternalCloudApiKeyService;
 import org.elasticsearch.xpack.core.security.cloud.PersistedCloudCredential;
 import org.elasticsearch.xpack.ml.datafeed.CredentialTransitions.Change;
@@ -339,6 +340,8 @@ public class CredentialTransitionsTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testValidateSearchBeforeMintWhenProbeReturnsNoMatchingProjectShouldDeferToRuntime() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+
         CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
         InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
         Client client = mock(Client.class);
@@ -389,6 +392,8 @@ public class CredentialTransitionsTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testValidateSearchBeforeMintWhenProbeReturnsNoMatchingProjectForQualifiedIndexShouldFail() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+
         CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
         InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
         Client client = mock(Client.class);


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ML] Guard CPS project_routing CredentialTransitionsTests with ML_CROSS_PROJECT flag (#152879)