### PR TITLE
ESQL:DS: Flip data_sources/sets provisioning APIs to public

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2767,6 +2767,15 @@ public class EsqlCapabilities {
         DATASET_IN_FROM_COMMAND,
 
         /**
+         * Signals that the data_source/dataset CRUD routes ({@code PUT/GET/DELETE /_query/data_source/{name}} and
+         * {@code PUT/GET/DELETE /_query/dataset/{name}}) are exposed with {@code @ServerlessScope(Scope.PUBLIC)}.
+         * Old nodes in a mixed cluster predate this annotation and will not report this capability via
+         * {@code /_capabilities}, so any mixed cluster containing such a node correctly returns
+         * {@code supported=false}.
+         */
+        DATA_SOURCES_SERVERLESS_SCOPE,
+
+        /**
          * {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantAggregateGroupings} rebuilds a pruned
          * derived external grouping reading the attribute the aggregate actually exposes (e.g. a rename alias) instead of the
          * pre-aggregate attribute it no longer surfaces, fixing the {@code optimized incorrectly due to missing references}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/EsqlDataSourcesCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/EsqlDataSourcesCapabilities.java
@@ -15,5 +15,13 @@ public final class EsqlDataSourcesCapabilities {
     /** The dataset PUT body accepts a declared `mappings` block (types, path renames, format, _id). */
     public static final String DATASET_DECLARED_SCHEMA = "dataset_declared_schema";
 
+    /**
+     * Signals that the data_source/dataset CRUD routes ({@code PUT/GET/DELETE /_query/data_source/{name}} and
+     * {@code PUT/GET/DELETE /_query/dataset/{name}}) are exposed with {@code @ServerlessScope(Scope.PUBLIC)}.
+     * Old nodes in a mixed cluster predate this annotation and will not report this capability via
+     * {@code /_capabilities}, so any mixed cluster containing such a node correctly returns {@code supported=false}.
+     */
+    public static final String DATA_SOURCES_SERVERLESS_SCOPE = "data_sources_serverless_scope";
+
     private EsqlDataSourcesCapabilities() {}
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestDeleteDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestDeleteDatasetAction.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestDeleteDatasetAction extends BaseRestHandler {
 
     @Override
@@ -47,6 +47,6 @@ public class RestDeleteDatasetAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES);
+        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES, EsqlDataSourcesCapabilities.DATA_SOURCES_SERVERLESS_SCOPE);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestGetDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestGetDatasetAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestGetDatasetAction extends BaseRestHandler {
 
     @Override
@@ -50,6 +50,10 @@ public class RestGetDatasetAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES, EsqlDataSourcesCapabilities.DATASET_DECLARED_SCHEMA);
+        return Set.of(
+            EsqlDataSourcesCapabilities.DATA_SOURCES,
+            EsqlDataSourcesCapabilities.DATASET_DECLARED_SCHEMA,
+            EsqlDataSourcesCapabilities.DATA_SOURCES_SERVERLESS_SCOPE
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestPutDatasetAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/RestPutDatasetAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestPutDatasetAction extends BaseRestHandler {
 
     @Override
@@ -52,6 +52,10 @@ public class RestPutDatasetAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES, EsqlDataSourcesCapabilities.DATASET_DECLARED_SCHEMA);
+        return Set.of(
+            EsqlDataSourcesCapabilities.DATA_SOURCES,
+            EsqlDataSourcesCapabilities.DATASET_DECLARED_SCHEMA,
+            EsqlDataSourcesCapabilities.DATA_SOURCES_SERVERLESS_SCOPE
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestDeleteDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestDeleteDataSourceAction.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestDeleteDataSourceAction extends BaseRestHandler {
 
     @Override
@@ -47,6 +47,6 @@ public class RestDeleteDataSourceAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES);
+        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES, EsqlDataSourcesCapabilities.DATA_SOURCES_SERVERLESS_SCOPE);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestGetDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestGetDataSourceAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestGetDataSourceAction extends BaseRestHandler {
 
     @Override
@@ -50,6 +50,6 @@ public class RestGetDataSourceAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES);
+        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES, EsqlDataSourcesCapabilities.DATA_SOURCES_SERVERLESS_SCOPE);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestPutDataSourceAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/RestPutDataSourceAction.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestPutDataSourceAction extends BaseRestHandler {
 
     @Override
@@ -52,6 +52,6 @@ public class RestPutDataSourceAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES);
+        return Set.of(EsqlDataSourcesCapabilities.DATA_SOURCES, EsqlDataSourcesCapabilities.DATA_SOURCES_SERVERLESS_SCOPE);
     }
 }


### PR DESCRIPTION
This updates the serverless decorators to make the APIs public.
