### PR TITLE
Fix and unmute RemoteClusterServiceTests#testCollectNodesConcurrentWithSettingsChanges

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -349,9 +349,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.inference.textembedding.TextEmbeddingOperatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/153693
-- class: org.elasticsearch.transport.RemoteClusterServiceTests
-  method: testCollectNodesConcurrentWithSettingsChanges
-  issue: https://github.com/elastic/elasticsearch/issues/153784
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:fuse.FuseWithRowLinearAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/153911

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -86,7 +87,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     }
 
     private MockTransportService startTransport(final String id, final List<DiscoveryNode> knownNodes, final Settings settings) {
-        return RemoteClusterConnectionTests.startTransport(
+        final MockTransportService transportService = RemoteClusterConnectionTests.startTransport(
             id,
             knownNodes,
             VersionInformation.CURRENT,
@@ -94,6 +95,8 @@ public class RemoteClusterServiceTests extends ESTestCase {
             threadPool,
             settings
         );
+        transportService.getTaskManager().setTaskCancellationService(new TaskCancellationService(transportService));
+        return transportService;
     }
 
     private MockTransportService startTransport() {


### PR DESCRIPTION
Tearing down a remote connection closes transport channels, triggering task cancellation — but the test's transport services
had no `TaskCancellationService`, causing the assertion `TaskCancellationService is not initialized`. To solve it we wire up the `TaskCancellationService` on the test's transport services.

Closes: #153784