### PR TITLE
Add opt-in security config change diff auditing

### DIFF
--- a/docs/changelog/154065.yaml
+++ b/docs/changelog/154065.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 154065
+summary: Add opt-in security config change diff auditing
+type: enhancement

--- a/x-pack/plugin/core/src/main/config/log4j2.properties
+++ b/x-pack/plugin/core/src/main/config/log4j2.properties
@@ -51,6 +51,7 @@ appender.audit_rolling.layout.pattern = {\
                 %varsNotEmpty{, "change":%map{change}}\
                 %varsNotEmpty{, "create":%map{create}}\
                 %varsNotEmpty{, "invalidate":%map{invalidate}}\
+                %varsNotEmpty{, "created":%map{created}}\
                 }%n
 # "node.name" node name from the `elasticsearch.yml` settings
 # "node.id" node id which should not change between cluster restarts
@@ -74,7 +75,7 @@ appender.audit_rolling.layout.pattern = {\
 # "authentication.token.name" this field is present if and only if the authenticating credential is a service account token
 # "authentication.token.type" this field is present if and only if the authenticating credential is a service account token
 # "cross_cluster_access" this field is present if and only if the associated authentication occurred cross cluster
-# "event.type" informs about what internal system generated the event; possible values are "rest", "transport", "ip_filter" and "security_config_change"
+# "event.type" informs about what internal system generated the event; possible values are "rest", "transport", "ip_filter", "security_config_change" and "security_config_change_diff"
 # "origin.address" the remote address and port of the first network hop, i.e. a REST proxy or another cluster node
 # "realm" name of a realm that has generated an "authentication_failed" or an "authentication_successful"; the subject is not yet authenticated
 # "realm_domain" if "realm" is under a domain, this is the name of the domain
@@ -93,6 +94,10 @@ appender.audit_rolling.layout.pattern = {\
 # "rule" name of the applied rule if the "origin.type" is "ip_filter"
 # the "put", "delete", "change", "create", "invalidate" fields are only present
 # when the "event.type" is "security_config_change" and contain the security config change (as an object) taking effect
+# the "created" field is a boolean only present when the "event.type" is "security_config_change_diff" (an opt-in, post-execution
+# record enabled by adding "security_config_change_diff" to the audit events); it indicates whether the object was created (true)
+# or updated (false). When the "xpack.security.audit.logfile.events.emit_security_config_change_diff" setting is also enabled, the
+# "put" object of that record additionally carries the reliable "before"/"after" states and the list of "changed_fields"
 
 appender.audit_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_audit-%d{yyyy-MM-dd}-%i.json.gz
 appender.audit_rolling.policies.type = Policies

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkRolesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/BulkRolesResponse.java
@@ -12,8 +12,10 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -24,6 +26,15 @@ import java.util.stream.Collectors;
 public class BulkRolesResponse extends ActionResponse implements ToXContentObject {
 
     private final List<Item> items;
+
+    /**
+     * The reliable "before" images of the upserted roles, keyed by role name, captured by {@code NativeRolesStore} during an
+     * opt-in compare-and-swap bulk upsert and consumed by {@code LoggingAuditTrail} to emit per-role before/after diff audit
+     * records. This is transient audit-only state: this response is local-only (never serialized, see {@link #writeTo}), so this
+     * map never crosses the wire nor appears in the REST response body. A role is absent from the map when diff capture is
+     * disabled or when it did not previously exist (i.e. the operation created it).
+     */
+    private transient Map<String, RoleDescriptor> previousRoleDescriptors = Map.of();
 
     public static class Builder {
 
@@ -140,6 +151,15 @@ public class BulkRolesResponse extends ActionResponse implements ToXContentObjec
 
     public List<Item> getItems() {
         return items;
+    }
+
+    public void setPreviousRoleDescriptors(Map<String, RoleDescriptor> previousRoleDescriptors) {
+        this.previousRoleDescriptors = previousRoleDescriptors;
+    }
+
+    @Nullable
+    public RoleDescriptor getPreviousRoleDescriptor(String roleName) {
+        return previousRoleDescriptors.get(roleName);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleResponse.java
@@ -8,8 +8,10 @@ package org.elasticsearch.xpack.core.security.action.role;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
 
@@ -21,12 +23,31 @@ public class PutRoleResponse extends ActionResponse implements ToXContentObject 
 
     private final boolean created;
 
+    /**
+     * The reliable "before" image of the role, captured by {@code NativeRolesStore} during an opt-in
+     * compare-and-swap upsert and consumed by {@code LoggingAuditTrail} to emit a before/after diff audit record. This is
+     * transient audit-only state: it is intentionally NOT serialized in {@link #writeTo} and NOT rendered in
+     * {@link #toXContent}, so it never crosses the wire nor appears in the REST response body. It is {@code null} when diff
+     * capture is disabled or when the role did not previously exist (i.e. the operation created a new role).
+     */
+    @Nullable
+    private transient RoleDescriptor previousRoleDescriptor;
+
     public PutRoleResponse(boolean created) {
         this.created = created;
     }
 
     public boolean isCreated() {
         return created;
+    }
+
+    @Nullable
+    public RoleDescriptor getPreviousRoleDescriptor() {
+        return previousRoleDescriptor;
+    }
+
+    public void setPreviousRoleDescriptor(@Nullable RoleDescriptor previousRoleDescriptor) {
+        this.previousRoleDescriptor = previousRoleDescriptor;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserResponse.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.core.security.action.user;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.user.User;
 
 import java.io.IOException;
 
@@ -22,12 +24,42 @@ public class PutUserResponse extends ActionResponse implements ToXContentObject 
 
     private final boolean created;
 
+    /**
+     * The reliable "before" image of the user, captured by {@code NativeUsersStore} during an opt-in compare-and-swap upsert and
+     * consumed by {@code LoggingAuditTrail} to emit a before/after diff audit record. This is transient audit-only state: it is
+     * intentionally NOT serialized in {@link #writeTo} and NOT rendered in {@link #toXContent}, so it never crosses the wire nor
+     * appears in the REST response body. It never contains the password hash. It is {@code null} when diff capture is disabled or
+     * when the user did not previously exist (i.e. the operation created a new user).
+     */
+    @Nullable
+    private transient User previousUser;
+
+    /**
+     * Whether the {@link #previousUser} had a password set. Transient audit-only state, paired with {@link #previousUser}; only
+     * meaningful when {@link #previousUser} is non-null.
+     */
+    private transient boolean previousHadPassword;
+
     public PutUserResponse(boolean created) {
         this.created = created;
     }
 
     public boolean created() {
         return created;
+    }
+
+    @Nullable
+    public User getPreviousUser() {
+        return previousUser;
+    }
+
+    public boolean previousHadPassword() {
+        return previousHadPassword;
+    }
+
+    public void setPreviousUser(@Nullable User previousUser, boolean previousHadPassword) {
+        this.previousUser = previousUser;
+        this.previousHadPassword = previousHadPassword;
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -848,7 +848,12 @@ public class Security extends Plugin
         components.add(tokenService);
 
         // realms construction
-        final NativeUsersStore nativeUsersStore = new NativeUsersStore(settings, client, systemIndices.getMainIndexManager());
+        final NativeUsersStore nativeUsersStore = new NativeUsersStore(
+            settings,
+            client,
+            systemIndices.getMainIndexManager(),
+            clusterService
+        );
         final NativeRoleMappingStore nativeRoleMappingStore = new NativeRoleMappingStore(
             settings,
             client,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleAction.java
@@ -30,13 +30,17 @@ public class TransportPutRoleAction extends TransportAction<PutRoleRequest, PutR
 
     @Override
     protected void doExecute(Task task, final PutRoleRequest request, final ActionListener<PutRoleResponse> listener) {
-        rolesStore.putRole(request.getRefreshPolicy(), request.roleDescriptor(), listener.safeMap(created -> {
-            if (created) {
+        rolesStore.putRoleWithPreviousState(request.getRefreshPolicy(), request.roleDescriptor(), listener.safeMap(result -> {
+            if (result.created()) {
                 logger.info("added role [{}]", request.name());
             } else {
                 logger.info("updated role [{}]", request.name());
             }
-            return new PutRoleResponse(created);
+            final PutRoleResponse response = new PutRoleResponse(result.created());
+            // Carry the reliable before-image (if captured) to the audit trail via a transient,
+            // non-serialized response field. It is null unless diff auditing is enabled and the role previously existed.
+            response.setPreviousRoleDescriptor(result.previous());
+            return response;
         }));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportPutUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportPutUserAction.java
@@ -55,15 +55,19 @@ public class TransportPutUserAction extends HandledTransportAction<PutUserReques
         if (validationException != null) {
             listener.onFailure(validationException);
         } else {
-            usersStore.putUser(request, new ActionListener<Boolean>() {
+            usersStore.putUserWithPreviousState(request, new ActionListener<NativeUsersStore.PutUserResult>() {
                 @Override
-                public void onResponse(Boolean created) {
-                    if (created) {
+                public void onResponse(NativeUsersStore.PutUserResult result) {
+                    if (result.created()) {
                         logger.info("added user [{}]", request.username());
                     } else {
                         logger.info("updated user [{}]", request.username());
                     }
-                    listener.onResponse(new PutUserResponse(created));
+                    final PutUserResponse response = new PutUserResponse(result.created());
+                    // Carry the reliable before-image (if captured) to the audit trail via a transient, non-serialized response
+                    // field. It is null unless diff auditing is enabled and the user previously existed, and never holds a password.
+                    response.setPreviousUser(result.previousUser(), result.previousHadPassword());
+                    listener.onResponse(response);
                 }
 
                 @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditLevel.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditLevel.java
@@ -23,6 +23,7 @@ public enum AuditLevel {
     CONNECTION_DENIED,
     SYSTEM_ACCESS_GRANTED,
     SECURITY_CONFIG_CHANGE,
+    SECURITY_CONFIG_CHANGE_DIFF,
     AUTHENTICATION_SUCCESS,
     RUN_AS_GRANTED,
     RUN_AS_DENIED;
@@ -43,6 +44,7 @@ public enum AuditLevel {
                 case "connection_denied" -> enumSet.add(CONNECTION_DENIED);
                 case "system_access_granted" -> enumSet.add(SYSTEM_ACCESS_GRANTED);
                 case "security_config_change" -> enumSet.add(SECURITY_CONFIG_CHANGE);
+                case "security_config_change_diff" -> enumSet.add(SECURITY_CONFIG_CHANGE_DIFF);
                 case "authentication_success" -> enumSet.add(AUTHENTICATION_SUCCESS);
                 case "run_as_granted" -> enumSet.add(RUN_AS_GRANTED);
                 case "run_as_denied" -> enumSet.add(RUN_AS_DENIED);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -78,14 +78,17 @@ import org.elasticsearch.xpack.core.security.action.profile.UpdateProfileDataAct
 import org.elasticsearch.xpack.core.security.action.profile.UpdateProfileDataRequest;
 import org.elasticsearch.xpack.core.security.action.role.BulkDeleteRolesRequest;
 import org.elasticsearch.xpack.core.security.action.role.BulkPutRolesRequest;
+import org.elasticsearch.xpack.core.security.action.role.BulkRolesResponse;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleRequest;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleRequest;
+import org.elasticsearch.xpack.core.security.action.role.PutRoleResponse;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingResponse;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccountTokenAction;
@@ -95,6 +98,7 @@ import org.elasticsearch.xpack.core.security.action.user.DeleteUserAction;
 import org.elasticsearch.xpack.core.security.action.user.DeleteUserRequest;
 import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
 import org.elasticsearch.xpack.core.security.action.user.PutUserRequest;
+import org.elasticsearch.xpack.core.security.action.user.PutUserResponse;
 import org.elasticsearch.xpack.core.security.action.user.SetEnabledRequest;
 import org.elasticsearch.xpack.core.security.audit.AuditEventContext;
 import org.elasticsearch.xpack.core.security.audit.AuditLogCustomizer;
@@ -121,6 +125,7 @@ import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -155,6 +160,7 @@ import static org.elasticsearch.xpack.security.audit.AuditLevel.REALM_AUTHENTICA
 import static org.elasticsearch.xpack.security.audit.AuditLevel.RUN_AS_DENIED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.RUN_AS_GRANTED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.SECURITY_CONFIG_CHANGE;
+import static org.elasticsearch.xpack.security.audit.AuditLevel.SECURITY_CONFIG_CHANGE_DIFF;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.SYSTEM_ACCESS_GRANTED;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.TAMPERED_REQUEST;
 import static org.elasticsearch.xpack.security.audit.AuditLevel.parse;
@@ -169,6 +175,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final String TRANSPORT_ORIGIN_FIELD_VALUE = "transport";
     public static final String IP_FILTER_ORIGIN_FIELD_VALUE = "ip_filter";
     public static final String SECURITY_CHANGE_ORIGIN_FIELD_VALUE = "security_config_change";
+    // event.type of the opt-in before/after diff record. Gated by the SECURITY_CONFIG_CHANGE_DIFF audit level.
+    public static final String SECURITY_CHANGE_DIFF_ORIGIN_FIELD_VALUE = "security_config_change_diff";
 
     // changing any of these field names requires changing the log4j2.properties file(s) too
     public static final String LOG_TYPE = "type";
@@ -222,6 +230,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final String CHANGE_CONFIG_FIELD_NAME = "change";
     public static final String CREATE_CONFIG_FIELD_NAME = "create";
     public static final String INVALIDATE_API_KEYS_FIELD_NAME = "invalidate";
+    // top-level audit field of the opt-in post-execution record (event.type=security_config_change_diff),
+    // a boolean indicating whether the security object was created (true) or updated (false). It has a matching entry in
+    // log4j2.properties. See coordinatingActionResponse.
+    public static final String CREATED_FIELD_NAME = "created";
 
     public static final String NAME = "logfile";
     public static final Setting<Boolean> EMIT_HOST_ADDRESS_SETTING = Setting.boolSetting(
@@ -286,6 +298,16 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     );
     public static final Setting<Boolean> INCLUDE_REQUEST_BODY = Setting.boolSetting(
         setting("audit.logfile.events.emit_request_body"),
+        false,
+        Property.NodeScope,
+        Property.Dynamic
+    );
+    // Opt-in, off by default. Independent of the SECURITY_CONFIG_CHANGE_DIFF audit level (which controls
+    // whether the post-execution outcome record is emitted at all): this setting additionally includes the reliable before/after
+    // diff in that record. Because capturing the "before" image requires a GET + compare-and-swap read-modify-write in the store,
+    // it changes the write path, so the cost is only paid when this is explicitly enabled (on top of the audit level).
+    public static final Setting<Boolean> EMIT_CONFIG_CHANGE_DIFF = Setting.boolSetting(
+        setting("audit.logfile.events.emit_security_config_change_diff"),
         false,
         Property.NodeScope,
         Property.Dynamic
@@ -358,6 +380,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     // package for testing
     volatile EnumSet<AuditLevel> events;
     volatile boolean includeRequestBody;
+    // Gates inclusion of the before/after diff (and the store's GET+CAS capture). See EMIT_CONFIG_CHANGE_DIFF.
+    volatile boolean emitConfigChangeDiff;
     // fields that all entries have in common
     EntryCommonFields entryCommonFields;
 
@@ -390,6 +414,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         this.logger = logger;
         this.events = parse(INCLUDE_EVENT_SETTINGS.get(settings), EXCLUDE_EVENT_SETTINGS.get(settings));
         this.includeRequestBody = INCLUDE_REQUEST_BODY.get(settings);
+        this.emitConfigChangeDiff = EMIT_CONFIG_CHANGE_DIFF.get(settings);
         this.threadContext = threadContext;
         this.securityContext = new SecurityContext(settings, threadContext);
         this.entryCommonFields = new EntryCommonFields(settings, null, clusterService);
@@ -398,6 +423,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(newSettings -> {
             this.entryCommonFields = this.entryCommonFields.withNewSettings(newSettings);
             this.includeRequestBody = INCLUDE_REQUEST_BODY.get(newSettings);
+            this.emitConfigChangeDiff = EMIT_CONFIG_CHANGE_DIFF.get(newSettings);
             // `events` is a volatile field! Keep `events` write last so that
             // `entryCommonFields` and `includeRequestBody` writes happen-before! `events` is
             // always read before `entryCommonFields` and `includeRequestBody`.
@@ -412,7 +438,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 EMIT_CLUSTER_UUID_SETTING,
                 INCLUDE_EVENT_SETTINGS,
                 EXCLUDE_EVENT_SETTINGS,
-                INCLUDE_REQUEST_BODY
+                INCLUDE_REQUEST_BODY,
+                EMIT_CONFIG_CHANGE_DIFF
             )
         );
         clusterService.getClusterSettings()
@@ -1127,7 +1154,70 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         TransportRequest transportRequest,
         TransportResponse transportResponse
     ) {
-        // not implemented yet
+        // Opt-in, off by default. When the SECURITY_CONFIG_CHANGE_DIFF audit level is enabled (via the audit
+        // events include/exclude settings), emit a post-execution `security_config_change_diff` record for the native upsert actions
+        // (put_user/put_role/put_role_mapping, plus one record per role for bulk_put_roles) carrying a top-level `created` flag that
+        // distinguishes creation from modification. This is a post-execution companion to the pre-execution `security_config_change`
+        // record and is correlated to it by request.id. Additionally, when the EMIT_CONFIG_CHANGE_DIFF setting is enabled, the records
+        // for put_role and bulk_put_roles also carry the reliable before/after states and changed fields captured by NativeRolesStore.
+        // Dispatch is on the response/request types, so when the level is disabled or the response is not one of these upserts this is a
+        // no-op and default audit output is unchanged. This hook fires only on successful completion, so failed writes (including
+        // exhausted compare-and-swap retries, and individually-failed items of a bulk request) emit no record.
+        if (events.contains(SECURITY_CONFIG_CHANGE_DIFF) == false) {
+            return;
+        }
+        try {
+            if (transportResponse instanceof PutRoleResponse putRoleResponse && transportRequest instanceof PutRoleRequest putRoleRequest) {
+                securityChangeDiffLogEntryBuilder(requestId).withPutRoleOutcome(
+                    putRoleRequest.name(),
+                    putRoleResponse.isCreated(),
+                    putRoleResponse.getPreviousRoleDescriptor(),
+                    putRoleRequest.roleDescriptor(),
+                    emitConfigChangeDiff
+                ).build();
+            } else if (transportResponse instanceof PutUserResponse putUserResponse
+                && transportRequest instanceof PutUserRequest putUserRequest) {
+                    securityChangeDiffLogEntryBuilder(requestId).withPutUserOutcome(
+                        putUserRequest,
+                        putUserResponse.created(),
+                        putUserResponse.getPreviousUser(),
+                        putUserResponse.previousHadPassword(),
+                        emitConfigChangeDiff
+                    ).build();
+                } else if (transportResponse instanceof PutRoleMappingResponse putRoleMappingResponse
+                    && transportRequest instanceof PutRoleMappingRequest putRoleMappingRequest) {
+                        securityChangeDiffLogEntryBuilder(requestId).withPutRoleMappingOutcome(
+                            putRoleMappingRequest.getName(),
+                            putRoleMappingResponse.isCreated()
+                        ).build();
+                    } else if (transportResponse instanceof BulkRolesResponse bulkRolesResponse
+                        && transportRequest instanceof BulkPutRolesRequest bulkPutRolesRequest) {
+                            // One diff record per successfully upserted role, correlated to the pre-execution records by request.id.
+                            // Failed items (validation errors, exhausted compare-and-swap retries) carry no outcome and are skipped.
+                            final Map<String, RoleDescriptor> afterByRoleName = new HashMap<>();
+                            for (RoleDescriptor roleDescriptor : bulkPutRolesRequest.getRoles()) {
+                                afterByRoleName.put(roleDescriptor.getName(), roleDescriptor);
+                            }
+                            for (BulkRolesResponse.Item item : bulkRolesResponse.getItems()) {
+                                if (item.isFailed()) {
+                                    continue;
+                                }
+                                final RoleDescriptor after = afterByRoleName.get(item.getRoleName());
+                                if (after == null) {
+                                    continue;
+                                }
+                                securityChangeDiffLogEntryBuilder(requestId).withPutRoleOutcome(
+                                    item.getRoleName(),
+                                    "created".equals(item.getResultType()),
+                                    bulkRolesResponse.getPreviousRoleDescriptor(item.getRoleName()),
+                                    after,
+                                    emitConfigChangeDiff
+                                ).build();
+                            }
+                        }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to build the security_config_change_diff audit record", e);
+        }
     }
 
     public boolean includeRequestBody() {
@@ -1136,6 +1226,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
 
     private LogEntryBuilder securityChangeLogEntryBuilder(String requestId) {
         return new LogEntryBuilder(false).with(EVENT_TYPE_FIELD_NAME, SECURITY_CHANGE_ORIGIN_FIELD_VALUE).withRequestId(requestId);
+    }
+
+    // Builder for the opt-in before/after diff record. Gated by the SECURITY_CONFIG_CHANGE_DIFF audit level.
+    private LogEntryBuilder securityChangeDiffLogEntryBuilder(String requestId) {
+        return new LogEntryBuilder(false).with(EVENT_TYPE_FIELD_NAME, SECURITY_CHANGE_DIFF_ORIGIN_FIELD_VALUE).withRequestId(requestId);
     }
 
     private class LogEntryBuilder {
@@ -1160,28 +1255,18 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         LogEntryBuilder withRequestBody(PutUserRequest putUserRequest) throws IOException {
             logEntry.with(EVENT_ACTION_FIELD_NAME, "put_user");
             XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
-            builder.startObject()
-                .startObject("user")
-                .field("name", putUserRequest.username())
-                .field("enabled", putUserRequest.enabled())
-                .array("roles", putUserRequest.roles());
-            if (putUserRequest.fullName() != null) {
-                builder.field("full_name", putUserRequest.fullName());
-            }
-            if (putUserRequest.email() != null) {
-                builder.field("email", putUserRequest.email());
-            }
-            // password and password hashes are not exposed in the audit log
-            builder.field("has_password", putUserRequest.passwordHash() != null);
-            if (putUserRequest.metadata() != null && false == putUserRequest.metadata().isEmpty()) {
-                // JSON building for the metadata might fail when encountering unknown class types.
-                // This is NOT a problem because such metadata (eg containing GeoPoint) will most probably
-                // cause troubles in downstream code (eg storing the metadata), so this simply introduces a new failure mode.
-                // Also the malevolent metadata can only be produced by the transport client.
-                builder.field("metadata", putUserRequest.metadata());
-            }
-            builder.endObject() // user
-                .endObject();
+            builder.startObject().field("user");
+            withUserObject(
+                builder,
+                putUserRequest.username(),
+                putUserRequest.enabled(),
+                putUserRequest.roles(),
+                putUserRequest.fullName(),
+                putUserRequest.email(),
+                putUserRequest.passwordHash() != null,
+                putUserRequest.metadata()
+            );
+            builder.endObject();
             logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
             return this;
         }
@@ -1216,6 +1301,106 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             withRoleDescriptor(builder, roleDescriptor);
             builder.endObject() // role
                 .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        // The post-execution outcome record for a put_role upsert. Always records the object identity plus a
+        // top-level `created` flag. When {@code includeDiff} is set (EMIT_CONFIG_CHANGE_DIFF enabled), the "put" object also carries
+        // the reliable "before" image captured by the store (null when the role was created), the "after" (requested) state, and the
+        // "changed_fields" list of differing top-level role fields.
+        LogEntryBuilder withPutRoleOutcome(
+            String roleName,
+            boolean created,
+            @Nullable RoleDescriptor before,
+            RoleDescriptor after,
+            boolean includeDiff
+        ) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_role");
+            logEntry.with(CREATED_FIELD_NAME, Boolean.toString(created));
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject().startObject("role").field("name", roleName);
+            if (includeDiff) {
+                builder.field("before");
+                if (before == null) {
+                    builder.nullValue();
+                } else {
+                    withRoleDescriptor(builder, before);
+                }
+                builder.field("after");
+                withRoleDescriptor(builder, after);
+                if (before != null) {
+                    builder.array("changed_fields", roleDescriptorChangedFields(before, after).toArray(String[]::new));
+                }
+            }
+            builder.endObject() // role
+                .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        // The post-execution outcome record for a put_user upsert. Always records the object identity plus a top-level `created`
+        // flag. When {@code includeDiff} is set (EMIT_CONFIG_CHANGE_DIFF enabled), the "put" object also carries the reliable
+        // "before" image captured by the store (null when the user was created), the "after" (requested) state, and the
+        // "changed_fields" list of differing top-level user fields. The password hash is never logged; only whether a password
+        // is set is surfaced (as "has_password"), and "password" appears in "changed_fields" only when that presence changes.
+        LogEntryBuilder withPutUserOutcome(
+            PutUserRequest request,
+            boolean created,
+            @Nullable User before,
+            boolean beforeHadPassword,
+            boolean includeDiff
+        ) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_user");
+            logEntry.with(CREATED_FIELD_NAME, Boolean.toString(created));
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject().startObject("user").field("name", request.username());
+            if (includeDiff) {
+                builder.field("before");
+                if (before == null) {
+                    builder.nullValue();
+                } else {
+                    // name omitted: it is carried on the enclosing "user" object
+                    withUserObject(
+                        builder,
+                        null,
+                        before.enabled(),
+                        before.roles(),
+                        before.fullName(),
+                        before.email(),
+                        beforeHadPassword,
+                        before.metadata()
+                    );
+                }
+                final boolean afterHasPassword = request.passwordHash() != null || beforeHadPassword;
+                builder.field("after");
+                withUserObject(
+                    builder,
+                    null,
+                    request.enabled(),
+                    request.roles(),
+                    request.fullName(),
+                    request.email(),
+                    afterHasPassword,
+                    request.metadata()
+                );
+                if (before != null) {
+                    builder.array("changed_fields", userChangedFields(before, beforeHadPassword, request).toArray(String[]::new));
+                }
+            }
+            builder.endObject() // user
+                .endObject();
+            logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        // The post-execution outcome record for a put_role_mapping upsert - the object identity plus a
+        // top-level `created` flag. No before/after diff is captured for role mappings.
+        LogEntryBuilder withPutRoleMappingOutcome(String roleMappingName, boolean created) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "put_role_mapping");
+            logEntry.with(CREATED_FIELD_NAME, Boolean.toString(created));
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject().startObject("role_mapping").field("name", roleMappingName).endObject().endObject();
             logEntry.with(PUT_CONFIG_FIELD_NAME, Strings.toString(builder));
             return this;
         }
@@ -1405,6 +1590,105 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 "expiration",
                 baseUpdateApiKeyRequest.getExpiration() != null ? baseUpdateApiKeyRequest.getExpiration().toString() : null
             );
+        }
+
+        // The top-level role fields that differ between the before and after images, using the same field
+        // names as the rendered role descriptor. Kept intentionally coarse (top-level only).
+        private static List<String> roleDescriptorChangedFields(RoleDescriptor before, RoleDescriptor after) {
+            final List<String> changed = new ArrayList<>();
+            if (Arrays.equals(before.getClusterPrivileges(), after.getClusterPrivileges()) == false) {
+                changed.add(RoleDescriptor.Fields.CLUSTER.getPreferredName());
+            }
+            if (Arrays.equals(before.getConditionalClusterPrivileges(), after.getConditionalClusterPrivileges()) == false) {
+                changed.add(RoleDescriptor.Fields.GLOBAL.getPreferredName());
+            }
+            if (Arrays.equals(before.getIndicesPrivileges(), after.getIndicesPrivileges()) == false) {
+                changed.add(RoleDescriptor.Fields.INDICES.getPreferredName());
+            }
+            if (Arrays.equals(before.getApplicationPrivileges(), after.getApplicationPrivileges()) == false) {
+                changed.add(RoleDescriptor.Fields.APPLICATIONS.getPreferredName());
+            }
+            if (Arrays.equals(before.getRunAs(), after.getRunAs()) == false) {
+                changed.add(RoleDescriptor.Fields.RUN_AS.getPreferredName());
+            }
+            if (Objects.equals(before.getMetadata(), after.getMetadata()) == false) {
+                changed.add(RoleDescriptor.Fields.METADATA.getPreferredName());
+            }
+            if (Arrays.equals(before.getRemoteIndicesPrivileges(), after.getRemoteIndicesPrivileges()) == false) {
+                changed.add(RoleDescriptor.Fields.REMOTE_INDICES.getPreferredName());
+            }
+            if (Objects.equals(before.getRemoteClusterPermissions(), after.getRemoteClusterPermissions()) == false) {
+                changed.add(RoleDescriptor.Fields.REMOTE_CLUSTER.getPreferredName());
+            }
+            if (Objects.equals(before.getDescription(), after.getDescription()) == false) {
+                changed.add(RoleDescriptor.Fields.DESCRIPTION.getPreferredName());
+            }
+            return changed;
+        }
+
+        // The single, canonical rendering of a user's redaction-safe profile as a JSON object, shared by both the pre-execution
+        // put_user record (via {@link #withRequestBody(PutUserRequest)}) and the before/after images of the post-execution diff
+        // record (via {@link #withPutUserOutcome}). The identity {@code name} is included when non-null and omitted when the
+        // caller carries it on the enclosing object (as the diff record does). The password hash is never rendered; only whether
+        // a password is set is surfaced via "has_password", which the caller computes.
+        private static void withUserObject(
+            XContentBuilder builder,
+            @Nullable String name,
+            boolean enabled,
+            String[] roles,
+            @Nullable String fullName,
+            @Nullable String email,
+            boolean hasPassword,
+            @Nullable Map<String, Object> metadata
+        ) throws IOException {
+            builder.startObject();
+            if (name != null) {
+                builder.field("name", name);
+            }
+            builder.field("enabled", enabled).array("roles", roles);
+            if (fullName != null) {
+                builder.field("full_name", fullName);
+            }
+            if (email != null) {
+                builder.field("email", email);
+            }
+            // password and password hashes are not exposed in the audit log
+            builder.field("has_password", hasPassword);
+            if (metadata != null && false == metadata.isEmpty()) {
+                // JSON building for the metadata might fail when encountering unknown class types.
+                // This is NOT a problem because such metadata (eg containing GeoPoint) will most probably
+                // cause troubles in downstream code (eg storing the metadata), so this simply introduces a new failure mode.
+                // Also the malevolent metadata can only be produced by the transport client.
+                builder.field("metadata", metadata);
+            }
+            builder.endObject();
+        }
+
+        // The top-level user fields that differ between the before image and the requested after state. "password" is reported
+        // only when the presence of a password changes (never by comparing hashes), since put_user cannot observe a hash change.
+        private static List<String> userChangedFields(User before, boolean beforeHadPassword, PutUserRequest after) {
+            final List<String> changed = new ArrayList<>();
+            if (before.enabled() != after.enabled()) {
+                changed.add("enabled");
+            }
+            if (Arrays.equals(before.roles(), after.roles()) == false) {
+                changed.add("roles");
+            }
+            if (Objects.equals(before.fullName(), after.fullName()) == false) {
+                changed.add("full_name");
+            }
+            if (Objects.equals(before.email(), after.email()) == false) {
+                changed.add("email");
+            }
+            final Map<String, Object> afterMetadata = after.metadata() == null ? Map.of() : after.metadata();
+            if (Objects.equals(before.metadata(), afterMetadata) == false) {
+                changed.add("metadata");
+            }
+            final boolean afterHasPassword = after.passwordHash() != null || beforeHadPassword;
+            if (afterHasPassword != beforeHadPassword) {
+                changed.add("password");
+            }
+            return changed;
         }
 
         private static void withRoleDescriptor(XContentBuilder builder, RoleDescriptor roleDescriptor) throws IOException {
@@ -1881,6 +2165,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         settings.add(INCLUDE_EVENT_SETTINGS);
         settings.add(EXCLUDE_EVENT_SETTINGS);
         settings.add(INCLUDE_REQUEST_BODY);
+        settings.add(EMIT_CONFIG_CHANGE_DIFF);
         settings.add(FILTER_POLICY_IGNORE_PRINCIPALS);
         settings.add(FILTER_POLICY_IGNORE_INDICES);
         settings.add(FILTER_POLICY_IGNORE_ROLES);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
@@ -16,23 +16,29 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.Requests;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
@@ -50,6 +56,7 @@ import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.core.security.user.ElasticUser;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.core.security.user.User.Fields;
+import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager.IndexState;
 
@@ -57,6 +64,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -90,10 +98,29 @@ public class NativeUsersStore {
 
     private final SecurityIndexManager securityIndex;
 
-    public NativeUsersStore(Settings settings, Client client, SecurityIndexManager securityIndex) {
+    /**
+     * Whether opt-in before/after ({@code security_config_change_diff}) auditing is enabled, via the dynamic
+     * {@link LoggingAuditTrail#EMIT_CONFIG_CHANGE_DIFF} setting. When {@code true}, {@link #putUserWithPreviousState} swaps its
+     * cheap last-write-wins upsert for a GET + compare-and-swap read-modify-write so it can capture a reliable before-image;
+     * otherwise the extra read + retry cost is not paid.
+     */
+    private volatile boolean emitConfigChangeDiff;
+
+    /**
+     * Backoff used to retry the compare-and-swap upsert when a concurrent writer causes a version conflict.
+     */
+    private static final BackoffPolicy CONFIG_CHANGE_DIFF_RETRY_BACKOFF = BackoffPolicy.exponentialBackoff(
+        TimeValue.timeValueMillis(10),
+        5
+    );
+
+    public NativeUsersStore(Settings settings, Client client, SecurityIndexManager securityIndex, ClusterService clusterService) {
         this.settings = settings;
         this.client = client;
         this.securityIndex = securityIndex;
+        this.emitConfigChangeDiff = LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF.get(settings);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF, emit -> this.emitConfigChangeDiff = emit);
     }
 
     /**
@@ -379,10 +406,26 @@ public class NativeUsersStore {
      * method will not modify the enabled value.
      */
     public void putUser(final PutUserRequest request, final ActionListener<Boolean> listener) {
+        putUserWithPreviousState(request, listener.map(PutUserResult::created));
+    }
+
+    /**
+     * Upsert a user, optionally capturing a reliable "before" image for before/after auditing. When before/after auditing is
+     * disabled ({@link #emitConfigChangeDiff} is {@code false}) this behaves exactly like the historical
+     * last-write-wins upsert ({@link #updateUserWithoutPassword} for a password-less update, {@link #indexUser} for a full
+     * index-with-password) and reports a {@code null} previous state. When it is {@code true} the write becomes a GET +
+     * compare-and-swap read-modify-write (see {@link #putUserCapturingPreviousState}), so the captured before-image provably
+     * corresponds to the state the successful write replaced. The captured before-image never includes the password hash.
+     */
+    public void putUserWithPreviousState(final PutUserRequest request, final ActionListener<PutUserResult> listener) {
+        if (emitConfigChangeDiff) {
+            putUserCapturingPreviousState(request, CONFIG_CHANGE_DIFF_RETRY_BACKOFF.iterator(), listener);
+            return;
+        }
         if (request.passwordHash() == null) {
-            updateUserWithoutPassword(request, listener);
+            updateUserWithoutPassword(request, listener.map(created -> new PutUserResult(created, null, false)));
         } else {
-            indexUser(request, listener);
+            indexUser(request, listener.map(created -> new PutUserResult(created, null, false)));
         }
     }
 
@@ -483,6 +526,160 @@ public class NativeUsersStore {
             );
         });
     }
+
+    /**
+     * One attempt of the GET + compare-and-swap upsert used to capture a reliable "before" image, re-invoked (with backoff) on
+     * version conflict. The current document is read first (yielding the authoritative before-image plus its
+     * {@code _seq_no}/{@code _primary_term}); the replacement is then written conditionally on that version, so a concurrent
+     * modification produces a {@link VersionConflictEngineException} that is retried rather than silently overwriting. Both
+     * put_user write paths are supported: a password-less request becomes a conditional partial update of an existing user (and
+     * fails with the same {@link ValidationException} as {@link #updateUserWithoutPassword} when the user is absent), while a
+     * request carrying a password becomes a conditional full index (create when the user did not previously exist). The captured
+     * before-image is a {@link User} without the password hash; only whether a password was previously set is retained.
+     */
+    private void putUserCapturingPreviousState(
+        final PutUserRequest request,
+        final Iterator<TimeValue> backoff,
+        final ActionListener<PutUserResult> listener
+    ) {
+        securityIndex.forCurrentProject()
+            .prepareIndexIfNeededThenExecute(
+                listener::onFailure,
+                () -> executeAsyncWithOrigin(
+                    client.threadPool().getThreadContext(),
+                    SECURITY_ORIGIN,
+                    client.prepareGet(SECURITY_MAIN_ALIAS, getIdForUser(USER_DOC_TYPE, request.username())).request(),
+                    ActionListener.<GetResponse>wrap(getResponse -> {
+                        final UserAndPassword previous = getResponse.isExists()
+                            ? transformUser(getResponse.getId(), getResponse.getSource())
+                            : null;
+                        final User previousUser = previous == null ? null : previous.user();
+                        final boolean previousHadPassword = previous != null
+                            && previous.passwordHash() != null
+                            && previous.passwordHash().length > 0;
+
+                        if (request.passwordHash() == null) {
+                            // password-less update: the user must already exist, mirroring updateUserWithoutPassword
+                            if (previous == null) {
+                                ValidationException validationException = new ValidationException();
+                                validationException.addValidationError(
+                                    "password must be specified unless you are updating an existing user"
+                                );
+                                listener.onFailure(validationException);
+                                return;
+                            }
+                            final UpdateRequest updateRequest = client.prepareUpdate(
+                                SECURITY_MAIN_ALIAS,
+                                getIdForUser(USER_DOC_TYPE, request.username())
+                            )
+                                .setDoc(
+                                    Requests.INDEX_CONTENT_TYPE,
+                                    Fields.USERNAME.getPreferredName(),
+                                    request.username(),
+                                    Fields.ROLES.getPreferredName(),
+                                    request.roles(),
+                                    Fields.FULL_NAME.getPreferredName(),
+                                    request.fullName(),
+                                    Fields.EMAIL.getPreferredName(),
+                                    request.email(),
+                                    Fields.METADATA.getPreferredName(),
+                                    request.metadata(),
+                                    Fields.ENABLED.getPreferredName(),
+                                    request.enabled(),
+                                    Fields.TYPE.getPreferredName(),
+                                    USER_DOC_TYPE
+                                )
+                                .setRefreshPolicy(request.getRefreshPolicy())
+                                .setIfSeqNo(getResponse.getSeqNo())
+                                .setIfPrimaryTerm(getResponse.getPrimaryTerm())
+                                .request();
+                            executeAsyncWithOrigin(
+                                client.threadPool().getThreadContext(),
+                                SECURITY_ORIGIN,
+                                updateRequest,
+                                ActionListener.<UpdateResponse>wrap(
+                                    updateResponse -> clearRealmCache(
+                                        request.username(),
+                                        listener,
+                                        new PutUserResult(false, previousUser, previousHadPassword)
+                                    ),
+                                    e -> retryCapturingPreviousStateOrFail(request, backoff, listener, e)
+                                ),
+                                client::update
+                            );
+                        } else {
+                            // full replace: create when the user did not previously exist, otherwise a conditional overwrite
+                            final IndexRequest indexRequest = client.prepareIndex(SECURITY_MAIN_ALIAS)
+                                .setId(getIdForUser(USER_DOC_TYPE, request.username()))
+                                .setSource(
+                                    Fields.USERNAME.getPreferredName(),
+                                    request.username(),
+                                    Fields.PASSWORD.getPreferredName(),
+                                    String.valueOf(request.passwordHash()),
+                                    Fields.ROLES.getPreferredName(),
+                                    request.roles(),
+                                    Fields.FULL_NAME.getPreferredName(),
+                                    request.fullName(),
+                                    Fields.EMAIL.getPreferredName(),
+                                    request.email(),
+                                    Fields.METADATA.getPreferredName(),
+                                    request.metadata(),
+                                    Fields.ENABLED.getPreferredName(),
+                                    request.enabled(),
+                                    Fields.TYPE.getPreferredName(),
+                                    USER_DOC_TYPE
+                                )
+                                .setRefreshPolicy(request.getRefreshPolicy())
+                                .request();
+                            if (previous == null) {
+                                indexRequest.opType(DocWriteRequest.OpType.CREATE);
+                            } else {
+                                indexRequest.setIfSeqNo(getResponse.getSeqNo()).setIfPrimaryTerm(getResponse.getPrimaryTerm());
+                            }
+                            executeAsyncWithOrigin(
+                                client.threadPool().getThreadContext(),
+                                SECURITY_ORIGIN,
+                                indexRequest,
+                                ActionListener.<DocWriteResponse>wrap(indexResponse -> {
+                                    final boolean created = indexResponse.getResult() == DocWriteResponse.Result.CREATED;
+                                    clearRealmCache(
+                                        request.username(),
+                                        listener,
+                                        new PutUserResult(created, previousUser, previousHadPassword)
+                                    );
+                                }, e -> retryCapturingPreviousStateOrFail(request, backoff, listener, e)),
+                                client::index
+                            );
+                        }
+                    }, listener::onFailure),
+                    client::get
+                )
+            );
+    }
+
+    private void retryCapturingPreviousStateOrFail(
+        final PutUserRequest request,
+        final Iterator<TimeValue> backoff,
+        final ActionListener<PutUserResult> listener,
+        final Exception e
+    ) {
+        if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException && backoff.hasNext()) {
+            final TimeValue delay = backoff.next();
+            logger.debug("version conflict capturing before-image for user [{}]; retrying after [{}]", request.username(), delay);
+            client.threadPool()
+                .schedule(() -> putUserCapturingPreviousState(request, backoff, listener), delay, client.threadPool().generic());
+        } else {
+            logger.error(() -> "failed to put user [" + request.username() + "] with before-image capture", e);
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Result of a put_user upsert, carrying whether the user was created (vs updated) and, when before/after diff auditing is
+     * enabled, the reliable "before" image ({@code null} when the user did not previously exist or when diff capture is
+     * disabled) together with whether that previous user had a password set. It never carries a password hash.
+     */
+    public record PutUserResult(boolean created, @Nullable User previousUser, boolean previousHadPassword) {}
 
     /**
      * Asynchronous method that will update the enabled flag of a user. If the user is reserved and the document does not exist, a document

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.security.authz.store;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.DelegatingActionListener;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -27,15 +29,20 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
+import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.license.LicenseUtils;
@@ -60,6 +67,7 @@ import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.IndicesPrivile
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
 import org.elasticsearch.xpack.core.security.authz.store.RoleRetrievalResult;
 import org.elasticsearch.xpack.core.security.authz.support.DLSRoleQueryValidator;
+import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.authz.ReservedRoleNameChecker;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager.IndexState;
@@ -76,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -145,6 +154,22 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
 
     private final NamedXContentRegistry xContentRegistry;
 
+    /**
+     * Whether opt-in before/after ({@code security_config_change_diff}) auditing is enabled, via the dynamic
+     * {@link LoggingAuditTrail#EMIT_CONFIG_CHANGE_DIFF} setting. When {@code true}, {@link #putRoleWithPreviousState} swaps its
+     * cheap last-write-wins upsert for a GET + compare-and-swap read-modify-write so it can capture a reliable before-image;
+     * otherwise the extra read + retry cost is not paid.
+     */
+    private volatile boolean emitConfigChangeDiff;
+
+    /**
+     * Backoff used to retry the compare-and-swap upsert when a concurrent writer causes a version conflict.
+     */
+    private static final BackoffPolicy CONFIG_CHANGE_DIFF_RETRY_BACKOFF = BackoffPolicy.exponentialBackoff(
+        TimeValue.timeValueMillis(10),
+        5
+    );
+
     public NativeRolesStore(
         Settings settings,
         Client client,
@@ -162,6 +187,9 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
         this.reservedRoleNameChecker = reservedRoleNameChecker;
         this.xContentRegistry = xContentRegistry;
         this.enabled = settings.getAsBoolean(NATIVE_ROLES_ENABLED, true);
+        this.emitConfigChangeDiff = LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF.get(settings);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF, emit -> this.emitConfigChangeDiff = emit);
     }
 
     public boolean isEnabled() {
@@ -518,6 +546,28 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
     }
 
     public void putRole(final WriteRequest.RefreshPolicy refreshPolicy, final RoleDescriptor role, final ActionListener<Boolean> listener) {
+        putRoleWithPreviousState(refreshPolicy, role, listener.map(PutRoleResult::created));
+    }
+
+    /**
+     * Upsert a role, optionally capturing a reliable "before" image for before/after auditing.
+     * <p>
+     * When before/after auditing is disabled ({@link #emitConfigChangeDiff} is {@code false}) this behaves exactly like the
+     * historical last-write-wins upsert and
+     * reports a {@code null} previous state. When it is {@code true} the write becomes a GET + compare-and-swap read-modify-write:
+     * the current document is read first (yielding the authoritative before-image plus its {@code _seq_no}/{@code _primary_term}),
+     * then the replacement is indexed conditionally on that version. A concurrent modification produces a
+     * {@link VersionConflictEngineException}, which is retried (re-reading the latest before-image) with
+     * {@link #CONFIG_CHANGE_DIFF_RETRY_BACKOFF}. This closes the time-of-check-to-time-of-use race that makes a naive "read then
+     * unconditionally write" before-image unreliable, at the cost of an extra read round-trip and possible retries under
+     * contention. If retries are exhausted the version conflict is surfaced to the caller (the write does not silently fall back
+     * to last-write-wins), so the auditor never records a before-image that does not correspond to the persisted write.
+     */
+    public void putRoleWithPreviousState(
+        final WriteRequest.RefreshPolicy refreshPolicy,
+        final RoleDescriptor role,
+        final ActionListener<PutRoleResult> listener
+    ) {
         if (enabled == false) {
             listener.onFailure(new IllegalStateException("Native role management is disabled"));
             return;
@@ -526,6 +576,11 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
 
         if (validationException != null) {
             listener.onFailure(validationException);
+            return;
+        }
+
+        if (emitConfigChangeDiff) {
+            putRoleCapturingPreviousState(refreshPolicy, role, CONFIG_CHANGE_DIFF_RETRY_BACKOFF.iterator(), listener);
             return;
         }
 
@@ -544,7 +599,7 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
                             public void onResponse(DocWriteResponse indexResponse) {
                                 final boolean created = indexResponse.getResult() == DocWriteResponse.Result.CREATED;
                                 logger.trace("Created role: [{}]", indexRequest);
-                                clearRoleCache(role.getName(), listener, created);
+                                clearRoleCache(role.getName(), listener, new PutRoleResult(created, null));
                             }
 
                             @Override
@@ -560,6 +615,77 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
             listener.onFailure(exception);
         }
     }
+
+    /**
+     * One attempt of the GET + compare-and-swap upsert, re-invoked (with backoff) on version conflict.
+     */
+    private void putRoleCapturingPreviousState(
+        final WriteRequest.RefreshPolicy refreshPolicy,
+        final RoleDescriptor role,
+        final Iterator<TimeValue> backoff,
+        final ActionListener<PutRoleResult> listener
+    ) {
+        securityIndex.forCurrentProject()
+            .prepareIndexIfNeededThenExecute(
+                listener::onFailure,
+                () -> executeAsyncWithOrigin(
+                    client.threadPool().getThreadContext(),
+                    SECURITY_ORIGIN,
+                    client.prepareGet(SECURITY_MAIN_ALIAS, getIdForRole(role.getName())).request(),
+                    ActionListener.<GetResponse>wrap(getResponse -> {
+                        final IndexRequest indexRequest = createRoleIndexRequest(role);
+                        indexRequest.setRefreshPolicy(refreshPolicy);
+                        final RoleDescriptor previous;
+                        if (getResponse.isExists()) {
+                            // capture the authoritative before-image and pin the write to this exact version
+                            previous = transformRole(getResponse);
+                            indexRequest.setIfSeqNo(getResponse.getSeqNo()).setIfPrimaryTerm(getResponse.getPrimaryTerm());
+                        } else {
+                            // no document yet: require a create so a racing create is detected as a conflict rather than silently lost
+                            previous = null;
+                            indexRequest.opType(DocWriteRequest.OpType.CREATE);
+                        }
+                        executeAsyncWithOrigin(
+                            client.threadPool().getThreadContext(),
+                            SECURITY_ORIGIN,
+                            indexRequest,
+                            ActionListener.<DocWriteResponse>wrap(indexResponse -> {
+                                final boolean created = indexResponse.getResult() == DocWriteResponse.Result.CREATED;
+                                logger.trace("put role [{}] capturing previous state (created={})", role.getName(), created);
+                                clearRoleCache(role.getName(), listener, new PutRoleResult(created, previous));
+                            }, e -> {
+                                if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException && backoff.hasNext()) {
+                                    final TimeValue delay = backoff.next();
+                                    logger.debug(
+                                        "version conflict capturing before-image for role [{}]; retrying after [{}]",
+                                        role.getName(),
+                                        delay
+                                    );
+                                    client.threadPool()
+                                        .schedule(
+                                            () -> putRoleCapturingPreviousState(refreshPolicy, role, backoff, listener),
+                                            delay,
+                                            client.threadPool().generic()
+                                        );
+                                } else {
+                                    logger.error(() -> "failed to put role [" + role.getName() + "] with before-image capture", e);
+                                    listener.onFailure(e);
+                                }
+                            }),
+                            client::index
+                        );
+                    }, listener::onFailure),
+                    client::get
+                )
+            );
+    }
+
+    /**
+     * Result of an upsert, carrying whether the role was created (vs updated) and, when before/after
+     * diff auditing is enabled, the reliable "before" image ({@code null} when the role did not previously exist or when diff
+     * capture is disabled).
+     */
+    public record PutRoleResult(boolean created, @Nullable RoleDescriptor previous) {}
 
     public void putRoles(
         final WriteRequest.RefreshPolicy refreshPolicy,
@@ -579,6 +705,12 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
             listener.onFailure(new IllegalStateException("Native role management is disabled"));
             return;
         }
+
+        if (emitConfigChangeDiff) {
+            putRolesCapturingPreviousState(refreshPolicy, roles, validateRoleDescriptors, listener);
+            return;
+        }
+
         BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(refreshPolicy);
         Map<String, Exception> validationErrorByRoleName = new HashMap<>();
 
@@ -630,6 +762,93 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
                     client::bulk
                 )
             );
+    }
+
+    /**
+     * Bulk upsert that captures a reliable "before" image per role for before/after auditing. This is the bulk analog of
+     * {@link #putRoleWithPreviousState}: it fans out to the single-role GET + compare-and-swap upsert
+     * ({@link #putRoleCapturingPreviousState}) for each role and then assembles the same {@link BulkRolesResponse} shape, tagging
+     * the response with the captured before-images. Because reliably pinning each write to the exact version it replaced requires
+     * a conditional (optimistic-concurrency) write per document, this opt-in audit mode trades the single batched bulk request
+     * for N conditional writes; it is only reached when {@link #emitConfigChangeDiff} is set, so
+     * the normal bulk path keeps its cheap batched last-write-wins upsert. Individual role failures (including exhausted
+     * compare-and-swap retries) surface as failed items, exactly as in the batched path; a NOOP update is reported as UPDATED
+     * because the conditional write always rewrites the document.
+     */
+    private void putRolesCapturingPreviousState(
+        final WriteRequest.RefreshPolicy refreshPolicy,
+        final Collection<RoleDescriptor> roles,
+        final boolean validateRoleDescriptors,
+        final ActionListener<BulkRolesResponse> listener
+    ) {
+        final Map<String, Exception> validationErrorByRoleName = new HashMap<>();
+        final List<RoleDescriptor> rolesToWrite = new ArrayList<>(roles.size());
+        for (RoleDescriptor role : roles) {
+            Exception validationException;
+            try {
+                validationException = validateRoleDescriptors ? validateRoleDescriptor(role) : null;
+            } catch (Exception e) {
+                validationException = e;
+            }
+            if (validationException != null) {
+                validationErrorByRoleName.put(role.getName(), validationException);
+            } else {
+                rolesToWrite.add(role);
+            }
+        }
+
+        final List<String> roleNames = roles.stream().map(RoleDescriptor::getName).toList();
+
+        if (rolesToWrite.isEmpty()) {
+            bulkResponseWithOnlyValidationErrors(roleNames, validationErrorByRoleName, listener);
+            return;
+        }
+
+        // Collect the per-role outcomes (or write failures) as they complete; the RefCountingRunnable fires once all have.
+        final Map<String, PutRoleResult> resultByRoleName = new ConcurrentHashMap<>();
+        final Map<String, Exception> writeErrorByRoleName = new ConcurrentHashMap<>();
+        try (
+            RefCountingRunnable refs = new RefCountingRunnable(
+                () -> assembleBulkResponse(roleNames, validationErrorByRoleName, resultByRoleName, writeErrorByRoleName, listener)
+            )
+        ) {
+            for (RoleDescriptor role : rolesToWrite) {
+                final Releasable ref = refs.acquire();
+                putRoleWithPreviousState(refreshPolicy, role, ActionListener.runAfter(ActionListener.wrap(result -> {
+                    resultByRoleName.put(role.getName(), result);
+                }, e -> writeErrorByRoleName.put(role.getName(), e)), ref::close));
+            }
+        }
+    }
+
+    private static void assembleBulkResponse(
+        final List<String> roleNames,
+        final Map<String, Exception> validationErrorByRoleName,
+        final Map<String, PutRoleResult> resultByRoleName,
+        final Map<String, Exception> writeErrorByRoleName,
+        final ActionListener<BulkRolesResponse> listener
+    ) {
+        final BulkRolesResponse.Builder builder = new BulkRolesResponse.Builder();
+        final Map<String, RoleDescriptor> previousByRoleName = new HashMap<>();
+        for (String roleName : roleNames) {
+            if (validationErrorByRoleName.containsKey(roleName)) {
+                builder.addItem(BulkRolesResponse.Item.failure(roleName, validationErrorByRoleName.get(roleName)));
+            } else if (writeErrorByRoleName.containsKey(roleName)) {
+                builder.addItem(BulkRolesResponse.Item.failure(roleName, writeErrorByRoleName.get(roleName)));
+            } else {
+                final PutRoleResult result = resultByRoleName.get(roleName);
+                final DocWriteResponse.Result resultType = result.created()
+                    ? DocWriteResponse.Result.CREATED
+                    : DocWriteResponse.Result.UPDATED;
+                builder.addItem(BulkRolesResponse.Item.success(roleName, resultType));
+                if (result.previous() != null) {
+                    previousByRoleName.put(roleName, result.previous());
+                }
+            }
+        }
+        final BulkRolesResponse response = builder.build();
+        response.setPreviousRoleDescriptors(previousByRoleName);
+        listener.onResponse(response);
     }
 
     private IndexRequest createRoleIndexRequest(final RoleDescriptor role) throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleActionTests.java
@@ -103,10 +103,10 @@ public class TransportPutRoleActionTests extends ESTestCase {
             Object[] args = invocation.getArguments();
             assert args.length == 3;
             @SuppressWarnings("unchecked")
-            ActionListener<Boolean> listener = (ActionListener<Boolean>) args[2];
+            ActionListener<NativeRolesStore.PutRoleResult> listener = (ActionListener<NativeRolesStore.PutRoleResult>) args[2];
             listener.onFailure(e);
             return null;
-        }).when(rolesStore).putRole(eq(request.getRefreshPolicy()), any(RoleDescriptor.class), anyActionListener());
+        }).when(rolesStore).putRoleWithPreviousState(eq(request.getRefreshPolicy()), any(RoleDescriptor.class), anyActionListener());
 
         final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         final AtomicReference<PutRoleResponse> responseRef = new AtomicReference<>();
@@ -125,6 +125,10 @@ public class TransportPutRoleActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), is(notNullValue()));
         assertThat(throwableRef.get(), is(sameInstance(e)));
-        verify(rolesStore, times(1)).putRole(eq(request.getRefreshPolicy()), any(RoleDescriptor.class), anyActionListener());
+        verify(rolesStore, times(1)).putRoleWithPreviousState(
+            eq(request.getRefreshPolicy()),
+            any(RoleDescriptor.class),
+            anyActionListener()
+        );
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportPutUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportPutUserActionTests.java
@@ -205,10 +205,10 @@ public class TransportPutUserActionTests extends ESTestCase {
             Object[] args = invocation.getArguments();
             assert args.length == 2;
             @SuppressWarnings("unchecked")
-            ActionListener<Boolean> listener = (ActionListener<Boolean>) args[1];
-            listener.onResponse(created);
+            ActionListener<NativeUsersStore.PutUserResult> listener = (ActionListener<NativeUsersStore.PutUserResult>) args[1];
+            listener.onResponse(new NativeUsersStore.PutUserResult(created, null, false));
             return null;
-        }).when(usersStore).putUser(eq(request), anyActionListener());
+        }).when(usersStore).putUserWithPreviousState(eq(request), anyActionListener());
 
         final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         final AtomicReference<PutUserResponse> responseRef = new AtomicReference<>();
@@ -227,7 +227,7 @@ public class TransportPutUserActionTests extends ESTestCase {
         assertThat(throwableRef.get(), is(nullValue()));
         assertThat(responseRef.get(), is(notNullValue()));
         assertThat(responseRef.get().created(), is(created));
-        verify(usersStore, times(1)).putUser(eq(request), anyActionListener());
+        verify(usersStore, times(1)).putUserWithPreviousState(eq(request), anyActionListener());
     }
 
     public void testInvalidUserWithSpecialChars() {
@@ -340,10 +340,10 @@ public class TransportPutUserActionTests extends ESTestCase {
             Object[] args = invocation.getArguments();
             assert args.length == 2;
             @SuppressWarnings("unchecked")
-            ActionListener<Boolean> listener = (ActionListener<Boolean>) args[1];
+            ActionListener<NativeUsersStore.PutUserResult> listener = (ActionListener<NativeUsersStore.PutUserResult>) args[1];
             listener.onFailure(e);
             return null;
-        }).when(usersStore).putUser(eq(request), anyActionListener());
+        }).when(usersStore).putUserWithPreviousState(eq(request), anyActionListener());
 
         final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         final AtomicReference<PutUserResponse> responseRef = new AtomicReference<>();
@@ -362,6 +362,6 @@ public class TransportPutUserActionTests extends ESTestCase {
         assertThat(responseRef.get(), is(nullValue()));
         assertThat(throwableRef.get(), is(notNullValue()));
         assertThat(throwableRef.get(), sameInstance(e));
-        verify(usersStore, times(1)).putUser(eq(request), anyActionListener());
+        verify(usersStore, times(1)).putUserWithPreviousState(eq(request), anyActionListener());
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -11,6 +11,7 @@ import io.netty.channel.Channel;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.bulk.BulkItemRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -79,6 +80,7 @@ import org.elasticsearch.xpack.core.security.action.profile.UpdateProfileDataAct
 import org.elasticsearch.xpack.core.security.action.profile.UpdateProfileDataRequest;
 import org.elasticsearch.xpack.core.security.action.role.BulkDeleteRolesRequest;
 import org.elasticsearch.xpack.core.security.action.role.BulkPutRolesRequest;
+import org.elasticsearch.xpack.core.security.action.role.BulkRolesResponse;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleRequest;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
@@ -3198,6 +3200,64 @@ public class LoggingAuditTrailTests extends ESTestCase {
     protected static InetAddress forge(String hostname, String address) throws IOException {
         final byte bytes[] = InetAddress.getByName(address).getAddress();
         return InetAddress.getByAddress(hostname, bytes);
+    }
+
+    /**
+     * The opt-in {@code security_config_change_diff} audit level emits one post-execution diff record per successfully upserted
+     * role of a bulk put-roles request, each correlated to the request by request.id and carrying a top-level {@code created}
+     * flag plus (because the diff setting is enabled here) the reliable before/after states and changed fields. Failed items
+     * produce no record.
+     */
+    public void testSecurityConfigChangeDiffForBulkPutRoles() throws Exception {
+        // A dedicated audit trail that opts in to the diff level and the (expensive) before/after diff capture; the default
+        // `auditTrail` used by the other tests intentionally does not emit these records.
+        final Settings diffSettings = Settings.builder()
+            .put(settings)
+            .putList(LoggingAuditTrail.INCLUDE_EVENT_SETTINGS.getKey(), "security_config_change_diff")
+            .put(LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF.getKey(), true)
+            .build();
+        final Logger diffLogger = CapturingLogger.newCapturingLogger(Level.INFO, patternLayout);
+        final LoggingAuditTrail diffAuditTrail = new LoggingAuditTrail(diffSettings, clusterService, diffLogger, threadContext);
+
+        // "after" (requested) states: an update to an existing role, and a brand-new role.
+        final RoleDescriptor existingAfter = new RoleDescriptor("role_existing", new String[] { "monitor", "manage" }, null, null);
+        final RoleDescriptor newRole = new RoleDescriptor("role_new", new String[] { "all" }, null, null);
+        final BulkPutRolesRequest request = new BulkPutRolesRequest(List.of(existingAfter, newRole));
+
+        // Response as the store would produce it: the existing role updated (with a captured before-image) and the new role created.
+        final RoleDescriptor existingBefore = new RoleDescriptor("role_existing", new String[] { "monitor" }, null, null);
+        final BulkRolesResponse response = new BulkRolesResponse.Builder().addItem(
+            BulkRolesResponse.Item.success("role_existing", DocWriteResponse.Result.UPDATED)
+        ).addItem(BulkRolesResponse.Item.success("role_new", DocWriteResponse.Result.CREATED)).build();
+        response.setPreviousRoleDescriptors(Map.of("role_existing", existingBefore));
+
+        final String requestId = randomRequestId();
+        diffAuditTrail.coordinatingActionResponse(requestId, createAuthentication(), ActionTypes.BULK_PUT_ROLES.name(), request, response);
+
+        final List<String> output = CapturingLogger.output(diffLogger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+
+        // One diff record per successfully upserted role, in the order of the response items.
+        final String updatedRecord = output.get(0);
+        assertThat(updatedRecord, containsString("\"event.type\":\"security_config_change_diff\""));
+        assertThat(updatedRecord, containsString("\"event.action\":\"put_role\""));
+        assertThat(updatedRecord, containsString("\"request.id\":\"" + requestId + "\""));
+        assertThat(updatedRecord, containsString("\"created\":false"));
+        assertThat(updatedRecord, containsString("\"put\":{\"role\":{\"name\":\"role_existing\""));
+        assertThat(updatedRecord, containsString("\"before\":{"));
+        assertThat(updatedRecord, containsString("\"after\":{"));
+        assertThat(updatedRecord, containsString("\"changed_fields\":[\"cluster\"]"));
+
+        final String createdRecord = output.get(1);
+        assertThat(createdRecord, containsString("\"event.type\":\"security_config_change_diff\""));
+        assertThat(createdRecord, containsString("\"request.id\":\"" + requestId + "\""));
+        assertThat(createdRecord, containsString("\"created\":true"));
+        assertThat(createdRecord, containsString("\"put\":{\"role\":{\"name\":\"role_new\""));
+        // A newly-created role has no before-image, hence a null "before" and no "changed_fields".
+        assertThat(createdRecord, containsString("\"before\":null"));
+        assertThat(createdRecord, not(containsString("\"changed_fields\"")));
+
+        CapturingLogger.output(diffLogger.getName(), Level.INFO).clear();
     }
 
     private Authentication createAuthentication() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStoreTests.java
@@ -20,7 +20,9 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.FilterClient;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -40,6 +42,7 @@ import org.elasticsearch.xpack.core.security.user.KibanaUser;
 import org.elasticsearch.xpack.core.security.user.LogstashSystemUser;
 import org.elasticsearch.xpack.core.security.user.RemoteMonitoringUser;
 import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.elasticsearch.xpack.security.support.SecuritySystemIndices;
 import org.junit.Before;
@@ -50,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
@@ -333,7 +337,11 @@ public class NativeUsersStoreTests extends ESTestCase {
             action.run();
             return null;
         }).when(projectIndex).checkIndexVersionThenExecute(any(Consumer.class), any(Runnable.class));
-        return new NativeUsersStore(Settings.EMPTY, client, securityIndex);
+        final ClusterService clusterService = mock(ClusterService.class, Mockito.RETURNS_DEEP_STUBS);
+        when(clusterService.getClusterSettings()).thenReturn(
+            new ClusterSettings(Settings.EMPTY, Set.of(LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF))
+        );
+        return new NativeUsersStore(Settings.EMPTY, client, securityIndex, clusterService);
     }
 
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
@@ -12,10 +12,15 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetRequestBuilder;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
@@ -41,12 +46,15 @@ import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.MockLicenseState;
@@ -62,6 +70,8 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.security.action.role.BulkRolesResponse;
+import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheAction;
+import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheResponse;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.IndicesPrivileges;
@@ -71,6 +81,7 @@ import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableCluster
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.authz.store.RoleRetrievalResult;
+import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.authz.ReservedRoleNameChecker;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.elasticsearch.xpack.security.support.SecuritySystemIndices;
@@ -86,6 +97,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -110,6 +122,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -730,6 +745,126 @@ public class NativeRolesStoreTests extends ESTestCase {
         verify(client, times(1)).bulk(any(BulkRequest.class), any());
     }
 
+    /**
+     * Settings that enable the expensive before/after diff capture, so that {@link NativeRolesStore} takes the GET +
+     * compare-and-swap path that records reliable before-images.
+     */
+    private static Settings diffCaptureEnabledSettings() {
+        return Settings.builder().put("xpack.security.audit.logfile.events.emit_security_config_change_diff", true).build();
+    }
+
+    /**
+     * When before/after diff auditing is enabled, a bulk put-roles request fans out to per-role GET + compare-and-swap upserts
+     * (instead of a single batched bulk request) and tags the response with the reliable before-image of each role that already
+     * existed. Here one role pre-exists (captured as an "updated" item with a before-image) and one is new (a "created" item with
+     * no before-image).
+     */
+    @SuppressWarnings("unchecked")
+    public void testBulkPutRolesCapturesBeforeImagesWhenDiffAuditingEnabled() throws Exception {
+        final NativeRolesStore rolesStore = createRoleStoreForTest(randomProjectIdOrDefault(), diffCaptureEnabledSettings());
+
+        // The authoritative "before" image that the GET will return for the pre-existing role.
+        final RoleDescriptor existingBefore = new RoleDescriptor("existing-role", new String[] { "monitor" }, null, null);
+        final BytesReference existingSource = BytesReference.bytes(rolesStore.createRoleXContentBuilder(existingBefore));
+
+        // The "after" states requested by the bulk call: an update to the existing role, plus a brand-new role.
+        final RoleDescriptor existingAfter = new RoleDescriptor("existing-role", new String[] { "monitor", "manage" }, null, null);
+        final RoleDescriptor newRole = new RoleDescriptor("new-role", new String[] { "all" }, null, null);
+
+        // Fresh index request builder per call so the two conditional writes do not share underlying request state.
+        when(client.prepareIndex(SECURITY_MAIN_ALIAS)).thenAnswer(inv -> new IndexRequestBuilder(client));
+        when(client.prepareGet(eq(SECURITY_MAIN_ALIAS), anyString())).thenAnswer(
+            inv -> new GetRequestBuilder(client, SECURITY_MAIN_ALIAS).setId(inv.getArgument(1))
+        );
+
+        doAnswer(inv -> {
+            final GetRequest getRequest = inv.getArgument(0);
+            final ActionListener<GetResponse> getListener = (ActionListener<GetResponse>) inv.getArgument(1);
+            if (getRequest.id().equals("role-existing-role")) {
+                getListener.onResponse(
+                    new GetResponse(new GetResult(SECURITY_MAIN_ALIAS, getRequest.id(), 3, 1, 1, true, existingSource, Map.of(), Map.of()))
+                );
+            } else {
+                getListener.onResponse(
+                    new GetResponse(
+                        new GetResult(
+                            SECURITY_MAIN_ALIAS,
+                            getRequest.id(),
+                            SequenceNumbers.UNASSIGNED_SEQ_NO,
+                            SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+                            -1,
+                            false,
+                            null,
+                            Map.of(),
+                            Map.of()
+                        )
+                    )
+                );
+            }
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+
+        doAnswer(inv -> {
+            final IndexRequest indexRequest = inv.getArgument(0);
+            final ActionListener<IndexResponse> indexListener = (ActionListener<IndexResponse>) inv.getArgument(1);
+            final boolean created = indexRequest.opType() == DocWriteRequest.OpType.CREATE;
+            indexListener.onResponse(
+                new IndexResponse(new ShardId(new Index(SECURITY_MAIN_ALIAS, "_na_"), 0), indexRequest.id(), 4, 1, 2, created)
+            );
+            return null;
+        }).when(client).index(any(IndexRequest.class), any());
+
+        doAnswer(inv -> {
+            final ActionListener<ClearRolesCacheResponse> cacheListener = (ActionListener<ClearRolesCacheResponse>) inv.getArgument(2);
+            cacheListener.onResponse(mock(ClearRolesCacheResponse.class));
+            return null;
+        }).when(client).execute(eq(ClearRolesCacheAction.INSTANCE), any(), any());
+
+        final PlainActionFuture<BulkRolesResponse> future = new PlainActionFuture<>();
+        rolesStore.putRoles(WriteRequest.RefreshPolicy.IMMEDIATE, List.of(existingAfter, newRole), future);
+        final BulkRolesResponse response = future.actionGet();
+
+        // The batched bulk API is never used on the diff-capture path; each role is written with its own conditional request.
+        verify(client, times(0)).bulk(any(BulkRequest.class), any());
+        verify(client, times(2)).get(any(GetRequest.class), any());
+        verify(client, times(2)).index(any(IndexRequest.class), any());
+
+        final Map<String, BulkRolesResponse.Item> itemsByName = new HashMap<>();
+        for (BulkRolesResponse.Item item : response.getItems()) {
+            itemsByName.put(item.getRoleName(), item);
+        }
+        assertThat(itemsByName.keySet(), equalTo(Set.of("existing-role", "new-role")));
+        assertThat(itemsByName.get("existing-role").isFailed(), is(false));
+        assertThat(itemsByName.get("existing-role").getResultType(), equalTo("updated"));
+        assertThat(itemsByName.get("new-role").isFailed(), is(false));
+        assertThat(itemsByName.get("new-role").getResultType(), equalTo("created"));
+
+        // The pre-existing role carries a reliable before-image; the newly created role has none.
+        final RoleDescriptor capturedBefore = response.getPreviousRoleDescriptor("existing-role");
+        assertThat(capturedBefore, is(notNullValue()));
+        assertThat(capturedBefore.getName(), equalTo("existing-role"));
+        assertThat(capturedBefore.getClusterPrivileges(), arrayContaining("monitor"));
+        assertThat(response.getPreviousRoleDescriptor("new-role"), is(nullValue()));
+    }
+
+    /**
+     * With diff auditing disabled (the default), a bulk put-roles request keeps using the cheap batched bulk request and never
+     * issues a GET, so no before-image is captured.
+     */
+    public void testBulkPutRolesUsesBatchedPathWhenDiffAuditingDisabled() {
+        final NativeRolesStore rolesStore = createRoleStoreForTest(randomProjectIdOrDefault());
+
+        final RoleDescriptor role = new RoleDescriptor("some-role", new String[] { "monitor" }, null, null);
+
+        final AtomicReference<BulkRolesResponse> response = new AtomicReference<>();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        rolesStore.putRoles(WriteRequest.RefreshPolicy.IMMEDIATE, List.of(role), ActionListener.wrap(response::set, exception::set));
+
+        assertNull(exception.get());
+        verify(client, times(1)).bulk(any(BulkRequest.class), any());
+        verify(client, times(0)).get(any(GetRequest.class), any());
+    }
+
     public void testBulkDeleteRoles() {
         final NativeRolesStore rolesStore = createRoleStoreForTest(randomProjectIdOrDefault());
 
@@ -823,6 +958,9 @@ public class NativeRolesStoreTests extends ESTestCase {
         final ClusterService clusterService = mock(ClusterService.class, Mockito.RETURNS_DEEP_STUBS);
         when(clusterService.state().getMinTransportVersion()).thenReturn(transportVersion);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(
+            new ClusterSettings(Settings.EMPTY, Set.of(LoggingAuditTrail.EMIT_CONFIG_CHANGE_DIFF))
+        );
         return clusterService;
     }
 


### PR DESCRIPTION
Native security config change audit records only capture the pre-execution request, so operators cannot tell whether an upsert created or modified an object, nor which fields actually changed.

Add an opt-in, post-execution "security_config_change_diff" record for `put_user`, `put_role`, `put_role_mapping` and `bulk_put_roles`. It is gated by a new `SECURITY_CONFIG_CHANGE_DIFF` audit level (off by default) and carries a top-level "created" flag that distinguishes creation from modification, correlated to the existing record by request.id.

When the `emit_security_config_change_diff` setting is also enabled, the record additionally includes the reliable before/after states and the list of changed fields. Capturing a trustworthy "before" image requires the native stores to replace their last-write-wins upserts with a GET + compare-and-swap read-modify-write (retried on version conflict), so this extra cost is paid only when explicitly enabled.

Default audit output is unchanged: with the level off, no new records are emitted and the stores keep their batched last-write-wins writes.
