### PR TITLE
Reverting log message change

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -1280,10 +1280,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         try {
             final Optional<IndexMetadata> indexMetadata = state.metadata().findIndex(shardRouting.index());
             if (indexMetadata.isEmpty()) {
-                logger.debug(() -> format("Not marking shard %s failed (reason: [%s]): index no longer exists", shardId, message));
+                logger.debug(() -> format("%s not marking shard failed (reason: [%s]): index no longer exists", shardId, message));
                 return;
             }
-            logger.warn(() -> format("Marking and sending shard failed %s due to [%s]", shardId, message), failure);
+            logger.warn(() -> format("%s marking and sending shard failed due to [%s]", shardId, message), failure);
             final long primaryTerm = indexMetadata.get().primaryTerm(shardRouting.id());
             failedShardsCache.put(shardRouting.shardId(), new FailedShardCacheEntry(shardRouting, primaryTerm));
             shardStateAction.localShardFailed(shardRouting, message, failure, ActionListener.noop(), state);


### PR DESCRIPTION
Log message: "marking and sending shard failed due to [failed recovery]" is used both in IndexShardRelocationIT and in dashboards to identify failed recoveries (or the lack of failed recoveries).

Reverting the log message seemed easier than changing the dashboards.

Updating the "not marking shard failed" to follow the same pattern of placing the shard id first in message.

Placing the shard id first in message also seem to be standard practise. See for example

```
[2026-07-15T14:18:50,556][DEBUG][o.e.i.s.IndexShard       ][node_t0][generic][T#3] [index-brtebigvcko][0] state: [CREATED]->[RECOVERING], reason [from store]
[2026-07-15T14:18:50,558][DEBUG][o.e.i.s.IndexShard       ][node_t0][generic][T#2] [index-brtebigvcko][0] starting recovery from store ...
[2026-07-15T14:18:50,619][DEBUG][o.e.i.s.IndexShard       ][node_t0][generic][T#2] [index-brtebigvcko][0] state: [RECOVERING]->[POST_RECOVERY], reason [post recovery from shard_store]
...
[2026-07-15T14:18:50,629][INFO ][o.e.t.s.M.Listener       ][node_t0][generic][T#2] [index-brtebigvcko][0] start check index
[2026-07-15T14:18:50,635][INFO ][o.e.t.s.M.Listener       ][node_t0][generic][T#2] [index-brtebigvcko][0] end check index
```