### PR TITLE
[9.5] Unmute GenerateInitialTransportVersionFuncTest (#154063)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -310,9 +310,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexTaskFailsWhenDataNodeIsShuttingDownAndTaskDoesNotFinishInTime
   issue: https://github.com/elastic/elasticsearch/issues/150295
-- class: org.elasticsearch.gradle.internal.transport.GenerateInitialTransportVersionFuncTest
-  method: cannot create upper bound file for patch
-  issue: https://github.com/elastic/elasticsearch/issues/150296
 - class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
   method: testTranslogStressRecoveryTest
   issue: https://github.com/elastic/elasticsearch/issues/150297


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Unmute GenerateInitialTransportVersionFuncTest (#154063)