### PR TITLE
[8.19] [ML] Fix MLModelDeploymentFullClusterRestartIT flaky failure (#145159)

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -108,15 +108,13 @@ public class MLModelDeploymentFullClusterRestartIT extends MlFullClusterRestartT
         } else {
             ensureHealth(".ml-inference-*,.ml-config*", (request -> {
                 request.addParameter("wait_for_status", "yellow");
-                request.addParameter("timeout", "70s");
+                request.addParameter("timeout", "120s");
             }));
             waitForDeploymentStarted(modelId);
             assertBusy(() -> {
                 try {
                     assertInfer(modelId);
                 } catch (ResponseException e) {
-                    // assertBusy only loops on AssertionErrors, so we have
-                    // to convert failure status exceptions to these
                     throw new AssertionError("Inference failed", e);
                 }
             }, 90, TimeUnit.SECONDS);
@@ -127,7 +125,12 @@ public class MLModelDeploymentFullClusterRestartIT extends MlFullClusterRestartT
     @SuppressWarnings("unchecked")
     private void waitForDeploymentStarted(String modelId) throws Exception {
         assertBusy(() -> {
-            var response = getTrainedModelStats(modelId);
+            Response response;
+            try {
+                response = getTrainedModelStats(modelId);
+            } catch (ResponseException e) {
+                throw new AssertionError("Model stats not available yet", e);
+            }
             Map<String, Object> map = entityAsMap(response);
             List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
             assertThat(stats, hasSize(1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix MLModelDeploymentFullClusterRestartIT flaky failure (#145159)](https://github.com/elastic/elasticsearch/pull/145159)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)