### PR TITLE
[9.5] Force off DLM frozen tier feature flag in mixed environment ESQL tests (#153957)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -424,12 +424,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/load four indices with single conversion function TO_IP}
   issue: https://github.com/elastic/elasticsearch/issues/151413
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/250_columnar_keyword/Test mv_min}
-  issue: https://github.com/elastic/elasticsearch/issues/147379
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/250_columnar_keyword/Test mv max}
-  issue: https://github.com/elastic/elasticsearch/issues/147379
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:SUBQUERIES}
   issue: https://github.com/elastic/elasticsearch/issues/149681

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -37,7 +37,11 @@ public class Clusters {
             .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
             .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))
             .configFile("ingest-geoip/GeoLite2-ASN.mmdb", Resource.fromClasspath("GeoLite2-ASN.mmdb"))
-            .setting("ingest.geoip.downloader.enabled", "false");
+            .setting("ingest.geoip.downloader.enabled", "false")
+            // DLM frozen tier serialization is gated on both a feature flag and a transport version, so nodes in a mixed cluster can
+            // disagree on the wire format when their build types differ (snapshot vs release). Disable the flag on every node so
+            // serialization is consistent regardless of build type. See https://github.com/elastic/elasticsearch/issues/153679.
+            .systemProperty("es.dlm_searchable_snapshots_feature_flag_enabled", "false");
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Force off DLM frozen tier feature flag in mixed environment ESQL tests (#153957)