### PR TITLE
ESQL:DS: Fix FromDatasetIT test compilation issue

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -1080,7 +1080,9 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
             "logs_csv_gz_explicit_format",
             ".csv.gz",
             "some_ts,alpha\n",
-            Map.of("header_row", false, "format", "csv")
+            Map.of("header_row", false, "format", "csv"),
+            "col0",
+            "col1"
         );
     }
 


### PR DESCRIPTION
`FromDatasetIT#testExplicitFormatOverGzipCsvReads` was calling `assertStrictGzippedTextReads` with 4 arguments; the helper needs 6 (`tsPath`, `notePath`).
