### PR TITLE
unmute #152601

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -203,9 +203,6 @@ tests:
 - class: org.elasticsearch.gradle.internal.precommit.TestingConventionsPrecommitPluginFuncTest
   method: testing convention tasks are cacheable and uptodate
   issue: https://github.com/elastic/elasticsearch/issues/152371
-- class: org.elasticsearch.xpack.security.authc.ldap.OpenLdapUserSearchSessionFactoryTests
-  method: testUserSearchWithBindUserOpenLDAP
-  issue: https://github.com/elastic/elasticsearch/issues/152601
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   method: test {csv-spec:stats.filterSometimesMatches}
   issue: https://github.com/elastic/elasticsearch/issues/152607


### PR DESCRIPTION
Fixes #152601 

This issue appears to be transitive; The LDAP server container crashed after reporting successful startup, leading to LDAP connection errors.

If this issue repeats, we can try adding more logging, or perhaps more robust checks around the LDAP container startup.