### PR TITLE
[9.4] Fix CC-unsafe provider in ElasticsearchCluster.module(TaskProvider<Sync>) (#154170)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -280,7 +280,15 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     }
 
     public void module(TaskProvider<Sync> module) {
-        module(project.getLayout().file(module.map(Sync::getDestinationDir)));
+        // Use TaskProvider.map() with an unbound method reference so that the resulting
+        // Provider<File> captures nothing from the outer scope. project.getLayout().file()
+        // would wrap the provider in a ProjectLayout-backed implementation that is not
+        // configuration-cache serializable in Gradle 9.5+; avoiding that call keeps the
+        // entire provider chain CC-safe. The task dependency is still tracked because the
+        // provider is derived from the TaskProvider.
+        Provider<File> moduleDir = module.map(Sync::getDestinationDir);
+        pluginAndModuleConfiguration.from(moduleDir);
+        nodes.all(each -> each.addModuleDirectory(moduleDir));
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -321,6 +321,17 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         this.modules.add(module.map(RegularFile::getAsFile));
     }
 
+    /**
+     * Adds a module directory directly from a plain file provider.
+     * Used by {@link ElasticsearchCluster} when wiring a {@link org.gradle.api.tasks.Sync} task output,
+     * where the destination directory is already resolved as a {@link java.io.File} and does not need
+     * to go through the {@code Provider<RegularFile>} abstraction.
+     */
+    void addModuleDirectory(Provider<File> moduleDir) {
+        checkFrozen();
+        this.modules.add(moduleDir);
+    }
+
     public void module(TaskProvider<Sync> module) {
         throw new IllegalStateException("Not Supported API");
     }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -183,14 +183,8 @@ tests:
   method: testFullClusterRestart
   issue: https://github.com/elastic/elasticsearch/issues/150960
 - class: org.elasticsearch.gradle.internal.test.rest.LegacyYamlRestTestPluginFuncTest
-  method: plugin projects are wired into test cluster setup
-  issue: https://github.com/elastic/elasticsearch/issues/148014
-- class: org.elasticsearch.gradle.internal.test.rest.LegacyYamlRestTestPluginFuncTest
   method: yamlRestTest does nothing when there are no tests
   issue: https://github.com/elastic/elasticsearch/issues/150983
-- class: org.elasticsearch.gradle.internal.test.rest.LegacyYamlRestTestPluginFuncTest
-  method: module projects are wired into test cluster setup
-  issue: https://github.com/elastic/elasticsearch/issues/150984
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testMaxQueueLatencyMetricIsPublished
   issue: https://github.com/elastic/elasticsearch/issues/146283


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix CC-unsafe provider in ElasticsearchCluster.module(TaskProvider<Sync>) (#154170)](https://github.com/elastic/elasticsearch/pull/154170)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)