### PR TITLE
Add diagnostics to RejectionActionIT on timeout

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -589,9 +589,6 @@ tests:
 - class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
   method: testMasterFailoverDuringCleanup
   issue: https://github.com/elastic/elasticsearch/issues/153174
-- class: org.elasticsearch.action.RejectionActionIT
-  method: testSimulatedSearchRejectionLoad
-  issue: https://github.com/elastic/elasticsearch/issues/153848
 - class: org.elasticsearch.xpack.stateless.StatelessAbortRunningMergesOnRelocationIT
   method: testConcurrentForceMergeIsNotAborted
   issue: https://github.com/elastic/elasticsearch/issues/153854

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/RejectionActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/RejectionActionIT.java
@@ -21,9 +21,11 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 
+import java.lang.management.ManagementFactory;
 import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -68,7 +70,10 @@ public class RejectionActionIT extends ESIntegTestCase {
         }
         // Bounded wait: some search requests can be stuck indefinitely (see #146022), in which case we'd
         // rather fail fast with a clear timeout than have the whole suite hang until it hits its own timeout.
-        safeAwait(latch, TimeValue.ONE_MINUTE);
+        if (latch.await(1, TimeUnit.MINUTES) == false) {
+            dumpStuckSearchDiagnostics(numberOfAsyncOps, responses.size());
+            fail("timed out: " + (numberOfAsyncOps - responses.size()) + " of " + numberOfAsyncOps + " searches never completed");
+        }
 
         // validate all responses
         for (Object response : responses) {
@@ -95,5 +100,46 @@ public class RejectionActionIT extends ESIntegTestCase {
             }
         }
         assertThat(responses.size(), equalTo(numberOfAsyncOps));
+    }
+
+    private void dumpStuckSearchDiagnostics(int numberOfAsyncOps, int completed) {
+        StringBuilder sb = new StringBuilder("RejectionActionIT stuck: ").append(numberOfAsyncOps - completed)
+            .append(" of ")
+            .append(numberOfAsyncOps)
+            .append(" searches never invoked their listener\n");
+
+        var threadBean = ManagementFactory.getThreadMXBean();
+        sb.append("thread dump:\n");
+        for (var info : threadBean.dumpAllThreads(true, true)) {
+            sb.append('"').append(info.getThreadName()).append("\" ").append(info.getThreadState());
+            if (info.getLockInfo() != null) {
+                sb.append(" waiting on ").append(info.getLockInfo());
+                if (info.getLockOwnerName() != null) {
+                    sb.append(" held by \"").append(info.getLockOwnerName()).append('"');
+                }
+            }
+            sb.append('\n');
+            for (var frame : info.getStackTrace()) {
+                sb.append("\tat ").append(frame).append('\n');
+            }
+            sb.append('\n');
+        }
+
+        sb.append("running search tasks:\n");
+        try {
+            var tasks = clusterAdmin().prepareListTasks()
+                .setActions("indices:data/read/search*")
+                .setDetailed(true)
+                .get(TimeValue.timeValueSeconds(10))
+                .getTasks();
+            sb.append("count=").append(tasks.size()).append('\n');
+            for (var task : tasks) {
+                sb.append("  ").append(task).append('\n');
+            }
+        } catch (Exception e) {
+            sb.append("failed to list running search tasks: ").append(e).append('\n');
+        }
+
+        logger.error("{}", sb);
     }
 }


### PR DESCRIPTION
## Summary

`RejectionActionIT#testSimulatedSearchRejectionLoad` very rarely hangs: under a size-1 `search` (and `get`) thread pool, one search occasionally never invokes its `ActionListener`, so the latch never reaches zero (#153848). The failure is too rare to reproduce on demand — it did **not** reproduce in ~1500+ iterations on the real CI environment (ubuntu-2404 / JDK 26), including runs with added CPU contention. So rather than keep brute-forcing, this makes the *next* natural occurrence actionable instead of a bare "latch did not reach zero" timeout.

## Changes

- Unmute `testSimulatedSearchRejectionLoad`.
- Replace the plain bounded `safeAwait` with a bounded wait that, on the one-minute timeout, dumps the currently-running search tasks and a **full JVM thread dump** before failing. Under `internalClusterTest` all nodes share the test JVM, so the dump reveals whether a search thread is genuinely **stuck** (a deadlock) or every pool is **idle** (a dropped listener).

## Notes for whoever investigates the next failure

- The hang lives on the **single-shard** search path (`numberOfShards() == 1` → inline query+fetch in `SearchService#executeFetchPhase`). A multi-shard index takes a different async-fetch path and does not reproduce it.
- The pinned `get` pool looks like a red herring: nothing in the search execution path uses `ThreadPool.Names.GET` (it uses the unconstrained REFRESH pool for `ensureShardSearchActive`).

Relates to https://github.com/elastic/elasticsearch/issues/153848

Made with [Cursor](https://cursor.com)