### PR TITLE
[9.5] ES|QL: Fix json_extract execution with foldable MV (#153771)

### DIFF
--- a/docs/changelog/153771.yaml
+++ b/docs/changelog/153771.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 153622
+pr: 153771
+summary: Fix `json_extract` execution with foldable MV
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/json_extract.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/json_extract.csv-spec
@@ -507,3 +507,34 @@ json:keyword                                                               | fn:
 "{""first"": ""Parto"", ""last"": ""Bamford""}"                            | Parto      | Bamford
 ;
 
+// Regression test for https://github.com/elastic/elasticsearch/issues/153622 —
+// passing a multi-value as the path argument must not throw a ClassCastException.
+jsonExtractMvPath
+required_capability: fn_json_extract
+required_capability: fn_json_extract_mv_path_fix
+ROW str = """{"name":"Alice"}""", mvPath = ["name", "age"]
+| EVAL result = JSON_EXTRACT(str, mvPath)
+| KEEP str, result
+;
+warning:Line 2:17: evaluation of [JSON_EXTRACT(str, mvPath)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:17: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+str:keyword              | result:keyword
+"{""name"":""Alice""}"  | null
+;
+
+// Both arguments are multi-value (the original issue reproduction).
+jsonExtractMvBothArgs
+required_capability: fn_json_extract
+required_capability: fn_json_extract_mv_path_fix
+ROW foo = ["a", "b"]
+| EVAL bar = JSON_EXTRACT(foo, foo)
+| KEEP bar
+;
+warning:Line 2:14: evaluation of [JSON_EXTRACT(foo, foo)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:14: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+bar:keyword
+null
+;
+

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtract.java
@@ -62,6 +62,8 @@ public class JsonExtract extends EsqlScalarFunction {
     );
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(JsonExtract.class)
         .binary(JsonExtract::new)
+        // Fix ClassCastException when path is a foldable multi-value expression.
+        .capabilities("mv_path_fix")
         .name("json_extract");
 
     private final Expression str;
@@ -436,11 +438,16 @@ public class JsonExtract extends EsqlScalarFunction {
         boolean isSource = str.dataType() == DataType.SOURCE;
         ExpressionEvaluator.Factory strExpr = toEvaluator.apply(str);
         if (path.foldable()) {
-            JsonPath jsonPath = JsonPath.parse(((BytesRef) path.fold(toEvaluator.foldCtx())).utf8ToString());
-            if (isSource) {
-                return new JsonExtractSourceConstantEvaluator.Factory(source(), strExpr, jsonPath);
+            Object foldedPath = path.fold(toEvaluator.foldCtx());
+            if (foldedPath instanceof BytesRef bytesRef) {
+                JsonPath jsonPath = JsonPath.parse(bytesRef.utf8ToString());
+                if (isSource) {
+                    return new JsonExtractSourceConstantEvaluator.Factory(source(), strExpr, jsonPath);
+                }
+                return new JsonExtractConstantEvaluator.Factory(source(), strExpr, jsonPath);
             }
-            return new JsonExtractConstantEvaluator.Factory(source(), strExpr, jsonPath);
+            // null or multi-value path: fall through to the non-constant evaluator, which handles
+            // null (→ null) and multi-value (→ warning + null) correctly at evaluation time.
         }
         ExpressionEvaluator.Factory pathExpr = toEvaluator.apply(path);
         if (isSource) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtractWarningTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/JsonExtractWarningTests.java
@@ -127,6 +127,24 @@ public class JsonExtractWarningTests extends AbstractScalarFunctionTestCase {
             )
         );
 
+        // Multi-value path: the standard MV single-value warning fires for the path argument.
+        suppliers.add(
+            new TestCaseSupplier(
+                "mv path",
+                types(DataType.KEYWORD, DataType.KEYWORD),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(new BytesRef("{\"name\":\"Alice\"}"), DataType.KEYWORD, "str"),
+                        new TestCaseSupplier.TypedData(List.of(new BytesRef("name"), new BytesRef("age")), DataType.KEYWORD, "path")
+                    ),
+                    "JsonExtractEvaluator[str=Attribute[channel=0], path=Attribute[channel=1]]",
+                    DataType.KEYWORD,
+                    nullValue()
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.IllegalArgumentException: single-value function encountered multi-value")
+            )
+        );
+
         // Null _source warning — only fires when str is SOURCE-typed and the input bytes are null.
         // Routes through JsonExtractSourceEvaluator instead of JsonExtractEvaluator.
         List<TestCaseSupplier> nullSourceSuppliers = new ArrayList<>();


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ES|QL: Fix json_extract execution with foldable MV (#153771)