### PR TITLE
[9.5] [ESQLDS] Fix Parquet inferred pushdown mis-pruning on unit/scale/sign mismatch (#153523)

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -512,6 +512,21 @@ final class ParquetPushedExpressions {
     }
 
     /**
+     * Whether {@code ptype} is {@code DECIMAL} with a nonzero scale — its on-disk value is the
+     * <b>unscaled</b> integer, not the value a declared/inferred {@code long}/{@code integer}/
+     * {@code keyword} column exposes. Pushing a raw literal against such stats compares mismatched
+     * units. {@code scale=0} is exempt: unscaled equals scaled there.
+     *
+     * <p>This only matters for <b>value</b> comparisons (EQ/ordered/IN); it must NOT gate IS
+     * NULL/IS NOT NULL dispatch, since nullability is orthogonal to scale — see the {@code value
+     * == null} carve-outs at call sites.
+     */
+    private static boolean isScaledDecimal(PrimitiveType ptype) {
+        return ptype.getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal
+            && decimal.getScale() > 0;
+    }
+
+    /**
      * Returns {@code true} when the file's physical primitive at {@code columnName} (which may be
      * a dotted path into a nested STRUCT) is {@link PrimitiveType.PrimitiveTypeName#DOUBLE}.
      */
@@ -538,7 +553,9 @@ final class ParquetPushedExpressions {
      */
     private static FilterPredicate buildLongPredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
-        if (ptype == null) {
+        // isScaledDecimal only matters for a real value comparison; IS NULL/IS NOT NULL (value ==
+        // null) doesn't care about the column's scale, so it's exempt — see buildPredicate's callers.
+        if (ptype == null || (value != null && isScaledDecimal(ptype))) {
             return null;
         }
         // A temporal-annotated column reaching a LONG predicate has a unit transform between the block value and
@@ -548,7 +565,9 @@ final class ParquetPushedExpressions {
         // unrecoverable — RECHECK guards against false positives, not against rows we never read — so decline and let
         // FilterExec apply the real semantics. Reached via a DECLARED long over a TIMESTAMP/DATE column or an
         // inferred TIME(MICROS) column; inferred datetime/date_nanos go through the unit-aware build*Predicate arms.
-        if (pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
+        // IS NULL/IS NOT NULL (value == null) is exempt: null-checks operate on the null mask only, not on the
+        // decoded value, so there is no unit mismatch to guard against.
+        if (value != null && pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
             return null;
         }
         return switch (ptype.getPrimitiveTypeName()) {
@@ -588,7 +607,7 @@ final class ParquetPushedExpressions {
         if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT32) {
             return null;
         }
-        if (pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
+        if (value != null && pushDeclinedForUnitMismatch(ptype.getLogicalTypeAnnotation())) {
             return null;
         }
         return orderedPredicate(FilterApi.intColumn(columnName), value != null ? ((Number) value).intValue() : null, op);
@@ -992,7 +1011,7 @@ final class ParquetPushedExpressions {
      */
     private static FilterPredicate translateLongIn(String columnName, List<Object> rawValues, MessageType schema) {
         PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
-        if (ptype == null) {
+        if (ptype == null || isScaledDecimal(ptype)) {
             return null;
         }
         // Same unit-mismatch decline as buildLongPredicate — a temporal physical carries a unit transform the
@@ -1001,7 +1020,17 @@ final class ParquetPushedExpressions {
             return null;
         }
         return switch (ptype.getPrimitiveTypeName()) {
-            case INT64 -> inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
+            case INT64 -> {
+                // parquet-mr's IN pruning takes ONE combined min/max over the whole set; a sign mix
+                // straddles the unsigned/signed halves and corrupts it, so decline only for a mix
+                // (same-sign sets, including all-negative, stay exact and pushable).
+                if (ParquetColumnDecoding.isUnsignedInt64(ptype)
+                    && rawValues.stream().anyMatch(v -> ((Number) v).longValue() < 0)
+                    && rawValues.stream().anyMatch(v -> ((Number) v).longValue() >= 0)) {
+                    yield null;
+                }
+                yield inPredicate(FilterApi.longColumn(columnName), rawValues, v -> ((Number) v).longValue());
+            }
             case INT32 -> {
                 List<Object> narrowed = new ArrayList<>();
                 for (Object v : rawValues) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -1645,6 +1645,50 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         assertThat(fp.toString(), containsString("score"));
     }
 
+    // A DECIMAL(scale>0) column reached via a *declared* long/integer/keyword pushed the literal
+    // against the column's *unscaled* on-disk stats (e.g. `price = 123` against stats stored as
+    // 12300 for scale=2).
+
+    public void testLongEqAgainstDecimalInt64IsNotPushed() {
+        MessageType schema = Types.buildMessage().required(INT64).as(decimalType(2, 18)).named("price").named("test");
+        Expression expr = eq("price", DataType.LONG, 123L);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        assertNull("LONG predicate against INT64+DECIMAL(scale>0) must be suppressed", pushed.toFilterPredicate(schema));
+    }
+
+    public void testLongInAgainstDecimalInt64IsNotPushed() {
+        MessageType schema = Types.buildMessage().required(INT64).as(decimalType(2, 18)).named("price").named("test");
+        Expression inExpr = new In(Source.EMPTY, attr("price", DataType.LONG), List.of(lit(123L, DataType.LONG), lit(456L, DataType.LONG)));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(inExpr));
+
+        assertNull("IN over LONG against INT64+DECIMAL(scale>0) must be suppressed", pushed.toFilterPredicate(schema));
+    }
+
+    public void testLongEqAgainstScaleZeroDecimalInt64IsPushed() {
+        // No-regression: DECIMAL(scale=0) is exempt — unscaled equals scaled, so the raw on-disk
+        // value already matches the exposed value and pushdown remains safe.
+        MessageType schema = Types.buildMessage().required(INT64).as(decimalType(0, 18)).named("price").named("test");
+        Expression expr = eq("price", DataType.LONG, 123L);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        FilterPredicate fp = pushed.toFilterPredicate(schema);
+        assertNotNull("DECIMAL(scale=0) must still push like a plain integral column", fp);
+        assertThat(fp.toString(), containsString("123"));
+    }
+
+    // Nullability is orthogonal to scale: IS NULL/IS NOT NULL over a LONG DECIMAL(scale>0)
+    // column must still push, unlike the value comparisons above.
+
+    public void testLongIsNullAgainstDecimalInt64IsPushed() {
+        MessageType schema = Types.buildMessage().required(INT64).as(decimalType(2, 18)).named("price").named("test");
+        Expression expr = new IsNull(Source.EMPTY, attr("price", DataType.LONG));
+
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull("IS NULL over LONG against INT64+DECIMAL(scale>0) must still push", fp);
+        assertThat(fp.toString(), containsString("price"));
+    }
+
     // -----------------------------------------------------------------------------------
     // esql-planning#1030: a Parquet UINT_32 column (physical INT32) widens to ESQL LONG
     // because unsigned 32-bit values can exceed signed int range. Pushing a longColumn
@@ -1818,6 +1862,49 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         MessageType schema = uint32Schema();
         Expression expr = eq("does_not_exist", DataType.LONG, 100_000L);
         assertNull(new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema));
+    }
+
+    // A UINT_64 column declared as (signed) LONG reads the raw bit pattern unflipped, but
+    // parquet-mr still orders its stats with an UNSIGNED comparator. All ordered ops must decline
+    // (signed and unsigned ordering disagree for any literal sign); only Eq/NotEq and same-sign
+    // IN sets are safe and unaffected.
+
+    private static MessageType uint64Schema() {
+        return Types.buildMessage().required(INT64).as(LogicalTypeAnnotation.intType(64, false)).named("u64").named("test");
+    }
+
+    public void testUint64DeclaredLongNegativeLiteralEqualsStillPushes() {
+        // Eq/NotEq only test raw-bit-pattern range membership — valid under either ordering.
+        MessageType schema = uint64Schema();
+        Expression expr = eq("u64", DataType.LONG, -1L);
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("eq(u64, -1)"));
+    }
+
+    public void testUint64DeclaredLongInMixedSignIsNotPushed() {
+        // A mixed-sign set straddles the sign-bit boundary and corrupts the combined min/max
+        // reasoning parquet-mr's IN pruning does over the whole set.
+        MessageType schema = uint64Schema();
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("u64", DataType.LONG),
+            List.of(lit(100_000L, DataType.LONG), lit(-1L, DataType.LONG))
+        );
+        assertNull(
+            "a mixed-sign IN set against a declared-LONG uint64 column must not be pushed",
+            new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema)
+        );
+    }
+
+    public void testUint64DeclaredLongInAllNegativeStillPushes() {
+        // All-negative (same-sign) literals don't straddle the boundary, so the combined min/max
+        // is still exact and the IN set can push normally.
+        MessageType schema = uint64Schema();
+        Expression inExpr = new In(Source.EMPTY, attr("u64", DataType.LONG), List.of(lit(-1L, DataType.LONG), lit(-2L, DataType.LONG)));
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("in(u64"));
     }
 
     // -----------------------------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ESQLDS] Fix Parquet inferred pushdown mis-pruning on unit/scale/sign mismatch (#153523)