### PR TITLE
ES|QL: reduce alloc in TimeSeriesAggregationOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -834,9 +834,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
-        // intervals may be larger than intervalsSize; only the first intervalsSize entries are valid
         int[] intervals = EMPTY_INTERVALS;
-        int intervalsSize;
 
         // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
         // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
@@ -850,17 +848,23 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
 
         void appendInterval(long lastTs, double lastValue, long firstTs, double firstValue) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            intervals = ArrayUtil.grow(intervals, intervalsSize + 1);
-            intervals[intervalsSize++] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+            // growExact is deliberate: each shard contributes at most one interval per group, so this
+            // array almost never grows beyond one or two entries. growExact avoids over-allocating
+            // capacity that would be wasted per group. TODO: benchmark in isolation and switch to
+            // grow() if real-world interval counts turn out larger than expected.
+            int currentSize = intervals.length;
+            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, DoubleBlock vs, int position) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
-            intervals = ArrayUtil.grow(intervals, intervalsSize + intervalCount);
+            int currentSize = intervals.length;
+            intervals = ArrayUtil.growExact(intervals, currentSize + intervalCount);
             for (int i = 0; i < intervalCount; i++) {
-                intervals[intervalsSize++] = firstIntervalId + i;
+                intervals[currentSize++] = firstIntervalId + i;
             }
         }
 
@@ -874,7 +878,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                 values.appendDouble(lastValue());
                 values.appendDouble(firstValue());
             } else {
-                for (int i = 0; i < intervalsSize; i++) {
+                for (int i = 0; i < intervals.length; i++) {
                     int intervalId = intervals[i];
                     timestamps.appendLong(intervalBuffer.lastTs(intervalId));
                     timestamps.appendLong(intervalBuffer.firstTs(intervalId));
@@ -887,7 +891,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
 
         public void appendDeltaValue(long timestamp, double value) {
-            assert intervalsSize == 0 : "cannot append delta data when intervals already exist";
+            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
             samples++;
             resets += value;
             deltaLastTs = Math.max(deltaLastTs, timestamp);
@@ -902,7 +906,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             if (hasDelta() == false) {
                 // Sort the intervals by the lastTs (most recent first) for the final evaluation
                 sortIntervals();
-                for (int i = 1; i < intervalsSize; i++) {
+                for (int i = 1; i < intervals.length; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
                     if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
@@ -941,7 +945,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                     intervals[j] = tmp;
                 }
 
-            }.sort(0, intervalsSize);
+            }.sort(0, intervals.length);
         }
 
         // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
@@ -964,14 +968,14 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             if (hasDelta()) {
                 return deltaFirstTs;
             }
-            return intervalBuffer.firstTs(intervals[intervalsSize - 1]);
+            return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         double firstValue() {
             if (hasDelta()) {
                 return deltaFirstValue;
             }
-            return intervalBuffer.firstValue(intervals[intervalsSize - 1]);
+            return intervalBuffer.firstValue(intervals[intervals.length - 1]);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -834,7 +834,9 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
+        // intervals may be larger than intervalsSize; only the first intervalsSize entries are valid
         int[] intervals = EMPTY_INTERVALS;
+        int intervalsSize;
 
         // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
         // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
@@ -848,19 +850,17 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
 
         void appendInterval(long lastTs, double lastValue, long firstTs, double firstValue) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+            intervals = ArrayUtil.grow(intervals, intervalsSize + 1);
+            intervals[intervalsSize++] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, DoubleBlock vs, int position) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
-            int currentSize = intervals.length;
-            intervals = ArrayUtil.growExact(intervals, currentSize + intervalCount);
+            intervals = ArrayUtil.grow(intervals, intervalsSize + intervalCount);
             for (int i = 0; i < intervalCount; i++) {
-                intervals[currentSize++] = firstIntervalId + i;
+                intervals[intervalsSize++] = firstIntervalId + i;
             }
         }
 
@@ -874,7 +874,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                 values.appendDouble(lastValue());
                 values.appendDouble(firstValue());
             } else {
-                for (int intervalId : intervals) {
+                for (int i = 0; i < intervalsSize; i++) {
+                    int intervalId = intervals[i];
                     timestamps.appendLong(intervalBuffer.lastTs(intervalId));
                     timestamps.appendLong(intervalBuffer.firstTs(intervalId));
                     values.appendDouble(intervalBuffer.lastValue(intervalId));
@@ -886,7 +887,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
 
         public void appendDeltaValue(long timestamp, double value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
+            assert intervalsSize == 0 : "cannot append delta data when intervals already exist";
             samples++;
             resets += value;
             deltaLastTs = Math.max(deltaLastTs, timestamp);
@@ -901,7 +902,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             if (hasDelta() == false) {
                 // Sort the intervals by the lastTs (most recent first) for the final evaluation
                 sortIntervals();
-                for (int i = 1; i < intervals.length; i++) {
+                for (int i = 1; i < intervalsSize; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
                     if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
@@ -940,7 +941,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                     intervals[j] = tmp;
                 }
 
-            }.sort(0, intervals.length);
+            }.sort(0, intervalsSize);
         }
 
         // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
@@ -963,14 +964,14 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             if (hasDelta()) {
                 return deltaFirstTs;
             }
-            return intervalBuffer.firstTs(intervals[intervals.length - 1]);
+            return intervalBuffer.firstTs(intervals[intervalsSize - 1]);
         }
 
         double firstValue() {
             if (hasDelta()) {
                 return deltaFirstValue;
             }
-            return intervalBuffer.firstValue(intervals[intervals.length - 1]);
+            return intervalBuffer.firstValue(intervals[intervalsSize - 1]);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -834,9 +834,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
-        // intervals may be larger than intervalsSize; only the first intervalsSize entries are valid
         int[] intervals = EMPTY_INTERVALS;
-        int intervalsSize;
 
         // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
         // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
@@ -850,17 +848,23 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
 
         void appendInterval(long lastTs, int lastValue, long firstTs, int firstValue) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            intervals = ArrayUtil.grow(intervals, intervalsSize + 1);
-            intervals[intervalsSize++] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+            // growExact is deliberate: each shard contributes at most one interval per group, so this
+            // array almost never grows beyond one or two entries. growExact avoids over-allocating
+            // capacity that would be wasted per group. TODO: benchmark in isolation and switch to
+            // grow() if real-world interval counts turn out larger than expected.
+            int currentSize = intervals.length;
+            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, IntBlock vs, int position) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
-            intervals = ArrayUtil.grow(intervals, intervalsSize + intervalCount);
+            int currentSize = intervals.length;
+            intervals = ArrayUtil.growExact(intervals, currentSize + intervalCount);
             for (int i = 0; i < intervalCount; i++) {
-                intervals[intervalsSize++] = firstIntervalId + i;
+                intervals[currentSize++] = firstIntervalId + i;
             }
         }
 
@@ -874,7 +878,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                 values.appendInt(lastValue());
                 values.appendInt(firstValue());
             } else {
-                for (int i = 0; i < intervalsSize; i++) {
+                for (int i = 0; i < intervals.length; i++) {
                     int intervalId = intervals[i];
                     timestamps.appendLong(intervalBuffer.lastTs(intervalId));
                     timestamps.appendLong(intervalBuffer.firstTs(intervalId));
@@ -887,7 +891,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
 
         public void appendDeltaValue(long timestamp, int value) {
-            assert intervalsSize == 0 : "cannot append delta data when intervals already exist";
+            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
             samples++;
             resets += value;
             deltaLastTs = Math.max(deltaLastTs, timestamp);
@@ -902,7 +906,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             if (hasDelta() == false) {
                 // Sort the intervals by the lastTs (most recent first) for the final evaluation
                 sortIntervals();
-                for (int i = 1; i < intervalsSize; i++) {
+                for (int i = 1; i < intervals.length; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
                     if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
@@ -941,7 +945,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                     intervals[j] = tmp;
                 }
 
-            }.sort(0, intervalsSize);
+            }.sort(0, intervals.length);
         }
 
         // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
@@ -964,14 +968,14 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             if (hasDelta()) {
                 return deltaFirstTs;
             }
-            return intervalBuffer.firstTs(intervals[intervalsSize - 1]);
+            return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         int firstValue() {
             if (hasDelta()) {
                 return deltaFirstValue;
             }
-            return intervalBuffer.firstValue(intervals[intervalsSize - 1]);
+            return intervalBuffer.firstValue(intervals[intervals.length - 1]);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -834,7 +834,9 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
+        // intervals may be larger than intervalsSize; only the first intervalsSize entries are valid
         int[] intervals = EMPTY_INTERVALS;
+        int intervalsSize;
 
         // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
         // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
@@ -848,19 +850,17 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
 
         void appendInterval(long lastTs, int lastValue, long firstTs, int firstValue) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+            intervals = ArrayUtil.grow(intervals, intervalsSize + 1);
+            intervals[intervalsSize++] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, IntBlock vs, int position) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
-            int currentSize = intervals.length;
-            intervals = ArrayUtil.growExact(intervals, currentSize + intervalCount);
+            intervals = ArrayUtil.grow(intervals, intervalsSize + intervalCount);
             for (int i = 0; i < intervalCount; i++) {
-                intervals[currentSize++] = firstIntervalId + i;
+                intervals[intervalsSize++] = firstIntervalId + i;
             }
         }
 
@@ -874,7 +874,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                 values.appendInt(lastValue());
                 values.appendInt(firstValue());
             } else {
-                for (int intervalId : intervals) {
+                for (int i = 0; i < intervalsSize; i++) {
+                    int intervalId = intervals[i];
                     timestamps.appendLong(intervalBuffer.lastTs(intervalId));
                     timestamps.appendLong(intervalBuffer.firstTs(intervalId));
                     values.appendInt(intervalBuffer.lastValue(intervalId));
@@ -886,7 +887,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
 
         public void appendDeltaValue(long timestamp, int value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
+            assert intervalsSize == 0 : "cannot append delta data when intervals already exist";
             samples++;
             resets += value;
             deltaLastTs = Math.max(deltaLastTs, timestamp);
@@ -901,7 +902,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             if (hasDelta() == false) {
                 // Sort the intervals by the lastTs (most recent first) for the final evaluation
                 sortIntervals();
-                for (int i = 1; i < intervals.length; i++) {
+                for (int i = 1; i < intervalsSize; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
                     if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
@@ -940,7 +941,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                     intervals[j] = tmp;
                 }
 
-            }.sort(0, intervals.length);
+            }.sort(0, intervalsSize);
         }
 
         // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
@@ -963,14 +964,14 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             if (hasDelta()) {
                 return deltaFirstTs;
             }
-            return intervalBuffer.firstTs(intervals[intervals.length - 1]);
+            return intervalBuffer.firstTs(intervals[intervalsSize - 1]);
         }
 
         int firstValue() {
             if (hasDelta()) {
                 return deltaFirstValue;
             }
-            return intervalBuffer.firstValue(intervals[intervals.length - 1]);
+            return intervalBuffer.firstValue(intervals[intervalsSize - 1]);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -834,7 +834,9 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
+        // intervals may be larger than intervalsSize; only the first intervalsSize entries are valid
         int[] intervals = EMPTY_INTERVALS;
+        int intervalsSize;
 
         // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
         // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
@@ -848,19 +850,17 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
 
         void appendInterval(long lastTs, long lastValue, long firstTs, long firstValue) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+            intervals = ArrayUtil.grow(intervals, intervalsSize + 1);
+            intervals[intervalsSize++] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, LongBlock vs, int position) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
-            int currentSize = intervals.length;
-            intervals = ArrayUtil.growExact(intervals, currentSize + intervalCount);
+            intervals = ArrayUtil.grow(intervals, intervalsSize + intervalCount);
             for (int i = 0; i < intervalCount; i++) {
-                intervals[currentSize++] = firstIntervalId + i;
+                intervals[intervalsSize++] = firstIntervalId + i;
             }
         }
 
@@ -874,7 +874,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                 values.appendLong(lastValue());
                 values.appendLong(firstValue());
             } else {
-                for (int intervalId : intervals) {
+                for (int i = 0; i < intervalsSize; i++) {
+                    int intervalId = intervals[i];
                     timestamps.appendLong(intervalBuffer.lastTs(intervalId));
                     timestamps.appendLong(intervalBuffer.firstTs(intervalId));
                     values.appendLong(intervalBuffer.lastValue(intervalId));
@@ -886,7 +887,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
 
         public void appendDeltaValue(long timestamp, long value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
+            assert intervalsSize == 0 : "cannot append delta data when intervals already exist";
             samples++;
             resets += value;
             deltaLastTs = Math.max(deltaLastTs, timestamp);
@@ -901,7 +902,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             if (hasDelta() == false) {
                 // Sort the intervals by the lastTs (most recent first) for the final evaluation
                 sortIntervals();
-                for (int i = 1; i < intervals.length; i++) {
+                for (int i = 1; i < intervalsSize; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
                     if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
@@ -940,7 +941,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                     intervals[j] = tmp;
                 }
 
-            }.sort(0, intervals.length);
+            }.sort(0, intervalsSize);
         }
 
         // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
@@ -963,14 +964,14 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             if (hasDelta()) {
                 return deltaFirstTs;
             }
-            return intervalBuffer.firstTs(intervals[intervals.length - 1]);
+            return intervalBuffer.firstTs(intervals[intervalsSize - 1]);
         }
 
         long firstValue() {
             if (hasDelta()) {
                 return deltaFirstValue;
             }
-            return intervalBuffer.firstValue(intervals[intervals.length - 1]);
+            return intervalBuffer.firstValue(intervals[intervalsSize - 1]);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -834,9 +834,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
-        // intervals may be larger than intervalsSize; only the first intervalsSize entries are valid
         int[] intervals = EMPTY_INTERVALS;
-        int intervalsSize;
 
         // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
         // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
@@ -850,17 +848,23 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
 
         void appendInterval(long lastTs, long lastValue, long firstTs, long firstValue) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            intervals = ArrayUtil.grow(intervals, intervalsSize + 1);
-            intervals[intervalsSize++] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+            // growExact is deliberate: each shard contributes at most one interval per group, so this
+            // array almost never grows beyond one or two entries. growExact avoids over-allocating
+            // capacity that would be wasted per group. TODO: benchmark in isolation and switch to
+            // grow() if real-world interval counts turn out larger than expected.
+            int currentSize = intervals.length;
+            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, LongBlock vs, int position) {
             assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
-            intervals = ArrayUtil.grow(intervals, intervalsSize + intervalCount);
+            int currentSize = intervals.length;
+            intervals = ArrayUtil.growExact(intervals, currentSize + intervalCount);
             for (int i = 0; i < intervalCount; i++) {
-                intervals[intervalsSize++] = firstIntervalId + i;
+                intervals[currentSize++] = firstIntervalId + i;
             }
         }
 
@@ -874,7 +878,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                 values.appendLong(lastValue());
                 values.appendLong(firstValue());
             } else {
-                for (int i = 0; i < intervalsSize; i++) {
+                for (int i = 0; i < intervals.length; i++) {
                     int intervalId = intervals[i];
                     timestamps.appendLong(intervalBuffer.lastTs(intervalId));
                     timestamps.appendLong(intervalBuffer.firstTs(intervalId));
@@ -887,7 +891,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
 
         public void appendDeltaValue(long timestamp, long value) {
-            assert intervalsSize == 0 : "cannot append delta data when intervals already exist";
+            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
             samples++;
             resets += value;
             deltaLastTs = Math.max(deltaLastTs, timestamp);
@@ -902,7 +906,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             if (hasDelta() == false) {
                 // Sort the intervals by the lastTs (most recent first) for the final evaluation
                 sortIntervals();
-                for (int i = 1; i < intervalsSize; i++) {
+                for (int i = 1; i < intervals.length; i++) {
                     int next = intervals[i - 1]; // reversed
                     int prev = intervals[i];
                     if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
@@ -941,7 +945,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                     intervals[j] = tmp;
                 }
 
-            }.sort(0, intervalsSize);
+            }.sort(0, intervals.length);
         }
 
         // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
@@ -964,14 +968,14 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             if (hasDelta()) {
                 return deltaFirstTs;
             }
-            return intervalBuffer.firstTs(intervals[intervalsSize - 1]);
+            return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         long firstValue() {
             if (hasDelta()) {
                 return deltaFirstValue;
             }
-            return intervalBuffer.firstValue(intervals[intervalsSize - 1]);
+            return intervalBuffer.firstValue(intervals[intervals.length - 1]);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.operator;
 
+import com.carrotsearch.hppc.LongLongHashMap;
+
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.util.BigArrays;
@@ -33,9 +35,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
@@ -540,11 +540,18 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                 nextGroupIds.fill(0, numGroups, -1);
                 prevGroupIds = driverContext.bigArrays().newIntArray(numGroups);
                 prevGroupIds.fill(0, numGroups, -1);
-                Map<Long, Long> nextTimestamps = new HashMap<>(); // cached the rounded up timestamps
+                LongLongHashMap nextTimestamps = new LongLongHashMap(); // cached the rounded up timestamps
                 for (int groupId = 0; groupId < numGroups; groupId++) {
                     long tsid = tsBlockHash.tsidForGroup(groupId);
                     long bucketTs = tsBlockHash.timestampForGroup(groupId);
-                    long nextBucketTs = nextTimestamps.computeIfAbsent(bucketTs, fastRounding::nextRoundingValue);
+                    int cacheIndex = nextTimestamps.indexOf(bucketTs);
+                    long nextBucketTs;
+                    if (cacheIndex >= 0) {
+                        nextBucketTs = nextTimestamps.indexGet(cacheIndex);
+                    } else {
+                        nextBucketTs = fastRounding.nextRoundingValue(bucketTs);
+                        nextTimestamps.put(bucketTs, nextBucketTs);
+                    }
                     int nextGroupId = Math.toIntExact(tsBlockHash.getGroupId(tsid, nextBucketTs));
                     if (nextGroupId >= 0) {
                         // https://github.com/elastic/elasticsearch/issues/152758


### PR DESCRIPTION
## What

While investigating #152770, allocation profiling showed `rate()` raw-sample buffering machinery accounts for ~40% of its total allocation. 

One thing stands out - `TimeSeriesAggregationOperator#computeAdjacentGroupIds` cache rounded bucket timestamps in a `Map<Long, Long>` (boxing). 

## Fix

Replace `HashMap<Long, Long>` with `LongLongHashMap`.

## Impact

prod build, JFR alloc prof attached, iterations_warmup: 150, iterations_measured: 300 on a query on 30K hosts

```text
TS bench-ts-30000 | STATS m = avg(rate(system.cpu.time)) BY host.name, tbucket = TBUCKET(5minute)
```

```diff
@@   |  p50 latency     | P99 latency     |  p50 cumulative bytes alloc | @@
-    | 170ms            | 197ms           | 1.40GB                      |
+    | 152ms (-10.6%)   | 162ms  (-17.8%) | 1.33GB (-5.0%)              |
```