### PR TITLE
Fix VerifyVersionConstantsIT: add V_7_9_1 with Lucene 8.6.2

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -307,9 +307,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
-  method: testLuceneVersionConstant
-  issue: https://github.com/elastic/elasticsearch/issues/139816
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/138128

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -61,6 +61,7 @@ public class IndexVersions {
     public static final IndexVersion V_7_7_0 = def(7_07_00_99, Version.LUCENE_8_5_1);
     public static final IndexVersion V_7_8_0 = def(7_08_00_99, Version.LUCENE_8_5_1);
     public static final IndexVersion V_7_9_0 = def(7_09_00_99, Version.LUCENE_8_6_0);
+    public static final IndexVersion V_7_9_1 = def(7_09_01_99, Version.LUCENE_8_6_2);
     public static final IndexVersion V_7_10_0 = def(7_10_00_99, Version.LUCENE_8_7_0);
     public static final IndexVersion V_7_11_0 = def(7_11_00_99, Version.LUCENE_8_7_0);
     public static final IndexVersion V_7_12_0 = def(7_12_00_99, Version.LUCENE_8_8_0);


### PR DESCRIPTION
IndexVersions.java only had V_7_9_0 (Lucene 8.6.0) but ES 7.9.1, 7.9.2,
and 7.9.3 all shipped with Lucene 8.6.2. The floor-entry lookup used by
IndexVersion.fromId() therefore resolved any 7.9.x ID to V_7_9_0, causing
VerifyVersionConstantsIT#testLuceneVersionConstant to fail with:

  Expected: <8.6.2> but: was <8.6.0>

Add V_7_9_1 = def(7_09_01_99, "8.6.2") so the lookup returns the correct
Lucene version for ES 7.9.1+. This mirrors the existing V_8_5_3 entry that
covers the analogous Lucene patch bump in the 8.5.x release line.

Closes #139816