### PR TITLE
[9.5] Fix non-compiling test (#154159)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -1064,7 +1064,9 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
             "logs_csv_gz_explicit_format",
             ".csv.gz",
             "some_ts,alpha\n",
-            Map.of("header_row", false, "format", "csv")
+            Map.of("header_row", false, "format", "csv"),
+            "col0",
+            "col1"
         );
     }
 


### PR DESCRIPTION
`FromDatasetIT#testExplicitFormatOverGzipCsvReads` was calling `assertStrictGzippedTextReads` with 4 arguments; the helper needs 6 (`tsPath`, `notePath`).

(cherry picked from commit fbf0df8b62b001f58c0e834b4c98aefee9e1ff7d)
