### PR TITLE
[9.5] Increase suite timeouts for encryption-at-rest CI step (#154076)

### DIFF
--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -65,8 +65,10 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.hamcrest.Matchers.is;
 
-//The default 20 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
+// The default 20 minutes timeout isn't always enough; Darwin CI hosts are very slow and the
+// encryption-at-rest periodic step copies the entire workspace onto a LUKS dm-crypt volume,
+// adding substantial I/O overhead that can push the suite beyond 60 minutes.
+@TimeoutSuite(millis = 80 * TimeUnits.MINUTE)
 public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final String USER = "test_admin";

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -343,9 +343,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=ml/data_frame_analytics_crud/Test put classification given max_trees is greater than 2k}
   issue: https://github.com/elastic/elasticsearch/issues/150629
-- class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
-  method: test {p0=ml/data_frame_analytics_crud/Test put valid config with default outlier detection, query, and filter}
-  issue: https://github.com/elastic/elasticsearch/issues/150630
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.forkTwoBranches [ndjson.bz/AZURE]}
   issue: https://github.com/elastic/elasticsearch/issues/150651
@@ -379,9 +376,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecUnionTypesIT
   method: test {csv-spec:union_types.singleIndexIpStats}
   issue: https://github.com/elastic/elasticsearch/issues/150982
-- class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
-  method: test {p0=ml/estimate_model_memory/Test partition field with independent influencer}
-  issue: https://github.com/elastic/elasticsearch/issues/151052
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testUnhollowOnUpdates
   issue: https://github.com/elastic/elasticsearch/issues/151100
@@ -391,9 +385,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/151132
-- class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
-  method: test {p0=ml/jobs_get_result_overall_buckets/Test overall buckets given top_n is negative}
-  issue: https://github.com/elastic/elasticsearch/issues/151160
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/140_metadata/Aggregate ignored field}
   issue: https://github.com/elastic/elasticsearch/issues/151216

--- a/x-pack/plugin/ml/qa/single-node-tests/src/yamlRestTest/java/org/elasticsearch/xpack/ml/qa/MlYamlRestIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/yamlRestTest/java/org/elasticsearch/xpack/ml/qa/MlYamlRestIT.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.ml.qa;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.http.HttpStatus;
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.CheckedFunction;
@@ -45,7 +47,12 @@ import java.util.function.Supplier;
  * under {@code x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/} so
  * that internal consumers using {@code restResources.restTests.includeXpack 'ml'}
  * continue to work; this project pulls them in via the same mechanism.
+ *
+ * <p>The suite timeout is raised above the default 30-minute inherited value because the
+ * encryption-at-rest periodic CI step copies the workspace onto a LUKS dm-crypt volume,
+ * adding significant I/O overhead that can cause the full ML YAML suite to exceed 30 minutes.
  */
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class MlYamlRestIT extends ESClientYamlSuiteTestCase {
 
     private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Increase suite timeouts for encryption-at-rest CI step (#154076)](https://github.com/elastic/elasticsearch/pull/154076)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)