### PR TITLE
[9.5] Resolve reader from format, also with compression (#154116)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -877,9 +877,9 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
 
         // Compressed .csv.gz goes through CompressionDelegatingFormatReader; the declared format must reach the wrapped
-        // CSV reader (a missing wrapper override would silently drop it and diverge from the uncompressed result). The
-        // format/compression is driven by the compound `.csv.gz` extension — an explicit `format` override would bypass
-        // the extension-based compression wrapping entirely, so leave it off.
+        // CSV reader (a missing wrapper override would silently drop it and diverge from the uncompressed result). Format
+        // here is inferred from the compound `.csv.gz` extension; testExplicitFormatOverGzipCsvReads covers the sibling
+        // case of an explicit `format` setting composing with the same compression suffix.
         Path gz = createTempFile("dataset-date-fixture-", ".csv.gz");
         byte[] csv = ("ts:keyword,note:keyword\n10/Oct/2000:13:55:36 -0700,alpha\n").getBytes(java.nio.charset.StandardCharsets.UTF_8);
         try (var out = new java.util.zip.GZIPOutputStream(Files.newOutputStream(gz))) {
@@ -920,6 +920,20 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         // with "No operator factory for sourceType: gz". It must now resolve to "csv" (through the compression-unwrapping
         // registry) and read the row. Regression guard for the strict compound-extension read fix.
         assertStrictGzippedTextReads("logs_csv_gz_strict", ".csv.gz", "some_ts,alpha\n", Map.of("header_row", false));
+    }
+
+    public void testExplicitFormatOverGzipCsvReads() throws Exception {
+        // Regression guard for the compressed-read-under-explicit-format fix: an explicit `format` setting used
+        // to bypass compression detection entirely (FormatNameResolver.resolveReader looked the format up by
+        // name with no regard for the resource's outer compression suffix), so this query used to fail trying
+        // to parse raw gzip bytes as CSV. `format: csv` must now compose with the `.csv.gz` suffix exactly like
+        // the extension-inferred path does.
+        assertStrictGzippedTextReads(
+            "logs_csv_gz_explicit_format",
+            ".csv.gz",
+            "some_ts,alpha\n",
+            Map.of("header_row", false, "format", "csv")
+        );
     }
 
     public void testStrictOverGzipTsvReads() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolver.java
@@ -29,6 +29,11 @@ import java.util.Set;
  *       and an empty value mean "no override" and fall through to the extension)</li>
  *   <li>File extension extracted from the source path</li>
  * </ol>
+ * <p>
+ * An explicit {@code reader}/{@code format} override selects the format but does not opt the resource out
+ * of compression detection: {@link #resolveReader} still composes the named format with the resource's
+ * outer compression suffix (e.g. {@code format: csv} over {@code hits.csv.gz} still decompresses), routing
+ * through {@link FormatReaderRegistry#byNameForObject} rather than a bare name lookup.
  */
 public final class FormatNameResolver {
 
@@ -163,9 +168,12 @@ public final class FormatNameResolver {
     /**
      * Resolves the format reader using config and source path, looking up the result in the registry.
      * <p>
-     * Config-based overrides ({@code reader}, {@code format}) are resolved via {@link #resolve} and
-     * looked up by name. Extension-based resolution delegates to {@link FormatReaderRegistry#byExtension}
-     * which handles compound extensions (e.g. {@code .ndjson.bz}) and compression codecs.
+     * Config-based overrides ({@code reader}, {@code format}) are resolved via {@link #resolve} and looked
+     * up by name through {@link FormatReaderRegistry#byNameForObject}, which composes the named format with
+     * {@code objectName}'s outer compression suffix (if any) exactly like the extension-based path — an
+     * explicit override selects the format but does not opt the resource out of compression detection.
+     * Extension-based resolution delegates to {@link FormatReaderRegistry#byExtension} which handles
+     * compound extensions (e.g. {@code .ndjson.bz}) and compression codecs.
      */
     public static FormatReader resolveReader(Map<String, Object> config, String objectName, FormatReaderRegistry registry) {
         if (config != null) {
@@ -176,11 +184,11 @@ public final class FormatNameResolver {
                 if (formatName == null) {
                     throw new IllegalArgumentException("Unknown reader [" + alias + "]; supported values: " + supportedReaderAliases());
                 }
-                return registry.byName(formatName);
+                return registry.byNameForObject(formatName, objectName);
             }
             String name = parseExplicitFormat(config.get(CONFIG_FORMAT));
             if (name != null) {
-                return registry.byName(name);
+                return registry.byNameForObject(name, objectName);
             }
         }
         return registry.byExtension(objectName);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatReaderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FormatReaderRegistry.java
@@ -126,12 +126,10 @@ public class FormatReaderRegistry {
             throw new IllegalArgumentException("Object name cannot be null or empty");
         }
 
-        int lastDot = objectName.lastIndexOf('.');
-        if (lastDot < 0 || lastDot == objectName.length() - 1) {
+        String extension = trailingExtension(objectName);
+        if (extension == null) {
             throw new IllegalArgumentException("Cannot infer format from object name without extension: " + objectName);
         }
-
-        String extension = objectName.substring(lastDot).toLowerCase(Locale.ROOT);
 
         // Check for compound extension (e.g. .csv.gz)
         if (codecRegistry != null) {
@@ -140,26 +138,7 @@ public class FormatReaderRegistry {
                 FormatReader inner = byExtension(stripped);
                 DecompressionCodec codec = codecRegistry.byExtension(extension);
                 if (codec != null) {
-                    if (inner.supportsWholeFileCompression() == false) {
-                        throw new IllegalArgumentException(
-                            "Format ["
-                                + inner.formatName()
-                                + "] does not support whole-file compression; the ["
-                                + extension
-                                + "] suffix is not valid on ["
-                                + objectName
-                                + "]. Use an uncompressed file and rely on the format's built-in column compression instead."
-                        );
-                    }
-                    // On release builds the text-format codec surface is limited to the benchmarked set; the
-                    // remaining codecs (bzip2, snappy, lz4, brotli) stay available on snapshot builds only. This
-                    // runs after the whole-file veto so Parquet/ORC still report the more specific error above.
-                    if (Build.current().isSnapshot() == false && GA_TEXT_CODECS.contains(codec.name()) == false) {
-                        throw new IllegalArgumentException(
-                            "compression codec [" + codec.name() + "] is not supported; supported: uncompressed, gzip, zstd"
-                        );
-                    }
-                    return new CompressionDelegatingFormatReader(inner, codec);
+                    return wrapWithCodec(inner, codec, extension, objectName);
                 }
             }
         }
@@ -167,6 +146,75 @@ public class FormatReaderRegistry {
         Supplier<FormatReader> supplier = byExtension.get(extension);
         Check.notNull(supplier, "No format reader registered for extension: {}. Supported: {}", extension, byExtension.keySet());
         return supplier.get();
+    }
+
+    /**
+     * Resolves the named format reader and, if {@code objectName} carries a trailing compression-codec
+     * extension (e.g. {@code .gz}), wraps it in a {@link CompressionDelegatingFormatReader} — applying the
+     * same whole-file-compression-support check and GA-codec gate as {@link #byExtension(String)}.
+     * <p>
+     * Used when the caller already knows the format via an explicit {@code format}/{@code reader} config
+     * override: without this, an explicit override would resolve the plain reader and feed it the resource's
+     * compressed bytes unchanged (the compressed-read-under-explicit-format fix). {@code objectName} with no
+     * compression suffix (the common case) returns the plain reader unchanged.
+     */
+    public FormatReader byNameForObject(String formatName, String objectName) {
+        FormatReader inner = byName(formatName);
+        if (codecRegistry == null || Strings.isNullOrEmpty(objectName)) {
+            return inner;
+        }
+        String extension = trailingExtension(objectName);
+        if (extension == null) {
+            return inner;
+        }
+        DecompressionCodec codec = codecRegistry.byExtension(extension);
+        if (codec == null) {
+            return inner;
+        }
+        return wrapWithCodec(inner, codec, extension, objectName);
+    }
+
+    /**
+     * Returns {@code objectName}'s trailing extension (e.g. {@code ".gz"}), lower-cased, or {@code null}
+     * if there is no dot or the dot is the last character. Shared by {@link #byExtension(String)} and
+     * {@link #byNameForObject(String, String)} so the two paths cannot diverge on how the compression
+     * suffix is detected; callers decide separately whether a missing extension is an error.
+     */
+    private static String trailingExtension(String objectName) {
+        int lastDot = objectName.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == objectName.length() - 1) {
+            return null;
+        }
+        return objectName.substring(lastDot).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Applies the whole-file-compression veto and the release-build GA-codec gate, then wraps {@code inner}
+     * in a {@link CompressionDelegatingFormatReader} for {@code codec}. Shared by {@link #byExtension(String)}
+     * (compound-extension inference) and {@link #byNameForObject(String, String)} (explicit format/reader
+     * override), so the two paths cannot diverge on which codecs/formats are compatible.
+     */
+    private static FormatReader wrapWithCodec(FormatReader inner, DecompressionCodec codec, String extension, String objectName) {
+        if (inner.supportsWholeFileCompression() == false) {
+            throw new IllegalArgumentException(
+                "Format ["
+                    + inner.formatName()
+                    + "] does not support whole-file compression; the ["
+                    + extension
+                    + "] suffix is not valid on ["
+                    + objectName
+                    + "]. Use an uncompressed file and rely on the format's built-in column compression instead."
+            );
+        }
+        // On release builds the text-format codec surface is limited to the benchmarked set; the
+        // remaining codecs (bzip2, snappy, lz4, brotli) stay available on snapshot builds only. This
+        // runs after the whole-file veto so Parquet/ORC still report the more specific error above.
+        if (Build.current().isSnapshot() == false && GA_TEXT_CODECS.contains(codec.name()) == false) {
+            throw new IllegalArgumentException(
+                "compression codec [" + codec.name() + "] is not supported; supported: uncompressed, gzip, zstd"
+            );
+        }
+        return new CompressionDelegatingFormatReader(inner, codec);
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
@@ -867,6 +867,132 @@ public class DataSourceModuleTests extends ESTestCase {
     }
 
     /**
+     * Regression test for the compressed-read-under-explicit-format fix: an explicit {@code format}
+     * override composes with the resource's outer compression suffix instead of bypassing it.
+     * {@code FormatNameResolver.resolveReader} is the exact chokepoint {@code FileSourceFactory} and
+     * {@code FileSplitProvider} use for the real read path.
+     */
+    public void testExplicitFormatComposesWithCompressionSuffix() {
+        List<DataSourcePlugin> plugins = List.of(new TestDataSourcePlugin(), new GzipDataSourcePlugin());
+        DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
+        FormatReaderRegistry registry = module.formatReaderRegistry();
+
+        // Mirrors the reported scenario: settings.format = "csv" over a resource that ends in .csv.gz.
+        FormatReader reader = FormatNameResolver.resolveReader(Map.of("format", "csv"), "hits_00.csv.gz", registry);
+        assertEquals("csv", reader.formatName());
+        assertTrue(
+            "An explicit format over a compressed resource should still wrap in CompressionDelegatingFormatReader",
+            reader.getClass().getSimpleName().contains("CompressionDelegating")
+        );
+    }
+
+    /**
+     * Same fix, via the {@code reader} alias override rather than {@code format}: {@code reader=java} maps
+     * to the {@code parquet} format name ({@link FormatNameResolver#READER_JAVA}), so a mock {@code parquet}
+     * format (unlike the real Parquet reader, this stand-in supports whole-file compression) is registered
+     * to exercise the alias branch of {@link FormatNameResolver#resolveReader} against a compressed object.
+     */
+    public void testExplicitReaderAliasComposesWithCompressionSuffix() {
+        List<DataSourcePlugin> plugins = List.of(new TestDataSourcePlugin(), new MockParquetFormatPlugin(), new GzipDataSourcePlugin());
+        DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
+        FormatReaderRegistry registry = module.formatReaderRegistry();
+
+        FormatReader reader = FormatNameResolver.resolveReader(Map.of("reader", "java"), "hits_00.parquet.gz", registry);
+        assertEquals("parquet", reader.formatName());
+        assertTrue(
+            "reader=java over a compressed resource should still wrap in CompressionDelegatingFormatReader",
+            reader.getClass().getSimpleName().contains("CompressionDelegating")
+        );
+    }
+
+    /**
+     * Test-only plugin registering a mock {@code parquet} format so {@code reader=java}/{@code reader=parquet-rs}
+     * resolve to a real registry entry without pulling in the actual (whole-file-compression-incompatible)
+     * Parquet reader.
+     */
+    private static class MockParquetFormatPlugin implements DataSourcePlugin {
+        @Override
+        public Set<String> supportedSchemes() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<FormatSpec> formatSpecs() {
+            return Set.of(FormatSpec.of("parquet", ".parquet"));
+        }
+
+        @Override
+        public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+            return Map.of("parquet", (s, bf) -> new MockCsvFormatReader("parquet", List.of(".parquet")));
+        }
+    }
+
+    /**
+     * An explicit {@code format} override over an uncompressed resource (the common case) must be
+     * unaffected by the fix: no compression suffix means no wrapping, same reader instance as before.
+     */
+    public void testExplicitFormatWithNoCompressionSuffixIsUnchanged() {
+        List<DataSourcePlugin> plugins = List.of(new TestDataSourcePlugin(), new GzipDataSourcePlugin());
+        DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
+        FormatReaderRegistry registry = module.formatReaderRegistry();
+
+        FormatReader reader = FormatNameResolver.resolveReader(Map.of("format", "csv"), "hits_00.csv", registry);
+        assertFalse("An uncompressed resource must not be wrapped", reader.getClass().getSimpleName().contains("CompressionDelegating"));
+        assertTrue(reader instanceof MockCsvFormatReader);
+    }
+
+    /**
+     * An explicit {@code format} naming a format that cannot be wrapped in a whole-file decompressor
+     * (e.g. Parquet/ORC) must be rejected up front — the same error {@link FormatReaderRegistry#byExtension}
+     * already raises for the equivalent extension-inferred case — rather than silently ignoring the
+     * resource's compression suffix and failing later with a confusing parse error.
+     */
+    public void testExplicitFormatRejectsWholeFileCompressionForIncompatibleFormats() {
+        List<DataSourcePlugin> plugins = List.of(
+            new TestDataSourcePlugin(),
+            new NoWholeFileCompressionPlugin(),
+            new GzipDataSourcePlugin()
+        );
+        DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
+        FormatReaderRegistry registry = module.formatReaderRegistry();
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FormatNameResolver.resolveReader(Map.of("format", "parq"), "data.parq.gz", registry)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("does not support whole-file compression"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("parq"));
+    }
+
+    /**
+     * On release builds, an explicit {@code format} over a codec outside the GA text-format surface
+     * (bzip2, snappy, lz4, brotli) must be rejected the same way the extension-inferred path already is —
+     * not silently accepted while misreading the compressed bytes. See elastic/esql-planning#938.
+     */
+    public void testExplicitFormatRejectsNonGaCodecsOnReleaseBuilds() {
+        assumeFalse("snapshot builds allow all registered codecs", Build.current().isSnapshot());
+
+        List<DataSourcePlugin> plugins = List.of(new TestDataSourcePlugin(), new GzipDataSourcePlugin(), new Bzip2DataSourcePlugin());
+        DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
+        FormatReaderRegistry registry = module.formatReaderRegistry();
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FormatNameResolver.resolveReader(Map.of("format", "csv"), "data.csv.bz2", registry)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("is not supported; supported: uncompressed, gzip, zstd"));
+
+        // The benchmarked codec still resolves and still composes with the explicit format.
+        FormatReader reader = FormatNameResolver.resolveReader(Map.of("format", "csv"), "data.csv.gz", registry);
+        assertTrue(reader.getClass().getSimpleName().contains("CompressionDelegating"));
+    }
+
+    /**
      * Test that DataSourceModule correctly reports table catalog availability.
      */
     public void testTableCatalogAvailability() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FormatNameResolverTests.java
@@ -127,6 +127,31 @@ public class FormatNameResolverTests extends ESTestCase {
         assertEquals("csv", FormatNameResolver.resolveFormatName(Map.of("format", "csv"), "hits.parquet.gz", registry));
     }
 
+    /**
+     * Regression test for the compressed-read-under-explicit-format fix: an explicit {@code format} override
+     * must still compose with the resource's outer compression suffix — the reader
+     * {@link FormatNameResolver#resolveReader} returns (not just the name
+     * {@link FormatNameResolver#resolveFormatName} reads back) must be wrapped in a
+     * {@link CompressionDelegatingFormatReader} so the returned reader actually decompresses at read time,
+     * rather than resolving the plain reader over compressed bytes.
+     */
+    public void testResolveReaderConfigOverrideComposesWithCompressionSuffix() {
+        FormatReaderRegistry registry = csvRegistry();
+        FormatReader reader = FormatNameResolver.resolveReader(Map.of("format", "csv"), "hits.csv.gz", registry);
+        assertEquals("csv", reader.formatName());
+        assertTrue(
+            "explicit format over a compressed resource must resolve a CompressionDelegatingFormatReader",
+            reader instanceof CompressionDelegatingFormatReader
+        );
+    }
+
+    /** An explicit {@code format} override over an uncompressed resource resolves the plain reader, unwrapped. */
+    public void testResolveReaderConfigOverrideWithoutCompressionSuffixIsUnwrapped() {
+        FormatReaderRegistry registry = csvRegistry();
+        FormatReader reader = FormatNameResolver.resolveReader(Map.of("format", "csv"), "hits.csv", registry);
+        assertFalse(reader instanceof CompressionDelegatingFormatReader);
+    }
+
     /** An extensionless, format-less strict resource fails loud at the registry rather than resolving null. */
     public void testResolveFormatNameThrowsOnExtensionless() {
         FormatReaderRegistry registry = csvRegistry();


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Resolve reader from format, also with compression (#154116)