### PR TITLE
ES|QL: Raise NdJsonCompressedFormatSpecIT suite timeout to 60 min (backport #153636 to 9.5)

### DIFF
--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedFormatSpecIT.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.esql.qa.ndjson;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.Build;
 import org.elasticsearch.test.AzureReactorThreadFilter;
 import org.elasticsearch.test.TestClustersThreadFilter;
@@ -22,7 +24,9 @@ import java.util.Set;
 /**
  * Parameterized integration tests for compressed NDJSON files (.ndjson.gz, .ndjson.zst, .ndjson.zstd, .ndjson.bz2, .ndjson.bz).
  * Each csv-spec test is run against every configured storage backend (S3, HTTP, LOCAL, GCS) and compression format.
+ * This class runs four csv-spec files and exceeds the default 10-minute suite budget.
  */
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class NdJsonCompressedFormatSpecIT extends AbstractNdJsonExternalSpecTestCase {
 


### PR DESCRIPTION
## Summary

Backport of #153636 to 9.5.

Adds `@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)` to `NdJsonCompressedFormatSpecIT`. The class-level annotation overrides the inherited 10-minute budget from `EsqlSpecTestCase` for this suite only — all other subclasses keep the stricter limit.

The change on 9.5 is functionally identical to the main PR; the only difference is the Javadoc does not reference `EsqlSpecTestCase` via a link (the import is not needed here since it is not referenced in code).

## Related

- #153636 (main)