### PR TITLE
Revert explicit CI disk size increase

### DIFF
--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -9,7 +9,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -33,7 +32,6 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
@@ -45,7 +43,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -71,7 +68,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -97,7 +93,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -123,7 +118,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -149,7 +143,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -175,7 +168,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -207,7 +199,6 @@ steps:
           preemptible: true
           spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -244,7 +235,6 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
@@ -256,7 +246,6 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - wait
   - trigger: elasticsearch-dra-workflow

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -10,7 +10,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -34,7 +33,6 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints checkPart1
@@ -46,7 +44,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -72,7 +69,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -98,7 +94,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -124,7 +119,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -150,7 +144,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -176,7 +169,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -208,7 +200,6 @@ steps:
           preemptible: true
           spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -245,7 +236,6 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: custom-32-98304
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
@@ -257,7 +247,6 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
   - wait
   - trigger: elasticsearch-dra-workflow

--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -26,5 +26,4 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -20,7 +20,6 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
         key: "bwc-snapshots-part2"
@@ -36,7 +35,6 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
         key: "bwc-snapshots-part3"
@@ -52,7 +50,6 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
         key: "bwc-snapshots-part4"
@@ -68,7 +65,6 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
         key: "bwc-snapshots-part5"
@@ -84,7 +80,6 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
         key: "bwc-snapshots-part6"
@@ -100,5 +95,4 @@ steps:
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -12,5 +12,4 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -7,7 +7,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -16,5 +16,4 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -13,7 +13,6 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-16
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -18,7 +18,6 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: n4-standard-8
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-1-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips-140-3.yml
@@ -11,7 +11,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -10,7 +10,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -9,7 +9,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-2-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips-140-3.yml
@@ -11,7 +11,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -10,7 +10,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -7,7 +7,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-3-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips-140-3.yml
@@ -11,7 +11,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -10,7 +10,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -7,7 +7,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-4-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips-140-3.yml
@@ -11,7 +11,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -10,7 +10,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -7,7 +7,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-32
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-5-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips-140-3.yml
@@ -11,7 +11,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -10,7 +10,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -7,7 +7,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-16
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/part-6-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips-140-3.yml
@@ -11,7 +11,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-6-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips.yml
@@ -10,7 +10,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -8,7 +8,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-standard-16
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -13,5 +13,4 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/rest-compatibility.yml
+++ b/.buildkite/pipelines/pull-request/rest-compatibility.yml
@@ -7,7 +7,6 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
       preemptible: true
       spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -9,5 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -71,7 +71,6 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-16
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
           preemptible: true
           spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -37,7 +37,6 @@ steps:
             image: family/elasticsearch-ubuntu-2404
             machineType: n4-standard-16
             diskType: hyperdisk-balanced
-            diskSizeGb: 250
             buildDirectory: /dev/shm/bk
             preemptible: true
             spotZones: 'asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c'


### PR DESCRIPTION
After mitigating a few ci image related issues in the ci image baking we should be fine with reverting the diskSize changes from #152860 and #152895, removing the explicit diskSizeGb/diskSize overrides added to the PR and intake pipelines and the pr/bc upgrade test scripts.

The cache usage has been reduced to:

```
8.4G	/opt/buildkite-agent/.gradle
3.8G	/opt/buildkite-agent/.gradle-minor1
3.3G	/opt/buildkite-agent/.gradle-minor2
2.7G	/opt/buildkite-agent/.gradle-minor3
3.8G	/opt/buildkite-agent/.gradle-major1
```