### PR TITLE
Use /run instead of /var/run in RPM packaging

### DIFF
--- a/distribution/packages/src/common/env/elasticsearch
+++ b/distribution/packages/src/common/env/elasticsearch
@@ -13,7 +13,7 @@
 ES_PATH_CONF=@path.conf@
 
 # Elasticsearch PID directory
-#PID_DIR=/var/run/elasticsearch
+#PID_DIR=/run/elasticsearch
 
 # Additional Java OPTS
 #ES_JAVA_OPTS=

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -78,9 +78,9 @@ if [ "$REMOVE_DIRS" = "true" ]; then
         echo " OK"
     fi
 
-    if [ -d /var/run/elasticsearch ]; then
+    if [ -d /run/elasticsearch ]; then
         echo -n "Deleting PID directory..."
-        rm -rf /var/run/elasticsearch
+        rm -rf /run/elasticsearch
         echo " OK"
     fi
 

--- a/distribution/packages/src/common/systemd/elasticsearch.conf
+++ b/distribution/packages/src/common/systemd/elasticsearch.conf
@@ -1,1 +1,1 @@
-d    /var/run/elasticsearch   0755 elasticsearch elasticsearch - -
+d    /run/elasticsearch   0755 elasticsearch elasticsearch - -

--- a/distribution/packages/src/common/systemd/elasticsearch.service
+++ b/distribution/packages/src/common/systemd/elasticsearch.service
@@ -14,7 +14,7 @@ RuntimeDirectory=elasticsearch
 PrivateTmp=true
 Environment=ES_HOME=/usr/share/elasticsearch
 Environment=ES_PATH_CONF=@path.conf@
-Environment=PID_DIR=/var/run/elasticsearch
+Environment=PID_DIR=/run/elasticsearch
 Environment=ES_SD_NOTIFY=true
 EnvironmentFile=-@path.env@
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,7 +1,4 @@
 tests:
-- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-  method: test20SecurityNotAutoConfiguredOnReInstallation
-  issue: https://github.com/elastic/elasticsearch/issues/112635
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445


### PR DESCRIPTION
## Summary

Fixes #112635.

Recent systemd versions on OracleLinux 8 (and other RHEL-family distros) return a non-zero exit code when `systemd-tmpfiles` encounters the legacy `/var/run/` prefix in a `tmpfiles.d` configuration file. This caused `rpm -U --force` (used by the CI packaging upgrade test) to report `erase failed` and abort, breaking `PackagesSecurityAutoConfigurationTests#test20SecurityNotAutoConfiguredOnReInstallation`.

Update all packaging references from `/var/run/elasticsearch` to the canonical `/run/elasticsearch` path:

- `elasticsearch.conf` (`tmpfiles.d`) — direct cause of the failure
- `elasticsearch.service` — `PID_DIR` environment variable
- `env/elasticsearch` — commented `PID_DIR` default
- `postrm` — PID directory cleanup on package removal

Unmutes the packaging test now that the root cause is fixed.

## Migration risk

**Negligible.** On every Linux distribution that Elasticsearch 8.x and 9.x officially supports (RHEL/CentOS 7+, OracleLinux 7+, Ubuntu 14.04+, Debian 8+), `/var/run` is a symlink to `/run`. The two paths are physically identical, so existing installations, upgrade flows, and any external scripts or monitoring tools that reference `/var/run/elasticsearch` are completely unaffected. The only platform where this would differ — RHEL 6, where `/var/run` is a real directory — has not been supported by Elasticsearch since 7.x.
