### PR TITLE
Fix negated RLIKE on shadowed ES|QL fields

### DIFF
--- a/docs/changelog/154270.yaml
+++ b/docs/changelog/154270.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154146
+pr: 154270
+summary: Fix negated match-all RLIKE on shadowed fields
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -857,8 +857,9 @@ required_capability: fix_negated_is_not_null_alias_inference
 FROM airports_no_doc_values
 | EVAL city = MV_CONCAT(city, ", ")
 | WHERE NOT city RLIKE ".*"
-| KEEP city
+| STATS rows = COUNT(*)
 ;
 
-city:keyword
+rows:long
+19
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -850,3 +850,15 @@ ROW x = null |  EVAL append_coalesce = MV_APPEND("2", COALESCE(null, "1"))
 x:null | append_coalesce:keyword
 null   | [2, 1]
 ;
+
+
+shadowedFieldWithNegatedMatchAllRegex
+required_capability: fix_negated_is_not_null_alias_inference
+FROM airports_no_doc_values
+| EVAL city = MV_CONCAT(city, ", ")
+| WHERE NOT city RLIKE ".*"
+| KEEP city
+;
+
+city:keyword
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2220,6 +2220,11 @@ public class EsqlCapabilities {
         FIX_REPLACE_ALIASING_EVAL_WITH_PROJECT_SHADOWING,
 
         /**
+         * Avoid inferring root-field null checks for negated checks on shadowing aliases.
+         */
+        FIX_NEGATED_IS_NOT_NULL_ALIAS_INFERENCE,
+
+        /**
          * Chunk function.
          */
         CHUNK_FUNCTION_V2(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferIsNotNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferIsNotNull.java
@@ -15,10 +15,13 @@ import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -56,8 +59,14 @@ public class InferIsNotNull extends Rule<LogicalPlan, LogicalPlan> {
     private LogicalPlan inspectPlan(LogicalPlan plan, AttributeMap.Builder<Expression> aliasesBuilder) {
         // inspect just this plan properties
         plan.forEachExpression(Alias.class, a -> aliasesBuilder.put(a.toAttribute(), a.child()));
+        // Inferred root checks cannot be pushed below an alias when they are beneath NOT.
+        Set<IsNotNull> negated = Collections.newSetFromMap(new IdentityHashMap<>());
+        plan.forEachExpression(Not.class, not -> not.forEachDown(IsNotNull.class, negated::add));
         // now go about finding isNull/isNotNull
-        LogicalPlan newPlan = plan.transformExpressionsOnlyUp(IsNotNull.class, inn -> inferNotNullable(inn, aliasesBuilder.build()));
+        LogicalPlan newPlan = plan.transformExpressionsOnlyUp(
+            IsNotNull.class,
+            inn -> negated.contains(inn) ? inn : inferNotNullable(inn, aliasesBuilder.build())
+        );
         return newPlan;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -61,6 +61,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.Wild
 import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
@@ -726,6 +727,17 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         inn = as(filter.condition(), IsNotNull.class);
         assertThat(Expressions.names(inn.children()), contains("emp_no"));
         var source = as(filter.child(), EsRelation.class);
+    }
+
+    public void testNegatedIsNotNullOnShadowingAlias() {
+        EsRelation relation = relation();
+        var field = getFieldAttribute("a");
+        var alias = new Alias(EMPTY, "a", new Add(EMPTY, field, ONE, TEST_CFG));
+        var eval = new Eval(EMPTY, relation, List.of(alias));
+        var condition = new Not(EMPTY, isNotNull(alias.toAttribute()));
+        var filter = new Filter(EMPTY, eval, condition);
+
+        assertEquals(filter, new InferIsNotNull().apply(filter));
     }
 
     public void testIsNotNullOnCase() {


### PR DESCRIPTION
Closes #154146

## Summary

- avoid inferring root-field null checks beneath `NOT`, where they cannot be pushed below a shadowing `EVAL` alias
- preserve positive `IS NOT NULL` inference and pushdown behavior
- add unit and CSV regression coverage for a negated match-all `RLIKE` on a shadowed field

## Tests

- `./gradlew :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests.testNegatedIsNotNullOnShadowingAlias`
- `./gradlew :x-pack:plugin:esql:internalClusterTest --tests 'org.elasticsearch.xpack.esql.CsvIT.*eval*shadowedFieldWithNegatedMatchAllRegex*'`\n- `./gradlew :x-pack:plugin:esql:spotlessJavaCheck`