### PR TITLE
Pins rolling upgrade multi cluster jobs to retry full suite

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
@@ -70,7 +70,8 @@ public abstract class InternalTestRerunPlugin implements Plugin<Project> {
             return;
         }
 
-        if (test.getPath().endsWith("remote-cluster") || test.getPath().endsWith("mixed-cluster")
+        if (test.getPath().endsWith("remote-cluster")
+            || test.getPath().endsWith("mixed-cluster")
             || test.getPath().contains("rolling-upgrade-multi-cluster")) {
             test.getLogger().lifecycle("Smart retry: running all tests for {} (multi-cluster task, never skipped)", test.getPath());
             return;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
@@ -70,7 +70,8 @@ public abstract class InternalTestRerunPlugin implements Plugin<Project> {
             return;
         }
 
-        if (test.getPath().endsWith("remote-cluster") || test.getPath().endsWith("mixed-cluster")) {
+        if (test.getPath().endsWith("remote-cluster") || test.getPath().endsWith("mixed-cluster")
+            || test.getPath().contains("rolling-upgrade-multi-cluster")) {
             test.getLogger().lifecycle("Smart retry: running all tests for {} (multi-cluster task, never skipped)", test.getPath());
             return;
         }


### PR DESCRIPTION
The smart retry mechanism that runs on Buildkite retries skips test tasks that passed in a previous attempt. For most tests this is fine, but the `rolling-upgrade-multi-cluster` test suite is stateful — the `leader#clusterTest` task sets up indices on a leader cluster that the `follower#clusterTest` task then tries to replicate via CCR. Since each Buildkite retry runs on a fresh agent with ephemeral clusters, skipping the leader task means the follower finds no indices to follow and fails every time, creating an unrecoverable retry loop.

I have a pr for 9.3 that keeps failing the rolling upgrade tests. When trying to replay the failures, the CI kept failing: https://buildkite.com/elastic/elasticsearch-pull-request/builds/163794/canvas?jid=019f69c3-cb0f-419d-9530-bf453bacfea4&tab=output

This PR forces that buildkite job to replay entirely. It's better to force it to do that than to have to re-execute the full CI.
