### PR TITLE
ES|QL: fix generative tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -76,7 +76,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     @Rule(order = Integer.MIN_VALUE)
     public ProfileLogger profileLogger = new ProfileLogger();
 
-    public static final int ITERATIONS = 100;
+    public static final int ITERATIONS = 10000;
     public static final int MAX_DEPTH = 20;
 
     /**
@@ -704,6 +704,15 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     );
 
     /**
+     * Matches "Options are not supported for [MATCH] function call on non-index-mapped field [X]".
+     * This is the error MATCH raises when called with options on a renamed/computed field.
+     */
+    private static final Pattern MATCH_OPTIONS_NON_INDEX_MAPPED_PATTERN = Pattern.compile(
+        ".*Options are not supported for \\[MATCH\\] function call on non-index-mapped field \\[([^]]+)\\].*",
+        Pattern.DOTALL
+    );
+
+    /**
      * Captures fields created by GROK patterns, e.g. {@code %{WORD:foo}} or {@code %{NUMBER:bar:int}}.
      */
     private static final Pattern GROK_GENERATED_FIELD_PATTERN = Pattern.compile("%\\{[^:}]+:([^}:]+)(?::[^}]+)?}");
@@ -898,7 +907,10 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     ) {
         Matcher m = NOT_A_FIELD_FROM_INDEX_PATTERN.matcher(errorMessage);
         if (m.matches() == false) {
-            return false;
+            m = MATCH_OPTIONS_NON_INDEX_MAPPED_PATTERN.matcher(errorMessage);
+            if (m.matches() == false) {
+                return false;
+            }
         }
         String fieldName = unquote(m.group(1));
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -76,7 +76,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     @Rule(order = Integer.MIN_VALUE)
     public ProfileLogger profileLogger = new ProfileLogger();
 
-    public static final int ITERATIONS = 10000;
+    public static final int ITERATIONS = 100;
     public static final int MAX_DEPTH = 20;
 
     /**

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -490,7 +490,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         ctx -> matchesAllowedErrorPatterns(ctx.normalizedErrorMessage),
         ctx -> isUnmappedFieldError(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isScalarTypeMismatchError(ctx.normalizedErrorMessage),
-        ctx -> isFieldFullTextError(ctx.normalizedErrorMessage, ctx.query, ctx.previousCommands, ctx.currentSchema),
+        ctx -> isFieldFullTextError(ctx.normalizedErrorMessage, ctx.currentSchema),
         ctx -> isFullTextAfterWhereBugs(ctx.normalizedErrorMessage),
         ctx -> isFullTextAfterSubqueryInFromBug(ctx.normalizedErrorMessage, ctx.query),
         ctx -> isLenientFalseFailedToCreateFullTextQueryError(ctx.normalizedErrorMessage, ctx.query),
@@ -896,15 +896,9 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
 
     /**
      * Checks if the error is a full-text function/operator rejecting a field that is not from an index mapping.
-     * Uses the {@link Column#indexMapped()} flag from the current schema when available; falls back to
-     * command-history heuristics otherwise.
+     * Uses the {@link Column#indexMapped()} flag from the current schema.
      */
-    static boolean isFieldFullTextError(
-        String errorMessage,
-        String query,
-        List<CommandGenerator.CommandDescription> previousCommands,
-        List<Column> currentSchema
-    ) {
+    static boolean isFieldFullTextError(String errorMessage, List<Column> currentSchema) {
         Matcher m = NOT_A_FIELD_FROM_INDEX_PATTERN.matcher(errorMessage);
         if (m.matches() == false) {
             m = MATCH_OPTIONS_NON_INDEX_MAPPED_PATTERN.matcher(errorMessage);

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.qa.rest.generative;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.generator.Column;
+
+import java.util.List;
 
 /**
  * Tests the predicates that classify known generative-test failures as allowed failures.
@@ -77,6 +80,22 @@ public class GenerativeRestTestTests extends ESTestCase {
         String error = "verification_exception: line 1:34: [QSTR] function cannot be used after LOOKUP";
 
         assertFalse(GenerativeRestTest.isFullTextAfterSubqueryInFromBug(error, query));
+    }
+
+    public void testMatchOptionsOnNonIndexMappedFieldIsAllowed() {
+        String query = "from idx | rename id as message | where match(message, \"test\", {\"zero_terms_query\": \"none\"})";
+        String error = "Options are not supported for [MATCH] function call on non-index-mapped field [message]";
+        List<Column> schema = List.of(new Column("message", "keyword", List.of(), false));
+
+        assertTrue(GenerativeRestTest.isFieldFullTextError(error, query, List.of(), schema));
+    }
+
+    public void testMatchOptionsOnIndexMappedFieldIsNotAllowed() {
+        String query = "from idx | where match(message, \"test\", {\"zero_terms_query\": \"none\"})";
+        String error = "Options are not supported for [MATCH] function call on non-index-mapped field [message]";
+        List<Column> schema = List.of(new Column("message", "keyword", List.of(), true));
+
+        assertFalse(GenerativeRestTest.isFieldFullTextError(error, query, List.of(), schema));
     }
 
 }

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
@@ -83,19 +83,17 @@ public class GenerativeRestTestTests extends ESTestCase {
     }
 
     public void testMatchOptionsOnNonIndexMappedFieldIsAllowed() {
-        String query = "from idx | rename id as message | where match(message, \"test\", {\"zero_terms_query\": \"none\"})";
         String error = "Options are not supported for [MATCH] function call on non-index-mapped field [message]";
         List<Column> schema = List.of(new Column("message", "keyword", List.of(), false));
 
-        assertTrue(GenerativeRestTest.isFieldFullTextError(error, query, List.of(), schema));
+        assertTrue(GenerativeRestTest.isFieldFullTextError(error, schema));
     }
 
     public void testMatchOptionsOnIndexMappedFieldIsNotAllowed() {
-        String query = "from idx | where match(message, \"test\", {\"zero_terms_query\": \"none\"})";
         String error = "Options are not supported for [MATCH] function call on non-index-mapped field [message]";
         List<Column> schema = List.of(new Column("message", "keyword", List.of(), true));
 
-        assertFalse(GenerativeRestTest.isFieldFullTextError(error, query, List.of(), schema));
+        assertFalse(GenerativeRestTest.isFieldFullTextError(error, schema));
     }
 
 }


### PR DESCRIPTION
Fix flakiness in how generative tests handle MATCH function.

`isFieldFullTextError` only matched "cannot operate on [X], which is not a field from an index mapping" but MATCH raises a different message when called with options on a non-index-mapped field: "Options are not supported for [MATCH] function call on non-index-mapped field [X]". 
