### PR TITLE
DLM frozen tier feature flag causing a ClassCastException in EsqlClientYamlIT [#153679]

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -397,12 +397,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/load four indices with single conversion function TO_IP}
   issue: https://github.com/elastic/elasticsearch/issues/151413
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/250_columnar_keyword/Test mv_min}
-  issue: https://github.com/elastic/elasticsearch/issues/147379
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/250_columnar_keyword/Test mv max}
-  issue: https://github.com/elastic/elasticsearch/issues/147379
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -37,7 +37,11 @@ public class Clusters {
             .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
             .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))
             .configFile("ingest-geoip/GeoLite2-ASN.mmdb", Resource.fromClasspath("GeoLite2-ASN.mmdb"))
-            .setting("ingest.geoip.downloader.enabled", "false");
+            .setting("ingest.geoip.downloader.enabled", "false")
+            // DLM frozen tier serialization is gated on both a feature flag and a transport version, so nodes in a mixed cluster can
+            // disagree on the wire format when their build types differ (snapshot vs release). Disable the flag on every node so
+            // serialization is consistent regardless of build type. See https://github.com/elastic/elasticsearch/issues/153679.
+            .systemProperty("es.dlm_searchable_snapshots_feature_flag_enabled", "false");
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }


### PR DESCRIPTION
Due to a mistake when DLM frozen tier's was initially introduced, it's wire format changes were put behind both a transport version and a feature flag.

Due to the fact feature flags are enabled by default in snapshot builds but disabled by default in release builds, this has caused issues with tests running mixed clusters.

To sidestep the issue, this PR forced the DLM frozen tier feature flag to be disabled in all environments to prevent serialization issues. This approach was discussed and agreed with es-core-infra as the best way forward.

Fixes #153679