### PR TITLE
Backport: ES|QL: Fix runtime match for potentially unmapped fields (#153800)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -217,6 +217,30 @@ sample_data_str | 2023-10-23T12:27:28.948Z  |  172.21.2.113     |  2764889      
 sample_data_str | 2023-10-23T12:15:03.360Z  |  172.21.2.162     |  3450233              |  Connected to 10.1.0.3
 ;
 
+multiIndexKeywordTextToTextAndMatch
+required_capability: fn_to_text
+required_capability: union_types
+required_capability: index_metadata_field
+required_capability: fn_match_unmapped_fields_pushdown_fix
+required_capability: match_function
+
+FROM employees, employees_gender_text METADATA _index
+| EVAL gender_text = TO_TEXT(gender)
+| WHERE gender_text:"a b c d e f"
+| KEEP emp_no, _index, gender_text
+| SORT emp_no, _index
+| LIMIT 6
+;
+
+emp_no:integer | _index:keyword        | gender_text:text
+10002          | employees             | F
+10002          | employees_gender_text | F
+10006          | employees             | F
+10006          | employees_gender_text | F
+10007          | employees             | F
+10007          | employees_gender_text | F
+;
+
 multiIndexWhereIpString
 required_capability: union_types
 required_capability: index_metadata_field
@@ -2577,3 +2601,5 @@ id:integer  | name:keyword
 2           | bbbbb
 3           | ccccc
 ;
+
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-type-conflicts.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-type-conflicts.csv-spec
@@ -95,6 +95,50 @@ null                         | null         | null                | Connected to
 null                         | null         | null                | Connected to 10.1.0.3! | no_mapping_sample_data
 ;
 
+typeConflictWithUnmappedToTextAndMatch
+required_capability: optional_fields_v5
+required_capability: optional_fields_unmapped_load_auto_cast_two_legged_punks
+required_capability: fn_to_text
+required_capability: fn_match_unmapped_fields_pushdown_fix
+required_capability: match_function
+
+SET unmapped_fields="load"\;
+FROM sample_data, no_mapping_sample_data METADATA _index
+| EVAL message_text = TO_TEXT(message)
+| WHERE message_text:"error connection"
+| KEEP _index, message, message_text
+;
+ignoreOrder:true
+
+_index:keyword         | message:keyword   | message_text:text
+no_mapping_sample_data | Connection error? | Connection error?
+no_mapping_sample_data | Connection error? | Connection error?
+no_mapping_sample_data | Connection error? | Connection error?
+sample_data            | Connection error  | Connection error
+sample_data            | Connection error  | Connection error
+sample_data            | Connection error  | Connection error
+;
+
+typeConflictWithUnmappedKeywordAndMatch
+required_capability: optional_fields_v5
+required_capability: optional_fields_unmapped_load_auto_cast_two_legged_punks
+required_capability: fn_to_text
+required_capability: fn_match_unmapped_fields_pushdown_fix
+required_capability: match_function
+
+SET unmapped_fields="load"\;
+FROM sample_data, no_mapping_sample_data METADATA _index
+| WHERE message:"Connection error"
+| KEEP _index, message
+;
+ignoreOrder:true
+
+_index:keyword | message:keyword
+sample_data    | Connection error
+sample_data    | Connection error
+sample_data    | Connection error
+;
+
 typeConflictWithUnmappedJustKeepWildcard
 required_capability: optional_fields_v5
 required_capability: optional_fields_unmapped_load_auto_cast_two_legged_punks

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
@@ -30,7 +30,7 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void setupIndex() {
-        createAndPopulateIndex(this::ensureYellow);
+        createAndPopulateIndices(this::ensureYellow);
     }
 
     public void testSimpleWhereMatch() {
@@ -483,6 +483,73 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    public void testUnmappedWithIndexedText() {
+        var query = """
+            SET unmapped_fields = "LOAD";
+            FROM test, test_unmapped METADATA _index
+            | EVAL content = to_text(content)
+            | WHERE match(content, "quick")
+            | KEEP id, _index
+            | SORT id, _index
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_index"));
+            assertColumnTypes(resp.columns(), List.of("integer", "keyword"));
+            assertValues(resp.values(), List.of(List.of(6, "test"), List.of(6, "test_unmapped")));
+        }
+    }
+
+    public void testUnmappedWithIndexedKeyword() {
+        var query = """
+            SET unmapped_fields = "LOAD";
+            FROM test_unmapped, test_keyword METADATA _index
+            | EVAL content = to_text(content)
+            | WHERE match(content, "quick")
+            | KEEP id, _index
+            | SORT id, _index
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_index"));
+            assertColumnTypes(resp.columns(), List.of("integer", "keyword"));
+            assertValues(resp.values(), List.of(List.of(6, "test_keyword"), List.of(6, "test_unmapped")));
+        }
+    }
+
+    public void testUnmappedWithIndexedTextAndKeyword() {
+        var query = """
+            SET unmapped_fields = "LOAD";
+            FROM test, test_keyword, test_unmapped METADATA _index
+            | EVAL content = to_text(content)
+            | WHERE match(content, "quick")
+            | KEEP id, _index
+            | SORT id, _index
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_index"));
+            assertColumnTypes(resp.columns(), List.of("integer", "keyword"));
+            assertValues(resp.values(), List.of(List.of(6, "test"), List.of(6, "test_keyword"), List.of(6, "test_unmapped")));
+        }
+    }
+
+    public void testWithKeywordAndTextConflictDataType() {
+        var query = """
+            FROM test, test_keyword METADATA _index
+            | EVAL content = to_text(content)
+            | WHERE match(content, "quick")
+            | KEEP id, _index
+            | SORT id, _index
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_index"));
+            assertColumnTypes(resp.columns(), List.of("integer", "keyword"));
+            assertValues(resp.values(), List.of(List.of(6, "test"), List.of(6, "test_keyword")));
+        }
+    }
+
     public void testMatchRuntimeEvalWithOptionsThrowsError() {
         var query = """
             FROM test
@@ -615,13 +682,33 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
         );
     }
 
-    static void createAndPopulateIndex(Consumer<String[]> ensureYellow) {
-        var indexName = "test";
+    static void createAndPopulateIndices(Consumer<String[]> ensureYellow) {
+        createTestIndex("test", """
+            {
+              "properties":{ "id": { "type": "integer" }, "content": { "type": "text" } }
+            }
+            """);
+        createTestIndex("test_keyword", """
+            {
+              "properties":{ "id": { "type": "integer" }, "content": { "type": "keyword" } }
+            }
+            """);
+        createTestIndex("test_unmapped", "{ \"dynamic\": false }");
+
+        var lookupIndexName = "test_lookup";
+        var client = client().admin().indices();
+        createAndPopulateLookupIndex(client, lookupIndexName);
+
+        ensureYellow.accept(new String[] { "test", "test_lookup", "test_keyword", "test_unmapped" });
+    }
+
+    static void createTestIndex(String indexName, String mapping) {
         var client = client().admin().indices();
         var createRequest = client.prepareCreate(indexName)
             .setSettings(Settings.builder().put("index.number_of_shards", 1))
-            .setMapping("id", "type=integer", "content", "type=text");
+            .setMapping(mapping);
         assertAcked(createRequest);
+
         client().prepareBulk()
             .add(new IndexRequest(indexName).id("1").source("id", 1, "content", "This is a brown fox"))
             .add(new IndexRequest(indexName).id("2").source("id", 2, "content", "This is a brown dog"))
@@ -631,11 +718,6 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest(indexName).id("6").source("id", 6, "content", "The quick brown fox jumps over the lazy dog"))
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
-
-        var lookupIndexName = "test_lookup";
-        createAndPopulateLookupIndex(client, lookupIndexName);
-
-        ensureYellow.accept(new String[] { indexName, lookupIndexName });
     }
 
     static void createAndPopulateLookupIndex(IndicesAdminClient client, String lookupIndexName) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchOperatorIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchOperatorIT.java
@@ -26,7 +26,7 @@ public class MatchOperatorIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void setupIndex() {
-        MatchFunctionIT.createAndPopulateIndex(this::ensureYellow);
+        MatchFunctionIT.createAndPopulateIndices(this::ensureYellow);
     }
 
     public void testSimpleWhereMatch() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
-import static org.elasticsearch.xpack.esql.plugin.MatchFunctionIT.createAndPopulateIndex;
+import static org.elasticsearch.xpack.esql.plugin.MatchFunctionIT.createAndPopulateIndices;
 import static org.hamcrest.CoreMatchers.containsString;
 
 //@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE,org.elasticsearch.compute:TRACE", reason = "debug")
@@ -25,7 +25,7 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void setupIndex() {
-        createAndPopulateIndex(this::ensureYellow);
+        createAndPopulateIndices(this::ensureYellow);
     }
 
     public void testSimpleWhereMatchPhrase() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.CompactMultiTypeEsField;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.UnionTypeEsField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
@@ -80,6 +81,7 @@ import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNotNull;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.expression.Foldables.TypeResolutionValidator.forPostOptimizationValidation;
 import static org.elasticsearch.xpack.esql.expression.Foldables.TypeResolutionValidator.forPreOptimizationValidation;
 import static org.elasticsearch.xpack.esql.expression.Foldables.resolveTypeQuery;
@@ -624,7 +626,22 @@ public abstract class FullTextFunction extends Function
         if (fieldExpression instanceof AbstractConvertFunction convertFunction) {
             fieldExpression = convertFunction.field();
         }
-        return fieldExpression instanceof FieldAttribute fieldAttribute ? fieldAttribute : null;
+
+        if (fieldExpression instanceof FieldAttribute == false) {
+            return null;
+        }
+
+        FieldAttribute fieldAttribute = (FieldAttribute) fieldExpression;
+
+        // we do an explicit to_text conversion and not all underlying fields already have the TEXT type
+        // which means we cannot effectively push down a single lexical match query to the shards
+        if (field.dataType() == TEXT
+            && fieldAttribute.field() instanceof CompactMultiTypeEsField compactMultiTypeEsField
+            && compactMultiTypeEsField.getTypeToConversionExpressions().keySet().stream().anyMatch(dataType -> dataType != TEXT)) {
+            return null;
+        }
+
+        return fieldAttribute;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.esql.common.Failure;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
@@ -106,7 +107,7 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Match", Match::readFrom);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Match.class)
         .ternaryConfig(Match::new)
-        .capabilities("runtime_filter")
+        .capabilities("runtime_filter", "unmapped_fields_pushdown_fix")
         .name("match");
     public static final Set<DataType> FIELD_DATA_TYPES = Set.of(
         NULL,
@@ -436,11 +437,17 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
             // Runtime search is disabled.
             return false;
         }
-        if (fieldAsFieldAttribute() == null) {
+        FieldAttribute fieldAttribute = fieldAsFieldAttribute();
+        if (fieldAttribute == null) {
             // This *isn't* a field in the index OR a pushed block loader
             return true;
         }
-        if (fieldAsFieldAttribute().field() instanceof FunctionEsField functionEsField) {
+
+        if (fieldAttribute.isPotentiallyUnmapped()) {
+            return true;
+        }
+
+        if (fieldAttribute.field() instanceof FunctionEsField functionEsField) {
             // This is a pushed block loader.
             // We can only support FIELD_EXTRACT(flattened, "constant"), here named EXTRACT_FLATTENED_SUBFIELD
             return functionEsField.functionConfig().function() == BlockLoaderFunctionConfig.Function.EXTRACT_FLATTENED_SUBFIELD;
@@ -450,9 +457,16 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
 
     @Override
     public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
-        if (fieldAsFieldAttribute() == null) {
+        FieldAttribute fieldAttribute = fieldAsFieldAttribute();
+
+        if (fieldAttribute == null) {
             return Translatable.NO;
         }
+
+        if (fieldAttribute.isPotentiallyUnmapped()) {
+            return Translatable.NO;
+        }
+
         return super.translatable(pushdownPredicates);
     }
 


### PR DESCRIPTION
manual backport of #153800