### PR TITLE
Patch fix: Register change history data stream as SystemDataStreamDescriptor

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -44,13 +44,24 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     private static final List<String> KIBANA_PRODUCT_ORIGIN = List.of("kibana");
 
-    private static final String KIBANA_WORKFLOWS_ORIGIN = "kibana";
+    private static final String KIBANA_ORIGIN = "kibana";
 
     private static final String KIBANA_WORKFLOWS_VERSION_VARIABLE = "kibana.workflows.version";
 
     private static final int WORKFLOWS_EVENTS_MAPPINGS_VERSION = 3;
 
     private static final int WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION = 2;
+
+    private static final int CHANGE_HISTORY_MAPPINGS_VERSION = 3;
+
+    /** Data stream registered in {@link #changeHistorySystemDataStreamDescriptor()}. */
+    public static final String CHANGE_HISTORY_DATA_STREAM_NAME = ".kibana_change_history";
+
+    /** Composable index template resource for {@value #CHANGE_HISTORY_DATA_STREAM_NAME}. */
+    public static final String CHANGE_HISTORY_COMPOSABLE_TEMPLATE_RESOURCE = "kibana-change-history.json";
+
+    /** Substitution key for the mappings version in {@value #CHANGE_HISTORY_COMPOSABLE_TEMPLATE_RESOURCE}. */
+    public static final String CHANGE_HISTORY_VERSION_VARIABLE = "kibana.change.history.version";
 
     /** Log data stream registered in {@link #workflowsEventsSystemDataStreamDescriptor()}. */
     public static final String WORKFLOWS_EVENTS_DATA_STREAM_NAME = ".workflows-events";
@@ -83,8 +94,20 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
      */
     public static final String WORKFLOWS_SYSTEM_INDEX_PATTERN = ".workflows~(-events*|-execution-data-stream-logs*)";
 
+    /**
+     * Matches Kibana system <strong>indices</strong> under {@code .kibana_}, but not the
+     * {@linkplain SystemDataStreamDescriptor system data stream} {@value #CHANGE_HISTORY_DATA_STREAM_NAME} registered in
+     * {@link #getSystemDataStreamDescriptors()}.
+     * <p>
+     * A plain {@code .kibana_*} pattern is invalid here: it matches the change history data stream name, and
+     * {@link org.elasticsearch.indices.SystemIndices} forbids overlap between a {@link SystemIndexDescriptor} pattern and
+     * a {@link SystemDataStreamDescriptor} (see {@code checkForOverlappingPatterns}). Uses the same complement style as Fleet's
+     * {@code .fleet-actions~(-results*)}; see {@link SystemIndexDescriptor} for pattern syntax.
+     */
+    public static final String KIBANA_SYSTEM_INDEX_PATTERN = ".kibana_~(change_history*)";
+
     public static final SystemIndexDescriptor KIBANA_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
-        .setIndexPattern(".kibana_*")
+        .setIndexPattern(KIBANA_SYSTEM_INDEX_PATTERN)
         .setDescription("Kibana saved objects system index")
         .setAliasName(".kibana")
         .setType(Type.EXTERNAL_UNMANAGED)
@@ -143,14 +166,44 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     @Override
     public Collection<SystemDataStreamDescriptor> getSystemDataStreamDescriptors() {
-        return List.of(workflowsEventsSystemDataStreamDescriptor(), workflowsExecutionDataStreamLogsSystemDataStreamDescriptor());
+        return List.of(
+            workflowsEventsSystemDataStreamDescriptor(),
+            workflowsExecutionDataStreamLogsSystemDataStreamDescriptor(),
+            changeHistorySystemDataStreamDescriptor()
+        );
+    }
+
+    private static SystemDataStreamDescriptor changeHistorySystemDataStreamDescriptor() {
+        try {
+            ComposableIndexTemplate composableIndexTemplate = loadDataStreamComposableTemplate(
+                CHANGE_HISTORY_COMPOSABLE_TEMPLATE_RESOURCE,
+                Map.of(CHANGE_HISTORY_VERSION_VARIABLE, Integer.toString(CHANGE_HISTORY_MAPPINGS_VERSION))
+            );
+            return new SystemDataStreamDescriptor(
+                CHANGE_HISTORY_DATA_STREAM_NAME,
+                "Kibana saved objects change history",
+                SystemDataStreamDescriptor.Type.EXTERNAL,
+                composableIndexTemplate,
+                Map.of(),
+                KIBANA_PRODUCT_ORIGIN,
+                KIBANA_ORIGIN,
+                ExecutorNames.DEFAULT_SYSTEM_DATA_STREAM_THREAD_POOLS
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private static SystemDataStreamDescriptor workflowsEventsSystemDataStreamDescriptor() {
         try {
-            ComposableIndexTemplate composableIndexTemplate = loadWorkflowsComposableTemplate(
+            ComposableIndexTemplate composableIndexTemplate = loadDataStreamComposableTemplate(
                 WORKFLOWS_EVENTS_COMPOSABLE_TEMPLATE_RESOURCE,
-                Map.of(WORKFLOWS_EVENTS_MANAGED_INDEX_VERSION_VARIABLE, Integer.toString(WORKFLOWS_EVENTS_MAPPINGS_VERSION))
+                Map.of(
+                    KIBANA_WORKFLOWS_VERSION_VARIABLE,
+                    Version.CURRENT.toString(),
+                    WORKFLOWS_EVENTS_MANAGED_INDEX_VERSION_VARIABLE,
+                    Integer.toString(WORKFLOWS_EVENTS_MAPPINGS_VERSION)
+                )
             );
             return new SystemDataStreamDescriptor(
                 WORKFLOWS_EVENTS_DATA_STREAM_NAME,
@@ -159,7 +212,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
                 composableIndexTemplate,
                 Map.of(),
                 KIBANA_PRODUCT_ORIGIN,
-                KIBANA_WORKFLOWS_ORIGIN,
+                KIBANA_ORIGIN,
                 ExecutorNames.DEFAULT_SYSTEM_DATA_STREAM_THREAD_POOLS
             );
         } catch (IOException e) {
@@ -169,9 +222,14 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     private static SystemDataStreamDescriptor workflowsExecutionDataStreamLogsSystemDataStreamDescriptor() {
         try {
-            ComposableIndexTemplate composableIndexTemplate = loadWorkflowsComposableTemplate(
+            ComposableIndexTemplate composableIndexTemplate = loadDataStreamComposableTemplate(
                 WORKFLOWS_EXECUTION_LOGS_COMPOSABLE_TEMPLATE_RESOURCE,
-                Map.of(WORKFLOWS_EXECUTION_LOGS_MANAGED_INDEX_VERSION_VARIABLE, Integer.toString(WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION))
+                Map.of(
+                    KIBANA_WORKFLOWS_VERSION_VARIABLE,
+                    Version.CURRENT.toString(),
+                    WORKFLOWS_EXECUTION_LOGS_MANAGED_INDEX_VERSION_VARIABLE,
+                    Integer.toString(WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION)
+                )
             );
             return new SystemDataStreamDescriptor(
                 WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME,
@@ -180,7 +238,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
                 composableIndexTemplate,
                 Map.of(),
                 KIBANA_PRODUCT_ORIGIN,
-                KIBANA_WORKFLOWS_ORIGIN,
+                KIBANA_ORIGIN,
                 ExecutorNames.DEFAULT_SYSTEM_DATA_STREAM_THREAD_POOLS
             );
         } catch (IOException e) {
@@ -189,26 +247,21 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
     }
 
     /**
-     * Loads a composable template from {@code org/elasticsearch/kibana/} resources using the same {@code ${variable}}
-     * substitution rules as {@code org.elasticsearch.xpack.core.template.TemplateUtils} (Fleet built-in templates).
+     * Loads a composable template from {@code org/elasticsearch/kibana/} resources with {@code ${variable}} substitution
+     * using the same semantics as {@code org.elasticsearch.xpack.core.template.TemplateUtils}.
      * <p>
      * Templates live in this module (not {@code x-pack} template-resources) so {@code org.elasticsearch.kibana} does not
      * {@code require org.elasticsearch.xcore}. That {@code requires} breaks JPMS plugin layer resolution: the kibana module
      * resolves in a layer where {@code org.elasticsearch.xcore} is not on the module path (see {@code PluginsLoader}).
      */
-    private static ComposableIndexTemplate loadWorkflowsComposableTemplate(String resourceFileName, Map<String, String> variables)
+    private static ComposableIndexTemplate loadDataStreamComposableTemplate(String resourceFileName, Map<String, String> variables)
         throws IOException {
         try (InputStream in = KibanaPlugin.class.getResourceAsStream(resourceFileName)) {
             if (in == null) {
-                throw new IOException("missing workflows template resource [" + resourceFileName + "]");
+                throw new IOException("missing composable template resource [" + resourceFileName + "]");
             }
             String raw = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-            String source = substituteWorkflowsTemplateVariables(
-                raw,
-                KIBANA_WORKFLOWS_VERSION_VARIABLE,
-                Version.CURRENT.toString(),
-                variables
-            );
+            String source = substituteTemplateVariables(raw, variables);
             try (
                 var parser = JsonXContent.jsonXContent.createParser(
                     XContentParserConfiguration.EMPTY,
@@ -221,20 +274,15 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
     }
 
     /** Same substitution semantics as {@code TemplateUtils.replaceVariables}. */
-    private static String substituteWorkflowsTemplateVariables(
-        String input,
-        String versionProperty,
-        String version,
-        Map<String, String> variables
-    ) {
-        String template = replaceWorkflowsTemplateVariable(input, versionProperty, version);
+    private static String substituteTemplateVariables(String input, Map<String, String> variables) {
+        String template = input;
         for (Map.Entry<String, String> variable : variables.entrySet()) {
-            template = replaceWorkflowsTemplateVariable(template, variable.getKey(), variable.getValue());
+            template = replaceTemplateVariable(template, variable.getKey(), variable.getValue());
         }
         return template;
     }
 
-    private static String replaceWorkflowsTemplateVariable(String input, String variable, String value) {
+    private static String replaceTemplateVariable(String input, String variable, String value) {
         return input.replace("${" + variable + "}", value);
     }
 

--- a/modules/kibana/src/main/resources/org/elasticsearch/kibana/kibana-change-history.json
+++ b/modules/kibana/src/main/resources/org/elasticsearch/kibana/kibana-change-history.json
@@ -1,0 +1,101 @@
+{
+  "index_patterns": [
+    ".kibana_change_history*"
+  ],
+  "data_stream": {
+    "allow_custom_routing": false
+  },
+  "template": {
+    "lifecycle": {
+      "enabled": true
+    },
+    "settings": {
+      "index.auto_expand_replicas": "0-1",
+      "index.hidden": true
+    },
+    "mappings": {
+      "_meta": {
+        "version": ${kibana.change.history.version}
+      },
+      "dynamic": false,
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "user": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "module": {
+              "type": "keyword"
+            },
+            "dataset": {
+              "type": "keyword"
+            },
+            "action": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            }
+          }
+        },
+        "span": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "object": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "sequence": {
+              "type": "long"
+            }
+          }
+        },
+        "tags": {
+          "type": "keyword"
+        },
+        "metadata": {
+          "type": "flattened"
+        },
+        "kibana": {
+          "properties": {
+            "space_ids": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "service": {
+          "properties": {
+            "version": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  },
+  "composed_of": [],
+  "priority": 100,
+  "version": 3
+}

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -25,7 +25,7 @@ public class KibanaPluginTests extends ESTestCase {
         assertThat(
             new KibanaPlugin().getSystemIndexDescriptors(Settings.EMPTY).stream().map(SystemIndexDescriptor::getIndexPattern).toList(),
             contains(
-                ".kibana_*",
+                KibanaPlugin.KIBANA_SYSTEM_INDEX_PATTERN,
                 ".reporting-*",
                 ".chat-*",
                 KibanaPlugin.WORKFLOWS_SYSTEM_INDEX_PATTERN,
@@ -35,22 +35,36 @@ public class KibanaPluginTests extends ESTestCase {
         );
     }
 
-    public void testWorkflowsDataStreamsRegistered() {
+    public void testKibanaDataStreamsRegistered() {
         assertThat(
             new KibanaPlugin().getSystemDataStreamDescriptors().stream().map(SystemDataStreamDescriptor::getDataStreamName).toList(),
-            contains(KibanaPlugin.WORKFLOWS_EVENTS_DATA_STREAM_NAME, KibanaPlugin.WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME)
+            contains(
+                KibanaPlugin.WORKFLOWS_EVENTS_DATA_STREAM_NAME,
+                KibanaPlugin.WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME,
+                KibanaPlugin.CHANGE_HISTORY_DATA_STREAM_NAME
+            )
         );
     }
 
-    public void testNoSystemIndexPatternCoversWorkflowsDataStreams() {
+    public void testNoSystemIndexPatternCoversRegisteredDataStreams() {
         var indexDescriptors = new KibanaPlugin().getSystemIndexDescriptors(Settings.EMPTY);
         assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".workflows-events")));
         assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".workflows-execution-data-stream-logs")));
+        assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".kibana_change_history")));
+        assertFalse(indexDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".kibana_change_history-000001")));
     }
 
     public void testWorkflowsSystemIndexDescriptorCoversOtherWorkflowsIndices() {
         assertTrue(KibanaPlugin.WORKFLOWS_INDEX_DESCRIPTOR.matchesIndexPattern(".workflows-internal"));
         assertTrue(KibanaPlugin.WORKFLOWS_INDEX_DESCRIPTOR.matchesIndexPattern(".workflows-state"));
+    }
+
+    public void testKibanaSystemIndexDescriptorStillCoversKibanaSavedObjects() {
+        assertTrue(KibanaPlugin.KIBANA_INDEX_DESCRIPTOR.matchesIndexPattern(".kibana_1"));
+        assertTrue(KibanaPlugin.KIBANA_INDEX_DESCRIPTOR.matchesIndexPattern(".kibana_alerting_cases"));
+        assertTrue(KibanaPlugin.KIBANA_INDEX_DESCRIPTOR.matchesIndexPattern(".kibana_task_manager_8.0.0_001"));
+        assertFalse(KibanaPlugin.KIBANA_INDEX_DESCRIPTOR.matchesIndexPattern(".kibana_change_history"));
+        assertFalse(KibanaPlugin.KIBANA_INDEX_DESCRIPTOR.matchesIndexPattern(".kibana_change_history-2026.07.16-000001"));
     }
 
     public void testKibanaFeaturePassesSystemIndicesOverlapChecks() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -190,7 +190,9 @@ public class InternalUsers {
                         // System data streams for storing uploaded file data for Agent diagnostics and Endpoint response actions
                         ".fleet-fileds*",
                         // System data stream for kibana workflows
-                        ".workflows*"
+                        ".workflows*",
+                        // System data stream for kibana saved objects change history
+                        ".kibana_change_history*"
                     )
                     .privileges(
                         filterNonNull(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -264,7 +264,12 @@ public class InternalUsersTests extends ESTestCase {
         );
         checkClusterAccess(InternalUsers.DATA_STREAM_LIFECYCLE_USER, role, randomFrom(sampleClusterActions), true);
 
-        final List<String> allowedSystemDataStreams = Arrays.asList(".fleet-actions-results", ".fleet-fileds*", ".workflows*");
+        final List<String> allowedSystemDataStreams = Arrays.asList(
+            ".fleet-actions-results",
+            ".fleet-fileds*",
+            ".workflows*",
+            ".kibana_change_history*"
+        );
         for (var group : role.indices().groups()) {
             if (group.allowRestrictedIndices()) {
                 assertThat(group.indices(), arrayContaining(allowedSystemDataStreams.toArray(new String[0])));


### PR DESCRIPTION
Cherrypicks the commit from https://github.com/elastic/elasticsearch/pull/154113 onto patch/serverless-fix for a serverless patch release.

From https://github.com/elastic/elasticsearch/pull/154113:

Registers Kibana's .kibana_change_history data stream as a SystemDataStreamDescriptor in KibanaPlugin, so it is a first-class system data stream on serverless. Tightens the previously broad .kibana_* SystemIndexDescriptor with a complement pattern (.kibana_~(change_history*)) so the two descriptors do not overlap (SystemIndices#checkForOverlappingPatterns).

