### PR TITLE
Grant DSL lifecycle user access to .kibana_change_history

### DIFF
--- a/docs/changelog/153969.yaml
+++ b/docs/changelog/153969.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 153969
+summary: Grant DSL lifecycle user access to `.kibana_change_history`
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -190,7 +190,9 @@ public class InternalUsers {
                         // System data streams for storing uploaded file data for Agent diagnostics and Endpoint response actions
                         ".fleet-fileds*",
                         // System data stream for kibana workflows
-                        ".workflows*"
+                        ".workflows*",
+                        // System data stream for kibana change history
+                        ".kibana_change_history"
                     )
                     .privileges(
                         filterNonNull(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -264,7 +264,12 @@ public class InternalUsersTests extends ESTestCase {
         );
         checkClusterAccess(InternalUsers.DATA_STREAM_LIFECYCLE_USER, role, randomFrom(sampleClusterActions), true);
 
-        final List<String> allowedSystemDataStreams = Arrays.asList(".fleet-actions-results", ".fleet-fileds*", ".workflows*");
+        final List<String> allowedSystemDataStreams = Arrays.asList(
+            ".fleet-actions-results",
+            ".fleet-fileds*",
+            ".workflows*",
+            ".kibana_change_history"
+        );
         for (var group : role.indices().groups()) {
             if (group.allowRestrictedIndices()) {
                 assertThat(group.indices(), arrayContaining(allowedSystemDataStreams.toArray(new String[0])));


### PR DESCRIPTION
## Summary

- `.kibana_change_history` matches the `.kibana_*` pattern registered by `KibanaPlugin`, making it a restricted (system) index.
- The `_data_stream_lifecycle` internal user's role has two `IndicesPrivileges` entries: one covering `*` with `allowRestrictedIndices(false)` (blocks all restricted indices), and one with `allowRestrictedIndices(true)` covering only `.fleet-actions-results`, `.fleet-fileds*`, and `.workflows*`.
- When Kibana started managing `.kibana_change_history` with DSL lifecycle, the DSL service's rollover requests were denied with `ElasticsearchSecurityException: action [indices:admin/rollover] is unauthorized for user [_data_stream_lifecycle]`.
- Fix adds `.kibana_change_history` to the `allowRestrictedIndices(true)` entry, following the same pattern used previously for `.workflows*`.

Similar to: https://github.com/elastic/elasticsearch/pull/143958

## Test plan

- Updated `InternalUsersTests.testDataStreamLifecycleUser` to assert `.kibana_change_history` is present in the restricted-indices allowlist.
- Full failure store selector test coverage (`::failures`) is being added in the companion PR #154021.