### PR TITLE
ES|QL: Fix external source IT fixture startup order (backport #153666 to 9.5)

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/csv/AbstractCsvExternalSpecTestCase.java
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/csv/AbstractCsvExternalSpecTestCase.java
@@ -11,6 +11,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 /**
  * Shared cluster base for CSV/TSV csv-spec tests.
@@ -25,8 +26,10 @@ import org.junit.ClassRule;
  */
 abstract class AbstractCsvExternalSpecTestCase extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     protected AbstractCsvExternalSpecTestCase(
         String fileName,

--- a/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/IcebergSpecIT.java
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/IcebergSpecIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -24,8 +25,10 @@ import java.util.List;
 public class IcebergSpecIT extends IcebergSpecTestCase {
 
     /** Elasticsearch cluster with S3 fixture and Iceberg catalog for testing. */
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public IcebergSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/AbstractNdJsonExternalSpecTestCase.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/ndjson/AbstractNdJsonExternalSpecTestCase.java
@@ -11,6 +11,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 /**
  * Shared cluster base for NDJSON csv-spec tests.
@@ -25,8 +26,10 @@ import org.junit.ClassRule;
  */
 abstract class AbstractNdJsonExternalSpecTestCase extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     protected AbstractNdJsonExternalSpecTestCase(
         String fileName,

--- a/x-pack/plugin/esql-datasource-orc/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/orc/OrcFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-orc/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/orc/OrcFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -26,8 +27,10 @@ import java.util.List;
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class OrcFormatSpecIT extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public OrcFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-parquet-rs/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetRsFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-parquet-rs/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetRsFormatSpecIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,8 +29,10 @@ import java.util.Set;
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class ParquetRsFormatSpecIT extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public ParquetRsFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/AbstractParquetExternalSpecTestCase.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/AbstractParquetExternalSpecTestCase.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 /**
  * Shared cluster base for Parquet csv-spec tests.
@@ -27,8 +28,10 @@ import org.junit.ClassRule;
  */
 abstract class AbstractParquetExternalSpecTestCase extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     protected AbstractParquetExternalSpecTestCase(
         String fileName,

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedSpecIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
@@ -52,13 +51,16 @@ public class ExternalDistributedSpecIT extends AbstractExternalSourceSpecTestCas
     private static final ElasticsearchCluster CLUSTER_INSTANCE = ExternalDistributedClusters.testCluster(() -> s3Fixture.getAddress());
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule((base, description) -> new org.junit.runners.model.Statement() {
-        @Override
-        public void evaluate() throws Throwable {
-            assumeFalse("FIPS mode requires security enabled; this test uses plain HTTP S3 fixtures", inFipsJvm());
-            base.evaluate();
-        }
-    }).around(CLUSTER_INSTANCE);
+    public static TestRule ruleChain = chainOuterRuleBeforeFixturesAndCluster(
+        (base, description) -> new org.junit.runners.model.Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                assumeFalse("FIPS mode requires security enabled; this test uses plain HTTP S3 fixtures", inFipsJvm());
+                base.evaluate();
+            }
+        },
+        CLUSTER_INSTANCE
+    );
 
     private final String distributionMode;
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.qa.rest;
 import org.elasticsearch.Version;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.CsvSpecReader.DatasetSource;
@@ -27,6 +28,8 @@ import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.S3RequestLog;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.net.URL;
@@ -177,17 +180,31 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         return parameterizedTests;
     }
 
-    @ClassRule
     public static DataSourcesS3HttpFixture s3Fixture = new DataSourcesS3HttpFixture();
 
     // Anonymous form: migrated specs read every backend via FROM <dataset> with auth=anonymous, so the
     // Azure fixture must serve unauthenticated reads (the S3/GCS fixtures already do). No shared-key
     // secret is stored, so these suites need no cluster encryption key.
-    @ClassRule
     public static DataSourcesAzureHttpFixture azureFixture = new DataSourcesAzureHttpFixture(true);
 
-    @ClassRule
     public static DataSourcesGcsHttpFixture gcsFixture = new DataSourcesGcsHttpFixture();
+
+    /**
+     * Builds a {@link ClassRule} that starts object-store fixtures before the test cluster. Without an
+     * explicit order, JUnit may boot the cluster while fixtures are not yet listening and external reads
+     * fail with transient {@code Connection is closed} errors (especially on Azure).
+     */
+    protected static TestRule chainFixturesBeforeCluster(ElasticsearchCluster cluster) {
+        return RuleChain.outerRule(s3Fixture).around(gcsFixture).around(azureFixture).around(cluster);
+    }
+
+    /**
+     * Like {@link #chainFixturesBeforeCluster(ElasticsearchCluster)} but runs {@code outer} first (e.g.
+     * an {@code assumeFalse} guard) before bringing up fixtures and the cluster.
+     */
+    protected static TestRule chainOuterRuleBeforeFixturesAndCluster(TestRule outer, ElasticsearchCluster cluster) {
+        return RuleChain.outerRule(outer).around(s3Fixture).around(gcsFixture).around(azureFixture).around(cluster);
+    }
 
     /** Cached path to local fixtures directory */
     private static Path localFixturesPath;


### PR DESCRIPTION
## Summary

Backport of #153666 to 9.5.

Chains object-store fixtures (S3 → GCS → Azure) before the Elasticsearch test cluster in all external-source csv-spec harnesses using a single `RuleChain`. Without an explicit order JUnit may boot the cluster while fixtures are not yet listening, causing transient `Connection is closed` failures especially on Azure-backed tests.

## Changes

- `AbstractExternalSourceSpecTestCase`: remove standalone `@ClassRule` from `s3Fixture`, `azureFixture`, `gcsFixture`; add `chainFixturesBeforeCluster(ElasticsearchCluster)` and `chainOuterRuleBeforeFixturesAndCluster(TestRule, ElasticsearchCluster)` helpers
- Wire `RuleChain` via the new helpers in: `AbstractNdJsonExternalSpecTestCase`, `AbstractParquetExternalSpecTestCase`, `AbstractCsvExternalSpecTestCase`, `OrcFormatSpecIT`, `ParquetRsFormatSpecIT`, `IcebergSpecIT`, `ExternalDistributedSpecIT`

## Related

- #153666 (main)