### PR TITLE
[CI] Add retry logic for Docker tmpfs remounting flake

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -202,10 +202,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:UNMAPPED_FIELDS_LOAD}
   issue: https://github.com/elastic/elasticsearch/issues/148619
-# Unmuted in PR #XXX with retry logic for Docker tmpfs remounting error (issue #149040)
-# - class: org.elasticsearch.packaging.test.BootstrapCheckTests
-#   method: test20RunWithBootstrapChecks
-#   issue: https://github.com/elastic/elasticsearch/issues/149040
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
   method: testRightClosedBucketIsNotSubstituted
   issue: https://github.com/elastic/elasticsearch/issues/149133

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -202,9 +202,10 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:UNMAPPED_FIELDS_LOAD}
   issue: https://github.com/elastic/elasticsearch/issues/148619
-- class: org.elasticsearch.packaging.test.BootstrapCheckTests
-  method: test20RunWithBootstrapChecks
-  issue: https://github.com/elastic/elasticsearch/issues/149040
+# Unmuted in PR #XXX with retry logic for Docker tmpfs remounting error (issue #149040)
+# - class: org.elasticsearch.packaging.test.BootstrapCheckTests
+#   method: test20RunWithBootstrapChecks
+#   issue: https://github.com/elastic/elasticsearch/issues/149040
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
   method: testRightClosedBucketIsNotSubstituted
   issue: https://github.com/elastic/elasticsearch/issues/149133

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/BootstrapCheckTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/BootstrapCheckTests.java
@@ -26,6 +26,13 @@ public class BootstrapCheckTests extends PackagingTestCase {
     }
 
     public void test20RunWithBootstrapChecks() throws Exception {
+        if (installation == null) {
+            fail(
+                "Installation failed to set up. This may indicate a Docker startup failure. "
+                    + "Check Docker daemon logs and the retry logic in Docker.executeDockerRun()."
+            );
+        }
+
         configureBootstrapChecksAndRun(
             Map.of(
                 "xpack.security.enabled",

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -176,9 +176,47 @@ public class Docker {
         removeContainer();
 
         final String command = builder.distribution(distribution).build();
-
         logger.info("Running command: " + command);
-        containerId = sh.run(command).stdout().trim();
+
+        // Retry on Docker daemon tmpfs remounting error (exit code 125)
+        // See: https://github.com/elastic/elasticsearch/issues/149040
+        final int maxAttempts = 3;
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                final Shell.Result result = sh.run(command);
+                containerId = result.stdout().trim();
+                return;
+            } catch (Shell.ShellException e) {
+                final String stderr = e.getMessage();
+                final boolean isTmpfsRemountError = stderr != null
+                    && stderr.contains("unable to remount dir as readonly")
+                    && stderr.contains("device or resource busy");
+
+                if (isTmpfsRemountError && attempt < maxAttempts - 1) {
+                    final long delayMs = 500L * (1L << attempt); // 500ms, 1s, 2s
+                    logger.warn(
+                        "Docker tmpfs remounting failed (attempt "
+                            + (attempt + 1)
+                            + "/"
+                            + maxAttempts
+                            + "), retrying in "
+                            + delayMs
+                            + "ms. Error: "
+                            + stderr
+                    );
+                    try {
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw e;
+                    }
+                } else {
+                    // Either not a tmpfs error, or final attempt — rethrow
+                    throw e;
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

`BootstrapCheckTests.test20RunWithBootstrapChecks` intermittently fails (1.3% of runs) with:
```
docker: Error response from daemon: unable to remount dir as readonly: 
  mount tmpfs:/var/lib/docker/containers/<id>/mounts/secrets, 
  flags: 0x21, data: uid=0,gid=0: device or resource busy
```

**Exit code 125** = Docker daemon error (not Elasticsearch code bug)

## Root Cause

Docker daemon on GCP CI agents (kernel `6.17.0-1013-gcp`) fails to remount container secrets tmpfs as read-only. This is a **kernel/Docker version incompatibility**, not an Elasticsearch code defect.

**Why it happens:**
1. Docker daemon creates tmpfs mount for container secrets on every `docker run`
2. Docker attempts to remount this tmpfs as read-only for security
3. On kernel 6.17.x with certain Docker versions, the kernel refuses: `EBUSY` ("device or resource busy")
4. This is a known race condition in Linux mount semantics

**Why it's intermittent:**
- The tmpfs remount succeeds ~98.7% of the time
- Failure only occurs under specific conditions (timing, load, mount table state)
- Not a deterministic bug—more of a transient kernel race condition


**Closes #149040**