### PR TITLE
ES|QL DS: read Parquet footer in a single GET

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -151,11 +151,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
 
     /**
-     * Bytes prefetched from the tail of a Parquet file by {@link #metadataAsync} to cover the footer
-     * in a single async read. The Parquet trailer is 8 bytes (4-byte little-endian footer length +
-     * 4-byte {@code PAR1} magic); footers for typical files fit comfortably within this window, so a
-     * single {@link StorageObject#readBytesAsync} suffices. When a footer exceeds this window a
-     * second exact-range read is issued (see {@link #metadataAsync}).
+     * Bytes prefetched from the tail of a Parquet file to cover the footer in a single read. Used by
+     * both the async metadata path ({@link #metadataAsync}) and the synchronous scan path, where
+     * {@link ParquetStorageObjectAdapter} fetches a backward-extending window of this size on a
+     * near-end-of-file read so the trailer and the footer body arrive in one GET. The Parquet trailer
+     * is 8 bytes (4-byte little-endian footer length + 4-byte {@code PAR1} magic); footers for typical
+     * files fit comfortably within this window. A footer larger than this window falls back to a
+     * second read for the remainder on both paths.
      */
     static final int FOOTER_TAIL_PREFETCH_BYTES = 64 * 1024;
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -128,7 +128,15 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         // opened before {@link #installPreWarmedChunks} (notably the one parquet-mr opens at
         // {@code ParquetFileReader.open}) must still observe a later install, otherwise the
         // pre-warm optimization would be silently bypassed.
-        return new WindowedSeekableInputStream(storageObject, cacheKey, length, windowSize, allocator, this::currentPreWarmedChunks);
+        return new WindowedSeekableInputStream(
+            storageObject,
+            cacheKey,
+            length,
+            windowSize,
+            ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES,
+            allocator,
+            this::currentPreWarmedChunks
+        );
     }
 
     private NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> currentPreWarmedChunks() {
@@ -172,6 +180,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private final FooterByteCache.Key cacheKey;
         private final long length;
         private final int windowSize;
+        private final int footerTailBytes;
         private final ArrowBuf window;
         // ArrowBuf.getBytes(inputstream) internally allocates an 8 kB buffer. To avoid it,
         // use a staging buffer filled from the InputStream then copied into {@link #window}.
@@ -196,6 +205,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             FooterByteCache.Key cacheKey,
             long length,
             int windowSize,
+            int footerTailBytes,
             BufferAllocator allocator,
             Supplier<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> preWarmedChunksSupplier
         ) {
@@ -203,6 +213,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             this.cacheKey = cacheKey;
             this.length = length;
             this.windowSize = windowSize;
+            this.footerTailBytes = footerTailBytes;
             this.window = allocator.buffer(windowSize);
             this.preWarmedChunksSupplier = preWarmedChunksSupplier;
             this.windowStart = -1;
@@ -260,11 +271,14 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             // footer-body read into a window hit instead of a second GET. The tail size matches the async
             // metadata prefetch so both paths read and cache identically shaped tails.
             long fetchStart = pos;
-            if (remaining <= ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES) {
-                long tail = Math.min(ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES, windowSize);
+            long fetchLen;
+            if (remaining <= footerTailBytes) {
+                long tail = Math.min(footerTailBytes, windowSize);
                 fetchStart = Math.max(0, length - tail);
+                fetchLen = length - fetchStart;
+            } else {
+                fetchLen = toRead;
             }
-            long fetchLen = Math.min(windowSize, length - fetchStart);
 
             FooterByteCache tailCache = FooterByteCache.getInstance();
             if (fillFromTailCache(tailCache, fetchStart, (int) fetchLen)) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -246,20 +246,38 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return;
             }
 
+            // Pre-warmed chunks are keyed to the exact requested position, so consult them before any
+            // backward tail extension. This keeps the pre-warm fast path intact for a column chunk that
+            // happens to sit within a tail window of end-of-file.
             if (fillFromPreWarmedChunk(pos, (int) toRead)) {
                 return;
             }
 
+            // Near-end-of-file read: extend the window backward to cover the file tail in a single GET.
+            // parquet-mr reads a footer by first fetching the trailing 8-byte trailer (footer length int
+            // plus magic) at length-8, then seeking back to the footer body just before it. Fetching
+            // [length-TAIL, length) on this first near-EOF read puts both in one window, turning the
+            // footer-body read into a window hit instead of a second GET. The tail size matches the async
+            // metadata prefetch so both paths read and cache identically shaped tails.
+            long fetchStart = pos;
+            if (remaining <= ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES) {
+                long tail = Math.min(ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES, windowSize);
+                fetchStart = Math.max(0, length - tail);
+            }
+            long fetchLen = Math.min(windowSize, length - fetchStart);
+
             FooterByteCache tailCache = FooterByteCache.getInstance();
-            if (fillFromTailCache(tailCache, pos, (int) toRead)) {
+            if (fillFromTailCache(tailCache, fetchStart, (int) fetchLen)) {
                 return;
             }
 
-            boolean isTailRead = pos + toRead == length;
-            if (isTailRead && toRead <= tailCache.maxEntryBytes()) {
+            boolean isTailRead = fetchStart + fetchLen == length;
+            if (isTailRead && fetchLen <= tailCache.maxEntryBytes()) {
+                final long loadStart = fetchStart;
+                final int loadLen = (int) fetchLen;
                 try {
-                    byte[] tailBytes = tailCache.getOrLoad(cacheKey, k -> readTailBytes(pos, (int) toRead));
-                    if (tailBytes.length > 0 && fillFromCachedTail(tailBytes, pos, (int) toRead)) {
+                    byte[] tailBytes = tailCache.getOrLoad(cacheKey, k -> readTailBytes(loadStart, loadLen));
+                    if (tailBytes.length > 0 && fillFromCachedTail(tailBytes, fetchStart, (int) fetchLen)) {
                         return;
                     }
                 } catch (ExecutionException e) {
@@ -270,15 +288,20 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             windowStart = -1;
             windowLength = 0;
 
-            int target = (int) toRead;
-            try (InputStream in = storageObject.newStream(pos, toRead)) {
+            int target = (int) fetchLen;
+            try (InputStream in = storageObject.newStream(fetchStart, fetchLen)) {
                 int totalRead = 0;
                 while (totalRead < target) {
                     int chunk = Math.min(STREAM_READ_CHUNK_SIZE, target - totalRead);
                     int n = in.read(streamReadBuf, 0, chunk);
                     if (n < 0) {
                         throw new IOException(
-                            "Unexpected end of stream while filling window at position " + pos + "; read " + totalRead + " of " + target
+                            "Unexpected end of stream while filling window at position "
+                                + fetchStart
+                                + "; read "
+                                + totalRead
+                                + " of "
+                                + target
                         );
                     }
                     if (n == 0 && chunk > 0) {
@@ -287,7 +310,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                     window.setBytes(totalRead, streamReadBuf, 0, n);
                     totalRead += n;
                 }
-                windowStart = pos;
+                windowStart = fetchStart;
                 windowLength = totalRead;
             }
 
@@ -322,9 +345,9 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             }
         }
 
-        private boolean fillFromTailCache(FooterByteCache tailCache, long pos, int toRead) {
+        private boolean fillFromTailCache(FooterByteCache tailCache, long fetchStart, int fetchLen) {
             byte[] cached = tailCache.get(cacheKey);
-            return cached != null && fillFromCachedTail(cached, pos, toRead);
+            return cached != null && fillFromCachedTail(cached, fetchStart, fetchLen);
         }
 
         /**
@@ -371,15 +394,15 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             return true;
         }
 
-        private boolean fillFromCachedTail(byte[] cached, long pos, int toRead) {
+        private boolean fillFromCachedTail(byte[] cached, long fetchStart, int fetchLen) {
             long cachedStart = length - cached.length;
-            if (pos >= cachedStart && pos + toRead <= length) {
-                int from = (int) (pos - cachedStart);
+            if (fetchStart >= cachedStart && fetchStart + fetchLen <= length) {
+                int from = (int) (fetchStart - cachedStart);
                 windowStart = -1;
                 windowLength = 0;
-                window.setBytes(0L, cached, from, toRead);
-                windowStart = pos;
-                windowLength = toRead;
+                window.setBytes(0L, cached, from, fetchLen);
+                windowStart = fetchStart;
+                windowLength = fetchLen;
                 return true;
             }
             return false;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -211,7 +211,11 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         ) {
             if (windowSize < footerTailBytes) {
                 throw new IllegalArgumentException(
-                    "windowSize (" + windowSize + ") must be >= footerTailBytes (" + footerTailBytes + "); "
+                    "windowSize ("
+                        + windowSize
+                        + ") must be >= footerTailBytes ("
+                        + footerTailBytes
+                        + "); "
                         + "tail extension computes fetchStart = length - min(footerTailBytes, windowSize), "
                         + "which exceeds pos when windowSize < footerTailBytes, leaving pos outside the window"
                 );

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -209,6 +209,13 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             BufferAllocator allocator,
             Supplier<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> preWarmedChunksSupplier
         ) {
+            if (windowSize < footerTailBytes) {
+                throw new IllegalArgumentException(
+                    "windowSize (" + windowSize + ") must be >= footerTailBytes (" + footerTailBytes + "); "
+                        + "tail extension computes fetchStart = length - min(footerTailBytes, windowSize), "
+                        + "which exceeds pos when windowSize < footerTailBytes, leaving pos outside the window"
+                );
+            }
             this.storageObject = storageObject;
             this.cacheKey = cacheKey;
             this.length = length;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -691,7 +692,7 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         int footerLen = ((parquetData[footerLenOffset] & 0xFF)) | ((parquetData[footerLenOffset + 1] & 0xFF) << 8)
             | ((parquetData[footerLenOffset + 2] & 0xFF) << 16) | ((parquetData[footerLenOffset + 3] & 0xFF) << 24);
         int footerStart = parquetData.length - 8 - footerLen;
-        java.util.Arrays.fill(parquetData, 4, footerStart, (byte) 0xFF);
+        Arrays.fill(parquetData, 4, footerStart, (byte) 0xFF);
 
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -60,6 +60,9 @@ public class OptimizedParquetReaderTests extends ESTestCase {
     @Before
     public void initBlockFactory() throws Exception {
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+        // Every test here reads through the same in-memory path with different content, so the JVM-wide
+        // footer/tail caches must be reset between tests to avoid one test's bytes being served to another.
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
     }
 
     public void testFormatUuidValidBytes() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -64,6 +64,20 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         ParquetStorageObjectAdapter.clearFooterCacheForTests();
     }
 
+    /**
+     * The tail-extension in fetchWindowAt computes fetchStart = length - min(footerTailBytes, windowSize).
+     * When windowSize &lt; footerTailBytes that makes fetchStart &gt; pos, leaving pos outside the window and
+     * causing an infinite ensureWindow loop. The default window size must therefore be at least as large
+     * as the footer-tail prefetch size; this test catches a bad change to either constant immediately.
+     */
+    public void testDefaultWindowSizeIsAtLeastFooterTailPrefetchBytes() {
+        assertTrue(
+            "DEFAULT_WINDOW_SIZE (" + ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + ") must be >= FOOTER_TAIL_PREFETCH_BYTES ("
+                + ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES + "); see fetchWindowAt tail-extension logic",
+            ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE >= ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES
+        );
+    }
+
     public void testNullStorageObjectThrowsException() {
         QlIllegalArgumentException e = expectThrows(
             QlIllegalArgumentException.class,

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -669,12 +670,12 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.seek(size - 8);
             byte[] trailer = new byte[8];
             stream.readFully(trailer);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8, size), trailer);
+            assertArrayEquals(Arrays.copyOfRange(data, size - 8, size), trailer);
 
             stream.seek(size - 8 - footerLength);
             byte[] footer = new byte[footerLength];
             stream.readFully(footer);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
+            assertArrayEquals(Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
         }
         assertEquals("Trailer and footer body must come from a single GET", 1, requests.size());
         // The single GET must be a backward-extending tail read, not a whole-file read: it starts within
@@ -704,17 +705,17 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.seek(size - 8);
             byte[] trailer = new byte[8];
             stream.readFully(trailer);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8, size), trailer);
+            assertArrayEquals(Arrays.copyOfRange(data, size - 8, size), trailer);
 
             stream.seek(size - 8 - footerLength);
             byte[] footer = new byte[footerLength];
             stream.readFully(footer);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
+            assertArrayEquals(Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
 
             stream.seek(0);
             byte[] head = new byte[64];
             stream.readFully(head);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, 0, 64), head);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, 64), head);
         }
         assertEquals("Small file must be read in a single GET", 1, requests.size());
         long[] request = requests.get(0);
@@ -741,12 +742,12 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.seek(size - 8);
             byte[] trailer = new byte[8];
             stream.readFully(trailer);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8, size), trailer);
+            assertArrayEquals(Arrays.copyOfRange(data, size - 8, size), trailer);
 
             stream.seek(size - 8 - footerLength);
             byte[] footer = new byte[footerLength];
             stream.readFully(footer);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
+            assertArrayEquals(Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
         }
         assertEquals("A footer larger than the tail window needs a second GET for the body", 2, rangeReadCount.get());
     }
@@ -1225,7 +1226,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         StorageObject obj2 = createCountingStorageObject(data, path, Instant.ofEpochMilli(500), rangeReadCount);
 
         int tailStart = data.length - 1024;
-        byte[] expected = java.util.Arrays.copyOfRange(data, tailStart, data.length);
+        byte[] expected = Arrays.copyOfRange(data, tailStart, data.length);
 
         ParquetStorageObjectAdapter first = new ParquetStorageObjectAdapter(obj1, allocator);
         try (SeekableInputStream s = first.newStream()) {
@@ -1299,7 +1300,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         };
 
         int tailStart = data.length - 1024;
-        byte[] expected = java.util.Arrays.copyOfRange(data, tailStart, data.length);
+        byte[] expected = Arrays.copyOfRange(data, tailStart, data.length);
         Thread[] threads = new Thread[8];
         AtomicReference<AssertionError> firstFailure = new AtomicReference<>();
 
@@ -1350,23 +1351,23 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] got = new byte[100];
             assertEquals(100, stream.read(got));
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, 0, 100), got);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, 100), got);
 
             stream.seek(1000);
             got = new byte[200];
             assertEquals(200, stream.read(got, 0, 200));
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, 1000, 1200), got);
+            assertArrayEquals(Arrays.copyOfRange(data, 1000, 1200), got);
 
             stream.seek(500);
             got = new byte[300];
             assertEquals(300, stream.read(got, 0, 300));
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, 500, 800), got);
+            assertArrayEquals(Arrays.copyOfRange(data, 500, 800), got);
 
             long endPos = data.length - 100L;
             stream.seek(endPos);
             got = new byte[100];
             stream.readFully(got);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, (int) endPos, data.length), got);
+            assertArrayEquals(Arrays.copyOfRange(data, (int) endPos, data.length), got);
 
             stream.seek(2048);
             ByteBuffer buf = ByteBuffer.allocate(64);
@@ -1374,7 +1375,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             buf.flip();
             byte[] bufBytes = new byte[64];
             buf.get(bufBytes);
-            assertArrayEquals(java.util.Arrays.copyOfRange(data, 2048, 2048 + 64), bufBytes);
+            assertArrayEquals(Arrays.copyOfRange(data, 2048, 2048 + 64), bufBytes);
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -646,8 +646,109 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.readFully(read);
         }
         assertArrayEquals(data, read);
-        // Exactly 2: one full 4 MiB window, one for the remaining 123-byte tail.
+        // Exactly 2: one full 4 MiB window, then one backward-extending tail window covering the
+        // final bytes (the near-EOF read fetches the file tail rather than only the 123 residual bytes).
         assertEquals(2, rangeReadCount[0]);
+    }
+
+    /**
+     * Mimics parquet-mr's footer access on a file larger than the tail window: read the trailing 8-byte
+     * trailer at {@code length - 8}, then seek back to the footer body just before it. Both reads must be
+     * served by a single backward-extending tail GET so the footer costs one round trip, not two.
+     */
+    public void testNearEofReadFetchesTailInSingleGet() throws IOException {
+        int size = 512 * 1024;
+        byte[] data = new byte[size];
+        randomBytes(data);
+        List<long[]> requests = new ArrayList<>();
+        StorageObject storage = createRecordingRangeReadStorageObject(data, requests);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+
+        int footerLength = 4096; // footerLength + 8 fits within the tail window
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(size - 8);
+            byte[] trailer = new byte[8];
+            stream.readFully(trailer);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8, size), trailer);
+
+            stream.seek(size - 8 - footerLength);
+            byte[] footer = new byte[footerLength];
+            stream.readFully(footer);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
+        }
+        assertEquals("Trailer and footer body must come from a single GET", 1, requests.size());
+        // The single GET must be a backward-extending tail read, not a whole-file read: it starts within
+        // the tail window and covers to end-of-file.
+        long[] request = requests.get(0);
+        assertEquals("Tail read must reach end-of-file", size, request[0] + request[1]);
+        assertTrue(
+            "Expected a tail read starting within the tail window, got position " + request[0],
+            request[0] >= size - ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES
+        );
+    }
+
+    /**
+     * A file smaller than the tail window is read whole in a single GET on the first near-EOF read, so the
+     * trailer, the footer body, and any earlier bytes are all served from one window.
+     */
+    public void testSmallFileReadWholeInSingleGet() throws IOException {
+        int size = 5000; // smaller than the 64 KiB tail window
+        byte[] data = new byte[size];
+        randomBytes(data);
+        List<long[]> requests = new ArrayList<>();
+        StorageObject storage = createRecordingRangeReadStorageObject(data, requests);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+
+        int footerLength = 1000;
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(size - 8);
+            byte[] trailer = new byte[8];
+            stream.readFully(trailer);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8, size), trailer);
+
+            stream.seek(size - 8 - footerLength);
+            byte[] footer = new byte[footerLength];
+            stream.readFully(footer);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
+
+            stream.seek(0);
+            byte[] head = new byte[64];
+            stream.readFully(head);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, 0, 64), head);
+        }
+        assertEquals("Small file must be read in a single GET", 1, requests.size());
+        long[] request = requests.get(0);
+        assertEquals("Small-file read must start at offset 0", 0, request[0]);
+        assertEquals("Small-file read must cover the whole file", size, request[1]);
+    }
+
+    /**
+     * A footer larger than the tail window keeps the two-GET fallback: the first near-EOF read fetches the
+     * tail, and the footer body that starts before the tail window triggers a second exact-range read.
+     * Correctness must hold regardless.
+     */
+    public void testLargeFooterBeyondTailUsesSecondGet() throws IOException {
+        int size = 512 * 1024;
+        byte[] data = new byte[size];
+        randomBytes(data);
+        AtomicInteger rangeReadCount = new AtomicInteger();
+        StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+
+        int footerLength = 100 * 1024; // footerLength + 8 exceeds the 64 KiB tail window
+        assertTrue(footerLength + 8 > ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES);
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.seek(size - 8);
+            byte[] trailer = new byte[8];
+            stream.readFully(trailer);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8, size), trailer);
+
+            stream.seek(size - 8 - footerLength);
+            byte[] footer = new byte[footerLength];
+            stream.readFully(footer);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, size - 8 - footerLength, size - 8), footer);
+        }
+        assertEquals("A footer larger than the tail window needs a second GET for the body", 2, rangeReadCount.get());
     }
 
     // --- Adaptive window tests ---
@@ -1566,6 +1667,48 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.readFully(result);
         }
         assertEquals("Empty map must not enable the pre-warm fast path", 1, rangeReadCount.get());
+    }
+
+    /**
+     * A range-read storage object that records each requested {@code (position, length)} pair so a test can
+     * assert not only how many range GETs happened but also their shape (e.g. that a footer read is a
+     * backward-extending tail read rather than a whole-file read).
+     */
+    private StorageObject createRecordingRangeReadStorageObject(byte[] data, List<long[]> requests) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                throw new UnsupportedOperationException("Full GET not supported in recording harness");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                requests.add(new long[] { position, length });
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.ofEpochMilli(0);
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://recording-test.parquet");
+            }
+        };
     }
 
     private StorageObject createCountingRangeReadStorageObject(byte[] data, AtomicInteger counter) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -72,8 +72,11 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
      */
     public void testDefaultWindowSizeIsAtLeastFooterTailPrefetchBytes() {
         assertTrue(
-            "DEFAULT_WINDOW_SIZE (" + ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + ") must be >= FOOTER_TAIL_PREFETCH_BYTES ("
-                + ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES + "); see fetchWindowAt tail-extension logic",
+            "DEFAULT_WINDOW_SIZE ("
+                + ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE
+                + ") must be >= FOOTER_TAIL_PREFETCH_BYTES ("
+                + ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES
+                + "); see fetchWindowAt tail-extension logic",
             ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE >= ParquetFormatReader.FOOTER_TAIL_PREFETCH_BYTES
         );
     }


### PR DESCRIPTION
Reading a Parquet footer on the synchronous scan path cost two sequential
range GETs per file: parquet-mr reads the 8-byte trailer at `length - 8`,
then seeks back to the footer body. The windowed adapter only extended its
window forward, so the trailer read fetched just 8 bytes and the body read
missed the window, forcing a second GET.

Now a near-end-of-file read (`remaining <= FOOTER_TAIL_PREFETCH_BYTES`, 64 KiB)
fetches a backward-extending tail window `[max(0, length - tail), length)` in
one GET, so the trailer and the footer body come from a single request: 2 GETs
become 1. Files smaller than the tail are read whole in one GET; footers larger
than the tail keep the existing second-GET fallback. This reuses the constant
the async metadata path already uses, so both paths read and cache identically
shaped tails. Behavior is byte-for-byte identical; only the number and shape of
range GETs change.

Also clears the JVM-wide footer cache between `OptimizedParquetReaderTests`,
which reuse one in-memory path with colliding lengths.

Closes elastic/esql-planning#1393
