### PR TITLE
Add changelog for #150194

### DIFF
--- a/docs/changelog/150194.yaml
+++ b/docs/changelog/150194.yaml
@@ -1,0 +1,5 @@
+pr: 150194
+summary: Update `repository-s3` to use the default request signer from AWS SDK for Java.
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
Turns out that some S3-compatible storage behaves differently with this
change so it's worth mentioning in the changelog after all.