### PR TITLE
[9.5] Fix comment typo introduced in #152426 (#153954)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -804,7 +804,7 @@ public class TransportService extends AbstractLifecycleComponent
      * If {@code request} is a {@link BytesTransportRequest} then it is not re-serialized, and is released when the request message has been
      * fully sent. This is the recommended way for high-volume callers to keep track of the size of their unsent outbound requests.
      * <p>
-     * This method also retains a reference to {@code handler} until it is is complete. Usually that means we received a response from the
+     * This method also retains a reference to {@code handler} until it is complete. Usually that means we received a response from the
      * remote node, but it could also be that the request timed out, or that the remote disconnected, or that there was some kind of failure
      * when sending the request or receiving the response. Callers must ensure that {@code handler} does not unnecessarily retain excessive
      * resources.
@@ -831,7 +831,7 @@ public class TransportService extends AbstractLifecycleComponent
      * If {@code request} is a {@link BytesTransportRequest} then it is not re-serialized, and is released when the request message has been
      * fully sent. This is the recommended way for high-volume callers to keep track of the size of their unsent outbound requests.
      * <p>
-     * This method also retains a reference to {@code handler} until it is is complete. Usually that means we received a response from the
+     * This method also retains a reference to {@code handler} until it is complete. Usually that means we received a response from the
      * remote node, but it could also be that the request timed out, or that the remote disconnected, or that there was some kind of failure
      * when sending the request or receiving the response. Callers must ensure that {@code handler} does not unnecessarily retain excessive
      * resources.
@@ -900,7 +900,7 @@ public class TransportService extends AbstractLifecycleComponent
      * If {@code request} is a {@link BytesTransportRequest} then it is not re-serialized, and is released when the request message has been
      * fully sent. This is the recommended way for high-volume callers to keep track of the size of their unsent outbound requests.
      * <p>
-     * This method also retains a reference to {@code handler} until it is is complete. Usually that means we received a response from the
+     * This method also retains a reference to {@code handler} until it is complete. Usually that means we received a response from the
      * remote node, but it could also be that the request timed out, or that the remote disconnected, or that there was some kind of failure
      * when sending the request or receiving the response. Callers must ensure that {@code handler} does not unnecessarily retain excessive
      * resources.
@@ -994,7 +994,7 @@ public class TransportService extends AbstractLifecycleComponent
      * If {@code request} is a {@link BytesTransportRequest} then it is not re-serialized, and is released when the request message has been
      * fully sent. This is the recommended way for high-volume callers to keep track of the size of their unsent outbound requests.
      * <p>
-     * This method also retains a reference to {@code handler} until it is is complete. Usually that means we received a response from the
+     * This method also retains a reference to {@code handler} until it is complete. Usually that means we received a response from the
      * remote node, but it could also be that the request timed out, or that the remote disconnected, or that there was some kind of failure
      * when sending the request or receiving the response. Callers must ensure that {@code handler} does not unnecessarily retain excessive
      * resources.
@@ -1026,7 +1026,7 @@ public class TransportService extends AbstractLifecycleComponent
      * If {@code request} is a {@link BytesTransportRequest} then it is not re-serialized, and is released when the request message has been
      * fully sent. This is the recommended way for high-volume callers to keep track of the size of their unsent outbound requests.
      * <p>
-     * This method also retains a reference to {@code handler} until it is is complete. Usually that means we received a response from the
+     * This method also retains a reference to {@code handler} until it is complete. Usually that means we received a response from the
      * remote node, but it could also be that the request timed out, or that the remote disconnected, or that there was some kind of failure
      * when sending the request or receiving the response. Callers must ensure that {@code handler} does not unnecessarily retain excessive
      * resources.
@@ -1054,7 +1054,7 @@ public class TransportService extends AbstractLifecycleComponent
      * If {@code request} is a {@link BytesTransportRequest} then it is not re-serialized, and is released when the request message has been
      * fully sent. This is the recommended way for high-volume callers to keep track of the size of their unsent outbound requests.
      * <p>
-     * This method also retains a reference to {@code handler} until it is is complete. Usually that means we received a response from the
+     * This method also retains a reference to {@code handler} until it is complete. Usually that means we received a response from the
      * remote node, but it could also be that the request timed out, or that the remote disconnected, or that there was some kind of failure
      * when sending the request or receiving the response. Callers must ensure that {@code handler} does not unnecessarily retain excessive
      * resources.


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix comment typo introduced in #152426 (#153954)