### PR TITLE
[9.4] AMD fallback to average skips docs with zero value count with warning (#154108)

### DIFF
--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleBlockLoader.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleBlockLoader.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
+import org.elasticsearch.index.mapper.blockloader.Warnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.DoublesBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.IntsBlockLoader;
@@ -147,8 +148,13 @@ public class AggregateMetricDoubleBlockLoader extends BlockDocValuesReader.DocVa
     public static class AvgBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
         NumberFieldMapper.NumberFieldType sumFieldType;
         NumberFieldMapper.NumberFieldType countFieldType;
+        private final Warnings warnings;
 
-        AvgBlockLoader(EnumMap<AggregateMetricDoubleFieldMapper.Metric, NumberFieldMapper.NumberFieldType> availableMetrics) {
+        AvgBlockLoader(
+            EnumMap<AggregateMetricDoubleFieldMapper.Metric, NumberFieldMapper.NumberFieldType> availableMetrics,
+            Warnings warnings
+        ) {
+            this.warnings = warnings;
             if (availableMetrics.containsKey(AggregateMetricDoubleFieldMapper.Metric.sum) == false
                 || availableMetrics.containsKey(AggregateMetricDoubleFieldMapper.Metric.value_count) == false) {
                 sumFieldType = null;
@@ -214,7 +220,17 @@ public class AggregateMetricDoubleBlockLoader extends BlockDocValuesReader.DocVa
                                 lastDoc = doc;
                                 double sum = NumericUtils.sortableLongToDouble(sumValues.longValue());
                                 long count = valueCountValues.longValue();
-                                builder.appendDouble(sum / count);
+                                if (count <= 0) {
+                                    warnings.registerException(
+                                        IllegalArgumentException.class,
+                                        "[aggregate_metric_double] fields has a non-positive count [value_count="
+                                            + count
+                                            + "], so it cannot fallback to a single average value, treating result as null"
+                                    );
+                                    builder.appendNull();
+                                } else {
+                                    builder.appendDouble(sum / count);
+                                }
                             } else {
                                 builder.appendNull();
                             }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -583,7 +583,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
             BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
             if (cfg != null) {
                 return switch (cfg.function()) {
-                    case AMD_DEFAULT -> new AggregateMetricDoubleBlockLoader.AvgBlockLoader(metricFields);
+                    case AMD_DEFAULT -> new AggregateMetricDoubleBlockLoader.AvgBlockLoader(metricFields, blContext.warnings());
                     case AMD_COUNT -> getIndividualBlockLoader(Metric.value_count);
                     case AMD_MAX -> getIndividualBlockLoader(Metric.max);
                     case AMD_MIN -> getIndividualBlockLoader(Metric.min);

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleAvgBlockLoaderTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleAvgBlockLoaderTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.aggregatemetric.mapper;
+
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AggregateMetricDoubleAvgBlockLoaderTests extends ESTestCase {
+
+    private static final String FIELD = "field";
+
+    public void testZeroCountProducesNullWithWarning() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            iw.addDocument(
+                List.of(
+                    new NumericDocValuesField(
+                        subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.sum),
+                        Double.doubleToLongBits(randomDouble())
+                    ),
+                    new NumericDocValuesField(subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.value_count), 0)
+                )
+            );
+            iw.forceMerge(1);
+
+            try (DirectoryReader reader = iw.getReader()) {
+                LeafReaderContext ctx = getOnlyLeafReader(reader).getContext();
+                List<String> capturedMessages = new ArrayList<>();
+                var loader = new AggregateMetricDoubleBlockLoader.AvgBlockLoader(metricFields(), (cls, msg) -> capturedMessages.add(msg));
+                var breaker = new NoopCircuitBreaker("test");
+                BlockLoader.Docs docs = TestBlock.docs(ctx);
+
+                try (BlockLoader.ColumnAtATimeReader r = loader.reader(breaker, ctx)) {
+                    try (TestBlock block = (TestBlock) r.read(TestBlock.factory(), docs, 0, false)) {
+                        assertNull("expected null for zero-count doc", block.get(0));
+                    }
+                }
+                assertThat(capturedMessages.size(), equalTo(1));
+                assertThat(capturedMessages.getFirst(), containsString("fields has a non-positive count [value_count="));
+            }
+        }
+    }
+
+    public void testNegativeCountProducesNullWithWarning() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            iw.addDocument(
+                List.of(
+                    new NumericDocValuesField(
+                        subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.sum),
+                        Double.doubleToLongBits(randomDouble())
+                    ),
+                    new NumericDocValuesField(
+                        subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.value_count),
+                        randomIntBetween(-100, -1)
+                    )
+                )
+            );
+            iw.forceMerge(1);
+
+            try (DirectoryReader reader = iw.getReader()) {
+                LeafReaderContext ctx = getOnlyLeafReader(reader).getContext();
+                List<String> capturedMessages = new ArrayList<>();
+                var loader = new AggregateMetricDoubleBlockLoader.AvgBlockLoader(metricFields(), (cls, msg) -> capturedMessages.add(msg));
+                var breaker = new NoopCircuitBreaker("test");
+                BlockLoader.Docs docs = TestBlock.docs(ctx);
+
+                try (BlockLoader.ColumnAtATimeReader r = loader.reader(breaker, ctx)) {
+                    try (TestBlock block = (TestBlock) r.read(TestBlock.factory(), docs, 0, false)) {
+                        assertNull("expected null for zero-count doc", block.get(0));
+                    }
+                }
+                assertThat(capturedMessages.size(), equalTo(1));
+                assertThat(capturedMessages.getFirst(), containsString("fields has a non-positive count [value_count="));
+            }
+        }
+    }
+
+    private static EnumMap<AggregateMetricDoubleFieldMapper.Metric, NumberFieldMapper.NumberFieldType> metricFields() {
+        var metricFields = new EnumMap<AggregateMetricDoubleFieldMapper.Metric, NumberFieldMapper.NumberFieldType>(
+            AggregateMetricDoubleFieldMapper.Metric.class
+        );
+        metricFields.put(
+            AggregateMetricDoubleFieldMapper.Metric.sum,
+            new NumberFieldMapper.NumberFieldType(
+                subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.sum),
+                NumberFieldMapper.NumberType.DOUBLE
+            )
+        );
+        metricFields.put(
+            AggregateMetricDoubleFieldMapper.Metric.value_count,
+            new NumberFieldMapper.NumberFieldType(
+                subfieldName(FIELD, AggregateMetricDoubleFieldMapper.Metric.value_count),
+                NumberFieldMapper.NumberType.INTEGER
+            )
+        );
+        return metricFields;
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [AMD fallback to average skips docs with zero value count with warning (#154108)](https://github.com/elastic/elasticsearch/pull/154108)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)