### PR TITLE
[9.5] ESQLDS/NDJSON - Null whole position on array item coercion failure (#154000)

### DIFF
--- a/docs/changelog/154000.yaml
+++ b/docs/changelog/154000.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154000
+summary: ESQLDS/NDJSON - Null whole position on array item coercion failure
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -185,6 +185,37 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
         ++size;
     }
 
+    /**
+     * Truncates this array to {@code newSize} elements, discarding all elements at index
+     * {@code >= newSize} and rolling the byte storage back to the end of element
+     * {@code newSize - 1}. Subsequent appends overwrite the discarded bytes. No-op when
+     * {@code newSize == size()}.
+     */
+    public void truncateTo(long newSize) {
+        assert newSize >= 0 && newSize <= size : "cannot truncate " + size + " elements to " + newSize;
+        if (newSize == size) {
+            return;
+        }
+        lastOffset = getOffset(newSize);
+        size = newSize;
+        bytes.truncateTo(lastOffset);
+        if (intOffsets != null) {
+            // Offset tables hold (oldSize + 1) entries; after truncation we need exactly (newSize + 1).
+            long entriesToKeep = newSize + 1;
+            long intEntriesToKeep = Math.min(intOffsets.size, entriesToKeep);
+            intOffsets.truncateTo(intEntriesToKeep);
+            if (longOffsets != null) {
+                long longEntriesToKeep = entriesToKeep - intEntriesToKeep;
+                if (longEntriesToKeep <= 0) {
+                    longOffsets.close();
+                    longOffsets = null;
+                } else {
+                    longOffsets.truncateTo(longEntriesToKeep);
+                }
+            }
+        }
+    }
+
     public BytesRef get(long id, BytesRef dest) {
         final long startOffset = getOffset(id);
         final int length = Math.toIntExact(getOffset(id + 1) - startOffset);
@@ -349,6 +380,34 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
             size++;
         }
 
+        /**
+         * Discards all entries at index {@code >= targetSize}, repositioning the write cursor so
+         * the next {@link #append} overwrites the first discarded slot. Pages that lie entirely
+         * beyond the target are released and their circuit-breaker reservation is returned.
+         */
+        void truncateTo(long targetSize) {
+            if (targetSize == size) {
+                return;
+            }
+            assert targetSize >= 0 && targetSize < size : targetSize + " >= " + size;
+            // PAGE_SHIFT is log2(INTS_PER_PAGE); the formula works for the small-first-page case
+            // too because targetSize < INTS_PER_PAGE implies targetPageIndex == 0.
+            int targetPageIndex = (int) (targetSize >> PAGE_SHIFT);
+            int targetPagePos = (int) (targetSize & PAGE_MASK) * Integer.BYTES;
+            for (int i = pageCount - 1; i > targetPageIndex; i--) {
+                if (caches[i] != null) {
+                    bigArrays.adjustBreaker(-PAGE_SIZE, true);
+                    caches[i].close();
+                    caches[i] = null;
+                }
+                pages[i] = null;
+            }
+            pageCount = targetPageIndex + 1;
+            currentPage = pages[targetPageIndex];
+            posInPage = targetPagePos;
+            size = targetSize;
+        }
+
         int get(long index) {
             int page = (int) (index >> PAGE_SHIFT);
             int off = (int) (index & PAGE_MASK) * Integer.BYTES;
@@ -446,6 +505,32 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
             int page = (int) (index >> PAGE_SHIFT);
             int off = (int) (index & PAGE_MASK) * Long.BYTES;
             return (long) LONG_HANDLE.get(pages[page], off);
+        }
+
+        /**
+         * Discards all entries at index {@code >= targetSize}, repositioning the write cursor so
+         * the next {@link #append} overwrites the first discarded slot. Pages that lie entirely
+         * beyond the target are released and their circuit-breaker reservation is returned.
+         */
+        void truncateTo(long targetSize) {
+            if (targetSize == size) {
+                return;
+            }
+            assert targetSize >= 0 && targetSize < size : targetSize + " >= " + size;
+            int targetPageIndex = (int) (targetSize >> PAGE_SHIFT);
+            int targetPagePos = (int) (targetSize & PAGE_MASK) * Long.BYTES;
+            for (int i = pageCount - 1; i > targetPageIndex; i--) {
+                if (caches[i] != null) {
+                    bigArrays.adjustBreaker(-PAGE_SIZE, true);
+                    caches[i].close();
+                    caches[i] = null;
+                }
+                pages[i] = null;
+            }
+            pageCount = targetPageIndex + 1;
+            currentPage = pages[targetPageIndex];
+            posInPage = targetPagePos;
+            size = targetSize;
         }
 
         @Override
@@ -621,6 +706,31 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
                 cursor.readPageChunk(scratch);
                 append(scratch.bytes, scratch.offset, scratch.length);
             }
+        }
+
+        /**
+         * Rolls the byte stream back to {@code targetByteOffset}, releasing any pages that
+         * lie entirely beyond that offset. The next {@link #append} will overwrite bytes
+         * starting at {@code targetByteOffset}, exactly as though those bytes had never been
+         * written. {@code targetByteOffset} must be {@code >= 0} and {@code <= size()}.
+         */
+        void truncateTo(long targetByteOffset) {
+            if (targetByteOffset == size()) {
+                return;
+            }
+            int targetPageIndex = (int) (targetByteOffset >> PAGE_SHIFT);
+            int targetPagePos = (int) (targetByteOffset & PAGE_MASK);
+            for (int i = pageCount - 1; i > targetPageIndex; i--) {
+                if (caches[i] != null) {
+                    bigArrays.adjustBreaker(-PAGE_SIZE, true);
+                    caches[i].close();
+                    caches[i] = null;
+                }
+                pages[i] = null;
+            }
+            pageCount = targetPageIndex + 1;
+            currentPage = pages[targetPageIndex];
+            currentPagePos = targetPagePos;
         }
 
         private byte[] allocateScratchBuffer(byte[] scratch, int requiredLength) {

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
@@ -316,6 +316,111 @@ public class BytesRefArrayTests extends ESTestCase {
         }
     }
 
+    public void testTruncateThenRead() {
+        int total = randomIntBetween(2, 50);
+        int kept = randomIntBetween(1, total - 1);
+        try (BytesRefArray array = new BytesRefArray(total, mockBigArrays())) {
+            List<BytesRef> values = new ArrayList<>();
+            for (int i = 0; i < total; i++) {
+                BytesRef v = new BytesRef(randomAlphaOfLengthBetween(1, 20));
+                array.append(v);
+                values.add(BytesRef.deepCopyOf(v));
+            }
+            array.truncateTo(kept);
+            assertThat(array.size(), equalTo((long) kept));
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < kept; i++) {
+                assertThat(array.get(i, scratch), equalTo(values.get(i)));
+            }
+        }
+    }
+
+    public void testTruncateThenAppend() {
+        int total = randomIntBetween(2, 50);
+        int kept = randomIntBetween(0, total - 1);
+        int extra = randomIntBetween(1, 20);
+        try (BytesRefArray array = new BytesRefArray(total, mockBigArrays())) {
+            List<BytesRef> expected = new ArrayList<>();
+            for (int i = 0; i < total; i++) {
+                BytesRef v = new BytesRef(randomAlphaOfLengthBetween(1, 20));
+                array.append(v);
+                if (i < kept) {
+                    expected.add(BytesRef.deepCopyOf(v));
+                }
+            }
+            array.truncateTo(kept);
+            for (int i = 0; i < extra; i++) {
+                BytesRef v = new BytesRef(randomAlphaOfLengthBetween(1, 20));
+                array.append(v);
+                expected.add(BytesRef.deepCopyOf(v));
+            }
+            assertThat(array.size(), equalTo((long) (kept + extra)));
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < expected.size(); i++) {
+                assertThat(array.get(i, scratch), equalTo(expected.get(i)));
+            }
+        }
+    }
+
+    public void testTruncateNoOp() {
+        int size = randomIntBetween(1, 20);
+        try (BytesRefArray array = new BytesRefArray(size, mockBigArrays())) {
+            List<BytesRef> values = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                BytesRef v = new BytesRef(randomAlphaOfLengthBetween(1, 20));
+                array.append(v);
+                values.add(BytesRef.deepCopyOf(v));
+            }
+            array.truncateTo(size);
+            assertThat(array.size(), equalTo((long) size));
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < size; i++) {
+                assertThat(array.get(i, scratch), equalTo(values.get(i)));
+            }
+        }
+    }
+
+    public void testTruncateNoOpAtPageBoundary() {
+        // Append one entry of exactly PAGE_SIZE_IN_BYTES bytes. After the append the byte stream's
+        // currentPagePos == PAGE_SIZE, so size() == PAGE_SIZE. Calling truncateTo(1) passes
+        // lastOffset == PAGE_SIZE to Bytes.truncateTo — the boundary that previously computed
+        // targetPageIndex == pageCount and threw ArrayIndexOutOfBoundsException.
+        int pageSize = PageCacheRecycler.PAGE_SIZE_IN_BYTES;
+        try (BytesRefArray array = new BytesRefArray(1, mockBigArrays())) {
+            BytesRef v = new BytesRef(new byte[pageSize]);
+            array.append(v);
+            array.truncateTo(1); // no-op: keep the single entry
+            assertThat(array.size(), equalTo(1L));
+            BytesRef scratch = new BytesRef();
+            assertThat(array.get(0, scratch), equalTo(v));
+        }
+    }
+
+    public void testTruncateMultiPageRelease() {
+        // Fill enough entries to span multiple internal pages, truncate back, verify that
+        // all released-page bytes are gone and the kept entries still read correctly.
+        int pageSize = PageCacheRecycler.PAGE_SIZE_IN_BYTES;
+        int entrySize = pageSize / 2 + 1; // each entry straddles a page boundary
+        int total = 6;
+        int kept = 2;
+        try (BytesRefArray array = new BytesRefArray(total, mockBigArrays())) {
+            List<BytesRef> values = new ArrayList<>();
+            for (int i = 0; i < total; i++) {
+                byte[] data = new byte[entrySize];
+                java.util.Arrays.fill(data, (byte) i);
+                BytesRef v = new BytesRef(data);
+                array.append(v);
+                values.add(BytesRef.deepCopyOf(v));
+            }
+            array.truncateTo(kept);
+            assertThat(array.size(), equalTo((long) kept));
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < kept; i++) {
+                assertThat(array.get(i, scratch), equalTo(values.get(i)));
+            }
+        }
+    }
+
     private static BigArrays mockBigArrays() {
         return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
     }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -20,6 +20,7 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.compute.data.AbstractBlockBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -1374,17 +1375,28 @@ public class NdJsonPageDecoder implements Closeable {
                 throw new NdJsonParseException(parser, "Expected JSON object");
             }
             String fieldName;
+            boolean poisoned = false;
             while ((fieldName = parser.nextFieldName()) != null) {
                 var childDecoder = lookupChild(fieldName);
                 parser.nextToken();
-                if (childDecoder == unprojected) {
+                if (childDecoder == unprojected || poisoned) {
                     // Unknown/unprojected field: advance to its value then skip (no decode).
                     // For string values nextFieldName() uses _skipString() internally on the next
                     // call, so we avoid _finishString2 for non-projected string fields.
+                    // Also used to drain remaining fields after a child poisoned this position.
                     parser.skipChildren();
                 } else {
-                    childDecoder.decodeValue(parser, inArray);
+                    try {
+                        childDecoder.decodeValue(parser, inArray);
+                    } catch (PoisonedPositionException e) {
+                        poisoned = true;
+                        parser.skipChildren(); // drain current field's value, then loop drains the rest
+                    }
                 }
+            }
+            // Parser is now at END_OBJECT. Re-throw so the enclosing array handler can cancel the position.
+            if (poisoned) {
+                throw PoisonedPositionException.INSTANCE;
             }
         }
 
@@ -1470,6 +1482,25 @@ public class NdJsonPageDecoder implements Closeable {
             if (includeChildren && children != null) {
                 for (var child : children.values()) {
                     child.endPositionEntry(includeChildren);
+                }
+            }
+        }
+
+        /**
+         * Cancels the current position entry (rolling back all values appended since
+         * {@link #beginPositionEntry}) and writes a null for this position instead. Used
+         * when a coercion failure poisoned an array: the whole position is nulled rather
+         * than committed as a partial multivalue, matching the columnar reader contract.
+         */
+        private void cancelAndNullPositionEntry(boolean includeChildren) {
+            if (blockBuilder != null && dataType != DataType.NULL) {
+                ((AbstractBlockBuilder) blockBuilder).cancelPositionEntry();
+                blockTracker.set(blockIdx);
+                blockBuilder.appendNull();
+            }
+            if (includeChildren && children != null) {
+                for (var child : children.values()) {
+                    child.cancelAndNullPositionEntry(includeChildren);
                 }
             }
         }
@@ -1568,15 +1599,32 @@ public class NdJsonPageDecoder implements Closeable {
                     }
                     boolean includeChildren = first == JsonToken.START_OBJECT;
                     beginPositionEntry(includeChildren);
-                    decodeValue(parser, true);
-                    while (parser.nextToken() != JsonToken.END_ARRAY) {
+                    try {
                         decodeValue(parser, true);
+                        while (parser.nextToken() != JsonToken.END_ARRAY) {
+                            decodeValue(parser, true);
+                        }
+                        endPositionEntry(includeChildren);
+                    } catch (PoisonedPositionException e) {
+                        while (parser.nextToken() != JsonToken.END_ARRAY) {
+                            parser.skipChildren();
+                        }
+                        cancelAndNullPositionEntry(includeChildren);
                     }
-                    endPositionEntry(includeChildren);
                     return;
                 }
                 while (parser.nextToken() != JsonToken.END_ARRAY) {
-                    decodeValue(parser, true);
+                    try {
+                        decodeValue(parser, true);
+                    } catch (PoisonedPositionException e) {
+                        // Drain the rest of this nested array, then rethrow so the
+                        // enclosing array handler can drain its own remaining elements
+                        // and cancel the position entry correctly.
+                        while (parser.nextToken() != JsonToken.END_ARRAY) {
+                            parser.skipChildren();
+                        }
+                        throw e;
+                    }
                 }
                 return;
             }
@@ -1974,6 +2022,11 @@ public class NdJsonPageDecoder implements Closeable {
                 // first bad field), not once per bad field. The record's scratch is discarded, so no null-fill is
                 // needed and further coercion failures on the same doomed record must not consume the budget again.
                 parser.skipChildren();
+                if (inArray) {
+                    // Inside an array, a normal return would let the array loop call endPositionEntry with no
+                    // values appended — an AssertionError. Throw so the array handler drains and cancels instead.
+                    throw PoisonedPositionException.INSTANCE;
+                }
                 return;
             }
             String value = parser.getValueAsString();
@@ -2011,6 +2064,12 @@ public class NdJsonPageDecoder implements Closeable {
             skipWarnings.add(message);
             checkErrorBudgetOrThrow();
             logger.log(errorPolicy.logErrors() ? Level.INFO : Level.DEBUG, message);
+            if (inArray) {
+                // Inside an array: throw to signal that the whole position must be nulled.
+                // The array decode loop catches PoisonedPositionException, drains remaining elements,
+                // and calls cancelAndNullPositionEntry to roll back any good elements already appended.
+                throw PoisonedPositionException.INSTANCE;
+            }
         }
 
         /**
@@ -2068,6 +2127,26 @@ public class NdJsonPageDecoder implements Closeable {
             skipWarnings.add(message);
             checkErrorBudgetOrThrow();
             logger.log(errorPolicy.logErrors() ? Level.INFO : Level.DEBUG, message);
+        }
+    }
+
+    /**
+     * Thrown by {@link BlockDecoder#coercionFailure} when a value inside a JSON array fails coercion,
+     * to signal that the entire array position must be nulled. Caught by the array decode loop in
+     * {@link BlockDecoder#decodeValue}, which drains remaining elements and calls
+     * {@link BlockDecoder#cancelAndNullPositionEntry}. Propagates through
+     * {@link BlockDecoder#decodeObject} (which drains remaining fields and re-throws) so that a
+     * failure inside a nested object also cancels the enclosing array position.
+     * <p>
+     * Uses a static singleton with a suppressed stack trace to keep the throw/catch overhead minimal
+     * on the failure path, since no stack context is needed — the error details are recorded by
+     * {@link BlockDecoder#coercionFailure} before throwing.
+     */
+    private static final class PoisonedPositionException extends RuntimeException {
+        static final PoisonedPositionException INSTANCE = new PoisonedPositionException();
+
+        private PoisonedPositionException() {
+            super(null, null, true, false);
         }
     }
 

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -847,6 +847,175 @@ public class NdJsonPageDecoderTests extends ESTestCase {
     }
 
     /**
+     * A coercion failure on any element of a declared-type array must null the whole position, not
+     * silently drop the bad element and keep the good ones as a partial multivalue. Matches the
+     * columnar reader contract (see {@code DeclaredTypeCoercionsTests.testMultiValuePositionNullsWholePositionOnFailure}).
+     * <p>
+     * Input: three rows — a clean multivalue, a poisoned multivalue (one bad element), and a second
+     * clean multivalue. Under {@code null_field} the poisoned position is null; both clean positions
+     * carry all their elements; one warning is emitted.
+     */
+    public void testArrayCoercionFailureNullsWholePositionUnderNullField() throws IOException {
+        String ndjson = "{\"v\":[10,20]}\n{\"v\":[10,\"notanumber\",30]}\n{\"v\":[40,50]}\n";
+        List<String> warnings = new ArrayList<>();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                null,
+                List.of(attribute("v", DataType.LONG)),
+                null,
+                10,
+                blockFactory,
+                ErrorPolicy.PERMISSIVE,
+                "test://array-poison",
+                new NdJsonReaderCounters(),
+                warnings::add
+            );
+            Page page = decoder.decodePage()
+        ) {
+            assertNotNull(page);
+            LongBlock block = page.getBlock(0);
+            assertEquals(3, block.getPositionCount());
+
+            // first position: [10, 20]
+            assertFalse("first row is not null", block.isNull(0));
+            assertEquals(2, block.getValueCount(0));
+            int i0 = block.getFirstValueIndex(0);
+            assertEquals(10L, block.getLong(i0));
+            assertEquals(20L, block.getLong(i0 + 1));
+
+            // second position: poisoned by "notanumber" → whole position is null
+            assertTrue("poisoned array position is null", block.isNull(1));
+
+            // third position: [40, 50]
+            assertFalse("third row is not null", block.isNull(2));
+            assertEquals(2, block.getValueCount(2));
+            int i2 = block.getFirstValueIndex(2);
+            assertEquals(40L, block.getLong(i2));
+            assertEquals(50L, block.getLong(i2 + 1));
+        }
+        // SkipWarnings.add() emits a one-time summary header on the first call, then the detail — 2 messages total.
+        assertEquals("one summary + one detail warning for the poisoned element", 2, warnings.size());
+        assertThat(warnings.get(1), Matchers.containsString("notanumber"));
+    }
+
+    /**
+     * Under {@code skip_row}, a coercion failure inside an array drops the entire record — matching
+     * the scalar coercion skip_row contract, and NOT just the poisoned position.
+     */
+    public void testArrayCoercionFailureSkipsRowUnderSkipRow() throws IOException {
+        String ndjson = "{\"v\":[10,20]}\n{\"v\":[10,\"notanumber\",30]}\n{\"v\":[40,50]}\n";
+        List<String> warnings = new ArrayList<>();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                null,
+                List.of(attribute("v", DataType.LONG)),
+                null,
+                10,
+                blockFactory,
+                ErrorPolicy.LENIENT,
+                "test://array-skip",
+                new NdJsonReaderCounters(),
+                warnings::add
+            );
+            Page page = decoder.decodePage()
+        ) {
+            assertNotNull(page);
+            LongBlock block = page.getBlock(0);
+            assertEquals("poisoned row is dropped, two remain", 2, block.getPositionCount());
+
+            // first surviving row: [10, 20]
+            assertFalse(block.isNull(0));
+            assertEquals(2, block.getValueCount(0));
+            int i0 = block.getFirstValueIndex(0);
+            assertEquals(10L, block.getLong(i0));
+            assertEquals(20L, block.getLong(i0 + 1));
+
+            // second surviving row: [40, 50]
+            assertFalse(block.isNull(1));
+            assertEquals(2, block.getValueCount(1));
+            int i1 = block.getFirstValueIndex(1);
+            assertEquals(40L, block.getLong(i1));
+            assertEquals(50L, block.getLong(i1 + 1));
+        }
+        // SkipWarnings.add() emits a one-time summary header on the first call, then the detail — 2 messages total.
+        assertEquals("one summary + one detail warning for the dropped row", 2, warnings.size());
+        assertThat(warnings.get(1), Matchers.containsString("notanumber"));
+    }
+
+    /**
+     * A coercion failure inside a nested array (array of arrays flattened) must not let the poison
+     * escape past the inner END_ARRAY — otherwise the outer array's drain loop stops too early and
+     * sibling fields on the same record read the wrong tokens and come back null.
+     *
+     * <p>Input: {@code {"v":[[10,"notanumber"],30],"w":1}} under {@code null_field}.
+     * Expected: {@code v} is null (whole position cancelled), {@code w} is 1.
+     */
+    public void testNestedArrayPoisonDrainsToInnerEndArray() throws IOException {
+        String ndjson = "{\"v\":[[10,\"notanumber\"],30],\"w\":1}\n";
+        List<String> warnings = new ArrayList<>();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                null,
+                List.of(attribute("v", DataType.LONG), attribute("w", DataType.LONG)),
+                null,
+                10,
+                blockFactory,
+                ErrorPolicy.PERMISSIVE,
+                "test://nested-array-poison",
+                new NdJsonReaderCounters(),
+                warnings::add
+            );
+            Page page = decoder.decodePage()
+        ) {
+            assertNotNull(page);
+            LongBlock v = page.getBlock(0);
+            LongBlock w = page.getBlock(1);
+            assertEquals(1, v.getPositionCount());
+            assertEquals(1, w.getPositionCount());
+            assertTrue("v is null because its nested array was poisoned", v.isNull(0));
+            assertFalse("w must not be null — sibling field after the poisoned array", w.isNull(0));
+            assertEquals(1L, w.getLong(w.getFirstValueIndex(0)));
+        }
+    }
+
+    /**
+     * Under {@code skip_row}, two poisoned arrays in the same record must not assert.
+     * The first array sets {@code rowDroppedBySkipRow = true}; the second array then re-enters
+     * {@code coercionFailure} with {@code rowDroppedBySkipRow} already set and {@code inArray = true}.
+     * Without the fix the early return exits without throwing {@code PoisonedPositionException}, so
+     * the array loop calls {@code endPositionEntry} with no values appended → {@code AssertionError}.
+     */
+    public void testSkipRowTwoPoisonedArraysNoAssert() throws IOException {
+        String ndjson = "{\"a\":[\"x\"],\"b\":[\"y\"]}\n{\"a\":[1],\"b\":[2]}\n";
+        List<String> warnings = new ArrayList<>();
+        try (
+            NdJsonPageDecoder decoder = new NdJsonPageDecoder(
+                new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
+                null,
+                List.of(attribute("a", DataType.LONG), attribute("b", DataType.LONG)),
+                null,
+                10,
+                blockFactory,
+                ErrorPolicy.LENIENT,
+                "test://skip-row-two-arrays",
+                new NdJsonReaderCounters(),
+                warnings::add
+            );
+            Page page = decoder.decodePage()
+        ) {
+            assertNotNull(page);
+            LongBlock a = page.getBlock(0);
+            LongBlock b = page.getBlock(1);
+            assertEquals("only the clean second row survives", 1, a.getPositionCount());
+            assertEquals(1L, a.getLong(a.getFirstValueIndex(0)));
+            assertEquals(2L, b.getLong(b.getFirstValueIndex(0)));
+        }
+    }
+
+    /**
      * Drift pin. setupBuilders no longer enumerates the type -> shape mapping; it derives it from the shared
      * authority. Every declarable type must therefore build, with the shape that authority prescribes, and no
      * type may reach unsupportedTypeForNdjson. This is what stops the next declarable type repeating the

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
@@ -95,6 +95,13 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
     }
 
     @Override
+    public BytesRefBlockBuilder cancelPositionEntry() {
+        values.truncateTo(firstValueIndexes[positionCount]);
+        super.cancelPositionEntry();
+        return this;
+    }
+
+    @Override
     public BytesRefBlockBuilder copyFrom(Block block, int beginInclusive, int endExclusive) {
         if (block.areAllValuesNull()) {
             for (int p = beginInclusive; p < endExclusive; p++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlockBuilder.java
@@ -88,6 +88,29 @@ public abstract class AbstractBlockBuilder implements Block.Builder {
         return this;
     }
 
+    /**
+     * Cancels the current position entry, discarding all values appended since the last
+     * {@link #beginPositionEntry()} call. After this call the builder is in the same state
+     * as before {@code beginPositionEntry} was called: the caller must immediately either
+     * start a new position entry or append a null or a scalar value for the current position.
+     *
+     * <p>Subclasses that maintain auxiliary storage beyond the base {@code valueCount} and
+     * values array (e.g., {@code BytesRefBlockBuilder} with its {@code BytesRefArray}) must
+     * override this to also roll back that auxiliary storage to the point recorded by
+     * {@link #beginPositionEntry()}.
+     */
+    public AbstractBlockBuilder cancelPositionEntry() {
+        assert positionEntryIsOpen : "cancelPositionEntry called without a matching beginPositionEntry";
+        valueCount = firstValueIndexes[positionCount];
+        positionEntryIsOpen = false;
+        // If rolling back brings valueCount to zero there are no previously committed non-null values:
+        // reset hasNonNullValue so build() does not take the constant-vector fast path while nullsMask is set.
+        if (valueCount == 0) {
+            hasNonNullValue = false;
+        }
+        return this;
+    }
+
     protected final boolean isDense() {
         return nullsMask == null;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
@@ -117,6 +117,13 @@ public class AggregateMetricDoubleBlockBuilder extends AbstractBlockBuilder impl
     }
 
     @Override
+    public AbstractBlockBuilder cancelPositionEntry() {
+        // AggregateMetricDoubleBlockBuilder delegates to inner builders; the inherited cancelPositionEntry rolls back
+        // only the outer valueCount and not the inner builders' state. Throw to make misuse obvious.
+        throw new UnsupportedOperationException("cancelPositionEntry is not supported by AggregateMetricDoubleBlockBuilder");
+    }
+
+    @Override
     public AggregateMetricDoubleBlockBuilder appendNull() {
         minBuilder.appendNull();
         maxBuilder.appendNull();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeBlockBuilder.java
@@ -108,6 +108,13 @@ public final class LongRangeBlockBuilder extends AbstractBlockBuilder implements
         return this;
     }
 
+    @Override
+    public AbstractBlockBuilder cancelPositionEntry() {
+        // LongRangeBlockBuilder delegates to inner builders; the inherited cancelPositionEntry rolls back
+        // only the outer valueCount and not the inner builders' state. Throw to make misuse obvious.
+        throw new UnsupportedOperationException("cancelPositionEntry is not supported by LongRangeBlockBuilder");
+    }
+
     public LongRangeBlockBuilder appendLongRange(long from, long to) {
         fromBuilder.appendLong(from);
         toBuilder.appendLong(to);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -122,6 +122,13 @@ $if(BytesRef)$
     protected void writeNullValue() {
         values.append(BytesRefBlock.NULL_VALUE);
     }
+
+    @Override
+    public $Type$BlockBuilder cancelPositionEntry() {
+        values.truncateTo(firstValueIndexes[positionCount]);
+        super.cancelPositionEntry();
+        return this;
+    }
 $endif$
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderTests.java
@@ -9,11 +9,13 @@ package org.elasticsearch.compute.data;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.test.BlockTestUtils;
 import org.elasticsearch.compute.test.RandomBlock;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -205,10 +207,112 @@ public class BlockBuilderTests extends ESTestCase {
         }
     }
 
+    public void testCancelPositionEntryNullsPosition() {
+        assumeAbstractBlockBuilder();
+        assumeMultiValued();
+        try (Block.Builder builder = elementType.newBlockBuilder(3, blockFactory)) {
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));   // position 0
+            builder.beginPositionEntry();
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
+            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.appendNull();                                                       // position 1 = null
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));   // position 2
+            try (Block block = builder.build()) {
+                assertThat(block.getPositionCount(), equalTo(3));
+                assertThat(block.isNull(0), is(false));
+                assertThat(block.isNull(1), is(true));
+                assertThat(block.isNull(2), is(false));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    public void testCancelPositionEntryThenRetry() {
+        assumeAbstractBlockBuilder();
+        assumeMultiValued();
+        Object good = BlockTestUtils.randomValue(elementType);
+        try (Block.Builder builder = elementType.newBlockBuilder(1, blockFactory)) {
+            builder.beginPositionEntry();
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
+            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.beginPositionEntry();
+            BlockTestUtils.append(builder, good);
+            builder.endPositionEntry();
+            try (Block block = builder.build()) {
+                assertThat(block.getPositionCount(), equalTo(1));
+                assertThat(block.isNull(0), is(false));
+                assertThat(BlockUtils.toJavaObject(block, 0), equalTo(good));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    /**
+     * Verifies that {@code cancelPositionEntry} resets {@code hasNonNullValue} when the rollback
+     * brings {@code valueCount} back to zero. Without the reset, {@code build()} takes the
+     * constant-vector fast path and ignores the nullsMask, producing a non-null block instead of
+     * a null block.
+     */
+    public void testCancelFirstPositionEntryResetsHasNonNullValue() {
+        assumeAbstractBlockBuilder();
+        assumeMultiValued();
+        try (Block.Builder builder = elementType.newBlockBuilder(1, blockFactory)) {
+            builder.beginPositionEntry();
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
+            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.appendNull();
+            try (Block block = builder.build()) {
+                assertThat(block.getPositionCount(), equalTo(1));
+                assertThat(block.isNull(0), is(true));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    /**
+     * Verifies that {@code BytesRefBlockBuilder.cancelPositionEntry} truncates the underlying
+     * {@code BytesRefArray} so that values appended after the cancel land at the correct offsets.
+     * Without the truncation, the offset table retains stale entries from the cancelled values
+     * and subsequent reads return the wrong bytes.
+     */
+    public void testCancelPositionEntryBytesRefRollsBackArray() {
+        assumeTrue("Only applicable to BytesRef", elementType == ElementType.BYTES_REF);
+        BytesRef alpha = new BytesRef("alpha");
+        BytesRef bad1 = new BytesRef("bad1_value");
+        BytesRef bad2 = new BytesRef("bad2_value_longer");
+        BytesRef gamma = new BytesRef("gamma");
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(alpha);           // position 0
+            builder.beginPositionEntry();
+            builder.appendBytesRef(bad1);
+            builder.appendBytesRef(bad2);
+            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.appendNull();                    // position 1 = null
+            builder.appendBytesRef(gamma);           // position 2
+            try (BytesRefBlock block = builder.build()) {
+                assertThat(block.getPositionCount(), equalTo(3));
+                assertThat(block.isNull(0), is(false));
+                assertThat(block.getBytesRef(block.getFirstValueIndex(0), new BytesRef()), equalTo(alpha));
+                assertThat(block.isNull(1), is(true));
+                assertThat(block.isNull(2), is(false));
+                assertThat(block.getBytesRef(block.getFirstValueIndex(2), new BytesRef()), equalTo(gamma));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
     private void assumeMultiValued() {
         assumeTrue(
             "Type must support multi-values",
             elementType != ElementType.AGGREGATE_METRIC_DOUBLE && elementType != ElementType.LONG_RANGE
+        );
+    }
+
+    private void assumeAbstractBlockBuilder() {
+        assumeTrue(
+            "Type must use AbstractBlockBuilder",
+            elementType != ElementType.EXPONENTIAL_HISTOGRAM && elementType != ElementType.TDIGEST
         );
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQLDS/NDJSON - Null whole position on array item coercion failure (#154000)