### PR TITLE
Change SML index prefix to .ai-index-*

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -716,10 +716,15 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // For connectors telemetry. Will be removed once we switched to connectors API
                 RoleDescriptor.IndicesPrivileges.builder().indices(".elastic-connectors*").privileges("read").build(),
+                // (Legacy. Will be removed after SML swaps to the below .ai-index* pattern
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".context-idx-sml-data", ".context-idx-sml-data-*")
+                    .privileges("all")
+                    .build(),
                 // Context Engine's SML storage. A regular (non-system) index that Kibana
                 // creates and manages itself at startup, including its alias.
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".context-idx-sml-data", ".context-idx-sml-data-*")
+                    .indices(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-*")
                     .privileges("all")
                     .build(),
                 // Significant events. Kibana system user manages index plumbing and document access.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -716,7 +716,7 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // For connectors telemetry. Will be removed once we switched to connectors API
                 RoleDescriptor.IndicesPrivileges.builder().indices(".elastic-connectors*").privileges("read").build(),
-                // (Legacy. Will be removed after SML swaps to the below .ai-index* pattern
+                // TODO: Remove after SML swaps to the below .ai-index* pattern
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".context-idx-sml-data", ".context-idx-sml-data-*")
                     .privileges("all")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1279,7 +1279,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Context Engine's SML storage: a regular (non-system) index that Kibana
         // creates and manages itself, including its alias.
-        Arrays.asList(".context-idx-sml-data", ".context-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+        Arrays.asList(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
             .forEach(index -> assertReadWriteAndManage(kibanaRole, index));
 
         // Agent Builder OTLP telemetry (traces + logs from span events)


### PR DESCRIPTION
Follow up on https://github.com/elastic/elasticsearch/pull/153525, we've decided to change the index prefix to `.ai-index-*` instead of `.context-*`. 

Leaves the old pattern in the role descriptor, temporarily, so that local development doesn't break before the corresponding Kibana change can get in.

