### PR TITLE
[9.5] ES|QL|DS: read widened text columns at their reconciled type (#153540)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
@@ -256,6 +256,41 @@ public abstract class AbstractExternalDataSourceIT extends AbstractEsqlIntegTest
         return name;
     }
 
+    /**
+     * Registers a NON-STRICT ({@code dynamic:true}) dataset with a declared mapping against the shared data source,
+     * creating it on first use, and records it for teardown. A non-strict mapping overlays the declared columns onto
+     * the inferred schema and leaves undeclared columns to normal inference/reconciliation, so it exercises the
+     * declared-overlay path on top of inference (e.g. {@code union_by_name} widening of an undeclared column).
+     */
+    protected String registerNonStrictDataset(
+        String name,
+        String resourceUri,
+        LinkedHashMap<String, DatasetFieldMapping> properties,
+        Map<String, Object> settings
+    ) {
+        if (registeredDataSources.contains(SHARED_TEST_DATA_SOURCE) == false) {
+            registerDataSource(SHARED_TEST_DATA_SOURCE, Map.of());
+        }
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    name,
+                    SHARED_TEST_DATA_SOURCE,
+                    resourceUri,
+                    null,
+                    new HashMap<>(settings),
+                    mapping
+                )
+            )
+        );
+        registeredDatasets.add(name);
+        return name;
+    }
+
     @After
     public void cleanupRegistry() {
         for (String dataset : registeredDatasets) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvUnionByNameNumericWideningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvUnionByNameNumericWideningIT.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Multi-file CSV glob reads under {@code schema_resolution = union_by_name} where one file's shared column is inferred
+ * from a narrow sampled prefix but carries a wider out-of-sample value further down, while another file infers the
+ * wider type. Reconciliation widens the column ({@code INTEGER} to {@code LONG} or {@code DOUBLE}, or a numeric/text mix
+ * to {@code KEYWORD}), and because a text reader parses each token at its pinned read type, the narrow-inferred file is
+ * read at the reconciled type so the out-of-sample value that does not fit the narrower type still parses instead of
+ * null-filling.
+ * <p>
+ * {@code schema_sample_size} is small so the narrow-inferred file's sample sees only its leading rows and never the
+ * wider trailing row. Under {@code error_mode = null_field} a value that does not fit its read type surfaces as a
+ * {@code null} cell; under {@code error_mode = fail_fast} it aborts the query. In both modes reading at the reconciled
+ * type lets the out-of-sample value parse, so it survives as its value and the {@code fail_fast} query succeeds.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class ExternalCsvUnionByNameNumericWideningIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class);
+    }
+
+    public void testNumericInferredColumnKeepsTextTailWhenWidenedToKeyword() throws Exception {
+        Path dir = createTempDir().resolve("ubn_numeric_widened_keyword");
+        Files.createDirectories(dir);
+        // a.csv: with schema_sample_size=2 the sampler sees only rows (1,100) and (2,200) -> col inferred numeric,
+        // but row (3,oops) carries a text value the sample never saw.
+        Files.writeString(dir.resolve("a.csv"), "id,col,note\n1,100,alpha\n2,200,beta\n3,oops,gamma\n", StandardCharsets.UTF_8);
+        // b.csv: col is text in every sampled row -> inferred keyword, so union_by_name widens col to keyword.
+        Files.writeString(dir.resolve("b.csv"), "id,col,note\n4,abc,delta\n5,def,epsilon\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.csv";
+        String dataset = registerDataset(
+            "ubn_numeric_widened_keyword",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field")
+        );
+
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            // col is keyword in the unified schema, so numeric tokens read back as their string form. The row-3 text
+            // value "oops" is the one the sample never saw; it must survive rather than null-fill.
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains("100", "200", "oops", "abc", "def"));
+            assertThat("the numeric-inferred file's text tail must not be dropped", rows.get(2).get(0), equalTo("oops"));
+        }
+    }
+
+    public void testIntInferredColumnKeepsOutOfSampleOverflowWhenWidenedToLong() throws Exception {
+        Path dir = createTempDir().resolve("ubn_int_widened_long");
+        Files.createDirectories(dir);
+        // a.csv: sample (10, 20) infers INTEGER, but the trailing value overflows int and the sample never saw it.
+        Files.writeString(dir.resolve("a.csv"), "id,col\n1,10\n2,20\n3,3000000000\n", StandardCharsets.UTF_8);
+        // b.csv: values exceed int range -> inferred LONG, so union_by_name widens col to LONG.
+        Files.writeString(dir.resolve("b.csv"), "id,col\n4,5000000000\n5,6000000000\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.csv";
+        String dataset = registerDataset(
+            "ubn_int_widened_long",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field")
+        );
+
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains(10L, 20L, 3000000000L, 5000000000L, 6000000000L));
+            assertThat("the out-of-sample overflow value must not be dropped", rows.get(2).get(0), equalTo(3000000000L));
+        }
+    }
+
+    public void testIntInferredColumnKeepsOutOfSampleDecimalWhenWidenedToDouble() throws Exception {
+        Path dir = createTempDir().resolve("ubn_int_widened_double");
+        Files.createDirectories(dir);
+        // a.csv: sample (10, 20) infers INTEGER, but the trailing value is a decimal the sample never saw.
+        Files.writeString(dir.resolve("a.csv"), "id,col\n1,10\n2,20\n3,1.5\n", StandardCharsets.UTF_8);
+        // b.csv: decimal values -> inferred DOUBLE, so union_by_name widens col to DOUBLE.
+        Files.writeString(dir.resolve("b.csv"), "id,col\n4,1.1\n5,2.2\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.csv";
+        String dataset = registerDataset(
+            "ubn_int_widened_double",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field")
+        );
+
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains(10.0, 20.0, 1.5, 1.1, 2.2));
+            assertThat("the out-of-sample decimal value must not be dropped", rows.get(2).get(0), equalTo(1.5));
+        }
+    }
+
+    public void testFailFastNumericInferredColumnKeepsTextTailWhenWidenedToKeyword() throws Exception {
+        Path dir = createTempDir().resolve("ubn_failfast_widened_keyword");
+        Files.createDirectories(dir);
+        // a.csv: sample (100, 200) infers numeric; the out-of-sample text "oops" would fail a numeric parse.
+        Files.writeString(dir.resolve("a.csv"), "id,col,note\n1,100,alpha\n2,200,beta\n3,oops,gamma\n", StandardCharsets.UTF_8);
+        // b.csv: col is text -> inferred keyword, so union_by_name widens col to keyword.
+        Files.writeString(dir.resolve("b.csv"), "id,col,note\n4,abc,delta\n5,def,epsilon\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.csv";
+        String dataset = registerDataset(
+            "ubn_failfast_widened_keyword",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "fail_fast")
+        );
+
+        // Under fail_fast, parsing "oops" at the sampled numeric type would abort the whole query. Pinned to KEYWORD
+        // the reader returns the raw token, so the query succeeds and no value is lost.
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains("100", "200", "oops", "abc", "def"));
+            assertThat("the numeric-inferred file's text tail must not abort the read", rows.get(2).get(0), equalTo("oops"));
+        }
+    }
+
+    public void testFailFastIntInferredColumnKeepsOutOfSampleOverflowWhenWidenedToLong() throws Exception {
+        Path dir = createTempDir().resolve("ubn_failfast_widened_long");
+        Files.createDirectories(dir);
+        // a.csv: sample (10, 20) infers INTEGER; the out-of-sample value overflows int and would abort a fail_fast read.
+        Files.writeString(dir.resolve("a.csv"), "id,col\n1,10\n2,20\n3,3000000000\n", StandardCharsets.UTF_8);
+        // b.csv: values exceed int range -> inferred LONG, so union_by_name widens col to LONG.
+        Files.writeString(dir.resolve("b.csv"), "id,col\n4,5000000000\n5,6000000000\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.csv";
+        String dataset = registerDataset(
+            "ubn_failfast_widened_long",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "fail_fast")
+        );
+
+        // Pinned to LONG the reader parses 3000000000 directly, so the fail_fast query succeeds instead of aborting.
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains(10L, 20L, 3000000000L, 5000000000L, 6000000000L));
+            assertThat("the out-of-sample overflow value must not abort the read", rows.get(2).get(0), equalTo(3000000000L));
+        }
+    }
+
+    public void testWidenedKeywordColumnStatsAggregateRawValuesAcrossRepeatedRuns() throws Exception {
+        Path dir = createTempDir().resolve("ubn_keyword_stats");
+        Files.createDirectories(dir);
+        // a.csv: sample (100, 200) infers numeric, trailing text "oops" is out of sample.
+        Files.writeString(dir.resolve("a.csv"), "id,col\n1,100\n2,200\n3,oops\n", StandardCharsets.UTF_8);
+        // b.csv: text values -> inferred keyword, so union_by_name widens col to KEYWORD.
+        Files.writeString(dir.resolve("b.csv"), "id,col\n4,abc\n5,def\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.csv";
+        String dataset = registerDataset(
+            "ubn_keyword_stats",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field")
+        );
+
+        // Run twice: the second run may serve warm per-column stats. The reconciled column is KEYWORD, read at KEYWORD,
+        // so MIN/MAX must be the lexicographic keyword extrema of the raw tokens, not a stale numeric extremum. MAX is
+        // the discriminating assertion: the keyword max "oops" differs from any numeric max (200), so a leaked numeric
+        // extremum would fail here.
+        String query = "FROM " + dataset + " | STATS mn = MIN(col), mx = MAX(col)";
+        for (int run = 0; run < 2; run++) {
+            try (var response = run(syncEsqlQueryRequest(query))) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat(rows.get(0).get(0), equalTo("100"));
+                assertThat(rows.get(0).get(1), equalTo("oops"));
+            }
+        }
+    }
+
+    public void testPinnedReadCommitMustNotPolluteSoloNarrowReadStats() throws Exception {
+        Path dir = createTempDir().resolve("ubn_pinned_commit");
+        Files.createDirectories(dir);
+        // a.csv: schema_sample_size=2 samples (10, 20) -> col inferred INTEGER; 3000000000 is out of
+        // sample and overflows int, so a solo INTEGER read null-fills it under error_mode=null_field.
+        Files.writeString(dir.resolve("a.csv"), "id,col\n1,10\n2,20\n3,3000000000\n", StandardCharsets.UTF_8);
+        // b.csv: long-range values -> col inferred LONG, so the glob's UNION_BY_NAME reconciliation
+        // widens col to LONG and pins a.csv's read to LONG.
+        Files.writeString(dir.resolve("b.csv"), "id,col\n4,-5000000000\n5,-6000000000\n", StandardCharsets.UTF_8);
+
+        Map<String, Object> settings = Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field");
+        String dsA = registerDataset("ubn_pinned_commit_a", StoragePath.fileUri(dir) + "/a.csv", settings);
+        String combined = registerDataset("ubn_pinned_commit_all", StoragePath.fileUri(dir) + "/*.csv", settings);
+
+        // Solo a.csv reads col at its inferred INTEGER: 3000000000 null-fills -> COUNT(col)=2. The scan's
+        // harvest commits value_count=2 into a.csv's schema-cache entry, keyed (path, mtime, config) --
+        // an identity with NO read-type component.
+        try (var response = run(syncEsqlQueryRequest("FROM " + dsA + " | STATS c = COUNT(col)"))) {
+            assertThat(getValuesList(response).get(0).get(0), equalTo(2L));
+        }
+
+        // The glob pins a.csv's read to the reconciled LONG: 3000000000 parses, COUNT(col)=5. That read's
+        // harvest carries value_count=3 for a.csv and, uncorrected, commits it into the SAME cache entry
+        // the solo INTEGER read serves from.
+        try (var response = run(syncEsqlQueryRequest("FROM " + combined + " | STATS c = COUNT(col)"))) {
+            assertThat(getValuesList(response).get(0).get(0), equalTo(5L));
+        }
+
+        // The solo dataset still reads a.csv at INTEGER, where 3000000000 null-fills, so COUNT(col) must
+        // still be 2. A warm serve of the pinned read's committed value_count returns 3 instead.
+        try (var response = run(syncEsqlQueryRequest("FROM " + dsA + " | STATS c = COUNT(col)"))) {
+            assertThat("solo COUNT(col) after the pinned glob read", getValuesList(response).get(0).get(0), equalTo(2L));
+        }
+    }
+
+    /**
+     * The commit-side pinned-column stats strip must survive a non-strict declared mapping on the dataset. This is
+     * {@link #testPinnedReadCommitMustNotPolluteSoloNarrowReadStats} with one added ingredient: both datasets carry a
+     * non-strict ({@code dynamic:true}) declared mapping that declares only the unrelated {@code id} column. {@code col}
+     * therefore stays the undeclared UNION_BY_NAME-widened+pinned column, but the mapping's presence routes resolution
+     * through the declared overlay.
+     * <p>
+     * The overlay must not erase the pin's pre-pin type snapshot. If it does, the widening glob read's {@code col}
+     * value_count=3 for a.csv is no longer recognized as a pinned contribution, so it is committed into the
+     * read-schema-blind {@code (path, mtime, config)} cache entry the solo INTEGER read serves from, and the solo
+     * COUNT(col) warm-serves 3 instead of 2.
+     */
+    public void testPinnedReadWithNonStrictDeclaredMappingMustNotPolluteSoloNarrowReadStats() throws Exception {
+        Path dir = createTempDir().resolve("ubn_pinned_commit_declared");
+        Files.createDirectories(dir);
+        // a.csv: schema_sample_size=2 samples (10, 20) -> col inferred INTEGER; 3000000000 is out of sample and
+        // overflows int, so a solo INTEGER read null-fills it under error_mode=null_field.
+        Files.writeString(dir.resolve("a.csv"), "id,col\n1,10\n2,20\n3,3000000000\n", StandardCharsets.UTF_8);
+        // b.csv: long-range values -> col inferred LONG, so the glob's UNION_BY_NAME reconciliation widens col to LONG
+        // and pins a.csv's read to LONG.
+        Files.writeString(dir.resolve("b.csv"), "id,col\n4,-5000000000\n5,-6000000000\n", StandardCharsets.UTF_8);
+
+        Map<String, Object> settings = Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field");
+        // Non-strict overlay over the unrelated id column only: col stays undeclared (still UBN-widened+pinned), but
+        // resolution now runs the declared overlay. Both datasets share the settings map, so they share a.csv's
+        // read-schema-blind schema-cache entry.
+        LinkedHashMap<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("id", new DatasetFieldMapping("integer", "id"));
+        String dsA = registerNonStrictDataset("ubn_pinned_commit_declared_a", StoragePath.fileUri(dir) + "/a.csv", properties, settings);
+        String combined = registerNonStrictDataset(
+            "ubn_pinned_commit_declared_all",
+            StoragePath.fileUri(dir) + "/*.csv",
+            properties,
+            settings
+        );
+
+        // Solo a.csv reads col at its inferred INTEGER: 3000000000 null-fills -> COUNT(col)=2, committed into a.csv's
+        // schema-cache entry.
+        try (var response = run(syncEsqlQueryRequest("FROM " + dsA + " | STATS c = COUNT(col)"))) {
+            assertThat(getValuesList(response).get(0).get(0), equalTo(2L));
+        }
+
+        // The glob pins a.csv's read to the reconciled LONG: 3000000000 parses, COUNT(col)=5. Its harvest carries
+        // value_count=3 for a.csv and must be stripped before commit so it does not pollute the shared cache entry.
+        try (var response = run(syncEsqlQueryRequest("FROM " + combined + " | STATS c = COUNT(col)"))) {
+            assertThat(getValuesList(response).get(0).get(0), equalTo(5L));
+        }
+
+        // The solo dataset still reads a.csv at INTEGER, where 3000000000 null-fills, so COUNT(col) must still be 2.
+        try (var response = run(syncEsqlQueryRequest("FROM " + dsA + " | STATS c = COUNT(col)"))) {
+            assertThat(
+                "solo COUNT(col) after the pinned glob read under a non-strict declared mapping",
+                getValuesList(response).get(0).get(0),
+                equalTo(2L)
+            );
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonUnionByNameNumericWideningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonUnionByNameNumericWideningIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * The NDJSON counterpart of {@link ExternalCsvUnionByNameNumericWideningIT}: a multi-file NDJSON glob read under
+ * {@code schema_resolution = union_by_name} where one file's shared column is inferred from a narrow sampled prefix
+ * but carries a wider out-of-sample value further down, while another file infers the wider type. Reconciliation
+ * widens the column ({@code INTEGER} to {@code LONG}, or a numeric/text mix to {@code KEYWORD}), and because the
+ * narrow-inferred file is pinned to the reconciled read type its out-of-sample value still parses instead of
+ * null-filling.
+ * <p>
+ * NDJSON is worth its own end-to-end coverage because it decodes through {@link org.elasticsearch.xpack.esql.datasource
+ * .ndjson.NdJsonPageDecoder}, a separate path from the {@code CsvFormatReader} the CSV/TSV suites exercise. The
+ * reconciliation-level pinning is asserted format-agnostically in {@code SchemaReconciliationTests}; this test proves
+ * the decoder honours the pin on real data.
+ * <p>
+ * {@code schema_sample_size} is small so the narrow-inferred file's sample sees only its leading rows and never the
+ * wider trailing row. Under {@code error_mode = null_field} a value that does not fit its read type surfaces as a
+ * {@code null} cell; under {@code error_mode = fail_fast} it aborts the query. NDJSON decodes strict reads through its
+ * own {@code decodePageFailFast} path, so both error modes are covered here rather than relying on the CSV suite.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class ExternalNdJsonUnionByNameNumericWideningIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(NdJsonDataSourcePlugin.class);
+    }
+
+    public void testNumericInferredColumnKeepsTextTailWhenWidenedToKeyword() throws Exception {
+        Path dir = createTempDir().resolve("ubn_ndjson_widened_keyword");
+        Files.createDirectories(dir);
+        // a.ndjson: with schema_sample_size=2 the sampler sees only col=100 and col=200 -> inferred numeric,
+        // but the third record carries a text value the sample never saw.
+        Files.writeString(
+            dir.resolve("a.ndjson"),
+            "{\"id\":1,\"col\":100}\n{\"id\":2,\"col\":200}\n{\"id\":3,\"col\":\"oops\"}\n",
+            StandardCharsets.UTF_8
+        );
+        // b.ndjson: col is text in every sampled record -> inferred keyword, so union_by_name widens col to keyword.
+        Files.writeString(dir.resolve("b.ndjson"), "{\"id\":4,\"col\":\"abc\"}\n{\"id\":5,\"col\":\"def\"}\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.ndjson";
+        String dataset = registerDataset(
+            "ubn_ndjson_widened_keyword",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field")
+        );
+
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            // col is keyword in the unified schema, so numeric tokens read back as their raw string form. The
+            // third record's text value "oops" is the one the sample never saw; it must survive rather than null-fill.
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains("100", "200", "oops", "abc", "def"));
+            assertThat("the numeric-inferred file's text tail must not be dropped", rows.get(2).get(0), equalTo("oops"));
+        }
+    }
+
+    public void testIntInferredColumnKeepsOutOfSampleOverflowWhenWidenedToLong() throws Exception {
+        Path dir = createTempDir().resolve("ubn_ndjson_widened_long");
+        Files.createDirectories(dir);
+        // a.ndjson: sample (10, 20) infers INTEGER, but the trailing value overflows int and the sample never saw it.
+        Files.writeString(
+            dir.resolve("a.ndjson"),
+            "{\"id\":1,\"col\":10}\n{\"id\":2,\"col\":20}\n{\"id\":3,\"col\":3000000000}\n",
+            StandardCharsets.UTF_8
+        );
+        // b.ndjson: values exceed int range -> inferred LONG, so union_by_name widens col to LONG.
+        Files.writeString(
+            dir.resolve("b.ndjson"),
+            "{\"id\":4,\"col\":5000000000}\n{\"id\":5,\"col\":6000000000}\n",
+            StandardCharsets.UTF_8
+        );
+
+        String glob = StoragePath.fileUri(dir) + "/*.ndjson";
+        String dataset = registerDataset(
+            "ubn_ndjson_widened_long",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "null_field")
+        );
+
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains(10L, 20L, 3000000000L, 5000000000L, 6000000000L));
+            assertThat("the out-of-sample overflow value must not be dropped", rows.get(2).get(0), equalTo(3000000000L));
+        }
+    }
+
+    public void testFailFastNumericInferredColumnKeepsTextTailWhenWidenedToKeyword() throws Exception {
+        Path dir = createTempDir().resolve("ubn_ndjson_failfast_keyword");
+        Files.createDirectories(dir);
+        // a.ndjson: sample (100, 200) infers numeric; the out-of-sample text "oops" would fail a numeric coercion.
+        Files.writeString(
+            dir.resolve("a.ndjson"),
+            "{\"id\":1,\"col\":100}\n{\"id\":2,\"col\":200}\n{\"id\":3,\"col\":\"oops\"}\n",
+            StandardCharsets.UTF_8
+        );
+        // b.ndjson: col is text -> inferred keyword, so union_by_name widens col to keyword.
+        Files.writeString(dir.resolve("b.ndjson"), "{\"id\":4,\"col\":\"abc\"}\n{\"id\":5,\"col\":\"def\"}\n", StandardCharsets.UTF_8);
+
+        String glob = StoragePath.fileUri(dir) + "/*.ndjson";
+        String dataset = registerDataset(
+            "ubn_ndjson_failfast_keyword",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "fail_fast")
+        );
+
+        // Under fail_fast, coercing "oops" to the sampled numeric type would abort the whole query through the NDJSON
+        // decodePageFailFast path. Pinned to KEYWORD the decoder returns the raw token, so the query succeeds.
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains("100", "200", "oops", "abc", "def"));
+            assertThat("the numeric-inferred file's text tail must not abort the read", rows.get(2).get(0), equalTo("oops"));
+        }
+    }
+
+    public void testFailFastIntInferredColumnKeepsOutOfSampleOverflowWhenWidenedToLong() throws Exception {
+        Path dir = createTempDir().resolve("ubn_ndjson_failfast_long");
+        Files.createDirectories(dir);
+        // a.ndjson: sample (10, 20) infers INTEGER; the out-of-sample value overflows int and would abort a fail_fast read.
+        Files.writeString(
+            dir.resolve("a.ndjson"),
+            "{\"id\":1,\"col\":10}\n{\"id\":2,\"col\":20}\n{\"id\":3,\"col\":3000000000}\n",
+            StandardCharsets.UTF_8
+        );
+        // b.ndjson: values exceed int range -> inferred LONG, so union_by_name widens col to LONG.
+        Files.writeString(
+            dir.resolve("b.ndjson"),
+            "{\"id\":4,\"col\":5000000000}\n{\"id\":5,\"col\":6000000000}\n",
+            StandardCharsets.UTF_8
+        );
+
+        String glob = StoragePath.fileUri(dir) + "/*.ndjson";
+        String dataset = registerDataset(
+            "ubn_ndjson_failfast_long",
+            glob,
+            Map.of("schema_resolution", "union_by_name", "schema_sample_size", 2, "error_mode", "fail_fast")
+        );
+
+        // Pinned to LONG the decoder parses 3000000000 directly, so the fail_fast query succeeds instead of aborting.
+        String query = "FROM " + dataset + " | SORT id ASC | KEEP col";
+        try (var response = run(syncEsqlQueryRequest(query))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows.stream().map(row -> row.get(0)).toList(), contains(10L, 20L, 3000000000L, 5000000000L, 6000000000L));
+            assertThat("the out-of-sample overflow value must not abort the read", rows.get(2).get(0), equalTo(3000000000L));
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -1384,13 +1384,25 @@ public class ExternalSourceResolver {
                 // COUNT/MIN/MAX is not a unit-blind numeric mix across DATETIME(millis)/DATE_NANOS(nanos) files.
                 Map<String, DataType> reconciledTypes = attributesToTypeMap(unifiedSchema);
                 Map<StoragePath, Map<String, DataType>> perFileTypes = new HashMap<>();
+                Map<StoragePath, Set<String>> perFilePinnedColumns = new HashMap<>();
                 for (Map.Entry<StoragePath, SchemaReconciliation.FileSchemaInfo> e : result.perFileInfo().entrySet()) {
-                    perFileTypes.put(e.getKey(), attributesToTypeMap(e.getValue().fileSchema().attributes()));
+                    SchemaReconciliation.FileSchemaInfo info = e.getValue();
+                    perFileTypes.put(e.getKey(), attributesToTypeMap(info.fileSchema().attributes()));
+                    Set<String> pinnedColumns = pinnedColumnsOf(info);
+                    if (pinnedColumns.isEmpty() == false) {
+                        perFilePinnedColumns.put(e.getKey(), pinnedColumns);
+                    }
                 }
+                // Under SKIP_ROW a narrow-read parse failure on a pinned column drops the whole row, so a pinned
+                // file's cached row count is untrustworthy too; NULL_FIELD keeps the row (only the cell nulls) and
+                // FAIL_FAST aborts the read cold before it can cache, so both keep the row count.
+                boolean dropPinnedRowCount = resolvesToSkipRow(firstMeta.sourceType(), config);
                 Map<String, Object> aggregatedStats = aggregateFileStatistics(
                     allMetadata,
                     perFileTypes,
                     reconciledTypes,
+                    perFilePinnedColumns,
+                    dropPinnedRowCount,
                     foldsAbsentColumnAsImplicitNull(firstMeta.sourceType())
                 );
                 aggregatedStats = applyDatasetAggregate(datasetPrefetch, aggregatedStats, fileList, firstMeta, config);
@@ -1463,9 +1475,13 @@ public class ExternalSourceResolver {
         for (Map.Entry<StoragePath, SchemaReconciliation.FileSchemaInfo> entry : result.perFileInfo().entrySet()) {
             SchemaReconciliation.FileSchemaInfo info = entry.getValue();
             // Recompute the mapping against the data-only unified schema; the file (physical) schema is
-            // unchanged so the reader still parses every column, including the shadowed one.
+            // unchanged so the reader still parses every column, including the shadowed one. Carry the pin's
+            // inferredTypes forward so a Hive-partitioned glob keeps the pinned-column stats boundary.
             ColumnMapping mapping = SchemaReconciliation.computeMapping(dataOnlyUnified, info.fileSchema().attributes());
-            perFileInfo.put(entry.getKey(), new SchemaReconciliation.FileSchemaInfo(info.fileSchema(), mapping, info.statistics()));
+            perFileInfo.put(
+                entry.getKey(),
+                new SchemaReconciliation.FileSchemaInfo(info.fileSchema(), mapping, info.statistics(), info.inferredTypes())
+            );
         }
         return new SchemaReconciliation.Result(new ExternalSchema(dataOnlyUnified), Map.copyOf(perFileInfo));
     }
@@ -1616,12 +1632,23 @@ public class ExternalSourceResolver {
      * safe-misses when a value cannot be normalized. {@code perFileTypes} maps each file's path to its own column
      * types; {@code reconciledTypes} is the unified schema's types. Without this, the source-level warm
      * MIN/MAX/COUNT would compare raw file-local values unit-blind (a wrong answer).
+     * <p>
+     * {@code perFilePinnedColumns} names, per file, the columns a text-format UNION_BY_NAME pin retyped above their
+     * inferred type (see {@link SchemaReconciliation#reconcileUnionByName}). Their cached per-file stats were harvested
+     * at the narrower read type, but the schema cache identity is read-schema-blind, so a stat harvested by a solo
+     * narrow read is shared with this widened read. That stat is not merely a wrong unit but a wrong value (the narrow
+     * read null-filled or row-dropped the out-of-sample cell that the wide read keeps), which normalization cannot
+     * rescue. So each pinned column is safe-missed via {@link SourceStatisticsSerializer#overlayPinnedColumnsOnStats}:
+     * its extrema are poisoned and its value/null counts dropped, and when {@code dropPinnedRowCount} (SKIP_ROW, where
+     * a narrow-read parse failure dropped the whole row) the file's row count is dropped too, forcing a full re-scan.
      */
     @Nullable
     static Map<String, Object> aggregateFileStatistics(
         Map<StoragePath, SourceMetadata> allMetadata,
         Map<StoragePath, Map<String, DataType>> perFileTypes,
         Map<String, DataType> reconciledTypes,
+        Map<StoragePath, Set<String>> perFilePinnedColumns,
+        boolean dropPinnedRowCount,
         boolean implicitNullsForAbsentColumn
     ) {
         List<Map<String, Object>> perFileFlatStats = new ArrayList<>(allMetadata.size());
@@ -1637,6 +1664,10 @@ public class ExternalSourceResolver {
             Map<String, DataType> fileTypes = perFileTypes.get(entry.getKey());
             if (fileTypes != null) {
                 flat = SourceStatisticsSerializer.normalizeStatsToReconciled(flat, fileTypes, reconciledTypes);
+            }
+            Set<String> pinnedColumns = perFilePinnedColumns.get(entry.getKey());
+            if (pinnedColumns != null && pinnedColumns.isEmpty() == false) {
+                flat = SourceStatisticsSerializer.overlayPinnedColumnsOnStats(flat, pinnedColumns, dropPinnedRowCount);
             }
             perFileFlatStats.add(flat);
         }
@@ -1702,6 +1733,46 @@ public class ExternalSourceResolver {
             types.put(a.name(), a.dataType());
         }
         return types;
+    }
+
+    /**
+     * The columns a UNION_BY_NAME pin retyped above their inferred type for this file, i.e. the columns whose read-time
+     * type differs from the type their cached stats were harvested at. Derived as {@code inferredTypes != fileSchema}:
+     * {@link SchemaReconciliation.FileSchemaInfo#inferredTypes()} snapshots the pre-pin types and is populated only when
+     * the pin actually retyped a column, so a null (nothing retyped) or type-equal entry yields the empty set.
+     */
+    public static Set<String> pinnedColumnsOf(SchemaReconciliation.FileSchemaInfo info) {
+        Map<String, DataType> inferred = info.inferredTypes();
+        if (inferred == null) {
+            return Set.of();
+        }
+        Map<String, DataType> fileTypes = attributesToTypeMap(info.fileSchema().attributes());
+        Set<String> pinned = new HashSet<>();
+        for (Map.Entry<String, DataType> e : inferred.entrySet()) {
+            DataType fileType = fileTypes.get(e.getKey());
+            if (fileType != null && fileType != e.getValue()) {
+                pinned.add(e.getKey());
+            }
+        }
+        return pinned;
+    }
+
+    /**
+     * Whether the effective {@link ErrorPolicy} for {@code sourceType} under {@code config} resolves to
+     * {@link ErrorPolicy.Mode#SKIP_ROW}, in which a narrow-read parse failure on a pinned column drops the whole row and
+     * so makes the file's cached row count untrustworthy. Resolved through {@link ErrorPolicy#fromConfig} against the
+     * reader's own default (mirrors {@link #warmsRowCountSafely}) so it is format-agnostic and catches the implicit
+     * SKIP_ROW that a bare {@code max_errors} selects. An invalid policy conservatively drops the row count: it must not
+     * fail resolution (the data node rejects it at scan time), and dropping only forces a safe re-scan.
+     */
+    public boolean resolvesToSkipRow(String sourceType, Map<String, Object> config) {
+        FormatReader reader = dataSourceModule.formatReaderRegistry().findByName(sourceType);
+        ErrorPolicy defaultPolicy = reader != null ? reader.defaultErrorPolicy() : ErrorPolicy.STRICT;
+        try {
+            return ErrorPolicy.fromConfig(config, defaultPolicy).mode() == ErrorPolicy.Mode.SKIP_ROW;
+        } catch (IllegalArgumentException e) {
+            return true;
+        }
     }
 
     /**
@@ -2816,15 +2887,22 @@ public class ExternalSourceResolver {
             ColumnMapping mapping = hasDeclaredColumns
                 ? SchemaReconciliation.computeMapping(dataOnlyUnifiedOverlaid, perFile.fileSchema())
                 : info.mapping();
+            // PRE-retype file types, physical-keyed, so the stats boundaries recover the file's real inferred types
+            // (the split-level footer normalize and the resolve/commit pinned-column safe-miss), not the overlaid
+            // declared ones. A UNION_BY_NAME pin already retyped this file's read schema and snapshotted the pre-pin
+            // inferred types onto info.inferredTypes(); preserve that snapshot so a widened+pinned column stays
+            // identifiable after the overlay. Only when nothing upstream retyped the file (inferredTypes null) does
+            // info.fileSchema() still carry the inferred types, so fall back to it for the declared-overlay-only path.
+            Map<String, DataType> preRetypeInferredTypes = info.inferredTypes() != null
+                ? info.inferredTypes()
+                : attributesToTypeMap(info.fileSchema().attributes());
             overlaidSchemaMap.put(
                 e.getKey(),
                 new SchemaReconciliation.FileSchemaInfo(
                     new ExternalSchema(perFile.fileSchema()),
                     mapping,
                     info.statistics(),
-                    // PRE-overlay file types (physical names, inferred types) so the split-level stats boundary can
-                    // normalize footer stats with the file's real types, not the overlaid declared ones.
-                    attributesToTypeMap(info.fileSchema().attributes())
+                    preRetypeInferredTypes
                 )
             );
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -310,8 +310,10 @@ public class FileSplitProvider implements SplitProvider {
                     if (mapping != null && mapping.isIdentity() == false) {
                         columnMapping = mappingCache.computeIfAbsent(mapping, k -> k);
                     }
-                    // Pin the reader to the coordinator's per-file inference so it doesn't re-infer
-                    // at runtime and disagree with the planner's view of this file.
+                    // Pin the reader to the coordinator's reconciled per-file read schema so it
+                    // doesn't re-infer at runtime and disagree with the planner's view of this file.
+                    // For text formats this schema already carries each widened column's reconciled
+                    // type (see SchemaReconciliation), so the reader reads at that type directly.
                     readSchema = info.fileSchema().attributes();
                 }
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -40,9 +41,12 @@ import java.util.Set;
  * This is NOT {@code EsqlDataTypeConverter.commonType()}, which allows LONG→DOUBLE (lossy above 2^53).
  * <p>
  * Under {@code UNION_BY_NAME}, any pair the lossless table cannot widen falls back to
- * {@link DataType#KEYWORD} (the cross-type join): values from numerically-typed files are stringified
- * via {@code ColumnMapping}'s per-block cast and a single response {@code Warning} header per
- * affected column tells the user what happened. This matches the industry baseline (DuckDB,
+ * {@link DataType#KEYWORD} (the cross-type join), and a single response {@code Warning} header per
+ * affected column tells the user what happened. How the wider (or KEYWORD) type is produced depends
+ * on the format: columnar files (Parquet, ORC) read the physically-typed value and stringify it via
+ * {@code ColumnMapping}'s per-block cast, while text files (CSV, TSV, NDJSON) are pinned to the
+ * reconciled type and read it at that type directly (see {@code readsColumnsAtReconciledType}). This
+ * matches the industry baseline (DuckDB,
  * ClickHouse, Spark all widen to string as the cross-type floor) and turns "samplers disagreed"
  * — the normal steady state for sampling-based readers — from a hard error into a benign
  * widening. Users who want the strict-mismatch error can opt into {@code schema_resolution =
@@ -62,7 +66,10 @@ import java.util.Set;
  * <dl>
  *   <dt><b>File schema</b> (per-file, file shape)</dt>
  *   <dd>What's literally in one file. Parquet/ORC: read from the file footer. CSV/NDJSON:
- *       inferred from a byte sample. Carried per-file on {@link FileSplit#readSchema()}.</dd>
+ *       inferred from a byte sample. Carried per-file on {@link FileSplit#readSchema()} as the
+ *       reader's read pin. Under UNION_BY_NAME this pin is the effective read schema after
+ *       reconciliation overrides: for text formats a widened column is pinned to its reconciled
+ *       type so the reader reads at that type directly rather than the narrower sampled type.</dd>
  *
  *   <dt><b>Unified schema</b> (one for the whole table)</dt>
  *   <dd>The cross-file harmonized schema. Produced here as {@link Result#unifiedSchema()}:
@@ -114,7 +121,9 @@ public final class SchemaReconciliation {
     /**
      * Per-file schema information collected during reconciliation.
      *
-     * @param fileSchema the original schema from this file
+     * @param fileSchema the effective read schema the reader is pinned to for this file: the file's
+     *                   inferred/footer schema, after any reconciliation overrides (a shape-conflict
+     *                   winner's shape, or a text format's columns pinned to their reconciled types)
      * @param mapping column mapping from unified schema to file schema, null for identity mapping
      * @param statistics optional statistics from file metadata
      */
@@ -122,10 +131,13 @@ public final class SchemaReconciliation {
         ExternalSchema fileSchema,
         @Nullable ColumnMapping mapping,
         @Nullable SourceStatistics statistics,
-        // PRE-overlay file types, physical-keyed; null means fileSchema IS the inferred schema (no declared overlay ran),
-        // so callers fall back to the fileSchema attributes' types (today's behavior). Populated only where the declared
-        // overlay rebuilds this info (ExternalSourceResolver.applyNonStrictOverlay) so the split-level stats boundary can
-        // normalize footer stats with the file's real inferred types instead of the overlaid declared types.
+        // PRE-retype file types, physical-keyed; null means fileSchema IS the inferred schema (nothing retyped this file),
+        // so callers fall back to the fileSchema attributes' types (today's behavior). Populated by the UNION_BY_NAME pin
+        // (reconcileUnionByName / pinToReconciledTypes) with the full pre-pin type map, and by the declared overlay
+        // (ExternalSourceResolver.applyNonStrictOverlay), which preserves an upstream pin's snapshot when present and
+        // otherwise snapshots its own pre-overlay types. It lets stats boundaries recover the file's real inferred types:
+        // the split-level boundary normalizes footer range stats with them instead of the retyped types, and the
+        // resolve/commit boundaries identify the retyped (pinned) column set to safe-miss its read-schema-blind cached stats.
         @Nullable Map<String, DataType> inferredTypes
     ) {
         public FileSchemaInfo(ExternalSchema fileSchema, @Nullable ColumnMapping mapping, @Nullable SourceStatistics statistics) {
@@ -373,10 +385,28 @@ public final class SchemaReconciliation {
             // resolveShapeConflicts for why this is what actually routes the file's real values
             // through the per-file shape-conflict/ErrorPolicy handling at read time.
             List<Attribute> fileSchema = shapeConflictOverrides.getOrDefault(filePath, meta.schema());
+            Map<String, DataType> inferredTypes = null;
+            if (readsColumnsAtReconciledType(meta.sourceType())) {
+                // Text readers parse each token at the pinned read type, so pin every widened column
+                // to its reconciled type. The reader then reads at the wider type directly (raw text
+                // for KEYWORD) instead of parsing at the narrower sampled type and failing on a value
+                // the sample never saw, which would otherwise null-fill or abort the read before the
+                // ColumnMapping cast could run. See readsColumnsAtReconciledType for why this is
+                // scoped to sample-inferring text formats.
+                List<Attribute> prePin = fileSchema;
+                fileSchema = pinToReconciledTypes(fileSchema, unified);
+                if (fileSchema != prePin) {
+                    // At least one column was pinned above its inferred type. Carry the pre-pin (inferred) types
+                    // so the resolve-side stats boundary can identify the pinned columns: their per-file stats were
+                    // harvested at the narrower read type but the cache identity is read-schema-blind, so they must
+                    // safe-miss rather than fold a stale count/extremum.
+                    inferredTypes = typeMap(prePin);
+                }
+            }
             SourceStatistics stats = meta.statistics().orElse(null);
 
             ColumnMapping mapping = computeMapping(unifiedSchema, fileSchema);
-            perFileInfo.put(filePath, new FileSchemaInfo(new ExternalSchema(fileSchema), mapping, stats));
+            perFileInfo.put(filePath, new FileSchemaInfo(new ExternalSchema(fileSchema), mapping, stats, inferredTypes));
         }
 
         return new Result(new ExternalSchema(unifiedSchema), Map.copyOf(perFileInfo));
@@ -741,6 +771,90 @@ public final class SchemaReconciliation {
         }
 
         return new ColumnMapping(globalToLocal, anyCasts ? casts : null);
+    }
+
+    /**
+     * Whether a format's reader parses each value at the pinned read type, so pinning a widened
+     * column to its reconciled type makes the reader read at the wider type directly. This holds
+     * for the sample-inferring text formats (CSV, TSV, NDJSON): their readers convert each token to
+     * the read schema's type (a KEYWORD read type yields the raw token), so an out-of-sample value
+     * that does not fit the narrower sampled type survives at the wider reconciled type instead of
+     * being destroyed at parse time. Columnar formats (Parquet, ORC) instead read the
+     * physically-typed value and rely on {@link ColumnMapping}'s post-read cast to widen it, so
+     * they must not be pinned here (there is no parse-time loss to avoid, and their readers do not
+     * honor a read type that disagrees with the footer-declared type).
+     */
+    private static boolean readsColumnsAtReconciledType(String sourceType) {
+        return READS_AT_RECONCILED_TYPE_FORMATS.contains(sourceType);
+    }
+
+    /**
+     * The sample-inferring text formats whose readers parse each token at the pinned read type, so a
+     * widened column can be pinned to its reconciled type (see {@link #readsColumnsAtReconciledType}).
+     * The columnar-vs-text axis lives here as a single documented constant, mirroring the sibling
+     * {@link #supportsShapeConflictResolution} check and {@code ExternalSourceResolver.FILE_TYPED_FORMATS},
+     * rather than on the {@code FormatReader} SPI. A new sample-inferring text reader must be added here
+     * to receive the pin.
+     */
+    private static final Set<String> READS_AT_RECONCILED_TYPE_FORMATS = Set.of("csv", "tsv", "ndjson");
+
+    /**
+     * Returns {@code fileSchema} with each column that {@link #shouldPinAtReconciledType safely reads
+     * at its reconciled type} replaced by an attribute of that reconciled type, preserving the column
+     * name and nullability. Returns the input list unchanged when no column needs pinning.
+     */
+    private static List<Attribute> pinToReconciledTypes(List<Attribute> fileSchema, Map<String, MergeEntry> unified) {
+        List<Attribute> pinned = null;
+        for (int i = 0; i < fileSchema.size(); i++) {
+            Attribute attr = fileSchema.get(i);
+            MergeEntry unifiedEntry = unified.get(attr.name());
+            if (unifiedEntry != null && shouldPinAtReconciledType(attr.dataType(), unifiedEntry.type)) {
+                if (pinned == null) {
+                    pinned = new ArrayList<>(fileSchema);
+                }
+                pinned.set(i, new ReferenceAttribute(Source.EMPTY, null, attr.name(), unifiedEntry.type, attr.nullable(), null, false));
+            }
+        }
+        return pinned != null ? pinned : fileSchema;
+    }
+
+    /**
+     * Physical-name-keyed type map of the given schema attributes. Used to snapshot a file's pre-pin
+     * (inferred) column types before {@link #pinToReconciledTypes} retypes them, so downstream code can
+     * recover which columns were pinned.
+     */
+    private static Map<String, DataType> typeMap(List<Attribute> schema) {
+        Map<String, DataType> types = new HashMap<>(schema.size());
+        for (Attribute attr : schema) {
+            types.put(attr.name(), attr.dataType());
+        }
+        return types;
+    }
+
+    /**
+     * Whether a text reader parsing a column directly at {@code reconciled} is equivalent to (or, for
+     * KEYWORD, the intended replacement of) reading it at the sampled {@code inferred} type and then
+     * applying {@link ColumnMapping}'s post-read cast.
+     * <ul>
+     *   <li>KEYWORD: the widened column is a string, so the reader returns the raw token. This is the
+     *       point of the pin: an out-of-sample non-numeric value survives verbatim instead of being
+     *       destroyed by a numeric parse before the cast can run.</li>
+     *   <li>LONG / DOUBLE: the reader's typed parse at the wider numeric type is exactly the sampled
+     *       type widened, so an out-of-sample value that overflows the narrower type (e.g. a value
+     *       above {@code Integer.MAX_VALUE} in an INTEGER-sampled column reconciled to LONG) still
+     *       parses instead of failing.</li>
+     * </ul>
+     * DATE_NANOS is deliberately excluded: a text reader parsing an epoch number at DATE_NANOS reads
+     * it as epoch-nanos, not the epoch-millis a DATETIME column holds, so a DATETIME to DATE_NANOS
+     * widening stays on the post-read cast that rescales the unit rather than a raw parse. Text
+     * inference produces only BOOLEAN, INTEGER, LONG, DOUBLE, DATETIME, and KEYWORD, so DATE_NANOS as
+     * a reconciled type reaches this predicate only from a declared schema.
+     */
+    private static boolean shouldPinAtReconciledType(DataType inferred, DataType reconciled) {
+        if (inferred == reconciled) {
+            return false;
+        }
+        return reconciled == DataType.KEYWORD || reconciled == DataType.LONG || reconciled == DataType.DOUBLE;
     }
 
     private static void validateNoDuplicateColumns(StoragePath filePath, List<Attribute> schema) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -325,6 +325,87 @@ public final class SourceStatisticsSerializer {
     }
 
     /**
+     * The widened-column pin's stats boundary — the sibling of {@link #overlayDeclaredSchemaOnStats} for the
+     * {@code union_by_name} reconciliation path. When a text file's shared column is inferred from a narrow sampled
+     * prefix and then read at the wider reconciled type (the pin), an out-of-sample value that does not fit the narrow
+     * type is null-filled (or its whole row dropped under {@code skip_row}) when that same file is read solo at the
+     * narrow type. The per-file stats cache identity is read-schema-blind ({@code (path, mtime, config)}), so a solo
+     * narrow read and the pinned wider read share one entry: the harvested {@code value_count}/{@code null_count} are
+     * short by the null-filled cells and the extremum is the narrow-read value, none of which a wider read would
+     * produce. These are wrong VALUES, not merely a wrong unit, so {@link #normalizeStatsToReconciled} and the
+     * cache-path coercion cannot rescue them. For each {@code pinnedColumns} entry this POISONS the extrema and DROPS
+     * {@code value_count}/{@code null_count} so the column safe-misses to a scan; {@code dropRowCount} additionally
+     * drops {@code row_count} for the {@code skip_row} case, where the narrow read dropped whole rows and even
+     * {@code COUNT(*)} would be short. {@code size_bytes} and non-column keys are untouched. Returns the input instance
+     * unchanged when there is nothing to do; otherwise a new map (inputs are routinely {@code Map.copyOf}-immutable).
+     *
+     * @param pinnedColumns columns whose read type was pinned above their inferred type
+     * @param dropRowCount  whether the error policy drops whole rows ({@code skip_row}), making {@code row_count} stale too
+     */
+    public static Map<String, Object> overlayPinnedColumnsOnStats(
+        Map<String, Object> statsMap,
+        Set<String> pinnedColumns,
+        boolean dropRowCount
+    ) {
+        if (statsMap == null || statsMap.isEmpty() || pinnedColumns.isEmpty()) {
+            return statsMap;
+        }
+        Map<String, Object> out = new HashMap<>(statsMap);
+        for (String column : pinnedColumns) {
+            poisonColumnExtrema(out, column);
+            out.remove(columnValueCountKey(column));
+            out.remove(columnNullCountKey(column));
+        }
+        if (dropRowCount) {
+            out.remove(STATS_ROW_COUNT);
+        }
+        return out;
+    }
+
+    /**
+     * The widened-column pin's stats boundary on the COMMIT path: the sibling of {@link #overlayPinnedColumnsOnStats},
+     * which is the serve-side boundary. The two guard opposite directions of the same read-schema-blind cache identity
+     * ({@code (path, mtime, config)}, no read-type component; see
+     * {@link org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheKey}): a solo narrow read and a widening glob's
+     * pinned wider read of the same file share one cache entry. The serve-side overlay stops a widening query from SERVING
+     * the narrow read's stale stats; this stops a widening read's harvest from COMMITTING (and so polluting) the entry a
+     * solo narrow read serves. A pinned wider read parses an out-of-sample value the narrow read null-filled (or
+     * row-dropped under {@code skip_row}), so its harvested {@code value_count} / {@code null_count} / extrema for a pinned
+     * column are values the narrow read never produces.
+     * <p>
+     * Unlike the serve-side overlay this STRIPS each pinned column's whole stat family rather than poisoning it: the commit
+     * is a last-writer-wins {@code putAll} into the shared entry, so removing the pinned column's keys leaves the solo
+     * narrow read's own correct stats intact and warm. A poison marker would instead persist into the shared entry and make
+     * the narrow read safe-miss too. Under {@code dropRowCount} ({@code skip_row}, where a narrow-read parse failure drops
+     * the whole row) {@code row_count} is stripped as well. {@code size_bytes} and non-column keys are untouched. Returns
+     * the input instance unchanged when there is nothing to do; otherwise a new map (inputs are routinely
+     * {@code Map.copyOf}-immutable).
+     *
+     * @param pinnedColumns columns whose read type was pinned above their inferred type for the harvested read
+     * @param dropRowCount  whether the error policy drops whole rows ({@code skip_row}), making {@code row_count} stale too
+     */
+    public static Map<String, Object> removeColumnStatFamilies(
+        Map<String, Object> statsMap,
+        Set<String> pinnedColumns,
+        boolean dropRowCount
+    ) {
+        if (statsMap == null || statsMap.isEmpty() || pinnedColumns.isEmpty()) {
+            return statsMap;
+        }
+        Map<String, Object> out = new HashMap<>(statsMap);
+        for (String column : pinnedColumns) {
+            String prefix = STATS_COL_PREFIX + column;
+            for (String suffix : COLUMN_STAT_SUFFIXES) {
+                out.remove(prefix + suffix);
+            }
+        }
+        if (dropRowCount) {
+            out.remove(STATS_ROW_COUNT);
+        }
+        return out;
+    }
+
+    /**
      * Compares two keyword/text stat extrema in UTF-8 byte order — the SAME order the runtime keyword MIN/MAX
      * aggregators and comparisons use ({@link BytesRef} unsigned-byte order) — NOT {@link String#compareTo}'s
      * UTF-16 code-unit order, which disagrees for supplementary (astral) chars vs BMP chars in

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -78,6 +78,7 @@ import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
 import org.elasticsearch.xpack.esql.datasources.ExternalStatsRequirementExtractor;
 import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
@@ -738,9 +739,12 @@ public class EsqlSession {
 
         // TODO: merge into one method
         if (subPlan != null) {
-            // code-path to execute subplans
+            // code-path to execute subplans. The pinned-read accumulator gathers union_by_name widened reads across
+            // every executed plan (each subplan and the final main plan) so the single reconcile at the end strips
+            // their polluting stat deltas regardless of which plan read a file pinned.
             executeSubPlan(
                 new DriverCompletionInfo.Accumulator(),
+                new HashMap<>(),
                 subPlan,
                 configuration,
                 foldContext,
@@ -756,13 +760,53 @@ public class EsqlSession {
             );
         } else {
             PhysicalPlan physicalPlan = logicalPlanToPhysicalPlan(optimizedPlan, request, physicalPlanOptimizer, planTimeProfile);
+            Map<String, PinnedColumns> pinnedReads = new HashMap<>();
+            collectPinnedReads(optimizedPlan, pinnedReads);
             // execute main plan. Wrap the listener so the coordinator reconciles any data-node-captured
             // source stats into ExternalSourceCacheService before delivering Result.
             runner.run(physicalPlan, configuration, foldContext, planTimeProfile, listener.delegateFailureAndWrap((next, result) -> {
-                reconcileCapturedSourceStats(result.completionInfo());
+                reconcileCapturedSourceStats(result.completionInfo(), pinnedReads);
                 next.onResponse(result);
             }));
         }
+    }
+
+    /**
+     * A file's columns whose read type was pinned above their inferred type for a {@code union_by_name} widening read,
+     * plus whether that read's error policy drops whole rows ({@code skip_row}). Collected from the executed plan's
+     * {@link ExternalRelation} nodes and used to strip a widening read's polluting stat deltas off the captured
+     * contributions before commit. See {@link SourceStatisticsSerializer#removeColumnStatFamilies}.
+     */
+    private record PinnedColumns(Set<String> columns, boolean dropRowCount) {
+        PinnedColumns mergedWith(PinnedColumns other) {
+            Set<String> union = new HashSet<>(columns);
+            union.addAll(other.columns);
+            return new PinnedColumns(union, dropRowCount || other.dropRowCount);
+        }
+    }
+
+    /**
+     * Collects the {@code union_by_name} pinned reads in {@code plan}, keyed by the file path string the data-node
+     * capture uses ({@code StoragePath#toString()}), merging into {@code into}. A pinned read of a file harvests
+     * {@code value_count}/{@code null_count}/extrema the same file's solo narrow read never produces, so those deltas
+     * must not commit into the read-schema-blind shared cache entry. Accumulates across every executed plan (each
+     * subplan and the final main plan) because a file may be read pinned inside a subquery.
+     */
+    private void collectPinnedReads(LogicalPlan plan, Map<String, PinnedColumns> into) {
+        plan.forEachDown(ExternalRelation.class, relation -> {
+            var schemaMap = relation.schemaMap();
+            if (schemaMap.isEmpty()) {
+                return;
+            }
+            boolean dropRowCount = externalSourceResolver.resolvesToSkipRow(relation.sourceType(), relation.metadata().config());
+            for (var entry : schemaMap.entrySet()) {
+                Set<String> pinned = ExternalSourceResolver.pinnedColumnsOf(entry.getValue());
+                if (pinned.isEmpty()) {
+                    continue;
+                }
+                into.merge(entry.getKey().toString(), new PinnedColumns(pinned, dropRowCount), PinnedColumns::mergedWith);
+            }
+        });
     }
 
     /**
@@ -770,8 +814,14 @@ public class EsqlSession {
      * into the coordinator's {@code ExternalSourceCacheService}, so the next query's planning-time
      * lookup finds the {@code _stats.*} keys embedded in the matching {@code SchemaCacheEntry}'s
      * {@code safeMetadata} — same shape Parquet's footer-derived stats already use.
+     * <p>
+     * For any file read at a {@code union_by_name} pinned (widened) type, first strips that read's pinned-column stat
+     * families off its contributions ({@link SourceStatisticsSerializer#removeColumnStatFamilies}): the per-file cache
+     * identity is read-schema-blind, so a solo narrow read and the pinned wider read share one entry, and committing the
+     * wider read's {@code value_count}/extrema would pollute the value the narrow read serves. This is the commit-side
+     * sibling of the serve-side {@code overlayPinnedColumnsOnStats}.
      */
-    private void reconcileCapturedSourceStats(DriverCompletionInfo info) {
+    private void reconcileCapturedSourceStats(DriverCompletionInfo info, Map<String, PinnedColumns> pinnedReads) {
         if (info == null) {
             return;
         }
@@ -780,9 +830,37 @@ public class EsqlSession {
             return;
         }
         ExternalSourceCacheService cache = externalSourceResolver.cacheService();
-        if (cache != null) {
-            cache.reconcileSourceStatsFromContributions(captured);
+        if (cache == null) {
+            return;
         }
+        cache.reconcileSourceStatsFromContributions(stripPinnedContributions(captured, pinnedReads));
+    }
+
+    /**
+     * Returns {@code captured} with each pinned file's per-contribution pinned-column stat families removed. Files not
+     * read at a pinned type pass through untouched; when nothing is pinned the input map is returned unchanged.
+     */
+    private static Map<String, List<Map<String, Object>>> stripPinnedContributions(
+        Map<String, List<Map<String, Object>>> captured,
+        Map<String, PinnedColumns> pinnedReads
+    ) {
+        if (pinnedReads.isEmpty()) {
+            return captured;
+        }
+        Map<String, List<Map<String, Object>>> out = new HashMap<>(captured.size());
+        for (Map.Entry<String, List<Map<String, Object>>> entry : captured.entrySet()) {
+            PinnedColumns pinned = pinnedReads.get(entry.getKey());
+            if (pinned == null) {
+                out.put(entry.getKey(), entry.getValue());
+                continue;
+            }
+            List<Map<String, Object>> stripped = new ArrayList<>(entry.getValue().size());
+            for (Map<String, Object> contribution : entry.getValue()) {
+                stripped.add(SourceStatisticsSerializer.removeColumnStatFamilies(contribution, pinned.columns(), pinned.dropRowCount()));
+            }
+            out.put(entry.getKey(), stripped);
+        }
+        return out;
     }
 
     private void logAnonymizedPlans(PlanSnapshot snap, Exception err) {
@@ -938,6 +1016,7 @@ public class EsqlSession {
 
     private void executeSubPlan(
         DriverCompletionInfo.Accumulator completionInfoAccumulator,
+        Map<String, PinnedColumns> pinnedReads,
         SubPlanAndCallback subPlan,
         Configuration configuration,
         FoldContext foldContext,
@@ -951,6 +1030,7 @@ public class EsqlSession {
         ActionListener<Result> listener
     ) {
         LOGGER.debug("Executing subplan:\n{}", subPlan.subPlan);
+        collectPinnedReads(subPlan.subPlan, pinnedReads);
         // Create a physical plan out of the logical sub-plan
         var physicalSubPlan = logicalPlanToPhysicalPlan(subPlan.subPlan, request, physicalPlanOptimizer, planTimeProfile);
         // An IN subquery may not have a pipeline breaker inside it, and mapper does not receive the SemiJoin node because only the right
@@ -975,6 +1055,7 @@ public class EsqlSession {
 
                 if (newSubPlan == null) {
                     executionInfo.finishSubPlans();
+                    collectPinnedReads(newMainPlan, pinnedReads);
                     var newPhysicalPlan = logicalPlanToPhysicalPlan(newMainPlan, request, physicalPlanOptimizer, planTimeProfile);
                     runner.run(
                         newPhysicalPlan,
@@ -984,7 +1065,7 @@ public class EsqlSession {
                         releasingNext.delegateFailureAndWrap((finalListener, finalResult) -> {
                             completionInfoAccumulator.accumulate(finalResult.completionInfo());
                             DriverCompletionInfo merged = completionInfoAccumulator.finish();
-                            reconcileCapturedSourceStats(merged);
+                            reconcileCapturedSourceStats(merged, pinnedReads);
                             EsqlCCSUtils.finalizeSubPlanOnlyRemoteClusters(executionInfo);
                             finalListener.onResponse(
                                 new Result(finalResult.schema(), finalResult.pages(), null, configuration, merged, executionInfo)
@@ -994,6 +1075,7 @@ public class EsqlSession {
                 } else {
                     executeSubPlan(
                         completionInfoAccumulator,
+                        pinnedReads,
                         newSubPlan,
                         configuration,
                         foldContext,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -327,6 +327,113 @@ public class ExternalSourceResolverTests extends ESTestCase {
         assertEquals(9L, agg.get(SourceStatisticsSerializer.columnMaxKey("id")));
     }
 
+    /**
+     * The UNION_BY_NAME reconciliation aggregate must safe-miss a text-format column that a widening pin retyped. Its
+     * cached per-file stats were harvested at the narrower read type (a solo narrow read shares the read-schema-blind
+     * cache entry), so under {@code null_field} the pinned column's extrema are poisoned and its value/null counts
+     * dropped, while a non-pinned column and the shared row count still fold normally. Without the boundary the fold
+     * would serve the narrow read's stale {@code max} (here 20) as the widened column's MAX, a silent wrong answer.
+     */
+    public void testReconcileAggregatePoisonsPinnedColumnUnderNullField() {
+        StoragePath pathA = StoragePath.of("s3://bucket/a.csv");
+        StoragePath pathB = StoragePath.of("s3://bucket/b.csv");
+
+        Map<String, Object> flatA = new HashMap<>();
+        flatA.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 3L);
+        flatA.put(SourceStatisticsSerializer.columnMinKey("val"), 1L);
+        flatA.put(SourceStatisticsSerializer.columnMaxKey("val"), 20L);
+        flatA.put(SourceStatisticsSerializer.columnValueCountKey("val"), 3L);
+        flatA.put(SourceStatisticsSerializer.columnNullCountKey("val"), 0L);
+        flatA.put(SourceStatisticsSerializer.columnMinKey("id"), 1L);
+        flatA.put(SourceStatisticsSerializer.columnMaxKey("id"), 3L);
+
+        Map<String, Object> flatB = new HashMap<>();
+        flatB.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 2L);
+        flatB.put(SourceStatisticsSerializer.columnMinKey("val"), -5L);
+        flatB.put(SourceStatisticsSerializer.columnMaxKey("val"), 100L);
+        flatB.put(SourceStatisticsSerializer.columnValueCountKey("val"), 2L);
+        flatB.put(SourceStatisticsSerializer.columnNullCountKey("val"), 0L);
+        flatB.put(SourceStatisticsSerializer.columnMinKey("id"), 4L);
+        flatB.put(SourceStatisticsSerializer.columnMaxKey("id"), 5L);
+
+        List<Attribute> longSchema = List.of(attr("val", DataType.LONG), attr("id", DataType.LONG));
+        Map<StoragePath, SourceMetadata> allMetadata = new LinkedHashMap<>();
+        allMetadata.put(pathA, new SimpleSourceMetadata(longSchema, "csv", pathA.toString(), null, null, flatA, null));
+        allMetadata.put(pathB, new SimpleSourceMetadata(longSchema, "csv", pathB.toString(), null, null, flatB, null));
+
+        Map<String, DataType> reconciledTypes = Map.of("val", DataType.LONG, "id", DataType.LONG);
+        Map<StoragePath, Map<String, DataType>> perFileTypes = new HashMap<>();
+        perFileTypes.put(pathA, Map.of("val", DataType.LONG, "id", DataType.LONG));
+        perFileTypes.put(pathB, Map.of("val", DataType.LONG, "id", DataType.LONG));
+        // a.csv's val was inferred INTEGER and pinned to LONG; b.csv was already LONG (not pinned).
+        Map<StoragePath, Set<String>> perFilePinnedColumns = Map.of(pathA, Set.of("val"));
+
+        Map<String, Object> agg = ExternalSourceResolver.aggregateFileStatistics(
+            allMetadata,
+            perFileTypes,
+            reconciledTypes,
+            perFilePinnedColumns,
+            false, // null_field keeps rows, so row count stays trustworthy
+            false  // csv does not fold an absent column as implicit null (irrelevant here: every column present)
+        );
+
+        assertNotNull(agg);
+        // Pinned "val" is untrustworthy -> extrema poisoned (value dropped, unservable marker set) -> MIN/MAX(val) safe-miss.
+        assertNull(agg.get(SourceStatisticsSerializer.columnMinKey("val")));
+        assertNull(agg.get(SourceStatisticsSerializer.columnMaxKey("val")));
+        assertEquals(Boolean.TRUE, agg.get(SourceStatisticsSerializer.columnMinUnservableKey("val")));
+        assertEquals(Boolean.TRUE, agg.get(SourceStatisticsSerializer.columnMaxUnservableKey("val")));
+        // ... and its value count is dropped, so COUNT(val) safe-misses rather than serving a subset count.
+        assertNull(agg.get(SourceStatisticsSerializer.columnValueCountKey("val")));
+        // Row count folds normally under null_field (the row is kept, only the cell nulls).
+        assertEquals(5L, ((Number) agg.get(SourceStatisticsSerializer.STATS_ROW_COUNT)).longValue());
+        // Non-pinned "id" folds normally.
+        assertEquals(1L, ((Number) agg.get(SourceStatisticsSerializer.columnMinKey("id"))).longValue());
+        assertEquals(5L, ((Number) agg.get(SourceStatisticsSerializer.columnMaxKey("id"))).longValue());
+    }
+
+    /**
+     * Under {@code skip_row} a narrow-read parse failure on a pinned column drops the whole row, so the pinned file's
+     * cached row count is short too. Dropping it forces the entire aggregate to safe-miss ({@code mergeStatistics}
+     * requires a numeric row count from every file), so even {@code COUNT(*)} re-scans rather than serving an undercount.
+     */
+    public void testReconcileAggregateDropsRowCountForPinnedColumnUnderSkipRow() {
+        StoragePath pathA = StoragePath.of("s3://bucket/a.csv");
+        StoragePath pathB = StoragePath.of("s3://bucket/b.csv");
+
+        Map<String, Object> flatA = new HashMap<>();
+        flatA.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 3L);
+        flatA.put(SourceStatisticsSerializer.columnMinKey("val"), 1L);
+        flatA.put(SourceStatisticsSerializer.columnMaxKey("val"), 20L);
+
+        Map<String, Object> flatB = new HashMap<>();
+        flatB.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 2L);
+        flatB.put(SourceStatisticsSerializer.columnMinKey("val"), -5L);
+        flatB.put(SourceStatisticsSerializer.columnMaxKey("val"), 100L);
+
+        List<Attribute> longSchema = List.of(attr("val", DataType.LONG));
+        Map<StoragePath, SourceMetadata> allMetadata = new LinkedHashMap<>();
+        allMetadata.put(pathA, new SimpleSourceMetadata(longSchema, "csv", pathA.toString(), null, null, flatA, null));
+        allMetadata.put(pathB, new SimpleSourceMetadata(longSchema, "csv", pathB.toString(), null, null, flatB, null));
+
+        Map<String, DataType> reconciledTypes = Map.of("val", DataType.LONG);
+        Map<StoragePath, Map<String, DataType>> perFileTypes = new HashMap<>();
+        perFileTypes.put(pathA, Map.of("val", DataType.LONG));
+        perFileTypes.put(pathB, Map.of("val", DataType.LONG));
+        Map<StoragePath, Set<String>> perFilePinnedColumns = Map.of(pathA, Set.of("val"));
+
+        Map<String, Object> agg = ExternalSourceResolver.aggregateFileStatistics(
+            allMetadata,
+            perFileTypes,
+            reconciledTypes,
+            perFilePinnedColumns,
+            true, // skip_row: a dropped row makes a.csv's cached row count untrustworthy
+            false
+        );
+
+        assertNull(agg);
+    }
+
     // ===== Stats partial / file-count flag tests =====
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -1053,6 +1053,161 @@ public class SchemaReconciliationTests extends ESTestCase {
         drainWarningMessages();
     }
 
+    public void testUnionByNameTextSourceWidenToKeywordPinsReadTypeInsteadOfCasting() {
+        // A text-format file whose column widens to KEYWORD is pinned to KEYWORD as its read type, so
+        // the reader returns the raw token instead of parsing at the narrower sampled type and then
+        // casting. The mapping therefore carries no cast for that column.
+        for (String sourceType : List.of("csv", "tsv", "ndjson")) {
+            List<Attribute> schema1 = List.of(attr("c", DataType.INTEGER));
+            List<Attribute> schema2 = List.of(attr("c", DataType.KEYWORD));
+
+            StoragePath f1 = path("s3://b/f1." + sourceType);
+            StoragePath f2 = path("s3://b/f2." + sourceType);
+
+            Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, sourceType), f2, meta(schema2, sourceType));
+            SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+            assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.KEYWORD));
+            // The numeric-inferred file is pinned to KEYWORD and carries no cast.
+            assertThat(result.perFileInfo().get(f1).fileSchema().get(0).dataType(), equalTo(DataType.KEYWORD));
+            assertThat(result.perFileInfo().get(f1).mapping().cast(0), nullValue());
+            // The already-keyword file keeps its KEYWORD read type and also carries no cast.
+            assertThat(result.perFileInfo().get(f2).fileSchema().get(0).dataType(), equalTo(DataType.KEYWORD));
+            assertThat(result.perFileInfo().get(f2).mapping().cast(0), nullValue());
+
+            drainWarningMessages();
+        }
+    }
+
+    public void testUnionByNameTextSourceWidenIntToLongPinsReadTypeInsteadOfCasting() {
+        // INTEGER widened to LONG: a text reader parses at LONG directly, so an out-of-sample value
+        // above Integer.MAX_VALUE still parses. The file is pinned to LONG with no cast.
+        for (String sourceType : List.of("csv", "tsv", "ndjson")) {
+            List<Attribute> schema1 = List.of(attr("c", DataType.INTEGER));
+            List<Attribute> schema2 = List.of(attr("c", DataType.LONG));
+
+            StoragePath f1 = path("s3://b/f1." + sourceType);
+            StoragePath f2 = path("s3://b/f2." + sourceType);
+
+            Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, sourceType), f2, meta(schema2, sourceType));
+            SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+            assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.LONG));
+            assertThat(result.perFileInfo().get(f1).fileSchema().get(0).dataType(), equalTo(DataType.LONG));
+            assertThat(result.perFileInfo().get(f1).mapping().cast(0), nullValue());
+            // The pinned file carries its pre-pin (inferred) types so the resolve-side stats boundary can identify the
+            // pinned column and safe-miss its read-schema-blind cached stats. The already-LONG file is not pinned.
+            assertThat(result.perFileInfo().get(f1).inferredTypes(), equalTo(Map.of("c", DataType.INTEGER)));
+            assertThat(result.perFileInfo().get(f2).inferredTypes(), nullValue());
+        }
+    }
+
+    public void testUnionByNameTextSourceWidenIntToDoublePinsReadTypeInsteadOfCasting() {
+        for (String sourceType : List.of("csv", "tsv", "ndjson")) {
+            List<Attribute> schema1 = List.of(attr("c", DataType.INTEGER));
+            List<Attribute> schema2 = List.of(attr("c", DataType.DOUBLE));
+
+            StoragePath f1 = path("s3://b/f1." + sourceType);
+            StoragePath f2 = path("s3://b/f2." + sourceType);
+
+            Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, sourceType), f2, meta(schema2, sourceType));
+            SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+            assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.DOUBLE));
+            assertThat(result.perFileInfo().get(f1).fileSchema().get(0).dataType(), equalTo(DataType.DOUBLE));
+            assertThat(result.perFileInfo().get(f1).mapping().cast(0), nullValue());
+        }
+    }
+
+    public void testUnionByNameTextSourceWidenDatetimeToDateNanosKeepsCastNotPinned() {
+        // DATE_NANOS is excluded from read-type pinning: a text reader parsing an epoch number at
+        // DATE_NANOS reads it as epoch-nanos, not the epoch-millis a DATETIME column holds, so the
+        // DATETIME file keeps its inferred read type and the post-read cast rescales the unit.
+        List<Attribute> schema1 = List.of(attr("c", DataType.DATETIME));
+        List<Attribute> schema2 = List.of(attr("c", DataType.DATE_NANOS));
+
+        StoragePath f1 = path("s3://b/f1.csv");
+        StoragePath f2 = path("s3://b/f2.csv");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, "csv"), f2, meta(schema2, "csv"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.DATE_NANOS));
+        assertThat(result.perFileInfo().get(f1).fileSchema().get(0).dataType(), equalTo(DataType.DATETIME));
+        assertThat(result.perFileInfo().get(f1).mapping().cast(0), equalTo(DataType.DATE_NANOS));
+        // DATE_NANOS is a cast, not a pin, so nothing retyped the read schema: no inferredTypes snapshot.
+        assertThat(result.perFileInfo().get(f1).inferredTypes(), nullValue());
+    }
+
+    public void testUnionByNameColumnarSourceWidenToKeywordKeepsCast() {
+        // Columnar formats read the physically-typed value, so a widened column keeps its inferred
+        // (footer) type as the read type and relies on the post-read KEYWORD cast. Not pinned.
+        List<Attribute> schema1 = List.of(attr("c", DataType.INTEGER));
+        List<Attribute> schema2 = List.of(attr("c", DataType.KEYWORD));
+
+        StoragePath f1 = path("s3://b/f1.parquet");
+        StoragePath f2 = path("s3://b/f2.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1), f2, meta(schema2));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.KEYWORD));
+        assertThat(result.perFileInfo().get(f1).fileSchema().get(0).dataType(), equalTo(DataType.INTEGER));
+        assertThat(result.perFileInfo().get(f1).mapping().cast(0), equalTo(DataType.KEYWORD));
+        // Columnar formats read the physically-typed value and cast afterwards; nothing pins the read schema, so the
+        // stats boundary is the split-level read-time normalize, not this resolve-side pin path: no inferredTypes here.
+        assertThat(result.perFileInfo().get(f1).inferredTypes(), nullValue());
+
+        drainWarningMessages();
+    }
+
+    /**
+     * A file with one widened+pinned column ({@code a}: INTEGER widened to LONG) and one column that does not widen
+     * ({@code b}: KEYWORD in both files) must pin only the widened column in its read schema, and its inferredTypes
+     * snapshot must carry the pre-pin type for every column so the pinned-column delta is exactly {@code {a}}.
+     */
+    public void testUnionByNameTextMultiColumnPartialPinSnapshotsPrePinTypes() {
+        List<Attribute> schema1 = List.of(attr("a", DataType.INTEGER), attr("b", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("a", DataType.LONG), attr("b", DataType.KEYWORD));
+
+        StoragePath f1 = path("s3://b/f1.csv");
+        StoragePath f2 = path("s3://b/f2.csv");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, "csv"), f2, meta(schema2, "csv"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        // Only the widened column is retyped in the read schema; the non-widened column stays as inferred.
+        assertThat(result.perFileInfo().get(f1).fileSchema().get(0).dataType(), equalTo(DataType.LONG));
+        assertThat(result.perFileInfo().get(f1).fileSchema().get(1).dataType(), equalTo(DataType.KEYWORD));
+        // The snapshot carries the pre-pin type for every column, so the pinned delta (inferred != fileSchema) is {a}.
+        assertThat(result.perFileInfo().get(f1).inferredTypes(), equalTo(Map.of("a", DataType.INTEGER, "b", DataType.KEYWORD)));
+    }
+
+    /**
+     * A widened column contributed by both a columnar (Parquet) and a text (CSV) file must pin only the text file: the
+     * CSV file is pinned to the reconciled type and carries an inferredTypes snapshot, while the Parquet file keeps its
+     * footer type plus a post-read cast and carries no snapshot (its stats boundary is the split-level normalize).
+     */
+    public void testUnionByNameMixedParquetAndCsvPinsOnlyTextFile() {
+        List<Attribute> csvSchema = List.of(attr("val", DataType.INTEGER));
+        List<Attribute> parquetSchema = List.of(attr("val", DataType.LONG));
+
+        StoragePath csv = path("s3://b/a.csv");
+        StoragePath parquet = path("s3://b/b.parquet");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(csv, meta(csvSchema, "csv"), parquet, meta(parquetSchema, "parquet"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileUnionByName(metadata);
+
+        assertThat(result.unifiedSchema().get(0).dataType(), equalTo(DataType.LONG));
+        // CSV file: pinned to LONG, no cast, carries the pre-pin snapshot.
+        assertThat(result.perFileInfo().get(csv).fileSchema().get(0).dataType(), equalTo(DataType.LONG));
+        assertThat(result.perFileInfo().get(csv).mapping().cast(0), nullValue());
+        assertThat(result.perFileInfo().get(csv).inferredTypes(), equalTo(Map.of("val", DataType.INTEGER)));
+        // Parquet file: already LONG, self-typed read, no pin, no snapshot.
+        assertThat(result.perFileInfo().get(parquet).fileSchema().get(0).dataType(), equalTo(DataType.LONG));
+        assertThat(result.perFileInfo().get(parquet).inferredTypes(), nullValue());
+    }
+
     // === Warning-header helpers ===
     //
     // ESTestCase sets up a fresh ThreadContext per test (auto-stashed in {@code @After}); the

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
@@ -677,4 +677,90 @@ public class SourceStatisticsSerializerTests extends ESTestCase {
         Map<String, Object> stats = Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         assertSame(stats, SourceStatisticsSerializer.overlayDeclaredSchemaOnStats(stats, Map.of(), Set.of()));
     }
+
+    public void testOverlayPinnedColumnsPoisonsExtremaAndDropsCountsKeepingRowCount() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 3L);
+        stats.put(SourceStatisticsSerializer.columnMinKey("col"), 10L);
+        stats.put(SourceStatisticsSerializer.columnMaxKey("col"), 20L);
+        stats.put(SourceStatisticsSerializer.columnValueCountKey("col"), 2L);
+        stats.put(SourceStatisticsSerializer.columnNullCountKey("col"), 1L);
+        stats.put(SourceStatisticsSerializer.columnSizeBytesKey("col"), 24L);
+
+        // null_field: the pinned column's harvest was taken at a narrower read type, so its extrema and value/null
+        // counts are untrustworthy and must safe-miss. The row count is unaffected under null_field (no row dropped).
+        Map<String, Object> out = SourceStatisticsSerializer.overlayPinnedColumnsOnStats(stats, Set.of("col"), false);
+
+        assertNull(out.get(SourceStatisticsSerializer.columnMinKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnMaxKey("col")));
+        assertEquals(Boolean.TRUE, out.get(SourceStatisticsSerializer.columnMinUnservableKey("col")));
+        assertEquals(Boolean.TRUE, out.get(SourceStatisticsSerializer.columnMaxUnservableKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnValueCountKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnNullCountKey("col")));
+        assertEquals("byte signal survives", 24L, out.get(SourceStatisticsSerializer.columnSizeBytesKey("col")));
+        assertEquals("null_field keeps the row count", 3L, out.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    public void testOverlayPinnedColumnsDropsRowCountUnderSkipRow() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 2L);
+        stats.put(SourceStatisticsSerializer.columnValueCountKey("col"), 2L);
+
+        // skip_row: the narrow read dropped the whole row that failed to parse, so the harvested row count is short
+        // by that row and COUNT(*) must safe-miss too.
+        Map<String, Object> out = SourceStatisticsSerializer.overlayPinnedColumnsOnStats(stats, Set.of("col"), true);
+
+        assertNull(out.get(SourceStatisticsSerializer.columnValueCountKey("col")));
+        assertNull("skip_row drops the stale row count", out.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    public void testOverlayPinnedColumnsIdentityReturnsSameInstance() {
+        Map<String, Object> stats = Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        assertSame(stats, SourceStatisticsSerializer.overlayPinnedColumnsOnStats(stats, Set.of(), false));
+    }
+
+    public void testRemoveColumnStatFamiliesStripsWholeFamilyKeepingRowCountAndOtherColumns() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 3L);
+        stats.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, 512L);
+        stats.put(SourceStatisticsSerializer.columnMinKey("col"), 10L);
+        stats.put(SourceStatisticsSerializer.columnMaxKey("col"), 20L);
+        stats.put(SourceStatisticsSerializer.columnValueCountKey("col"), 3L);
+        stats.put(SourceStatisticsSerializer.columnNullCountKey("col"), 0L);
+        stats.put(SourceStatisticsSerializer.columnSizeBytesKey("col"), 24L);
+        stats.put(SourceStatisticsSerializer.columnValueCountKey("other"), 5L);
+
+        // Commit path under null_field: strip the pinned column's whole family so the shared entry keeps the solo
+        // narrow read's own committed stats. Unlike the serve-side overlay, no unservable markers are written and
+        // size_bytes is removed too, and the row count survives (null_field keeps the row).
+        Map<String, Object> out = SourceStatisticsSerializer.removeColumnStatFamilies(stats, Set.of("col"), false);
+
+        assertNull(out.get(SourceStatisticsSerializer.columnMinKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnMaxKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnValueCountKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnNullCountKey("col")));
+        assertNull(out.get(SourceStatisticsSerializer.columnSizeBytesKey("col")));
+        assertNull("strip does not write unservable markers", out.get(SourceStatisticsSerializer.columnMinUnservableKey("col")));
+        assertNull("strip does not write unservable markers", out.get(SourceStatisticsSerializer.columnMaxUnservableKey("col")));
+        assertEquals("null_field keeps the row count", 3L, out.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals("file byte signal is untouched", 512L, out.get(SourceStatisticsSerializer.STATS_SIZE_BYTES));
+        assertEquals("an unpinned column's stats survive", 5L, out.get(SourceStatisticsSerializer.columnValueCountKey("other")));
+    }
+
+    public void testRemoveColumnStatFamiliesDropsRowCountUnderSkipRow() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 3L);
+        stats.put(SourceStatisticsSerializer.columnValueCountKey("col"), 3L);
+
+        // skip_row: the pinned read parsed a row the narrow read drops, so its row count is stale for the shared entry.
+        Map<String, Object> out = SourceStatisticsSerializer.removeColumnStatFamilies(stats, Set.of("col"), true);
+
+        assertNull(out.get(SourceStatisticsSerializer.columnValueCountKey("col")));
+        assertNull("skip_row drops the stale row count", out.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+    }
+
+    public void testRemoveColumnStatFamiliesIdentityReturnsSameInstanceWhenNothingPinned() {
+        Map<String, Object> stats = Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        assertSame(stats, SourceStatisticsSerializer.removeColumnStatFamilies(stats, Set.of(), false));
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL|DS: read widened text columns at their reconciled type (#153540)](https://github.com/elastic/elasticsearch/pull/153540)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)