### PR TITLE
[9.5] ESQL: Fix flaky Percentile tests (#153675)

### DIFF
--- a/docs/changelog/153675.yaml
+++ b/docs/changelog/153675.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 153270
+pr: 153675
+summary: Fix off-by-one in `ZeroBucket.index()` due to rounding errors
+type: bug

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ZeroBucketTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ZeroBucketTests.java
@@ -89,5 +89,4 @@ public class ZeroBucketTests extends ExponentialHistogramTestCase {
         assertThat(a, equalTo(b));
         assertThat(a.hashCode(), equalTo(b.hashCode()));
     }
-
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -394,9 +394,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/151132
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.PercentileTests
-  method: "testAggregateIntermediate {TestCase=<exponential_histogram>, <integer>}"
-  issue: https://github.com/elastic/elasticsearch/issues/153270
 - class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
   method: test {p0=ml/jobs_get_result_overall_buckets/Test overall buckets given top_n is negative}
   issue: https://github.com/elastic/elasticsearch/issues/151160

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1300,6 +1300,14 @@ public final class EsqlTestUtils {
     }
 
     public static ExponentialHistogram randomExponentialHistogram() {
+        return randomExponentialHistogram(false);
+    }
+
+    /**
+     * @param zeroThresholdIsZero when {@code true}, always use 0.0 as the zero threshold (avoids floating point inaccuracies when
+     *                            computing percentiles from histograms with non-zero thresholds)
+     */
+    public static ExponentialHistogram randomExponentialHistogram(boolean zeroThresholdIsZero) {
         // TODO(b/133393): allow (index,scale) based zero thresholds as soon as we support them in the block
         // ideally Replace this with the shared random generation in ExponentialHistogramTestUtils
         int numBuckets = randomIntBetween(4, 300);
@@ -1320,7 +1328,7 @@ public final class EsqlTestUtils {
             rawValues
         );
         // Setup a proper zeroThreshold based on a random chance
-        if (histo.zeroBucket().count() > 0 && randomBoolean()) {
+        if (zeroThresholdIsZero == false && histo.zeroBucket().count() > 0 && randomBoolean()) {
             double smallestNonZeroValue = DoubleStream.of(rawValues).map(Math::abs).filter(val -> val != 0).min().orElse(0.0);
             double zeroThreshold = smallestNonZeroValue * randomDouble();
             try (ReleasableExponentialHistogram releaseAfterCopy = histo) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
@@ -525,6 +525,14 @@ public final class MultiRowTestCaseSupplier {
     }
 
     public static List<TypedDataSupplier> exponentialHistogramCases(int minRows, int maxRows) {
+        return exponentialHistogramCases(minRows, maxRows, false);
+    }
+
+    /**
+     * @param zeroThresholdIsZero when {@code true}, always use 0.0 as the zero threshold (avoids floating point inaccuracies when
+     *                            computing percentiles from histograms with non-zero thresholds)
+     */
+    public static List<TypedDataSupplier> exponentialHistogramCases(int minRows, int maxRows, boolean zeroThresholdIsZero) {
         List<TypedDataSupplier> cases = new ArrayList<>();
         addSuppliers(
             cases,
@@ -540,7 +548,7 @@ public final class MultiRowTestCaseSupplier {
             maxRows,
             "random exponential histogram",
             DataType.EXPONENTIAL_HISTOGRAM,
-            EsqlTestUtils::randomExponentialHistogram
+            () -> EsqlTestUtils.randomExponentialHistogram(zeroThresholdIsZero)
         );
         return cases;
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -1722,10 +1722,19 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
      * Generate cases for {@link DataType#EXPONENTIAL_HISTOGRAM}.
      */
     public static List<TypedDataSupplier> exponentialHistogramCases() {
+        return exponentialHistogramCases(false);
+    }
+
+    /**
+     * Generate cases for {@link DataType#EXPONENTIAL_HISTOGRAM}.
+     * @param zeroThresholdIsZero when {@code true}, always use 0.0 as the zero threshold (avoids floating point inaccuracies when
+     *                            computing percentiles from histograms with non-zero thresholds)
+     */
+    public static List<TypedDataSupplier> exponentialHistogramCases(boolean zeroThresholdIsZero) {
         return List.of(
             new TypedDataSupplier(
                 "<random exponential histogram>",
-                EsqlTestUtils::randomExponentialHistogram,
+                () -> EsqlTestUtils.randomExponentialHistogram(zeroThresholdIsZero),
                 DataType.EXPONENTIAL_HISTOGRAM
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
@@ -49,7 +49,7 @@ public class MedianTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.intCases(1, 1000, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
             MultiRowTestCaseSupplier.longCases(1, 1000, Long.MIN_VALUE, Long.MAX_VALUE, true),
             MultiRowTestCaseSupplier.doubleCases(1, 1000, -Double.MAX_VALUE, Double.MAX_VALUE, true),
-            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100)
+            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100, true)
                 .stream()
                 .map(s -> s.withAppliesTo(histogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
                 .toList()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
@@ -59,7 +59,7 @@ public class PercentileTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.intCases(1, 1000, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
             MultiRowTestCaseSupplier.longCases(1, 1000, Long.MIN_VALUE, Long.MAX_VALUE, true),
             MultiRowTestCaseSupplier.doubleCases(1, 1000, -Double.MAX_VALUE, Double.MAX_VALUE, true),
-            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100)
+            MultiRowTestCaseSupplier.exponentialHistogramCases(1, 100, true)
                 .stream()
                 .map(s -> s.withAppliesTo(histogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
                 .toList(),


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: Fix flaky Percentile tests (#153675)