### PR TITLE
Unmute PackageUpgradeTests after fix in #153101

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -514,9 +514,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testSourceRelocationAndTargetRestart
   issue: https://github.com/elastic/elasticsearch/issues/153173
-- class: org.elasticsearch.packaging.test.PackageUpgradeTests
-  method: test12SetupBwcVersion
-  issue: https://github.com/elastic/elasticsearch/issues/152819
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecUnmappedLoadIT
   method: test {csv-spec:unmapped-load.loadMultiIndexPartialMultiFieldInSubquery}
   issue: https://github.com/elastic/elasticsearch/issues/153176
@@ -541,9 +538,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTermVectorsApiRealtimeGet
   issue: https://github.com/elastic/elasticsearch/issues/153282
-- class: org.elasticsearch.packaging.test.PackageUpgradeTests
-  method: test21CheckUpgradedVersion
-  issue: https://github.com/elastic/elasticsearch/issues/153329
 - class: org.elasticsearch.xpack.spatial.search.aggregations.metrics.InternalCartesianCentroidTests
   method: testReduceRandom
   issue: https://github.com/elastic/elasticsearch/issues/153353


### PR DESCRIPTION
## Summary

- Removes the two leftover mute entries for `PackageUpgradeTests` that were not cleaned up by the original fix PR.

## Background

The root cause was a race condition in `test12SetupBwcVersion`: the test created the `library` and `library2` indices and immediately issued indexed writes without waiting for primary shard activation. On slower CI machines (Ubuntu 24.04, Rocky Linux 8) the 1-minute server-side write timeout was exceeded, producing a 503 `unavailable_shards_exception`.

PR #153101 (commit `f4e37c583530`) already fixed the code by adding `?wait_for_active_shards=all` to both index-creation `PUT` requests and following each with a `ServerUtils.waitForElasticsearch("green", <index>, ...)` call. That fix also removed two mute entries — but it missed the independently-added mute for issue #152819 (added the same day by a separate automated CI run).

With `test12SetupBwcVersion` still muted, the `library` index is never created, causing `test21CheckUpgradedVersion` to fail with a 404 `index_not_found_exception` — which is tracked as the cascading issue #153329.

## Changes

- `muted-tests.yml`: removes the mute for `test12SetupBwcVersion` (issue #152819)
- `muted-tests.yml`: removes the mute for `test21CheckUpgradedVersion` (issue #153329), which was a cascading failure caused solely by test12 being skipped

## Test plan

- [ ] Verify `elasticsearch-periodic-packaging` runs green for `PackageUpgradeTests` on both Ubuntu 24.04 and Rocky Linux 8 agent pools after this merges