### PR TITLE
[9.5] [ESQL] Skip read when external prune removes all files (#153946)

### DIFF
--- a/docs/changelog/153946.yaml
+++ b/docs/changelog/153946.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 153873
+pr: 153946
+summary: Skip read when external prune removes all files
+type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractExternalDataSourceIT.java
@@ -460,4 +460,23 @@ public abstract class AbstractExternalDataSourceIT extends AbstractEsqlIntegTest
         }
         return nodes;
     }
+
+    /**
+     * Every {@link AsyncExternalSourceOperator.Status} across the query's driver profiles. Lets a caller assert on the
+     * <em>real I/O</em> a scan performed (splits totalled, bytes read), not merely the post-prune profile counters —
+     * the two differ exactly when the read path scans files the pruning already eliminated. Requires
+     * {@code profile(true)}.
+     */
+    protected static List<AsyncExternalSourceOperator.Status> externalScanStatuses(EsqlQueryResponse response) {
+        assertThat("query must be run with profile(true) to inspect the external scan", response.profile(), notNullValue());
+        List<AsyncExternalSourceOperator.Status> statuses = new ArrayList<>();
+        for (var driver : response.profile().drivers()) {
+            for (var op : driver.operators()) {
+                if (op.status() instanceof AsyncExternalSourceOperator.Status status) {
+                    statuses.add(status);
+                }
+            }
+        }
+        return statuses;
+    }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPruningIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceOperator;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
@@ -29,8 +30,10 @@ import static org.elasticsearch.common.xcontent.ChunkedToXContent.wrapAsToXConte
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Verifies that filtering a Hive-partitioned external dataset on a partition column reads only the matching partition
@@ -215,6 +218,49 @@ public class ExternalHivePartitionPruningIT extends AbstractExternalDataSourceIT
 
     public void testParquetZeroMatchPrunesToNoFiles() throws Exception {
         assertPrune("pq_zero", "parquet", "WHERE year == 2099", 0, idsWhere((y, m, d) -> y == 2099));
+    }
+
+    /**
+     * Perf guard for elastic/elasticsearch#153873: a partition filter that prunes <em>every</em> file must make the
+     * read path scan nothing, not read the whole dataset only to drop every row in a downstream row filter. The
+     * {@code files_scanned == 0} the tests above assert does not prove this on its own — that counter reports
+     * <em>survivors</em>, so it was already {@code 0} before the fix while the scan operator still opened all
+     * {@link #TOTAL_FILES} files. This pins the real I/O the operator performed: no split total and no bytes read,
+     * asserted on both the {@code round_robin} and {@code coordinator_only} distribution strategies (a fully-pruned
+     * query short-circuits to coordinator-local under either, so the swap must reach both paths).
+     */
+    public void testZeroMatchPruneReadsNothing() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        for (String distribution : List.of("round_robin", "coordinator_only")) {
+            String dataset = registerTree("csv_prune_io_" + distribution, "csv");
+
+            QueryPragmas pragmas = new QueryPragmas(
+                Settings.builder().put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), distribution).build()
+            );
+            var request = syncEsqlQueryRequest("FROM " + dataset + " | WHERE year == 1999 | KEEP id");
+            request.pragmas(pragmas);
+            request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+            request.profile(true);
+
+            try (var response = run(request)) {
+                assertThat("[" + distribution + "] a zero-match partition filter must return no rows", getValuesList(response), empty());
+                assertThat(
+                    "[" + distribution + "] the pruned-away files must not be scanned",
+                    response.getExecutionInfo().queryProfile().filesScanned(),
+                    equalTo(0)
+                );
+                List<AsyncExternalSourceOperator.Status> statuses = externalScanStatuses(response);
+                assertThat(
+                    "[" + distribution + "] the scan operator must run so its zero-I/O can be asserted (not vacuously skipped)",
+                    statuses,
+                    not(empty())
+                );
+                for (AsyncExternalSourceOperator.Status status : statuses) {
+                    assertEquals("[" + distribution + "] exhaustively-pruned read must total no splits", 0, status.splitsTotal());
+                    assertEquals("[" + distribution + "] exhaustively-pruned read must read no bytes", 0L, status.bytesRead());
+                }
+            }
+        }
     }
 
     // -- NOT-EQUALS on a partition column: prunes the excluded folder, keeps the rest --

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -241,6 +241,10 @@ public class FileSplitProvider implements SplitProvider {
 
         // Phase 1: sequential filtering — cheap, in-memory predicates applied per file to
         // build the list of FileTask items that need I/O (footer reads, boundary scans).
+        // Tracks whether any file was dropped by the row-count-unsafe no-column-overlap heuristic:
+        // such a file still contributes rows to COUNT(*), so an all-dropped result driven by it is
+        // NOT an exhaustive prune and must fall back to a full read (see SplitDiscoveryResult).
+        boolean droppedByColumnOverlap = false;
         List<FileTask> tasks = new ArrayList<>(fileList.fileCount());
         for (int i = 0; i < fileList.fileCount(); i++) {
             StoragePath filePath = fileList.path(i);
@@ -265,6 +269,10 @@ public class FileSplitProvider implements SplitProvider {
 
             if (fileBackedQuerySchema.isEmpty() == false && fileSchemaInfo != null) {
                 if (skipIfNoColumnOverlap(fileSchemaInfo.fileSchema(), fileBackedQuerySchema)) {
+                    // Row-count-unsafe: the file's rows still exist (they would be all-NULL for the query's
+                    // columns), so COUNT(*) and other row-count-sensitive queries need them. Skipping is a
+                    // best-effort optimization that relies on a full-read fallback when it empties the plan.
+                    droppedByColumnOverlap = true;
                     continue;
                 }
             }
@@ -340,7 +348,11 @@ public class FileSplitProvider implements SplitProvider {
         }
 
         if (tasks.isEmpty()) {
-            return SplitDiscoveryResult.EMPTY;
+            // Every file was dropped. Only a resolved, non-empty file list whose files were all removed by
+            // row-count-preserving filter contradictions (no no-overlap heuristic among them) is a true
+            // exhaustive prune the phase may trust to read nothing; otherwise fall back to a full read.
+            boolean exhaustivelyPruned = fileList.fileCount() > 0 && droppedByColumnOverlap == false;
+            return new SplitDiscoveryResult(List.of(), 0, exhaustivelyPruned);
         }
 
         // Phase 2: I/O-bound split discovery — parallelize when executor is available.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -301,6 +301,14 @@ public final class SplitDiscoveryPhase {
         }
         List<ExternalSplit> splits = result.splits();
         if (splits.isEmpty()) {
+            // No splits because every file was eliminated by a row-count-preserving filter contradiction (see
+            // SplitDiscoveryResult#exhaustivelyPruned). Swap in FileList.EMPTY so the read path scans nothing; a row
+            // filter still runs downstream, so the answer is unchanged (0 rows). An empty result that is NOT an
+            // exhaustive prune (unresolved glob, SINGLE source, or a row-count-unsafe no-overlap drop) falls through
+            // to the whole read. Return before the stats increments below to keep honest zero scanned counts.
+            if (result.exhaustivelyPruned()) {
+                return exec.withFileList(FileList.EMPTY);
+            }
             return exec;
         }
         stats.filesScanned += result.filesScanned();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryResult.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryResult.java
@@ -20,13 +20,28 @@ import java.util.List;
  * {@link ExternalSplit#estimatedSizeInBytes()}, excluding splits that report an unknown size) —
  * are derived by {@code SplitDiscoveryPhase} from the {@link #splits()} list, so they are not
  * carried here.
+ *
+ * <p>{@code exhaustivelyPruned} is {@code true} only when {@link #splits()} is empty <em>because</em>
+ * every file was eliminated by a row-count-preserving filter contradiction — a partition/metadata
+ * predicate that evaluated to {@code false}, or a filter over a column absent from the file (both
+ * make the {@code WHERE} unsatisfiable, so a full read would emit zero rows too). It is deliberately
+ * {@code false} when the empty result is a best-effort heuristic that a downstream read would have
+ * disagreed with (e.g. a file dropped for having no column overlap with the query still contributes
+ * rows to {@code COUNT(*)}). Only the former is safe for {@code SplitDiscoveryPhase} to trust as
+ * "read nothing"; the latter must fall back to a full read so the row filter runs. An empty result
+ * from an unresolved or empty file list is not a prune and reports {@code false}.
  */
-public record SplitDiscoveryResult(List<ExternalSplit> splits, int filesScanned) {
+public record SplitDiscoveryResult(List<ExternalSplit> splits, int filesScanned, boolean exhaustivelyPruned) {
 
-    public static final SplitDiscoveryResult EMPTY = new SplitDiscoveryResult(List.of(), 0);
+    public static final SplitDiscoveryResult EMPTY = new SplitDiscoveryResult(List.of(), 0, false);
 
     public SplitDiscoveryResult {
         splits = List.copyOf(splits);
+    }
+
+    /** Splits with the given {@code filesScanned}; not an exhaustive prune (there are splits to read). */
+    public SplitDiscoveryResult(List<ExternalSplit> splits, int filesScanned) {
+        this(splits, filesScanned, false);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelation.java
@@ -413,4 +413,23 @@ public class ExternalRelation extends LeafPlan implements ExecutesOn.Coordinator
             declaredReadSpec
         );
     }
+
+    /**
+     * Returns a copy of this relation with its {@link #fileList()} replaced. Used by the fragment discovery path to
+     * swap in {@link FileList#EMPTY} when coordinator-side split discovery prunes every file, so the read path scans
+     * nothing instead of reading the whole dataset only to have a downstream row filter drop every row.
+     */
+    public ExternalRelation withFileList(FileList newFileList) {
+        return new ExternalRelation(
+            source(),
+            sourcePath,
+            metadata,
+            output,
+            newFileList,
+            schemaMap,
+            datasetName,
+            metadataFields,
+            declaredReadSpec
+        );
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -70,6 +70,7 @@ import org.elasticsearch.xpack.esql.datasources.SplitDiscoveryPhase;
 import org.elasticsearch.xpack.esql.datasources.SplitStats;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.enrich.LookupFromIndexService;
@@ -320,14 +321,19 @@ public class ComputeService {
         EsqlExecutionInfo execInfo,
         BooleanSupplier isCancelled
     ) {
-        List<ExternalSplit> externalSplits = collectExternalSplits(plan, configuration, execInfo, isCancelled);
+        CollectedSplits collected = collectExternalSplits(plan, configuration, execInfo, isCancelled);
+        // Fragment-path discovery may have rewritten exhaustively-pruned relations to FileList.EMPTY; use the
+        // rewritten plan from here on so the empty-splits (coordinator-local) and distributed paths both read nothing
+        // for those relations instead of scanning the whole dataset only to have a downstream row filter drop it all.
+        PhysicalPlan resolvedPlan = collected.plan();
+        List<ExternalSplit> externalSplits = collected.splits();
         if (externalSplits.isEmpty()) {
-            return new ExternalDistributionResult(collapseExternalSourceExchanges(plan), null, List.of());
+            return new ExternalDistributionResult(collapseExternalSourceExchanges(resolvedPlan), null, List.of());
         }
 
         ExternalDistributionStrategy strategy = resolveExternalDistributionStrategy(configuration.pragmas());
         ExternalDistributionContext context = new ExternalDistributionContext(
-            plan,
+            resolvedPlan,
             externalSplits,
             clusterService.state().nodes(),
             configuration.pragmas()
@@ -341,11 +347,14 @@ public class ComputeService {
                 externalSplits.size(),
                 distributionPlan.nodeAssignments().size()
             );
-            return new ExternalDistributionResult(plan, distributionPlan, List.of());
+            return new ExternalDistributionResult(resolvedPlan, distributionPlan, List.of());
         }
 
-        return new ExternalDistributionResult(collapseExternalSourceExchanges(plan), null, externalSplits);
+        return new ExternalDistributionResult(collapseExternalSourceExchanges(resolvedPlan), null, externalSplits);
     }
+
+    /** Bundles the (possibly rewritten) plan produced by split discovery with the splits collected from it. */
+    private record CollectedSplits(PhysicalPlan plan, List<ExternalSplit> splits) {}
 
     record ExternalDistributionResult(PhysicalPlan plan, ExternalDistributionPlan distributionPlan, List<ExternalSplit> coordinatorSplits) {
         boolean isDistributed() {
@@ -353,7 +362,7 @@ public class ComputeService {
         }
     }
 
-    private List<ExternalSplit> collectExternalSplits(
+    private CollectedSplits collectExternalSplits(
         PhysicalPlan plan,
         Configuration configuration,
         EsqlExecutionInfo execInfo,
@@ -365,7 +374,8 @@ public class ComputeService {
         // ExternalRelation in a FragmentExec (handled by discoverSplitsFromFragments below), while the
         // LocalMapper lowers each one to a physical ExternalSourceExec. Splits already attached to a
         // top-level ExternalSourceExec were accounted for by discoverSplits, so only the fragment path
-        // needs to record scan stats here.
+        // needs to record scan stats here. On that top-level path the phase already swapped any
+        // exhaustively-pruned ExternalSourceExec to FileList.EMPTY, so the plan is returned unchanged here.
         plan.forEachDown(ExternalSourceExec.class, exec -> splits.addAll(exec.splits()));
         if (splits.isEmpty()) {
             if (canSkipSplitDiscovery(plan, formatReaderRegistry)) {
@@ -374,7 +384,7 @@ public class ComputeService {
                 // here, the one place it is observable — no scan operator runs for a warm relation.
                 recordExternalWarmAggregates(execInfo, plan);
             } else {
-                discoverSplitsFromFragments(plan, splits, maxRecordBytes(configuration), execInfo, isCancelled);
+                PhysicalPlan rewritten = discoverSplitsFromFragments(plan, splits, maxRecordBytes(configuration), execInfo, isCancelled);
                 if (splits.size() > SplitCoalescer.COALESCING_THRESHOLD) {
                     List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
                     if (coalesced != splits) {
@@ -382,10 +392,11 @@ public class ComputeService {
                         splits.addAll(coalesced);
                     }
                 }
+                return new CollectedSplits(rewritten, splits);
             }
             // else: splits stays empty — the optimizer will use sourceMetadata for pushdown
         }
-        return splits;
+        return new CollectedSplits(plan, splits);
     }
 
     /**
@@ -506,7 +517,7 @@ public class ComputeService {
         );
     }
 
-    private void discoverSplitsFromFragments(
+    private PhysicalPlan discoverSplitsFromFragments(
         PhysicalPlan plan,
         List<ExternalSplit> splits,
         int maxRecordBytes,
@@ -514,9 +525,14 @@ public class ComputeService {
         BooleanSupplier isCancelled
     ) {
         if (operatorFactoryRegistry == null) {
-            return;
+            return plan;
         }
-        plan.forEachDown(FragmentExec.class, fragment -> {
+        return plan.transformDown(FragmentExec.class, fragment -> {
+            // Relations whose coordinator-side discovery pruned every file. Their fragment must be rewritten to read
+            // FileList.EMPTY so the operator scans nothing; a downstream row filter still runs, so the answer (0 rows)
+            // is unchanged. Identity is stable because guardedRelations returns the relation instances living in the
+            // fragment tree, so the transformDown below can swap them by reference.
+            List<ExternalRelation> exhaustivelyPruned = new ArrayList<>();
             // Each relation is discovered with the Filter conjuncts that guard it inside the fragment. Lowering a
             // relation to a standalone ExternalSourceExec drops the surrounding plan, so those conjuncts have to be
             // recovered before the lowering or partition pruning never sees the predicate at all.
@@ -530,9 +546,28 @@ public class ComputeService {
                 );
                 if (result.plan() instanceof ExternalSourceExec withSplits) {
                     splits.addAll(withSplits.splits());
+                    // The phase swaps an exhaustively-pruned source's fileList to FileList.EMPTY (its authoritative,
+                    // row-count-safe verdict). Detect that swap by identity and propagate it into the fragment's logical
+                    // relation so coordinator-local execution reads nothing; a downstream row filter still runs, so the
+                    // answer (0 rows) is unchanged.
+                    if (withSplits.fileList() == FileList.EMPTY) {
+                        exhaustivelyPruned.add(guarded.relation());
+                    }
                 }
                 recordExternalScanStats(execInfo, result);
             }
+            if (exhaustivelyPruned.isEmpty()) {
+                return fragment;
+            }
+            LogicalPlan rewrittenFragment = fragment.fragment().transformDown(ExternalRelation.class, relation -> {
+                for (ExternalRelation pruned : exhaustivelyPruned) {
+                    if (relation == pruned) {
+                        return relation.withFileList(FileList.EMPTY);
+                    }
+                }
+                return relation;
+            });
+            return fragment.withFragment(rewrittenFragment);
         });
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -158,6 +158,54 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals(1, result.splits().size());
     }
 
+    /**
+     * The signal the coordinator relies on to swap in {@link FileList#EMPTY}: when a partition filter prunes every
+     * file of a resolved, non-empty fileList, {@link FileSplitProvider} emits zero splits, reports
+     * {@code filesScanned == 0}, and flags the result {@code exhaustivelyPruned} — because the files were removed by a
+     * row-count-preserving filter contradiction, so a full read would emit zero rows too.
+     */
+    public void testAllPartitionsPrunedYieldsNoSplitsAndExhaustivePrune() {
+        StoragePath path2024 = StoragePath.of("s3://b/year=2024/file.parquet");
+        StoragePath path2023 = StoragePath.of("s3://b/year=2023/file.parquet");
+        FileList fileList = GlobExpander.fileListOf(
+            List.of(new StorageEntry(path2024, 100, Instant.EPOCH), new StorageEntry(path2023, 200, Instant.EPOCH)),
+            "s3://b/year=*/*.parquet"
+        );
+        PartitionMetadata partitions = new PartitionMetadata(
+            Map.of("year", DataType.INTEGER),
+            Map.of(path2024, Map.of("year", 2024), path2023, Map.of("year", 2023))
+        );
+        // No file carries year == 1999, so every partition is pruned.
+        Expression filter = new Equals(SRC, fieldAttr("year"), intLiteral(1999));
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), partitions, List.of(filter));
+        SplitDiscoveryResult result = provider.discoverSplits(ctx);
+
+        assertTrue("a zero-match partition filter must prune every file", result.splits().isEmpty());
+        assertEquals("filesScanned reports survivors only, so it must be 0 when nothing survives", 0, result.filesScanned());
+        assertTrue("a filter-contradiction prune of a resolved, non-empty fileList is exhaustive", result.exhaustivelyPruned());
+        assertTrue("the fileList itself is still resolved and non-empty", fileList.isResolved() && fileList.fileCount() > 0);
+    }
+
+    /**
+     * An unresolved or already-empty fileList yields zero splits, but that is NOT an exhaustive prune: there is
+     * nothing to read anyway (empty) or the listing happens at runtime (unresolved), so the coordinator must not
+     * treat it as "pruned to nothing" and swap in {@link FileList#EMPTY}.
+     */
+    public void testEmptyOrUnresolvedFileListIsNotExhaustivePrune() {
+        SplitDiscoveryContext empty = new SplitDiscoveryContext(null, FileList.EMPTY, Map.of(), PartitionMetadata.EMPTY, List.of());
+        assertFalse("an already-empty fileList is not an exhaustive prune", provider.discoverSplits(empty).exhaustivelyPruned());
+
+        SplitDiscoveryContext unresolved = new SplitDiscoveryContext(
+            null,
+            FileList.UNRESOLVED,
+            Map.of(),
+            PartitionMetadata.EMPTY,
+            List.of()
+        );
+        assertFalse("an unresolved fileList is not an exhaustive prune", provider.discoverSplits(unresolved).exhaustivelyPruned());
+    }
+
     public void testFilesScannedZeroForEmptyOrUnresolved() {
         SplitDiscoveryContext empty = new SplitDiscoveryContext(null, FileList.EMPTY, Map.of(), PartitionMetadata.EMPTY, List.of());
         assertEquals(0, provider.discoverSplits(empty).filesScanned());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -223,6 +223,109 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         assertEquals(0L, result.bytesScanned());
     }
 
+    /**
+     * Exhaustive prune: a resolved, non-empty fileList whose split discovery yields nothing (every file pruned) must
+     * have its {@link ExternalSourceExec} swapped to read {@link FileList#EMPTY}, so the read path scans nothing
+     * instead of reading the whole dataset only to drop every row in a downstream filter. Stats stay honestly zero.
+     */
+    public void testExhaustivelyPrunedResolvedFileListSwappedToEmpty() {
+        FileList fileList = createFileList(3); // resolved, non-empty
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        // A provider that exhaustively prunes: zero splits out, reported as a row-count-safe prune.
+        Map<String, ExternalSourceFactory> factories = Map.of(
+            "parquet",
+            testFactory(new FixedSplitProvider(new SplitDiscoveryResult(List.of(), 0, true)))
+        );
+
+        SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+        );
+
+        assertTrue(result.plan() instanceof ExternalSourceExec);
+        ExternalSourceExec resolved = (ExternalSourceExec) result.plan();
+        assertSame("an exhaustively-pruned resolved fileList must be swapped to FileList.EMPTY", FileList.EMPTY, resolved.fileList());
+        assertTrue(resolved.splits().isEmpty());
+        assertEquals(0, result.filesScanned());
+        assertEquals(0, result.splitsScanned());
+        assertEquals(0L, result.bytesScanned());
+    }
+
+    /**
+     * Empty splits are NOT enough to swap: when the provider reports the empty result is not an exhaustive prune
+     * (e.g. files were dropped by the row-count-unsafe no-column-overlap heuristic, whose rows a {@code COUNT(*)}
+     * still needs), the source must fall through unchanged to the whole read so the row filter runs.
+     */
+    public void testEmptySplitsNotExhaustivelyPrunedNotSwapped() {
+        FileList fileList = createFileList(3); // resolved, non-empty
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        // Zero splits, but explicitly NOT an exhaustive prune.
+        Map<String, ExternalSourceFactory> factories = Map.of(
+            "parquet",
+            testFactory(new FixedSplitProvider(new SplitDiscoveryResult(List.of(), 0, false)))
+        );
+
+        PhysicalPlan result = SplitDiscoveryPhase.resolveExternalSplits(exec, factories);
+
+        assertSame("a non-exhaustive empty result must fall through unchanged, not be swapped to EMPTY", exec, result);
+        assertSame("the resolved fileList must be preserved for the whole read", fileList, ((ExternalSourceExec) result).fileList());
+    }
+
+    /**
+     * An unresolved fileList (glob not yet expanded — resolved and read at runtime) must NOT be swapped when discovery
+     * returns no splits: there is nothing to prune yet, and swapping to EMPTY would make the source read nothing at
+     * all. It falls through unchanged to the runtime whole-fileList read.
+     */
+    public void testUnresolvedFileListNotSwappedOnEmptySplits() {
+        ExternalSourceExec exec = createExternalSourceExec(FileList.UNRESOLVED, "parquet");
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(new RecordingSplitProvider()));
+
+        PhysicalPlan result = SplitDiscoveryPhase.resolveExternalSplits(exec, factories);
+
+        assertSame("an unresolved fileList must fall through unchanged, not be swapped to EMPTY", exec, result);
+        assertSame(FileList.UNRESOLVED, ((ExternalSourceExec) result).fileList());
+    }
+
+    /**
+     * A non-splitting SINGLE/connector source (no resolved fileList, carries {@link FileList#UNRESOLVED} in
+     * production) returns empty splits by design and must be left untouched — the whole-read at runtime is the
+     * intended behavior, not an exhaustive prune.
+     */
+    public void testSingleProviderLeavesUnresolvedFileListUnchanged() {
+        ExternalSourceExec exec = createExternalSourceExec(FileList.UNRESOLVED, "unknown_type");
+
+        PhysicalPlan result = SplitDiscoveryPhase.resolveExternalSplits(exec, Map.of());
+
+        assertSame("SINGLE provider on an unresolved fileList must not be swapped to EMPTY", exec, result);
+    }
+
+    /**
+     * An already-empty glob ({@link FileList#EMPTY}, {@code fileCount() == 0}) reads nothing regardless, so the
+     * {@code fileCount() > 0} guard leaves it untouched — no redundant swap.
+     */
+    public void testAlreadyEmptyFileListNotReswapped() {
+        ExternalSourceExec exec = createExternalSourceExec(FileList.EMPTY, "parquet");
+        Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(new RecordingSplitProvider()));
+
+        PhysicalPlan result = SplitDiscoveryPhase.resolveExternalSplits(exec, factories);
+
+        assertSame("an already-empty glob needs no swap", exec, result);
+    }
+
+    /** {@link ExternalRelation#withFileList} swaps only the fileList, preserving the rest of the relation. */
+    public void testExternalRelationWithFileListSwapsOnlyFileList() {
+        ExternalRelation relation = externalRelation();
+        assertSame(FileList.UNRESOLVED, relation.fileList());
+
+        ExternalRelation swapped = relation.withFileList(FileList.EMPTY);
+
+        assertSame(FileList.EMPTY, swapped.fileList());
+        assertEquals(relation.sourcePath(), swapped.sourcePath());
+        assertEquals(relation.output(), swapped.output());
+        assertEquals(relation.metadata(), swapped.metadata());
+    }
+
     public void testFilterExecAboveExternalSourceCollectsFilters() {
         FileList fileList = createFileList(2);
         ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
@@ -508,6 +611,20 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         public SplitDiscoveryResult discoverSplits(SplitDiscoveryContext context) {
             this.lastContext = context;
             return SplitDiscoveryResult.EMPTY;
+        }
+    }
+
+    /** Returns a fixed {@link SplitDiscoveryResult}, so a test can pin the phase's reaction to a specific result. */
+    private static class FixedSplitProvider implements SplitProvider {
+        private final SplitDiscoveryResult result;
+
+        FixedSplitProvider(SplitDiscoveryResult result) {
+            this.result = result;
+        }
+
+        @Override
+        public SplitDiscoveryResult discoverSplits(SplitDiscoveryContext context) {
+            return result;
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ESQL] Skip read when external prune removes all files (#153946)