### PR TITLE
Fixing ReplicationTracker behavior when a replica recovery is cancelled

### DIFF
--- a/docs/changelog/154195.yaml
+++ b/docs/changelog/154195.yaml
@@ -1,0 +1,6 @@
+area: Recovery
+issues:
+ - 153497
+pr: 154195
+summary: Fixing `ReplicationTracker` behavior when a replica recovery is cancelled
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -490,9 +490,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/153434
-- class: org.elasticsearch.xpack.monitoring.MultiNodesStatsTests
-  method: testMultipleNodes
-  issue: https://github.com/elastic/elasticsearch/issues/153497
 - class: org.elasticsearch.xpack.transform.checkpoint.TransformGetCheckpointIT
   method: testGetCheckpointTimeoutExceeded
   issue: https://github.com/elastic/elasticsearch/issues/150934

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1279,7 +1279,15 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
                     }
                 }
             } finally {
-                pendingInSync.remove(allocationId);
+                /*
+                 * If the allocation ID is still in pendingInSync when we get here, then we did not complete normally. We bailed out of the
+                 * thread running waitForLocalCheckpointToAdvance(), likely because the recovery was cancelled and the thread was
+                 * interrupted before updateLocalCheckpoint() completed. So we need to recompute the global checkpoint to avoid problems,
+                 * including an assertion in the invariant() method.
+                 */
+                if (pendingInSync.remove(allocationId)) {
+                    updateGlobalCheckpointOnPrimary();
+                }
             }
         } else {
             cps.inSync = true;

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
@@ -706,6 +706,59 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         assertThat(tracker.getGlobalCheckpoint(), equalTo((long) nextActiveLocalCheckpoint));
     }
 
+    /**
+     * Mirrors {@link #testRaceUpdatingGlobalCheckpoint} for the case where the thread marking an allocation ID as in-sync is
+     * interrupted (as happens when a peer recovery is cancelled) while it is still pending in-sync and blocking global checkpoint
+     * advancement. Removing the allocation ID from the pending set on the way out unblocks advancement, so the global checkpoint
+     * must be recomputed; otherwise it is left stale and an assertion in {@link ReplicationTracker} is violated on the next operation
+     * with a "global checkpoint is not up-to-date" assertion error.
+     */
+    public void testGlobalCheckpointUpdateAfterInterruptedMarkAsInSync() throws Exception {
+        final AllocationId active = AllocationId.newInitializing();
+        final AllocationId initializing = AllocationId.newInitializing();
+
+        final long activeLocalCheckpoint = randomIntBetween(1, 1024);
+        final ReplicationTracker tracker = newTracker(active);
+        tracker.updateFromMaster(
+            randomNonNegativeLong(),
+            Collections.singleton(active.getId()),
+            routingTable(Collections.singleton(initializing), active)
+        );
+        tracker.activatePrimaryMode(activeLocalCheckpoint);
+        addPeerRecoveryRetentionLease(tracker, initializing);
+        tracker.initiateTracking(initializing.getId());
+
+        // Mark the initializing shard as in-sync with a local checkpoint below the global checkpoint on a separate thread. This
+        // adds it to the pending-in-sync set and blocks the thread waiting for its local checkpoint to advance.
+        final long initializingLocalCheckpoint = randomLongBetween(NO_OPS_PERFORMED, activeLocalCheckpoint - 1);
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        final Thread markingThread = new Thread(() -> {
+            try {
+                tracker.markAllocationIdAsInSync(initializing.getId(), initializingLocalCheckpoint);
+            } catch (final InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+        markingThread.start();
+
+        assertBusy(() -> assertTrue(tracker.pendingInSync.contains(initializing.getId())));
+
+        // Advance the active (in-sync) shard's local checkpoint. The global checkpoint cannot advance yet because the initializing
+        // shard is still pending in-sync and blocks advancement.
+        final long nextActiveLocalCheckpoint = randomLongBetween(activeLocalCheckpoint + 1, Integer.MAX_VALUE);
+        tracker.updateLocalCheckpoint(active.getId(), nextActiveLocalCheckpoint);
+        assertThat(tracker.getGlobalCheckpoint(), equalTo(activeLocalCheckpoint));
+
+        // Interrupt the marking thread while it is still pending in-sync, simulating a cancelled peer recovery. Removing the
+        // initializing shard from the pending set unblocks advancement, so the global checkpoint must now reflect the advanced
+        // local checkpoint of the sole remaining in-sync shard.
+        markingThread.interrupt();
+        markingThread.join();
+        assertTrue(interrupted.get());
+
+        assertThat(tracker.getGlobalCheckpoint(), equalTo(nextActiveLocalCheckpoint));
+    }
+
     public void testPrimaryContextHandoff() throws IOException {
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
         final ShardId shardId = new ShardId("test", "_na_", 0);


### PR DESCRIPTION
This fixes a minor bug that can happen if a recovery is cancelled. When that happens, it can cause the thread running ReplicationTracker.updateLocalCheckpoint() to get interrupted before it calls pendingInSync.remove(allocationId) and updateGlobalCheckpointOnPrimary(), and the wait in ReplicationTracker.waitForLocalCheckpointToAdvance() to throw an InterruptedException. In the finally block in waitForLocalCheckpointToAdvance(), we clean up by removing allocationId from pendingInSync, but we don't also recompute the global checkpoint. This leaves us in a state where the invariant() method will throw a `global checkpoint is not up-to-date` assertion. This does not cause problems in production because assertions are off, and the global checkpoint is recomputed later.
Closes #153497