### PR TITLE
[9.5] ESQL:DS: Fix ParquetTestingIT download flakiness (#153997)

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
@@ -279,9 +279,11 @@ tasks.named('javaRestTest') {
   maxParallelForks = 1
   enabled = buildParams.snapshotBuild
 
-  // Increase timeouts for S3/Parquet operations which may take longer than standard queries
-  systemProperty 'tests.rest.client_timeout', '60'
-  systemProperty 'tests.rest.socket_timeout', '60'
+  // The http datasource fetch triggered by runEsqlSync() retries transient failures against
+  // raw.githubusercontent.com with its own bounded backoff (~30s) before giving up; give the
+  // REST client enough headroom to outlast that plus real transfer time.
+  systemProperty 'tests.rest.client_timeout', '120'
+  systemProperty 'tests.rest.socket_timeout', '120'
 
   // Enable more verbose logging for debugging
   testLogging {

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTestingIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTestingIT.java
@@ -283,7 +283,12 @@ public class ParquetTestingIT extends ESRestTestCase {
             // but ESQL might handle it fine — verify ESQL doesn't error out
             logger.warn("Ground truth reader failed for {}: {} — verifying ESQL reads it OK", parquetFile, e.getMessage());
             String query = buildQuery(dataset, 100000);
-            Map<String, Object> result = runEsqlSync(requestObjectBuilder().query(query), new AssertWarnings.NoWarnings(), null);
+            Map<String, Object> result;
+            try {
+                result = runEsqlSync(requestObjectBuilder().query(query), new AssertWarnings.NoWarnings(), null);
+            } catch (IOException ioe) {
+                throw skipIfTransientFailure(ioe, "querying");
+            }
             assertNotNull("ESQL should read " + parquetFile + " despite parquet-mr failure", result.get("columns"));
             return;
         }
@@ -297,6 +302,8 @@ public class ParquetTestingIT extends ESRestTestCase {
         Map<String, Object> result;
         try {
             result = runEsqlSync(requestObjectBuilder().query(query), new AssertWarnings.NoWarnings(), null);
+        } catch (IOException e) {
+            throw skipIfTransientFailure(e, "querying");
         } catch (org.elasticsearch.xcontent.XContentParseException e) {
             // ESQL returned 200 but the response contains raw binary that isn't valid UTF-8/JSON.
             // This happens for files with raw BINARY/FIXED_LEN_BYTE_ARRAY columns without string annotation.
@@ -357,21 +364,63 @@ public class ParquetTestingIT extends ESRestTestCase {
                 Map<String, Object> result = runEsqlSync(requestObjectBuilder().query(query), new AssertWarnings.NoWarnings(), null);
                 assertNotNull("Expected " + parquetFile + " to read successfully (known readable)", result.get("columns"));
                 logger.info("Confirmed: {} is readable by ESQL despite being in bad_data/", parquetFile);
-            } catch (ResponseException ex) {
+            } catch (IOException ex) {
+                skipIfTransientFailure(ex, "testing bad data");
                 throw new AssertionError("File " + parquetFile + " is in BAD_DATA_READS_OK but returned error: " + ex.getMessage(), ex);
             }
             return;
         }
 
-        ResponseException ex = expectThrows(
-            ResponseException.class,
-            () -> runEsqlSync(requestObjectBuilder().query(query), new AssertWarnings.NoWarnings(), null)
-        );
+        // Not using expectThrows here: a transient external-host failure (client-side timeout, or a
+        // server-side 503 after the cluster exhausts its own retry budget) must be told apart from the
+        // expected 4xx client error *before* asserting on the status code below.
+        ResponseException ex;
+        try {
+            runEsqlSync(requestObjectBuilder().query(query), new AssertWarnings.NoWarnings(), null);
+            throw new AssertionError("Expected " + parquetFile + " to produce a 4xx error, but the query succeeded");
+        } catch (ResponseException e) {
+            ex = skipIfTransientFailure(e, "testing bad data");
+        } catch (IOException e) {
+            throw skipIfTransientFailure(e, "testing bad data");
+        }
         int status = ex.getResponse().getStatusLine().getStatusCode();
         assertTrue(
             "Bad data file " + parquetFile + " should produce a 4xx error but got " + status + ": " + ex.getMessage(),
             status >= 400 && status < 500
         );
+    }
+
+    /**
+     * Whether {@code failure} is an environmental symptom of {@code raw.githubusercontent.com}
+     * throttling/slowness reaching the cluster's {@code http} data source read, rather than a query or
+     * reader defect: either the REST client gave up waiting on a response (a bare transport-level
+     * {@link IOException}, e.g. {@link java.net.SocketTimeoutException}, carrying no HTTP response), or
+     * the cluster itself gave up after exhausting its own retry budget against the throttled/unavailable
+     * host (surfaced as a {@code 503} -- see {@code ExternalUnavailableException#status()} in the ESQL
+     * datasources retry layer). Mirrors the handling already applied to {@link #downloadFile} failures.
+     */
+    private static boolean isTransientExternalFailure(IOException failure) {
+        if (failure instanceof ResponseException responseException) {
+            return responseException.getResponse().getStatusLine().getStatusCode() == 503;
+        }
+        return true;
+    }
+
+    /**
+     * Skips the test via {@code assumeNoException} if {@code failure} is a
+     * {@linkplain #isTransientExternalFailure transient external-host failure} encountered while
+     * {@code action} (e.g. {@code "querying"}); {@code assumeNoException} always throws, so this
+     * method never returns normally in that case. Otherwise returns {@code failure} unchanged, so
+     * callers can either {@code throw} it to propagate as-is, or assign it (the declared type is the
+     * caller's exception type, e.g. {@link ResponseException}, so no cast is needed) to keep handling
+     * it below -- centralizing the classify-and-skip logic that would otherwise be repeated at every
+     * {@code runEsqlSync} call site in this class.
+     */
+    private <T extends IOException> T skipIfTransientFailure(T failure, String action) {
+        if (isTransientExternalFailure(failure)) {
+            assumeNoException("External host unavailable while " + action + " [" + parquetFile + "]", failure);
+        }
+        return failure;
     }
 
     // -- Ground truth generation using parquet-mr --


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL:DS: Fix ParquetTestingIT download flakiness (#153997)