### PR TITLE
[9.5] Rename cluster state encryption health section (#154022)

### DIFF
--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/ProjectEncryptionKeyHealthIndicatorService.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/ProjectEncryptionKeyHealthIndicatorService.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.health.HealthStatus.YELLOW;
  */
 class ProjectEncryptionKeyHealthIndicatorService implements HealthIndicatorService {
 
-    static final String NAME = "project_encryption_key";
+    static final String NAME = "cluster_state_encryption";
 
     // TODO add URL when available
     private static final String HELP_URL = null;
@@ -57,7 +57,7 @@ class ProjectEncryptionKeyHealthIndicatorService implements HealthIndicatorServi
             NAME,
             "encryption_key_not_persisted",
             2,
-            "The project encryption key cannot be persisted to disk. This node will fail to start after a restart.",
+            "The cluster state encryption key cannot be persisted to disk. This node will fail to start after a restart.",
             List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
         )
     );
@@ -83,7 +83,7 @@ class ProjectEncryptionKeyHealthIndicatorService implements HealthIndicatorServi
     static final Diagnosis.Definition MISSING_WRAP_CREDENTIALS_DEFINITION = new Diagnosis.Definition(
         NAME,
         "missing_wrap_credentials",
-        "A project encryption key is installed but this node lacks the password material to wrap it for disk.",
+        "A cluster state encryption key is installed but this node lacks the password material to wrap it for disk.",
         "Provision cluster.state.encryption.active_password_id and the matching cluster.state.encryption.password.<id> in the keystore"
             + " (stateful) or operator file settings (serverless). If the password was added to the keystore call"
             + " POST /_nodes/reload_secure_settings (stateful).",
@@ -92,14 +92,14 @@ class ProjectEncryptionKeyHealthIndicatorService implements HealthIndicatorServi
     static final Diagnosis.Definition DECRYPTION_FAILED_DEFINITION = new Diagnosis.Definition(
         NAME,
         "decryption_failed",
-        "The project encryption key could not be decrypted on startup, likely due to a wrong or missing password.",
+        "The cluster state encryption key could not be decrypted on startup, likely due to a wrong or missing password.",
         "Fix the password configuration and restart the node, or reset encryption via POST /_encryption/_reset?accept_data_loss=true.",
         HELP_URL
     );
     static final Diagnosis.Definition MISSING_PASSWORD_DEFINITION = new Diagnosis.Definition(
         NAME,
         "missing_password",
-        "No active password is configured on this node; the project encryption key cannot be decrypted.",
+        "No active password is configured on this node; the cluster state encryption key cannot be decrypted.",
         "Provision cluster.state.encryption.active_password_id and the matching cluster.state.encryption.password.<id> in the keystore"
             + " (stateful) or operator file settings (serverless). If the password was added to the keystore call"
             + " POST /_nodes/reload_secure_settings (stateful).",


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Rename cluster state encryption health section (#154022)