### PR TITLE
[8.19] Test now sets a less verbose log level (#153683)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -574,7 +574,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertEquals("Unknown level constant [BOOM].", e.getMessage());
 
         try {
-            final Settings.Builder testSettings = Settings.builder().put("logger.test", "DEBUG").put("logger._root", "debug");
+            final Settings.Builder testSettings = Settings.builder().put("logger.test", "ERROR").put("logger._root", "error");
             ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings(
                 TEST_REQUEST_TIMEOUT,
                 TEST_REQUEST_TIMEOUT
@@ -582,8 +582,8 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             consumer.accept(testSettings, updateBuilder);
 
             updateBuilder.get();
-            assertEquals(Level.DEBUG, LogManager.getLogger("test").getLevel());
-            assertEquals(Level.DEBUG, LogManager.getRootLogger().getLevel());
+            assertEquals(Level.ERROR, LogManager.getLogger("test").getLevel());
+            assertEquals(Level.ERROR, LogManager.getRootLogger().getLevel());
         } finally {
             ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings(
                 TEST_REQUEST_TIMEOUT,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Test now sets a less verbose log level (#153683)](https://github.com/elastic/elasticsearch/pull/153683)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)