### PR TITLE
[backport 9.5] ESQL: Fixup AllSupporterFieldITs

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/AllSupportedFieldsIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/AllSupportedFieldsIT.java
@@ -104,6 +104,12 @@ public class AllSupportedFieldsIT extends AllSupportedFieldsTestCase {
 
     @Override
     protected String allIndexPattern() {
+        if (indexMode() == IndexMode.LOGSDB) {
+            // logsdb* would also match logsdb_columnar* indices created by the LOGSDB_COLUMNAR test setup,
+            // on both the local and the remote cluster.
+            String columnarName = IndexMode.LOGSDB_COLUMNAR.getName();
+            return "*:%mode%*,%mode%*,-" + Clusters.REMOTE_CLUSTER_NAME + ":" + columnarName + "*,-" + columnarName + "*";
+        }
         return "*:%mode%*,%mode%*";
     }
 
@@ -139,7 +145,11 @@ public class AllSupportedFieldsIT extends AllSupportedFieldsTestCase {
     }
 
     public final void testFetchAllOnlyFromRemotes() throws IOException {
-        doTestFetchAll(fromAllQuery("*:%mode%*", """
+        // logsdb* would also match logsdb_columnar* indices created by the LOGSDB_COLUMNAR test setup.
+        String indexPattern = indexMode() == IndexMode.LOGSDB
+            ? "*:%mode%*,-" + Clusters.REMOTE_CLUSTER_NAME + ":" + IndexMode.LOGSDB_COLUMNAR.getName() + "*"
+            : "*:%mode%*";
+        doTestFetchAll(fromAllQuery(indexPattern, """
             , _id, _ignored, _index_mode, _score, _source, _version
             | LIMIT 1000
             """), remoteNodeToInfo(), allNodeToInfo(), false);

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/AllSupportedFieldsIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/AllSupportedFieldsIT.java
@@ -108,7 +108,9 @@ public class AllSupportedFieldsIT extends AllSupportedFieldsTestCase {
             // logsdb* would also match logsdb_columnar* indices created by the LOGSDB_COLUMNAR test setup,
             // on both the local and the remote cluster.
             String columnarName = IndexMode.LOGSDB_COLUMNAR.getName();
-            return "*:%mode%*,%mode%*,-" + Clusters.REMOTE_CLUSTER_NAME + ":" + columnarName + "*,-" + columnarName + "*";
+            // Old (pre-#148497) branches only understand "remote:-index", not "-remote:index" - use the former so this
+            // works against release BWC nodes too.
+            return "*:%mode%*,%mode%*," + Clusters.REMOTE_CLUSTER_NAME + ":-" + columnarName + "*,-" + columnarName + "*";
         }
         return "*:%mode%*,%mode%*";
     }
@@ -146,8 +148,10 @@ public class AllSupportedFieldsIT extends AllSupportedFieldsTestCase {
 
     public final void testFetchAllOnlyFromRemotes() throws IOException {
         // logsdb* would also match logsdb_columnar* indices created by the LOGSDB_COLUMNAR test setup.
+        // Old (pre-#148497) branches only understand "remote:-index", not "-remote:index" - use the former so this
+        // works against release BWC nodes too.
         String indexPattern = indexMode() == IndexMode.LOGSDB
-            ? "*:%mode%*,-" + Clusters.REMOTE_CLUSTER_NAME + ":" + IndexMode.LOGSDB_COLUMNAR.getName() + "*"
+            ? "*:%mode%*," + Clusters.REMOTE_CLUSTER_NAME + ":-" + IndexMode.LOGSDB_COLUMNAR.getName() + "*"
             : "*:%mode%*";
         doTestFetchAll(fromAllQuery(indexPattern, """
             , _id, _ignored, _index_mode, _score, _source, _version

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -1154,16 +1154,21 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
                 yield nullValue();
             }
             case DATE_RANGE -> {
-                if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, Build.current().isSnapshot())) {
-                    if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, false) == false) {
-                        // Old snapshot nodes (before tech preview) returned inclusive upper bounds
-                        // without the +1 conversion added in DateRangeDocValuesLoader.
-                        yield anyOf(
-                            equalTo("1989-01-01T00:00:00.000Z..2025-01-01T00:00:00.000Z"),
-                            equalTo("1989-01-01T00:00:00.000Z..2024-12-31T23:59:59.999Z")
-                        );
-                    }
+                if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, false)) {
                     yield equalTo("1989-01-01T00:00:00.000Z..2025-01-01T00:00:00.000Z");
+                }
+                if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, true) && Build.current().isSnapshot()) {
+                    // On previous versions where DATE_RANGE was still under construction, we don't know
+                    // which exact historical shape an old/mixed-version node will emit: the buggy
+                    // formatted string (inclusive upper bound, no +1 conversion), the correctly
+                    // formatted string, or the raw, unformatted {gte, lte} doc value map (older
+                    // release builds never ran the snapshot-only formatting logic at all). Accept any
+                    // of them rather than guessing which one a given old build should produce.
+                    yield anyOf(
+                        equalTo("1989-01-01T00:00:00.000Z..2025-01-01T00:00:00.000Z"),
+                        equalTo("1989-01-01T00:00:00.000Z..2024-12-31T23:59:59.999Z"),
+                        matchesMap().entry("gte", "1989-01-01T00:00:00.000Z").entry("lte", "2024-12-31T23:59:59.999Z")
+                    );
                 }
                 yield nullValue();
             }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -1380,8 +1380,15 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
                 yield equalTo("unsupported");
             }
             case DATE_RANGE -> {
-                if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, Build.current().isSnapshot())) {
+                // Same dance as for AGGREGATE_METRIC_DOUBLE/DENSE_VECTOR: the coordinator that actually resolves the field type
+                // may be any node in the cluster (e.g. during a rolling upgrade), and IndexResolver's snapshot/release gating
+                // reflects that coordinator's own build, not this test JVM's. We can't tell from here which node coordinated, so
+                // once the type is merely under-construction-supported (not yet release-supported), accept either outcome.
+                if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, false)) {
                     yield equalTo("date_range");
+                }
+                if (DATE_RANGE.supportedVersion().supportedOn(minimumVersion, true) && Build.current().isSnapshot()) {
+                    yield anyOf(equalTo("date_range"), equalTo("unsupported"));
                 }
                 yield equalTo("unsupported");
             }


### PR DESCRIPTION
Handle release of `date_range` and `logsdb`.

Backport of #153321