### PR TITLE
[8.19] fix and unmute test (#154110)

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -83,7 +84,16 @@ public class RemoteClusterServiceTests extends ESTestCase {
         final TransportVersion transportVersion,
         final Settings settings
     ) {
-        return RemoteClusterConnectionTests.startTransport(id, knownNodes, version, transportVersion, threadPool, settings);
+        final MockTransportService transportService = RemoteClusterConnectionTests.startTransport(
+            id,
+            knownNodes,
+            version,
+            transportVersion,
+            threadPool,
+            settings
+        );
+        transportService.getTaskManager().setTaskCancellationService(new TaskCancellationService(transportService));
+        return transportService;
     }
 
     public void testSettingsAreRegistered() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.3` to `8.19`:
 - [fix and unmute test (#154110)](https://github.com/elastic/elasticsearch/pull/154110)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)