### PR TITLE
[9.4] [CI] Add retry logic for Docker tmpfs remounting flake (#154096)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/BootstrapCheckTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/BootstrapCheckTests.java
@@ -26,6 +26,13 @@ public class BootstrapCheckTests extends PackagingTestCase {
     }
 
     public void test20RunWithBootstrapChecks() throws Exception {
+        if (installation == null) {
+            fail(
+                "Installation failed to set up. This may indicate a Docker startup failure. "
+                    + "Check Docker daemon logs and the retry logic in Docker.executeDockerRun()."
+            );
+        }
+
         configureBootstrapChecksAndRun(
             Map.of(
                 "xpack.security.enabled",

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -176,9 +176,47 @@ public class Docker {
         removeContainer();
 
         final String command = builder.distribution(distribution).build();
-
         logger.info("Running command: " + command);
-        containerId = sh.run(command).stdout().trim();
+
+        // Retry on Docker daemon tmpfs remounting error (exit code 125)
+        // See: https://github.com/elastic/elasticsearch/issues/149040
+        final int maxAttempts = 3;
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                final Shell.Result result = sh.run(command);
+                containerId = result.stdout().trim();
+                return;
+            } catch (Shell.ShellException e) {
+                final String stderr = e.getMessage();
+                final boolean isTmpfsRemountError = stderr != null
+                    && stderr.contains("unable to remount dir as readonly")
+                    && stderr.contains("device or resource busy");
+
+                if (isTmpfsRemountError && attempt < maxAttempts - 1) {
+                    final long delayMs = 500L * (1L << attempt); // 500ms, 1s, 2s
+                    logger.warn(
+                        "Docker tmpfs remounting failed (attempt "
+                            + (attempt + 1)
+                            + "/"
+                            + maxAttempts
+                            + "), retrying in "
+                            + delayMs
+                            + "ms. Error: "
+                            + stderr
+                    );
+                    try {
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw e;
+                    }
+                } else {
+                    // Either not a tmpfs error, or final attempt — rethrow
+                    throw e;
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[CI] Add retry logic for Docker tmpfs remounting flake (#154096)](https://github.com/elastic/elasticsearch/pull/154096)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)