### PR TITLE
perf(ESQL): replace rate aggregator internal priority queue with in-place primitive heap

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.aggregation;
 
-import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
@@ -26,7 +25,7 @@ import java.util.Arrays;
 import static org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.BufferedArray.indexInPage;
 import static org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.BufferedArray.pageIndex;
 
-class AbstractRateGroupingFunction {
+public class AbstractRateGroupingFunction {
     /**
      * Buffers data points in two arrays: one for timestamps and one for values, partitioned into multiple slices.
      * Each slice is sorted in descending order of timestamp. A new slice is created when a data point has a
@@ -135,86 +134,191 @@ class AbstractRateGroupingFunction {
             int groupIndex = groupId - minGroupId;
             int endIndex = runningOffsets[groupIndex];
             int startIndex = groupIndex == 0 ? 0 : runningOffsets[groupIndex - 1];
-            int numSlices = endIndex - startIndex;
-            if (numSlices == 0) {
+            if (startIndex >= endIndex) {
                 return null;
             }
-            FlushQueue queue = new FlushQueue(numSlices);
+            // Compact empty pairs into the front of this group's range, then heapify in place.
+            // Ownership: the queue may reorder and mutate sliceOffsets[startIndex*2 .. endIndex*2)
+            // during flush; original pair order/starts are not needed afterward.
+            int write = startIndex;
+            int valueCount = 0;
             for (int i = startIndex; i < endIndex; i++) {
                 int start = sliceOffsets[i * 2];
                 int end = sliceOffsets[i * 2 + 1];
                 if (start < end) {
-                    queue.valueCount += (end - start);
-                    queue.add(new Slice(buffer.timestamps, start, end));
+                    if (write != i) {
+                        sliceOffsets[write * 2] = start;
+                        sliceOffsets[write * 2 + 1] = end;
+                    }
+                    valueCount += end - start;
+                    write++;
                 }
             }
-            if (queue.valueCount == 0) {
+            int size = write - startIndex;
+            if (valueCount == 0) {
                 return null;
             }
-            return queue;
+            return new FlushQueue(buffer.timestamps, sliceOffsets, startIndex * 2, size, valueCount);
         }
     }
 
-    static final class Slice {
-        int start;
-        int end;
-        long nextTimestamp;
-        private long lastTimestamp = Long.MAX_VALUE;
-        final LongBuffer timestamps;
+    /**
+     * Floyd's max-heap of slices {@code (start, end)}.
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Heapsort#Algorithm">Heapsort</a>
+     */
+    public static final class FlushQueue {
+        private final LongBuffer timestamps;
+        private final int[] slices;
+        private final int base;
+        private int size;
+        public final int valueCount;
 
-        Slice(LongBuffer timestamps, int start, int end) {
+        public FlushQueue(LongBuffer timestamps, int[] slices, int base, int size, int valueCount) {
             this.timestamps = timestamps;
-            this.start = start;
-            this.end = end;
-            this.nextTimestamp = timestamps.get(start);
+            this.slices = slices;
+            this.base = base;
+            this.size = size;
+            this.valueCount = valueCount;
+            heapify();
         }
 
-        boolean exhausted() {
-            return start >= end;
+        public int size() {
+            return size;
         }
 
-        int next() {
-            int currentIndex = start;
-            start++;
-            if (start < end) {
-                nextTimestamp = timestamps.get(start); // next timestamp
-            }
-            return currentIndex;
+        public int topStart() {
+            return start(0);
         }
 
-        long lastTimestamp() {
-            if (lastTimestamp == Long.MAX_VALUE) {
-                lastTimestamp = timestamps.get(end - 1);
-            }
-            return lastTimestamp;
+        public int topEnd() {
+            return end(0);
         }
-    }
 
-    static final class FlushQueue extends PriorityQueue<Slice> {
-        int valueCount;
+        public long topNextTimestamp() {
+            return nextTimestamp(0);
+        }
 
-        FlushQueue(int maxSize) {
-            super(maxSize);
+        public long topLastTimestamp() {
+            return timestamps.get(end(0) - 1);
+        }
+
+        public boolean topExhausted() {
+            return start(0) >= end(0);
         }
 
         /**
-         * Returns the timestamp of the slice that would be next in line after the best slice.
+         * Returns the current root sample index and advances the root slice's start.
+         * Does not restore heap order; callers must {@link #updateTop()} or {@link #popTop()}.
          */
-        long secondNextTimestamp() {
-            final Object[] heap = getHeapArray();
-            final int size = size();
+        public int consumeTop() {
+            int position = start(0);
+            slices[base + (0 << 1)] = position + 1;
+            return position;
+        }
+
+        public void updateTop() {
+            assert start(0) < end(0) : "updateTop on exhausted root";
+            siftDown(0);
+        }
+
+        public void popTop() {
+            size--;
+            if (size == 0) {
+                return;
+            }
+            copyNode(size, 0);
+            siftDown(0);
+        }
+
+        /**
+         * Greatest next-timestamp among the root's children, or {@link Long#MIN_VALUE} if none.
+         */
+        public long secondNextTimestamp() {
             if (size == 2) {
-                return ((Slice) heap[2]).nextTimestamp;
+                return nextTimestamp(1);
             } else if (size >= 3) {
-                return Math.max(((Slice) heap[2]).nextTimestamp, ((Slice) heap[3]).nextTimestamp);
+                return Math.max(nextTimestamp(1), nextTimestamp(2));
             } else {
                 return Long.MIN_VALUE;
             }
         }
 
-        @Override
-        protected boolean lessThan(Slice a, Slice b) {
-            return a.nextTimestamp > b.nextTimestamp; // want the latest timestamp first
+        private void heapify() {
+            if (size <= 1) {
+                return;
+            }
+            for (int i = (size - 2) >>> 1; i >= 0; i--) {
+                siftDown(i);
+            }
+        }
+
+        /**
+         * Floyd sift-down with a hole: move larger children up until {@code x} fits, then install it.
+         * Early-exits rather than always descending to a leaf.
+         */
+        private void siftDown(int node) {
+            final int xStart = start(node);
+            final int xEnd = end(node);
+            final long xKey = timestamps.get(xStart);
+            while (true) {
+                int left = (node << 1) + 1;
+                if (left >= size) {
+                    break;
+                }
+                int best = left;
+                int right = left + 1;
+                if (right < size && precedes(right, left)) {
+                    best = right;
+                }
+                if (precedesKeyValue(xKey, xStart, best) == false) {
+                    copyNode(best, node);
+                    node = best;
+                } else {
+                    break;
+                }
+            }
+            int offset = base + (node << 1);
+            slices[offset] = xStart;
+            slices[offset + 1] = xEnd;
+        }
+
+        /** {@code true} if node {@code left} should be nearer the root than node {@code right}. */
+        private boolean precedes(int left, int right) {
+            long leftTs = nextTimestamp(left);
+            long rightTs = nextTimestamp(right);
+            if (leftTs != rightTs) {
+                return leftTs > rightTs;
+            }
+            return start(left) < start(right);
+        }
+
+        /** {@code true} if {@code (key,start)} should be nearer the root than node {@code right}. */
+        private boolean precedesKeyValue(long key, int start, int right) {
+            long rightTs = nextTimestamp(right);
+            if (key != rightTs) {
+                return key > rightTs;
+            }
+            return start < start(right);
+        }
+
+        private int start(int node) {
+            return slices[base + (node << 1)];
+        }
+
+        private int end(int node) {
+            return slices[base + (node << 1) + 1];
+        }
+
+        private long nextTimestamp(int node) {
+            return timestamps.get(start(node));
+        }
+
+        private void copyNode(int from, int to) {
+            int fromOffset = base + (from << 1);
+            int toOffset = base + (to << 1);
+            slices[toOffset] = slices[fromOffset];
+            slices[toOffset + 1] = slices[fromOffset + 1];
         }
     }
 
@@ -251,11 +355,11 @@ class AbstractRateGroupingFunction {
             capacity = (long) newNumPages << PAGE_SHIFT;
         }
 
-        final int size() {
+        public final int size() {
             return size;
         }
 
-        final void clear() {
+        public final void clear() {
             size = 0;
         }
 
@@ -280,10 +384,10 @@ class AbstractRateGroupingFunction {
      * Append-only paged long array backed by {@code long[][]}.
      * Avoids the VarHandle byte[]-backed LongArray and leverages {@link System#arraycopy} when possible.
      */
-    static final class LongBuffer extends BufferedArray {
+    public static final class LongBuffer extends BufferedArray {
         long[][] pages;
 
-        LongBuffer(CircuitBreaker breaker, long initialCapacity) {
+        public LongBuffer(CircuitBreaker breaker, long initialCapacity) {
             super(breaker, initialCapacity, Long.BYTES);
             pages = new long[numPages][];
             for (int i = 0; i < numPages; i++) {
@@ -291,12 +395,12 @@ class AbstractRateGroupingFunction {
             }
         }
 
-        long get(long index) {
+        public long get(long index) {
             assert index < size : "Index [" + index + "] out of bounds, size: " + size;
             return pages[pageIndex(index)][indexInPage(index)];
         }
 
-        void append(long value) {
+        public void append(long value) {
             pages[pageIndex(size)][indexInPage(size)] = value;
             size++;
         }
@@ -314,7 +418,7 @@ class AbstractRateGroupingFunction {
             size += count;
         }
 
-        void ensureCapacity(long minCapacity) {
+        public void ensureCapacity(long minCapacity) {
             int oldNumPages = numPages;
             grow(minCapacity, Long.BYTES);
             if (numPages > oldNumPages) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IncreaseExponentialHistogramGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IncreaseExponentialHistogramGroupingAggregatorFunction.java
@@ -552,30 +552,25 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
         var timestamps = buffer.timestamps;
         var values = buffer.values;
         if (flushQueue.valueCount == 1) {
+            int p = flushQueue.topStart();
             state.samples++;
-            long t = timestamps.get(flushQueue.top().start);
-            var v = values.get(flushQueue.top().start, new ExponentialHistogramScratch());
+            long t = timestamps.get(p);
+            var v = values.get(p, new ExponentialHistogramScratch());
             state.appendInterval(t, v, t, v);
             return;
         }
         // first
-        final long lastTimestamp;
         // JIT scalar replacement should have an easy job on these values
         final ValueWithScratch lastValue = new ValueWithScratch();
         final ValueWithScratch prevValue = new ValueWithScratch();
-        Slice top;
-        {
-            top = flushQueue.top();
-            int position = top.next();
-            lastTimestamp = timestamps.get(position);
-            lastValue.load(values, position);
-            prevValue.load(values, position);
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
-            } else {
-                top = flushQueue.updateTop();
-            }
+        int position = flushQueue.consumeTop();
+        final long lastTimestamp = timestamps.get(position);
+        lastValue.load(values, position);
+        prevValue.load(values, position);
+        if (flushQueue.topExhausted()) {
+            flushQueue.popTop();
+        } else {
+            flushQueue.updateTop();
         }
         final ValueWithScratch currentValue = new ValueWithScratch();
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
@@ -583,36 +578,33 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
-            if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
+            if (flushQueue.topLastTimestamp() > secondNextTimestamp) {
+                for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
                     currentValue.load(values, p);
                     if (currentValue.v.valueCount() > prevValue.v.valueCount()) {
                         state.addToResets(currentValue.v);
                     }
                     prevValue.assignFrom(currentValue);
                 }
-                flushQueue.pop();
-                top = flushQueue.top();
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
                 continue;
             }
-            currentValue.load(values, top.next());
+            currentValue.load(values, flushQueue.consumeTop());
             if (currentValue.v.valueCount() > prevValue.v.valueCount()) {
                 state.addToResets(currentValue.v);
             }
             prevValue.assignFrom(currentValue);
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
+            if (flushQueue.topExhausted()) {
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
-            } else if (top.nextTimestamp < secondNextTimestamp) {
-                top = flushQueue.updateTop();
+            } else if (flushQueue.topNextTimestamp() < secondNextTimestamp) {
+                flushQueue.updateTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
             }
         }
         // last slice
-        top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
+        for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
             currentValue.load(values, p);
             if (currentValue.v.valueCount() > prevValue.v.valueCount()) {
                 state.addToResets(currentValue.v);
@@ -620,7 +612,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             prevValue.assignFrom(currentValue);
         }
         state.samples += flushQueue.valueCount;
-        state.appendInterval(lastTimestamp, lastValue.v, timestamps.get(top.end - 1), prevValue.v);
+        state.appendInterval(lastTimestamp, lastValue.v, timestamps.get(flushQueue.topEnd() - 1), prevValue.v);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -599,72 +599,63 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         var timestamps = buffer.timestamps;
         var values = buffer.values;
         if (flushQueue.valueCount == 1) {
+            int p = flushQueue.topStart();
             state.samples++;
-            long t = timestamps.get(flushQueue.top().start);
-            var v = values.get(flushQueue.top().start);
+            long t = timestamps.get(p);
+            double v = values.get(p);
             state.appendInterval(t, v, t, v);
             return;
         }
         // first
-        final long lastTimestamp;
-        final double lastValue;
-        Slice top;
-        {
-            top = flushQueue.top();
-            int position = top.next();
-            lastTimestamp = timestamps.get(position);
-            lastValue = values.get(position);
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
-            } else {
-                top = flushQueue.updateTop();
-            }
+        int position = flushQueue.consumeTop();
+        final long lastTimestamp = timestamps.get(position);
+        final double lastValue = values.get(position);
+        if (flushQueue.topExhausted()) {
+            flushQueue.popTop();
+        } else {
+            flushQueue.updateTop();
         }
-        var prevValue = lastValue;
+        double prevValue = lastValue;
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
-            if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
+            if (flushQueue.topLastTimestamp() > secondNextTimestamp) {
+                for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
+                    double val = values.get(p);
                     if (val > prevValue) {
                         state.resets += val;
                     }
                     prevValue = val;
                 }
-                flushQueue.pop();
-                top = flushQueue.top();
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
                 continue;
             }
-            var val = values.get(top.next());
+            double val = values.get(flushQueue.consumeTop());
             if (val > prevValue) {
                 state.resets += val;
             }
             prevValue = val;
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
+            if (flushQueue.topExhausted()) {
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
-            } else if (top.nextTimestamp < secondNextTimestamp) {
-                top = flushQueue.updateTop();
+            } else if (flushQueue.topNextTimestamp() < secondNextTimestamp) {
+                flushQueue.updateTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
             }
         }
         // last slice
-        top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
+        for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
+            double val = values.get(p);
             if (val > prevValue) {
                 state.resets += val;
             }
             prevValue = val;
         }
         state.samples += flushQueue.valueCount;
-        state.appendInterval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue);
+        state.appendInterval(lastTimestamp, lastValue, timestamps.get(flushQueue.topEnd() - 1), prevValue);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -599,72 +599,63 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         var timestamps = buffer.timestamps;
         var values = buffer.values;
         if (flushQueue.valueCount == 1) {
+            int p = flushQueue.topStart();
             state.samples++;
-            long t = timestamps.get(flushQueue.top().start);
-            var v = values.get(flushQueue.top().start);
+            long t = timestamps.get(p);
+            int v = values.get(p);
             state.appendInterval(t, v, t, v);
             return;
         }
         // first
-        final long lastTimestamp;
-        final int lastValue;
-        Slice top;
-        {
-            top = flushQueue.top();
-            int position = top.next();
-            lastTimestamp = timestamps.get(position);
-            lastValue = values.get(position);
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
-            } else {
-                top = flushQueue.updateTop();
-            }
+        int position = flushQueue.consumeTop();
+        final long lastTimestamp = timestamps.get(position);
+        final int lastValue = values.get(position);
+        if (flushQueue.topExhausted()) {
+            flushQueue.popTop();
+        } else {
+            flushQueue.updateTop();
         }
-        var prevValue = lastValue;
+        int prevValue = lastValue;
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
-            if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
+            if (flushQueue.topLastTimestamp() > secondNextTimestamp) {
+                for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
+                    int val = values.get(p);
                     if (val > prevValue) {
                         state.resets += val;
                     }
                     prevValue = val;
                 }
-                flushQueue.pop();
-                top = flushQueue.top();
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
                 continue;
             }
-            var val = values.get(top.next());
+            int val = values.get(flushQueue.consumeTop());
             if (val > prevValue) {
                 state.resets += val;
             }
             prevValue = val;
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
+            if (flushQueue.topExhausted()) {
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
-            } else if (top.nextTimestamp < secondNextTimestamp) {
-                top = flushQueue.updateTop();
+            } else if (flushQueue.topNextTimestamp() < secondNextTimestamp) {
+                flushQueue.updateTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
             }
         }
         // last slice
-        top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
+        for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
+            int val = values.get(p);
             if (val > prevValue) {
                 state.resets += val;
             }
             prevValue = val;
         }
         state.samples += flushQueue.valueCount;
-        state.appendInterval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue);
+        state.appendInterval(lastTimestamp, lastValue, timestamps.get(flushQueue.topEnd() - 1), prevValue);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -599,72 +599,63 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         var timestamps = buffer.timestamps;
         var values = buffer.values;
         if (flushQueue.valueCount == 1) {
+            int p = flushQueue.topStart();
             state.samples++;
-            long t = timestamps.get(flushQueue.top().start);
-            var v = values.get(flushQueue.top().start);
+            long t = timestamps.get(p);
+            long v = values.get(p);
             state.appendInterval(t, v, t, v);
             return;
         }
         // first
-        final long lastTimestamp;
-        final long lastValue;
-        Slice top;
-        {
-            top = flushQueue.top();
-            int position = top.next();
-            lastTimestamp = timestamps.get(position);
-            lastValue = values.get(position);
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
-            } else {
-                top = flushQueue.updateTop();
-            }
+        int position = flushQueue.consumeTop();
+        final long lastTimestamp = timestamps.get(position);
+        final long lastValue = values.get(position);
+        if (flushQueue.topExhausted()) {
+            flushQueue.popTop();
+        } else {
+            flushQueue.updateTop();
         }
-        var prevValue = lastValue;
+        long prevValue = lastValue;
         long secondNextTimestamp = flushQueue.secondNextTimestamp();
         while (flushQueue.size() > 1) {
             // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
             // there is no overlap with subsequent slices, so batch merging can be performed without comparing
             // timestamps from the buffer.
-            if (top.lastTimestamp() > secondNextTimestamp) {
-                for (int p = top.start; p < top.end; p++) {
-                    var val = values.get(p);
+            if (flushQueue.topLastTimestamp() > secondNextTimestamp) {
+                for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
+                    long val = values.get(p);
                     if (val > prevValue) {
                         state.resets += val;
                     }
                     prevValue = val;
                 }
-                flushQueue.pop();
-                top = flushQueue.top();
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
                 continue;
             }
-            var val = values.get(top.next());
+            long val = values.get(flushQueue.consumeTop());
             if (val > prevValue) {
                 state.resets += val;
             }
             prevValue = val;
-            if (top.exhausted()) {
-                flushQueue.pop();
-                top = flushQueue.top();
+            if (flushQueue.topExhausted()) {
+                flushQueue.popTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
-            } else if (top.nextTimestamp < secondNextTimestamp) {
-                top = flushQueue.updateTop();
+            } else if (flushQueue.topNextTimestamp() < secondNextTimestamp) {
+                flushQueue.updateTop();
                 secondNextTimestamp = flushQueue.secondNextTimestamp();
             }
         }
         // last slice
-        top = flushQueue.top();
-        for (int p = top.start; p < top.end; p++) {
-            var val = values.get(p);
+        for (int p = flushQueue.topStart(); p < flushQueue.topEnd(); p++) {
+            long val = values.get(p);
             if (val > prevValue) {
                 state.resets += val;
             }
             prevValue = val;
         }
         state.samples += flushQueue.valueCount;
-        state.appendInterval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue);
+        state.appendInterval(lastTimestamp, lastValue, timestamps.get(flushQueue.topEnd() - 1), prevValue);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FlushQueueTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FlushQueueTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.FlushQueue;
+import org.elasticsearch.compute.aggregation.AbstractRateGroupingFunction.FlushQueues;
+import org.elasticsearch.compute.aggregation.RateLongGroupingAggregatorFunction.LongRawBuffer;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.hamcrest.Matchers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FlushQueueTests extends ComputeTestCase {
+
+    public void testEmptyGroupReturnsNull() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 1, 2 }, new long[] { 0, 0 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 0, 1, 1 }).getFlushQueue(0);
+            assertThat(queue, Matchers.nullValue());
+        }
+    }
+
+    public void testOneSlice() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 30, 20, 10 }, new long[] { 1, 2, 3 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 3 }).getFlushQueue(0);
+            assertThat(queue.size(), Matchers.equalTo(1));
+            assertThat(queue.valueCount, Matchers.equalTo(3));
+            assertThat(queue.topStart(), Matchers.equalTo(0));
+            assertThat(queue.topEnd(), Matchers.equalTo(3));
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(30L));
+            assertThat(queue.topLastTimestamp(), Matchers.equalTo(10L));
+
+            assertThat(queue.consumeTop(), Matchers.equalTo(0));
+            assertThat(queue.topStart(), Matchers.equalTo(1));
+            assertFalse(queue.topExhausted());
+            queue.updateTop();
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(20L));
+        }
+    }
+
+    public void testTwoSlicesAlreadyOrdered() {
+        // slice `A`: 50,40 ; slice B: 30,20 - `A` should stay root
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 50, 40, 30, 20 }, new long[] { 1, 2, 3, 4 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 2, 2, 4 }).getFlushQueue(0);
+            assertThat(queue.size(), Matchers.equalTo(2));
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(50L));
+            assertThat(queue.secondNextTimestamp(), Matchers.equalTo(30L));
+        }
+    }
+
+    public void testTwoSlicesRequireSwap() {
+        // first pair older, second newer - heapify must swap
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 10, 5, 40, 30 }, new long[] { 1, 2, 3, 4 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 2, 2, 4 }).getFlushQueue(0);
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(40L));
+            assertThat(queue.topStart(), Matchers.equalTo(2));
+        }
+    }
+
+    public void testThreeOrMoreSlices() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 10, 9, 50, 40, 30, 20 }, new long[] { 1, 2, 3, 4, 5, 6 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 2, 2, 4, 4, 6 }).getFlushQueue(0);
+            assertThat(queue.size(), Matchers.equalTo(3));
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(50L));
+            assertThat(queue.secondNextTimestamp(), Matchers.equalTo(Math.max(10L, 30L)));
+        }
+    }
+
+    public void testRootAdvanceWithoutExhaustion() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 50, 40, 30, 20 }, new long[] { 1, 2, 3, 4 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 2, 2, 4 }).getFlushQueue(0);
+            assertThat(queue.consumeTop(), Matchers.equalTo(0));
+            assertFalse(queue.topExhausted());
+            queue.updateTop();
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(40L));
+        }
+    }
+
+    public void testRootExhaustionAndReplacement() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 50, 30, 20 }, new long[] { 1, 2, 3 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 1, 1, 3 }).getFlushQueue(0);
+            assertThat(queue.consumeTop(), Matchers.equalTo(0));
+            assertTrue(queue.topExhausted());
+            queue.popTop();
+            assertThat(queue.size(), Matchers.equalTo(1));
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(30L));
+        }
+    }
+
+    public void testRepeatedRootRemovals() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 90, 80, 70, 60, 50, 40 }, new long[] { 1, 2, 3, 4, 5, 6 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 2, 2, 4, 4, 6 }).getFlushQueue(0);
+            List<Long> order = new ArrayList<>();
+            while (queue.size() > 0) {
+                order.add(buf.timestamps.get(queue.consumeTop()));
+                if (queue.topExhausted()) {
+                    queue.popTop();
+                } else {
+                    queue.updateTop();
+                }
+            }
+            assertThat(order, Matchers.equalTo(List.of(90L, 80L, 70L, 60L, 50L, 40L)));
+        }
+    }
+
+    public void testEqualTimestampsPreferSmallerStart() {
+        // both slices start at ts=100; smaller start index should win
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 100, 50, 100, 40 }, new long[] { 1, 2, 3, 4 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 2, 4, 0, 2 }).getFlushQueue(0);
+            assertThat(queue.topStart(), Matchers.equalTo(0));
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(100L));
+        }
+    }
+
+    public void testEmptyRangesExcluded() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 30, 20 }, new long[] { 1, 2 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 0, 0, 2, 2, 2 }).getFlushQueue(0);
+            assertThat(queue.size(), Matchers.equalTo(1));
+            assertThat(queue.valueCount, Matchers.equalTo(2));
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(30L));
+        }
+    }
+
+    public void testLengthOneSlices() {
+        try (LongRawBuffer buf = newLongRawBuffer(new long[] { 10, 30, 20 }, new long[] { 1, 2, 3 })) {
+            FlushQueue queue = flushQueues(buf, new int[] { 0, 1, 1, 2, 2, 3 }).getFlushQueue(0);
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(30L));
+            assertThat(queue.consumeTop(), Matchers.equalTo(1));
+            assertTrue(queue.topExhausted());
+            queue.popTop();
+            assertThat(queue.topNextTimestamp(), Matchers.equalTo(20L));
+        }
+    }
+
+    private static FlushQueues flushQueues(LongRawBuffer buffer, int[] sliceOffsets) {
+        int numSlices = sliceOffsets.length / 2;
+        // runningOffsets holds exclusive end indices per group (see RawBuffer.prepareForFlush)
+        return new FlushQueues(buffer, 0, 0, new int[] { numSlices }, Arrays.copyOf(sliceOffsets, sliceOffsets.length));
+    }
+
+    private LongRawBuffer newLongRawBuffer(long[] timestamps, long[] values) {
+        return newLongRawBuffer(blockFactory().breaker(), timestamps, values);
+    }
+
+    private static LongRawBuffer newLongRawBuffer(CircuitBreaker breaker, long[] timestamps, long[] values) {
+        assert timestamps.length == values.length;
+        LongRawBuffer buffer = new LongRawBuffer(breaker);
+        if (timestamps.length == 0) {
+            return buffer;
+        }
+        buffer.prepareForAppend(0, timestamps.length, timestamps[0]);
+        for (int i = 0; i < timestamps.length; i++) {
+            buffer.appendWithoutResize(timestamps[i], values[i]);
+        }
+        return buffer;
+    }
+}


### PR DESCRIPTION
## What

While investigating #152770, allocation profiling of the `rate()` grouping aggregator (30k hosts) showed flush-path allocations that scale with host cardinality and slice count:

- `AbstractRateGroupingFunction$Slice` (~28 MB / 4.6%) - one object per slice per group flush
- `AbstractRateGroupingFunction$FlushQueue` (~36 MB / 6.0%) - Lucene `PriorityQueue<Slice>` allocated per group per flush

We can likely reduce these allocations by replacing Lucene general purpose priority queue with custom max heap over primitives. 

## Fix

Replace the Lucene `PriorityQueue<Slice>` with an in-place primitive max-heap over each group's `sliceOffsets` pairs (`[start0, end0, ...]`).

EDIT: 

This PR does not include the earlier ([~draft](https://github.com/elastic/elasticsearch/compare/c884aa40c6ae59396dd47fda62f22f11cc9b45df..f6f3e449ac930f22267b29ac6dbfc6af6adabd1f)) SOA `ReducedState` repack and object-pooling experiments; those remain follow-ups.

## Impact

TBD