### PR TITLE
[8.19] Use /run instead of /var/run in RPM packaging (#154104)

### DIFF
--- a/distribution/packages/src/common/env/elasticsearch
+++ b/distribution/packages/src/common/env/elasticsearch
@@ -13,7 +13,7 @@
 ES_PATH_CONF=@path.conf@
 
 # Elasticsearch PID directory
-#PID_DIR=/var/run/elasticsearch
+#PID_DIR=/run/elasticsearch
 
 # Additional Java OPTS
 #ES_JAVA_OPTS=

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -78,9 +78,9 @@ if [ "$REMOVE_DIRS" = "true" ]; then
         echo " OK"
     fi
 
-    if [ -d /var/run/elasticsearch ]; then
+    if [ -d /run/elasticsearch ]; then
         echo -n "Deleting PID directory..."
-        rm -rf /var/run/elasticsearch
+        rm -rf /run/elasticsearch
         echo " OK"
     fi
 

--- a/distribution/packages/src/common/systemd/elasticsearch.conf
+++ b/distribution/packages/src/common/systemd/elasticsearch.conf
@@ -1,1 +1,1 @@
-d    /var/run/elasticsearch   0755 elasticsearch elasticsearch - -
+d    /run/elasticsearch   0755 elasticsearch elasticsearch - -

--- a/distribution/packages/src/common/systemd/elasticsearch.service
+++ b/distribution/packages/src/common/systemd/elasticsearch.service
@@ -14,7 +14,7 @@ RuntimeDirectory=elasticsearch
 PrivateTmp=true
 Environment=ES_HOME=/usr/share/elasticsearch
 Environment=ES_PATH_CONF=@path.conf@
-Environment=PID_DIR=/var/run/elasticsearch
+Environment=PID_DIR=/run/elasticsearch
 Environment=ES_SD_NOTIFY=true
 EnvironmentFile=-@path.env@
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -45,9 +45,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testPutJob_GivenFarequoteConfig
   issue: https://github.com/elastic/elasticsearch/issues/112382
-- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-  method: test20SecurityNotAutoConfiguredOnReInstallation
-  issue: https://github.com/elastic/elasticsearch/issues/112635
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDelete_multipleRequest
   issue: https://github.com/elastic/elasticsearch/issues/112701


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Use /run instead of /var/run in RPM packaging (#154104)](https://github.com/elastic/elasticsearch/pull/154104)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)