### PR TITLE
[DOCS] Preview Elasticsearch release notes

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -144,6 +144,7 @@ pivot:
     Packaging: ":Delivery/Packaging"
     Percolator: ":Search Relevance/Percolator"
     Performance: ":Performance"
+    PromQL: ":SearchOrg/PromQL"
     "Query languages": ":Query Languages/EQL, :Query Languages/SQL"
     Ranking: ":Search Relevance/Ranking"
     Recovery: ":Distributed Indexing/Recovery"

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -304,6 +304,7 @@ bundle:
   repo: elasticsearch
   # Optional: default GitHub owner applied to all profiles that do not specify their own.
   owner: elastic
+  branch: main
   # PR/issue link allowlist: when set (including []), only links to these owner/repo pairs are kept
   # in bundle output; others are rewritten to '# PRIVATE:' sentinels (requires resolve: true).
   link_allow_repos:
@@ -312,12 +313,13 @@ bundle:
     - elastic/kibana
     - elastic/roadmap
   # Optional: control auto-population of release-date for all profiles by default.
-  release_dates: false
+  release_dates: true
   # Optional: default description text for bundles. Supports {version}, {lifecycle}, {owner}, and {repo} placeholders.
   # Use YAML literal block scalar (|) for multiline descriptions. See docs/contribute/changelog.md for examples.
   # description: |
   #   Download the release binaries: https://github.com/{owner}/{repo}/releases/tag/v{version}
-  #   
+  #
+  # use_local_changelogs: true
 
   # Named bundle profiles for different release scenarios.
   # Profiles can be used with both 'changelog bundle' and 'changelog remove':
@@ -332,7 +334,7 @@ bundle:
     #   # Filter: which input changelogs to include ({version} and {lifecycle} are substituted at runtime)
     #   products: "elasticsearch {version} {lifecycle}"
     #   # Output filename ({version} is substituted at runtime)
-      output: "elasticsearch-{version}.yaml"
+      output: "elasticsearch/elasticsearch-{version}.yaml"
     #   # Optional: override the products array written to the bundle output.
       output_products: "elasticsearch {version}"
     #   # Optional: profile-specific description (overrides bundle.description)
@@ -341,7 +343,7 @@ bundle:
 
     # Example: Serverless release profile (filter by promotion report, PR, or issue list)
     serverless-release:
-      output: "serverless-{version}.yaml"
+      output: "cloud-serverless/elasticsearch-{version}.yaml"
       output_products: "cloud-serverless {version}"
     #   # Feature IDs to hide when bundling with this profile (accepts string or list)
     #   hide_features:

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,12 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 
 % ## Next version [elasticsearch-nextversion-breaking-changes]
 
+:::{changelog} /releases/elasticsearch
+:config: /changelog.yml
+:type: breaking-change
+:subsections:
+:::
+
 ## 9.4.3 [elasticsearch-9.4.3-breaking-changes]
 
 There are no breaking changes associated with this release.

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -16,6 +16,12 @@ To give you insight into what deprecated features you’re using, {{es}}:
 
 % ## Next version [elasticsearch-nextversion-deprecations]
 
+:::{changelog} /releases/elasticsearch
+:config: /changelog.yml
+:type: deprecation
+:subsections:
+:::
+
 ## 9.4.3 [elasticsearch-9.4.3-deprecations]
 
 There are no deprecations associated with this release.

--- a/docs/release-notes/highlights.md
+++ b/docs/release-notes/highlights.md
@@ -1,0 +1,14 @@
+---
+navigation_title: "Highlights"
+---
+
+# {{es}} release highlights [elasticsearch-release-highlights]
+
+
+:::{changelog} /releases/elasticsearch
+:config: /changelog.yml
+:type: highlight
+:subsections:
+:dropdowns:
+:description-visibility: keep-descriptions
+:::

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,11 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-next-fixes]
 % *
 
+:::{changelog} /releases/elasticsearch
+:config: /changelog.yml
+:subsections:
+:::
+
 ## 9.4.3 [elasticsearch-9.4.3-release-notes]
 
 ### Features and enhancements [elasticsearch-9.4.3-features-enhancements]

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -8,6 +8,11 @@ mapped_pages:
 
 Known issues are significant defects or limitations that may impact your implementation. These issues are actively being worked on and will be addressed in a future release. Review the Elasticsearch known issues to help you make informed decisions, such as upgrading to a new version.
 
+:::{changelog} /releases/elasticsearch
+:config: /changelog.yml
+:type: known-issue
+:::
+
 ## 9.3.6 [elasticsearch-9.3.6-known-issues]
 
 * The [create trained model API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-trained-model) enforces overly restrictive input limits that may reject valid requests. Version 9.3.6 introduced caps on `description`, `tags`, `prefix_strings.ingest_prefix`, `prefix_strings.search_prefix`, `input.field_names`, `default_field_map` and `metadata`. These limits are too low for some existing use cases.

--- a/docs/release-notes/toc.yml
+++ b/docs/release-notes/toc.yml
@@ -1,5 +1,6 @@
 toc:
   - file: index.md
+  - file: highlights.md
   - file: known-issues.md
   - file: breaking-changes.md
   - file: deprecations.md

--- a/docs/releases/elasticsearch/elasticsearch-9.5.0.yaml
+++ b/docs/releases/elasticsearch/elasticsearch-9.5.0.yaml
@@ -1,0 +1,8834 @@
+products:
+- product: elasticsearch
+  target: 9.5.0
+  repo: elasticsearch
+  owner: elastic
+release-date: 2026-07-15
+entries:
+- file:
+    name: 148287.yaml
+    checksum: 166b4e3a2d93c2123e2387839ae78f94db3b67d0
+  type: enhancement
+  title: Tuned AVX-512 int4 dot product implementations (~20% gain)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148287
+- file:
+    name: 153074.yaml
+    checksum: f5f9ebe181fedaecc4ed42d0e0be3fe3523c0fcb
+  type: enhancement
+  title: Fix external text-read drain deadlock
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153074
+- file:
+    name: 151767.yaml
+    checksum: ab591ceea5e4952539a88633411a3d366ae9a194
+  type: feature
+  title: Support keyword/text in TOP(field,...,outputField)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151767
+  issues:
+  - "151751"
+- file:
+    name: 151337.yaml
+    checksum: dbc934f43dbb9e002a294078e93b846e6769f9f8
+  type: enhancement
+  title: 'Painless: `script_aware` Stream.collect(Collector) and primitive `forEachRema...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151337
+- file:
+    name: 149642.yaml
+    checksum: 400e29b0f80b27ec30b0d7f1106ac7058c2e57ec
+  type: enhancement
+  title: Make DOC partitioning universally applicable
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149642
+- file:
+    name: 148680.yaml
+    checksum: e9a50a804f5e7df2a27e596f9d59d4e279dcd6ec
+  type: enhancement
+  title: Fast paths for prefix/suffix/contains `LIKE` patterns (SIMD substring search...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148680
+- file:
+    name: 149992.yaml
+    checksum: c42d1ecfbf9b5bc9d98b9161603a17162e33c891
+  type: enhancement
+  title: 'ES|QL|DS: ndjson - avoid String allocation in KEYWORD value decoder'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149992
+- file:
+    name: 150475.yaml
+    checksum: fc705dfdb20eb059fad350cf446efdf89a0df643
+  type: bug-fix
+  title: Fix `date_range` encoding/decoding in TopN
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150475
+  issues:
+  - "150383"
+- file:
+    name: 149592.yaml
+    checksum: a90357591e5d740ca36034e5ab89a0faac942ea2
+  type: enhancement
+  title: Per-query nullability for partition columns on external sources
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149592
+- file:
+    name: 150834.yaml
+    checksum: c7174c4d470685bce1806058313b03fccb7ee9a8
+  type: bug-fix
+  title: Preserve `dimensions_set_by_user` for SageMaker text embeddings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150834
+  issues:
+  - "146881"
+- file:
+    name: 151399.yaml
+    checksum: 633daa01e6cc55dbc6155ce657ca3c6805674f69
+  type: bug-fix
+  title: Retry datafeed STARTED state write on system reassignment
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151399
+- file:
+    name: 148439.yaml
+    checksum: ef9bc27900cde6275dbf4afd19f3da1d1a5962d1
+  type: enhancement
+  title: Two-phase I/O for Parquet on remote storage
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148439
+- file:
+    name: 150009.yaml
+    checksum: b70e88ddcb041ed188c3de08c49ad54d9a3410ac
+  type: enhancement
+  title: 'ES|QL: default CSV/TSV `multi_value_syntax` to `none` (RFC 4180-compliant; fa...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150009
+- file:
+    name: 146077.yaml
+    checksum: 1a9c1eab34406e6a46a3c2488ec5b4b9ffd1dc26
+  type: enhancement
+  title: Implement bucket metadata
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146077
+  issues:
+  - "138146"
+- file:
+    name: 152171.yaml
+    checksum: e106a36b210d139f61717878691ff90ea4cf3c7e
+  type: enhancement
+  title: 'PromQL: Add basic support for native (exponential) histograms'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  description: >-
+    You can now query exponential_histogram fields with PromQL syntax for native histograms.
+
+    The supported functions are `increase()`, `sum()`, `histogram_quantile()`, `histogram_avg()`, `histogram_count()` and `histogram_sum()`.
+  highlight: true
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152171
+  issues:
+  - "150074"
+- file:
+    name: 148086.yaml
+    checksum: 6d6d1945b07d58c8972f664369857366d739e88a
+  type: enhancement
+  title: Skip split discovery for aggregate pushdown
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148086
+- file:
+    name: 148340.yaml
+    checksum: ab2549597a310bc79e36d3304433b19a29dc8f60
+  type: enhancement
+  title: Enable multiple items per content object for Elastic service
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148340
+- file:
+    name: 149506.yaml
+    checksum: ce463d0b7f9de118d6a5b32f5037f0c427846c74
+  type: enhancement
+  title: Stop retrying shard requests on replicas for non-retriable errors
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149506
+  issues:
+  - "72349"
+- file:
+    name: 147148.yaml
+    checksum: 937368d2eb145d08d3f859b9713e2c31b7e6e8f4
+  type: bug-fix
+  title: Fix Windows path separators in fixture loading
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147148
+  issues:
+  - "147015"
+  - "147012"
+  - "147013"
+  - "147027"
+  - "147029"
+  - "147036"
+  - "147037"
+  - "147040"
+  - "146982"
+  - "147046"
+  - "146983"
+  - "147044"
+  - "147050"
+  - "147051"
+  - "147048"
+  - "146985"
+  - "147049"
+  - "146990"
+  - "146991"
+  - "147055"
+  - "147053"
+  - "146993"
+  - "146999"
+  - "146997"
+  - "147000"
+  - "147001"
+  - "147006"
+  - "147007"
+  - "147004"
+- file:
+    name: 148028.yaml
+    checksum: 51785f2a4f313fabbec550264261a4c57e05cb1c
+  type: enhancement
+  title: Add remote fetch transport and context-retention plumbing
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148028
+- file:
+    name: 150048.yaml
+    checksum: ef4a01430ee8a4e98690d1a772aba9d0feda95db
+  type: enhancement
+  title: Extract CSV record splitter
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150048
+- file:
+    name: 148881.yaml
+    checksum: c9ae3027e3b7d2ba6d4f5fd11c6837244cc37b2a
+  type: enhancement
+  title: Reduce the amount of memory used by `TranslogReplicator#BlobTranslogFile`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Engine
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148881
+- file:
+    name: 148497.yaml
+    checksum: 08cbe761449421ab58f03bd23d3e3123df25029b
+  type: enhancement
+  title: Support `-remote:index`-style exclusion syntax
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - CCS
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148497
+- file:
+    name: 146870.yaml
+    checksum: af79510c59e4daa18e7bc83200f0912c0de0bc1e
+  type: enhancement
+  title: Allow appending synonyms to existing rules via append=true (default false)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Analysis
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146870
+  issues:
+  - "146864"
+- file:
+    name: 149005.yaml
+    checksum: 40c82678135d9c5fe4d17c89fa34a65ad306273c
+  type: enhancement
+  title: Support form encoded REST bodies for authenticated requests
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Infra/REST API
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149005
+- file:
+    name: 148585.yaml
+    checksum: 9ccd3c3d1c404bacd8995b1b916911341180c636
+  type: bug-fix
+  title: Honor `?` wildcard for `constant_keyword` wildcard query
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148585
+  issues:
+  - "141785"
+- file:
+    name: 152864.yaml
+    checksum: 51df2346cfe36506532354941ee9aa35e6551513
+  type: bug-fix
+  title: Fix `COUNT` and `IS NOT NULL` over top-level external Parquet list columns
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152864
+- file:
+    name: 146718.yaml
+    checksum: a28e72349d4943e182879c33ff1775f57d650977
+  type: bug-fix
+  title: Grant file read entitlement for Snappy musl detection
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146718
+  issues:
+  - "146717"
+- file:
+    name: 148356.yaml
+    checksum: 284ce981037c2960d86767f04c3923cc7fd0450f
+  type: bug-fix
+  title: Use lat/lon ordering for DECAY `geo_point` origin
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148356
+- file:
+    name: 150204.yaml
+    checksum: 5066f94109339a69247f7c479e70402f98429822
+  type: bug-fix
+  title: 'ES|QL|DS: self-heal external object-store reads on transient faults'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150204
+- file:
+    name: 149926.yaml
+    checksum: 4928162652d3fd50441c962718b9ed871299e5ac
+  type: enhancement
+  title: Share numeric TopN thresholds
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149926
+- file:
+    name: 143701.yaml
+    checksum: 40eb1809c52540984a34870594ab8969264a528f
+  type: enhancement
+  title: Verify overwrite protection in repository analysis
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    The safety of the snapshot algorithm relies on the repository preventing
+
+    certain objects from being overwritten. From version 9.5.0 onwards,
+
+    Elasticsearch will verify that the repository implements overwrite
+
+    protection correctly during repository analysis.
+  highlight: true
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/143701
+  issues:
+  - "134632"
+- file:
+    name: 146503.yaml
+    checksum: ffdc9d4708811c151f50224758a2d9cfbd3afc15
+  type: bug-fix
+  title: Heap attack tests and fixes for SPARKLINE
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146503
+- file:
+    name: 152405.yaml
+    checksum: e85133547f6288f583710bacf2f2fd1d9efab89a
+  type: bug-fix
+  title: Fix empty `DocIdSetIterator` behaviour for `exponential_histogram` field type
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152405
+  issues:
+  - "152318"
+- file:
+    name: 150746.yaml
+    checksum: d6a5446482eacdbd0bfab19c722ca255323915ed
+  type: bug-fix
+  title: 'ES|QL|DS: release the S3 read buffer when onComplete loses the completion race'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150746
+- file:
+    name: 144990.yaml
+    checksum: 83ccf405886197edeedd4b3f8fddacb48e4b921c
+  type: bug-fix
+  title: Fix multiple exclusion query rules not removing documents from results
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144990
+  issues:
+  - "141384"
+- file:
+    name: 145552.yaml
+    checksum: 4a52a4ec1dfa38b6d9dd15cc7ca56e936811582f
+  type: breaking-change
+  title: Decrease tsdb `look_ahead_time` to 9 minutes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  description: >-
+    In time series data streams (TSDS) all backing indices are potentially write indices because the documents are being routed to the right backing index based on their `@timestamp`. Assuming that the majority of ingestion traffic has a current `@timestamp`, after a rollover occurs, there is a delay up to `index.look_ahead_time` for the majority of the ingestion traffic to be routed to the new index. This delays the benefits of writing to the new index.
+
+    We reduce this delay from 30 minutes to 9 minutes. This will make the rollover more effective. The side-effect is that documents with `@timest...
+  impact: This change will make the rollover more effective; a side-effect is that the future time window will also be reduced to 9 minutes.
+  highlight: true
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145552
+  issues:
+  - "142602"
+- file:
+    name: 148360.yaml
+    checksum: 6f656cadc657617882dc89b612929631eabb37f3
+  type: enhancement
+  title: Pre-warm dictionary/bloom for predicate columns
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148360
+- file:
+    name: 152501.yaml
+    checksum: 0da074f1e55f12e88c3d7362534b1484b785ebb7
+  type: enhancement
+  title: '[Datasources] Add TV Guard for new global datasource privileges'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152501
+- file:
+    name: 147353.yaml
+    checksum: 2816685cb1da4d09c11d4207c26bbd49e13d535a
+  type: enhancement
+  title: Disable optional S3 response checksum validation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147353
+- file:
+    name: 146811.yaml
+    checksum: 8590799aa4775cb00d6a7c27d00d5615243480c4
+  type: enhancement
+  title: Support numeric range expansion in glob patterns
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146811
+- file:
+    name: 150479.yaml
+    checksum: 770227bbd588ee0f3db985a34abb377c98d97563
+  type: enhancement
+  title: Add Arrow output support for `date_nanos` and `date_range` data types
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150479
+  issues:
+  - "146350"
+- file:
+    name: 149176.yaml
+    checksum: 31eb8889bef54e72043bb882d459c6f1b59602cb
+  type: enhancement
+  title: Default ES|QL external source schema resolution to `UNION_BY_NAME`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  description: >-
+    Multi-file ES|QL external source globs (the Tech Preview `EXTERNAL` command) now default
+
+    to `schema_resolution = union_by_name` instead of `first_file_wins`. Files in the same
+
+    glob no longer have to share the exact schema of the lex-smallest file: columns are merged
+
+    by name across all matched files, missing columns are null-filled per file, and types are
+
+    reconciled via conservative widening (`INTEGER` -> `LONG`, `INTEGER` -> `DOUBLE`,
+
+    `DATETIME` -> `DATE_NANOS`). Schemas that genuinely disagree on a column's type now fail
+
+    at planning time with a clear error instead of silently coercing data...
+  highlight: true
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149176
+- file:
+    name: 148622.yaml
+    checksum: 8872352e5888570674e3b2a1c106ac6a0abf6228
+  type: enhancement
+  title: Batched execution in the query phase
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  description: >-
+    Searches that target multiple shards on the same data node now batch shards into a single round-trip per data node, with partial reductions performed on the data nodes.
+
+    This reduces transport layer overhead and spreads the load of reductions across multiple nodes.
+
+    The enhancement is controlled by a setting `search.batched_query_phase`, which is enabled by default in 9.5.0.
+  highlight: true
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148622
+- file:
+    name: 149033.yaml
+    checksum: 89bc3910cc2e01e3734292450068f530f7943398
+  type: enhancement
+  title: Speed up REPLACE on constant regex
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149033
+- file:
+    name: 149463.yaml
+    checksum: 42150395eb1fc0cab6193c22a82486b041afe864
+  type: enhancement
+  title: '[ESQLDS] `NdJsonPageDecoder:` schema-aware fast-skip, improve string decoding'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149463
+- file:
+    name: 152385.yaml
+    checksum: cbed52b67ba5d8e02032b7cf7303b17407599c57
+  type: bug-fix
+  title: Add more defensive protections when parsing `query_string`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152385
+- file:
+    name: 133946.yaml
+    checksum: f5fc1caa25aed726d0babc2104b772ce492fac4c
+  type: enhancement
+  title: Merging is now more aggressive by default, especially for segments under 16MB.
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Engine
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/133946
+  issues:
+  - "120624"
+  - "129764"
+  - "130328"
+- file:
+    name: 150838.yaml
+    checksum: ca96a9d313e50dd3d80c21f603b4ec83fab9cd0a
+  type: enhancement
+  title: Add resumable write buffer size client setting for GCS repository
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150838
+- file:
+    name: 152043.yaml
+    checksum: 68b6bc8fd49744891793ffab78e6fab3f17868d5
+  type: enhancement
+  title: Shadow Hive partition column collisions
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152043
+- file:
+    name: 150906.yaml
+    checksum: 5b62f65e09bd5b706918de21b3765ccb7f238118
+  type: enhancement
+  title: Use panama bulk methods for bulk vector scoring
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150906
+- file:
+    name: 152203.yaml
+    checksum: 20376b94669590c26253bb46456419a65daddead
+  type: enhancement
+  title: Enforce NDJSON `max_record_size` in the decode loop
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152203
+- file:
+    name: 149859.yaml
+    checksum: 7651186cf51d238e94419c731e0c1e9088879a22
+  type: enhancement
+  title: Rollover ignoring active shards can ignore reroute
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Indices APIs
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149859
+  issues:
+  - "149730"
+- file:
+    name: 152716.yaml
+    checksum: 85199f9b85dd637f7e44648b113128f1b275447c
+  type: enhancement
+  title: Create backing indices for backfilling past timestamps in TSDB (opt-in)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    Bulk requests that create documents in a time series data stream no longer fail
+
+    outright when a document's `@timestamp` falls outside the boundaries of all
+
+    existing backing indices. If the timestamp is still within the data stream's
+
+    eligible write window and the new `data_stream.past_tsdb_index_creation_enabled`
+
+    cluster setting is enabled (defaults to `false`), Elasticsearch now creates the
+
+    necessary backing indices needed to cover it before indexing, instead of rejecting
+
+    the write. Timestamps outside the eligible window, or in the future, are still
+
+    rejected.
+  highlight: true
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152716
+  issues:
+  - "149856"
+- file:
+    name: 148198.yaml
+    checksum: d56b5968bc1112e391d2bea15724617beac1bb92
+  type: bug-fix
+  title: '`DoHandleStartHandoff` runs allocation-ID check even when PIT is disabled'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148198
+  issues:
+  - "147957"
+- file:
+    name: 147797.yaml
+    checksum: a0443d14d00cab68b7e80c39f109cc5c1f7e45df
+  type: bug-fix
+  title: Return 400 for malformed OTLP protobuf
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147797
+- file:
+    name: 151593.yaml
+    checksum: dbf97d4d36a0b55d6216c167c0df5d4af7796b10
+  type: enhancement
+  title: Set OTel span status ERROR for HTTP 5xx responses
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151593
+- file:
+    name: 151086.yaml
+    checksum: 4ede4a52c50d44488881b263a8ca4ed685ac84a4
+  type: enhancement
+  title: 'Painless: `script_aware` String search + regex limit-factor for `replaceAll/r...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151086
+- file:
+    name: 147502.yaml
+    checksum: 52c76750fb572ad1037241370441350b5659d5ce
+  type: enhancement
+  title: Widen numeric stats values during merge for UNION_BY_NAME
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147502
+- file:
+    name: 152583.yaml
+    checksum: 458f3557a396d9c6d1b1bc7eb22c430dba9581f2
+  type: enhancement
+  title: Decode Parquet temporal footer stats to epoch-millis
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152583
+- file:
+    name: 144904.yaml
+    checksum: 0a4469c8259479d23c254cb20ae91bb719aa6025
+  type: enhancement
+  title: Add maintenance task to close idle AD jobs
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144904
+- file:
+    name: 148474.yaml
+    checksum: ede059cffec3ee1a55db07a55a35627207d41b3e
+  type: bug-fix
+  title: Drop late-mat byte-ratio gate, fix trivially-passes shortcut
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148474
+- file:
+    name: 147781.yaml
+    checksum: 8d96211becf95a28ddf6e267db676c83ae0ba3da
+  type: enhancement
+  title: Surface implicit privileges in get-role API
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147781
+- file:
+    name: 150802.yaml
+    checksum: d6ee031ccdaa6f17722cbb32537d0158787f8c5e
+  type: enhancement
+  title: Throttle concurrent downsampling operations in data stream lifecycle.
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: A new dynamic cluster setting, `data_streams.lifecycle.downsampling.max_indices_in_progress` (default 10), caps the number of backing indices per data stream that data stream lifecycle will submit to downsampling in a single run. Indices that are deferred are recorded in the error store with a warning and will be retried in a subsequent run.
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150802
+  issues:
+  - "150624"
+- file:
+    name: 150551.yaml
+    checksum: 271d3b84552b90badc7f2764aaa5034645d02008
+  type: bug-fix
+  title: Fix `RecoveryTarget` `hasReferences` assertion error
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150551
+  issues:
+  - "150311"
+  - "150213"
+  - "150206"
+- file:
+    name: 152096.yaml
+    checksum: 4991e5337de1291944ce07a28a35003b947369ba
+  type: bug-fix
+  title: Fix infinite loop in `GeoLineDecomposer` dateline crossing checks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Geo
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152096
+  issues:
+  - "152066"
+- file:
+    name: 152757.yaml
+    checksum: 449d0aebe3cf081b4315abc15eca416576acbad1
+  type: bug-fix
+  title: Dispatch remote cluster connection failures on response executor
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Network
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152757
+  issues:
+  - "152518"
+- file:
+    name: 149662.yaml
+    checksum: 1f324bbe7e8c7a6aa2a93625fc15766a7e868e69
+  type: enhancement
+  title: Parquet/ORC nested STRUCT subfield projection
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149662
+- file:
+    name: 146597.yaml
+    checksum: b3e3f49f43eb8ddcb375579233be85131b4a0adb
+  type: enhancement
+  title: Filtered aggregate pushdown for external sources
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146597
+- file:
+    name: 147369.yaml
+    checksum: e0787e6b9d743ac81f1636b6535bbd4911845fe7
+  type: enhancement
+  title: Add analyzer option in ES|QL `TOP_SNIPPETS` function
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147369
+- file:
+    name: 148422.yaml
+    checksum: 5a429ba9ef6de168fb8d195e62a7c557d3443a60
+  type: bug-fix
+  title: Fix Page leak on partial deserialization
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148422
+- file:
+    name: 148072.yaml
+    checksum: 50e2575794b32483c0d12296539cb15ea4e07cc3
+  type: enhancement
+  title: Parallel split discovery and provider caching
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148072
+- file:
+    name: 152869.yaml
+    checksum: 3f0d69e9a0ec2389a9586b48f3e62f8f5be1528e
+  type: enhancement
+  title: Update the rerank endpoint for the Elastic inference service
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152869
+- file:
+    name: 147738.yaml
+    checksum: 7e26736d13fd2d70fa2a2fcdf812dbac24526f42
+  type: bug-fix
+  title: Stop sharing decode buffers between Parquet pages
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147738
+- file:
+    name: 152243.yaml
+    checksum: c099d517183b585357d382a143ba2316c3a25c5b
+  type: bug-fix
+  title: '[DiskBBQ] Fix a bug where we might incorrectly assign to centroid 0'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152243
+- file:
+    name: 145990.yaml
+    checksum: 6e2fe8aa33d28cc733c00b69747676d405922667
+  type: enhancement
+  title: Add primary encryption key generation and distribution
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145990
+- file:
+    name: 153686.yaml
+    checksum: a305bf6d7696ab8848e8cf49036eb643ed2d2b89
+  type: enhancement
+  title: Bypass permits for storage metadata ops
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153686
+- file:
+    name: 147153.yaml
+    checksum: 5861287739ec1be40e48df3fc467a135fbbb331c
+  type: bug-fix
+  title: Fix `DateRangeDocValuesReader` to `appendNull` for empty positions
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147153
+  issues:
+  - "146380"
+- file:
+    name: 149767.yaml
+    checksum: f73c6047d24bb5c4dda9ed59ce04cc15ffd3616a
+  type: enhancement
+  title: Add Workload Identity Issuer Client
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149767
+- file:
+    name: 147329.yaml
+    checksum: 0e544855cbc19779158d67733f24a691220d035a
+  type: enhancement
+  title: Add support for audio, video and pdf inputs for embedding task
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147329
+  issues:
+  - "146432"
+- file:
+    name: 153043.yaml
+    checksum: 98ca8b2f7a1c675ce50355d1638a41498b6375b8
+  type: bug-fix
+  title: 'Fix flattened field array-offset corruption with preserve_leaf_arrays: exact'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153043
+  issues:
+  - "153014"
+- file:
+    name: 148434.yaml
+    checksum: fb09941066b0a6a080a7d0040588af95cd03b7ce
+  type: enhancement
+  title: Push LIKE to Parquet late materialization
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148434
+- file:
+    name: 148121.yaml
+    checksum: 4971520e62fea4496250d902990cb7a7dd7f5d72
+  type: enhancement
+  title: Support wildcard application names in implicit privilege SPI
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148121
+- file:
+    name: 151750.yaml
+    checksum: d69447d833243117dbbb035151b2f6e90a088e34
+  type: enhancement
+  title: Unmapped_fields="load" for views, subqueries and fork
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151750
+  issues:
+  - "142033"
+- file:
+    name: 150141.yaml
+    checksum: bb2f877bccf2bf81328df208f02a1931d6c08032
+  type: enhancement
+  title: Hot-reload workload-identity client SSL
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150141
+- file:
+    name: 146095.yaml
+    checksum: 4aa43cbd5dd832fc54c50997a8bb8f6419b4bfa4
+  type: enhancement
+  title: 'ES-14041: Add regression test suite for trace/span export'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146095
+- file:
+    name: 147811.yaml
+    checksum: a461827c6e2a9974382e854ee6f562a5509f3826
+  type: enhancement
+  title: Enable OTLP logs and traces by default
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Logs
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147811
+- file:
+    name: 146353.yaml
+    checksum: 8ca4c9af6ff1c3c38bc70fa695fbf7d42c84a34e
+  type: bug-fix
+  title: Fix `testConcurrentEquals` for TDigest-based aggregations
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Aggregations
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146353
+  issues:
+  - "146113"
+- file:
+    name: 152941.yaml
+    checksum: 8259b07108e47cc0b6a545aede435d2a74b1b139
+  type: enhancement
+  title: Release support for match with non-mapped expressions
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    The `match` function and `:` operator can now work with expressions that
+
+    no longer need to represent a mapped field in an Elasticsearch index.
+
+
+    The `match` function no longer needs to be pushed down as a Lucene query
+
+    to the shard. When matching on an expression that does not represent an
+
+    Elasticsearch mapped field, but has the `text` data type, we evaluate
+
+    the `match` function on-the-fly by analyzing the value of the expression
+
+    for each row and checking whether any of the analyzed tokens match the
+
+    analyzed tokens of the given query string.
+  highlight: true
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152941
+- file:
+    name: 152691.yaml
+    checksum: f7c2895331fe62237108da8cd7dd6bbadd1ed565
+  type: enhancement
+  title: Async external source metadata discovery
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152691
+- file:
+    name: 147493.yaml
+    checksum: 228e56182fbe6233239b31590e42f59a3c6b7d6e
+  type: enhancement
+  title: Shared metadata byte cache for Parquet and ORC
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147493
+- file:
+    name: 148273.yaml
+    checksum: 49d0c14f122d30757f57f0c07f3c9d7002213650
+  type: bug-fix
+  title: Invalidate cache of max shard write load proportion on shard movements
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Allocation
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148273
+  issues:
+  - "148219"
+- file:
+    name: 147217.yaml
+    checksum: 01b224b6193a25aadcd7f5d1e89bc882a1c72f80
+  type: enhancement
+  title: Add `byte_level_bpe` ML tokenization with merges
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147217
+- file:
+    name: 144342.yaml
+    checksum: db249394f5396c58ab1917ea92eefedd70f722b1
+  type: enhancement
+  title: '`ExpandSearchPhase:` fix inner hits lifecycle to use pooled hits'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144342
+- file:
+    name: 152783.yaml
+    checksum: 0e0e9198c556f2d83bce0b64b507e98bba0fa76f
+  type: enhancement
+  title: Sanitize external UTF-8 at source boundary
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152783
+- file:
+    name: 153038.yaml
+    checksum: e570f84d93a152f2892002fef9b5ebaf5eb9f6a3
+  type: bug-fix
+  title: Release external-Parquet page decompress buffers per page, not per row group
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153038
+- file:
+    name: 148674.yaml
+    checksum: ce9d489bec6fa89eea471feae38904b830e11b17
+  type: feature
+  title: Updating `ecs@mappings` to include new flattened `gen_ai` fields
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148674
+- file:
+    name: 150194.yaml
+    checksum: 685b8cce0e6f972866b499d5a0704ae73676c4e5
+  type: bug-fix
+  title: Update `repository-s3` to use the default request signer from AWS SDK for Java.
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150194
+- file:
+    name: 151156.yaml
+    checksum: 911e1ae8ef0fc5af408ce944beabdf1259dfce8f
+  type: bug-fix
+  title: Fix `auto_date_histogram` `RoundingInfo` equals/hashCode to include all seria...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Aggregations
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151156
+  issues:
+  - "151155"
+- file:
+    name: 150602.yaml
+    checksum: e5d512c4c33cc8ec0d98c62db149fc230f49627f
+  type: bug-fix
+  title: Test race condition in `RecoveriesCollection`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Recovery
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150602
+- file:
+    name: 152111.yaml
+    checksum: 87d7378b87d14c6d3535be67addec6015dcf57fa
+  type: enhancement
+  title: Restrict doc values multi_value/nullability parameters to columnar mode
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152111
+- file:
+    name: 151697.yaml
+    checksum: 452fdecabfce0e58b3f565ff01b9fbe08d8e852c
+  type: bug-fix
+  title: Call Project.output() only when Project.expressionsResolved() is true
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151697
+  issues:
+  - "149681"
+- file:
+    name: 152957.yaml
+    checksum: 3ec514daee247fb54946ff71997978b75cf83b6b
+  type: enhancement
+  title: ES|QL [JSON_EXTRACT function](/reference/query-languages/esql/functions-opera...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152957
+- file:
+    name: 147606.yaml
+    checksum: eec6a9a3fa821e0f76d1c397159ef4f841422dfe
+  type: bug-fix
+  title: Fix up FTF error after MV_EXPAND
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147606
+- file:
+    name: 149248.yaml
+    checksum: 509a40b7300932c205918c02d47ab37d68439644
+  type: enhancement
+  title: Cut S3 download + Snappy copies on hot path
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149248
+- file:
+    name: 149618.yaml
+    checksum: a86d82fbd19fcca9360808914a6c05a80a46d66a
+  type: enhancement
+  title: Parquet zstd page decompress via Panama FFI
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149618
+- file:
+    name: 148992.yaml
+    checksum: 944724f4e983141d6b030ecdedc42309dc8e21e8
+  type: enhancement
+  title: Avoid storing in `BlobTranslogFile` `totalOps` for active shards when it is e...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Engine
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148992
+- file:
+    name: 149454.yaml
+    checksum: f92341df164829fc8f2ca11b42b77bcb8a6e2721
+  type: enhancement
+  title: Reject ES|QL requests for datasets with DLS or FLS
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149454
+- file:
+    name: 145924.yaml
+    checksum: edf2515938ca7375a3f4cfb5ac816c921d77e3af
+  type: enhancement
+  title: Fix filter pushdown review nits
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145924
+- file:
+    name: 148880.yaml
+    checksum: 1be97ee2ead0f3d0c6fcbe251ede4d9198d6380f
+  type: enhancement
+  title: '[Evaluations] Register .evaluation-* as hidden indices with viewer/editor access'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Authorization
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148880
+- file:
+    name: 149287.yaml
+    checksum: 7d3667ede1523002bdd0f818b4ae7d79473bc1e3
+  type: bug-fix
+  title: Close `GeoIp` `configDatabases` to release open file locks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Ingest node
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149287
+  issues:
+  - "149276"
+- file:
+    name: 147333.yaml
+    checksum: 9abc7ba9cb91a5a515297d31f2bf2f7340215996
+  type: enhancement
+  title: Allow audit logging to be turned on/off without server restart
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Audit
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147333
+- file:
+    name: 152998.yaml
+    checksum: 476df5da1b816f5a28204525b3ff1dcf1e292778
+  type: enhancement
+  title: De-snapshot column metadata for BUCKET
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152998
+  issues:
+  - "148508"
+- file:
+    name: 149911.yaml
+    checksum: ce0041c286d8902406213d9a7e14bf9a23a65ef6
+  type: bug-fix
+  title: Keep LIMIT BY above MV_EXPAND when needed
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149911
+  issues:
+  - "148513"
+- file:
+    name: 153809.yaml
+    checksum: 88dd269c52c9e10aabd77d03bee82a7e2d3157ba
+  type: bug-fix
+  title: Fix Parquet MAP column footer-stats crash
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153809
+- file:
+    name: 151137.yaml
+    checksum: c7b45051a295080e2a75709bfdc63f11cfc2b912
+  type: enhancement
+  title: Allow deleting a backing index via modify data streams API
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151137
+- file:
+    name: 152577.yaml
+    checksum: 7ea7a93b7ed3aee883b8a0e05dc08600f7e46ff0
+  type: enhancement
+  title: Add operational telemetry for ES|QL external data sources
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152577
+- file:
+    name: 148879.yaml
+    checksum: 0d2f11bb7c8c0a38c66b4ba3450ae46d223e23ea
+  type: feature
+  title: Optimize `field_extract` on flattened fields
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148879
+- file:
+    name: 149045.yaml
+    checksum: c539ab6b366d7e4f5b033788aec13809232ce6d2
+  type: enhancement
+  title: Tighten parsed-footer cache after review feedback
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149045
+- file:
+    name: 148341.yaml
+    checksum: ab2409fa492606fc3e97fe61974460f5e13357da
+  type: bug-fix
+  title: Record authc time histograms in milliseconds
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148341
+- file:
+    name: 146975.yaml
+    checksum: 044f76aa00d51fa43ca7137f8c922ec823450554
+  type: enhancement
+  title: Add `effective_config_hash` keyword mapping to fleet-agents index
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Plugins
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146975
+- file:
+    name: 152035.yaml
+    checksum: 299652a0f0c97a0dcedfbf0ec2d3a3143d37fed5
+  type: bug-fix
+  title: Avoid dense run-len allocation in HLL
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152035
+- file:
+    name: 146076.yaml
+    checksum: 73e6cbbca2e23c641e5cbfcb1f827bd6c14d33cc
+  type: enhancement
+  title: Cleanup post-merge nits in DataSourceValidator SPI
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146076
+- file:
+    name: 147688.yaml
+    checksum: 25fb67bc0e5922c4c807f9b573d067123b67d9b4
+  type: bug-fix
+  title: Automatically repair ML anomaly results aliases pointing at a .reindexed-v7 i...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147688
+  issues:
+  - "147686"
+- file:
+    name: 153825.yaml
+    checksum: 61b1d72481bbcffa719e26dc984d62c18e8c51fc
+  type: bug-fix
+  title: Corrects bug with LOOKUP JOIN, empty scopes and security enabled
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153825
+- file:
+    name: 147470.yaml
+    checksum: 76ad5338df3c7186908497a0494c811c9b21a893
+  type: bug-fix
+  title: Fix Parquet sliding-window cache corruption
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147470
+- file:
+    name: 149317.yaml
+    checksum: c392b8777ddc89b003ac878d5e0900193e711446
+  type: feature
+  title: '`ThrottlingRecoveryService` can throttle recoveries on data node'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Recovery
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149317
+- file:
+    name: 147759.yaml
+    checksum: 7a5de90ceb625075cd4871907b8fb3791fd3cace
+  type: bug-fix
+  title: Log entitlement agent attach timing
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147759
+- file:
+    name: 151377.yaml
+    checksum: 828f1c81abe8cf37115da02df966d6bf08a9a3a1
+  type: enhancement
+  title: Surface external read failures with typed exceptions
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151377
+- file:
+    name: 148910.yaml
+    checksum: a756b5b488c2834249609b8572162963b1b93331
+  type: enhancement
+  title: Route Prometheus remote write via `data_stream` labels
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148910
+- file:
+    name: 146373.yaml
+    checksum: 4cf1509d278efaab283d0d65feee9b76b0abfe01
+  type: bug-fix
+  title: 'ESQL:DS: fix single file splitting and bzip2 bytes counting'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146373
+  issues:
+  - "146330"
+- file:
+    name: 149985.yaml
+    checksum: a03cdd450657f3e06ca3ae2c14438f9832e3d945
+  type: enhancement
+  title: 'ES|QL PromQL: implicit type coercion for counter/gauge'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149985
+  issues:
+  - "140035"
+- file:
+    name: 147562.yaml
+    checksum: a3897b7150cd822e62327301541016e146b0fee6
+  type: enhancement
+  title: ES|QL — route FROM dataset through the EXTERNAL pipeline (Phase 1)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147562
+- file:
+    name: 148678.yaml
+    checksum: d61b345203bd5552fc32db902c31c5b75209ff01
+  type: enhancement
+  title: Constant-RHS fast path for `MOD` and `DIV` evaluators
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148678
+- file:
+    name: 146666.yaml
+    checksum: dba131b63df8da773c2fd5dbea4ef77252832c0a
+  type: feature
+  title: ES|QL - Add timeout to inference operations COMPLETION, RERANK and TEXT_EMBED...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146666
+  issues:
+  - "146528"
+- file:
+    name: 149069.yaml
+    checksum: eaf8f02fa140e4fa554d4cbc5a268ffb2701564e
+  type: enhancement
+  title: 'S3HttpFixture: track and expose storage class on blobs'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149069
+- file:
+    name: 152625.yaml
+    checksum: 89ba8855d9bc6b70e2c05a77c5277e45a3bc9b34
+  type: bug-fix
+  title: Fix null-leading concat in Parquet sparse reads
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152625
+  issues:
+  - "152592"
+- file:
+    name: 148551.yaml
+    checksum: 32136c35fc18dc488ac9b6e629977bad33af3e71
+  type: enhancement
+  title: Support jina-embeddings-v5-omni input format for Jina integration
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148551
+- file:
+    name: 150531.yaml
+    checksum: af395dbf15fea3586284be2365928e6cf26eb90a
+  type: enhancement
+  title: '[ES|QL|DS] Add "datetime_format" to ndjson reader settings'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150531
+- file:
+    name: 149710.yaml
+    checksum: b7f7578f9b3b1b93eb8730bcd25f67343621d525
+  type: feature
+  title: '`FieldExtract` double-sided and single-sided range query pushdown'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149710
+- file:
+    name: 153258.yaml
+    checksum: 95da4a34010186c21dab40b29b6262935eb4828c
+  type: enhancement
+  title: Restore compressed multi-file warm-fold IT
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153258
+- file:
+    name: 147574.yaml
+    checksum: 9f2c89be5656ece554aa8c9795636b77a4072489
+  type: enhancement
+  title: Implement DEDUP command
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147574
+  issues:
+  - "133322"
+- file:
+    name: 152326.yaml
+    checksum: 65645a537118f005be48d9e2b60d21566dd59b01
+  type: enhancement
+  title: Emit Painless static-type string concat allocation pre-checks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152326
+- file:
+    name: 147962.yaml
+    checksum: 86388208aa7e2f6b14aaccb11d33aaaeaab4ad92
+  type: enhancement
+  title: Eliminate redundant S3 HEAD calls via suffix range and object reuse
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147962
+- file:
+    name: 145230.yaml
+    checksum: 86177bfb68ffc84993ec7297a604d97d0d2ae09f
+  type: enhancement
+  title: Include target indices and query in profiled search results
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145230
+  issues:
+  - "143783"
+- file:
+    name: 149881.yaml
+    checksum: 67a17e98f4dacce1461760107267030a26b356db
+  type: enhancement
+  title: 'ESQL|DS: remove zstd-jni from Parquet codec via Panama FFI'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149881
+- file:
+    name: 152664.yaml
+    checksum: 2f2122fe5a4f22dd13a8733c18fbce683640b269
+  type: bug-fix
+  title: Trivial hardening of data uri validation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152664
+- file:
+    name: 148140.yaml
+    checksum: a11a1c07dd8564201929863e2cd8a9bf3fc3ecef
+  type: enhancement
+  title: '[Inference API] Add product use case and origin to telemetry'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148140
+- file:
+    name: 153219.yaml
+    checksum: 55cdd22c8c2a95bfe0553bbcd4ae9cad9e944217
+  type: bug-fix
+  title: Fix snapshot creation on CIFS shares in case of access denied exception
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153219
+  issues:
+  - "152053"
+- file:
+    name: 149023.yaml
+    checksum: d16bfc0b2d2b7cef59a1a4beee9d4c5d45840bde
+  type: enhancement
+  title: Pool S3 async receive buffers via Netty allocator
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149023
+- file:
+    name: 146440.yaml
+    checksum: 5bbc80df09d731c42f175466cada67dbc26fe704
+  type: enhancement
+  title: Adding a check to verify that `BlobContainer::listBlobsByPrefix` works as exp...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146440
+- file:
+    name: 148665.yaml
+    checksum: e94ebb282981a21590c3f90c216764b5a4c3e3c2
+  type: enhancement
+  title: Add AI bots to user-agent regex
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Ingest node
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148665
+- file:
+    name: 153479.yaml
+    checksum: ad1734524977eba7cf785332fc19386ad1d5d8b9
+  type: bug-fix
+  title: Apply search timeout to the DFS phase query rewrite
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153479
+- file:
+    name: 146801.yaml
+    checksum: ffc6572e4c2548c41a47139dbec9869a8eb7af8f
+  type: feature
+  title: Enable ES|QL EMBEDDING function for calculating dense vector embeddings on mu...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146801
+- file:
+    name: 144979.yaml
+    checksum: 7a599a14b5b9462964ea4d912058b4fe6c67c2f7
+  type: enhancement
+  title: 'ESQL: Push down unrelated filters past MV_EXPAND'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144979
+  issues:
+  - "144636"
+- file:
+    name: 149577.yaml
+    checksum: fd4e5223890d762aa84fbf9287c20e8a4da4e176
+  type: enhancement
+  title: Fast-path CSV datetime parsing
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149577
+- file:
+    name: 146378.yaml
+    checksum: 96f932610a9747fa9932ae06f07018f0c8b7fc85
+  type: enhancement
+  title: Wait for shard readiness before executing search on data node
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146378
+  issues:
+  - "139672"
+- file:
+    name: 147586.yaml
+    checksum: 53f8491b8b5bb9bf8c2a300197889039e5d1153f
+  type: enhancement
+  title: Integrate circuit breaker with Parquet prefetch
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147586
+- file:
+    name: 149598.yaml
+    checksum: 3b742106b405f4c16142050baf2694efe2408ba8
+  type: enhancement
+  title: 'Snappy codec follow-up: override read(byte[])'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149598
+- file:
+    name: 149062.yaml
+    checksum: 7f42f2b82a0bb8794ea967a88f3795e29674f89c
+  type: enhancement
+  title: Add reader-heap circuit breaker for the stateless search engine
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149062
+- file:
+    name: 152854.yaml
+    checksum: c65be6237cffcb399dfa0eaeb5f17760d1807d26
+  type: enhancement
+  title: Preserve secrets on data source PUT
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152854
+- file:
+    name: 146401.yaml
+    checksum: 30edc94c91b5c3616aa78fdce735cc6350878c7a
+  type: enhancement
+  title: Buffer metrics if APM server returns an error
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146401
+- file:
+    name: 152012.yaml
+    checksum: 79044c212f6ddb00fe8b02ad47d286bf2f1e9900
+  type: enhancement
+  title: Support multimodal (image) rerank for the Elastic Inference Service
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152012
+- file:
+    name: 148331.yaml
+    checksum: 01d5a9cc2765e503de42ab970c3884ca0c6bfcf2
+  type: feature
+  title: Add `x-pack-kibana` plugin contributing implicit index privileges for Kibana...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148331
+- file:
+    name: 144742.yaml
+    checksum: 7b9352e4d5fd1e0b172cb5f8c13214f5652a591d
+  type: enhancement
+  title: Highlighting in `TOP_SNIPPETS`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144742
+- file:
+    name: 151405.yaml
+    checksum: aefdf5559c627435d86a990fceb785c4a70238bf
+  type: enhancement
+  title: '[Encryption] Graceful degradation when no password configured'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151405
+- file:
+    name: 152803.yaml
+    checksum: 722d4cb1d60c5bb6f77424f717795a1783490584
+  type: bug-fix
+  title: Tighten retry startup logic
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Transform
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152803
+- file:
+    name: 151393.yaml
+    checksum: d3b819366bb1c5746fa83d7aa2aba8e7968db6f0
+  type: bug-fix
+  title: Restore CSV/TSV/NDJSON read perf after cap enforcement
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151393
+- file:
+    name: 153013.yaml
+    checksum: cb1d99ae8c76479b72dac362ca60b77592155adb
+  type: bug-fix
+  title: Fix COUNT on an unmapped field
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153013
+  issues:
+  - "152884"
+- file:
+    name: 151868.yaml
+    checksum: aa60cb70a9214bb9e1abe8b745b030a61c530b9e
+  type: enhancement
+  title: Prune row groups for string TopN sources
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151868
+- file:
+    name: 153785.yaml
+    checksum: cfe7ee62c905d5633deb3277b470edbc37059b93
+  type: bug-fix
+  title: '[ESQLDS] Separate the external dataset-aggregate cache so warm dataset COUNT...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153785
+- file:
+    name: 152481.yaml
+    checksum: 521e5efb0a9639ecdd401aae9932d3306bfe61a8
+  type: feature
+  title: Columnar index mode (Tech Preview)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    Two new index modes, `columnar` and `logsdb_columnar`, are now available as
+
+    a Tech Preview. With columnar mode enabled, Elasticsearch becomes a fully
+
+    columnar store for search and analytics, offering a significantly smaller
+
+    storage footprint and the building blocks for faster analytical queries in
+
+    future releases.
+
+
+    Fields are stored **once, as doc values only** — no inverted index or BKD
+
+    tree is created by default, which eliminates redundant index structures
+
+    and significantly reduces the storage footprint. Doc values skippers
+
+    (compact skip lists with min/max metadata) are enabled by default...
+  highlight: true
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152481
+- file:
+    name: 147729.yaml
+    checksum: 4e3f3739e2ec0fdcd0b49769acecbf02ca7d4331
+  type: enhancement
+  title: 'ES-14041: Lock APM-agent trace contract in regression test'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147729
+- file:
+    name: 150845.yaml
+    checksum: 2fac912bc34b33a6672793f02d6f855ea7f5a690
+  type: enhancement
+  title: Add keyless workload-identity auth to S3 datasource
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150845
+- file:
+    name: 145939.yaml
+    checksum: f13147f6d8687fed15af173cb9d71a9e65683a20
+  type: enhancement
+  title: Flush OTel traces at shutdown
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145939
+- file:
+    name: 148937.yaml
+    checksum: 556d6e54d45fb78f9eb69e8b8badaf1ce25975b5
+  type: enhancement
+  title: ESQL planning and streaming changes for bulk keyword lookup
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148937
+- file:
+    name: 148521.yaml
+    checksum: a3bf7f990a76ed4792d77adc85d3fc9eedbafc23
+  type: bug-fix
+  title: Make `CompoundOutputEval` implement `SortAgnostic`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148521
+  issues:
+  - "148500"
+- file:
+    name: 146600.yaml
+    checksum: 1b33374fae555abe0f5103daec8e8525de72f92e
+  type: enhancement
+  title: Add CRUD REST API for data sources and datasets
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146600
+- file:
+    name: 147912.yaml
+    checksum: e98d0e01fbd64712908b469c3cb6530cb2b0bcd1
+  type: bug-fix
+  title: '`SampleProbabilityPlaceHolder` to have Nullability.FALSE'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147912
+- file:
+    name: 145885.yaml
+    checksum: c68a876f6a357b13995823d678cecfb83b68f375
+  type: enhancement
+  title: Add DataSourceValidator SPI for CRUD-time validation of external data source...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145885
+- file:
+    name: 151080.yaml
+    checksum: e0a860f4e7c7d1e045e2541f66e365df638d0e7f
+  type: enhancement
+  title: 'Painless: `script_aware` wrappers for stream terminal ops'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151080
+- file:
+    name: 147504.yaml
+    checksum: f47231e834b64e538b2399b75c5fb07e85be45d9
+  type: enhancement
+  title: '`DenseVectorQuery`: lazy filter evaluation and use bulk scorer'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147504
+  issues:
+  - "137042"
+- file:
+    name: 146745.yaml
+    checksum: f7b1f5b6c222a01ed6d16269b0f1e54131680bd4
+  type: enhancement
+  title: '`SplitStats` compact serialization and typed API'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146745
+- file:
+    name: 152585.yaml
+    checksum: aad974b573449ac1751b4f25ab032eaa4a590200
+  type: enhancement
+  title: Async STOP / cancel / DELETE contract for EXTERNAL queries
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152585
+- file:
+    name: 150107.yaml
+    checksum: b0f09d06255a763c2a4d460f03212c0e0bb21b6e
+  type: enhancement
+  title: DOC partitioning by default for COUNT
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150107
+- file:
+    name: 153005.yaml
+    checksum: c0d98bd6028338b058a17824cef2caa97a0e7ef3
+  type: other
+  title: Bump ES|QL/Arrow Jackson to 2.21.4
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153005
+- file:
+    name: 146207.yaml
+    checksum: 18de5267f89670724932db3b395e4150564bb931
+  type: enhancement
+  title: Cache miss no longer blocked by fetch
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Searchable snapshots
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146207
+- file:
+    name: 149664.yaml
+    checksum: 73943c9ea4a2269830a016cb4bb8c42b245b02cf
+  type: enhancement
+  title: Parquet/ORC nested STRUCT pushdown
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149664
+- file:
+    name: 148517.yaml
+    checksum: bf5f5ddd28e60b7ff42d404e08896e675243b908
+  type: bug-fix
+  title: Repro and fix `updateShardState` allocation check edge case
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148517
+- file:
+    name: 150824.yaml
+    checksum: 4032c81c4ea075c71727b0b670adf79363bd6a67
+  type: enhancement
+  title: Add keyless workload-identity auth to ESQL Azure
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150824
+- file:
+    name: 149613.yaml
+    checksum: 1f6b2e617a82664e846d272131f3c395eeced4bc
+  type: enhancement
+  title: Bulk decode dictionary indices in parquet reader
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149613
+- file:
+    name: 153137.yaml
+    checksum: abc57a9b01bc8b47b092da5ec341faaeaf05d30e
+  type: bug-fix
+  title: Fix unmapped fields optimized incorrectly bug on empty mappings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153137
+  issues:
+  - "141990"
+- file:
+    name: 149185.yaml
+    checksum: 0731aaf074cecdde852e71921ad55c3286028f42
+  type: enhancement
+  title: Introduce `ExternalOptimizerContext`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149185
+- file:
+    name: 149886.yaml
+    checksum: d5ec8a5e3ce90b25b2645f46c3d9b07dcaa0cda7
+  type: bug-fix
+  title: Fix TSV record-boundary scanner livelock on literal quotes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149886
+- file:
+    name: 144426.yaml
+    checksum: e7510c9f890bd7935266884d7af244249a3c608f
+  type: enhancement
+  title: Scrolling ref counts hits
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144426
+- file:
+    name: 150465.yaml
+    checksum: 6b25507fdf267a27d058118739247b21843b06a6
+  type: enhancement
+  title: '[kibana_system] add significant_events-* data access for `kibana_system` user'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150465
+- file:
+    name: 152771.yaml
+    checksum: 736110f046cf6a4547bd3f288de8ffef96ff45fe
+  type: enhancement
+  title: Unify external blob-store read concurrency under a single per-scheme permit k...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152771
+- file:
+    name: 148556.yaml
+    checksum: dce56dcf139bb0771ce849c74e81f9487e7aedc2
+  type: bug-fix
+  title: Report shutdowns as IN_PROGRESS if a remaining shard has `canAllocate=NOT_PRE...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Allocation
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148556
+- file:
+    name: 147359.yaml
+    checksum: b355b6f47ae3c85386bcb2176b9b4cac765cc1c7
+  type: enhancement
+  title: Port Parquet I/O coalescing and row-group prefetch pipeline
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147359
+- file:
+    name: 150920.yaml
+    checksum: edccdfe8c0dd3f13620a9699dacf0c4fe88b0d1c
+  type: enhancement
+  title: Add canonical-stripe statistics for warm COUNT/MIN/MAX over external text for...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150920
+- file:
+    name: 151632.yaml
+    checksum: eeb033c4935ee658299dbb0157fed5b757c06ea3
+  type: bug-fix
+  title: Fix union type class cast exception
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151632
+  issues:
+  - "151525"
+- file:
+    name: 150473.yaml
+    checksum: 177ec017c021640e5840284de950db8839c11749
+  type: enhancement
+  title: Expose datafeed `authorization.cloud_api_key.id` on GET for CPS operator visi...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150473
+- file:
+    name: 149202.yaml
+    checksum: f1c1f59fcfa27a9512cf4cd9168a65064e072bc4
+  type: bug-fix
+  title: Use appropriate rerank code path for validation call
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149202
+- file:
+    name: 148690.yaml
+    checksum: 4e10574dd4565183c6080020e71cfafbe3c77490
+  type: enhancement
+  title: Add TS_COLLAPSE command
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148690
+- file:
+    name: 152622.yaml
+    checksum: 50528a57531d4b83241b55617dc815e5bc6db5c5
+  type: enhancement
+  title: '[otel-data] Add HTTP body size, severity aliases'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152622
+- file:
+    name: 148501.yaml
+    checksum: e26ece184fa849b477df890a16cf17a1b4587caf
+  type: bug-fix
+  title: Fix Parquet trivially-passes shortcut leaking rows when LIKE is AND'd with a...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148501
+- file:
+    name: 147162.yaml
+    checksum: bb75c812c550578c0b0b9b6b22658c1daa8b7640
+  type: enhancement
+  title: Add Rust FFI foundation using Panama for Parquet metadata
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147162
+- file:
+    name: 151059.yaml
+    checksum: e65f165234fd0fe66a5a5c706cc2086f75577faa
+  type: enhancement
+  title: 'Painless: `script_aware` wrappers for native iteration methods'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151059
+- file:
+    name: 152225.yaml
+    checksum: 269191c851a1f7b162e2a7dfadb12d157e8df278
+  type: other
+  title: Upgrade qa/vector opentelemetry dependency for security vulnerability
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152225
+- file:
+    name: 152874.yaml
+    checksum: 3179a44814e72e441772e1534cc5853b1d96294e
+  type: bug-fix
+  title: Fix Clone API Key silently dropping fields that follow a null expiration
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authentication
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152874
+- file:
+    name: 148203.yaml
+    checksum: 885987bf30e5a54dc44646678abda2d1d16e03ef
+  type: enhancement
+  title: Add automatic key rotation for primary encryption key
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148203
+- file:
+    name: 150326.yaml
+    checksum: 745e649ca9302d258938e32ae557b9c0dfdfda60
+  type: enhancement
+  title: Add async AWS workload-identity provider
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150326
+- file:
+    name: 152435.yaml
+    checksum: 60fc50ec46a9603c95b2a3f0da50287af9b74a01
+  type: enhancement
+  title: '[ESQLDS] Move config validation to `ExternalSourceResolver`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152435
+- file:
+    name: 152065.yaml
+    checksum: c8838b5b1d871c72a4a03777473fe5293cc86ce3
+  type: enhancement
+  title: 'PromQL: Add support for increase on histograms'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152065
+- file:
+    name: 148891.yaml
+    checksum: 410ecd1440ac310c00e2065ebc22a531d5a16097
+  type: feature
+  title: Optimize `field_extract` on flattened fields
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148891
+- file:
+    name: 149279.yaml
+    checksum: 22724db2ce379448bc7d0f1801cd438795368ebf
+  type: enhancement
+  title: Fix UBN COUNT/MIN/MAX pushdown for absent columns
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149279
+- file:
+    name: 149015.yaml
+    checksum: 1b625479c90bb0d18d44fdc2085ebd8680e29738
+  type: bug-fix
+  title: Add error message for SPARKLINE after TS
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149015
+- file:
+    name: 144762.yaml
+    checksum: da79b440fc031070d0a1771126676090c6e82185
+  type: enhancement
+  title: Remove `RecoveryMonitor`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Recovery
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144762
+  issues:
+  - "93544"
+- file:
+    name: 152835.yaml
+    checksum: 951c89d36d8b38fe4a58fcf03f42732dc46247b7
+  type: bug-fix
+  title: Fix Zstd DStream `VarHandle` offset on JDK 21
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152835
+- file:
+    name: 148242.yaml
+    checksum: 200e7543e47e56959e9a6322da4af31db36e2493
+  type: enhancement
+  title: Emit ordinal blocks for dictionary parquet strings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148242
+- file:
+    name: 147158.yaml
+    checksum: 2de9ddad72e427003b4753c38cc1f930d14705cb
+  type: bug-fix
+  title: Fix misleading error for missing external files
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147158
+  issues:
+  - "146715"
+- file:
+    name: 151576.yaml
+    checksum: e24fbe73c6d5cbb8eb4aae404f3440cd070fb082
+  type: feature
+  title: Add cache-miss wait time to search response
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151576
+- file:
+    name: 148583.yaml
+    checksum: 8fc857a9c0e35e9e7083a8cfbf38381203949024
+  type: enhancement
+  title: Add ECS event.ingested to ML anomaly detection result documents
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148583
+  issues:
+  - "144836"
+- file:
+    name: 149668.yaml
+    checksum: f21cd3d44559bb695d8864c33f22d4fecec0a9ca
+  type: enhancement
+  title: Move encryption key management into a dedicated x-pack-encryption module
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149668
+- file:
+    name: 149687.yaml
+    checksum: bf31571bcbdbd6f157379921d4ed23cec274d15c
+  type: enhancement
+  title: Add TO_COUNTER() function and ::counter cast operator
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149687
+- file:
+    name: 149541.yaml
+    checksum: c0d098afe47f68ab71c958c9137f8a6b52e4a4c1
+  type: bug-fix
+  title: Nullable defaults for ORC and Parquet attributes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149541
+- file:
+    name: 149405.yaml
+    checksum: 71f54da3384a7a8446e1df43e0f2ff0754542401
+  type: bug-fix
+  title: Support Parquet unsigned integer types
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149405
+- file:
+    name: 146965.yaml
+    checksum: 33e7c565518cad4ac4ab4d182bceecb585b9ca41
+  type: enhancement
+  title: Synonyms search_after pagination
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146965
+- file:
+    name: 151609.yaml
+    checksum: 473c3c3b53c64ce51406cc90d761ad4c721a05b0
+  type: enhancement
+  title: '[Encryption] Move PEK password wrap/unwrap to disk write/read only'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151609
+- file:
+    name: 146089.yaml
+    checksum: 7450d57839ab6d94986aa33945d5e49952fed3e1
+  type: enhancement
+  title: Determine inference timeout based on task type
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146089
+- file:
+    name: 147698.yaml
+    checksum: 3e0d1b7a049d4c097a84ae449fd08423713ea72e
+  type: bug-fix
+  title: Check cluster state block in `_resolve/index`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147698
+- file:
+    name: 153771.yaml
+    checksum: 298fb3efc5bd8a8ea8a27f0c0e71c0670d6e1616
+  type: bug-fix
+  title: Fix `json_extract` execution with foldable MV
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153771
+  issues:
+  - "153622"
+- file:
+    name: 151961.yaml
+    checksum: db59f2035edd5da5520e3a758f88a75acb6ec635
+  type: bug-fix
+  title: SPARKLINE fixes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151961
+  issues:
+  - "150224"
+- file:
+    name: 148756.yaml
+    checksum: ec20c57c7ee400e8c105e0f92a93e2732f2cee72
+  type: bug-fix
+  title: Thread per-file planner-resolved read schema to runtime readers
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148756
+- file:
+    name: 147765.yaml
+    checksum: 636555ef7fcd98ecf8aa786db30eb6003376b46a
+  type: bug-fix
+  title: Fix ordering race in `RoleReferenceIntersection`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147765
+- file:
+    name: 150235.yaml
+    checksum: 5e1fa6d47e3199356676233e2c032265666d45b1
+  type: enhancement
+  title: Implement GET /_prometheus/api/v1/status/buildinfo
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150235
+- file:
+    name: 150665.yaml
+    checksum: b96008e30a6324a36c84cf2a5279972b45c705b2
+  type: enhancement
+  title: '[ES|QL|DS] Parquet reader: handle TIME, INTERVAL & BSON types'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150665
+- file:
+    name: 151977.yaml
+    checksum: 19372b9ae59e560567269be0309f3e86fe05e981
+  type: enhancement
+  title: Allow heterogeneous `FROM idx, ds` and pushdown optimizations
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151977
+- file:
+    name: 148255.yaml
+    checksum: 1b2b217c02d0fdc2565e9811edb181db9684f267
+  type: enhancement
+  title: Bulk-decode Parquet definition levels
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148255
+- file:
+    name: 153675.yaml
+    checksum: a0618457bae4fdf3aabc8850943ed6d0eeee9656
+  type: bug-fix
+  title: Fix off-by-one in `ZeroBucket.index()` due to rounding errors
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153675
+  issues:
+  - "153270"
+- file:
+    name: 147266.yaml
+    checksum: 1db8d771131b87ad03febf3e956e652639af952d
+  type: bug-fix
+  title: Fix row over-read and lost-wakeup hang on external source
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147266
+- file:
+    name: 152121.yaml
+    checksum: a6f9aafef07082577ad8ed5e76504624f19c7f53
+  type: enhancement
+  title: Improve allocation explain API for `canRemain`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152121
+  issues:
+  - "131603"
+- file:
+    name: 149385.yaml
+    checksum: 3b78456480da653420e6ffa0f73153faf2297fb1
+  type: bug-fix
+  title: Clearer error message on nested aggregations
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149385
+- file:
+    name: 152176.yaml
+    checksum: 94f7968fbcdfbef55bd9ff2ff5183a18d54779e4
+  type: enhancement
+  title: Lenient truncate on `max_record_size` cap-hit
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152176
+- file:
+    name: 146288.yaml
+    checksum: 644638d200ccbbf0b807572d5a2a55204d19901c
+  type: enhancement
+  title: Wire native async reads for S3 and Azure
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146288
+- file:
+    name: 153120.yaml
+    checksum: aa6419f984445e71b2436ad3125880403657b396
+  type: enhancement
+  title: Bound concurrent streaming segmentators
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153120
+- file:
+    name: 151058.yaml
+    checksum: aaedfae15865f074cfdf9be5d475f21fdb3a0a59
+  type: enhancement
+  title: Add `data_storage_class` and `metadata_storage_class` settings for GCP reposi...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151058
+- file:
+    name: 148500.yaml
+    checksum: bd0294c22957e971087dfdea50ff96adf66f0c8c
+  type: enhancement
+  title: Decouple Parquet late materialization from two-phase byte-ratio gate
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148500
+- file:
+    name: 150075.yaml
+    checksum: 77b076891e98721f76d9b411f042d6a0f6d9b5b2
+  type: enhancement
+  title: Honor search timeout by not retrying on replicas
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150075
+  issues:
+  - "149508"
+- file:
+    name: 149716.yaml
+    checksum: ca8ad52bf894de106e6fd35692f721999940eb52
+  type: enhancement
+  title: Extend FIRST and EARLIEST to support dense_vector, `exponential_histogram` an...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149716
+- file:
+    name: 149346.yaml
+    checksum: 0fe7900fef544fdaeeca538c20190cd49dc304da
+  type: enhancement
+  title: Wire search-timeout cancellation to Painless script contexts
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149346
+- file:
+    name: 147358.yaml
+    checksum: 31e086d9207a42ccc250f211ebcfb7f6013383a8
+  type: enhancement
+  title: Fix wrong stats pushdown for multi-file glob queries
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147358
+- file:
+    name: 152859.yaml
+    checksum: cbe98f02253aa227ce0aa758294c9039fbf2f370
+  type: enhancement
+  title: Reconcile temporal stat units in cross-file merge
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152859
+- file:
+    name: 148412.yaml
+    checksum: c85894e5b537232bb35cc760d5e865f6391f8cba
+  type: feature
+  title: ES|QL query approximation support for FORK
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148412
+- file:
+    name: 152635.yaml
+    checksum: 67c570518d62c1fcb6106cbaee7972137f39bece
+  type: bug-fix
+  title: Fix NDJSON NPE on null nested objects
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152635
+- file:
+    name: 150608.yaml
+    checksum: 803e2c2ea5d45ebfd9f6d79233225412f5ba116e
+  type: enhancement
+  title: Return 400 instead of 500 for suggest requests across indices with different...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Suggesters
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150608
+- file:
+    name: 147964.yaml
+    checksum: b71627404c080ae822af5ff3a2e53ec7dd1e80f6
+  type: enhancement
+  title: 'Caching: Prefetch from blob storage, if local prefetching fails'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147964
+- file:
+    name: 149645.yaml
+    checksum: 87b33507507282a44e23b73b4709aae92dadc937
+  type: enhancement
+  title: Early publish `DesiredBalance` when newly created replicas are assigned
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Allocation
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149645
+- file:
+    name: 149491.yaml
+    checksum: c645d4d868af289edc3bf454c5a9f64bd25e9610
+  type: enhancement
+  title: Tighten async external source coverage
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149491
+- file:
+    name: 147460.yaml
+    checksum: 81a5176c7024e39629e4f63c43c9817a11ba36bd
+  type: bug-fix
+  title: Fixed workflow `dataStream` descriptor
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147460
+- file:
+    name: 149307.yaml
+    checksum: b0d956a3e1e869a98d8af60b26b5809f7ca01bda
+  type: enhancement
+  title: Extend FIRST and EARLIEST aggregations to support additional types including...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149307
+  issues:
+  - "141596"
+- file:
+    name: 148453.yaml
+    checksum: b7b0c557ee4c5e6168b0d0645ad6d37c934a85ac
+  type: bug-fix
+  title: Fix double-release in two-phase parquet path
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148453
+- file:
+    name: 148648.yaml
+    checksum: 2d9ffba505e313a740d06c6032a1dca2be2225be
+  type: bug-fix
+  title: Reject non-Smile content in Smile stream parser
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148648
+  issues:
+  - "61489"
+- file:
+    name: 151486.yaml
+    checksum: e404b02f7888876132e923bdf0ce929cb98012ee
+  type: enhancement
+  title: 'Implement PromQL set operator: top-level `or` (UNION)'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151486
+- file:
+    name: 147552.yaml
+    checksum: c79cc79b97e0930cf2188685e6e55e6a305e1427
+  type: enhancement
+  title: Add diagnostic fields to reader context lifecycle logs
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147552
+  issues:
+  - "112680"
+- file:
+    name: 148473.yaml
+    checksum: f7ab1a5b0ef5a30d834563fcf50aa48fd11e65f3
+  type: feature
+  title: Add a BY subclause to CHANGE_POINT command
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148473
+- file:
+    name: 148920.yaml
+    checksum: 889d50d97af6471d10f19ad2eca7e04892b532a2
+  type: enhancement
+  title: Add distinct storage class settings for S3
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148920
+- file:
+    name: 152091.yaml
+    checksum: a89048ee9db982cf6899974c2632f7b8c2155b6d
+  type: enhancement
+  title: Add native support for metric temporality
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    TSDB now supports metric temporality natively: Counters and histograms can be ingested through the OTLP endpoint
+
+    with both cumulative and delta temporality. The temporality will be stored as an additional metric dimension
+
+    and ES|QL `TS` queries will interpret the data automatically, taking the temporality into account. There is no new
+
+    query syntax for this functionality. Existing queries will continue to work as expected. The temporality is also respected
+
+    and preserved during downsampling. Metrics ingested using other means can use the new `index.time_series.temporality_field`
+
+    index setting...
+  highlight: true
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152091
+- file:
+    name: 148865.yaml
+    checksum: 556133948f7a3ff5c4f70af09988b5a54fb465a9
+  type: enhancement
+  title: Cache `FieldInfo` instances per shard Directory
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148865
+- file:
+    name: 147293.yaml
+    checksum: 9c64ac715d445007ffad31459e85d86d504eb6cc
+  type: bug-fix
+  title: Fix false-positive duplicate time-bucket in TS aggregate
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147293
+  issues:
+  - "143697"
+- file:
+    name: 147769.yaml
+    checksum: bcbba091f4089673d734871422674236d355f392
+  type: feature
+  title: Prune constant sort keys from TopN
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147769
+  issues:
+  - "143518"
+- file:
+    name: 152838.yaml
+    checksum: d04cc7c2a60a9af780e9800c07d7bdca4c926354
+  type: bug-fix
+  title: Fix Parquet TopN early-termination race and error detail
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152838
+- file:
+    name: 144796.yaml
+    checksum: aa5bcf6bbd5cde42896e09eb3e62c12a90519cc5
+  type: enhancement
+  title: Allow semantic text use with embedding models
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144796
+- file:
+    name: 147155.yaml
+    checksum: 06c78b13bd5133364747ea3075473afb6152d1cd
+  type: enhancement
+  title: Collapse `SearchHit.readFrom` and `SearchHits.readFrom` signatures
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147155
+- file:
+    name: 152357.yaml
+    checksum: 8f46e9ff3a072176ac4f2bb75ab00255e7cdeb73
+  type: enhancement
+  title: Support nested fields under subobjects:false
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152357
+- file:
+    name: 146928.yaml
+    checksum: 9d8ebbf3fce51278f15719b133cf8f32d055dd24
+  type: enhancement
+  title: Expose `DesiredBalanceStats` as metrics
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Allocation
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146928
+- file:
+    name: 145191.yaml
+    checksum: e171e31dceafd9bb0deff5dda52735713523d55f
+  type: enhancement
+  title: Add file metadata virtual columns for external sources
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145191
+- file:
+    name: 148259.yaml
+    checksum: ec89db9a39f6213662023cb5e4557ef4e983ebe9
+  type: enhancement
+  title: Prune `NotEq` pages where min == max == value
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148259
+- file:
+    name: 149018.yaml
+    checksum: c230600ad6517317fd0a73c35fb1995cce063797
+  type: enhancement
+  title: Cache parsed Parquet and ORC footers across producers
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149018
+- file:
+    name: 153100.yaml
+    checksum: cfa29023da2620dc6337869d190cbc8163838f85
+  type: enhancement
+  title: Honest `waitForReady` for seekable parse drain
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153100
+- file:
+    name: 149389.yaml
+    checksum: 96d347f0ec69ec46989ef4cc5a889a3c5c929d61
+  type: enhancement
+  title: Track remote reindex HTTP response bytes in REQUEST circuit breaker
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Reindex
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149389
+- file:
+    name: 153012.yaml
+    checksum: b977881f278fe3f54be74169ebaab6bced934eff
+  type: enhancement
+  title: '[DiskBBQ] Version DiskBBQ format to ES950'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153012
+- file:
+    name: 149809.yaml
+    checksum: 9a42330eea84c1607fb44b5a65f9b69ee007c07c
+  type: enhancement
+  title: 'ESQL|DS: Panama FFI streaming zstd for `.csv.zst` / `.ndjson.zstd`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149809
+- file:
+    name: 145980.yaml
+    checksum: b7c7cfd6aa4a9455e9fb879d6b4360b270d236f4
+  type: feature
+  title: Lookup join and Inline stats support for query approximation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145980
+- file:
+    name: 152551.yaml
+    checksum: 362737523a0d4989c3d0e4a651508b804db30f0f
+  type: bug-fix
+  title: Encode external Parquet `unsigned_long` reads
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152551
+- file:
+    name: 151687.yaml
+    checksum: 226e783e6d89b1677658947e00c267e8d44bc3a9
+  type: enhancement
+  title: Emit Painless array runtime-size allocation pre-checks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151687
+- file:
+    name: 152697.yaml
+    checksum: 278042444b6195afcc2805703b73b3b3c6e3cb2b
+  type: bug-fix
+  title: '[ES|QL]: Fix EVAL after STATS with union types/PUNK'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152697
+  issues:
+  - "152496"
+- file:
+    name: 149521.yaml
+    checksum: 9b2b7fe442aad3e86d248da418301494598a7970
+  type: bug-fix
+  title: '`JSON_EXTRACT(_source, ...)` warns when `_source` is null instead of returnin...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149521
+  issues:
+  - "149513"
+- file:
+    name: 151054.yaml
+    checksum: 14723b723dea34e883026c98dc966e101c2fef94
+  type: enhancement
+  title: Support the Google Vertex AI global endpoint for inference endpoints
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151054
+  issues:
+  - "150990"
+- file:
+    name: 152855.yaml
+    checksum: 206f2f6eea460f707be12eddbaee5c7c4552e108
+  type: enhancement
+  title: Preserve Parquet micros/nanos timestamp precision
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152855
+- file:
+    name: 145693.yaml
+    checksum: 945dd3584964e5e9645d8fc39f5280233a131044
+  type: enhancement
+  title: Add Defer Flag
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Transform
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145693
+  issues:
+  - "140456"
+- file:
+    name: 153252.yaml
+    checksum: 0d95b3e09fb86804a3d60b7c606d35ed69f77fb5
+  type: bug-fix
+  title: '[ES|QL|DS] Parse CSV file-level `datetime_format` with the ES `DateFormatter`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153252
+- file:
+    name: 149576.yaml
+    checksum: 4eaa4ff79f7b3e88e6542a5e6199a0cb75dacb76
+  type: enhancement
+  title: NDJSON keyword decode reuses one `BytesRef` scratch
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149576
+- file:
+    name: 152290.yaml
+    checksum: f149fdd5ab6bdeedf2f7de9445c0bfae371999b9
+  type: enhancement
+  title: Encryption at rest for sensitive cluster state
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    Elasticsearch provides encryption at rest for sensitive credentials stored in cluster state,
+
+    starting with credentials (for example, access key and secret key pairs) for ES|QL external
+
+    data sources. Credentials are encrypted using a project-scoped primary encryption key before
+
+    being written to cluster state, and are decrypted only when needed, such as during query
+
+    execution. The primary encryption key itself is generated automatically and is protected at
+
+    rest using a password configured through secure settings or the keystore.
+  highlight: true
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152290
+- file:
+    name: 148672.yaml
+    checksum: 1e823ac70da12a3e13d5fc042d1bb0d79213fad8
+  type: bug-fix
+  title: Added Optional `num_candidates` to `KnnRetriever` to Mirror Knn Behavior
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148672
+  issues:
+  - "148636"
+- file:
+    name: 153244.yaml
+    checksum: 480493e892aa83d698fc4a9e69820b8e3168ee3c
+  type: bug-fix
+  title: '[ESQLDS] Fix escaped CSV/TSV double-decode when `_rowPosition` is projected'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153244
+- file:
+    name: 149833.yaml
+    checksum: 5bc07194cb404e965bb7f7625c2719e4c4f00ded
+  type: enhancement
+  title: Enlarge GZIPInputStream raw buffer to 64 KiB
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149833
+- file:
+    name: 152793.yaml
+    checksum: eb9484d1f67709b9c8e27be39c86d4519b569e8b
+  type: enhancement
+  title: Enable the adaptive replica selection formula adjustment
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152793
+- file:
+    name: 150604.yaml
+    checksum: 6f2cf03858aaff10699fd041dea64edc5cfaec6a
+  type: enhancement
+  title: Add PIT context relocation metrics to stateless recovery
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150604
+- file:
+    name: 152639.yaml
+    checksum: 7b31406368ad5222e17baa3bef7b047469d6e955
+  type: bug-fix
+  title: '[PromQL] Fix wrong window filter boundaries'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152639
+  issues:
+  - "151971"
+- file:
+    name: 149976.yaml
+    checksum: 6e9e0081f2c84ac6d754fa0348b4fd5ea1631e37
+  type: bug-fix
+  title: '[ESQLDS] Parquet: Fix deferred extraction for struct leaf columns'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149976
+- file:
+    name: 152951.yaml
+    checksum: 3281daf5ba596b2640d5c3a470290cee49080bf6
+  type: bug-fix
+  title: '[ESQLDS] Fix Parquet footer-stats MIN/MAX for FLOAT16/DECIMAL'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152951
+- file:
+    name: 149167.yaml
+    checksum: 2dc2d65455d15e11cacb75ed4f50bb150b56a008
+  type: enhancement
+  title: REPLACE fast-path review fixes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149167
+- file:
+    name: 153090.yaml
+    checksum: 4241c6e07b262a09d8b0eeea744df15b6d74241b
+  type: feature
+  title: Unmatched DROP wildcard no-op if unmapped
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153090
+  issues:
+  - "143226"
+- file:
+    name: 149022.yaml
+    checksum: ebf3632ca8b4a28d45fbf841de365138b2b5219f
+  type: enhancement
+  title: Bulk-grow TopN UTF-8 string encoding
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149022
+- file:
+    name: 145700.yaml
+    checksum: ddbe6cd036ee4c079faaa61326fd7047652d3170
+  type: bug-fix
+  title: Fix several ContextualAI integration issues in the Inference plugin
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145700
+- file:
+    name: 150017.yaml
+    checksum: 18406dc9863454c18da8df1adaa415f14931a9c1
+  type: enhancement
+  title: Add release hook to Vector and Block
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150017
+- file:
+    name: 148974.yaml
+    checksum: 19e99805767d005aab3e4723f9909c89c61698c6
+  type: enhancement
+  title: Support form-encoded POST on PromQL HTTP query and discovery routes when secu...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148974
+- file:
+    name: 152180.yaml
+    checksum: df8563258c026a8b79f55c7fd1ffca9f404bfe60
+  type: bug-fix
+  title: Rebuild the indices lookup when a cluster-state diff changes only ES|QL datas...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152180
+- file:
+    name: 146069.yaml
+    checksum: 7ec54e2d9f4ce6a0b91f13deda6a36c3c12a6e16
+  type: enhancement
+  title: '[Native] AVX-512 BBQ vector operations'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146069
+- file:
+    name: 152092.yaml
+    checksum: b5dcbc4d13f7fcb19caea76fd64ea044bbea4a6c
+  type: other
+  title: '[Inference API] Bumping commons-text library version to match commons.lang3'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152092
+- file:
+    name: 148470.yaml
+    checksum: 62d3ac20689c7d254e71af0ae409f35642300d7b
+  type: bug-fix
+  title: No re-sync for paused or re-assigned shard snapshot
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148470
+- file:
+    name: 147855.yaml
+    checksum: 6d075c44fe38d997e3392108832230e86eb5131b
+  type: bug-fix
+  title: Fix `SearchHit` leak in chunked fetch failure cleanup path
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147855
+  issues:
+  - "147812"
+- file:
+    name: 149762.yaml
+    checksum: b78557bb99dfc856adb97546ab40900d2282aea6
+  type: bug-fix
+  title: Fix inconsistent data type with counter types referenced by subqueries
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149762
+  issues:
+  - "149694"
+- file:
+    name: 146182.yaml
+    checksum: 99312fcd6490eaab63f9002d53ff4790f3ea5561
+  type: enhancement
+  title: Ref count EQL `_source` (search hits and events)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146182
+- file:
+    name: 148935.yaml
+    checksum: 16e13260c7af881b2fbb276b9ca0beec18af8b31
+  type: enhancement
+  title: 'Parquet: nested-And short-circuit + filter eval cleanups'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148935
+- file:
+    name: 143338.yaml
+    checksum: a00c1b655073926cd16dec74749e226d7d4d2181
+  type: breaking-change
+  title: Order remote cluster exclusions
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    An exclusion affects targets listed before it and has no impact on targets listed after it.
+
+
+    Cluster exclusions in cross-cluster search index expressions are now processed left-to-right, matching the existing behavior of index exclusions. An exclusion only applies to clusters already included by a preceding expression.
+  impact: Queries that place a cluster exclusion before the corresponding inclusion (e.g., `/-remote1:*,*:*/_search`) will now return an error. Reorder expressions so that exclusions follow inclusions (e.g., `/*:*,-remote1:*/_search`).
+  subtype: api
+  areas:
+  - CCS
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/143338
+- file:
+    name: 152179.yaml
+    checksum: bd726dd18ec937258872cd67579e7503ee947452
+  type: enhancement
+  title: Add timeout support to the update inference endpoint API
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152179
+  issues:
+  - "140501"
+- file:
+    name: 149220.yaml
+    checksum: 03f60b82b88a11c4505ae7ceb225a7199e267fd3
+  type: enhancement
+  title: 'APM OTel SDK: flush metrics and traces under a single shared timeout'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149220
+  issues:
+  - "149072"
+- file:
+    name: 151885.yaml
+    checksum: 0b9b973ce4b7e06195d92cc771462946b10e3300
+  type: feature
+  title: Make FUSE command GA
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151885
+  issues:
+  - "123389"
+- file:
+    name: 145628.yaml
+    checksum: 6fda33eb6193416103b30af8b325874904bf4f07
+  type: bug-fix
+  title: '`IndicesClusterStateService#failedShardsCache` tracks primary term'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145628
+- file:
+    name: 147615.yaml
+    checksum: 9f17562d16d8755a905544211ba0fca584dcae07
+  type: enhancement
+  title: Support `BufferParameters` in ST_BUFFER
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - Geo
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147615
+- file:
+    name: 152552.yaml
+    checksum: d23de4a431af76192cb70551b03daf0970e8bc5e
+  type: bug-fix
+  title: Trip request breaker on big completion suggest size/shardSize
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152552
+- file:
+    name: 152102.yaml
+    checksum: e78f55cdf80449d55eebd9851017db78de6cc091
+  type: enhancement
+  title: Add inference flag to field caps
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152102
+  issues:
+  - "147575"
+  - "124567"
+- file:
+    name: 153085.yaml
+    checksum: 77b5bea7687d16738a40669934a532f688fabefb
+  type: bug-fix
+  title: '[ESQLDS] Fix external multi-file warm COUNT/MIN/MAX re-scanning under schema-...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153085
+- file:
+    name: 147496.yaml
+    checksum: 56f0d0bab5f109fdccacb492833b1c06bb3d7de0
+  type: enhancement
+  title: Create settings for platform architecture
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147496
+- file:
+    name: 148333.yaml
+    checksum: 14ad74dc023c72141d2c856d56678789deafa767
+  type: enhancement
+  title: Ordinal fast path for `BytesRefTopNBlockHash`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148333
+- file:
+    name: 152010.yaml
+    checksum: 28db6ca2b41b7ed0aeabab8e229053dbfed6f6da
+  type: enhancement
+  title: Route `(LONG, BYTES_REF)` STATS through an adaptive composite BlockHash
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152010
+- file:
+    name: 147584.yaml
+    checksum: 4191bdb76466b20ac12260a36a111eb7fda995c2
+  type: enhancement
+  title: Deduplicate Parquet iterator decode logic
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147584
+- file:
+    name: 152293.yaml
+    checksum: b017259f314d82ef35c6bb3824d90055126f0342
+  type: bug-fix
+  title: Fix aggregation filters in TS group by all queries
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152293
+- file:
+    name: 146680.yaml
+    checksum: bb22c4924b562632dcded74457dd25dd7d944bc8
+  type: bug-fix
+  title: '`ZstdDecompressor:` fall back to copy path on `AlreadyClosedException`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Codec
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146680
+- file:
+    name: 151016.yaml
+    checksum: 5128681c89f986a133f0983b4daad81ae22990f3
+  type: enhancement
+  title: 'Painless: `script_aware` Iterable/Collection/Map augmentations'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151016
+- file:
+    name: 151850.yaml
+    checksum: e48776cb5027a513a62467c39a7c572d246268c5
+  type: bug-fix
+  title: Fix LOOKUP JOIN index scope in subqueries
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151850
+- file:
+    name: 144351.yaml
+    checksum: 564e9126b15bf2c9f0b58e1a010c3552807e2fb2
+  type: enhancement
+  title: '`CompletionSuggestion:` ref-count hits, released by `SearchResponse`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144351
+- file:
+    name: 148722.yaml
+    checksum: 36a9895f248a6cdd7578e35e4b0b35c0aa67e39a
+  type: enhancement
+  title: Reserve CB memory for automaton construction
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148722
+  issues:
+  - "147428"
+- file:
+    name: 147253.yaml
+    checksum: f09b329f5e200d251de00da95097400b368da3a1
+  type: enhancement
+  title: Suppress `ColumnIndexFilter` INFO log spam
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147253
+- file:
+    name: 150083.yaml
+    checksum: 51e5b746cc121bf5efa901b5c89c75a98bcb8851
+  type: bug-fix
+  title: Update `TransformIndexer` `RetentionPolicyException` to correctly include ver...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150083
+- file:
+    name: 148260.yaml
+    checksum: 7062eb004f7009c753f9eaca53f3eb01b5da7606
+  type: enhancement
+  title: 'Painless: honor search timeout in score scripts'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148260
+- file:
+    name: 153093.yaml
+    checksum: e459ccb01e95ed0c2518c54d1092acc69e89f607
+  type: feature
+  title: '[Inference API] Region policy for inference requests'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153093
+- file:
+    name: 150332.yaml
+    checksum: da1ab2454622a7699b2308dc9db20d56120c45c8
+  type: bug-fix
+  title: Honor WITHOUT exclusion for wildcard TSDB dims
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150332
+- file:
+    name: 145833.yaml
+    checksum: dd825b2cb3031d2a6e1edc7c21317cb7ff7a5e8a
+  type: enhancement
+  title: Enable EMBEDDING task for `OpenAiService`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145833
+- file:
+    name: 147418.yaml
+    checksum: be671c13b012f898af769a9296f8010372c481cf
+  type: enhancement
+  title: Add `EncryptionService` for encrypt/decrypt operations using PEK
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147418
+- file:
+    name: 141466.yaml
+    checksum: ea908afc435d4c057ac65a60cc69dea13df68d95
+  type: enhancement
+  title: Avoid tracking group ids for intermediate input
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/141466
+- file:
+    name: 150277.yaml
+    checksum: aa2015dabf900ff273f2b2c4e8bdf03f26e40d01
+  type: enhancement
+  title: Add GCS keyless auth via workload identity
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150277
+- file:
+    name: 144234.yaml
+    checksum: 831f35bbe6dfd871b24c342d6e9bab19de2093ca
+  type: enhancement
+  title: '`RoundTo` Block Loader Optimization'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/144234
+- file:
+    name: 152499.yaml
+    checksum: 0c10f3ec97a1bead949607c5b58d782fb8d191b9
+  type: other
+  title: Bump `OpenTelemetry` to 1.62.0 in GCS modules
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152499
+- file:
+    name: 152163.yaml
+    checksum: 15722d9607295936b5dd92a976f2bc45b93b7ae0
+  type: other
+  title: Upgrade jackson
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152163
+- file:
+    name: 152476.yaml
+    checksum: c0f2b7479237429587feac74018f86e6643177eb
+  type: bug-fix
+  title: Return a 400 (Bad Request) for invalid tokens in a `script` query
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152476
+- file:
+    name: 149390.yaml
+    checksum: 6a4e7a5ff450d349d6f9d9774857541887518bc8
+  type: bug-fix
+  title: Fix NPE in `bucket_sort` on unresolvable sort path
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149390
+  issues:
+  - "136418"
+- file:
+    name: 147224.yaml
+    checksum: d826931d2bf6ae1fd52049b04c3fc6173bb1545a
+  type: enhancement
+  title: Use IOContext to detect random access for bloom filters
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Codec
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147224
+- file:
+    name: 150220.yaml
+    checksum: 56f936cfbe7eca5fea3f761825e67e9dcb350576
+  type: breaking-change
+  title: Rewire FUSE to use FIRST for passthrough columns
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  description: In previous versions `FUSE` merged rows with matching `key_columns` by keeping all distinct values for each passthrough column. Now `FUSE` selects the first non-null value for each passthrough column, or null in the absence of a value. `FUSE` now supports passing through all field types except `aggregate_metric_double`, `histogram`, and `date_range`.
+  impact: This has no impact if passthrough columns come from the same document with identical column values across fork branches. Queries that relied on `FUSE` collecting multiple distinct values for a passthrough column will need to aggregate those values separately.
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150220
+  issues:
+  - "141596"
+- file:
+    name: 151431.yaml
+    checksum: 933af4d271a0357355624c23a5cd0fee9858d12f
+  type: enhancement
+  title: Make views REST API available in serverless
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151431
+- file:
+    name: 152837.yaml
+    checksum: 95a7b6d11bf1842fc3f4622f1020b06109a7783f
+  type: bug-fix
+  title: Normalize local `StorageObject` path for stats reconcile
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152837
+- file:
+    name: 148539.yaml
+    checksum: 2312f5e424bd1c0488d95a078f6a2bffc5814e94
+  type: enhancement
+  title: Add `chat_completion` task type to the Anthropic inference service
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148539
+  issues:
+  - "147188"
+- file:
+    name: 148493.yaml
+    checksum: cf14661ba48615f7a1176681a18497e028d13527
+  type: enhancement
+  title: Add max_field_bytes to attachment processor and ingest.attachment.max_field_s...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Ingest node
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148493
+- file:
+    name: 146931.yaml
+    checksum: 891c907fa29be865d0c33f4515e1f79d47e10003
+  type: enhancement
+  title: Stop carrying shard request with each shard search result
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146931
+  issues:
+  - "146684"
+- file:
+    name: 148256.yaml
+    checksum: 2125425a6378574b8b13c50ebf54b5c2f47e36f8
+  type: enhancement
+  title: Prune non-top-N groups during aggregation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148256
+- file:
+    name: 146248.yaml
+    checksum: c168f654312bad1c80ca2837835e75527b9ba40f
+  type: bug-fix
+  title: Ensure that indices with auto-expand replicas have refresh blocks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146248
+- file:
+    name: 147320.yaml
+    checksum: e8c0ed11a1a0fa3fced69797f94986303a6a7e0e
+  type: bug-fix
+  title: Log cancelled snapshot fetch failure at DEBUG
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147320
+  issues:
+  - "142785"
+- file:
+    name: 149555.yaml
+    checksum: cdd921d75e514fffbd71455044a7331a46b50276
+  type: bug-fix
+  title: Roll reindexed ML state indices in daily maintenance
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149555
+- file:
+    name: 150324.yaml
+    checksum: ca2fe4c1e8c4acb541a7088800bd665646599c26
+  type: bug-fix
+  title: More tests and bug fix for In Subquery with TS
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150324
+- file:
+    name: 150148.yaml
+    checksum: b2fe15b5c3c9454319038aba05dfece0fd566d15
+  type: enhancement
+  title: Parallel TopN Operator
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150148
+- file:
+    name: 146589.yaml
+    checksum: a2ba68b71bb25626fee4c7ff818ecbb6a151e149
+  type: enhancement
+  title: Remove `FilterPushdownRegistry,` use `FormatReader`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146589
+- file:
+    name: 149892.yaml
+    checksum: 10a7b5ee9525c874fedb5d09c43657143a92294f
+  type: enhancement
+  title: Ability to configure a number of replicas for system indices
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149892
+  issues:
+  - "99720"
+- file:
+    name: 152362.yaml
+    checksum: ef25077dec742879a655afc7637120d628402f99
+  type: feature
+  title: Provide default `jwt_audience`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authentication
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152362
+- file:
+    name: 149484.yaml
+    checksum: fefdba85861d00017fd14a4c09dbd8e1a07ec6ad
+  type: enhancement
+  title: Log BCC upload progress and BCC queueing time
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Engine
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149484
+- file:
+    name: 148915.yaml
+    checksum: 9408f6aefcf0912a29a41834c20d71ef2901d0b3
+  type: bug-fix
+  title: Fix inner hits overwrite when collapse and nested query both set inner hits
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148915
+  issues:
+  - "148905"
+- file:
+    name: 148411.yaml
+    checksum: 077a2ee5a7114c6963d2e34e41a741b67cde5a1b
+  type: bug-fix
+  title: Closing async instrument removes it from registry
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148411
+- file:
+    name: 151325.yaml
+    checksum: e3009dbb18ff7e194861426e0549f79b350de683
+  type: bug-fix
+  title: '[PROMQL] Bug fix: correctly adjust quantile phi to percentile scale'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151325
+- file:
+    name: 148554.yaml
+    checksum: 25bc680c8945318831188def0b12c98af211cf07
+  type: bug-fix
+  title: Stash ML_ORIGIN for `hasIlm` `GetIndex` during daily maintenance
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148554
+- file:
+    name: 152509.yaml
+    checksum: f1f120f088cdcf54dfb2e8351d3d4fa499f9d854
+  type: bug-fix
+  title: Fork `ensureShardSearchActive` callbacks off the refresh thread
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152509
+  issues:
+  - "97280"
+- file:
+    name: 149345.yaml
+    checksum: b1afba22976d0f34f2b1f40632b4e5e8b7fe9323
+  type: enhancement
+  title: Add `data_access_tier` and `metadata_access_tier` settings to Azure repository
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149345
+- file:
+    name: 149996.yaml
+    checksum: 2041654c248baf0c45723730663957f80fa38fa6
+  type: enhancement
+  title: Introduce `RecordSplitter` SPI
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149996
+- file:
+    name: 152773.yaml
+    checksum: 38fdb54f20e2b68287d1df92a0cf2c888ea23529
+  type: bug-fix
+  title: 'Aggs: Avoid OOMs by accounting memory on cardinality agg reduction phase'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Aggregations
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152773
+  issues:
+  - "150290"
+- file:
+    name: 145235.yaml
+    checksum: ad1a6be1a45ff37e5e91a516409ee9809fe3e0ad
+  type: enhancement
+  title: '`SearchHitRowSet` uses pooled `SearchHits`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145235
+- file:
+    name: 150172.yaml
+    checksum: 6ec4b2ef687706ebbb0ee8f428641f85ab9623d9
+  type: enhancement
+  title: Change EIS rerank request format to use objects for query and documents
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150172
+- file:
+    name: 152231.yaml
+    checksum: c8a40c762278836ddbd71a3a39285f3e99da990f
+  type: enhancement
+  title: Wire columnar index mode through synthetic source test framework
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152231
+- file:
+    name: 147176.yaml
+    checksum: 77592db7c35d5063964f79b8d704a887ebccac52
+  type: enhancement
+  title: Implicit Index Privileges SPI
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147176
+- file:
+    name: 153135.yaml
+    checksum: d45cc8230096e469cbb9683aad8bf6e9627210ee
+  type: bug-fix
+  title: Correctly detect is sub-query is performing remote lookup join
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153135
+- file:
+    name: 149754.yaml
+    checksum: b8dabeda29151c0b69d0f9dd213aa69a4f3f722a
+  type: enhancement
+  title: Add Painless cancellation checks to fetch, agg-reduce, and bulk-write script...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149754
+- file:
+    name: 148846.yaml
+    checksum: fb9b4d88c9db1e828edb72111e9944e8a2777baf
+  type: enhancement
+  title: '[ESQLDS - Parquet] Speed up allocations and remove array copies'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148846
+- file:
+    name: 148001.yaml
+    checksum: 36b579918ce088fa22ab16dec1a1064df57c6b5a
+  type: bug-fix
+  title: '[Inference API] Fix issues in VoyageAI integration'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148001
+- file:
+    name: 151670.yaml
+    checksum: 6a1f0797dad7512c1332ab2c0099193eceedca8c
+  type: feature
+  title: Chunk time-series aggregation output
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151670
+  issues:
+  - "147286"
+- file:
+    name: 149885.yaml
+    checksum: 78b72c1765fcfd2cd7d2272205520e7c824dcd37
+  type: enhancement
+  title: Adding support for IPinfo Plus database
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Ingest node
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149885
+- file:
+    name: 148797.yaml
+    checksum: ba33907e3a0cb51b7ff57c690d9b9f4e0536f6bd
+  type: bug-fix
+  title: Yield producer-loop when streaming-parallel iterator not ready
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148797
+- file:
+    name: 152230.yaml
+    checksum: 7fa9b2731d07e8d6d945c37175498d79aa556960
+  type: enhancement
+  title: '[Inference API] Add reasoning fields to Elastic Service `TaskSettings`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152230
+- file:
+    name: 150036.yaml
+    checksum: 9f1850315c39636cc6a9b975b166d29a3d14ef1d
+  type: enhancement
+  title: Count read bytes for Lucene operators
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150036
+- file:
+    name: 150466.yaml
+    checksum: 9fde2cded83d14c573f6be0eff8361a2a0b7b6d0
+  type: enhancement
+  title: Add destructive reset endpoint for project encryption key
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150466
+- file:
+    name: 148410.yaml
+    checksum: 76947c3bea3d449d83d5372187c621add0566c30
+  type: enhancement
+  title: Surface external source operator's emitted rows as `documents_found`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148410
+- file:
+    name: 151774.yaml
+    checksum: 95df46ce3db794f8a8a4f53d35b2b65213c6e3b2
+  type: bug-fix
+  title: Fix `NoSuchMethodError` in `JdkMacCLibrary.ErrorReference.toString` on JDK 22+
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151774
+- file:
+    name: 149344.yaml
+    checksum: 709f383d3e0de76e8c53c3f670c1ff60bb27ce11
+  type: enhancement
+  title: 'DiskBBQ: switches from striped dibit to packed'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149344
+  issues:
+  - "144608"
+- file:
+    name: 147566.yaml
+    checksum: 5848cc44353ccb1713a00d1b17211e05e17a4138
+  type: enhancement
+  title: Include index and shard id in shard failure exception message
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147566
+  issues:
+  - "113489"
+- file:
+    name: 150132.yaml
+    checksum: ffefc297ec963666de188d7b23d192265d7db781
+  type: enhancement
+  title: '[Inference API] Adding OpenAI OAuth2 implementation'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150132
+- file:
+    name: 151959.yaml
+    checksum: b28a4183e6b3a44f107abd9e9f0f90e3ffb142e3
+  type: other
+  title: Update to lucene 10.5
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Codec
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151959
+- file:
+    name: 149190.yaml
+    checksum: dffde42ca46d558d509ae771d15327cbcb9c3ef6
+  type: enhancement
+  title: Encrypt data-source secret settings at rest
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149190
+- file:
+    name: 152733.yaml
+    checksum: ba3e02c96c9804ba3ec963060f1229f047213ea6
+  type: bug-fix
+  title: Ignore OTLP number data points without a value
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152733
+- file:
+    name: 152877.yaml
+    checksum: 8ce116f264d23b8eab47b0af0a1eadb6ab985aff
+  type: bug-fix
+  title: Fix errors/warnings with spatial functions that parse invalid BBOX
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152877
+  issues:
+  - "152876"
+- file:
+    name: 152932.yaml
+    checksum: 97ef3603adb5fd9783687c0d6844ebeb4c8f2391
+  type: bug-fix
+  title: Include ingest metadata in self reference checks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Ingest node
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152932
+- file:
+    name: 146588.yaml
+    checksum: 49c6b7ce715aa1b015e1042d076d8f4ffb37bdf7
+  type: enhancement
+  title: DiskBBQ Bulk collect knn docs to improve query latency
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146588
+- file:
+    name: 150775.yaml
+    checksum: ab0bedf32cf873c6a80742ad8c686444741ee32e
+  type: bug-fix
+  title: Reconcile external source statistics by coverage range, not scan count
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150775
+  issues:
+  - "150571"
+  - "150594"
+  - "150595"
+  - "150599"
+  - "150614"
+  - "150615"
+  - "150616"
+  - "150620"
+  - "150628"
+  - "150642"
+  - "150643"
+  - "150653"
+  - "150657"
+  - "150670"
+  - "150678"
+  - "150705"
+  - "150710"
+  - "150723"
+  - "150744"
+  - "150758"
+  - "150771"
+  - "150783"
+- file:
+    name: 148938.yaml
+    checksum: 8a950d737a856d554866cade6153edd4bab43694
+  type: enhancement
+  title: Add raw histogram mapping hint
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148938
+- file:
+    name: 152973.yaml
+    checksum: 1a3bfd0769747187255037290d3f01d9a7136fdb
+  type: feature
+  title: Unmapped fields/full text null warning
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152973
+  issues:
+  - "151403"
+- file:
+    name: 152861.yaml
+    checksum: 6fd29c160f5665a92d59dfc1c6fc6d26e2642a20
+  type: feature
+  title: ES95 is the default TSDB doc values codec
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    ES95 is now the default doc values codec for new time series indices. On host
+
+    metrics data it reduces total doc values storage by about 30% versus ES819,
+
+    driven by `@timestamp` (up to 90% smaller) and floating-point gauges and counters
+
+    via adaptive floating-point encoding, at no indexing or query cost. Existing
+
+    indices keep their codec; opt out with `index.time_series.es95_codec.enabled: false`.
+  highlight: true
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152861
+- file:
+    name: 147225.yaml
+    checksum: da1138c7f0d186de3b45ae0935f7f07509b1f93a
+  type: enhancement
+  title: Align bfloat16 vector data to minimize page crossings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147225
+- file:
+    name: 151522.yaml
+    checksum: 15606063f9236549847ab560fa82ff8043812639
+  type: enhancement
+  title: '[Encryption] Add encryption password to auto-configuration'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151522
+- file:
+    name: 148703.yaml
+    checksum: 184ae38430c108a53210ab597a316ec6ec6305e4
+  type: enhancement
+  title: Add `config.name` mapping to fleet-agents index
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Plugins
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148703
+- file:
+    name: 150626.yaml
+    checksum: 23d411608e81fb567abf529b62b7ddcdd3e425de
+  type: enhancement
+  title: Add stack trace suppression for OTel traces
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150626
+- file:
+    name: 149889.yaml
+    checksum: 44e49a1ab12e1f04965335230f2bfe5d0552fd32
+  type: enhancement
+  title: Wire internal refresh listeners on `SearchEngine`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Engine
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149889
+- file:
+    name: 148261.yaml
+    checksum: 8146454608a3cfe4645d2d13012ee45556da9f96
+  type: enhancement
+  title: Skip filter eval when row group stats prove all rows pass
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148261
+- file:
+    name: 147481.yaml
+    checksum: 0b759019294fe1c55545e7bfbbabaa66eb200aa5
+  type: bug-fix
+  title: Preserve emit size in `AdaptiveBlockHash`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147481
+  issues:
+  - "147361"
+- file:
+    name: 145146.yaml
+    checksum: 27c57034866acc4572bf75ace87ea7181f00c9b8
+  type: enhancement
+  title: Reindex parse exception has document index and ID
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Reindex
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145146
+  issues:
+  - "48432"
+- file:
+    name: 152953.yaml
+    checksum: 70986cc7368b51cf79706cedd6643c32bf8f0bb0
+  type: bug-fix
+  title: Fix fetch-phase `store_bytes_read` miscount
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152953
+- file:
+    name: 153641.yaml
+    checksum: 7d7995b6abf2396b9317fdb579ad35b5d662fa47
+  type: enhancement
+  title: Abort external read backoff on hard cancel
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153641
+- file:
+    name: 150981.yaml
+    checksum: c495953c08be0127f4dc0e7b4a7563d1e5244bf4
+  type: bug-fix
+  title: Adds type to message on wrong mutation of attributes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150981
+- file:
+    name: 151017.yaml
+    checksum: 30a2cbd99772014c15e227c5c7723f7405fe087c
+  type: enhancement
+  title: Add Painless allocation-limit setting scaffolding
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151017
+- file:
+    name: 149098.yaml
+    checksum: eac5e768f0b51947ea7da34771bb808bd53e5d29
+  type: enhancement
+  title: '[Inference API] Adding deployment type to Inference API telemetry'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149098
+- file:
+    name: 147985.yaml
+    checksum: fe551c50c017eb32c54640cb0400b3e9b456e31e
+  type: enhancement
+  title: '[Inference API] Apply Retry-After header if present in EIS responses'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147985
+- file:
+    name: 151502.yaml
+    checksum: cb2bfd6c75e5d5b413029febe2435ade7087bd26
+  type: enhancement
+  title: 'PromQL: Add support for `histogram_count`, `histogram_sum` and `histogram_avg`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151502
+- file:
+    name: 151152.yaml
+    checksum: 66f3e9a0a9dc4b6993822ee6cc13444b8422e64e
+  type: bug-fix
+  title: Include `size` in `time_series` aggregation builder equality
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Aggregations
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151152
+  issues:
+  - "151151"
+- file:
+    name: 146044.yaml
+    checksum: 9e7c3275bcdc60fa73853e7cfb7c8e70f58cc0fd
+  type: enhancement
+  title: Add GET /_prometheus/api/v1/metadata endpoint
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146044
+  issues:
+  - "146045"
+- file:
+    name: 146802.yaml
+    checksum: 249b65a9412985b595690660012d92cb02486d13
+  type: bug-fix
+  title: Fixes a bug in AbstractAsyncBulkByScrollAction which removed the scroll param...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Reindex
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146802
+  issues:
+  - "146741"
+- file:
+    name: 150240.yaml
+    checksum: c6ce1194ccc31aa2c87d922aae436ca95649606e
+  type: enhancement
+  title: Enforce datasource record caps
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150240
+- file:
+    name: 148220.yaml
+    checksum: 706a2000429b1a8a07e5b03b981e0e8f2eae101a
+  type: enhancement
+  title: Assign downsampling to least loaded candidate node
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Downsampling
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148220
+- file:
+    name: 152011.yaml
+    checksum: 7cba772f669c68c4be3777e4e5f4c56da4ae9793
+  type: bug-fix
+  title: Support term queries on flattened fields when index=false
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152011
+- file:
+    name: 152154.yaml
+    checksum: a511b2210408c450bb41d00bcbd9bc8cb67422a4
+  type: enhancement
+  title: Extend LAST and LATEST to support the same field types as FIRST and EARLIEST
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152154
+  issues:
+  - "149478"
+- file:
+    name: 149348.yaml
+    checksum: 5b1bc8214f09d9dbf72a5f3fa226e3c3ec473f45
+  type: bug-fix
+  title: Repro and fix `recoveryStats` double decrement
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149348
+- file:
+    name: 152857.yaml
+    checksum: 4f3e18e57e5aae090f14429f764adc1391517d4a
+  type: enhancement
+  title: Fix Parquet list-under-struct read as null
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152857
+- file:
+    name: 148277.yaml
+    checksum: e7b18f9a1bc2e12d5751f0a739902360c0fce632
+  type: bug-fix
+  title: Try to bypass jvm recompilation probably-bug
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148277
+- file:
+    name: 149466.yaml
+    checksum: baf350f681a7f1f8c03f5afde302e0529a31e041
+  type: enhancement
+  title: Expose `_clusters` metadata in open point-in-time response for CCS
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149466
+  issues:
+  - "84400"
+- file:
+    name: 149870.yaml
+    checksum: 96fbfbf9fc0cb0ee9d475368734cca353faa0fc4
+  type: enhancement
+  title: Parquet pushdown for CONTAINS and ENDS_WITH
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149870
+- file:
+    name: 148332.yaml
+    checksum: 4a06bcd793fbfc449950ea2bb3fd7f1707f50c88
+  type: enhancement
+  title: Dictionary short-circuit for late-mat filters
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148332
+- file:
+    name: 148918.yaml
+    checksum: 8167fceb878ecfdd82f8d349612ca02b57f62924
+  type: enhancement
+  title: 'Parquet: dictionary filter fast paths and per-row-group memo'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148918
+- file:
+    name: 147614.yaml
+    checksum: bee036157953e010f372680c69485c388a337a88
+  type: bug-fix
+  title: Fix validation error when search functions are used after FORK
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147614
+  issues:
+  - "142710"
+- file:
+    name: 150978.yaml
+    checksum: eb5d4e990b71cc889949fdafc4f7f1f95dab8852
+  type: bug-fix
+  title: Fix PromQL name matchers
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150978
+- file:
+    name: 148349.yaml
+    checksum: 944fd69d33e668e3aa3071badc76b1bf093bc9c6
+  type: enhancement
+  title: Cache parquet dictionary array across batches
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148349
+- file:
+    name: 152528.yaml
+    checksum: 90add7966dadbc2ee61790e153ddd9a3744ff7ed
+  type: feature
+  title: Release semantic field
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152528
+  issues:
+  - "143287"
+- file:
+    name: 152894.yaml
+    checksum: 34022e96ca0ed99a08823fddf4f5ac0383c06def
+  type: enhancement
+  title: DiskBBQ - wire auto calibration at merge time
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152894
+- file:
+    name: 147157.yaml
+    checksum: 4f8951d686927ecd0ce3dc747a818132a0c4692d
+  type: enhancement
+  title: Allow multiple synonym sets per filter using the synonyms API
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Analysis
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147157
+  issues:
+  - "144941"
+- file:
+    name: 147507.yaml
+    checksum: 6984e7828473fce626171aa400481e0c82c97023
+  type: enhancement
+  title: Improve `float` & `byte` comparisons for `RankVectors`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147507
+- file:
+    name: 152210.yaml
+    checksum: 02065e1a4d1721f50191aed93fa8109af3fcc0d6
+  type: bug-fix
+  title: 'FORK: Fix error handling for unsupported types'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152210
+  issues:
+  - "147603"
+- file:
+    name: 118003.yaml
+    checksum: 13828aad38bb3eaa30132792f6ba66808b09a1cb
+  type: bug-fix
+  title: Create system index on first put
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Transform
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/118003
+  issues:
+  - "117995"
+- file:
+    name: 153682.yaml
+    checksum: fac0db6c5dab812e14c73737794960e8807ff2d5
+  type: bug-fix
+  title: Fix hint-blind external-dataset listing cache and rewrite-to-empty throw
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153682
+- file:
+    name: 146087.yaml
+    checksum: 6d794f878e3937f7a5775468bc9808982b46cadd
+  type: enhancement
+  title: Make synonym rule limit configurable at the cluster level and increase the li...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146087
+- file:
+    name: 150016.yaml
+    checksum: ca9737c8289a076a1f55ca6dc4182f650e48b69b
+  type: bug-fix
+  title: Skip unrelated files when scanning config dir for log4j2.properties
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150016
+- file:
+    name: 152181.yaml
+    checksum: f1616b38866833db74987f3fb64e7be27538fd13
+  type: enhancement
+  title: '[Encryption] Add datasources destructive reset'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152181
+- file:
+    name: 149816.yaml
+    checksum: a1d5a2d73d08631f2b029de76a601a5ac9030506
+  type: bug-fix
+  title: Add `PartitionConfig.CONFIG_KEYS` and thread into `FileSourceFactory.COORDINA...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149816
+- file:
+    name: 148354.yaml
+    checksum: 6eb72253e2e1adea9281436e0a47b17d786fd5ff
+  type: enhancement
+  title: Cache `FilterOperator/EvalOperator` `toString`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148354
+- file:
+    name: 152759.yaml
+    checksum: 7600996834c13be3aa4dfa05eea3405bf099fe38
+  type: bug-fix
+  title: Fix Parquet COUNT(col) missing `null_count` stat
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152759
+- file:
+    name: 149050.yaml
+    checksum: b6b4fcd0a569f3b5c1d5508e7d4de77525ab21c3
+  type: bug-fix
+  title: Rebuild `IsNotNull` list when nullified by the JVM workaround
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149050
+- file:
+    name: 146576.yaml
+    checksum: 5578f14ca47d36dd4c402d48459dbfcd52efc2b3
+  type: enhancement
+  title: Add `doc_values` mapping attribute to `RoutingFieldMapper`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146576
+- file:
+    name: 147367.yaml
+    checksum: f26efd0c9d16206bb8a0de104cb36d588e9c36e8
+  type: bug-fix
+  title: Set `locationToSync` for no-op FAILURE results
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147367
+- file:
+    name: 153774.yaml
+    checksum: c5cf7d422ccdecf8b42715a1aac82af1cc2380ad
+  type: enhancement
+  title: 'ILM & DLM create snapshots with `partial: true` to prevent blocking cluster r...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ILM
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153774
+  issues:
+  - "153643"
+- file:
+    name: 148568.yaml
+    checksum: 64a68af16f221553274921d9fc1a3b7ec43bd5ca
+  type: enhancement
+  title: Add encryption at rest for primary encryption key
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148568
+- file:
+    name: 147672.yaml
+    checksum: fcf7a507339a2586ccf794e55007c37f46159dc5
+  type: enhancement
+  title: BF16 bulk AVX-512 K-unroll for sequential paths
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147672
+- file:
+    name: 147222.yaml
+    checksum: 3a4ebde103e477bf31196b35f5b35f74fb34ba54
+  type: enhancement
+  title: 'FSDirectoryFactory: fix read advice for slices inside CFS'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147222
+- file:
+    name: 146063.yaml
+    checksum: e7d85c9b0db779bc15c5e238b8d1913b30f4f819
+  type: enhancement
+  title: Add cluster state metadata for data sources and datasets
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146063
+- file:
+    name: 146433.yaml
+    checksum: 0f7c8f5e8e538628093b77b4f4b1180c108c42c8
+  type: bug-fix
+  title: 'ESQL:DS: have NDJSON plugin respect error policy'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146433
+  issues:
+  - "146331"
+- file:
+    name: 149841.yaml
+    checksum: b93177bdfb1301b0d72a54fb22582258df82eeff
+  type: enhancement
+  title: Specialize TopN for numeric keys on external sources
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149841
+- file:
+    name: 150676.yaml
+    checksum: 118324ffef0b3bd5f84501658d4bf0908b591690
+  type: bug-fix
+  title: Fix `UnsupportedOperationException` for partially unmapped keyword fields wit...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150676
+  issues:
+  - "150667"
+- file:
+    name: 152098.yaml
+    checksum: f047c2902a166537656c90249f06b4a35b9d6b6d
+  type: bug-fix
+  title: Treat empty list query parameters as null
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152098
+  issues:
+  - "152271"
+- file:
+    name: 152427.yaml
+    checksum: 44cddb52c1995ae388df1f1e2c59d096f22b6e96
+  type: bug-fix
+  title: Translate `tools` and `tool_choice` to Anthropic format for Google Model Gard...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152427
+- file:
+    name: 150949.yaml
+    checksum: 3f6d0dbd6eae234f8993de632600665d95ead5ab
+  type: bug-fix
+  title: Preserve _doc metadata for Prometheus info-command plans
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150949
+- file:
+    name: 148179.yaml
+    checksum: afe2103c7086483afc65b11925fcfa6db40df176
+  type: bug-fix
+  title: Fix data stream privilege checking
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authorization
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148179
+- file:
+    name: 148529.yaml
+    checksum: 23e484541f3162d7920863b81a30bb725ad22138
+  type: enhancement
+  title: Two-phase I/O fixes — sparse read, mask short-circuit, coalesce gap
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148529
+- file:
+    name: 147633.yaml
+    checksum: f8fc47a300ec5c8d72928107dee068915e17d873
+  type: enhancement
+  title: '[Inference API] Add stack version and production environment to APM attributes'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147633
+- file:
+    name: 152523.yaml
+    checksum: 37aa9ea0e64a590365cf2f44c4027d85bf39f35d
+  type: enhancement
+  title: Release `to_text` conversion function
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152523
+- file:
+    name: 149380.yaml
+    checksum: 5572d61f5a076dad442920ca29cbdb1f7cb02e64
+  type: enhancement
+  title: Aggregate metadata pushdown for external text formats
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149380
+- file:
+    name: 148786.yaml
+    checksum: 8ee3c7254b16e1fe02a4fff5d7de9166f0bf4e3c
+  type: enhancement
+  title: Improved reindex resilience and new reindex management APIs
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  description: >-
+    We're making multiple changes to the resilience and ease-of-use of the
+
+    reindex API. Firstly, asynchronous reindex operations will now survive
+
+    the graceful shutdown of the node where they are running. This makes
+
+    long-running operations much more reliable, especially in a managed
+
+    cluster. Secondly, reindex operations will now normally use the
+
+    point-in-time API instead of the scroll API for paginated search. This
+
+    is the preferred approach for deep pagination, and allows reindex to
+
+    benefit from recent improvements to PIT resilience (where available).
+
+    Finally, we are adding dedicated new APIs to...
+  highlight: true
+  areas:
+  - Reindex
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148786
+- file:
+    name: 152221.yaml
+    checksum: 039ad8be2f5246a37b1662587aab5b06e8be63e0
+  type: enhancement
+  title: NDJSON field-name identity cache
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152221
+- file:
+    name: 147865.yaml
+    checksum: cf995bad08dd622c2e127527188a4c070dd3f8f3
+  type: enhancement
+  title: '[Native] i8 bulk AVX-512 shared-b'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147865
+- file:
+    name: 147166.yaml
+    checksum: 3a5d7a8bb25e4400150fa3da281c1f9baae73c58
+  type: bug-fix
+  title: Fix Sparkline generating extra bucket bug
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147166
+- file:
+    name: 149085.yaml
+    checksum: b299316e635d559d1aa05cd118e82238961bfd0d
+  type: bug-fix
+  title: Mark histogram and tsid as unsortable
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149085
+- file:
+    name: 149206.yaml
+    checksum: a81ad0f316c88818d1581968b26eb6279ba69c26
+  type: enhancement
+  title: 'ES|QL: unify `SET` and request-body parameters into one settings framework'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149206
+  issues:
+  - "143239"
+- file:
+    name: 149713.yaml
+    checksum: f9b8447ead2980bc0726436f94411674e323938d
+  type: enhancement
+  title: Add TO_GAUGE() function and ::gauge cast operator
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149713
+- file:
+    name: 147598.yaml
+    checksum: 10a0a7dc7c65d98edde21d5b8a4faffe6c2f8b7d
+  type: enhancement
+  title: Add per-query concurrency budget for S3 connections
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147598
+- file:
+    name: 146673.yaml
+    checksum: 95d70e0d48f97d7ea1d5dfb72eed4868339acea5
+  type: enhancement
+  title: Migrate rank-eval `SearchHits` from unpooled to pooled
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146673
+- file:
+    name: 147936.yaml
+    checksum: 6366900c592c397ae09c407dbc0c01e64d813ea8
+  type: enhancement
+  title: Adaptive S3 prefetch depth and zero-copy strings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147936
+- file:
+    name: 150066.yaml
+    checksum: 67abe643a3341e9c08419ed7d2e815d1030efa3c
+  type: feature
+  title: Advise MADV_RANDOM on blob cache regions backing vector data files
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150066
+- file:
+    name: 148143.yaml
+    checksum: c82c52f002a6c329b09e6aba8331aad484ae2d6f
+  type: enhancement
+  title: Tune NDJSON parallel parsing throughput
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148143
+- file:
+    name: 147691.yaml
+    checksum: 51f73117db70fe62d9184444012cebe892715eb9
+  type: enhancement
+  title: Filtered prefetch custom Parquet reader
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147691
+- file:
+    name: 152493.yaml
+    checksum: 5cd9a5d3855db3c1a461b73b52bab281ed7fb12e
+  type: enhancement
+  title: Document and slim `ExternalSourceExec` field layering
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152493
+- file:
+    name: 149375.yaml
+    checksum: 021aaae4c3cf5f128b8cc547cae77ce95479e24b
+  type: bug-fix
+  title: Fix Potential of NPE in PIT search after relocation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149375
+  issues:
+  - "149371"
+- file:
+    name: 146595.yaml
+    checksum: 2db885252f36fd228162e680650ab1a7b20044b6
+  type: enhancement
+  title: Adding a check to verify that `BlobContainer::blobExists` works as expected i...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146595
+  issues:
+  - "119303"
+- file:
+    name: 149660.yaml
+    checksum: 3fcbb23c002bf8f97b9d371da933c609bf33eb6c
+  type: bug-fix
+  title: Anchor CSV row errors in fused fast path too
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149660
+  issues:
+  - "149567"
+- file:
+    name: 152186.yaml
+    checksum: 3615d314f28df881b554e9cee16b29352c1107d3
+  type: bug-fix
+  title: Add necessary attribute for internal JVM metrics
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152186
+- file:
+    name: 145839.yaml
+    checksum: e16c048e077f8e5e2738ca30cb254523382272a7
+  type: enhancement
+  title: Flush OTel SDK metrics at shutdown
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145839
+- file:
+    name: 150553.yaml
+    checksum: 1f6421d2000ccc38d9e05387f3df40be8db374b9
+  type: enhancement
+  title: Improve `DocumentParser#parseObjectDynamic()` if subobjects are disabled and...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150553
+- file:
+    name: 149637.yaml
+    checksum: a54811c7684d8341405f8997d2f1922b24fb747a
+  type: enhancement
+  title: Integrate with UIAM tokens
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Transform
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149637
+- file:
+    name: 147500.yaml
+    checksum: 514133a4f9d4422900cb4deea97da77a8c66f70b
+  type: enhancement
+  title: Surface skipped/null-filled external rows as response `Warning` headers
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147500
+- file:
+    name: 151987.yaml
+    checksum: 6dfb41e6a39103ee4caef150b2b38d2a5efd3006
+  type: enhancement
+  title: Track search phase request/result bytes at coordinator
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151987
+- file:
+    name: 151968.yaml
+    checksum: e36e18b1b574a64083a8a32ca7bb0f06f243674a
+  type: other
+  title: Upgrade opentelemetry in ms-graph-authz
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authentication
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151968
+- file:
+    name: 150380.yaml
+    checksum: 8ecd46a4af8cea90ba2b5f30e75ebb204833295e
+  type: bug-fix
+  title: Fix cluster details mrt false
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150380
+- file:
+    name: 146868.yaml
+    checksum: 5e1e11c479c02597b9e3151fbdcfcbdcb0913ad0
+  type: enhancement
+  title: Pool `ClientHit` PIT hits via ref-counting
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146868
+- file:
+    name: 150115.yaml
+    checksum: 6d275147c3728f8f8dd73cf2405c0746045629d4
+  type: enhancement
+  title: Add circuit breaker to `TransportMultiSearchAction`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150115
+- file:
+    name: 152082.yaml
+    checksum: ad00e8553567bbb805554c9812fda1a368e9f535
+  type: enhancement
+  title: 'PromQL: Add support for sum aggregation on exponential histograms'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152082
+- file:
+    name: 146491.yaml
+    checksum: 21c75d217e0d4c86cdbd31d5d1e10e5293714e14
+  type: bug-fix
+  title: 'ESQL:DS: NDJSON plugin fixes'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146491
+- file:
+    name: 150545.yaml
+    checksum: 0f265e18a05ccee7cebc7027d9c3e45c14e2ba54
+  type: enhancement
+  title: Add points memory estimate to tier heap estimate
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150545
+- file:
+    name: 151211.yaml
+    checksum: 2f389889025865908671a0a27a8c2c8f944d353d
+  type: enhancement
+  title: Estimate `PointRangeQuery` memory in the circuit breaker
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151211
+- file:
+    name: 152714.yaml
+    checksum: 2dc87dfd37ba77772fc884faa4272076233aa8cf
+  type: feature
+  title: Add `KibanaCasesImplicitPrivilegesProvider` contributing implicit index privi...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152714
+- file:
+    name: 151138.yaml
+    checksum: a402441f8ecbfe708b9705960afb5e41baae883d
+  type: enhancement
+  title: Make INDICES_RECOVERY_MAX_CONCURRENT_OUTGOING_RECOVERIES setting dynamic
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151138
+- file:
+    name: 150396.yaml
+    checksum: 944ccd9a6af91a5c226d93d5cd4a340f19617ef5
+  type: enhancement
+  title: Add azure snapshot repository access tier settings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Snapshot and restore
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150396
+- file:
+    name: 152651.yaml
+    checksum: 1123da38968ef03e2063b97bdf9e16c14ff85e1a
+  type: enhancement
+  title: '[ESQLDS] Add multi-key TopN pushdown for external sources'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152651
+- file:
+    name: 149699.yaml
+    checksum: 1fa3e69a77d7f73bad3a926143ef7ae9938218ec
+  type: bug-fix
+  title: 'Query approximation: fix chained STATS verification for FORKed queries'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149699
+  issues:
+  - "149501"
+- file:
+    name: 146096.yaml
+    checksum: b2eb815b14e4b7b1236316cbeb4ce80a721f0ceb
+  type: enhancement
+  title: 'ES-14041: Port trace/span export from APM agent to OTel SDK'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/146096
+- file:
+    name: 147238.yaml
+    checksum: f906af2119ba09c69d7610f982d244a124c3d51e
+  type: enhancement
+  title: Write skipindex to a separate file in TSDB Codec
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Codec
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147238
+- file:
+    name: 150457.yaml
+    checksum: 1f59a25a1ba13972fd8cade9619edc4fba180c6b
+  type: feature
+  title: Data stream lifecycle can move data to the frozen tier
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    Data stream lifecycle (DLM) now supports the frozen tier. Set a `frozen_after`
+
+    value in a data stream's lifecycle, and DLM moves aging backing indices to the
+
+    frozen tier as partially-mounted searchable snapshots once they pass that age,
+
+    reducing storage cost while keeping the data fully searchable. `frozen_after`
+
+    sits alongside `data_retention` and `downsampling` in the lifecycle
+
+    configuration, with no ILM policy required. DLM writes frozen data to a new
+
+    cluster-level default snapshot repository. This capability requires an
+
+    Enterprise license and is not available in Elastic Cloud Serverless.
+  highlight: true
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150457
+- file:
+    name: 147541.yaml
+    checksum: 7046c74612e264ac37aee3ba742f3d9f888b5116
+  type: enhancement
+  title: Reject `pathPrefix` containing consecutive slashes
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147541
+  issues:
+  - "117048"
+- file:
+    name: 147404.yaml
+    checksum: 0828c19ae5c0f4788571760eb68c85b530b99f7e
+  type: bug-fix
+  title: Disable sliding-window cache in Parquet adapter
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147404
+- file:
+    name: 153715.yaml
+    checksum: 9942d43629cfa262c522e1bf2ca136b024484dc2
+  type: enhancement
+  title: Cache single-file metadata, skip warm probe
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153715
+- file:
+    name: 148509.yaml
+    checksum: c13f53c2af03a85d3f50e651fd0fae6bdf3c452e
+  type: bug-fix
+  title: Return an empty response for scrolls with no shard contexts
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148509
+  issues:
+  - "143532"
+- file:
+    name: 152387.yaml
+    checksum: 6ef1c7da2281538a1a6678eb1a4a7b767ea2a7e2
+  type: enhancement
+  title: Store semantic_text input in doc values
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Mapping
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152387
+- file:
+    name: 153579.yaml
+    checksum: 891050ebe037dcde11d74b7ecdf25b5bd2d556ce
+  type: bug-fix
+  title: Fix `SORT` crash and partition-column `WHERE` wrong answers on Hive-partition...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153579
+  issues:
+  - "153503"
+- file:
+    name: 153129.yaml
+    checksum: 210a194c33925564e9f296577e1160ed130a49f8
+  type: bug-fix
+  title: '[ESQLDS] Fix CSV/TSV declared string columns rejecting literal null'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153129
+- file:
+    name: 150181.yaml
+    checksum: e223c6cf2797624d5713fd85e65c5577dab7b0de
+  type: bug-fix
+  title: Refund per-iteration CB memory in percolator
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150181
+- file:
+    name: 147701.yaml
+    checksum: c416bda53aed98fca85cf912d8b1cd72a63ff2c2
+  type: bug-fix
+  title: Helpful logging for NPE investigation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147701
+  issues:
+  - "146545"
+- file:
+    name: 147078.yaml
+    checksum: 18db96dc04d88b78d57043475872cc3b100a123d
+  type: enhancement
+  title: Improve `LongLongSwissHash` for high cardinality
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147078
+- file:
+    name: 152780.yaml
+    checksum: 4622ba8c01ad8e19c7ac5cb0749f192c7026b9da
+  type: enhancement
+  title: Report `vectordb_document` usage in _xpack/usage
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152780
+- file:
+    name: 145946.yaml
+    checksum: 1f68729e5f47578fc1c34749be43a528cdaaa090
+  type: enhancement
+  title: Add order option to TOP_SNIPPETS
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145946
+- file:
+    name: 152295.yaml
+    checksum: d755462c5091ca46e5c6201e9ae22558bd857a8a
+  type: bug-fix
+  title: Read OTel SDK switches from assembled JVM options
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152295
+- file:
+    name: 152515.yaml
+    checksum: a7e0b09c6dc00abe9497c01fe6efbf694e9566ca
+  type: enhancement
+  title: Two-phase iterator for TSDB numeric range doc values
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152515
+- file:
+    name: 151339.yaml
+    checksum: ef663732f52cb2ceeacafd35a2a28d94c574be0a
+  type: enhancement
+  title: Emit Painless compile-time allocation pre-checks
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151339
+- file:
+    name: 151913.yaml
+    checksum: 0cc0cf6404384f202e28769f946ec37ca9e70d77
+  type: enhancement
+  title: Azure event loop default threads
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Searchable snapshots
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151913
+- file:
+    name: 152542.yaml
+    checksum: d754c2094edd67cd7a85a72f2a415cfe64a3523c
+  type: bug-fix
+  title: OTel sdk service runtime name
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152542
+- file:
+    name: 153580.yaml
+    checksum: 0b241695d914ffff16f72e44e39f8970488d9c5c
+  type: bug-fix
+  title: 'ES|QL: NDJSON `error_mode` treats every unrepresentable cell the same for dec...'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153580
+- file:
+    name: 152391.yaml
+    checksum: 106d51289879df94428f230cdabc38bea945219d
+  type: enhancement
+  title: Make external split discovery cancellable
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152391
+- file:
+    name: 150656.yaml
+    checksum: 566c8e772da3a0ec610f2b080b5c27378fe43a01
+  type: bug-fix
+  title: Fix JDK 21 FFM regressions in zstd native binding
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150656
+  issues:
+  - "149943"
+  - "150156"
+- file:
+    name: 149532.yaml
+    checksum: 88e04e0cdab943468eb187d4dc13306b49df658e
+  type: enhancement
+  title: Parquet reader support for legacy LZ4 codec
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149532
+- file:
+    name: 152684.yaml
+    checksum: 90a8a39af058fbbba7676dd2e5cfd8577a764d7a
+  type: enhancement
+  title: Introduce feature flag for keyless auth
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authentication
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152684
+- file:
+    name: 151102.yaml
+    checksum: 3843ac1b18de91ae11b8e66fdcef485a29d252fa
+  type: bug-fix
+  title: Enforce read authorization on `FROM <dataset>`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151102
+- file:
+    name: 153581.yaml
+    checksum: 64264529aa5b1a8b914ebe24ac418bf982fa2d31
+  type: bug-fix
+  title: Fix remote write with audit request bodies
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Network
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153581
+  issues:
+  - "152713"
+- file:
+    name: 149026.yaml
+    checksum: 152932ae633acc494af59a63d17e4b06defe499a
+  type: enhancement
+  title: SIMD contains for *literal* LIKE patterns
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149026
+- file:
+    name: 149533.yaml
+    checksum: e3df6a9dd18fe236d5575ec07ba69ddbd8991d15
+  type: enhancement
+  title: Anchor CSV row errors on the parser fault offset
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149533
+- file:
+    name: 145510.yaml
+    checksum: 177cb8168988dbd73174580a2fcc473ceb674730
+  type: enhancement
+  title: Rewrite SUM(X+c) to SUM(X) + c*COUNT(X)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145510
+  issues:
+  - "140470"
+- file:
+    name: 151103.yaml
+    checksum: 9ef03c888f72180f3be0d5f908468039700a2341
+  type: enhancement
+  title: Make the worker queue dynamic
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151103
+- file:
+    name: 149421.yaml
+    checksum: 47c61c454c8cd5da5c674a1ce0c564a50a4faa13
+  type: feature
+  title: Add IP_LOCATION command
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149421
+  issues:
+  - "150231"
+  - "132489"
+- file:
+    name: 149972.yaml
+    checksum: 7d964b27ccd568f4b147fe23566c4605ffee6269
+  type: enhancement
+  title: Fix PromQL round(to_nearest) floating point accuracy
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149972
+- file:
+    name: 148660.yaml
+    checksum: 60066184cf8302f23f51d5bd0fb40470e1f2de09
+  type: bug-fix
+  title: Explicitly reject multiple grouped inputs for chunked inference
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148660
+- file:
+    name: 151154.yaml
+    checksum: 5843ca51dcf9be27574a18939b7bccb32495c55b
+  type: bug-fix
+  title: Fix `matrix_stats` aggregation builder equals/hashCode to include `missingMap...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-26
+  areas:
+  - Aggregations
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151154
+  issues:
+  - "151153"
+- file:
+    name: 147829.yaml
+    checksum: 52f642cc8ccc3d9f35acf90d650adafe63903aab
+  type: enhancement
+  title: 'Parquet decode-in-place: eliminate scratch-to-block copy'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-04
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147829
+- file:
+    name: 152328.yaml
+    checksum: a60284eba2d04fce926cbbfb02c5591d084609b1
+  type: enhancement
+  title: Defer FFW footer reads when stats unneeded
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152328
+- file:
+    name: 152847.yaml
+    checksum: 5241c2b7d5687fcd91f543d32f388c62bb553648
+  type: bug-fix
+  title: Fix multi-file range-split schema reconciliation
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152847
+- file:
+    name: 153755.yaml
+    checksum: d2a4aff0637165396b19d6b5a781e821062362be
+  type: bug-fix
+  title: Extend AD results template for reindexed indices and generalize heal beyond j...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153755
+  issues:
+  - "147686"
+- file:
+    name: 151841.yaml
+    checksum: f0a1edcaef6f1072f78e25a2514d02b64da2c38e
+  type: feature
+  title: Support for `flattened` fields in ES|QL
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    ES|QL now supports the `flattened` field type. Fields mapped as `flattened` were previously
+
+    unsupported and could not be referenced in queries. They can now be loaded and, together with
+
+    the new `FIELD_EXTRACT` ES|QL function, queried by sub-field.
+
+
+    `FIELD_EXTRACT(<flattened field>, "<sub-field>")` extracts the value of a single sub-field from a
+
+    `flattened` object and returns it as a `keyword`. The second argument is the literal name of the
+
+    sub-field exactly as it is stored, for example `FIELD_EXTRACT(attributes, "host.name")`. The dot is
+
+    part of the key, so the same dotted form addresses bo...
+  highlight: true
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151841
+- file:
+    name: 149572.yaml
+    checksum: dba54d20ddafc32e1af7a51e83152dbace744cad
+  type: enhancement
+  title: Snappy codec accepts Hadoop and xerial framings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149572
+- file:
+    name: 153485.yaml
+    checksum: 3d1005e9a1aea42871e7eb958c710043796153ae
+  type: bug-fix
+  title: Fix declared-schema read correctness on external datasets (Parquet filter-pus...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153485
+- file:
+    name: 152851.yaml
+    checksum: fe613a6fa2ac0f26bbeef136dc5875d501a6800e
+  type: enhancement
+  title: Implement watchdog timeout for GROK
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152851
+- file:
+    name: 152152.yaml
+    checksum: 02b2d970e18d253e7574f1c9ba5c702b9f7d68ec
+  type: bug-fix
+  title: Fix NPE when aggregation param scripts return null
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Aggregations
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152152
+  issues:
+  - "136639"
+- file:
+    name: 149030.yaml
+    checksum: e140b5edfeae8045326cb9980d1c11b638163729
+  type: enhancement
+  title: Generic byte matchers for pushdown predicates
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149030
+- file:
+    name: 153082.yaml
+    checksum: d3e8889f09548e0386da30c60937e3a385be0e89
+  type: bug-fix
+  title: Apply search timeout to the query rewrite step
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153082
+  issues:
+  - "104187"
+- file:
+    name: 153128.yaml
+    checksum: 2620999bd09eaa3e9c40e86475421344e0603481
+  type: bug-fix
+  title: Resolve prefixed searchable-snapshot backing indices to their data stream in...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153128
+- file:
+    name: 150354.yaml
+    checksum: d206e0853d64b348f3d1f13b9f90db9a136ab0e0
+  type: enhancement
+  title: Add missing OTel resource information
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150354
+- file:
+    name: 150092.yaml
+    checksum: 47dcc24c5bd3d7bd7437ce12625e2a57df9965dc
+  type: enhancement
+  title: 'Painless: `cancellation_aware` augmentation infrastructure'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150092
+- file:
+    name: 150138.yaml
+    checksum: b61040eeda40e1fc3ce61a3dec20c26e47e4f8bb
+  type: enhancement
+  title: Optimize sorted numeric field data loading for dense fields
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - Logs
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150138
+- file:
+    name: 149319.yaml
+    checksum: 6c589b117319e55f446f5e84293b7b2e37e4d4b8
+  type: feature
+  title: Support outbound peer recovery throttling
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Distributed
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149319
+- file:
+    name: 145290.yaml
+    checksum: dbb40762ff3a5e851cf58c2899cb4289ceb8f33b
+  type: enhancement
+  title: Reject reindexes with wrong parameters
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-20
+  areas:
+  - Reindex
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145290
+  issues:
+  - "37855"
+- file:
+    name: 140143.yaml
+    checksum: 622e7c9cc1bce7a8bfebb0c43c535e21e18d3ba3
+  type: enhancement
+  title: Add stats parameter support to Count API
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/140143
+  issues:
+  - "67528"
+- file:
+    name: 151617.yaml
+    checksum: 670959c93d4541c254f40cd46841eae9e5253b41
+  type: deprecation
+  title: Using the Elasticsearch Monitoring plugin to collect and ship monitoring data...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    Using the Elasticsearch Monitoring plugin to collect and ship monitoring data is deprecated since 7.16 and will
+
+    finally be removed in 10.0. All corresponding settings are deprecated for removal.
+  impact: >-
+    **[AutoOps](https://www.elastic.co/docs/deploy-manage/monitor/autoops)** is our recommended replacement.
+
+    Alternatively you may consider Stack monitoring with [Elastic Agent](https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-elastic-agent)
+
+    or [Metricbeat](https://www.elastic.co/docs/deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-metricbeat).
+
+    To help you decide, refer to the [AutoOps and Stack Monitoring comparison](https://www.elastic.co/docs/deploy-manage/monitor/autoops-vs-stack-monitoring).
+  areas:
+  - Monitoring
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151617
+- file:
+    name: 152938.yaml
+    checksum: afd692d3312f7b9378addfc6b9ca98b9bbeb4799
+  type: enhancement
+  title: Reuse resolved privilege automata in implicit SPI
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152938
+- file:
+    name: 152200.yaml
+    checksum: 8dc5854572dc48b7d4ad761935fb1114e2a97e5c
+  type: feature
+  title: Support full-text search functions for unmapped fields with `LOAD` and return...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152200
+  issues:
+  - "144121"
+- file:
+    name: 150114.yaml
+    checksum: fc10edd3e535df8fb05f839ff9de3626ed5ad98e
+  type: enhancement
+  title: Add NDJSON record splitter
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150114
+- file:
+    name: 151085.yaml
+    checksum: 1ddb4900fbb609ad0ac3605553d164737b123787
+  type: enhancement
+  title: Add Painless allocation counter mechanics
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Scripting
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151085
+- file:
+    name: 147151.yaml
+    checksum: eaec32b0cc84e31108353ced18dd0ba8e30f1bda
+  type: enhancement
+  title: Expand index pressure on update expansion
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - CRUD
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147151
+- file:
+    name: 148162.yaml
+    checksum: 521da1ffdd8f54651baf3fe67fbfeb4a7a320ca8
+  type: enhancement
+  title: Resilient CSV parsing, COUNT(*) fast path, and 400-status malformed-data errors
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148162
+- file:
+    name: 147782.yaml
+    checksum: 39add79934cec64e7f6948827a985b70057d0a7d
+  type: enhancement
+  title: Add ES|QL datasource and dataset index privileges
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Security
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147782
+- file:
+    name: 147043.yaml
+    checksum: 33957f86b812f1a4dad9e3ab108aab9c014244f8
+  type: bug-fix
+  title: Allow service implementation to determine inference timeout
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147043
+- file:
+    name: 152611.yaml
+    checksum: 4ed0b7f0fe14bb8563965d024b86c7d921f989f1
+  type: bug-fix
+  title: Fixing too-eager IP-location DB deletion
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - Ingest node
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152611
+- file:
+    name: 151949.yaml
+    checksum: e46ace00e3f4272689813b31a2a783009ded1d17
+  type: enhancement
+  title: '`date_range` field type available as tech preview'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    The `date_range` field type is now available in ES|QL as a technical
+
+    preview. This unlocks the range-specific functions `TO_DATE_RANGE`,
+
+    `TO_RANGE`, `RANGE_MIN`, `RANGE_MAX`, `RANGE_CONTAINS`,
+
+    `RANGE_INTERSECTS`, and `RANGE_WITHIN`, as well as support for
+
+    `date_range` fields in generic functions such as `COUNT`, `PRESENT`,
+
+    `ABSENT`, and the `MV_*` family.
+  highlight: true
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151949
+- file:
+    name: 153098.yaml
+    checksum: f747fa909648ac579587144bd66348551ab1eaa1
+  type: enhancement
+  title: Change federated feature flag to cluster config
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authentication
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153098
+- file:
+    name: 150030.yaml
+    checksum: 30d6f437f513105d5b38197b266f9960bb2bbf61
+  type: enhancement
+  title: Prune redundant stats groupings
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-02
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150030
+- file:
+    name: 150876.yaml
+    checksum: 048a00d813f190b7fcae25c8ed5e78f365920641
+  type: enhancement
+  title: Setting for trace sampling and batch processor
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Metrics
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150876
+- file:
+    name: 153309.yaml
+    checksum: fa88216ecec35e1447ec1e0b5531f63d59e8668f
+  type: breaking-change
+  title: '[Inference API] Prevent overriding `secret_parameters`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: The Inference API incorrectly allowed users to override values within `secret_parameters` with the contents of `task_settings.parameters` during a POST request. This change prevents that behavior, ensuring that `secret_parameters` cannot be overridden."
+  impact: Users who relied on the previous behavior to override `secret_parameters` will need to create a new inference endpoint with the `secret_parameters` moved to `task_settings` or no longer rely on the ability to override the `secret_parameters` within a POST request."
+  subtype: api
+  areas:
+  - Inference
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/153309
+- file:
+    name: 150175.yaml
+    checksum: d0e23a7701721a78fb13d44e0fd5580b3205df05
+  type: enhancement
+  title: 'Blob store prefetching: Allow for all nodes'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150175
+- file:
+    name: 152148.yaml
+    checksum: 21e2b5c67f4a758fb14e28e479a2439da62784ee
+  type: bug-fix
+  title: Improve simulate bulk action authz
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Authorization
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152148
+- file:
+    name: 149092.yaml
+    checksum: 9f3a554a4ffa196c794547c99efe241dfcb06b8b
+  type: enhancement
+  title: Support ST_UNION, ST_INTERSECTION, ST_DIFFERENCE, ST_SYMDIFFERENCE
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149092
+- file:
+    name: 145674.yaml
+    checksum: 86926203e0394511ac6ed7375946d06002b80f18
+  type: enhancement
+  title: Add AVX-512 f32 dot product and squared L2 kernels
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145674
+- file:
+    name: 151637.yaml
+    checksum: ea8c23981ffd626fc09482f6550c7fd1e2e8b7e0
+  type: deprecation
+  title: Implicit configuration of child loggers on logger setting updates is deprecated.
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  description: >-
+    Implicit configuration of child loggers on logger setting updates is deprecated.
+
+    Starting with 10.0 updating the log level of `foo` will not impact a child logger `foo.bar`.
+  impact: >-
+    We are changing the behavior how logger settings are handled. If you want to clear all dynamically configured loggers
+
+    in one operation, use the existing wildcard support for settings (e.g. `"logger.*": null`) rather than attempting to
+
+    configure a high level logger (e.g. `"logger.org.elasticsearch": "INFO"`)
+  areas:
+  - Infra/Logging
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/151637
+- file:
+    name: 148945.yaml
+    checksum: d654260412eb753eb6e5680dd9b8755241795260
+  type: enhancement
+  title: '[Native] head+spread prefetch in amd64 bulk kernels'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148945
+- file:
+    name: 150026.yaml
+    checksum: 23a52c9120b7c50c3602a49d9c3ca8034eb895ed
+  type: enhancement
+  title: Wire OTel SDK self-monitoring metrics into the span exporter
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Core
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150026
+- file:
+    name: 150499.yaml
+    checksum: 0a68a08fa13bf9a4c72fb7d45b6aa7db2aac4690
+  type: enhancement
+  title: Support short-lived credentials for EXTERNAL cloud reads
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150499
+- file:
+    name: 145361.yaml
+    checksum: 31342f5c8fdeb974d3676a3b95e6919d6953a118
+  type: enhancement
+  title: Use ref-counted `SearchHits` in data frame analytics paths
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145361
+- file:
+    name: 147976.yaml
+    checksum: 66a26d2829848edfbd6d06e92f4a6746d5bed46e
+  type: enhancement
+  title: Minimize the amount of memory used by `CommitReferencesInfo`
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - CRUD
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147976
+- file:
+    name: 149591.yaml
+    checksum: d9dbd61382af51a2adc0ec7275156455018d648c
+  type: enhancement
+  title: Handle OTLP explicit-bounds histograms without buckets in tdigest and exponen...
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - TSDB
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149591
+- file:
+    name: 152627.yaml
+    checksum: 59e6a75eddd601bad22a1c28ee41fdc18a55624d
+  type: bug-fix
+  title: Route source resolver off SEARCH pool
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152627
+- file:
+    name: 147999.yaml
+    checksum: f778df34ef3ce5c02e9f84a128a161a0a5f0221d
+  type: enhancement
+  title: '[Native] i7u bulk AVX-512 shared-b'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/147999
+- file:
+    name: 149600.yaml
+    checksum: 688bd358ca841944591dd8289f05ab30affc0a7a
+  type: enhancement
+  title: CSV datetime fast path follow-ups
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149600
+- file:
+    name: 148713.yaml
+    checksum: ac61f3c3f23fc2794973518ce4d84a3cc7cf8159
+  type: enhancement
+  title: Add `range_intersects` and `range_contains` functions
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148713
+- file:
+    name: 148656.yaml
+    checksum: 174ca0a0059c90c9c297f05e833fa0b0a4619348
+  type: bug-fix
+  title: Reserve REQUEST circuit breaker for reindex bulk batches
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-28
+  areas:
+  - Reindex
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148656
+- file:
+    name: 150266.yaml
+    checksum: aa9dd3d5884d4b65d29777a9880a3107524504f4
+  type: enhancement
+  title: Introduce params support for query logging (ESQL & SQL)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Infra/Logging
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150266
+- file:
+    name: 149339.yaml
+    checksum: def7e15c256fb13ed8fffa30b6235e19d2203485
+  type: enhancement
+  title: DiskBBQ - add symmetric 1-bit OSQ vector scorer
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-29
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149339
+- file:
+    name: 152349.yaml
+    checksum: d0c63c271b1f108c9e8cff67bba4484e12e63e2a
+  type: bug-fix
+  title: Avoid implicit cast for `dense_vector` under LOAD
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152349
+  issues:
+  - "152184"
+- file:
+    name: 149505.yaml
+    checksum: 25842e90afcab8e3ba2ef736053eca652f0c507c
+  type: feature
+  title: Adding dynamic template for `*.lifecycle.last_activity` fields
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/149505
+- file:
+    name: 150948.yaml
+    checksum: 9bb4c2c95a53f2153fb17f0d6b802ffa0a295ba6
+  type: enhancement
+  title: Use `MetricsInfo` for Prometheus labels API
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-06-16
+  areas:
+  - PromQL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150948
+- file:
+    name: 150362.yaml
+    checksum: f32671aa9f5217523dd73b29333f71535c682790
+  type: bug-fix
+  title: Fix ML jobs stuck in starting state on Serverless trial projects
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Machine learning
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150362
+- file:
+    name: 150677.yaml
+    checksum: f69a038395b11d4925d08c72096e7ed1165437ae
+  type: enhancement
+  title: Add ENRICH to bytes counting
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/150677
+- file:
+    name: 152867.yaml
+    checksum: 54f0a06c02c43c75ea5b5f9c06389aaa4eba063f
+  type: bug-fix
+  title: Solves `NoSuchElementException` in `ViewUnionAll` analyzer retries
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-07-09
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152867
+- file:
+    name: 148093.yaml
+    checksum: 72d8567f5849412ff272cac9f85c83a9be4bc2a4
+  type: enhancement
+  title: Add streaming parallel parsing for gzip-compressed files
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/148093
+- file:
+    name: 152021.yaml
+    checksum: b12488410c1d183a1330e4453604a26b5dd75e7e
+  type: enhancement
+  title: Bound and cancel external-source resolution
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - ES|QL
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/152021
+  issues:
+  - "960"
+- file:
+    name: 145567.yaml
+    checksum: 4fd8551bbf2cc4d5ff704d0bc1889e60c64a3cd3
+  type: feature
+  title: Native BBQ apply corrections (all distance types)
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  areas:
+  - Vector search
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145567
+- file:
+    name: 145971.yaml
+    checksum: 42638e278f6da4d20efc78c471718ad83c901138
+  type: bug-fix
+  title: '[otel-data] Change `exception.message` to `match_only_text`'
+  products:
+  - product: elasticsearch
+    target: 9.5.0
+    lifecycle: ga
+  - product: cloud-serverless
+    target: 2026-05-11
+  areas:
+  - Data streams
+  prs:
+  - https://github.com/elastic/elasticsearch/pull/145971


### PR DESCRIPTION
This PR is for preview purposes only

The list of PRs was derived from https://github.com/elastic/elasticsearch/tree/9.5/docs/changelog 
And that list was used with a script and the `docs-builder changelog add` command to generate changelogs and reconcile them with what existed in docs/changelog. The new files were then pushed to S3 with this command:

```sh
 docs-builder changelog upload --artifact-type changelog --target s3 --s3-bucket-name elastic-docs-v3-changelog-bundles-private --directory ./docs/changelog-new/ --branch main
```

The preview bundles could then be generated via:
```sh
docs-builder changelog bundle elasticsearch-release 9.5.0 ./docs/temp/prs.txt
```
