### PR TITLE
[9.5] ES|QL|DS: keep literal '+' in Hive partition values (#153908)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/RestUtils.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestUtils.java
@@ -147,7 +147,7 @@ public class RestUtils {
      * @throws IllegalArgumentException if the string contains a malformed
      *                                  escape sequence.
      */
-    private static String decodeComponent(final String s, final Charset charset, boolean plusAsSpace) {
+    public static String decodeComponent(final String s, final Charset charset, boolean plusAsSpace) {
         if (s == null) {
             return "";
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPlusValueIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalHivePartitionPlusValueIT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end guard that a Hive partition value holding a literal {@code +} is surfaced unchanged and remains
+ * queryable. Hive partition folders are {@code %XX}-escaped only and write {@code +} literally, so a folder
+ * {@code tag=a+b/} must surface {@code tag = "a+b"}; decoding the value the {@code application/x-www-form-urlencoded}
+ * way turns the {@code +} into a space, so {@code WHERE tag == "a+b"} matches nothing and silently drops the rows.
+ */
+public class ExternalHivePartitionPlusValueIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(CsvDataSourcePlugin.class);
+    }
+
+    public void testLiteralPlusPartitionValueIsQueryable() throws IOException {
+        Path root = createTempDir().resolve("hive_plus");
+        writeTagRow(root, "a+b", 1);
+        writeTagRow(root, "c", 2);
+
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String dataset = registerDataset("hive_plus", glob, Map.of("hive_partitioning", true));
+
+        var request = syncEsqlQueryRequest("FROM " + dataset + " | WHERE tag == \"a+b\" | KEEP id | SORT id ASC");
+        try (var response = run(request)) {
+            List<Long> ids = getValuesList(response).stream().map(row -> ((Number) row.get(0)).longValue()).toList();
+            assertThat("WHERE tag == \"a+b\" must return the tag=a+b folder's row, not drop it", ids, equalTo(List.of(1L)));
+        }
+    }
+
+    /** Writes {@code root/tag=<tag>/f.csv} carrying one row with a single {@code id} column. */
+    private static void writeTagRow(Path root, String tag, int id) throws IOException {
+        Path dir = root.resolve("tag=" + tag);
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("f.csv"), "id\n" + id + "\n", StandardCharsets.UTF_8);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
@@ -8,12 +8,12 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -177,7 +177,7 @@ public final class HivePartitionDetector implements PartitionDetector {
                 continue;
             }
             String key = segment.substring(0, eqIdx);
-            String value = urlDecode(afterEq);
+            String value = decodePartitionValue(afterEq);
             if (partitions.containsKey(key)) {
                 continue;
             }
@@ -187,9 +187,21 @@ public final class HivePartitionDetector implements PartitionDetector {
         return partitions;
     }
 
-    private static String urlDecode(String value) {
+    /**
+     * Decodes a partition folder value that a Hive-style writer percent-escaped. Hive escapes partition folder names
+     * with {@code %XX} only and writes a literal {@code +} unescaped (it is not in the escape set). This is therefore
+     * a plain UTF-8 percent-decode that keeps {@code +} literal, unlike {@code application/x-www-form-urlencoded}
+     * decoding, which maps {@code +} to a space and so corrupts {@code a+b} to {@code "a b"} (a filter on the true
+     * value then drops every row of that folder). This decodes {@code %XX} escapes as UTF-8 and keeps a literal
+     * {@code +} as {@code +} by passing {@code plusAsSpace=false} explicitly, so the result does not depend on the
+     * REST-only {@code es.rest.url_plus_as_space} setting; a malformed escape is left as the raw value rather than
+     * failing the detection.
+     *
+     * <p>Shared by {@link TemplatePartitionDetector}, which decodes its own directory segments the same way.
+     */
+    static String decodePartitionValue(String value) {
         try {
-            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+            return RestUtils.decodeComponent(value, StandardCharsets.UTF_8, false);
         } catch (IllegalArgumentException e) {
             return value;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetector.java
@@ -11,8 +11,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -140,18 +138,10 @@ public final class TemplatePartitionDetector implements PartitionDetector {
         LinkedHashMap<String, String> result = Maps.newLinkedHashMapWithExpectedSize(expectedSegments);
         for (int i = 0; i < expectedSegments; i++) {
             String segment = nonEmpty.get(startIdx + i);
-            String decoded = urlDecode(segment);
+            String decoded = HivePartitionDetector.decodePartitionValue(segment);
             result.put(columnNames.get(i), decoded);
         }
         return result;
-    }
-
-    private static String urlDecode(String value) {
-        try {
-            return URLDecoder.decode(value, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
-            return value;
-        }
     }
 
     public static List<String> parseTemplateColumns(String template) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
@@ -205,6 +205,85 @@ public class HivePartitionDetectorTests extends ESTestCase {
         assertEquals("São Paulo", partitions.get("city"));
     }
 
+    /**
+     * A literal {@code +} in a partition folder must survive as {@code +}, not be turned into a space. Hive
+     * partition folders are {@code %XX}-escaped only and write {@code +} literally, so decoding a value the
+     * {@code application/x-www-form-urlencoded} way corrupts {@code tag=a+b/} to {@code "a b"} and a filter on the
+     * true value drops every row of that folder.
+     */
+    public void testLiteralPlusIsNotDecodedToSpace() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a+b/file.parquet"));
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        assertEquals(DataType.KEYWORD, result.partitionColumns().get("tag"));
+
+        Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a+b/file.parquet"));
+        assertEquals("a+b", partitions.get("tag"));
+    }
+
+    /** An escaped {@code +} ({@code %2B}) decodes to a literal {@code +}, round-tripping the {@code %XX} escape. */
+    public void testPercentEncodedPlusDecodesToPlus() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a%2Bb/file.parquet"));
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a%2Bb/file.parquet"));
+        assertEquals("a+b", partitions.get("tag"));
+    }
+
+    /** An escaped {@code :} ({@code %3A}) decodes to a literal colon (the everyday shape for namespace/timestamp values). */
+    public void testPercentEncodedColonDecodesToColon() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=ns%3Aclick/file.parquet"));
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=ns%3Aclick/file.parquet"));
+        assertEquals("ns:click", partitions.get("tag"));
+    }
+
+    /**
+     * Within one value a literal {@code +} stays {@code +} while an escaped space ({@code %20}) decodes to a space.
+     * Form-urlencoded decoding would collapse both to spaces.
+     */
+    public void testLiteralPlusAndEscapedSpaceInOneValue() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a+b%20c/file.parquet"));
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a+b%20c/file.parquet"));
+        assertEquals("a+b c", partitions.get("tag"));
+    }
+
+    /** A malformed escape ({@code %} not followed by two hex digits) is left as the raw value, never throwing. */
+    public void testMalformedPercentEscapeFallsBackToRawValue() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a%2/file.parquet"));
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a%2/file.parquet"));
+        assertEquals("a%2", partitions.get("tag"));
+    }
+
+    /**
+     * A literal {@code +} next to a malformed escape falls back to the raw value, keeping the {@code +} literal rather
+     * than surfacing the {@code %2B} form the decoder would use for a well-formed value.
+     */
+    public void testLiteralPlusWithMalformedEscapeFallsBackToRawValue() {
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/tag=a+%2/file.parquet"));
+
+        PartitionMetadata result = HivePartitionDetector.detect(files);
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> partitions = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/tag=a+%2/file.parquet"));
+        assertEquals("a+%2", partitions.get("tag"));
+    }
+
     public void testSingleFile() {
         List<StorageEntry> files = List.of(entry("s3://bucket/data/year=2024/file.parquet"));
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/TemplatePartitionDetectorTests.java
@@ -190,6 +190,65 @@ public class TemplatePartitionDetectorTests extends ESTestCase {
         assertEquals("São Paulo", values.get("city"));
     }
 
+    /**
+     * A literal {@code +} in a directory segment must survive as {@code +}, not be turned into a space:
+     * {@code application/x-www-form-urlencoded} decoding corrupts an {@code a+b} folder to {@code "a b"} and a filter
+     * on the true value drops every row. Mirrors the Hive detector's guard (both share the same decoder).
+     */
+    public void testLiteralPlusIsNotDecodedToSpace() {
+        TemplatePartitionDetector detector = new TemplatePartitionDetector("{tag}");
+
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/a+b/file.parquet"));
+
+        PartitionMetadata result = detector.detect(files, Map.of());
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a+b/file.parquet"));
+        assertEquals("a+b", values.get("tag"));
+    }
+
+    /** Parity guard with the Hive detector: {@code %XX} escapes still decode ({@code %2B} -> {@code +}, {@code %3A} -> {@code :}). */
+    public void testPercentEscapesStillDecode() {
+        TemplatePartitionDetector detector = new TemplatePartitionDetector("{tag}");
+
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/a%2Bns%3Ab/file.parquet"));
+
+        PartitionMetadata result = detector.detect(files, Map.of());
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a%2Bns%3Ab/file.parquet"));
+        assertEquals("a+ns:b", values.get("tag"));
+    }
+
+    /**
+     * Parity guard with the Hive detector: within one segment a literal {@code +} stays {@code +} while an escaped
+     * space ({@code %20}) decodes to a space, where form-urlencoded decoding would collapse both to spaces.
+     */
+    public void testLiteralPlusAndEscapedSpaceInOneValue() {
+        TemplatePartitionDetector detector = new TemplatePartitionDetector("{tag}");
+
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/a+b%20c/file.parquet"));
+
+        PartitionMetadata result = detector.detect(files, Map.of());
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a+b%20c/file.parquet"));
+        assertEquals("a+b c", values.get("tag"));
+    }
+
+    /** Parity guard with the Hive detector: a malformed escape ({@code %} not followed by two hex digits) is left as the raw value. */
+    public void testMalformedPercentEscapeFallsBackToRawValue() {
+        TemplatePartitionDetector detector = new TemplatePartitionDetector("{tag}");
+
+        List<StorageEntry> files = List.of(entry("s3://bucket/data/a%2/file.parquet"));
+
+        PartitionMetadata result = detector.detect(files, Map.of());
+
+        assertFalse(result.isEmpty());
+        Map<String, Object> values = result.filePartitionValues().get(StoragePath.of("s3://bucket/data/a%2/file.parquet"));
+        assertEquals("a%2", values.get("tag"));
+    }
+
     public void testEmptyFilesReturnsEmpty() {
         TemplatePartitionDetector detector = new TemplatePartitionDetector("{year}");
         PartitionMetadata result = detector.detect(List.of(), Map.of());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL|DS: keep literal '+' in Hive partition values (#153908)](https://github.com/elastic/elasticsearch/pull/153908)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)