### PR TITLE
[9.5] [ML] Fix flaky ForecastIT#testOverflowToDisk (#152881)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -217,9 +217,6 @@ tests:
 - class: org.elasticsearch.index.mapper.DateRangeDocValuesLoaderTests
   method: testEmptyRangesAppendsNull
   issue: https://github.com/elastic/elasticsearch/issues/148378
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/148606
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:UNMAPPED_FIELDS_LOAD}
   issue: https://github.com/elastic/elasticsearch/issues/148619

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -212,7 +212,8 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
 
         putJob(job);
         openJob(job.getId());
-        createDataWithLotsOfClientIps(bucketSpan, job);
+        // Partition count must exceed the 30MB analysis limit so native memoryStatus is not OK at forecast time.
+        createDataWithLotsOfClientIps(bucketSpan, job, MEMORY_STATUS_CLIENT_IP_GRID_I, MEMORY_STATUS_CLIENT_IP_GRID_J);
         ElasticsearchException e = expectThrows(
             ElasticsearchException.class,
             () -> forecast(job.getId(), TimeValue.timeValueMinutes(120), null)
@@ -237,10 +238,17 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
 
         putJob(job);
         openJob(job.getId());
-        createDataWithLotsOfClientIps(bucketSpan, job);
+        long numClientIps = createDataWithLotsOfClientIps(bucketSpan, job, CLIENT_IP_GRID_SIZE, CLIENT_IP_GRID_SIZE);
+
+        // Force the forecast to spill its per-partition models to disk (the behaviour this test targets) via an
+        // explicit low max_model_memory, rather than relying on a huge number of partitions to organically exceed
+        // the native default. A smaller partition count keeps the single-threaded native model-clone/serialize
+        // step (which runs before the forecast leaves the "scheduled" state) fast and CI-disk-I/O-tolerant.
+        // See https://github.com/elastic/elasticsearch/issues/148606.
+        Long lowMaxModelMemory = ByteSizeValue.ofMb(1).getBytes();
 
         try {
-            String forecastId = forecast(job.getId(), TimeValue.timeValueHours(1), null);
+            String forecastId = forecast(job.getId(), TimeValue.timeValueHours(1), null, lowMaxModelMemory);
 
             waitForecastToFinish(job.getId(), forecastId);
         } catch (ElasticsearchStatusException e) {
@@ -262,12 +270,12 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         ForecastRequestStats forecastRequestStats = forecastStats.get(0);
         List<Forecast> forecasts = getForecasts(job.getId(), forecastRequestStats);
 
-        assertThat(forecastRequestStats.getRecordCount(), equalTo(8000L));
-        assertThat(forecasts.size(), equalTo(8000));
+        assertThat(forecastRequestStats.getRecordCount(), equalTo(numClientIps));
+        assertThat(forecasts.size(), equalTo((int) numClientIps));
 
         // run forecast a 2nd time
         try {
-            String forecastId = forecast(job.getId(), TimeValue.timeValueHours(1), null);
+            String forecastId = forecast(job.getId(), TimeValue.timeValueHours(1), null, lowMaxModelMemory);
 
             waitForecastToFinish(job.getId(), forecastId);
         } catch (ElasticsearchStatusException e) {
@@ -288,8 +296,8 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         for (ForecastRequestStats stats : forecastStats) {
             forecasts = getForecasts(job.getId(), stats);
 
-            assertThat(forecastRequestStats.getRecordCount(), equalTo(8000L));
-            assertThat(forecasts.size(), equalTo(8000));
+            assertThat(forecastRequestStats.getRecordCount(), equalTo(numClientIps));
+            assertThat(forecasts.size(), equalTo((int) numClientIps));
         }
 
     }
@@ -612,15 +620,24 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         assertThat(forecasts.size(), equalTo(1));
     }
 
-    private void createDataWithLotsOfClientIps(TimeValue bucketSpan, Job.Builder job) {
+    // Grid dimensions for testMemoryStatus: enough distinct clientIP partitions to exceed the 30MB analysis limit.
+    private static final int MEMORY_STATUS_CLIENT_IP_GRID_I = 100;
+    private static final int MEMORY_STATUS_CLIENT_IP_GRID_J = 80;
+
+    // Grid dimensions for testOverflowToDisk. Kept small deliberately: partition count no longer forces the
+    // forecast's disk-overflow code path (that's done via an explicit low max_model_memory on the forecast request).
+    // See https://github.com/elastic/elasticsearch/issues/148606.
+    private static final int CLIENT_IP_GRID_SIZE = 20;
+
+    private long createDataWithLotsOfClientIps(TimeValue bucketSpan, Job.Builder job, int gridSizeI, int gridSizeJ) {
         long now = Instant.now().getEpochSecond();
         long timestamp = now - 15 * bucketSpan.seconds();
 
         List<String> data = new ArrayList<>();
         for (int h = 0; h < 15; h++) {
             double value = 10.0 + h;
-            for (int i = 1; i < 101; i++) {
-                for (int j = 1; j < 81; j++) {
+            for (int i = 1; i <= gridSizeI; i++) {
+                for (int j = 1; j <= gridSizeJ; j++) {
                     String json = Strings.format("""
                         {"time": %s, "value": %f, "clientIP": "192.168.%d.%d"}
                         """, timestamp, value, i, j);
@@ -632,6 +649,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
 
         postData(job.getId(), data.stream().collect(Collectors.joining()));
         flushJob(job.getId(), false);
+        return (long) gridSizeI * gridSizeJ;
     }
 
     private static Map<String, Object> createRecord(long timestamp, double value) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ML] Fix flaky ForecastIT#testOverflowToDisk (#152881)](https://github.com/elastic/elasticsearch/pull/152881)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)