### PR TITLE
[9.5] Fix _ignored_source format flip for TSDB indices (#153904)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -266,6 +266,7 @@ public class IndexVersions {
     public static final IndexVersion UPGRADE_TO_LUCENE_10_5_0 = def(9_104_0_00, Version.LUCENE_10_5_0);
     public static final IndexVersion DISK_BBQ_ES950_AUTO_CALIBRATE = def(9_105_0_00, Version.LUCENE_10_5_0);
     public static final IndexVersion TIME_SERIES_ES95_CODEC_DEFAULT = def(9_106_0_00, Version.LUCENE_10_5_0);
+    public static final IndexVersion IGNORED_SOURCE_AS_DOC_VALUES_NO_FF = def(9_107_0_00, Version.LUCENE_10_5_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -611,7 +612,12 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
     public static IgnoredSourceFormat ignoredSourceFormat(IndexSettings indexSettings) {
         IndexVersion indexCreatedVersion = indexSettings.getIndexVersionCreated();
         // we need TSDB doc values format to use binary doc values for ignored source, otherwise the source will be uncompressed
-        if (indexCreatedVersion.onOrAfter(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES) && indexSettings.useTimeSeriesDocValuesFormat()) {
+
+        IndexVersion switchToDocValuesFormatVersion = Build.current().isSnapshot()
+            ? IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES
+            : IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF;
+
+        if (indexCreatedVersion.onOrAfter(switchToDocValuesFormatVersion) && indexSettings.useTimeSeriesDocValuesFormat()) {
             return IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -10,11 +10,13 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DirectoryReader;
+import org.elasticsearch.Build;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.test.WildcardFieldMaskingReader;
@@ -2652,29 +2654,25 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             .build();
 
         // with TSDB doc values format enabled and matching index version, the doc values ignored source format should be used
+        IndexVersion switchToDocValuesFormatVersion = Build.current().isSnapshot()
+            ? IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES
+            : IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES_NO_FF;
         assertEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
-            IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES, tsdbDocValuesFormatEnabled)
-            )
+            IgnoredSourceFieldMapper.ignoredSourceFormat(createIndexSettings(switchToDocValuesFormatVersion, tsdbDocValuesFormatEnabled))
         );
 
         // index version alone is not enough, TSDB doc values setting must also be enabled.
         assertNotEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
-            IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES, tsdbDocValuesFormatDisabled)
-            )
+            IgnoredSourceFieldMapper.ignoredSourceFormat(createIndexSettings(switchToDocValuesFormatVersion, tsdbDocValuesFormatDisabled))
         );
 
         // TSDB doc values format is not enough, the index version must also match
         assertNotEquals(
             IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
             IgnoredSourceFieldMapper.ignoredSourceFormat(
-                createIndexSettings(
-                    IndexVersionUtils.getPreviousVersion(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES),
-                    tsdbDocValuesFormatEnabled
-                )
+                createIndexSettings(IndexVersionUtils.getPreviousVersion(switchToDocValuesFormatVersion), tsdbDocValuesFormatEnabled)
             )
         );
     }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix _ignored_source format flip for TSDB indices (#153904)