### PR TITLE
ES|QL: fix MATCH fuzziness ClassCastException on version fields

### DIFF
--- a/docs/changelog/154094.yaml
+++ b/docs/changelog/154094.yaml
@@ -1,4 +1,4 @@
-area: "ES|QL, Search"
+area: "ES|QL"
 issues:
  - 154068
 pr: 154094

--- a/docs/changelog/154094.yaml
+++ b/docs/changelog/154094.yaml
@@ -1,0 +1,6 @@
+area: "ES|QL, Search"
+issues:
+ - 154068
+pr: 154094
+summary: Fix MATCH fuzziness `ClassCastException` on version fields
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -465,11 +465,25 @@ name:keyword | version:version
 bbbbb        | 2.1
 ;
 
+testMatchVersionFieldWithFuzziness
+required_capability: match_function
+required_capability: match_additional_types
+required_capability: fix_match_fuzziness_on_version_field
+
+from apps
+| where match(version, "2.1", {"fuzziness": 1})
+| keep name, version
+| sort name;
+
+name:keyword | version:version
+bbbbb        | 2.1
+;
+
 testMatchIntegerAsDouble
 required_capability: match_function
 required_capability: match_additional_types
 
-from employees 
+from employees
 | where match(emp_no, 10004.0)
 | keep emp_no, first_name;
 ignoreOrder:true

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3392,6 +3392,12 @@ public class EsqlCapabilities {
          */
         SPATIAL_BBOX_VALIDATION_FIX,
 
+        /**
+         * Fix for MATCH with fuzziness on version fields throwing a ClassCastException when lenient is false.
+         * See <a href="https://github.com/elastic/elasticsearch/issues/154068">#154068</a>
+         */
+        FIX_MATCH_FUZZINESS_ON_VERSION_FIELD,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -257,7 +257,7 @@ public class VersionStringFieldMapper extends FieldMapper {
                 ? rewriteMethod
                 : FuzzyQuery.defaultRewriteMethod(maxExpansions);
             FuzzyQuery query = new FuzzyQuery(
-                new Term(name(), (BytesRef) value),
+                new Term(name(), BytesRefs.toBytesRef(value)),
                 fuzziness.asDistance(BytesRefs.toString(value)),
                 prefixLength,
                 maxExpansions,

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldTypeTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldTypeTests.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.versionfield;
 
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
@@ -15,6 +18,23 @@ import java.io.IOException;
 import java.util.List;
 
 public class VersionStringFieldTypeTests extends FieldTypeTestCase {
+
+    /**
+     * Regression test for https://github.com/elastic/elasticsearch/issues/154068:
+     * fuzzyQuery must accept both String and BytesRef values without ClassCastException,
+     * and both must produce equivalent queries.
+     */
+    public void testFuzzyQueryWithStringAndBytesRef() {
+        MappedFieldType ft = new VersionStringFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false)).fieldType();
+        // String value — the path that used to throw ClassCastException (from MatchQueryParser)
+        FuzzyQuery fromString = (FuzzyQuery) ft.fuzzyQuery("2.1", Fuzziness.ONE, 0, 50, true, MOCK_CONTEXT, null);
+        // BytesRef value — the pre-existing path
+        FuzzyQuery fromBytesRef = (FuzzyQuery) ft.fuzzyQuery(new BytesRef("2.1"), Fuzziness.ONE, 0, 50, true, MOCK_CONTEXT, null);
+
+        assertEquals("field", fromString.getTerm().field());
+        assertEquals(fromString.getTerm(), fromBytesRef.getTerm());
+        assertEquals(fromString.getMaxEdits(), fromBytesRef.getMaxEdits());
+    }
 
     public void testFetchSourceValue() throws IOException {
         MappedFieldType mapper = new VersionStringFieldMapper.Builder("field").build(MapperBuilderContext.root(false, false)).fieldType();


### PR DESCRIPTION
Fix a `ClassCastException` thrown when using MATCH with fuzziness on a version field. `VersionStringFieldMapper.fuzzyQuery()` was casting the query value directly to `BytesRef`, but `MatchQueryParser` passes it as a String. Fixed by using `BytesRefs.toBytesRef()` which handles both types.

Fixes: https://github.com/elastic/elasticsearch/issues/154068