### PR TITLE
Reshard/flush before handoff

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardFlushFailureIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardFlushFailureIT.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -28,9 +29,10 @@ import org.elasticsearch.xpack.stateless.engine.translog.TranslogReplicator;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -42,7 +44,7 @@ public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginInteg
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         var plugins = new ArrayList<>(super.nodePlugins());
         plugins.remove(TestUtils.StatelessPluginWithTrialLicense.class);
-        plugins.add(org.elasticsearch.xpack.stateless.TestStatelessPlugin.class);
+        plugins.add(TestStatelessPlugin.class);
         return plugins;
     }
 
@@ -52,14 +54,19 @@ public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginInteg
         return super.nodeSettings().put(RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD.getKey(), TimeValue.ZERO);
     }
 
-    private static final AtomicInteger flushFailureCountdown = new AtomicInteger(0);
+    private interface FlushCallback {
+        // return null to prevent actual flush from being invoked, or wrap the listener to observe its result
+        Engine.FlushResultListener onFlush(boolean force, boolean waitIfOngoing, Engine.FlushResultListener listener);
+    }
 
-    public void testSourceReleasesPermitsUponFlushFailure() throws Exception {
+    private static volatile FlushCallback flushCallback = null;
+
+    public void testSourceReleasesPermitsUponFlushFailure() {
         var indexNode = startMasterAndIndexNode();
         startSearchNode();
         ensureStableCluster(2);
 
-        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final String indexName = randomIndexName();
         createIndex(indexName, indexSettings(1, 1).build());
         Index index = resolveIndex(indexName);
         ensureGreen(indexName);
@@ -69,12 +76,28 @@ public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginInteg
 
         var splitSourceService = internalCluster().getInstance(SplitSourceService.class, indexNode);
         var setFlushFailureCountdown = new AtomicBoolean(false);
+        final AtomicInteger flushFailureCountdown = new AtomicInteger(0);
+        final AtomicBoolean flushFailed = new AtomicBoolean(false);
         splitSourceService.setPreHandoffHook(() -> {
             if (setFlushFailureCountdown.getAndSet(true) == false) {
                 // Fail the second flush which occurs after acquiring permits
                 flushFailureCountdown.set(2);
             }
         });
+        var shardId = new ShardId(index, 0);
+        flushCallback = (force, waitIfOngoing, listener) -> {
+            if (flushFailureCountdown.getAndUpdate(val -> val == 0 ? 0 : val - 1) == 1) {
+                flushFailed.set(true);
+                if (randomBoolean()) {
+                    listener.onFailure(new EngineException(shardId, "test failure"));
+                    return null;
+                } else {
+                    throw new IllegalArgumentException("test flush exception");
+                }
+            } else {
+                return listener;
+            }
+        };
 
         logger.info("starting reshard");
         client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
@@ -82,6 +105,8 @@ public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginInteg
         awaitClusterState((state) -> state.getMetadata().indexMetadata(index).getReshardingMetadata() == null);
         ensureGreen(indexName);
         refresh(indexName);
+        flushCallback = null;
+
         assertHitCount(
             client().prepareSearch(indexName)
                 .setQuery(QueryBuilders.matchAllQuery())
@@ -90,6 +115,69 @@ public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginInteg
                 .setAllowPartialSearchResults(false),
             numDocs
         );
+        assertTrue(flushFailed.get());
+    }
+
+    public void testPreFlushWaitsForOngoingFlushes() throws Exception {
+        var indexNode = startMasterAndIndexNode();
+        startSearchNode();
+        ensureStableCluster(2);
+
+        final String indexName = randomIndexName();
+        createIndex(indexName, indexSettings(1, 1).build());
+        Index index = resolveIndex(indexName);
+        ensureGreen(indexName);
+
+        // Trigger an ongoing flush by kicking off a refresh thread, which then blocks flush until we are in the prehandoff flush.
+        // Release refresh flush and validate that preflush never skips due to ongoing flush. This isn't foolproof since the
+        // refresh flush is unblocked just before preflush invokes the actual flush call, but it catches regression reliably
+        // on my laptop.
+        var refreshLatch = new CountDownLatch(1);
+        var refreshInProgress = new AtomicBoolean(false);
+        var preflushResult = new AtomicReference<Engine.FlushResult>();
+        flushCallback = (force, waitIfOngoing, listener) -> {
+            if (force) {
+                // refresh called
+                refreshInProgress.set(true);
+                safeAwait(refreshLatch);
+            } else if (refreshInProgress.get()) {
+                // preflush has now started, so refresh can be unblocked
+                refreshLatch.countDown();
+                refreshInProgress.set(false);
+
+                return new Engine.FlushResultListener() {
+                    @Override
+                    public void onResponse(Engine.FlushResult flushResult) {
+                        preflushResult.set(flushResult);
+                        listener.onResponse(flushResult);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(e);
+                    }
+                };
+            }
+            return listener;
+        };
+
+        indexDocs(indexName, 200);
+
+        var refreshThread = new Thread(() -> {
+            refresh(indexName);
+            refreshInProgress.set(false);
+        });
+        refreshThread.start();
+
+        logger.info("starting reshard");
+        client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
+
+        awaitClusterState((state) -> state.getMetadata().indexMetadata(index).getReshardingMetadata() == null);
+        ensureGreen(indexName);
+        safeJoin(refreshThread);
+
+        flushCallback = null;
+        assertFalse(preflushResult.get().skippedDueToCollision());
     }
 
     public static class TestStatelessPlugin extends TestUtils.StatelessPluginWithTrialLicense {
@@ -126,17 +214,13 @@ public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginInteg
             ) {
                 @Override
                 protected void flushHoldingLock(boolean force, boolean waitIfOngoing, FlushResultListener listener) {
-                    final ShardId shardId = engineConfig.getShardId();
-                    // Fail if countdown goes to 0
-                    if (flushFailureCountdown.getAndUpdate(val -> val == 0 ? 0 : val - 1) == 1) {
-                        if (randomBoolean()) {
-                            listener.onFailure(new EngineException(shardId, "test failure"));
-                        } else {
-                            throw new IllegalArgumentException("test flush exception");
+                    if (flushCallback != null) {
+                        listener = flushCallback.onFlush(force, waitIfOngoing, listener);
+                        if (listener == null) {
+                            return;
                         }
-                    } else {
-                        super.flushHoldingLock(force, waitIfOngoing, listener);
                     }
+                    super.flushHoldingLock(force, waitIfOngoing, listener);
                 }
             };
         }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardFlushIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardFlushIT.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.xpack.stateless.reshard.SplitSourceService.RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD;
 
-public class StatelessReshardFlushFailureIT extends AbstractStatelessPluginIntegTestCase {
+public class StatelessReshardFlushIT extends AbstractStatelessPluginIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
@@ -350,7 +350,7 @@ public class SplitSourceService {
             logger.debug("handoff: flushing {} for {} before acquiring permits", sourceShard.shardId(), targetShardId);
             // Similar to relocation, flush before blocking operations because we expect this to reduce the amount of work done by the
             // flush that happens while operations are blocked. NB the flush has force=false so may do nothing.
-            engine.flush(/* force */ false, /* waitIfOngoing */ false, afterFirstFlush);
+            engine.flush(/* force */ false, /* waitIfOngoing */ true, afterFirstFlush);
             return null;
         }))
             .<Releasable>andThen(acquiredPermits -> stateMachine.split().withPermits(acquiredPermits))


### PR DESCRIPTION
If there is a large flush ongoing when we're preparing to enter handoff, it's better to wait for it before we've blocked indexing than after.
