### PR TITLE
[9.5] ES|QL|DS Fix crash casting capitalized boolean Hive partition values (#153866)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -43,8 +44,57 @@ public class ExternalParquetHivePartitionedIT extends AbstractExternalDataSource
     }
 
     /**
+     * A capitalized boolean partition folder ({@code flag=True/}, {@code flag=False/}, the casing common data
+     * writers emit) must type the {@code flag} column as {@code BOOLEAN} and be queryable rather than failing
+     * partition-value casting. Partition-value casting is format-agnostic ({@code HivePartitionDetector.castValue}),
+     * so a single format end-to-end guard suffices; the detector-level coverage (any casing, hive/template
+     * delegation, null-sentinel mix) lives in {@code HivePartitionDetectorTests} / {@code TemplatePartitionDetectorTests}.
+     */
+    public void testCapitalizedBooleanPartitionFolderQueryable() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        Path root = createTempDir().resolve("hive_parquet_bool");
+        writeSingleColumnIdParquet(root.resolve("flag=True"), 3); // ids 0,1,2
+        writeSingleColumnIdParquet(root.resolve("flag=False"), 2); // ids 0,1
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.parquet";
+        String dataset = registerDataset("hive_parquet_bool", glob, Map.of("hive_partitioning", true));
+
+        var request = syncEsqlQueryRequest("FROM " + dataset + " | SORT flag, id");
+        request.profile(true);
+        try (var response = run(request)) {
+            assertFalse("external scan must run on a data node", externalScanNodeNames(response).isEmpty());
+
+            int flagIdx = response.columns().stream().map(ColumnInfoImpl::name).toList().indexOf("flag");
+            assertThat(
+                "path-derived boolean partition types as BOOLEAN",
+                response.columns().get(flagIdx).type(),
+                equalTo(DataType.BOOLEAN)
+            );
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("all five rows return across both boolean partitions", rows.size(), equalTo(5));
+            long trueRows = rows.stream().filter(r -> Boolean.TRUE.equals(r.get(flagIdx))).count();
+            long falseRows = rows.stream().filter(r -> Boolean.FALSE.equals(r.get(flagIdx))).count();
+            assertThat("flag=True folder contributes 3 rows typed boolean true", trueRows, equalTo(3L));
+            assertThat("flag=False folder contributes 2 rows typed boolean false", falseRows, equalTo(2L));
+        }
+
+        // Typed boolean equality over the path-derived column keeps only the flag=False rows.
+        try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | WHERE flag == false"))) {
+            int flagIdx = response.columns().stream().map(ColumnInfoImpl::name).toList().indexOf("flag");
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("WHERE flag == false keeps exactly the two flag=False rows", rows.size(), equalTo(2));
+            assertTrue(
+                "every kept row is flag=false, not just the right count",
+                rows.stream().allMatch(r -> Boolean.FALSE.equals(r.get(flagIdx)))
+            );
+        }
+    }
+
+    /**
      * Two partitions ({@code p=a}: 3 rows, {@code p=b}: 2 rows). {@code COUNT(p)} must SAFE-MISS to a scan on the
-     * data node — proving the partition-column signal reaches the data-node fold via the serialized
+     * data node, proving the partition-column signal reaches the data-node fold via the serialized
      * {@code _partition.columns} metadata (the coordinator-only {@code FileList} is {@code UNRESOLVED} there), not
      * just the coordinator gate. Without the serialized stamp the data-node fold warm-folds {@code COUNT(p)} to 0
      * (a {@code LocalSourceExec} with no scan operator).

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
@@ -8,9 +8,9 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.net.URLDecoder;
@@ -267,7 +267,9 @@ public final class HivePartitionDetector implements PartitionDetector {
             return Double.parseDouble(value);
         }
         if (type == DataType.BOOLEAN) {
-            return Booleans.parseBoolean(value);
+            // Match tryAllBoolean's case-insensitive inference: a folder typed BOOLEAN there (e.g. a standard
+            // writer's flag=True/flag=False) must cast, so parse the same true/false-in-any-case token set.
+            return DeclaredTypeCoercions.strictParseBoolean(value);
         }
         return value;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -56,6 +57,57 @@ public class HivePartitionDetectorTests extends ESTestCase {
 
     public void testTypeInferenceKeywordFallback() {
         assertEquals(DataType.KEYWORD, HivePartitionDetector.inferType(List.of("us-east", "eu-west")));
+    }
+
+    /**
+     * The other half of the inference/cast symmetry: a token that is not {@code true}/{@code false} in any
+     * case (here {@code yes}, and a whitespace-padded {@code " true"}) infers {@code KEYWORD}, so it never
+     * routes to the BOOLEAN cast branch. Inference admits exactly the token set the cast accepts, so a
+     * KEYWORD-typed value cannot reach {@code strictParseBoolean}.
+     */
+    public void testTypeInferenceRejectsNonBooleanTokens() {
+        assertEquals(DataType.KEYWORD, HivePartitionDetector.inferType(List.of("true", "yes")));
+        assertEquals(DataType.KEYWORD, HivePartitionDetector.inferType(List.of(" true", "false")));
+    }
+
+    /**
+     * A hive tree with capitalized boolean folders ({@code flag=True/}, {@code flag=False/}) types the column
+     * {@code BOOLEAN} and casts each folder to its boolean value.
+     */
+    public void testCapitalizedBooleanPartitionFoldersInferAndCast() {
+        List<StorageEntry> files = List.of(
+            entry("s3://bucket/data/flag=True/file1.parquet"),
+            entry("s3://bucket/data/flag=False/file2.parquet")
+        );
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        assertEquals(DataType.BOOLEAN, result.partitionColumns().get("flag"));
+
+        assertEquals(true, result.filePartitionValues().get(StoragePath.of("s3://bucket/data/flag=True/file1.parquet")).get("flag"));
+        assertEquals(false, result.filePartitionValues().get(StoragePath.of("s3://bucket/data/flag=False/file2.parquet")).get("flag"));
+    }
+
+    /**
+     * A capitalized boolean folder mixed with the Hive null sentinel: the column still infers {@code BOOLEAN},
+     * the sentinel casts to {@code null} (the null short-circuit precedes the boolean branch), and {@code True}
+     * casts to {@code true}.
+     */
+    public void testCapitalizedBooleanPartitionWithNullSentinel() {
+        List<StorageEntry> files = List.of(
+            entry("s3://bucket/data/flag=True/file1.parquet"),
+            entry("s3://bucket/data/flag=__HIVE_DEFAULT_PARTITION__/file2.parquet")
+        );
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        assertEquals(DataType.BOOLEAN, result.partitionColumns().get("flag"));
+        assertEquals(true, result.filePartitionValues().get(StoragePath.of("s3://bucket/data/flag=True/file1.parquet")).get("flag"));
+        assertNull(
+            result.filePartitionValues().get(StoragePath.of("s3://bucket/data/flag=__HIVE_DEFAULT_PARTITION__/file2.parquet")).get("flag")
+        );
     }
 
     public void testMixedTypesInferKeyword() {
@@ -209,6 +261,30 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testCastValueBoolean() {
         assertEquals(true, HivePartitionDetector.castValue("true", DataType.BOOLEAN));
         assertEquals(false, HivePartitionDetector.castValue("false", DataType.BOOLEAN));
+    }
+
+    /**
+     * Capitalized boolean partition folders ({@code flag=True/}, {@code flag=False/}) are accepted by
+     * {@code tryAllBoolean} case-insensitively, so the cast agrees: any casing of {@code true}/{@code false}
+     * casts to the boolean value, keeping inference and cast symmetric.
+     */
+    public void testCastValueBooleanCaseInsensitive() {
+        assertEquals(true, HivePartitionDetector.castValue("True", DataType.BOOLEAN));
+        assertEquals(false, HivePartitionDetector.castValue("FALSE", DataType.BOOLEAN));
+        assertEquals(true, HivePartitionDetector.castValue("TrUe", DataType.BOOLEAN));
+        assertEquals(false, HivePartitionDetector.castValue("False", DataType.BOOLEAN));
+        assertEquals(true, HivePartitionDetector.castValue("TRUE", DataType.BOOLEAN));
+    }
+
+    /**
+     * The cast side of the symmetry: a token outside the case-insensitive {@code true}/{@code false} set
+     * ({@code yes}, or a whitespace-padded {@code " true"}) throws when cast to {@code BOOLEAN}. Such tokens
+     * infer {@code KEYWORD} (see {@code testTypeInferenceRejectsNonBooleanTokens}), so they never reach this
+     * branch in practice, but the cast pins the same accepted set.
+     */
+    public void testCastValueBooleanRejectsNonBooleanTokens() {
+        expectThrows(InvalidArgumentException.class, () -> HivePartitionDetector.castValue("yes", DataType.BOOLEAN));
+        expectThrows(InvalidArgumentException.class, () -> HivePartitionDetector.castValue(" true", DataType.BOOLEAN));
     }
 
     public void testCastValueKeyword() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetectorTests.java
@@ -225,6 +225,24 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
         assertEquals("template", detector.name());
     }
 
+    /**
+     * The template detector delegates type inference and casting to {@link HivePartitionDetector}, so it shares
+     * the capitalized-boolean handling: a {@code {flag}} template over {@code True/} and {@code False/} segments
+     * infers {@code BOOLEAN} and casts each to its boolean value.
+     */
+    public void testCapitalizedBooleanTemplatePartition() {
+        TemplatePartitionDetector detector = new TemplatePartitionDetector("{flag}");
+
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/True/file1.parquet"), entry("s3://bucket/data/False/file2.parquet"));
+
+        PartitionMetadata result = detector.detect(files, Map.of());
+
+        assertFalse(result.isEmpty());
+        assertEquals(DataType.BOOLEAN, result.partitionColumns().get("flag"));
+        assertEquals(true, result.filePartitionValues().get(StoragePath.of("s3://bucket/data/True/file1.parquet")).get("flag"));
+        assertEquals(false, result.filePartitionValues().get(StoragePath.of("s3://bucket/data/False/file2.parquet")).get("flag"));
+    }
+
     public void testMixedIntegerAndKeyword() {
         TemplatePartitionDetector detector = new TemplatePartitionDetector("{year}/{region}");
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL|DS Fix crash casting capitalized boolean Hive partition values (#153866)](https://github.com/elastic/elasticsearch/pull/153866)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)