### PR TITLE
[9.4] Update byte bfloat16 vector yaml tests with a lucene 10.4 check (#154268)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized_bfloat16.yml
@@ -196,6 +196,9 @@ setup:
 
 ---
 "KNN Vector similarity search only":
+  - requires:
+      cluster_features: [ "lucene_10_4_upgrade" ]
+      reason: "Approximate int8_hnsw scoring differs between Lucene 10.3 and 10.4+ quantizers"
   - do:
       search:
         index: hnsw_byte_quantized
@@ -214,6 +217,9 @@ setup:
   - match: {hits.hits.0.fields.name.0: "moose.jpg"}
 ---
 "Vector similarity with filter only":
+  - requires:
+      cluster_features: [ "lucene_10_4_upgrade" ]
+      reason: "Approximate int8_hnsw scoring differs between Lucene 10.3 and 10.4+ quantizers"
   - do:
       search:
         index: hnsw_byte_quantized


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/154268 to 9.4