### PR TITLE
[8.19] ES|QL: Fix NPE caused by null calling toString() in search aggregation (#152152)

### DIFF
--- a/docs/changelog/152152.yaml
+++ b/docs/changelog/152152.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 136639
+pr: 152152
+summary: Fix NPE when aggregation param scripts return null
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -395,12 +395,20 @@ public abstract class ValuesSource {
                         count = bytesValues.docValueCount();
                         grow();
                         script.setDocument(doc);
+                        int j = 0;
                         for (int i = 0; i < count; ++i) {
                             final BytesRef value = bytesValues.nextValue();
                             script.setNextAggregationValue(value.utf8ToString());
                             Object run = script.execute();
-                            CollectionUtils.ensureNoSelfReferences(run, "ValuesSource.BytesValues script");
-                            values[i].copyChars(run.toString());
+                            if (run != null) {
+                                CollectionUtils.ensureNoSelfReferences(run, "ValuesSource.BytesValues script");
+                                values[j].copyChars(run.toString());
+                                j++;
+                            }
+                        }
+                        count = j;
+                        if (count == 0) {
+                            return false;
                         }
                         sort();
                         return true;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -460,7 +460,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, NULL_RETURNING_VALUE_SCRIPT, emptyMap()));
         final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
 
-        testAggregation(aggregationBuilder, Queries.ALL_DOCS_INSTANCE, iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("two"))));
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("three"))));
@@ -479,7 +479,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, PARTIAL_NULL_RETURNING_VALUE_SCRIPT, emptyMap()));
         final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
 
-        testAggregation(aggregationBuilder, Queries.ALL_DOCS_INSTANCE, iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             // Mixed doc: "skip" -> null, "one" and "two" survive (partial compaction, j < i)
             iw.addDocument(
                 List.of(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -83,6 +83,12 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     /** Script to extract the value from any field **/
     public static final String VALUE_SCRIPT = "_value";
 
+    /** Script that always returns null regardless of the input value **/
+    public static final String NULL_RETURNING_VALUE_SCRIPT = "null_returning_value_script";
+
+    /** Script that returns null for the value "skip", otherwise passes the value through **/
+    public static final String PARTIAL_NULL_RETURNING_VALUE_SCRIPT = "partial_null_returning_value_script";
+
     /** Script to extract the single string value of the 'str_value' field **/
     public static final String STRING_VALUE_SCRIPT = "doc['str_value'].value";
 
@@ -100,6 +106,13 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         final Map<String, Function<Map<String, Object>, Object>> scripts = new HashMap<>();
 
         scripts.put(VALUE_SCRIPT, vars -> vars.get("_value"));
+
+        scripts.put(NULL_RETURNING_VALUE_SCRIPT, vars -> null);
+
+        scripts.put(PARTIAL_NULL_RETURNING_VALUE_SCRIPT, vars -> {
+            final Object value = vars.get("_value");
+            return "skip".equals(value) ? null : value;
+        });
 
         scripts.put(STRING_VALUE_SCRIPT, vars -> {
             final Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
@@ -436,6 +449,68 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
         }, card -> {
             assertEquals(2, card.getValue(), 0);
+            assertTrue(AggregationInspectionHelper.hasValue(card));
+        }, mappedFieldTypes);
+    }
+
+    public void testSingleValuedStringValueScriptReturningNull() throws IOException {
+        // Regression test: value script returning null must not cause NPE (GitHub #136639).
+        // Null results are skipped regardless of what the field value is.
+        final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value")
+            .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, NULL_RETURNING_VALUE_SCRIPT, emptyMap()));
+        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+
+        testAggregation(aggregationBuilder, Queries.ALL_DOCS_INSTANCE, iw -> {
+            iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
+            iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("two"))));
+            iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("three"))));
+        }, card -> {
+            assertEquals(0, card.getValue(), 0); // all null → all skipped
+            assertFalse(AggregationInspectionHelper.hasValue(card));
+        }, mappedFieldTypes);
+    }
+
+    public void testMultiValuedStringValueScriptSomeNullValues() throws IOException {
+        // Regression test for GitHub #136639: within a single multi-valued document, the value
+        // script can return null for some values and non-null for others. This exercises the
+        // compaction logic in ValuesSource.Bytes.WithScript.BytesValues#advanceExact, where the
+        // number of retained (non-null) values is smaller than the number of raw doc values.
+        final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_values")
+            .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, PARTIAL_NULL_RETURNING_VALUE_SCRIPT, emptyMap()));
+        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
+
+        testAggregation(aggregationBuilder, Queries.ALL_DOCS_INSTANCE, iw -> {
+            // Mixed doc: "skip" -> null, "one" and "two" survive (partial compaction, j < i)
+            iw.addDocument(
+                List.of(
+                    new SortedSetDocValuesField("str_values", new BytesRef("one")),
+                    new SortedSetDocValuesField("str_values", new BytesRef("skip")),
+                    new SortedSetDocValuesField("str_values", new BytesRef("two"))
+                )
+            );
+            // Mixed doc: "skip" -> null, "three" survives
+            iw.addDocument(
+                List.of(
+                    new SortedSetDocValuesField("str_values", new BytesRef("skip")),
+                    new SortedSetDocValuesField("str_values", new BytesRef("three"))
+                )
+            );
+            // All null doc: every value maps to null, count becomes 0
+            iw.addDocument(
+                List.of(
+                    new SortedSetDocValuesField("str_values", new BytesRef("skip")),
+                    new SortedSetDocValuesField("str_values", new BytesRef("skip"))
+                )
+            );
+            // No nulls doc: full compaction is a no-op (j == i)
+            iw.addDocument(
+                List.of(
+                    new SortedSetDocValuesField("str_values", new BytesRef("one")),
+                    new SortedSetDocValuesField("str_values", new BytesRef("four"))
+                )
+            );
+        }, card -> {
+            assertEquals(4, card.getValue(), 0); // "one", "two", "three", "four"
             assertTrue(AggregationInspectionHelper.hasValue(card));
         }, mappedFieldTypes);
     }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ES|QL: Fix NPE caused by null calling toString() in search aggregation (#152152)