### PR TITLE
[8.19] Fix package upgrade test readiness (#153101)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -64,13 +64,15 @@ public class PackageUpgradeTests extends PackagingTestCase {
 
         // create indexes explicitly with 0 replicas so when restarting we can reach green state
         ServerUtils.makeRequest(
-            Request.Put("http://localhost:9200/library")
+            Request.Put("http://localhost:9200/library?wait_for_active_shards=all")
                 .bodyString("{\"settings\":{\"index\":{\"number_of_replicas\":0}}}", ContentType.APPLICATION_JSON)
         );
         ServerUtils.makeRequest(
-            Request.Put("http://localhost:9200/library2")
+            Request.Put("http://localhost:9200/library2?wait_for_active_shards=all")
                 .bodyString("{\"settings\":{\"index\":{\"number_of_replicas\":0}}}", ContentType.APPLICATION_JSON)
         );
+        ServerUtils.waitForElasticsearch("green", "library", installation, null, null, null);
+        ServerUtils.waitForElasticsearch("green", "library2", installation, null, null, null);
 
         // add some docs
         ServerUtils.makeRequest(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix package upgrade test readiness (#153101)](https://github.com/elastic/elasticsearch/pull/153101)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)