### PR TITLE
Add `repository-s3` signer fix to 8.19.17 release notes

### DIFF
--- a/docs/reference/release-notes/8.19.17.asciidoc
+++ b/docs/reference/release-notes/8.19.17.asciidoc
@@ -47,6 +47,9 @@ Query Languages::
 Security::
 * Make Automatons wildcard code-point aware {es-pull}151143[#151143]
 
+Snapshot/Restore::
+* Update `repository-s3` to use the default request signer from AWS SDK for Java {es-pull}150237[#150237]
+
 Transform::
 * Honor `ClusterHealth` timeout when waiting for transform internal index shards {es-pull}149462[#149462] (issue: {es-issue}149400[#149400])
 


### PR DESCRIPTION
Adds the `repository-s3` default request signer bug fix (#150237) to the 8.19.17 release notes. It shipped in 8.19.17 but was merged `>non-issue`, so it never got a changelog entry.