### PR TITLE
Improve plugin installation error diagnostics for Windows CI failures (#149124)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -724,13 +724,27 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                     .toList();
 
                 if (spec.getVersion().onOrAfter("7.6.0")) {
-                    runToolScript(
-                        "elasticsearch-plugin",
-                        null,
-                        Stream.concat(Stream.of("install", "--batch"), toInstall.stream()).toArray(String[]::new)
-                    );
+                    LOGGER.info("Installing {} plugins via single elasticsearch-plugin invocation", toInstall.size());
+                    try {
+                        runToolScript(
+                            "elasticsearch-plugin",
+                            null,
+                            Stream.concat(Stream.of("install", "--batch"), toInstall.stream()).toArray(String[]::new)
+                        );
+                    } catch (RuntimeException e) {
+                        LOGGER.error("Failed to install plugins: {}", toInstall, e);
+                        throw e;
+                    }
                 } else {
-                    toInstall.forEach(plugin -> runToolScript("elasticsearch-plugin", null, "install", "--batch", plugin));
+                    for (String plugin : toInstall) {
+                        LOGGER.info("Installing plugin: {}", plugin);
+                        try {
+                            runToolScript("elasticsearch-plugin", null, "install", "--batch", plugin);
+                        } catch (RuntimeException e) {
+                            LOGGER.error("Failed to install plugin: {}", plugin, e);
+                            throw e;
+                        }
+                    }
                 }
             }
         }
@@ -954,7 +968,20 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                     }
 
                     if (attempt >= TOOL_SCRIPT_RETRY_TIMES) {
-                        throw new RuntimeException("Execution of " + tool + " failed with exit code " + exit);
+                        String argsDesc = "[" + String.join(", ", args) + "]";
+                        throw new RuntimeException(
+                            "Execution of "
+                                + tool
+                                + " failed with exit code "
+                                + exit
+                                + "; tool='"
+                                + tool
+                                + "', args='"
+                                + argsDesc
+                                + "'. Check test cluster logs for full stderr output from "
+                                + tool
+                                + ".bat on Windows."
+                        );
                     }
 
                     attempt++;


### PR DESCRIPTION
**Addresses**: #149124

## Summary

Improves CI debuggability for Windows 2025 test cluster setup failures by surfacing plugin names and tool arguments in error messages when `elasticsearch-plugin.bat` installation fails.

## Changes

- Surface plugin names and tool arguments in error messages when `elasticsearch-plugin.bat` installation fails
- Add explicit logging for plugin installation attempts and failures
- Include instructions to check test cluster logs for full stderr output from tool scripts on Windows

## Context

This addresses the mitigation proposal from the analysis in #149124 for improving CI debuggability when plugin installation fails on Windows 2025 CI hosts. The error messages now clearly identify which plugins were being installed and provide context for investigating failures captured in test cluster logs and process output streams.

## Testing

- ✅ Compiles successfully: `./gradlew :test:test-clusters:compileJava`
- ✅ Formatting checks pass: `./gradlew :test:test-clusters:spotlessJavaCheck`
- ✅ Unit checks pass: `./gradlew :test:test-clusters:check`