### PR TITLE
ES|QL: remove testCompositeExpressionReturnsNullWhenNoColumnsMatch

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -841,9 +841,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {yaml=ml/inference_crud/Test delete already-deleted model returns 404 not 409}
   issue: https://github.com/elastic/elasticsearch/issues/153812
-- class: org.elasticsearch.xpack.esql.generator.CompositeFunctionGeneratorTests
-  method: testCompositeExpressionReturnsNullWhenNoColumnsMatch
-  issue: https://github.com/elastic/elasticsearch/issues/153817
 - class: org.elasticsearch.xpack.esql.action.S3ManagedIdentityAuthIT
   method: testManagedIdentityAuthReadsRowsAndUsesWorkloadIdentityCredential
   issue: https://github.com/elastic/elasticsearch/issues/153820

--- a/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/generator/CompositeFunctionGeneratorTests.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/generator/CompositeFunctionGeneratorTests.java
@@ -14,11 +14,6 @@ import java.util.List;
 
 public class CompositeFunctionGeneratorTests extends ESTestCase {
 
-    public void testCompositeExpressionReturnsNullWhenNoColumnsMatch() {
-        // No columns of any type — leaf() cannot find a field, so the result should be null
-        assertNull(CompositeFunctionGenerator.compositeExpression(List.of(), false, "integer", 2));
-    }
-
     public void testCompositeExpressionWithMatchingColumn() {
         List<Column> columns = List.of(new Column("x", "integer", List.of("integer")));
         // With an integer column and depth >= 1, a result is expected (either a plain field or a function call)


### PR DESCRIPTION
Fixing the tests for function generators (Generative Tests). One of the tests was too strict, asserting a condition that is not valid for all the functions (no columns = null result)

Fixes: https://github.com/elastic/elasticsearch/issues/153817