### PR TITLE
[9.4] Skip MatchAllDocsQuery when building KNN filter query (#154027)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.vectors;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
@@ -620,11 +621,13 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
     private static Query buildFilterQuery(List<Query> filters) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         for (Query f : filters) {
-            builder.add(f, BooleanClause.Occur.FILTER);
+            // MatchAllDocsQuery adds no selectivity; skip to avoid materializing a full-index bitset via CachingEnableFilterQuery.
+            if (f.getClass() != MatchAllDocsQuery.class) {
+                builder.add(f, BooleanClause.Occur.FILTER);
+            }
         }
         BooleanQuery booleanQuery = builder.build();
-        Query filterQuery = booleanQuery.clauses().isEmpty() ? null : booleanQuery;
-        return filterQuery;
+        return booleanQuery.clauses().isEmpty() ? null : booleanQuery;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DenseVectorFieldType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.InnerHitsRewriteContext;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -44,6 +45,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
@@ -667,6 +669,52 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
         List<QueryBuilder> newFilters = randomList(5, () -> RandomQueryBuilder.createQuery(random()));
         knnQueryBuilder.setFilterQueries(newFilters);
         assertThat(knnQueryBuilder.filterQueries(), equalTo(newFilters));
+    }
+
+    public void testMatchAllFilterIsDropped() throws IOException {
+        float[] vector = new float[vectorDimensions];
+        Arrays.fill(vector, 1.0f);
+        int k = 3;
+        int numCands = 10;
+        RescoreVectorBuilder rescoreVectorBuilder = isIndextypeBBQ() ? randomBBQRescoreVectorBuilder() : null;
+        SearchExecutionContext context = createSearchExecutionContext();
+
+        KnnVectorQueryBuilder withNoFilter = new KnnVectorQueryBuilder(VECTOR_FIELD, vector, k, numCands, null, rescoreVectorBuilder, null);
+
+        // A sole MatchAllQueryBuilder is equivalent to no filter
+        KnnVectorQueryBuilder withMatchAll = new KnnVectorQueryBuilder(VECTOR_FIELD, vector, k, numCands, null, rescoreVectorBuilder, null);
+        withMatchAll.addFilterQuery(new MatchAllQueryBuilder());
+        assertThat(withMatchAll.doToQuery(context), equalTo(withNoFilter.doToQuery(context)));
+
+        // Multiple MatchAllQueryBuilders are all dropped
+        KnnVectorQueryBuilder withMultipleMatchAlls = new KnnVectorQueryBuilder(
+            VECTOR_FIELD,
+            vector,
+            k,
+            numCands,
+            null,
+            rescoreVectorBuilder,
+            null
+        );
+        withMultipleMatchAlls.addFilterQuery(new MatchAllQueryBuilder());
+        withMultipleMatchAlls.addFilterQuery(new MatchAllQueryBuilder());
+        assertThat(withMultipleMatchAlls.doToQuery(context), equalTo(withNoFilter.doToQuery(context)));
+
+        // MatchAllQueryBuilder mixed with a selective filter preserves the selective filter
+        KnnVectorQueryBuilder withMatchAllAndTerm = new KnnVectorQueryBuilder(
+            VECTOR_FIELD,
+            vector,
+            k,
+            numCands,
+            null,
+            rescoreVectorBuilder,
+            null
+        );
+        withMatchAllAndTerm.addFilterQuery(new MatchAllQueryBuilder());
+        withMatchAllAndTerm.addFilterQuery(QueryBuilders.termQuery(KEYWORD_FIELD_NAME, "test"));
+        KnnVectorQueryBuilder withTermOnly = new KnnVectorQueryBuilder(VECTOR_FIELD, vector, k, numCands, null, rescoreVectorBuilder, null);
+        withTermOnly.addFilterQuery(QueryBuilders.termQuery(KEYWORD_FIELD_NAME, "test"));
+        assertThat(withMatchAllAndTerm.doToQuery(context), equalTo(withTermOnly.doToQuery(context)));
     }
 
     protected String encodeToBase64(float[] vector) {


### PR DESCRIPTION
Backports the following commits to 9.4: https://github.com/elastic/elasticsearch/pull/154027
