### PR TITLE
[9.5] Exclude grpc-context from esql-datasource-grpc bundle, unmute lintian test (#154075)

### DIFF
--- a/distribution/packages/src/deb/lintian/elasticsearch
+++ b/distribution/packages/src/deb/lintian/elasticsearch
@@ -31,8 +31,8 @@ unstripped-binary-or-object [usr/share/elasticsearch/jdk/*]
 # the system java version that lintian assumes is far behind what elasticsearch uses
 unknown-java-class-version
 
-# grpc-context is a metadata-only jar (module-info only, no application classes)
-codeless-jar [usr/share/elasticsearch/modules/esql-datasource-grpc/grpc-context-*.jar]
+# server-launcher is a GraalVM native image; GraalVM does not produce PIE binaries by default
+hardening-no-pie [usr/share/elasticsearch/lib/tools/server-launcher/server-launcher]
 
 # There's no `License` field in Debian control files, but earlier versions
 # of `lintian` were more permissive. Override this warning so that we can
@@ -60,6 +60,9 @@ non-standard-dir-perm etc/elasticsearch/jvm.options.d/ 2750 != 0755
 non-standard-file-perm etc/elasticsearch/*
 non-standard-dir-perm var/lib/elasticsearch/ 2750 != 0755
 non-standard-dir-perm var/log/elasticsearch/ 2750 != 0755
+
+# server-launcher is a GraalVM native image; GraalVM does not produce PIE binaries by default
+hardening-no-pie usr/share/elasticsearch/lib/tools/server-launcher/server-launcher
 
 # bundled JDK
 unstripped-binary-or-object usr/share/elasticsearch/jdk/*

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -44,9 +44,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
   method: testIndexPoints
   issue: https://github.com/elastic/elasticsearch/issues/142439
-- class: org.elasticsearch.packaging.test.DebMetadataTests
-  method: test05CheckLintian
-  issue: https://github.com/elastic/elasticsearch/issues/142819
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:METRICS}
   issue: https://github.com/elastic/elasticsearch/issues/153507

--- a/x-pack/plugin/esql-datasource-grpc/build.gradle
+++ b/x-pack/plugin/esql-datasource-grpc/build.gradle
@@ -78,6 +78,12 @@ tasks.named("test").configure {
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
 }
 
+// Exclude grpc-context: intentionally empty compatibility shim since gRPC 1.57.0
+// (classes absorbed into grpc-api). Bundling it triggers lintian codeless-jar warnings.
+configurations.runtimeClasspath {
+  exclude group: 'io.grpc', module: 'grpc-context'
+}
+
 tasks.named("dependencyLicenses").configure {
   mapping from: /arrow-.*/, to: 'arrow'
   mapping from: /flight-.*/, to: 'arrow'


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Exclude grpc-context from esql-datasource-grpc bundle, unmute lintian test (#154075)