### PR TITLE
Remove now-unused index prefix

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -716,11 +716,6 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // For connectors telemetry. Will be removed once we switched to connectors API
                 RoleDescriptor.IndicesPrivileges.builder().indices(".elastic-connectors*").privileges("read").build(),
-                // TODO: Remove after SML swaps to the below .ai-index* pattern
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".context-idx-sml-data", ".context-idx-sml-data-*")
-                    .privileges("all")
-                    .build(),
                 // Context Engine's SML storage. A regular (non-system) index that Kibana
                 // creates and manages itself at startup, including its alias.
                 RoleDescriptor.IndicesPrivileges.builder()


### PR DESCRIPTION
Now that https://github.com/elastic/kibana/pull/278580 is merged, it's safe to remove Kibana's access to the old prefix. Devs will be able to resolve permission issues by pulling latest ES and Kibana.

Related to https://github.com/elastic/elasticsearch/pull/154015

