### PR TITLE
[9.5] Delegate Regex.simpleMatch to Glob.globMatch (#153025)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/regex/Regex.java
+++ b/server/src/main/java/org/elasticsearch/common/regex/Regex.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Glob;
 import org.elasticsearch.core.Predicates;
 
 import java.util.ArrayList;
@@ -207,43 +208,7 @@ public class Regex {
             pattern = Strings.toLowercaseAscii(pattern);
             str = Strings.toLowercaseAscii(str);
         }
-        return simpleMatchWithNormalizedStrings(pattern, str);
-    }
-
-    private static boolean simpleMatchWithNormalizedStrings(String pattern, String str) {
-        final int firstIndex = pattern.indexOf('*');
-        if (firstIndex == -1) {
-            return pattern.equals(str);
-        }
-        if (firstIndex == 0) {
-            if (pattern.length() == 1) {
-                return true;
-            }
-            final int nextIndex = pattern.indexOf('*', firstIndex + 1);
-            if (nextIndex == -1) {
-                // str.endsWith(pattern.substring(1)), but avoiding the construction of pattern.substring(1):
-                return str.regionMatches(str.length() - pattern.length() + 1, pattern, 1, pattern.length() - 1);
-            } else if (nextIndex == 1) {
-                // Double wildcard "**" detected - skipping all "*"
-                int wildcards = nextIndex + 1;
-                while (wildcards < pattern.length() && pattern.charAt(wildcards) == '*') {
-                    wildcards++;
-                }
-                return simpleMatchWithNormalizedStrings(pattern.substring(wildcards - 1), str);
-            }
-            final String part = pattern.substring(1, nextIndex);
-            int partIndex = str.indexOf(part);
-            while (partIndex != -1) {
-                if (simpleMatchWithNormalizedStrings(pattern.substring(nextIndex), str.substring(partIndex + part.length()))) {
-                    return true;
-                }
-                partIndex = str.indexOf(part, partIndex + 1);
-            }
-            return false;
-        }
-        return str.regionMatches(0, pattern, 0, firstIndex)
-            && (firstIndex == pattern.length() - 1 // only wildcard in pattern is at the end, so no need to look at the rest of the string
-                || simpleMatchWithNormalizedStrings(pattern.substring(firstIndex), str.substring(firstIndex)));
+        return Glob.globMatch(pattern, str);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
@@ -108,6 +108,45 @@ public class RegexTests extends ESTestCase {
         );
     }
 
+    public void testManyWildcardsStillMatch() {
+        final int wildcards = 500;
+        final StringBuilder pattern = new StringBuilder();
+        final StringBuilder str = new StringBuilder();
+        for (int i = 0; i < wildcards; i++) {
+            pattern.append('a').append('*');
+            str.append('a');
+        }
+        pattern.append('b');
+        str.append('b');
+        assertTrue(Regex.simpleMatch(pattern.toString(), str.toString()));
+    }
+
+    public void testShallowWideBacktrackingResolvesCorrectly() {
+        // Shape that caused combinatorial backtracking blowup in the old recursive implementation;
+        // the iterative algorithm resolves it in a single pass with no backtracking possible.
+        final int groups = 15;
+        final StringBuilder pattern = new StringBuilder();
+        for (int i = 0; i < groups; i++) {
+            pattern.append("*a");
+        }
+        pattern.append('b'); // 'b' never occurs in str, so the correct result is no match
+        final String str = "a".repeat(groups * 2);
+        assertFalse(Regex.simpleMatch(pattern.toString(), str));
+    }
+
+    public void testVeryLongPatternMatchesCorrectly() {
+        // Shape that could exhaust the call stack in the old recursive implementation; the iterative
+        // algorithm has no recursion at all, so pattern length alone is never a problem.
+        final int wildcards = 50_000;
+        final StringBuilder pattern = new StringBuilder();
+        final StringBuilder str = new StringBuilder();
+        for (int i = 0; i < wildcards; i++) {
+            pattern.append('a').append('*');
+            str.append('a');
+        }
+        assertTrue(Regex.simpleMatch(pattern.toString(), str.toString()));
+    }
+
     public void testSimpleMatch() {
         for (int i = 0; i < 1000; i++) {
             final String matchingString = randomAlphaOfLength(between(0, 50));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Delegate Regex.simpleMatch to Glob.globMatch (#153025)](https://github.com/elastic/elasticsearch/pull/153025)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)