### PR TITLE
[9.5] Simplify EXTERNAL enabling. gRPC behind FF (#153989)

### DIFF
--- a/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/GrpcDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/main/java/org/elasticsearch/xpack/esql/datasource/grpc/GrpcDataSourcePlugin.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.grpc;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.datasources.spi.ConnectorFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
@@ -21,27 +22,55 @@ import java.util.Set;
 /**
  * Registers the Arrow Flight connector and storage SPI for ESQL.
  * Handles {@code flight://} and {@code grpc://} URIs for columnar data streaming via gRPC.
+ *
+ * <p>gRPC/Flight is not in the released ship set yet, so registration of both schemes and the
+ * Flight connector is gated on {@link #ESQL_EXTERNAL_DATASOURCES_GRPC_FEATURE_FLAG}: available in
+ * snapshot/development builds, disabled in release. When the gate is off the {@code flight}/
+ * {@code grpc} schemes and connector are not registered, so a source targeting either resolves to
+ * the generic "unsupported storage scheme" rejection.
  */
 public class GrpcDataSourcePlugin extends Plugin implements DataSourcePlugin {
 
+    /**
+     * Gates the gRPC/Flight storage providers and connector. Snapshot-on, release-off; override in
+     * release with {@code -Des.esql_external_datasources_grpc_feature_flag_enabled=true}.
+     */
+    public static final FeatureFlag ESQL_EXTERNAL_DATASOURCES_GRPC_FEATURE_FLAG = new FeatureFlag("esql_external_datasources_grpc");
+
+    private static boolean enabled() {
+        return ESQL_EXTERNAL_DATASOURCES_GRPC_FEATURE_FLAG.isEnabled();
+    }
+
     @Override
     public Set<String> supportedSchemes() {
+        if (enabled() == false) {
+            return Set.of();
+        }
         return Set.of("flight", "grpc");
     }
 
     @Override
     public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+        if (enabled() == false) {
+            return Map.of();
+        }
         StorageProviderFactory factory = StorageProviderFactory.noConfigKeys(FlightStorageProvider::new);
         return Map.of("flight", factory, "grpc", factory);
     }
 
     @Override
     public Set<String> supportedConnectorSchemes() {
+        if (enabled() == false) {
+            return Set.of();
+        }
         return Set.of("flight", "grpc");
     }
 
     @Override
     public Map<String, ConnectorFactory> connectors(Settings settings) {
+        if (enabled() == false) {
+            return Map.of();
+        }
         return Map.of("flight", new FlightConnectorFactory());
     }
 

--- a/x-pack/plugin/esql/src/main/antlr/EsqlBaseLexer.g4
+++ b/x-pack/plugin/esql/src/main/antlr/EsqlBaseLexer.g4
@@ -13,6 +13,7 @@ lexer grammar EsqlBaseLexer;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 }
 
 options {

--- a/x-pack/plugin/esql/src/main/antlr/EsqlBaseParser.g4
+++ b/x-pack/plugin/esql/src/main/antlr/EsqlBaseParser.g4
@@ -13,6 +13,7 @@ parser grammar EsqlBaseParser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 }
 
 options {
@@ -45,7 +46,7 @@ sourceCommand
     | promqlCommand
     // in development
     | {this.isDevVersion()}? explainCommand
-    | {this.isExternalDataSourcesEnabled()}? externalCommand
+    | {EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled()}? externalCommand
     ;
 
 processingCommand

--- a/x-pack/plugin/esql/src/main/antlr/lexer/From.g4
+++ b/x-pack/plugin/esql/src/main/antlr/lexer/From.g4
@@ -14,8 +14,8 @@ FROM : 'from'                 -> pushMode(FROM_MODE);
 // TS command
 TS : 'ts' -> pushMode(FROM_MODE);
 
-// EXTERNAL command (gated by esql_external_datasources feature flag)
-DEV_EXTERNAL : {this.isExternalDataSourcesEnabled()}? 'external' -> pushMode(FROM_MODE);
+// EXTERNAL command (internal, deprecated, snapshot-only)
+DEV_EXTERNAL : {EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled()}? 'external' -> pushMode(FROM_MODE);
 
 mode FROM_MODE;
 FROM_PIPE : PIPE -> type(PIPE), popMode;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2665,9 +2665,9 @@ public class EsqlCapabilities {
         STR_COMMANDS_ACCEPT_NULL,
 
         /**
-         * Support for the EXTERNAL command (datasource access). Snapshot-only: the grammar itself is gated by
-         * {@link org.elasticsearch.xpack.esql.parser.EsqlConfig#isExternalDataSourcesEnabled()}, so this capability
-         * mirrors that build-type check rather than reporting unconditionally enabled.
+         * Support for the EXTERNAL command (datasource access). Snapshot-only: the grammar predicates in
+         * {@code EsqlBaseParser.g4}/{@code From.g4} read this capability directly to gate the EXTERNAL
+         * grammar surface, rather than this capability mirroring a separate build-type check.
          */
         EXTERNAL_COMMAND(Build.current().isSnapshot()),
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseLexer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseLexer.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.esql.parser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;
@@ -397,7 +398,7 @@ public class EsqlBaseLexer extends LexerConfig {
   private boolean DEV_EXTERNAL_sempred(RuleContext _localctx, int predIndex) {
     switch (predIndex) {
     case 2:
-      return this.isExternalDataSourcesEnabled();
+      return EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled();
     }
     return true;
   }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParser.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.esql.parser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
@@ -594,7 +595,7 @@ public class EsqlBaseParser extends ParserConfig {
         enterOuterAlt(_localctx, 7);
         {
         setState(268);
-        if (!(this.isExternalDataSourcesEnabled())) throw new FailedPredicateException(this, "this.isExternalDataSourcesEnabled()");
+        if (!(EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled())) throw new FailedPredicateException(this, "EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled()");
         setState(269);
         externalCommand();
         }
@@ -10188,7 +10189,7 @@ public class EsqlBaseParser extends ParserConfig {
     case 1:
       return this.isDevVersion();
     case 2:
-      return this.isExternalDataSourcesEnabled();
+      return EsqlCapabilities.Cap.EXTERNAL_COMMAND.isEnabled();
     }
     return true;
   }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserBaseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserBaseListener.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.esql.parser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserBaseVisitor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserBaseVisitor.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.esql.parser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserListener.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.esql.parser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserVisitor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlBaseParserVisitor.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.esql.parser;
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlConfig.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlConfig.java
@@ -29,16 +29,6 @@ public class EsqlConfig {
         return isDevVersion;
     }
 
-    /**
-     * Whether the EXTERNAL command and external data source grammar are enabled. Mirrors {@link #isDevVersion()}:
-     * enabled in snapshot builds, disabled in release builds. Snapshot test runs may also use
-     * {@link #EsqlConfig(boolean, EsqlFunctionRegistry) EsqlConfig(false, ...)} to simulate production parsing, in
-     * which case EXTERNAL is disabled regardless of the actual build type.
-     */
-    public boolean isExternalDataSourcesEnabled() {
-        return isDevVersion;
-    }
-
     public EsqlFunctionRegistry functionRegistry() {
         return functionRegistry;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LexerConfig.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LexerConfig.java
@@ -29,10 +29,6 @@ public abstract class LexerConfig extends Lexer {
         return config == null || config.isDevVersion();
     }
 
-    boolean isExternalDataSourcesEnabled() {
-        return config == null || config.isExternalDataSourcesEnabled();
-    }
-
     void setEsqlConfig(EsqlConfig config) {
         this.config = config;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ParserConfig.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ParserConfig.java
@@ -23,10 +23,6 @@ public abstract class ParserConfig extends Parser {
         return config == null || config.isDevVersion();
     }
 
-    boolean isExternalDataSourcesEnabled() {
-        return config == null || config.isExternalDataSourcesEnabled();
-    }
-
     void setEsqlConfig(EsqlConfig config) {
         this.config = config;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/IcebergParsingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/IcebergParsingTests.java
@@ -27,16 +27,17 @@ import static org.hamcrest.Matchers.instanceOf;
  * Tests for parsing the EXTERNAL command.
  *
  * <p>The {@code EXTERNAL} grammar surface is gated to snapshot builds; release builds reject it at
- * the lexer level ({@link EsqlConfig#isExternalDataSourcesEnabled()}). Each positive/parsing test
- * asserts the snapshot precondition rather than executing under release — release-build CI silently
- * skips those, which is the intended behaviour for a snapshot-only feature.
+ * the lexer/parser level via {@link EsqlCapabilities.Cap#EXTERNAL_COMMAND}, which the grammar
+ * predicates read directly. Each positive/parsing test asserts the snapshot precondition rather
+ * than executing under release — release-build CI silently skips those, which is the intended
+ * behaviour for a snapshot-only feature.
  *
- * <p>Conversely, {@link #testExternalCommandUnavailableOnRealReleaseBuild} asserts the opposite
- * precondition ({@code assumeFalse} on a snapshot build) and drives the real, non-overridden
- * {@link EsqlConfig}/{@link EsqlCapabilities} — the same objects {@code EsqlPlugin} builds at
- * runtime — so it is a no-op on ordinary snapshot test runs and only actually exercises the
- * release-build gate when the suite is run with {@code -Dbuild.snapshot=false} (see
- * {@code TESTING.asciidoc}), e.g. via the CI {@code release-tests} job.
+ * <p>{@link #testExternalCommandUnavailableOnRealReleaseBuild} is the sole test covering the
+ * release-build rejection path: it drives the real, default {@link EsqlConfig}/{@link EsqlParser}
+ * construction (the same one {@code EsqlPlugin} uses at runtime) against the actual running build,
+ * so it is a no-op on ordinary snapshot test runs and only actually exercises the release-build gate
+ * when the suite is run with {@code -Dbuild.snapshot=false} (see {@code TESTING.asciidoc}), e.g. via
+ * the CI {@code release-tests} job.
  */
 public class IcebergParsingTests extends AbstractStatementParserTests {
 
@@ -93,30 +94,14 @@ public class IcebergParsingTests extends AbstractStatementParserTests {
         assertThat(config.get("use_cache"), equalTo(true));
     }
 
-    public void testIcebergCommandNotAvailableInProduction() {
-        // Deliberately no assumeTrue(Build.current().isSnapshot()) here: the production behaviour is
-        // forced below via new EsqlConfig(false, ...), independent of the real build type, so this
-        // regression check must run on every build (including under -Dbuild.snapshot=false), unlike
-        // the snapshot-only positive tests in this file.
-
-        // Create a parser with production mode (dev version = false)
-        EsqlConfig config = new EsqlConfig(false, TEST_FUNCTION_REGISTRY);
-        EsqlParser prodParser = new EsqlParser(config);
-
-        ParsingException pe = expectThrows(ParsingException.class, () -> prodParser.createStatement("EXTERNAL \"s3://bucket/table\""));
-        assertThat(pe.getMessage(), containsString("mismatched input 'EXTERNAL'"));
-    }
-
     /**
-     * Regression test for the EXTERNAL command leaking into release builds: unlike
-     * {@link #testIcebergCommandNotAvailableInProduction}, which forces production mode via an
-     * explicit {@code EsqlConfig(false, ...)} override, this test drives the real, default
-     * {@link EsqlConfig}/{@link EsqlParser} construction (the same one {@code EsqlPlugin} uses at
-     * runtime) against the actual running build. It only meaningfully executes — rather than being
-     * skipped — when the test JVM is a genuine release build (e.g. {@code -Dbuild.snapshot=false},
-     * as used by the CI {@code release-tests} job), which is the only way to catch a build-type
-     * check that is accidentally inverted, since such a bug is invisible while
-     * {@code Build.current().isSnapshot()} is {@code true}.
+     * Regression test for the EXTERNAL command leaking into release builds: drives the real,
+     * default {@link EsqlConfig}/{@link EsqlParser} construction (the same one {@code EsqlPlugin}
+     * uses at runtime) against the actual running build. It only meaningfully executes — rather
+     * than being skipped — when the test JVM is a genuine release build (e.g.
+     * {@code -Dbuild.snapshot=false}, as used by the CI {@code release-tests} job), which is the
+     * only way to catch a build-type check that is accidentally inverted, since such a bug is
+     * invisible while {@code Build.current().isSnapshot()} is {@code true}.
      */
     public void testExternalCommandUnavailableOnRealReleaseBuild() {
         assumeFalse("only exercises the real release-build gate", Build.current().isSnapshot());


### PR DESCRIPTION
This minimizes further the release footprint:
- it simplifies the code around EXTERNAL command availability;
- it puts grpc plugin behind a feature flag (snapshot-only-enabled).

EXTERNAL enablement depends now solely on its corresponding capability (which is snapshot-only). No further conditions, in multiple places, that can lead to leaking it. It should also make its removal easier.

GRPC functionality has been in theory available before, but one cannot define a datasource/set for it, so it couldn't have been use (in FROM). With this change, it'll also be disabled in release builds.

Related #153926

(cherry picked from commit 67ee2d4c668d04a9b99960773c269530fcd739c5)
