### PR TITLE
[9.4] Increase suite timeouts for encryption-at-rest CI step (#154076)

### DIFF
--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -56,8 +56,10 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.hamcrest.Matchers.is;
 
-//The default 20 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
+// The default 20 minutes timeout isn't always enough; Darwin CI hosts are very slow and the
+// encryption-at-rest periodic step copies the entire workspace onto a LUKS dm-crypt volume,
+// adding substantial I/O overhead that can push the suite beyond 60 minutes.
+@TimeoutSuite(millis = 80 * TimeUnits.MINUTE)
 public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     public DocsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -101,9 +101,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
   issue: https://github.com/elastic/elasticsearch/issues/145904
-- class: org.elasticsearch.xpack.ml.qa.MlYamlRestIT
-  method: test {p0=ml/delete_expired_data/Test delete expired data with body parameters}
-  issue: https://github.com/elastic/elasticsearch/issues/147656
 - class: org.elasticsearch.smoketest.SmokeTestWatcherTestSuiteIT
   method: testMonitorClusterHealth
   issue: https://github.com/elastic/elasticsearch/issues/148615

--- a/x-pack/plugin/ml/qa/single-node-tests/src/yamlRestTest/java/org/elasticsearch/xpack/ml/qa/MlYamlRestIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/yamlRestTest/java/org/elasticsearch/xpack/ml/qa/MlYamlRestIT.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.ml.qa;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.http.HttpStatus;
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.CheckedFunction;
@@ -45,7 +47,12 @@ import java.util.function.Supplier;
  * under {@code x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/} so
  * that internal consumers using {@code restResources.restTests.includeXpack 'ml'}
  * continue to work; this project pulls them in via the same mechanism.
+ *
+ * <p>The suite timeout is raised above the default 30-minute inherited value because the
+ * encryption-at-rest periodic CI step copies the workspace onto a LUKS dm-crypt volume,
+ * adding significant I/O overhead that can cause the full ML YAML suite to exceed 30 minutes.
  */
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class MlYamlRestIT extends ESClientYamlSuiteTestCase {
 
     private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Increase suite timeouts for encryption-at-rest CI step (#154076)](https://github.com/elastic/elasticsearch/pull/154076)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)