### PR TITLE
[9.5] ES|QL|DS Cap and de-duplicate Parquet declared-coercion warnings (#153469)

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -68,6 +68,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
 
 /**
  * Default Parquet column iterator with vectorized decoding and I/O prefetch.
@@ -111,6 +112,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private final String fileLocation;
     /** See {@link #coercionWarnings()}. */
     private SkipWarnings coercionWarnings;
+    /**
+     * Relay for this eager read's per-value coercion warnings, or {@code null} to fall back to
+     * emitting directly via {@code HeaderWarning}. This iterator
+     * runs on a background reader thread under the async source, so a non-null sink (the source
+     * buffer relay) is required for the warnings to reach the response; see {@link #coercionWarnings()}.
+     */
+    @Nullable
+    private final Consumer<String> warningSink;
     /** The read's error policy; strict ({@code fail_fast}) makes {@link #coercionWarnings()} return {@code null}. */
     private final ErrorPolicy errorPolicy;
     private final ColumnInfo[] columnInfos;
@@ -153,7 +162,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private final int rowPositionColumnIndex;
     /**
      * Owning {@link ParquetFormatReader}; only consulted when the iterator builds a matching
-     * {@link ColumnExtractor} via {@link #createColumnExtractor()}. Kept out of the regular emit
+     * {@link ColumnExtractor} via {@link #createColumnExtractor(Consumer)}. Kept out of the regular emit
      * paths so the iterator does not depend on the broader format reader's state for forward scan.
      */
     private final ParquetFormatReader formatReader;
@@ -170,7 +179,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /**
      * High bits OR-ed into every emitted {@code _rowPosition} value once
      * {@link #setExtractorId(int)} has been called: {@code ((long) extractorId) << LOCAL_POSITION_BITS}.
-     * The factory installs the id between {@link #createColumnExtractor()} and the first call to
+     * The factory installs the id between {@link #createColumnExtractor(Consumer)} and the first call to
      * {@link #next()}, so by the time we materialise {@code _rowPosition} we always have a value
      * for it. Stays at {@code -1} when the projection has no row-position column ({@link
      * #rowPositionColumnIndex} {@code < 0}); we never read the field in that case.
@@ -328,9 +337,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         DynamicThreshold dynamicThreshold,
         ColumnDescriptor sortColumnDescriptor,
         ParquetReaderCounters counters,
-        ErrorPolicy errorPolicy
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> warningSink
     ) {
         this.errorPolicy = errorPolicy;
+        this.warningSink = warningSink;
         this.reader = reader;
         this.projectedSchema = projectedSchema;
         this.attributes = attributes;
@@ -2278,14 +2289,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 "Parquet file ["
                     + fileLocation
                     + "] has values that could not be coerced to the declared column type; "
-                    + "they are returned as null"
+                    + "they are returned as null",
+                warningSink
             );
         }
         return coercionWarnings;
     }
 
     @Override
-    public ColumnExtractor createColumnExtractor() {
+    public ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) {
         if (rowPositionColumnIndex < 0) {
             throw new IllegalStateException(
                 "createColumnExtractor called on iterator without [" + ColumnExtractor.ROW_POSITION_COLUMN + "] in projection"
@@ -2295,7 +2307,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         // regardless of whether this iterator was opened on the full file or on a range. That's
         // the whole point of file-global addressing: any iterator that emits identities and any
         // extractor over the same file agree without coordination.
-        return new ParquetColumnExtractor(storageObject, formatReader, fullFooter, errorPolicy);
+        // The extractor runs on the driver thread (the eager warningSink relays through the source
+        // buffer, which the driver drains before the extractor runs), so it takes the caller's
+        // driver-thread sink rather than this iterator's buffered one.
+        return new ParquetColumnExtractor(storageObject, formatReader, fullFooter, errorPolicy, driverThreadWarningSink);
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 
 /**
  * Parquet implementation of {@link ColumnExtractor}.
@@ -122,6 +123,23 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      * in the file's address space; the extractor does not need or want a subset view).
      */
     private final long[] rowGroupOffsets;
+    /**
+     * Relay for per-value declared-coercion warnings, or {@code null} to fall back to emitting
+     * directly via {@code HeaderWarning}. The extractor runs on the
+     * driver thread, so direct emission is correct; a non-null sink is the budget-gated wrapper that
+     * caps the whole source. See {@link #coercionWarnings()}.
+     */
+    @Nullable
+    private final Consumer<String> warningSink;
+
+    /**
+     * Delegates to {@link #ParquetColumnExtractor(StorageObject, ParquetFormatReader, ParquetMetadata, ErrorPolicy, Consumer)}
+     * with no warning sink, so coercion warnings emit directly via {@code HeaderWarning} (per-instance
+     * cap only). Used by tests and any on-driver-thread caller that does not centrally cap the channel.
+     */
+    ParquetColumnExtractor(StorageObject storageObject, ParquetFormatReader reader, ParquetMetadata ownedFooter, ErrorPolicy errorPolicy) {
+        this(storageObject, reader, ownedFooter, errorPolicy, null);
+    }
 
     /**
      * @param storageObject the storage handle for the file (extractor borrows it; caller closes)
@@ -134,12 +152,22 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      * @param errorPolicy   the read's error policy, inherited from the iterator that produced the
      *                      row identities so the deferred columns fail (or warn+null) exactly like
      *                      the eagerly scanned ones
+     * @param warningSink   where per-value coercion warnings are relayed (budget-gated direct
+     *                      emission on the driver thread), or {@code null} for direct
+     *                      {@code HeaderWarning} emission
      */
-    ParquetColumnExtractor(StorageObject storageObject, ParquetFormatReader reader, ParquetMetadata ownedFooter, ErrorPolicy errorPolicy) {
+    ParquetColumnExtractor(
+        StorageObject storageObject,
+        ParquetFormatReader reader,
+        ParquetMetadata ownedFooter,
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> warningSink
+    ) {
         this.storageObject = Objects.requireNonNull(storageObject, "storageObject");
         this.reader = Objects.requireNonNull(reader, "reader");
         this.ownedFooter = Objects.requireNonNull(ownedFooter, "ownedFooter");
         this.errorPolicy = Objects.requireNonNull(errorPolicy, "errorPolicy");
+        this.warningSink = warningSink;
         List<BlockMetaData> blocks = ownedFooter.getBlocks();
         this.rowGroupOffsets = new long[blocks.size() + 1];
         long acc = 0;
@@ -571,9 +599,11 @@ final class ParquetColumnExtractor implements ColumnExtractor {
     /**
      * Lazily-created sink for per-value declared-coercion failures (capped response Warning
      * headers + nulled cells); shared by every column and {@link #extract} call of this extractor
-     * so the cap is per deferred-extraction pass, mirroring the per-iterator sink the eager scan
-     * paths keep ({@code ParquetColumnIterator#coercionWarnings()}). Single driver thread owns
-     * the instance (see the class Javadoc threading note).
+     * so the per-instance cap is per deferred-extraction pass, mirroring the per-iterator sink the
+     * eager scan paths keep ({@code ParquetColumnIterator#coercionWarnings()}). Emitted messages go
+     * to {@link #warningSink} when supplied (the budget-gated driver-thread relay that caps the whole
+     * source) or directly via {@code HeaderWarning} otherwise. Single driver thread owns the instance
+     * (see the class Javadoc threading note).
      */
     private SkipWarnings coercionWarnings;
 
@@ -582,7 +612,8 @@ final class ParquetColumnExtractor implements ColumnExtractor {
             coercionWarnings = new SkipWarnings(
                 "Parquet file ["
                     + storageObject.path()
-                    + "] has values that could not be coerced to the declared column type; they are returned as null"
+                    + "] has values that could not be coerced to the declared column type; they are returned as null",
+                warningSink
             );
         }
         return coercionWarnings;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -1951,7 +1951,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 dynamicThreshold,
                 resolveDynamicThresholdColumn(fileSchema, dynamicThreshold),
                 counters,
-                errorPolicy
+                errorPolicy,
+                warningSink
             );
             // Constructor succeeded — iterator now owns preloadedMetadata. Set the flag after
             // construction so that a throw inside the constructor does not suppress cleanup.
@@ -2710,6 +2711,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         private SkipWarnings coercionWarnings;
         /** The read's error policy; strict ({@code fail_fast}) makes {@link #coercionWarnings()} return {@code null}. */
         private final ErrorPolicy errorPolicy;
+        /**
+         * Relay for this read's per-value coercion warnings, or {@code null} to fall back to emitting
+         * directly via {@code HeaderWarning}. Under the async source
+         * this iterator runs on a background reader thread, so a non-null sink (the source buffer
+         * relay) is required for the warnings to reach the response; see {@link #coercionWarnings()}.
+         */
+        @Nullable
+        private final Consumer<String> warningSink;
 
         /**
          * The coercion-failure sink for this read, or {@code null} under {@code fail_fast} — the
@@ -2727,7 +2736,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                     "Parquet file ["
                         + fileLocation
                         + "] has values that could not be coerced to the declared column type; "
-                        + "they are returned as null"
+                        + "they are returned as null",
+                    warningSink
                 );
             }
             return coercionWarnings;
@@ -2751,6 +2761,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             @Nullable Consumer<String> warningSink
         ) {
             this.errorPolicy = errorPolicy;
+            this.warningSink = warningSink;
             this.reader = reader;
             this.projectedSchema = projectedSchema;
             this.attributes = attributes;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
@@ -305,6 +305,48 @@ public class ParquetColumnExtractorTests extends ESTestCase {
         }
     }
 
+    public void testDeferredDeclaredCoercionWarningsRouteToSuppliedSink() throws IOException {
+        // A declared long over unparseable string tokens null-fills each bad value on the deferred path and
+        // records a per-value coercion Warning. When a driver-thread sink is supplied, every such warning must
+        // reach that sink (the budget-gated relay) and not this thread's HeaderWarning context.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("v")
+            .named("strings");
+        byte[] data = writeFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                Group g = factory.newGroup();
+                g.add("v", "notanumber" + i);
+                groups.add(g);
+            }
+            return groups;
+        }, /* rowGroupBytes = */ 1024L);
+        StorageObject so = createStorageObject(data);
+        ParquetFormatReader reader = (ParquetFormatReader) new ParquetFormatReader(blockFactory).withDeclaredTypeColumns(Set.of("v"));
+        List<String> sink = new ArrayList<>();
+        try (ColumnExtractor extractor = new ParquetColumnExtractor(so, reader, loadFooter(so), ErrorPolicy.PERMISSIVE, sink::add)) {
+            long[] positions = { 0, 1, 2 };
+            Block[] blocks = extractor.extract(new String[] { "v" }, new DataType[] { DataType.LONG }, positions, blockFactory);
+            try (Block block = blocks[0]) {
+                assertEquals(3, block.getPositionCount());
+                for (int i = 0; i < positions.length; i++) {
+                    assertTrue("an unparseable long token null-fills its cell", block.isNull(i));
+                }
+            }
+        }
+        assertTrue(
+            "per-value coercion warnings must reach the supplied sink, got: " + sink,
+            sink.stream().anyMatch(w -> w.contains("cannot coerce value"))
+        );
+        List<String> leaked = drainWarnings();
+        assertTrue(
+            "no coercion warning may leak to this thread's HeaderWarning context when a sink is supplied, got: " + leaked,
+            leaked.stream().noneMatch(w -> w.contains("cannot coerce value"))
+        );
+    }
+
     private byte[] writeSingleInt64File(long[] values) throws IOException {
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("v").named("longs");
         return writeFile(schema, factory -> {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -65,6 +65,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -109,6 +110,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ParquetFormatReaderTests extends ESTestCase {
 
@@ -3992,6 +3994,68 @@ public class ParquetFormatReaderTests extends ESTestCase {
             "warning must name the incompatibility, got: " + warnings,
             warnings.toString().contains("incompatible with planner type")
         );
+    }
+
+    /**
+     * Fixture of {@code count} rows in a single {@code ts} keyword column, every value a DISTINCT
+     * unparseable date token (namespaced by {@code offset} so tokens never repeat across fixtures).
+     * Declared as {@code datetime}, each value fails the fused string-&gt;datetime coercion and, under a
+     * non-strict policy, nulls its cell and emits a distinct per-value {@code Warning} detail.
+     */
+    private byte[] badDatetimeTokenFixture(int offset, int count) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("ts")
+            .named("test_schema");
+        return createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                Group g = factory.newGroup();
+                g.add("ts", "not-a-date-" + (offset + i));
+                groups.add(g);
+            }
+            return groups;
+        });
+    }
+
+    public void testDeclaredCoercionWarningsRouteToSuppliedSink() throws Exception {
+        // A declared datetime over unparseable keyword tokens nulls each bad cell under a non-strict
+        // policy and records a per-value coercion Warning. When the caller supplies an
+        // informationalWarningSink, every such warning must be relayed to that sink, not emitted to
+        // this thread's HeaderWarning response context: an async read runs the decode loop on a
+        // background thread whose ThreadContext is never merged into the client response, so a warning
+        // emitted there is silently lost. Cover both columnar decode paths: the optimized
+        // PageColumnReader and the baseline row-at-a-time reader.
+        int distinctBad = SkipWarnings.MAX_ADDED_WARNINGS + 5;
+        byte[] data = badDatetimeTokenFixture(0, distinctBad);
+        List<Attribute> plannerTypes = List.of(new ReferenceAttribute(Source.EMPTY, "ts", DataType.DATETIME));
+        for (ParquetFormatReader reader : List.of(declaredReader("ts"), declaredReader("ts").withBaselinePath())) {
+            List<String> sink = new ArrayList<>();
+            StorageObject storageObject = createStorageObject(data);
+            try (
+                CloseableIterator<Page> it = reader.readRange(
+                    storageObject,
+                    new RangeReadContext(List.of("ts"), 10_000, 0, data.length, plannerTypes, ErrorPolicy.PERMISSIVE, sink::add)
+                )
+            ) {
+                while (it.hasNext()) {
+                    it.next().releaseBlocks();
+                }
+            }
+            long coercionDetails = sink.stream().filter(w -> w.contains("cannot coerce value")).count();
+            assertThat("per-value coercion warnings must reach the supplied sink", coercionDetails, greaterThan(0L));
+            assertThat(
+                "each reader instance caps its per-value coercion details at MAX_ADDED_WARNINGS",
+                coercionDetails,
+                lessThanOrEqualTo((long) SkipWarnings.MAX_ADDED_WARNINGS)
+            );
+            List<String> leaked = drainWarnings();
+            assertTrue(
+                "no coercion warning may leak to this thread's HeaderWarning context when a sink is supplied, got: " + leaked,
+                leaked.stream().noneMatch(w -> w.contains("cannot coerce value"))
+            );
+        }
     }
 
     /** Fixture for the fused string->datetime tests: good ISO, bad token, good ISO. */

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetRowPositionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetRowPositionTests.java
@@ -251,7 +251,7 @@ public class ParquetRowPositionTests extends ESTestCase {
                     page.releaseBlocks();
                 }
             }
-            extractor = ((ColumnExtractorProducer) iter).createColumnExtractor();
+            extractor = ((ColumnExtractorProducer) iter).createColumnExtractor(null);
         }
         try {
             // Extractor sees the full file regardless of which split the iterator was for.

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNullFieldParallelWarningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNullFieldParallelWarningIT.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
+import org.elasticsearch.cluster.metadata.DatasetMapping;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * {@code error_mode:null_field} null-fills unparseable fields and must emit a client-visible {@code Warning} so
+ * the drift is not silent. The warning must reach the client whichever read path handles the file.
+ *
+ * <p>Both read paths run under the async source on a background reader thread, so their reader-level
+ * {@code SkipWarnings} are relayed through the source buffer and re-emitted on the driver thread whose
+ * response headers reach the client. The parallel-parse path (above the 2 MiB threshold) additionally fans
+ * the decode loop out across forked {@code esql_external_io} segment-parser threads; each segment's
+ * {@code SkipWarnings} must route through that same relay, since a {@code ThreadContext} on a forked worker
+ * is never merged back into the response.
+ *
+ * <p>Both tests read a single-column all-unparseable CSV with the column declared {@code long} under
+ * {@code error_mode:null_field}: every value null-fills. The small twin stays on the serial path; the large
+ * twin crosses the 2 MiB parallel gate. Each asserts the null-fill warnings reach the client.
+ */
+public class ExternalNullFieldParallelWarningIT extends AbstractExternalDataSourceIT {
+
+    /** Just under the 2 MiB (2 x 1 MiB minimumSegmentSize) parallel gate: stays serial. */
+    private static final int SMALL_ROWS = 50;
+    /** Comfortably past the 2 MiB parallel gate so the file splits into several segments. */
+    private static final int LARGE_ROWS = 300_000;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class);
+    }
+
+    /** Baseline: a small (serial-path) all-unparseable declared-long CSV delivers the null-fill warnings. */
+    public void testSerialPathDeliversNullFieldWarnings() throws Exception {
+        assumeTrue("parsing_parallelism pragma is snapshot-only", Build.current().isSnapshot());
+        List<String> warnings = runAndCollectWarnings("null_field_small", SMALL_ROWS, SMALL_ROWS);
+        assertTrue(
+            "serial path must deliver at least one per-field parse warning, got: " + warnings,
+            warnings.stream().anyMatch(w -> w.contains("Failed to parse") && w.contains("[LONG]"))
+        );
+        assertTrue(
+            "serial path must deliver the one-time policy summary, got: " + warnings,
+            warnings.stream().anyMatch(w -> w.contains("encountered parse errors handled per policy"))
+        );
+    }
+
+    /**
+     * An all-unparseable declared-long CSV above the parallel gate null-fills the entire column and must still
+     * deliver at least one per-field parse warning, so a client does not conclude the parse was clean.
+     */
+    public void testParallelPathDeliversNullFieldWarnings() throws Exception {
+        assumeTrue("parsing_parallelism pragma is snapshot-only", Build.current().isSnapshot());
+        List<String> warnings = runAndCollectWarnings("null_field_large", LARGE_ROWS, LARGE_ROWS);
+        assertTrue(
+            "parallel path must still deliver at least one per-field parse warning, got: " + warnings,
+            warnings.stream().anyMatch(w -> w.contains("Failed to parse") && w.contains("[LONG]"))
+        );
+    }
+
+    /**
+     * Registers a single-column CSV of {@code rows} unparseable values with the column declared {@code long}
+     * under {@code error_mode:null_field}, runs {@code STATS total=COUNT(*), present=COUNT(val)} on a random
+     * coordinator with {@code parsing_parallelism=4}, asserts the data is correct (all values null-filled), and
+     * returns that coordinator's accumulated response {@code Warning} headers.
+     */
+    private List<String> runAndCollectWarnings(String datasetName, int rows, long expectedTotal) throws Exception {
+        Path file = createTempDir().resolve(datasetName + ".csv");
+        StringBuilder sb = new StringBuilder("val\n");
+        for (int i = 0; i < rows; i++) {
+            sb.append("notanumber").append(i).append('\n');
+        }
+        Files.writeString(file, sb.toString());
+
+        registerDataSource("null_field_ds", Map.of());
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("val", new DatasetFieldMapping("long", "val"));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    datasetName,
+                    "null_field_ds",
+                    StoragePath.fileUri(file),
+                    null,
+                    new HashMap<>(Map.of("format", "csv", "error_mode", "null_field")),
+                    mapping
+                )
+            )
+        );
+
+        String query = "FROM " + datasetName + " | STATS total = COUNT(*), present = COUNT(val)";
+        EsqlQueryRequest request = syncEsqlQueryRequest(query).pragmas(
+            new QueryPragmas(Settings.builder().put(QueryPragmas.PARSING_PARALLELISM.getKey(), 4).build())
+        );
+
+        DiscoveryNode coordinator = randomFrom(clusterService().state().nodes().stream().toList());
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> warnings = new CopyOnWriteArrayList<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        AtomicReference<List<List<Object>>> values = new AtomicReference<>();
+        client(coordinator.getName()).execute(EsqlQueryAction.INSTANCE, request, ActionListener.wrap(response -> {
+            try {
+                values.set(getValuesList(response));
+                ThreadContext threadContext = internalCluster().getInstance(TransportService.class, coordinator.getName())
+                    .getThreadPool()
+                    .getThreadContext();
+                warnings.addAll(threadContext.getResponseHeaders().getOrDefault("Warning", List.of()));
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            failure.set(e);
+            latch.countDown();
+        }));
+        assertTrue("query did not complete within timeout", latch.await(2, TimeUnit.MINUTES));
+        if (failure.get() != null) {
+            throw new AssertionError("null_field read must not fail, but did", failure.get());
+        }
+        assertThat("COUNT(*) must see every row", ((Number) values.get().get(0).get(0)).longValue(), equalTo(expectedTotal));
+        assertThat(
+            "every declared-long value is unparseable -> null-filled",
+            ((Number) values.get().get(0).get(1)).longValue(),
+            equalTo(0L)
+        );
+        return warnings;
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCoercionWarningFloodIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCoercionWarningFloodIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
+import org.elasticsearch.cluster.metadata.DatasetMapping;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * End-to-end guard that declared-coercion {@code Warning} headers from the columnar Parquet reader stay bounded
+ * across a query's whole fan-out. A read of a multi-file glob, each file spanning several row groups, splits into
+ * many units spread over parallel drivers on each data node. Each unit builds its own capped collector, so without
+ * a per-node ceiling the total {@code Warning} header count grows with the unit count until the response is
+ * effectively undeliverable.
+ *
+ * <p>The fixture declares a {@code datetime} column over Parquet {@code keyword} values that are all unparseable,
+ * so every value null-fills under {@code error_mode:null_field} and every unit wants to warn. The assertion is
+ * that the coordinator's accumulated coercion warnings do not exceed {@code numDataNodes * (MAX_ADDED_WARNINGS + 1)}
+ * (each node caps and deduplicates the whole informational channel through one shared budget), even though the
+ * fixture presents far more distinct unparseable values than that ceiling.
+ */
+public class ExternalParquetCoercionWarningFloodIT extends AbstractExternalDataSourceIT {
+
+    private static final int FILE_COUNT = 6;
+    private static final int ROWS_PER_FILE = 200;
+    /** Small row groups so each file spans several, multiplying the per-file unit count the budget must bound. */
+    private static final int ROW_GROUP_BYTES = 4 * 1024;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    public void testDeclaredCoercionWarningsStayBoundedAcrossFanOut() throws Exception {
+        Path dir = createTempDir();
+        for (int f = 0; f < FILE_COUNT; f++) {
+            final int fileOrdinal = f;
+            writeParquet(
+                dir.resolve("part-" + f + ".parquet"),
+                "message ts_schema { required binary ts (UTF8); }",
+                ROWS_PER_FILE,
+                ROW_GROUP_BYTES,
+                // Every token is distinct across the whole dataset and unparseable as a datetime, so a naive
+                // per-unit cap would still admit many hundreds of distinct detail warnings.
+                (g, i) -> g.add("ts", "notadate-" + fileOrdinal + "-" + i)
+            );
+        }
+
+        registerDataSource("coercion_flood_ds", Map.of());
+        Map<String, DatasetFieldMapping> properties = new LinkedHashMap<>();
+        properties.put("ts", new DatasetFieldMapping("datetime", "ts"));
+        DatasetMapping mapping = new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.TRUE, properties));
+        String datasetName = "coercion_flood";
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    datasetName,
+                    "coercion_flood_ds",
+                    globUri(dir, "*.parquet"),
+                    null,
+                    new HashMap<>(Map.of("error_mode", "null_field")),
+                    mapping
+                )
+            )
+        );
+
+        // COUNT(ts) reads the ts column rather than answering purely from footer metadata; the present == 0
+        // assertion below is the guarantee that a real scan-and-coerce happened (a metadata-only answer would
+        // report the non-null row count instead of zero).
+        String query = "FROM " + datasetName + " | STATS total = COUNT(*), present = COUNT(ts)";
+        EsqlQueryRequest request = syncEsqlQueryRequest(query);
+
+        DiscoveryNode coordinator = randomFrom(clusterService().state().nodes().stream().toList());
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> warnings = new CopyOnWriteArrayList<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        AtomicReference<List<List<Object>>> values = new AtomicReference<>();
+        client(coordinator.getName()).execute(EsqlQueryAction.INSTANCE, request, ActionListener.wrap(response -> {
+            try {
+                values.set(getValuesList(response));
+                ThreadContext threadContext = internalCluster().getInstance(TransportService.class, coordinator.getName())
+                    .getThreadPool()
+                    .getThreadContext();
+                warnings.addAll(threadContext.getResponseHeaders().getOrDefault("Warning", List.of()));
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            failure.set(e);
+            latch.countDown();
+        }));
+        assertTrue("query did not complete within timeout", latch.await(2, TimeUnit.MINUTES));
+        if (failure.get() != null) {
+            throw new AssertionError("declared-coercion read must not fail, but did", failure.get());
+        }
+
+        long expectedTotal = (long) FILE_COUNT * ROWS_PER_FILE;
+        assertThat("COUNT(*) must see every row", ((Number) values.get().get(0).get(0)).longValue(), equalTo(expectedTotal));
+        assertThat(
+            "every declared-datetime value is unparseable -> null-filled",
+            ((Number) values.get().get(0).get(1)).longValue(),
+            equalTo(0L)
+        );
+
+        List<String> coercionWarnings = warnings.stream().filter(w -> w.contains("coerce")).toList();
+        assertThat(
+            "the null-fill drift must still surface at least one coercion warning, got: " + warnings,
+            coercionWarnings.size(),
+            greaterThan(0)
+        );
+        // One shared budget per data node caps the whole informational channel (summaries, per-value details, and
+        // the single overflow marker) at MAX_ADDED_WARNINGS + 1; the coordinator unions the per-node headers.
+        int dataNodes = internalCluster().numDataNodes();
+        long ceiling = (long) dataNodes * (SkipWarnings.MAX_ADDED_WARNINGS + 1);
+        assertThat(
+            "coercion Warning headers must stay within the per-node budget across the whole fan-out (dataNodes="
+                + dataNodes
+                + "), got "
+                + coercionWarnings.size()
+                + ": "
+                + coercionWarnings,
+            (long) coercionWarnings.size(),
+            lessThanOrEqualTo(ceiling)
+        );
+    }
+
+    private static String globUri(Path dir, String pattern) {
+        String dirUri = StoragePath.fileUri(dir);
+        if (dirUri.endsWith("/") == false) {
+            dirUri += "/";
+        }
+        return dirUri + pattern;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -181,11 +181,10 @@ public final class AsyncExternalSourceBuffer {
      * Use this for warnings relayed from format-reader {@code SkipWarnings} sinks (see {@code
      * FormatReadContext#informationalWarningSink()} / {@code RangeReadContext#informationalWarningSink()})
      * — e.g. CSV/NDJSON per-record skip/null-fill handling or Parquet on-disk/planner type mismatches.
-     * This preserves these warnings' pre-existing behavior of never flipping {@link #partial} (previously
-     * they only ever reached {@link org.elasticsearch.common.logging.HeaderWarning} directly, which has
-     * no notion of {@link #partial} either); this method only fixes their delivery when the read runs
-     * off the driver thread, without changing what they signal. See {@link #recordWarning} for the one
-     * warning that has always mapped to {@link #partial}.
+     * These warnings never flip {@link #partial} ({@link #partial} tracks only the {@code max_record_size}
+     * truncation, not per-record null-fills); this method relays them so they are re-emitted on the driver
+     * thread rather than lost on a background reader thread, without changing what they signal. See
+     * {@link #recordWarning} for the one warning that maps to {@link #partial}.
      * <p>
      * Each {@code SkipWarnings} instance caps its own per-event details at
      * {@code SkipWarnings.MAX_ADDED_WARNINGS} (20), but that cap is per reader instance, not per query:
@@ -194,6 +193,12 @@ public final class AsyncExternalSourceBuffer {
      * split into many chunks/segments cannot multiply {@link #pendingWarnings}'s size by chunk/segment
      * count — otherwise a large enough split count can grow response headers past what the client (or
      * an intermediate proxy) is willing to accept.
+     * <p>
+     * That cap bounds a single driver's contribution, because one buffer is created per driver. To bound
+     * the channel per source per node rather than only per driver (a multi-file glob or macro-split read
+     * fans across parallel drivers, each with its own buffer), {@code AsyncExternalSourceOperatorFactory}
+     * additionally gates every informational sink through one shared {@code InformationalWarningBudget}
+     * before it reaches this method; the per-source and per-buffer bounds compose.
      */
     public void recordInformationalWarning(String warning) {
         int count = informationalWarningsAdded.incrementAndGet();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
@@ -51,6 +52,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RecordSplitter;
 import org.elasticsearch.xpack.esql.datasources.spi.RowPositionStrategy;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec;
@@ -309,6 +311,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * factory created from the same driver context.
      */
     private final Map<DriverContext, SourceExtractors> sourceExtractorsPerDriver = new ConcurrentHashMap<>();
+
+    /**
+     * One budget shared across every driver this factory hands out, so the informational-warning
+     * channel is capped and deduplicated per source per node rather than per driver (see
+     * {@link InformationalWarningBudget}). Every informational sink built below routes through it.
+     */
+    private final InformationalWarningBudget informationalWarningBudget = new InformationalWarningBudget(SkipWarnings.MAX_ADDED_WARNINGS);
 
     private AsyncExternalSourceOperatorFactory(
         StorageProvider storageProvider,
@@ -969,8 +978,40 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * {@link Builder#build} time.
      */
     private int registerExtractorFromProducer(ColumnExtractorProducer producer, DriverContext driverContext) throws IOException {
-        ColumnExtractor extractor = producer.createColumnExtractor();
+        ColumnExtractor extractor = producer.createColumnExtractor(driverThreadInformationalWarningSink());
         return sourceExtractorsFor(driverContext).register(extractor);
+    }
+
+    /**
+     * Budget-gated informational-warning sink for readers that run off the driver thread (the eager
+     * scan on a background reader thread). A surviving warning is recorded on {@code buffer} and
+     * re-emitted on the driver thread when the source operator closes (see
+     * {@link AsyncExternalSourceBuffer#recordInformationalWarning}); emitting from the reader thread
+     * directly would land the header on a {@code ThreadContext} that is never merged into the response.
+     */
+    private Consumer<String> bufferedInformationalWarningSink(AsyncExternalSourceBuffer buffer) {
+        return warning -> {
+            String toRecord = informationalWarningBudget.accept(warning);
+            if (toRecord != null) {
+                buffer.recordInformationalWarning(toRecord);
+            }
+        };
+    }
+
+    /**
+     * Budget-gated informational-warning sink for the deferred (TopN) extractor, which runs on the
+     * driver thread and therefore emits directly to {@link HeaderWarning}. It must not route through
+     * the source buffer: {@code Driver} closes the source operator (draining the buffer's pending
+     * warnings) as soon as it finishes, which can happen before the paired extract operator runs, so
+     * a buffered extractor warning would never be drained.
+     */
+    private Consumer<String> driverThreadInformationalWarningSink() {
+        return warning -> {
+            String toRecord = informationalWarningBudget.accept(warning);
+            if (toRecord != null) {
+                HeaderWarning.addWarning(toRecord);
+            }
+        };
     }
 
     /**
@@ -1932,7 +1973,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     rangeEnd,
                     PhysicalNames.translateSchema(perFileResolvedAttributes, renames),
                     errorPolicy,
-                    state.buffer::recordInformationalWarning
+                    bufferedInformationalWarningSink(state.buffer)
                 );
                 if (fileContext != null) {
                     rangeCtx.setFileContext(fileContext);
@@ -1998,7 +2039,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     fileSplit.offset(),
                     state.buffer.capturedSourceMetadataSink(),
                     state.buffer::recordWarning,
-                    state.buffer::recordInformationalWarning
+                    bufferedInformationalWarningSink(state.buffer)
                 );
                 if (pages == null) {
                     boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
@@ -2023,7 +2064,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         // its trailing stripe to EOF).
                         .stats(fileSplit.offset(), statsStripeSize, splitIsFileFinal)
                         .statsColumnScope(statsColumnScope)
-                        .informationalWarningSink(state.buffer::recordInformationalWarning)
+                        .informationalWarningSink(bufferedInformationalWarningSink(state.buffer))
                         .build();
                     pages = fileReader.read(obj, ctx);
                 }
@@ -2196,7 +2237,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 0L,
                 state.buffer.capturedSourceMetadataSink(),
                 state.buffer::recordWarning,
-                state.buffer::recordInformationalWarning
+                bufferedInformationalWarningSink(state.buffer)
             );
             if (pages == null) {
                 int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining;
@@ -2208,7 +2249,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .readSchema(PhysicalNames.translateSchema(perFileReadSchema, renames))
                     .maxRecordBytes(maxRecordBytes)
                     .statsColumnScope(statsColumnScope)
-                    .informationalWarningSink(state.buffer::recordInformationalWarning)
+                    .informationalWarningSink(bufferedInformationalWarningSink(state.buffer))
                     .build();
                 pages = fileReader.read(obj, ctx);
             }
@@ -2288,7 +2329,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             .errorPolicy(errorPolicy)
             .maxRecordBytes(maxRecordBytes)
             .statsColumnScope(statsColumnScope)
-            .informationalWarningSink(buffer::recordInformationalWarning)
+            .informationalWarningSink(bufferedInformationalWarningSink(buffer))
             .build();
         FormatReader reader = readerWithDynamicThreshold(formatReader);
         reader.readAsync(storageObject, ctx, executor, ActionListener.wrap(iterator -> {
@@ -2334,7 +2375,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     0L,
                     buffer.capturedSourceMetadataSink(),
                     buffer::recordWarning,
-                    buffer::recordInformationalWarning
+                    bufferedInformationalWarningSink(buffer)
                 );
                 if (opened == null) {
                     FormatReadContext ctx = FormatReadContext.builder()
@@ -2344,7 +2385,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         .errorPolicy(errorPolicy)
                         .maxRecordBytes(maxRecordBytes)
                         .statsColumnScope(statsColumnScope)
-                        .informationalWarningSink(buffer::recordInformationalWarning)
+                        .informationalWarningSink(bufferedInformationalWarningSink(buffer))
                         .build();
                     opened = reader.read(storageObject, ctx);
                 }
@@ -2667,7 +2708,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         statsStripeSize,
                         statsColumnScope,
                         splitIsFileFinal,
-                        externalSourceMetrics
+                        externalSourceMetrics,
+                        warningSink
                     );
                 }
                 // Bracket multi-value CSV cannot prove a record start at a mid-file offset (bracket depth is

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/InformationalWarningBudget.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/InformationalWarningBudget.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Central, thread-safe cap and de-duplicator for the informational-warning channel of a single
+ * external source on one node. A read fans out into many units (row-group macro-splits, one
+ * iterator per globbed file) spread across parallel drivers, each unit building its own
+ * {@link SkipWarnings} capped only per instance; without a shared budget the total grows with the
+ * unit count until the response {@code Warning} headers are undeliverable. One budget owned by
+ * {@code AsyncExternalSourceOperatorFactory} (shared across all its drivers) bounds the whole source
+ * per node.
+ * <p>
+ * {@link #accept(String)} is the gate every informational sink calls before delivering a warning. It
+ * dedups by value (matching how {@code ThreadContext} dedups response headers) and admits at most
+ * {@code cap} distinct payload messages plus one overflow marker, whichever layer the warning came
+ * from (an eager reader relaying through the source buffer, or the driver-thread deferred extractor).
+ * Lock-free: concurrent producer threads across drivers share one budget.
+ */
+final class InformationalWarningBudget {
+
+    private final int cap;
+    private final Set<String> seen = ConcurrentHashMap.newKeySet();
+    private final AtomicInteger count = new AtomicInteger();
+    private final AtomicBoolean overflow = new AtomicBoolean();
+
+    InformationalWarningBudget(int cap) {
+        if (cap < 1) {
+            // cap 0 would deliver only the overflow marker (the first warning already crosses the cap),
+            // suppressing every summary and detail; a negative cap is nonsensical.
+            throw new IllegalArgumentException("cap must be at least 1, got [" + cap + "]");
+        }
+        this.cap = cap;
+    }
+
+    /**
+     * Decides what to deliver for one informational warning: the input itself when it fits within
+     * the cap and is not a duplicate, the one-time overflow marker for the caller that first crosses
+     * the cap, or {@code null} to drop (a duplicate, or any warning once the budget is full).
+     * <p>
+     * A warning equal to {@link SkipWarnings#overflowMessage()} is a per-instance meta-notice (that
+     * one chunk's own {@code MAX_ADDED_WARNINGS} detail cap was exceeded), not real summary/detail
+     * content, so it is relayed at most once via the {@link #seen} dedup check without spending one
+     * of the {@code cap} slots reserved for content; several chunks hitting their own cap independently
+     * therefore cost this budget one dedup entry, not one slot each. It reuses the identical text this
+     * budget's own overflow marker uses, so the two are indistinguishable to the client either way.
+     * <p>
+     * Once overflow is set, later calls short-circuit before touching {@link #seen}. The dedup set is
+     * therefore bounded by {@code cap} plus the distinct warnings (including at most one overflow-marker
+     * entry) offered concurrently in the window before overflow becomes visible; it stops growing once
+     * overflow flips. This is a small, bounded overshoot on the informational (warning-time) path, not
+     * a per-row cost.
+     */
+    @Nullable
+    String accept(String warning) {
+        // Warnings are always non-null messages built by SkipWarnings; fail fast on a broken caller
+        // rather than letting the null propagate into the dedup set or a response header.
+        Objects.requireNonNull(warning, "warning");
+        if (overflow.get()) {
+            return null;
+        }
+        if (seen.add(warning) == false) {
+            return null;
+        }
+        if (warning.equals(SkipWarnings.overflowMessage())) {
+            return warning;
+        }
+        if (count.incrementAndGet() <= cap) {
+            return warning;
+        }
+        // Exactly one caller crosses the cap first and emits the single overflow marker; the rest drop.
+        return overflow.compareAndSet(false, true) ? SkipWarnings.overflowMessage() : null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaAdaptingIterator.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 /**
  * Wraps a format reader's page iterator and runs each page through a {@link ColumnMapping}
@@ -44,7 +45,7 @@ import java.util.NoSuchElementException;
  *
  * <h2>{@link ColumnExtractorProducer} forwarding</h2>
  * The adapter unconditionally declares the {@link ColumnExtractorProducer} capability and forwards
- * {@link #createColumnExtractor()} / {@link #setExtractorId(int)} to its delegate. Whether those
+ * {@link #createColumnExtractor(Consumer)} / {@link #setExtractorId(int)} to its delegate. Whether those
  * calls actually succeed depends on the delegate: a non-producer delegate makes
  * {@code instanceof ColumnExtractorProducer} a necessary-but-not-sufficient guard at consumer
  * sites — the dispatch into the delegate fails loud (see {@link #innerProducer()}). The only
@@ -200,8 +201,8 @@ final class SchemaAdaptingIterator implements CloseableIterator<Page>, ColumnExt
     }
 
     @Override
-    public ColumnExtractor createColumnExtractor() throws IOException {
-        return innerProducer().createColumnExtractor();
+    public ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) throws IOException {
+        return innerProducer().createColumnExtractor(driverThreadWarningSink);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StatsCapturingIterator.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources.cache;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractorProducer;
 
@@ -17,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
 
 /**
  * Wraps a {@link CloseableIterator} so the iterator's {@code close()} runs with an
@@ -31,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <h2>{@link ColumnExtractorProducer} forwarding</h2>
  * The wrapper unconditionally declares the {@link ColumnExtractorProducer} capability and forwards
- * {@link #createColumnExtractor()} / {@link #setExtractorId(int)} to its delegate, mirroring
+ * {@link #createColumnExtractor(Consumer)} / {@link #setExtractorId(int)} to its delegate, mirroring
  * {@code SchemaAdaptingIterator}. A non-producer delegate makes the consumer's
  * {@code instanceof ColumnExtractorProducer} check a necessary-but-not-sufficient guard — the
  * dispatch into the delegate fails loud (see {@link #innerProducer()}). Without this forwarding the
@@ -92,8 +94,8 @@ public final class StatsCapturingIterator implements CloseableIterator<Page>, Co
     }
 
     @Override
-    public ColumnExtractor createColumnExtractor() throws IOException {
-        return innerProducer().createColumnExtractor();
+    public ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) throws IOException {
+        return innerProducer().createColumnExtractor(driverThreadWarningSink);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorProducer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorProducer.java
@@ -7,7 +7,10 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import org.elasticsearch.core.Nullable;
+
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Implemented by reader iterators that emit the synthetic
@@ -25,7 +28,7 @@ import java.io.IOException;
  * <h2>Encoding handshake</h2>
  * <ol>
  *   <li>The factory wraps the iterator's pages and calls
- *       {@link #createColumnExtractor()} to build a matching {@link ColumnExtractor}.</li>
+ *       {@link #createColumnExtractor(Consumer)} to build a matching {@link ColumnExtractor}.</li>
  *   <li>The factory registers the extractor with {@code SourceExtractors}, receiving an id.</li>
  *   <li>The factory calls {@link #setExtractorId(int)} <em>before</em> draining the first page,
  *       handing the iterator the id it must OR into every {@code _rowPosition} value it emits.</li>
@@ -39,7 +42,7 @@ import java.io.IOException;
  * step from the producer thread.
  * <p>
  * Implementations should construct the extractor lazily — typically on the first call to
- * {@link #createColumnExtractor()} — and may return the same instance on subsequent calls.
+ * {@link #createColumnExtractor(Consumer)} and may return the same instance on subsequent calls.
  * Lifetime is owned by the caller via {@code SourceExtractors} (the registry calls
  * {@link ColumnExtractor#close()} when the driver finishes).
  */
@@ -51,13 +54,21 @@ public interface ColumnExtractorProducer {
      * The iterator must already be positioned to emit pages with {@link ColumnExtractor#ROW_POSITION_COLUMN}
      * before this is called; implementations may capture iterator-internal state (such as a
      * range-restricted footer) at construction time.
+     *
+     * @param driverThreadWarningSink where the extractor relays per-value declared-coercion warnings
+     *                                (see {@link SkipWarnings}). The extractor runs on the driver
+     *                                thread, so this sink emits directly to the response headers; it
+     *                                is budget-gated so the whole source stays within one cap. May be
+     *                                {@code null}, in which case the extractor falls back to emitting
+     *                                warnings directly (per-instance cap only): the on-driver-thread
+     *                                default used by tests and benchmarks.
      */
-    ColumnExtractor createColumnExtractor() throws IOException;
+    ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) throws IOException;
 
     /**
      * Hands the iterator the {@code SourceExtractors}-assigned id under which its matching
      * {@link ColumnExtractor} is registered. Must be called once, after
-     * {@link #createColumnExtractor()} and before the first page is drained. Every subsequent
+     * {@link #createColumnExtractor(Consumer)} and before the first page is drained. Every subsequent
      * page the iterator emits must carry {@code _rowPosition} values already encoded with this
      * id (typically by OR-ing {@code ((long) id << 48)} into each value as it is materialised).
      * <p>

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -47,6 +47,19 @@ public class SkipWarnings {
     public static final int MAX_ADDED_WARNINGS = 20;
 
     /**
+     * The single "further warnings suppressed" line emitted once per collector when the per-event
+     * cap is exceeded. Exposed as the one source of truth for the overflow text so a central budget
+     * that caps the same channel (see {@code InformationalWarningBudget}) emits a byte-identical
+     * marker: identical text dedups against a per-collector overflow line by value, and clients that
+     * match on "further warnings suppressed" keep working regardless of which layer capped.
+     */
+    public static String overflowMessage() {
+        return OVERFLOW_MESSAGE;
+    }
+
+    private static final String OVERFLOW_MESSAGE = "... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)";
+
+    /**
      * Shared sink used when the current {@link ErrorPolicy} never triggers skip/null-fill behavior
      * (e.g. {@link ErrorPolicy#isStrict()}). All {@link #add(String)} calls are silently dropped.
      */
@@ -115,7 +128,7 @@ public class SkipWarnings {
             emit(detail);
             added++;
         } else if (overflowEmitted == false) {
-            emit("... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)");
+            emit(overflowMessage());
             overflowEmitted = true;
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryDeferredExtractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryDeferredExtractionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -48,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -794,7 +796,7 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
         }
 
         @Override
-        public ColumnExtractor createColumnExtractor() {
+        public ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) {
             extractorsCreated.incrementAndGet();
             return new InMemoryColumnExtractor(rows);
         }
@@ -902,7 +904,7 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
         }
 
         @Override
-        public ColumnExtractor createColumnExtractor() {
+        public ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) {
             extractorsCreated.incrementAndGet();
             return new InMemoryColumnExtractor(rowsPerFile);
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalReaderWarningFloodTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalReaderWarningFloodTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * The CSV/NDJSON analog of {@code ExternalParquetCoercionWarningFloodIT}, at the unit level: a lenient
+ * ({@code null_field} / {@code skip_row}) external read of a multi-file glob or macro-split text source
+ * fans out into many units spread across parallel drivers, and its client-visible {@code Warning} channel
+ * must stay bounded no matter how many units or drivers the read fans into.
+ *
+ * <p>This models the real two-layer bound the async source applies:
+ * <ul>
+ *   <li>{@link AsyncExternalSourceBuffer#recordInformationalWarning} caps each driver's own buffer, so a
+ *       single driver's chunks/segments cannot flood on their own.</li>
+ *   <li>One buffer is created per driver, so that per-buffer cap alone still lets the total grow with the
+ *       driver count. {@code AsyncExternalSourceOperatorFactory} therefore gates every informational sink
+ *       through one shared {@link InformationalWarningBudget} so the ceiling holds per source per node.</li>
+ * </ul>
+ * The per-buffer cap is what a single-driver read needs; the shared budget is what a fanned-out read needs.
+ * This test exercises the fanned-out case: several per-driver buffers, each already capped, all sharing one
+ * budget, with real per-unit {@link SkipWarnings} carrying the exact summary and per-value detail text
+ * {@code CsvFormatReader} / {@code NdJsonPageDecoder} emit. Removing the shared budget leaves the total at
+ * {@code drivers x per-buffer-cap}, which is the cross-driver flood the per-buffer cap does not cover.
+ */
+public class ExternalReaderWarningFloodTests extends ESTestCase {
+
+    /** Parallel drivers a fanned-out read uses, each with its own {@link AsyncExternalSourceBuffer}. */
+    private static final int DRIVERS = 16;
+    /** Units (chunks/segments/globbed files) each driver processes; each builds its own {@link SkipWarnings}. */
+    private static final int UNITS_PER_DRIVER = 4;
+    /** Distinct unparseable values per unit; above the per-instance cap so each unit alone already overflows. */
+    private static final int BAD_ROWS_PER_UNIT = 40;
+
+    public void testCsvNullFieldWarningsStayBoundedAcrossDriverFanOut() {
+        assertChannelBounded("CSV", "affected rows/fields are listed below");
+    }
+
+    public void testNdjsonNullFieldWarningsStayBoundedAcrossDriverFanOut() {
+        assertChannelBounded("NDJSON", "affected rows are listed below");
+    }
+
+    /**
+     * Replays {@link #DRIVERS} drivers, each draining its own buffer, every driver processing
+     * {@link #UNITS_PER_DRIVER} reader units that each emit {@link #BAD_ROWS_PER_UNIT} distinct null-fill
+     * warnings of the given format's shape through the one shared budget. Unions the drained per-driver
+     * headers the way the coordinator unions per-driver response headers, then asserts the drift still
+     * surfaces and that the whole channel stays within {@code MAX_ADDED_WARNINGS + 1} regardless of the
+     * driver, unit, and per-unit row counts.
+     */
+    private void assertChannelBounded(String format, String summaryTail) {
+        int cap = SkipWarnings.MAX_ADDED_WARNINGS;
+        InformationalWarningBudget budget = new InformationalWarningBudget(cap);
+
+        List<String> delivered = new ArrayList<>();
+        for (int driver = 0; driver < DRIVERS; driver++) {
+            AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
+            // Exactly what AsyncExternalSourceOperatorFactory#bufferedInformationalWarningSink does: gate every
+            // reader warning through the one per-source budget, then record survivors on this driver's buffer
+            // (which additionally caps per buffer) for the driver thread to re-emit on close.
+            Consumer<String> sink = warning -> {
+                String toRecord = budget.accept(warning);
+                if (toRecord != null) {
+                    buffer.recordInformationalWarning(toRecord);
+                }
+            };
+
+            for (int unit = 0; unit < UNITS_PER_DRIVER; unit++) {
+                // One collector per unit, mirroring the reader's per-chunk/per-file SkipWarnings. The summary
+                // embeds a per-unit source location, as a multi-file glob would, so summaries are distinct too.
+                String file = "part-" + driver + "-" + unit + "." + format.toLowerCase(Locale.ROOT);
+                String summary = format
+                    + " read from ["
+                    + file
+                    + "] "
+                    + "encountered parse errors handled per policy (policy: null_field); "
+                    + summaryTail;
+                SkipWarnings unitWarnings = SkipWarnings.of(ErrorPolicy.PERMISSIVE, summary, sink);
+                for (int row = 0; row < BAD_ROWS_PER_UNIT; row++) {
+                    unitWarnings.add("Failed to parse " + format + " value [notanumber-" + driver + "-" + unit + "-" + row + "] as [LONG]");
+                }
+            }
+
+            // Drain this driver's buffer the way AsyncExternalSourceOperator#close() does, then union into the
+            // response-wide set as the coordinator would.
+            String warning;
+            while ((warning = buffer.pollWarning()) != null) {
+                delivered.add(warning);
+            }
+        }
+
+        assertThat(
+            "the null-fill drift must still surface at least one per-value warning, got: " + delivered,
+            delivered,
+            hasItem(containsString("as [LONG]"))
+        );
+        // Sanity: the fixture presents far more distinct warnings than the cap, so a passing bound is a real
+        // cap and not an artifact of too little input.
+        assertThat((long) DRIVERS * UNITS_PER_DRIVER * BAD_ROWS_PER_UNIT, greaterThan((long) cap + 1));
+        assertThat(
+            "the informational Warning channel must stay bounded across the whole driver fan-out (drivers="
+                + DRIVERS
+                + ", units/driver="
+                + UNITS_PER_DRIVER
+                + ", rows/unit="
+                + BAD_ROWS_PER_UNIT
+                + "), got "
+                + delivered.size()
+                + ": "
+                + delivered,
+            delivered.size(),
+            lessThanOrEqualTo(cap + 1)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/InformationalWarningBudgetTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/InformationalWarningBudgetTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * Pins the contract {@link InformationalWarningBudget} exists to enforce: across all callers sharing one
+ * budget it admits at most {@code cap} distinct payloads plus a single overflow marker, deduplicates by
+ * value, spends no cap slot on a relayed per-collector overflow marker, and stays within that ceiling
+ * under concurrent access from many threads (the multi-driver, multi-segment fan-out it guards).
+ */
+public class InformationalWarningBudgetTests extends ESTestCase {
+
+    public void testAdmitsUpToCapDistinctThenOneOverflowMarker() {
+        int cap = 20;
+        InformationalWarningBudget budget = new InformationalWarningBudget(cap);
+        List<String> survivors = new ArrayList<>();
+        for (int i = 0; i < cap + 15; i++) {
+            String out = budget.accept("warning-" + i);
+            if (out != null) {
+                survivors.add(out);
+            }
+        }
+        // cap distinct payloads plus exactly one overflow marker.
+        assertThat(survivors.size(), equalTo(cap + 1));
+        assertThat(survivors.subList(0, cap), equalTo(distinctInputs(cap)));
+        assertThat(survivors.get(cap), equalTo(SkipWarnings.overflowMessage()));
+    }
+
+    public void testDuplicatesAreDropped() {
+        InformationalWarningBudget budget = new InformationalWarningBudget(20);
+        assertThat(budget.accept("same"), equalTo("same"));
+        assertNull("a repeated value costs no slot and is dropped", budget.accept("same"));
+        assertNull(budget.accept("same"));
+        assertThat("a distinct value still admits", budget.accept("other"), equalTo("other"));
+    }
+
+    public void testOverflowMarkerEmittedExactlyOnce() {
+        int cap = 5;
+        InformationalWarningBudget budget = new InformationalWarningBudget(cap);
+        int markers = 0;
+        for (int i = 0; i < cap + 50; i++) {
+            if (SkipWarnings.overflowMessage().equals(budget.accept("w-" + i))) {
+                markers++;
+            }
+        }
+        assertThat(markers, equalTo(1));
+    }
+
+    public void testLocalOverflowMarkerDoesNotSpendACapSlot() {
+        int cap = 5;
+        InformationalWarningBudget budget = new InformationalWarningBudget(cap);
+        // A chunk that hit its own per-instance MAX_ADDED_WARNINGS cap relays this exact text; relaying
+        // it must not cost one of the cap slots reserved for real summary/detail content.
+        assertThat(budget.accept(SkipWarnings.overflowMessage()), equalTo(SkipWarnings.overflowMessage()));
+        // A second, independent chunk hitting its own cap relays the identical text; it costs nothing
+        // further (already seen) rather than spending a second slot.
+        assertNull(budget.accept(SkipWarnings.overflowMessage()));
+        // All `cap` real slots are still available afterward.
+        List<String> survivors = new ArrayList<>();
+        for (int i = 0; i < cap; i++) {
+            String out = budget.accept("warning-" + i);
+            if (out != null) {
+                survivors.add(out);
+            }
+        }
+        assertThat(survivors, equalTo(distinctInputs(cap)));
+        // The cap is now exhausted by real content alone; the next distinct warning triggers overflow.
+        assertThat(budget.accept("one-too-many"), equalTo(SkipWarnings.overflowMessage()));
+    }
+
+    public void testConstructorRejectsNonPositiveCap() {
+        expectThrows(IllegalArgumentException.class, () -> new InformationalWarningBudget(0));
+        expectThrows(IllegalArgumentException.class, () -> new InformationalWarningBudget(-1));
+    }
+
+    public void testAcceptRejectsNull() {
+        expectThrows(NullPointerException.class, () -> new InformationalWarningBudget(20).accept(null));
+    }
+
+    public void testConcurrentAcceptAdmitsAtMostCapPlusOne() throws Exception {
+        int cap = 20;
+        InformationalWarningBudget budget = new InformationalWarningBudget(cap);
+        int threads = 8;
+        int perThread = 50;
+        Set<String> survivors = ConcurrentHashMap.newKeySet();
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        List<Thread> workers = new ArrayList<>(threads);
+        for (int t = 0; t < threads; t++) {
+            final int base = t * perThread;
+            Thread worker = new Thread(() -> {
+                safeAwait(barrier);
+                for (int i = 0; i < perThread; i++) {
+                    String out = budget.accept("warning-" + (base + i));
+                    if (out != null) {
+                        survivors.add(out);
+                    }
+                }
+            });
+            workers.add(worker);
+            worker.start();
+        }
+        for (Thread worker : workers) {
+            worker.join();
+        }
+        // At most cap distinct payloads plus the single overflow marker survive, regardless of races.
+        assertThat(survivors.size(), lessThanOrEqualTo(cap + 1));
+        assertTrue("the overflow marker must be emitted once the cap is exceeded", survivors.contains(SkipWarnings.overflowMessage()));
+    }
+
+    private static List<String> distinctInputs(int count) {
+        List<String> expected = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            expected.add("warning-" + i);
+        }
+        return expected;
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL|DS Cap and de-duplicate Parquet declared-coercion warnings (#153469)](https://github.com/elastic/elasticsearch/pull/153469)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)