### PR TITLE
test(tsdb): reproduce `_ignored_source` format flip issue

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFormatFlipTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFormatFlipTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.test.index.IndexVersionUtils;
+
+import java.io.IOException;
+
+public class IgnoredSourceFormatFlipTests extends MapperServiceTestCase {
+
+    public void testFormatFlipFailsWritePath() throws IOException {
+        final ParsedDocument storedFormatDocument = parseTimeSeriesDocument(storedFormatMapperService().documentMapper());
+        final ParsedDocument docValuesFormatDocument = parseTimeSeriesDocument(docValuesFormatMapperService().documentMapper());
+
+        try (Directory directory = newDirectory()) {
+            final IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig().setIndexSort(timeSeriesIndexSort()));
+            try {
+                writer.addDocument(storedFormatDocument.rootDoc());
+                writer.commit();
+                expectThrows(IllegalArgumentException.class, () -> writer.addDocument(docValuesFormatDocument.rootDoc()));
+                writer.commit();
+            } finally {
+                IOUtils.closeWhileHandlingException(writer);
+            }
+        }
+    }
+
+    public void testFormatFlipFailsReadPath() throws IOException {
+        final MapperService storedFormatMapperService = storedFormatMapperService();
+        final DocumentMapper docValuesFormatMapper = docValuesFormatMapperService().documentMapper();
+        final ParsedDocument storedFormatDocument = parseTimeSeriesDocument(storedFormatMapperService.documentMapper());
+
+        withLuceneIndex(
+            storedFormatMapperService,
+            writer -> writer.addDocuments(storedFormatDocument.docs()),
+            reader -> syntheticSource(docValuesFormatMapper, reader, 0)
+        );
+    }
+
+    private MapperService storedFormatMapperService() throws IOException {
+        final MapperService mapperService = createTimeSeriesMapperService(
+            IndexVersionUtils.getPreviousVersion(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES)
+        );
+        assertEquals(
+            IgnoredSourceFieldMapper.IgnoredSourceFormat.COALESCED_SINGLE_IGNORED_SOURCE,
+            IgnoredSourceFieldMapper.ignoredSourceFormat(mapperService.getIndexSettings())
+        );
+        return mapperService;
+    }
+
+    private MapperService docValuesFormatMapperService() throws IOException {
+        final MapperService mapperService = createTimeSeriesMapperService(IndexVersion.current());
+        assertEquals(
+            IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE,
+            IgnoredSourceFieldMapper.ignoredSourceFormat(mapperService.getIndexSettings())
+        );
+        return mapperService;
+    }
+
+    private MapperService createTimeSeriesMapperService(final IndexVersion indexVersion) throws IOException {
+        final Settings settings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.name())
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dim")
+            .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2021-04-28T00:00:00Z")
+            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2021-10-29T00:00:00Z")
+            .put(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING.getKey(), true)
+            .build();
+        return createMapperService(indexVersion, settings, mapping(b -> {
+            b.startObject("@timestamp").field("type", "date").endObject();
+            b.startObject("dim").field("type", "keyword").field("time_series_dimension", true).endObject();
+            b.startObject("disabled_object").field("type", "object").field("enabled", false).endObject();
+        }));
+    }
+
+    private ParsedDocument parseTimeSeriesDocument(final DocumentMapper documentMapper) throws IOException {
+        final ParsedDocument document = documentMapper.parse(source(null, b -> {
+            b.field("@timestamp", "2021-10-01");
+            b.field("dim", "series-1");
+            // NOTE: with synthetic source the content of a disabled object is kept only in _ignored_source,
+            // so this value forces both mappers to write the _ignored_source field in their respective formats.
+            b.startObject("disabled_object").field("key", "value").endObject();
+        }, TimeSeriesRoutingHashFieldMapper.DUMMY_ENCODED_VALUE));
+        assertNotNull(document.rootDoc().getField(IgnoredSourceFieldMapper.NAME));
+        return document;
+    }
+
+    private static Sort timeSeriesIndexSort() {
+        return new Sort(
+            new SortField(TimeSeriesIdFieldMapper.NAME, SortField.Type.STRING, false),
+            new SortedNumericSortField(DataStreamTimestampFieldMapper.DEFAULT_PATH, SortField.Type.LONG, true)
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFormatFlipTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFormatFlipTests.java
@@ -77,21 +77,6 @@ public class IgnoredSourceFormatFlipTests extends MapperServiceTestCase {
         }
     }
 
-    public void testWriteAndReadAfterFlip() throws IOException {
-        try (MapperService docValuesFormatMapperService = docValuesFormatMapperService()) {
-            final ParsedDocument document = parseTimeSeriesDocument(docValuesFormatMapperService.documentMapper());
-
-            withLuceneIndex(
-                docValuesFormatMapperService,
-                writer -> writer.addDocuments(document.docs()),
-                reader -> assertThat(
-                    syntheticSource(docValuesFormatMapperService.documentMapper(), reader, 0),
-                    containsString("\"disabled_object\":{\"key\":\"value\"}")
-                )
-            );
-        }
-    }
-
     private MapperService storedFormatMapperService() throws IOException {
         final MapperService mapperService = createTimeSeriesMapperService(
             IndexVersionUtils.getPreviousVersion(IndexVersions.IGNORED_SOURCE_AS_DOC_VALUES)
@@ -119,8 +104,6 @@ public class IgnoredSourceFormatFlipTests extends MapperServiceTestCase {
             .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2021-04-28T00:00:00Z")
             .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2021-10-29T00:00:00Z")
             .put(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING.getKey(), true)
-            // NOTE: synthetic _id is unrelated to the format flip and its terms producer trips CheckIndex assertions here.
-            .put(IndexSettings.SYNTHETIC_ID.getKey(), false)
             .build();
         return createMapperService(indexVersion, settings, mapping(b -> {
             b.startObject("@timestamp").field("type", "date").endObject();

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFormatFlipTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFormatFlipTests.java
@@ -25,35 +25,71 @@ import org.elasticsearch.test.index.IndexVersionUtils;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class IgnoredSourceFormatFlipTests extends MapperServiceTestCase {
 
     public void testFormatFlipFailsWritePath() throws IOException {
-        final ParsedDocument storedFormatDocument = parseTimeSeriesDocument(storedFormatMapperService().documentMapper());
-        final ParsedDocument docValuesFormatDocument = parseTimeSeriesDocument(docValuesFormatMapperService().documentMapper());
+        try (
+            MapperService storedFormatMapperService = storedFormatMapperService();
+            MapperService docValuesFormatMapperService = docValuesFormatMapperService()
+        ) {
+            final ParsedDocument storedFormatDocument = parseTimeSeriesDocument(storedFormatMapperService.documentMapper());
+            final ParsedDocument docValuesFormatDocument = parseTimeSeriesDocument(docValuesFormatMapperService.documentMapper());
 
-        try (Directory directory = newDirectory()) {
-            final IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig().setIndexSort(timeSeriesIndexSort()));
-            try {
-                writer.addDocument(storedFormatDocument.rootDoc());
-                writer.commit();
-                expectThrows(IllegalArgumentException.class, () -> writer.addDocument(docValuesFormatDocument.rootDoc()));
-                writer.commit();
-            } finally {
-                IOUtils.closeWhileHandlingException(writer);
+            try (Directory directory = newDirectory()) {
+                final IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig().setIndexSort(timeSeriesIndexSort()));
+                try {
+                    writer.addDocument(storedFormatDocument.rootDoc());
+                    writer.commit();
+                    expectThrows(IllegalArgumentException.class, () -> writer.addDocument(docValuesFormatDocument.rootDoc()));
+                    final NullPointerException poisonedSortField = expectThrows(NullPointerException.class, writer::commit);
+                    assertThat(
+                        poisonedSortField.getMessage(),
+                        containsString(
+                            "Cannot invoke \"org.apache.lucene.index.FieldInfo.getDocValuesType()\" because \"pf.fieldInfo\" is null"
+                        )
+                    );
+                } finally {
+                    IOUtils.closeWhileHandlingException(writer);
+                }
             }
         }
     }
 
     public void testFormatFlipFailsReadPath() throws IOException {
-        final MapperService storedFormatMapperService = storedFormatMapperService();
-        final DocumentMapper docValuesFormatMapper = docValuesFormatMapperService().documentMapper();
-        final ParsedDocument storedFormatDocument = parseTimeSeriesDocument(storedFormatMapperService.documentMapper());
+        try (
+            MapperService storedFormatMapperService = storedFormatMapperService();
+            MapperService docValuesFormatMapperService = docValuesFormatMapperService()
+        ) {
+            final ParsedDocument storedFormatDocument = parseTimeSeriesDocument(storedFormatMapperService.documentMapper());
 
-        withLuceneIndex(
-            storedFormatMapperService,
-            writer -> writer.addDocuments(storedFormatDocument.docs()),
-            reader -> syntheticSource(docValuesFormatMapper, reader, 0)
-        );
+            withLuceneIndex(storedFormatMapperService, writer -> writer.addDocuments(storedFormatDocument.docs()), reader -> {
+                final IllegalStateException mismatch = expectThrows(
+                    IllegalStateException.class,
+                    () -> syntheticSource(docValuesFormatMapperService.documentMapper(), reader, 0)
+                );
+                assertThat(
+                    mismatch.getMessage(),
+                    containsString("unexpected docvalues type NONE for field '" + IgnoredSourceFieldMapper.NAME + "'")
+                );
+            });
+        }
+    }
+
+    public void testWriteAndReadAfterFlip() throws IOException {
+        try (MapperService docValuesFormatMapperService = docValuesFormatMapperService()) {
+            final ParsedDocument document = parseTimeSeriesDocument(docValuesFormatMapperService.documentMapper());
+
+            withLuceneIndex(
+                docValuesFormatMapperService,
+                writer -> writer.addDocuments(document.docs()),
+                reader -> assertThat(
+                    syntheticSource(docValuesFormatMapperService.documentMapper(), reader, 0),
+                    containsString("\"disabled_object\":{\"key\":\"value\"}")
+                )
+            );
+        }
     }
 
     private MapperService storedFormatMapperService() throws IOException {
@@ -83,6 +119,8 @@ public class IgnoredSourceFormatFlipTests extends MapperServiceTestCase {
             .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2021-04-28T00:00:00Z")
             .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2021-10-29T00:00:00Z")
             .put(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING.getKey(), true)
+            // NOTE: synthetic _id is unrelated to the format flip and its terms producer trips CheckIndex assertions here.
+            .put(IndexSettings.SYNTHETIC_ID.getKey(), false)
             .build();
         return createMapperService(indexVersion, settings, mapping(b -> {
             b.startObject("@timestamp").field("type", "date").endObject();


### PR DESCRIPTION
## TL;DR

Tests reproducing both production failures caused by the `_ignored_source` format flip from #152481. The write path fails the Lucene commit with `NullPointerException: Cannot invoke "FieldInfo.getDocValuesType()" because "pf.fieldInfo" is null`, and the read path fails with `unexpected docvalues type NONE for field '_ignored_source' (expected=BINARY)`.

## Summary

#152481 removed the `ignored_source_as_doc_values` feature flag check from `IgnoredSourceFieldMapper#ignoredSourceFormat` without bumping the gating index version. The flag was disabled on release builds, so existing TSDB indices hold `_ignored_source` as a stored field (`docValuesType == NONE`) but switch to reading and writing it as binary doc values after the upgrade. #153904 fixes the format selection on `main` and #153905 carries the same fix for serverless.

These tests document how indices written before the flip fail. On the write path every new document is rejected with a doc values type conflict; metadata mappers are sorted by field name in `Mapping`, so `_ignored_source` precedes `_tsid` in the parsed document and the conflict fires before `_tsid` gets a `FieldInfo`. Lucene keeps the half-initialized `PerField` in `IndexingChain`, and sorting the segment at flush dereferences the null `FieldInfo`, failing the commit and the shard. On the read path, loading synthetic source from a stored-format segment through the doc values format fails in `DocValues.getBinary`. The first commit has both tests failing on purpose so the production stack traces are visible in the test report; the second commit asserts the exceptions with `expectThrows`.

## Test scenarios

| Test | Scenario |
|------|----------|
| `testFormatFlipFailsWritePath` | Indexing a doc-values-format document into a `_tsid` sorted index holding a stored-format segment is rejected with a doc values type conflict, and the following commit fails with the production `NullPointerException` from `IndexingChain.maybeSortSegment`. |
| `testFormatFlipFailsReadPath` | Loading synthetic source from a stored-format segment through the doc values format fails in `DocValues.getBinary` with `unexpected docvalues type NONE for field '_ignored_source' (expected=BINARY)`. |

## Testing

```
./gradlew :server:test --tests "org.elasticsearch.index.mapper.IgnoredSourceFormatFlipTests"
```
