### PR TITLE
[8.19] Revert explicit CI disk size increase (#154060)

### DIFF
--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -9,7 +9,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -44,7 +43,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -70,7 +68,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -96,7 +93,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -122,7 +118,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -148,7 +143,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -174,7 +168,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -206,7 +199,6 @@ steps:
           preemptible: true
           spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -10,7 +10,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -45,7 +44,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -71,7 +69,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -97,7 +94,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -123,7 +119,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -149,7 +144,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -175,7 +169,6 @@ steps:
       preemptible: true
       spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
       diskType: hyperdisk-balanced
-      diskSizeGb: 250
       buildDirectory: /dev/shm/bk
     retry:
       manual:
@@ -207,7 +200,6 @@ steps:
           preemptible: true
           spotZones: "asia-south2-a,asia-south2-b,asia-south2-c,europe-west2-a,europe-west2-b,europe-west2-c,northamerica-northeast2-b,northamerica-northeast2-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c"
           diskType: hyperdisk-balanced
-          diskSizeGb: 250
           buildDirectory: /dev/shm/bk
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Revert explicit CI disk size increase (#154060)](https://github.com/elastic/elasticsearch/pull/154060)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)