### PR TITLE
Isolate datasource tests into externalDatasourceTest task

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -180,6 +180,14 @@ tasks.named("internalClusterTest").configure {
   // Data sources require the project encryption key feature (EsqlPlugin fails fast otherwise); pair the flags.
   systemProperty 'es.project_encryption_key_feature_flag_enabled', 'true'
 
+  // Datasource-related tests are excluded from the main run and collected into externalDataSourceTest
+  // so that their failures (flaky network, S3, Parquet, etc.) do not interrupt the core suite.
+  exclude '**/External*.class'
+  exclude '**/FromDataset*.class'
+  exclude '**/FileSourceSecretDecryption*.class'
+  exclude '**/S3*AuthIT.class'
+  exclude '**/datasources/**/*.class'
+
   def injected = project.objects.newInstance(Injected)
   File snippetsFolder = file("build/testrun/internalClusterTest/temp/esql/_snippets")
   def snippetsDocFolder = file("${rootDir}/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql")
@@ -227,6 +235,25 @@ tasks.named("internalClusterTest").configure {
     }
   }
 }
+
+// External data-source tests (External*IT) reach live remote HTTP endpoints and are inherently
+// flaky. Run them in their own task after internalClusterTest so their failures don't interrupt
+// the main suite. The task reuses the internalClusterTest source set's compiled classes and
+// classpath, so no extra compilation is needed.
+tasks.register("externalDataSourceTest", Test) {
+  include '**/External*.class'
+  include '**/FromDataset*.class'
+  include '**/FileSourceSecretDecryption*.class'
+  include '**/S3*AuthIT.class'
+  include '**/datasources/**/*.class'
+  testClassesDirs = sourceSets.internalClusterTest.output.classesDirs
+  classpath = sourceSets.internalClusterTest.runtimeClasspath
+  mustRunAfter 'internalClusterTest'
+  jvmArgs '-XX:-OmitStackTraceInFastThrow'
+  systemProperty 'es.esql_external_datasources_feature_flag_enabled', 'true'
+  systemProperty 'es.project_encryption_key_feature_flag_enabled', 'true'
+}
+tasks.named("check").configure { dependsOn "externalDataSourceTest" }
 
 /****************************************************************
  *  Enable QA/rest integration tests for snapshot builds only   *


### PR DESCRIPTION
Datasource-related tests (`External*`, `FromDataset*`, `FileSourceSecretDecryption*`,
`S3*AuthIT`, `datasources/**`) account for ~33% of Analytics team CI failures over
the last 30 days. Their failures are typically caused by flaky network calls, S3
connectivity, or Parquet format issues — not core ES|QL regressions — yet they run
mixed into `internalClusterTest` and obscure signal from the core suite.

This PR introduces a dedicated `externalDataSourceTest` Gradle task that:

- Excludes all datasource-related classes from `internalClusterTest` so core suite
  results are clean
- Runs the excluded classes in a separate task after `internalClusterTest` succeeds
  (`mustRunAfter`), so datasource failures never block or mask core failures
- Reuses the `internalClusterTest` source set's compiled classes and classpath — no
  extra compilation step
- Remains part of `check`, so datasource tests are still gated in CI

## Test plan

- [ ] Run `./gradlew :x-pack:plugin:esql:internalClusterTest` and confirm no
  `External*`, `FromDataset*`, `FileSourceSecretDecryption*`, `S3*AuthIT`, or
  `datasources/**` classes appear in the results
- [ ] Run `./gradlew :x-pack:plugin:esql:externalDataSourceTest` and confirm only
  datasource-related classes run
- [ ] Run `./gradlew :x-pack:plugin:esql:check` and confirm both tasks execute in
  order