### PR TITLE
[9.5] Unmute msearch test and potentially expose failure (#154188)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/10_basic.yml
@@ -4,6 +4,12 @@ setup:
       test_runner_features: allowed_warnings
 
   - do:
+      cluster.put_settings:
+        body:
+          transient:
+            search.default_allow_partial_results: false
+
+  - do:
       index:
           index:  index_1
           id:     "1"
@@ -29,6 +35,14 @@ setup:
 
   - do:
       indices.refresh: {}
+
+---
+teardown:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            search.default_allow_partial_results: null
 
 ---
 "Basic multi-search":


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Unmute msearch test and potentially expose failure (#154188)](https://github.com/elastic/elasticsearch/pull/154188)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)