### PR TITLE
[9.5] Fix reindex relocation failing with basic auth (#154133)

### DIFF
--- a/docs/changelog/154133.yaml
+++ b/docs/changelog/154133.yaml
@@ -1,0 +1,6 @@
+area: Reindex
+issues:
+ - 154103
+pr: 154133
+summary: Fix reindex relocation failing with basic auth
+type: bug

--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -66,7 +66,7 @@ public enum Releasables {
         }
     }
 
-    /** Release the provided {@link Releasable} expecting no exception to by thrown. */
+    /** Release the provided {@link Releasable} expecting no exception to be thrown. */
     public static void closeExpectNoException(@Nullable Releasable releasable) {
         try {
             close(releasable);

--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexRelocationIT.java
@@ -269,17 +269,25 @@ public class ReindexRelocationIT extends ESIntegTestCase {
         capturedSearchSlices.forEach(slice -> assertThat(slice.getField(), equalTo("num")));
     }
 
-    public void testNonSlicedRemoteReindexRelocation() throws Exception {
+    public void testNonSlicedRemoteReindexRelocationWithoutAuth() throws Exception {
+        testNonSlicedRemoteReindexRelocationWithBasicAuth(false);
+    }
+
+    public void testNonSlicedRemoteReindexRelocationWithBasicAuth() throws Exception {
+        testNonSlicedRemoteReindexRelocationWithBasicAuth(true);
+    }
+    // no test for remote sliced reindex since it's not allowed
+
+    private void testNonSlicedRemoteReindexRelocationWithBasicAuth(final boolean basicAuthEnabled) throws Exception {
         final int slices = 1;
         testReindexRelocation((nodeAName, nodeBName) -> {
             final InetSocketAddress nodeAAddress = internalCluster().getInstance(HttpServerTransport.class, nodeAName)
                 .boundAddress()
                 .publishAddress()
                 .address();
-            return List.of(startAsyncNonSlicedThrottledRemoteReindexOnNode(nodeBName, nodeAAddress));
+            return List.of(startAsyncNonSlicedThrottledRemoteReindexOnNodeWithBasicAuthEnabled(nodeBName, nodeAAddress, basicAuthEnabled));
         }, remoteReindexDescription(), slices, true, randomIntBetween(1, 4));
     }
-    // no test for remote sliced reindex since it's not allowed
 
     /// Performs a reindex task. The `startReindexGivenNodeAAndB` parameter must do one of:
     /// - start a single non-sliced reindex and return its task ID;
@@ -928,28 +936,45 @@ public class ReindexRelocationIT extends ESIntegTestCase {
         return taskIds;
     }
 
-    private TaskId startAsyncNonSlicedThrottledRemoteReindexOnNode(final String nodeName, final InetSocketAddress remoteAddress)
-        throws Exception {
+    private TaskId startAsyncNonSlicedThrottledRemoteReindexOnNodeWithBasicAuthEnabled(
+        final String nodeName,
+        final InetSocketAddress remoteAddress,
+        final boolean basicAuthEnabled
+    ) throws Exception {
         try (RestClient restClient = createRestClient(nodeName)) {
             final Request request = new Request("POST", "/_reindex");
             request.addParameter("wait_for_completion", "false");
             request.addParameter("slices", Integer.toString(1));
             request.addParameter("requests_per_second", Integer.toString(requestsPerSecond));
-            request.setJsonEntity(Strings.format("""
-                {
-                  "source": {
-                    "remote": {
-                      "host": "http://%s:%d"
-                    },
-                    "index": "%s",
-                    "size": %d
-                  },
-                  "dest": {
-                    "index": "%s"
-                  }
-                }
-                """, InetAddresses.toUriString(remoteAddress.getAddress()), remoteAddress.getPort(), SOURCE_INDEX, bulkSize, DEST_INDEX));
-
+            final String credentials = basicAuthEnabled ? """
+                ,
+                      "username": "elastic",
+                      "password": "password"\
+                """ : "";
+            request.setJsonEntity(
+                Strings.format(
+                    """
+                        {
+                          "source": {
+                            "remote": {
+                              "host": "http://%s:%d"%s
+                            },
+                            "index": "%s",
+                            "size": %d
+                          },
+                          "dest": {
+                            "index": "%s"
+                          }
+                        }
+                        """,
+                    InetAddresses.toUriString(remoteAddress.getAddress()),
+                    remoteAddress.getPort(),
+                    credentials,
+                    SOURCE_INDEX,
+                    bulkSize,
+                    DEST_INDEX
+                )
+            );
             final Response response = restClient.performRequest(request);
             final String task = (String) ESRestTestCase.entityAsMap(response).get("task");
             assertNotNull("reindex did not return a task id", task);

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -187,21 +187,22 @@ public class Reindexer {
     }
 
     public void execute(
-        BulkByPaginatedSearchTask task,
-        ReindexRequest request,
-        Client bulkClient,
-        ActionListener<BulkByPaginatedSearchResponse> listener
+        final BulkByPaginatedSearchTask task,
+        final ReindexRequest request,
+        final Client bulkClient,
+        final ActionListener<BulkByPaginatedSearchResponse> listener
     ) {
+        final var closeRemoteInfoListener = ActionListener.releaseAfter(listener, request.getRemoteInfo()); // null-safe
         final ResumeInfo resumeInfo = request.getResumeInfo().orElse(null);
         if (resumeInfo != null && resumeInfo.sourceTaskResult() != null) {
             // source task result should be present for top-level tasks only (e.g. leader or non-sliced worker)
             storeRelocationSourceTaskResult(
                 task,
                 resumeInfo,
-                ActionListener.wrap(v -> doExecute(task, request, bulkClient, listener), listener::onFailure)
+                ActionListener.wrap(v -> doExecute(task, request, bulkClient, closeRemoteInfoListener), closeRemoteInfoListener::onFailure)
             );
         } else {
-            doExecute(task, request, bulkClient, listener);
+            doExecute(task, request, bulkClient, closeRemoteInfoListener);
         }
     }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSource.java
@@ -176,7 +176,6 @@ public class RemotePitPaginatedHitSource extends PitPaginatedHitSource {
             try {
                 client.close();
                 logger.debug("Shut down remote connection");
-                remote.close();
             } catch (IOException e) {
                 logger.error("Failed to shutdown the remote connection", e);
             } finally {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSource.java
@@ -222,7 +222,6 @@ public class RemoteScrollablePaginatedHitSource extends ScrollablePaginatedHitSo
             try {
                 client.close();
                 logger.debug("Shut down remote connection");
-                remote.close();
             } catch (IOException e) {
                 logger.error("Failed to shutdown the remote connection", e);
             } finally {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
@@ -1154,6 +1155,63 @@ public class ReindexerTests extends ESTestCase {
             runRemotePitTestWithMockServer(server, request -> request.setMaxRetries(0), initFuture -> {
                 ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, initFuture::actionGet);
                 assertThat(e.status(), equalTo(INTERNAL_SERVER_ERROR));
+            });
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * The {@link RemoteInfo} credentials are owned by {@link Reindexer}, not the hit sources, and are zeroed exactly once when the
+     * operation terminates normally. This guards the contract that hit sources no longer close the credentials (they must survive a
+     * relocation handoff serialization).
+     */
+    @SuppressForbidden(reason = "use http server for testing")
+    public void testRemoteReindexClosesRemoteInfoOnNormalCompletion() throws Exception {
+        HttpServer server = createRemotePitMockServer((path, method) -> false, exchange -> {});
+        server.start();
+        final SecureString password = new SecureString(randomAlphaOfLength(12).toCharArray());
+        try {
+            runRemotePitTestWithMockServer(
+                server,
+                request -> request.setRemoteInfo(remoteInfoWithPassword(server, password)),
+                initFuture -> {
+                    assertNotNull(initFuture.actionGet());
+                    assertThat(
+                        expectThrows(IllegalStateException.class, password::getChars).getMessage(),
+                        containsString("SecureString has already been closed")
+                    );
+                }
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * When a remote reindex fails before any hit source is built (here the version lookup returns 500), {@link Reindexer} still zeroes
+     * the {@link RemoteInfo} credentials via its terminal listener. This guards against the latent credential leak on the early-failure
+     * path, where previously only a built hit source would have closed them.
+     */
+    @SuppressForbidden(reason = "use http server for testing")
+    public void testRemoteReindexClosesRemoteInfoOnEarlyFailure() throws Exception {
+        HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(INTERNAL_SERVER_ERROR.getStatus(), -1);
+            exchange.close();
+        });
+        server.start();
+        final SecureString password = new SecureString(randomAlphaOfLength(12).toCharArray());
+        try {
+            runRemotePitTestWithMockServer(server, request -> {
+                request.setMaxRetries(0);
+                request.setRemoteInfo(remoteInfoWithPassword(server, password));
+            }, initFuture -> {
+                expectThrows(ElasticsearchStatusException.class, initFuture::actionGet);
+                assertThat(
+                    expectThrows(IllegalStateException.class, password::getChars).getMessage(),
+                    containsString("SecureString has already been closed")
+                );
             });
         } finally {
             server.stop(0);
@@ -2947,6 +3005,26 @@ public class ReindexerTests extends ESTestCase {
         try (OutputStream out = exchange.getResponseBody()) {
             out.write(body);
         }
+    }
+
+    /**
+     * Builds a {@link RemoteInfo} pointing at {@code server} that carries a password-bearing {@link SecureString}, so tests can assert
+     * the credential's lifecycle (owned and closed by {@link Reindexer}).
+     */
+    @SuppressForbidden(reason = "use http server for testing")
+    private static RemoteInfo remoteInfoWithPassword(HttpServer server, SecureString password) {
+        return new RemoteInfo(
+            "http",
+            server.getAddress().getHostString(),
+            server.getAddress().getPort(),
+            null,
+            new BytesArray("{\"match_all\":{}}"),
+            randomAlphaOfLength(8),
+            password,
+            emptyMap(),
+            TimeValue.timeValueSeconds(5),
+            TimeValue.timeValueSeconds(5)
+        );
     }
 
     /**

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemotePitPaginatedHitSourceTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -343,7 +344,7 @@ public class RemotePitPaginatedHitSourceTests extends ESTestCase {
         assertTrue(called.get());
     }
 
-    /** Verifies cleanup closes the RestClient and RemoteInfo. */
+    /** Verifies cleanup closes the RestClient. */
     public void testCleanupSuccessful() throws Exception {
         AtomicBoolean cleanupCallbackCalled = new AtomicBoolean();
         RestClient client = mock(RestClient.class);
@@ -392,6 +393,52 @@ public class RemotePitPaginatedHitSourceTests extends ESTestCase {
         hitSource.cleanup(() -> cleanupCallbackCalled.set(true));
         verify(client).close();
         assertTrue(cleanupCallbackCalled.get());
+    }
+
+    /**
+     * Verifies cleanup closes the (search-scoped) RestClient but does not close the (request-scoped) RemoteInfo credentials. Ownership of
+     * the RemoteInfo lifecycle belongs to {@code Reindexer}, so the credentials must remain usable after cleanup (they need to survive a
+     * relocation handoff serialization).
+     */
+    public void testCleanupDoesNotCloseRemoteInfoCredentials() throws Exception {
+        AtomicBoolean cleanupCallbackCalled = new AtomicBoolean();
+        RestClient client = mock(RestClient.class);
+        SecureString password = new SecureString(randomAlphaOfLength(12).toCharArray());
+        RemoteInfo remoteInfo = new RemoteInfo(
+            "http",
+            randomAlphaOfLength(8),
+            randomIntBetween(4000, 9000),
+            null,
+            new BytesArray("{}"),
+            randomAlphaOfLength(8),
+            password,
+            Map.of(),
+            TimeValue.timeValueSeconds(randomIntBetween(5, 30)),
+            TimeValue.timeValueSeconds(randomIntBetween(5, 30))
+        );
+        try {
+            RemotePitPaginatedHitSource hitSource = new RemotePitPaginatedHitSource(
+                logger,
+                BackoffPolicy.constantBackoff(TimeValue.ZERO, 0),
+                threadPool,
+                Assert::fail,
+                r -> fail(),
+                e -> fail(),
+                client,
+                remoteInfo,
+                searchRequest,
+                Version.CURRENT,
+                keepaliveDeadline(),
+                new NoopCircuitBreaker(CircuitBreaker.REQUEST),
+                1024L
+            );
+            hitSource.cleanup(() -> cleanupCallbackCalled.set(true));
+            verify(client).close();
+            assertTrue(cleanupCallbackCalled.get());
+            assertArrayEquals(password.getChars(), remoteInfo.getPassword().getChars());
+        } finally {
+            remoteInfo.close();
+        }
     }
 
     /** Verifies getPitId returns the PIT ID from the response after doFirstSearch. */

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollablePaginatedHitSourceTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -451,6 +452,38 @@ public class RemoteScrollablePaginatedHitSourceTests extends ESTestCase {
         paginatedHitSource.cleanup(() -> cleanupCallbackCalled.set(true));
         verify(client).close();
         assertTrue(cleanupCallbackCalled.get());
+    }
+
+    /**
+     * Verifies cleanup and close shut down the (search-scoped) RestClient but do not close the (request-scoped) RemoteInfo credentials.
+     * Ownership of the RemoteInfo lifecycle belongs to {@code Reindexer}, so the credentials must remain usable afterwards (they need to
+     * survive a relocation handoff serialization).
+     */
+    public void testCleanupDoesNotCloseRemoteInfoCredentials() throws Exception {
+        RestClient client = mock(RestClient.class);
+        SecureString password = new SecureString(randomAlphaOfLength(12).toCharArray());
+        RemoteInfo remoteInfo = new RemoteInfo(
+            "http",
+            randomAlphaOfLength(8),
+            randomIntBetween(4000, 9000),
+            null,
+            new BytesArray("{}"),
+            randomAlphaOfLength(8),
+            password,
+            Map.of(),
+            TimeValue.timeValueSeconds(randomIntBetween(5, 30)),
+            TimeValue.timeValueSeconds(randomIntBetween(5, 30))
+        );
+        try {
+            TestRemoteScrollablePaginatedHitSource paginatedHitSource = new TestRemoteScrollablePaginatedHitSource(client, remoteInfo);
+            AtomicBoolean closeCallbackCalled = new AtomicBoolean();
+            paginatedHitSource.close(() -> closeCallbackCalled.set(true));
+            assertTrue(closeCallbackCalled.get());
+            verify(client).close();
+            assertArrayEquals(password.getChars(), remoteInfo.getPassword().getChars());
+        } finally {
+            remoteInfo.close();
+        }
     }
 
     /** When scroll ID is empty or null, close runs cleanup immediately without calling clearScroll. */

--- a/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -28,7 +29,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -38,7 +38,7 @@ import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
-public class RemoteInfo implements Writeable, ToXContentObject, Closeable {
+public class RemoteInfo implements Writeable, ToXContentObject, Releasable {
     /**
      * Default {@link #socketTimeout} for requests that don't have one set.
      */
@@ -132,7 +132,7 @@ public class RemoteInfo implements Writeable, ToXContentObject, Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (password != null) {
             password.close();
         }

--- a/server/src/test/java/org/elasticsearch/index/reindex/RemoteInfoWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/RemoteInfoWireSerializingTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static org.elasticsearch.index.reindex.BulkByPaginatedSearchWireSerializingTestUtils.matchAllQueryBytes;
@@ -204,10 +203,6 @@ public class RemoteInfoWireSerializingTests extends AbstractWireSerializingTestC
      */
     @Override
     protected void dispose(RemoteInfo remoteInfo) {
-        try {
-            remoteInfo.close();
-        } catch (IOException ioException) {
-            throw new UncheckedIOException(ioException);
-        }
+        remoteInfo.close();
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix reindex relocation failing with basic auth (#154133)