### PR TITLE
ESQL: add limited support for equality inner join

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/EqJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/EqJoin.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.join;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
+
+/**
+ * The engine's INNER equi-join, currently used to implement PromQL vector matching. It is a specialized INNER join: the right ("build")
+ * side must have unique keys (the physical {@link org.elasticsearch.xpack.esql.plan.physical.EqJoinExec} builds a {@code RowInTableLookup}
+ * from it), so each probe row matches at most one build row - i.e. it covers 1:1 and many-to-one, never many-to-many. It is the INNER
+ * counterpart of the hash flavor of LEFT join ({@code HashJoinExec}): same broadcast, in-memory, single-valued-key, unique-build machinery,
+ * differing only in that unmatched probe rows are dropped rather than null-filled.
+ * <p>
+ * As an {@link AbstractHashJoin} its right side is an independent subquery, materialized to a {@code LocalRelation} by the
+ * coordinator phase loop before the {@code Mapper} lowers it to an {@code EqJoinExec}. The left side is the "many"/probe side
+ * (its identity is preserved). {@code addedFields} are the build columns copied into the result (value + copied labels).
+ * {@code unique} selects 1:1 matching (at most one probe row per build row) vs many-to-one ({@code group_left}/{@code group_right}).
+ * Being coordinator-only and ephemeral, it is never serialized (see {@link AbstractHashJoin#writeTo}).
+ */
+public class EqJoin extends AbstractHashJoin {
+
+    private final List<Attribute> addedFields;
+    private final boolean unique;
+    private List<Attribute> lazyOutput;
+
+    public EqJoin(
+        Source source,
+        LogicalPlan left,
+        LogicalPlan right,
+        List<Attribute> leftFields,
+        List<Attribute> rightFields,
+        List<Attribute> addedFields,
+        boolean unique
+    ) {
+        super(source, left, right, JoinTypes.INNER, leftFields, rightFields);
+        this.addedFields = addedFields;
+        this.unique = unique;
+    }
+
+    public List<Attribute> leftFields() {
+        return config().leftFields();
+    }
+
+    public List<Attribute> rightFields() {
+        return config().rightFields();
+    }
+
+    public List<Attribute> addedFields() {
+        return addedFields;
+    }
+
+    public boolean unique() {
+        return unique;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            List<Attribute> leftOutputWithoutKeys = left().output().stream().filter(attr -> leftFields().contains(attr) == false).toList();
+            List<Attribute> rightWithAppendedKeys = new ArrayList<>(right().output());
+            rightWithAppendedKeys.removeAll(rightFields());
+            rightWithAppendedKeys.addAll(leftFields());
+            lazyOutput = mergeOutputAttributes(rightWithAppendedKeys, leftOutputWithoutKeys);
+        }
+        return lazyOutput;
+    }
+
+    /**
+     * {@link Join#computeOutputExpressions(List, List)} throws for non-LEFT join types, so INNER computes its own output (mirroring
+     * {@link #output()}, which is what the physical {@code EqJoinExec} produces).
+     */
+    @Override
+    public List<NamedExpression> computeOutputExpressions(List<? extends NamedExpression> left, List<? extends NamedExpression> right) {
+        return new ArrayList<>(output());
+    }
+
+    @Override
+    public boolean expressionsResolved() {
+        return true;
+    }
+
+    /**
+     * Rebuilds the main plan after the right-side subquery has been materialized, replacing the matching EqJoin's right child with
+     * the materialized local relation.
+     */
+    public static LogicalPlan newMainPlan(
+        LogicalPlan optimizedPlan,
+        AbstractHashJoin.LogicalPlanTuple subPlans,
+        LocalRelation resultWrapper
+    ) {
+        LogicalPlan newPlan = optimizedPlan.transformUp(
+            EqJoin.class,
+            join -> join.right() == subPlans.originalSubPlan() ? join.replaceRight(resultWrapper) : join
+        );
+        newPlan.setOptimized();
+        return newPlan;
+    }
+
+    @Override
+    public EqJoin replaceChildren(LogicalPlan left, LogicalPlan right) {
+        return new EqJoin(source(), left, right, leftFields(), rightFields(), addedFields, unique);
+    }
+
+    @Override
+    protected NodeInfo<Join> info() {
+        return NodeInfo.create(this, EqJoin::new, left(), right(), leftFields(), rightFields(), addedFields, unique);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (super.equals(o) == false) {
+            return false;
+        }
+        EqJoin eqJoin = (EqJoin) o;
+        return unique == eqJoin.unique && addedFields.equals(eqJoin.addedFields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), addedFields, unique);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EqJoinExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EqJoinExec.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
+
+/**
+ * Coordinator-only INNER equi-join over a materialized "build" side, used to implement PromQL
+ * vector matching. It is an ephemeral node: it never crosses the wire and is expanded into a chain
+ * of existing operators by {@link org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner#planEqJoin}
+ * (row lookup + optional 1:1 uniqueness guard + inner-drop filter + column load), so it is not
+ * serialized (see {@link #writeTo}).
+ * <p>
+ * Shape mirrors {@link HashJoinExec} so translation can later map a logical {@code EqJoin} onto it
+ * exactly as {@code Join} maps onto {@link HashJoinExec}. The extra {@link #unique} flag selects 1:1
+ * ({@code true}: enforce at-most-one probe row per build row) vs many-to-one ({@code false}:
+ * {@code group_left}/{@code group_right}, fan-out allowed).
+ */
+public class EqJoinExec extends BinaryExec implements EstimatesRowSize {
+
+    private final List<Attribute> leftFields;
+    private final List<Attribute> rightFields;
+    private final List<Attribute> addedFields;
+    private final boolean unique;
+    private List<Attribute> lazyOutput;
+    private AttributeSet lazyAddedFields;
+
+    public EqJoinExec(
+        Source source,
+        PhysicalPlan left,
+        PhysicalPlan joinData,
+        List<Attribute> leftFields,
+        List<Attribute> rightFields,
+        List<Attribute> addedFields,
+        boolean unique
+    ) {
+        super(source, left, joinData);
+        this.leftFields = leftFields;
+        this.rightFields = rightFields;
+        this.addedFields = addedFields;
+        this.unique = unique;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    public PhysicalPlan joinData() {
+        return right();
+    }
+
+    public List<Attribute> leftFields() {
+        return leftFields;
+    }
+
+    public List<Attribute> rightFields() {
+        return rightFields;
+    }
+
+    public Set<Attribute> addedFields() {
+        if (lazyAddedFields == null) {
+            lazyAddedFields = AttributeSet.of(addedFields);
+        }
+        return lazyAddedFields;
+    }
+
+    /**
+     * {@code true} for 1:1 matching (enforce at-most-one probe row per build row); {@code false} for
+     * many-to-one ({@code group_left}/{@code group_right}).
+     */
+    public boolean unique() {
+        return unique;
+    }
+
+    @Override
+    public PhysicalPlan estimateRowSize(State state) {
+        state.add(false, addedFields);
+        return this;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            List<Attribute> leftOutputWithoutKeys = left().output().stream().filter(attr -> leftFields.contains(attr) == false).toList();
+            List<Attribute> rightWithAppendedKeys = new ArrayList<>(right().output());
+            rightWithAppendedKeys.removeAll(rightFields);
+            rightWithAppendedKeys.addAll(leftFields);
+
+            lazyOutput = mergeOutputAttributes(rightWithAppendedKeys, leftOutputWithoutKeys);
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public AttributeSet inputSet() {
+        // The build side is materialized; only the probe (left) side flows in.
+        return left().outputSet();
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return Expressions.references(leftFields);
+    }
+
+    @Override
+    public AttributeSet leftReferences() {
+        return Expressions.references(leftFields);
+    }
+
+    @Override
+    public AttributeSet rightReferences() {
+        return Expressions.references(rightFields);
+    }
+
+    @Override
+    public EqJoinExec replaceChildren(PhysicalPlan left, PhysicalPlan right) {
+        return new EqJoinExec(source(), left, right, leftFields, rightFields, addedFields, unique);
+    }
+
+    @Override
+    protected NodeInfo<? extends PhysicalPlan> info() {
+        return NodeInfo.create(this, EqJoinExec::new, left(), right(), leftFields, rightFields, addedFields, unique);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (super.equals(o) == false) {
+            return false;
+        }
+        EqJoinExec eqJoin = (EqJoinExec) o;
+        return unique == eqJoin.unique
+            && leftFields.equals(eqJoin.leftFields)
+            && rightFields.equals(eqJoin.rightFields)
+            && addedFields.equals(eqJoin.addedFields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), leftFields, rightFields, addedFields, unique);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -23,7 +23,9 @@ import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
@@ -160,6 +162,7 @@ import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
 import org.elasticsearch.xpack.esql.plan.physical.CompoundOutputEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
+import org.elasticsearch.xpack.esql.plan.physical.EqJoinExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -450,6 +453,8 @@ public class LocalExecutionPlanner {
             return planEnrich(enrich, context);
         } else if (node instanceof HashJoinExec join) {
             return planHashJoin(join, context);
+        } else if (node instanceof EqJoinExec join) {
+            return planEqJoin(join, context);
         } else if (node instanceof LookupJoinExec join) {
             return planLookupJoin(join, context);
         }
@@ -1461,6 +1466,115 @@ public class LocalExecutionPlanner {
         IntStream.range(0, positionsChannel).boxed().forEach(projection::add);
         IntStream.range(positionsChannel + 1, positionsChannel + 1 + join.addedFields().size()).boxed().forEach(projection::add);
         return source.with(new ProjectOperatorFactory(projection), layout);
+    }
+
+    /**
+     * Ephemeral coordinator-only INNER equi-join for PromQL vector matching. Expands into a chain of
+     * existing operators: probe -&gt; {@link RowInTableLookupOperator} (append match ordinal) -&gt;
+     * [1:1 {@link org.elasticsearch.compute.operator.DistinctByOperator} guard] -&gt;
+     * {@link org.elasticsearch.compute.operator.FilterOperator} (drop unmatched) -&gt;
+     * {@link ColumnLoadOperator} (gather build columns) -&gt; drop the ordinal. Mirrors
+     * {@link #planHashJoin} plus the uniqueness guard and the inner-drop filter.
+     */
+    private PhysicalOperation planEqJoin(EqJoinExec join, LocalExecutionPlannerContext context) {
+        PhysicalOperation source = plan(join.left(), context);
+        int positionsChannel = source.layout.numberOfChannels();
+
+        Layout.Builder layoutBuilder = source.layout.builder();
+        for (Attribute f : join.output()) {
+            if (join.left().outputSet().contains(f)) {
+                continue;
+            }
+            layoutBuilder.append(f);
+        }
+        Layout layout = layoutBuilder.build();
+        LocalSourceExec localSourceExec = (LocalSourceExec) join.joinData();
+        Page localData = localSourceExec.supplier().get();
+
+        RowInTableLookupOperator.Key[] keys = new RowInTableLookupOperator.Key[join.leftFields().size()];
+        int[] blockMapping = new int[join.leftFields().size()];
+        for (int k = 0; k < join.leftFields().size(); k++) {
+            Attribute left = join.leftFields().get(k);
+            Attribute right = join.rightFields().get(k);
+            Block localField = null;
+            List<Attribute> output = join.joinData().output();
+            for (int l = 0; l < output.size(); l++) {
+                if (output.get(l).name().equals(right.name())) {
+                    localField = localData.getBlock(l);
+                }
+            }
+            if (localField == null) {
+                throw new IllegalArgumentException("can't find local data for [" + right + "]");
+            }
+
+            keys[k] = new RowInTableLookupOperator.Key(left.name(), localField);
+            Layout.ChannelAndType input = source.layout.get(left.id());
+            blockMapping[k] = input.channel();
+        }
+
+        // Append the match ordinal of each probe row (null for a miss).
+        source = source.with(new RowInTableLookupOperator.Factory(keys, blockMapping), layout);
+
+        // 1:1 matching: throw if a build row is matched by more than one probe row.
+        if (join.unique()) {
+            source = source.with(new DistinctByOperator.OrdinalIntKeyFactory(positionsChannel, false), layout);
+        }
+
+        // INNER join: drop probe rows that did not match (null ordinal).
+        source = source.with(new FilterOperatorFactory(notNullChannel(positionsChannel)), layout);
+
+        // Load the "values" from each match
+        var joinDataOutput = join.joinData().output();
+        for (Attribute f : join.addedFields()) {
+            Block localField = null;
+            for (int l = 0; l < joinDataOutput.size(); l++) {
+                if (joinDataOutput.get(l).name().equals(f.name())) {
+                    localField = localData.getBlock(l);
+                }
+            }
+            if (localField == null) {
+                throw new IllegalArgumentException("can't find local data for [" + f + "]");
+            }
+            source = source.with(
+                new ColumnLoadOperator.Factory(new ColumnLoadOperator.Values(f.name(), localField), positionsChannel),
+                layout
+            );
+        }
+
+        // Drop the "positions" (ordinal) of the match
+        List<Integer> projection = new ArrayList<>();
+        IntStream.range(0, positionsChannel).boxed().forEach(projection::add);
+        IntStream.range(positionsChannel + 1, positionsChannel + 1 + join.addedFields().size()).boxed().forEach(projection::add);
+        return source.with(new ProjectOperatorFactory(projection), layout);
+    }
+
+    /**
+     * A boolean condition, true where block {@code channel} is non-null. Used to drop unmatched
+     * (null-ordinal) probe rows in {@link #planEqJoin}. The ordinal is a synthetic channel (not a
+     * plan attribute), so this reads it directly rather than through {@code EvalMapper}.
+     */
+    private static ExpressionEvaluator.Factory notNullChannel(int channel) {
+        return driverContext -> new ExpressionEvaluator() {
+            @Override
+            public Block eval(Page page) {
+                IntBlock ordinals = page.getBlock(channel);
+                int positions = page.getPositionCount();
+                try (BooleanVector.FixedBuilder builder = driverContext.blockFactory().newBooleanVectorFixedBuilder(positions)) {
+                    for (int p = 0; p < positions; p++) {
+                        builder.appendBoolean(p, ordinals.isNull(p) == false);
+                    }
+                    return builder.build().asBlock();
+                }
+            }
+
+            @Override
+            public long baseRamBytesUsed() {
+                return 0;
+            }
+
+            @Override
+            public void close() {}
+        };
     }
 
     private PhysicalOperation planLookupJoin(LookupJoinExec join, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/Mapper.java
@@ -30,9 +30,11 @@ import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
 import org.elasticsearch.xpack.esql.plan.logical.TsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.EqJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
+import org.elasticsearch.xpack.esql.plan.physical.EqJoinExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
 import org.elasticsearch.xpack.esql.plan.physical.HashJoinExec;
@@ -202,6 +204,24 @@ public class Mapper {
     }
 
     private PhysicalPlan mapBinary(BinaryPlan bp) {
+        // EqJoin is an INNER Join subtype, so it must be matched before the generic Join branch below (which only supports LEFT). Its
+        // right ("build") side is materialized to a LocalRelation by the coordinator phase loop before it reaches here.
+        if (bp instanceof EqJoin eqJoin) {
+            PhysicalPlan left = mapInner(bp.left());
+            PhysicalPlan right = mapInner(bp.right());
+            if (right instanceof LocalSourceExec localData) {
+                return new EqJoinExec(
+                    eqJoin.source(),
+                    left,
+                    localData,
+                    eqJoin.leftFields(),
+                    eqJoin.rightFields(),
+                    eqJoin.addedFields(),
+                    eqJoin.unique()
+                );
+            }
+            return MapperUtils.unsupported(bp);
+        }
         if (bp instanceof Join join) {
             JoinConfig config = join.config();
             if (config.type() != JoinTypes.LEFT) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -113,7 +113,9 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedIpLocation;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+import org.elasticsearch.xpack.esql.plan.logical.join.AbstractHashJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.EqJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
@@ -946,7 +948,7 @@ public class EsqlSession {
     ) {
         SubPlanAndCallback subPlanAndCallback = null;
 
-        // Find the first (bottom-up) SemiJoin or InlineJoin that needs subplan execution.
+        // Find the first (bottom-up) hash join or InlineJoin that needs subplan execution.
         // Processing bottom-up ensures inner subplans (e.g. INLINE STATS inside IN subquery)
         // are resolved before outer ones that depend on them.
         LogicalPlan firstJoin = findFirstSubPlanJoin(mainPlan, subPlansResults);
@@ -970,6 +972,17 @@ public class EsqlSession {
                         blockFactory,
                         localRelationPage
                     );
+                }, () -> releaseLocalRelationBlocks(localRelationPage), true);
+            }
+        } else if (firstJoin instanceof EqJoin) {
+            AbstractHashJoin.LogicalPlanTuple subPlans = AbstractHashJoin.firstSubPlan(mainPlan, subPlansResults);
+            if (subPlans != null) {
+                AtomicReference<Page> localRelationPage = new AtomicReference<>();
+                subPlanAndCallback = new SubPlanAndCallback(subPlans.subPlan(), result -> {
+                    LocalRelation resultWrapper = resultToPlan(subPlans.subPlan().source(), result);
+                    localRelationPage.set(resultWrapper.supplier().get());
+                    subPlansResults.add(resultWrapper);
+                    return EqJoin.newMainPlan(mainPlan, subPlans, resultWrapper);
                 }, () -> releaseLocalRelationBlocks(localRelationPage), true);
             }
         } else if (firstJoin instanceof InlineJoin) {
@@ -1005,23 +1018,23 @@ public class EsqlSession {
     }
 
     /**
-     * Finds the first (bottom-up) SemiJoin or InlineJoin in the plan that has an unresolved subplan.
+     * Finds the first (bottom-up) hash join or InlineJoin in the plan that has an unresolved subplan.
      * Returns the join node itself, or null if none found.
      */
     private static LogicalPlan findFirstSubPlanJoin(LogicalPlan plan, Set<LocalRelation> subPlansResults) {
         Holder<LogicalPlan> result = new Holder<>();
-        // Evaluate the right hand side of a SemiJoin or InlineJoin, unless it is a LocalRelation and registered in subPlansResults already
+        // Evaluate the right hand side of a hash join or InlineJoin, unless it is a LocalRelation and registered in subPlansResults already
         plan.forEachUp(p -> {
             if (result.get() != null) {
                 return;
             }
-            // Whether checking the subquery join or InlineJoin first does not matter, the plan is processed bottom up, looking for
+            // Whether checking the hash join or InlineJoin first does not matter, the plan is processed bottom up, looking for
             // joins whose right child haven't been evaluated yet
-            if (p instanceof AbstractSubqueryJoin sj) {
-                if (sj.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) {
+            if (p instanceof AbstractHashJoin hj) {
+                if (hj.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) {
                     return; // already processed
                 }
-                result.set(sj);
+                result.set(hj);
             } else if (p instanceof InlineJoin ij) {
                 if (ij.right().anyMatch(r -> r instanceof StubRelation)) {
                     result.set(ij);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
@@ -90,6 +90,7 @@ import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractHashJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.AntiJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.EqJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.MarkJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.SemiJoin;
@@ -197,6 +198,7 @@ public class ApproximationSupportTests extends ESTestCase {
         AntiJoin.class,
         Dedup.class,
         Drop.class,
+        EqJoin.class,
         InlineStats.class,
         Keep.class,
         MarkJoin.class,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/join/EqJoinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/join/EqJoinTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.join;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getFieldAttribute;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Unit tests for {@link EqJoin}: it is an INNER {@link Join} subtype, and it participates in the coordinator phase loop via the shared
+ * {@link AbstractHashJoin#firstSubPlan} machinery. Unlike the SEMI family ({@link AbstractSubqueryJoin}), its
+ * {@link EqJoin#newMainPlan} path simply replaces the right child with the materialized {@link LocalRelation} so the mapper can
+ * lower the node to an {@code EqJoinExec} - it does not rewrite into an {@code IN} list or hash join.
+ */
+public class EqJoinTests extends ESTestCase {
+
+    public void testIsInnerJoinWithEqJoinShape() {
+        FieldAttribute leftKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute rightKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute value = getFieldAttribute("v", DataType.LONG);
+        EqJoin eqJoin = eqJoin(leftKey, rightKey, value, true);
+
+        assertThat(eqJoin, instanceOf(Join.class));
+        assertThat(eqJoin.config().type(), sameInstance(JoinTypes.INNER));
+        assertThat(eqJoin.leftFields(), equalTo(List.of(leftKey)));
+        assertThat(eqJoin.rightFields(), equalTo(List.of(rightKey)));
+        assertThat(eqJoin.addedFields(), equalTo(List.of(value)));
+        assertThat(eqJoin.unique(), is(true));
+        // INNER equi-join output: the copied build column(s) plus the (probe) join key, as the physical EqJoinExec produces.
+        assertThat(eqJoin.output(), equalTo(List.of(value, leftKey)));
+    }
+
+    public void testNotSerialized() {
+        EqJoin eqJoin = eqJoin(getFieldAttribute("k", DataType.LONG), getFieldAttribute("k", DataType.LONG), null, false);
+        expectThrows(UnsupportedOperationException.class, () -> eqJoin.writeTo((StreamOutput) null));
+        expectThrows(UnsupportedOperationException.class, eqJoin::getWriteableName);
+    }
+
+    public void testFirstSubPlanFindsEqJoinRight() {
+        EqJoin eqJoin = eqJoin(getFieldAttribute("k", DataType.LONG), getFieldAttribute("k", DataType.LONG), null, true);
+
+        AbstractHashJoin.LogicalPlanTuple tuple = AbstractHashJoin.firstSubPlan(eqJoin, new HashSet<>());
+        assertThat(tuple, notNullValue());
+        // The right subquery is the very instance held on the join, doubling as the identity key for newMainPlan.
+        assertThat(tuple.subPlan(), sameInstance(eqJoin.right()));
+        assertThat(tuple.originalSubPlan(), sameInstance(eqJoin.right()));
+    }
+
+    public void testFirstSubPlanSkipsAlreadyMaterializedRight() {
+        FieldAttribute leftKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute rightKey = getFieldAttribute("k", DataType.LONG);
+        LocalRelation materializedRight = localRelation(List.of(rightKey));
+        EqJoin eqJoin = new EqJoin(
+            Source.EMPTY,
+            localRelation(List.of(leftKey)),
+            materializedRight,
+            List.of(leftKey),
+            List.of(rightKey),
+            List.of(),
+            false
+        );
+
+        Set<LocalRelation> processed = new HashSet<>();
+        processed.add(materializedRight);
+        assertThat(AbstractHashJoin.firstSubPlan(eqJoin, processed), nullValue());
+    }
+
+    public void testNewMainPlanReplacesRightWithLocalRelation() {
+        FieldAttribute leftKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute rightKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute value = getFieldAttribute("v", DataType.LONG);
+        EqJoin eqJoin = eqJoin(leftKey, rightKey, value, true);
+
+        AbstractHashJoin.LogicalPlanTuple tuple = AbstractHashJoin.firstSubPlan(eqJoin, new HashSet<>());
+        assertThat(tuple, notNullValue());
+
+        LocalRelation materialized = localRelation(List.of(rightKey, value));
+        LogicalPlan newMain = EqJoin.newMainPlan(eqJoin, tuple, materialized);
+
+        // Still an EqJoin (not rewritten into a Filter/HashJoin like the SEMI family), now with the materialized build side on its right.
+        EqJoin rebuilt = as(newMain, EqJoin.class);
+        assertThat(rebuilt.right(), sameInstance(materialized));
+        assertThat(rebuilt.left(), sameInstance(eqJoin.left()));
+        assertThat(rebuilt.leftFields(), equalTo(eqJoin.leftFields()));
+        assertThat(rebuilt.rightFields(), equalTo(eqJoin.rightFields()));
+        assertThat(rebuilt.addedFields(), equalTo(eqJoin.addedFields()));
+        assertThat(rebuilt.unique(), is(eqJoin.unique()));
+    }
+
+    private static EqJoin eqJoin(FieldAttribute leftKey, FieldAttribute rightKey, FieldAttribute addedValue, boolean unique) {
+        List<Attribute> rightOutput = addedValue == null ? List.of(rightKey) : List.of(rightKey, addedValue);
+        List<Attribute> added = addedValue == null ? List.of() : List.of(addedValue);
+        return new EqJoin(
+            Source.EMPTY,
+            localRelation(List.of(leftKey)),
+            localRelation(rightOutput),
+            List.of(leftKey),
+            List.of(rightKey),
+            added,
+            unique
+        );
+    }
+
+    private static LocalRelation localRelation(List<Attribute> output) {
+        return new LocalRelation(Source.EMPTY, output, LocalSupplier.of(new Page(0)));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -22,6 +22,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.EmptyIndexedByShardId;
 import org.elasticsearch.compute.lucene.IndexedByShardIdFromList;
@@ -29,12 +31,19 @@ import org.elasticsearch.compute.lucene.query.DataPartitioning;
 import org.elasticsearch.compute.lucene.query.LuceneSourceOperator;
 import org.elasticsearch.compute.lucene.query.LuceneTopNSourceOperator;
 import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.ColumnLoadOperator;
+import org.elasticsearch.compute.operator.DistinctByOperator;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.FilterOperator;
 import org.elasticsearch.compute.operator.LocalSourceOperator;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.ProjectOperator;
+import org.elasticsearch.compute.operator.RowInTableLookupOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.compute.test.NoOpReleasable;
 import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -81,9 +90,12 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.ProjectAwayColumns;
 import org.elasticsearch.xpack.esql.plan.QuerySettings;
 import org.elasticsearch.xpack.esql.plan.ResolvedSettings;
 import org.elasticsearch.xpack.esql.plan.logical.MetricsInfo;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.physical.EqJoinExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.MetricsInfoExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
@@ -103,6 +115,8 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -795,6 +809,256 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
                 }
             };
         };
+    }
+
+    public void testPlanEqJoinManyToOne() throws IOException {
+        // group_left: no uniqueness guard, just lookup -> inner-drop filter -> column load -> drop ordinal.
+        assertThat(
+            planEqJoinFactories(false),
+            contains(
+                RowInTableLookupOperator.Factory.class,
+                FilterOperator.FilterOperatorFactory.class,
+                ColumnLoadOperator.Factory.class,
+                ProjectOperator.ProjectOperatorFactory.class
+            )
+        );
+    }
+
+    public void testPlanEqJoinOneToOneAddsUniquenessGuard() throws IOException {
+        // 1:1: the DistinctByOperator guard is inserted right after the lookup.
+        assertThat(
+            planEqJoinFactories(true),
+            contains(
+                RowInTableLookupOperator.Factory.class,
+                DistinctByOperator.OrdinalIntKeyFactory.class,
+                FilterOperator.FilterOperatorFactory.class,
+                ColumnLoadOperator.Factory.class,
+                ProjectOperator.ProjectOperatorFactory.class
+            )
+        );
+    }
+
+    public void testEqJoinManyToOneGathersAndDropsMisses() throws IOException {
+        // group_left: many probe rows per build row; the miss (99) is dropped by the inner-join filter.
+        List<Page> results = runEqJoin(
+            eqJoinExec(false, new long[] { 10, 20, 10, 99, 30 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 })
+        );
+        assertEqJoinOutput(results, List.of(10L, 20L, 10L, 30L), List.of(100L, 200L, 100L, 300L));
+    }
+
+    public void testEqJoinOneToOneUniqueProbe() throws IOException {
+        List<Page> results = runEqJoin(
+            eqJoinExec(true, new long[] { 10, 20, 30 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 })
+        );
+        assertEqJoinOutput(results, List.of(10L, 20L, 30L), List.of(100L, 200L, 300L));
+    }
+
+    public void testEqJoinOneToOneDuplicateProbeThrows() {
+        // Two probe rows map to build ordinal 0 -> the 1:1 guard throws (a many-to-one match where 1:1 was declared).
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> runEqJoin(eqJoinExec(true, new long[] { 10, 20, 10 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 }))
+        );
+        assertThat(e.getMessage(), containsString("found a duplicate key"));
+    }
+
+    public void testEqJoinDuplicateBuildKeyThrows() {
+        // A duplicate key on the build ("one") side is rejected when the lookup table is built.
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> runEqJoin(eqJoinExec(false, new long[] { 10 }, new long[] { 10, 10, 20 }, new long[] { 100, 100, 200 }))
+        );
+        assertThat(e.getMessage(), containsString("found a duplicate row"));
+    }
+
+    public void testEqJoinManyToOneFanOutAllowsProbeDuplicates() throws IOException {
+        // group_left: several probe rows share one build key. Unlike 1:1 there is no guard, so probe
+        // duplicates are allowed and each row fans out carrying the same build value.
+        List<Page> results = runEqJoin(eqJoinExec(false, new long[] { 10, 10, 10, 20 }, new long[] { 10, 20 }, new long[] { 100, 200 }));
+        assertEqJoinOutput(results, List.of(10L, 10L, 10L, 20L), List.of(100L, 100L, 100L, 200L));
+    }
+
+    public void testEqJoinMultiColumnKey() throws IOException {
+        // The real join key spans (labels..., step): a match requires equality on BOTH key columns.
+        // Probe (10, 2) matches only the first column of build (10, 1) -> miss, dropped.
+        EqJoinExec eqJoin = eqJoinExec(
+            true,
+            List.of(new long[] { 10, 20, 10 }, new long[] { 1, 1, 2 }), // probe (k0, k1)
+            List.of(new long[] { 10, 20, 30 }, new long[] { 1, 1, 1 }), // build (k0, k1)
+            List.of(new long[] { 100, 200, 300 })                       // build v0
+        );
+        assertEqJoinRows(runEqJoin(eqJoin), List.of(List.of(10L, 1L, 100L), List.of(20L, 1L, 200L)));
+    }
+
+    public void testEqJoinCopiesMultipleBuildColumns() throws IOException {
+        // group_left(l1, l2): more than one build column is gathered onto each surviving probe row.
+        EqJoinExec eqJoin = eqJoinExec(
+            false,
+            List.of(new long[] { 10, 20, 10 }),                        // probe (k0)
+            List.of(new long[] { 10, 20 }),                            // build (k0)
+            List.of(new long[] { 100, 200 }, new long[] { 111, 222 })  // build (v0, v1)
+        );
+        assertEqJoinRows(runEqJoin(eqJoin), List.of(List.of(10L, 100L, 111L), List.of(20L, 200L, 222L), List.of(10L, 100L, 111L)));
+    }
+
+    public void testEqJoinEmptyBuildProducesNoRows() throws IOException {
+        // Empty "one" side -> every probe row misses -> the inner join drops everything.
+        List<Page> results = runEqJoin(eqJoinExec(false, new long[] { 10, 20 }, new long[] {}, new long[] {}));
+        assertEqJoinOutput(results, List.of(), List.of());
+    }
+
+    public void testEqJoinEmptyProbeProducesNoRows() throws IOException {
+        List<Page> results = runEqJoin(eqJoinExec(false, new long[] {}, new long[] { 10, 20 }, new long[] { 100, 200 }));
+        assertEqJoinOutput(results, List.of(), List.of());
+    }
+
+    public void testEqJoinAllProbeRowsMissProduceNoRows() throws IOException {
+        // Non-empty build, but no probe key exists on the build side -> empty inner-join result.
+        List<Page> results = runEqJoin(eqJoinExec(false, new long[] { 1, 2, 3 }, new long[] { 10, 20 }, new long[] { 100, 200 }));
+        assertEqJoinOutput(results, List.of(), List.of());
+    }
+
+    public void testEqJoinMultivaluedBuildKeyThrows() {
+        // The lookup table only supports single-valued keys; a multivalued build key is rejected.
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+        ReferenceAttribute buildKey = new ReferenceAttribute(Source.EMPTY, "k0", DataType.LONG);
+        ReferenceAttribute buildValue = new ReferenceAttribute(Source.EMPTY, "v0", DataType.LONG);
+        LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(2);
+        keyBuilder.beginPositionEntry().appendLong(10).appendLong(20).endPositionEntry(); // multivalued key
+        keyBuilder.appendLong(30);
+        LocalSourceExec build = new LocalSourceExec(
+            Source.EMPTY,
+            List.of(buildKey, buildValue),
+            LocalSupplier.of(new Page(keyBuilder.build(), blockFactory.newLongArrayVector(new long[] { 100, 200 }, 2).asBlock()))
+        );
+        ReferenceAttribute probeKey = new ReferenceAttribute(Source.EMPTY, "k0", DataType.LONG);
+        LocalSourceExec probe = new LocalSourceExec(
+            Source.EMPTY,
+            List.of(probeKey),
+            LocalSupplier.of(new Page(blockFactory.newLongArrayVector(new long[] { 10 }, 1).asBlock()))
+        );
+        EqJoinExec eqJoin = new EqJoinExec(Source.EMPTY, probe, build, List.of(probeKey), List.of(buildKey), List.of(buildValue), false);
+        var e = expectThrows(IllegalArgumentException.class, () -> runEqJoin(eqJoin));
+        assertThat(e.getMessage(), containsString("only single valued keys are supported"));
+    }
+
+    /**
+     * Builds an {@link EqJoinExec} over a materialized build ("one") side with a single {@code LONG} key
+     * column and a single copied {@code LONG} value column.
+     */
+    private EqJoinExec eqJoinExec(boolean unique, long[] probeKeys, long[] buildKeys, long[] buildValues) {
+        return eqJoinExec(unique, List.of(probeKeys), List.of(buildKeys), List.of(buildValues));
+    }
+
+    /**
+     * Builds an {@link EqJoinExec} over a materialized build ("one") side. The join key may span several
+     * columns (the real join key is {@code (labels..., step)}) and any number of build columns may be
+     * copied onto the probe rows (as {@code group_left(...)} does). All columns are {@code LONG}; each
+     * {@code long[]} is one column's values, and every column on a side must have the same length.
+     */
+    private EqJoinExec eqJoinExec(boolean unique, List<long[]> probeKeyCols, List<long[]> buildKeyCols, List<long[]> buildValueCols) {
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+
+        List<Attribute> buildKeyAttrs = new ArrayList<>();
+        for (int c = 0; c < buildKeyCols.size(); c++) {
+            buildKeyAttrs.add(new ReferenceAttribute(Source.EMPTY, "k" + c, DataType.LONG));
+        }
+        List<Attribute> buildValueAttrs = new ArrayList<>();
+        for (int c = 0; c < buildValueCols.size(); c++) {
+            buildValueAttrs.add(new ReferenceAttribute(Source.EMPTY, "v" + c, DataType.LONG));
+        }
+        List<Block> buildBlocks = new ArrayList<>();
+        for (long[] col : buildKeyCols) {
+            buildBlocks.add(blockFactory.newLongArrayVector(col, col.length).asBlock());
+        }
+        for (long[] col : buildValueCols) {
+            buildBlocks.add(blockFactory.newLongArrayVector(col, col.length).asBlock());
+        }
+        List<Attribute> buildOutput = new ArrayList<>(buildKeyAttrs);
+        buildOutput.addAll(buildValueAttrs);
+        LocalSourceExec build = new LocalSourceExec(
+            Source.EMPTY,
+            buildOutput,
+            LocalSupplier.of(new Page(buildBlocks.toArray(new Block[0])))
+        );
+
+        List<Attribute> probeKeyAttrs = new ArrayList<>();
+        for (int c = 0; c < probeKeyCols.size(); c++) {
+            probeKeyAttrs.add(new ReferenceAttribute(Source.EMPTY, "k" + c, DataType.LONG));
+        }
+        List<Block> probeBlocks = new ArrayList<>();
+        for (long[] col : probeKeyCols) {
+            probeBlocks.add(blockFactory.newLongArrayVector(col, col.length).asBlock());
+        }
+        LocalSourceExec probe = new LocalSourceExec(
+            Source.EMPTY,
+            probeKeyAttrs,
+            LocalSupplier.of(new Page(probeBlocks.toArray(new Block[0])))
+        );
+
+        return new EqJoinExec(Source.EMPTY, probe, build, probeKeyAttrs, buildKeyAttrs, buildValueAttrs, unique);
+    }
+
+    private LocalExecutionPlanner.LocalExecutionPlan planEqJoin(EqJoinExec eqJoin) throws IOException {
+        return planner().plan("test", FoldContext.small(), PlannerSettings.DEFAULTS, eqJoin, EmptyIndexedByShardId.instance());
+    }
+
+    /**
+     * Classes of the intermediate operator factories, i.e. the chain that {@code planEqJoin} expands to.
+     */
+    private List<Class<?>> planEqJoinFactories(boolean unique) throws IOException {
+        EqJoinExec eqJoin = eqJoinExec(unique, new long[] { 10, 20, 10 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 });
+        List<Class<?>> factories = new ArrayList<>();
+        for (var factory : planEqJoin(eqJoin).driverFactories.get(0).driverSupplier().physicalOperation().intermediateOperatorFactories) {
+            factories.add(factory.getClass());
+        }
+        return factories;
+    }
+
+    /**
+     * Plans then runs an {@link EqJoinExec} end to end, returning the (deep-copied) result pages.
+     */
+    private List<Page> runEqJoin(EqJoinExec eqJoin) throws IOException {
+        var op = planEqJoin(eqJoin).driverFactories.get(0).driverSupplier().physicalOperation();
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        var runner = new TestDriverRunner().builder(driverContext);
+        runner.input(op.sourceOperatorFactory.get(driverContext));
+        return runner.run(op.intermediateOperatorFactories.toArray(new Operator.OperatorFactory[0]));
+    }
+
+    private void assertEqJoinOutput(List<Page> results, List<Long> expectedKeys, List<Long> expectedValues) {
+        List<Long> keys = new ArrayList<>();
+        List<Long> values = new ArrayList<>();
+        for (Page page : results) {
+            LongBlock keyBlock = page.getBlock(0);
+            LongBlock valueBlock = page.getBlock(1);
+            for (int p = 0; p < page.getPositionCount(); p++) {
+                keys.add(keyBlock.getLong(keyBlock.getFirstValueIndex(p)));
+                values.add(valueBlock.getLong(valueBlock.getFirstValueIndex(p)));
+            }
+        }
+        assertThat(keys, equalTo(expectedKeys));
+        assertThat(values, equalTo(expectedValues));
+    }
+
+    /**
+     * Asserts the full output rows of an {@link EqJoinExec} whose output is entirely {@code LONG} columns
+     * (probe key columns followed by the copied build columns), in output order.
+     */
+    private void assertEqJoinRows(List<Page> results, List<List<Long>> expectedRows) {
+        List<List<Long>> rows = new ArrayList<>();
+        for (Page page : results) {
+            for (int p = 0; p < page.getPositionCount(); p++) {
+                List<Long> row = new ArrayList<>();
+                for (int b = 0; b < page.getBlockCount(); b++) {
+                    LongBlock block = page.getBlock(b);
+                    row.add(block.getLong(block.getFirstValueIndex(p)));
+                }
+                rows.add(row);
+            }
+        }
+        assertThat(rows, equalTo(expectedRows));
     }
 
     private LocalExecutionPlanner planner() throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/mapper/EqJoinMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/mapper/EqJoinMapperTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.planner.mapper;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.logical.join.EqJoin;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.physical.EqJoinExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.session.Versioned;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Verifies the {@link Mapper} lowers a logical {@link EqJoin} (over a materialized build side) to a
+ * physical {@link EqJoinExec}, carrying the join fields and the {@code unique} flag through unchanged.
+ */
+public class EqJoinMapperTests extends ESTestCase {
+
+    public void testMapsEqJoinToEqJoinExec() {
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+
+        ReferenceAttribute probeKey = new ReferenceAttribute(Source.EMPTY, "k", DataType.LONG);
+        LocalRelation probe = new LocalRelation(
+            Source.EMPTY,
+            List.of(probeKey),
+            LocalSupplier.of(new Page(blockFactory.newLongArrayVector(new long[] { 10, 20 }, 2).asBlock()))
+        );
+
+        ReferenceAttribute buildKey = new ReferenceAttribute(Source.EMPTY, "k", DataType.LONG);
+        ReferenceAttribute buildValue = new ReferenceAttribute(Source.EMPTY, "bval", DataType.LONG);
+        LocalRelation build = new LocalRelation(
+            Source.EMPTY,
+            List.of(buildKey, buildValue),
+            LocalSupplier.of(
+                new Page(
+                    blockFactory.newLongArrayVector(new long[] { 10, 20 }, 2).asBlock(),
+                    blockFactory.newLongArrayVector(new long[] { 100, 200 }, 2).asBlock()
+                )
+            )
+        );
+
+        EqJoin eqJoin = new EqJoin(Source.EMPTY, probe, build, List.of(probeKey), List.of(buildKey), List.of(buildValue), true);
+
+        PhysicalPlan physical = new Mapper().map(new Versioned<>(eqJoin, TransportVersion.current()));
+
+        EqJoinExec exec = as(physical, EqJoinExec.class);
+        assertThat(exec.leftFields(), equalTo(List.of(probeKey)));
+        assertThat(exec.rightFields(), equalTo(List.of(buildKey)));
+        assertThat(exec.addedFields().size(), equalTo(1));
+        assertThat(exec.addedFields().contains(buildValue), equalTo(true));
+        assertThat(exec.unique(), equalTo(true));
+        assertThat(exec.joinData(), instanceOf(LocalSourceExec.class));
+    }
+}


### PR DESCRIPTION
## What

ES|QL only executes LEFT joins today - `Mapper` rejects every other `JoinType`. PromQL vector matching (`a / on(x) b`, `group_left`, ...) needs an INNER equi-join over two already-aggregated, coordinator-side series pipelines, so this adds INNER as a real, executable join type (PromQL is the first consumer).

## How

Add `EqJoin`, an INNER `Join` subtype of `AbstractHashJoin` (#154365), and its physical `EqJoinExec`. As an `AbstractHashJoin`, its right ("build") side runs as an independent subquery that the coordinator phase loop materializes to a `LocalRelation` before the join; `Mapper` then lowers the materialized `EqJoin` to `EqJoinExec`, which `LocalExecutionPlanner#planEqJoin` expands to:

`RowInTableLookup` -> `[1:1 DistinctBy guard]` -> `Filter(ordinal not null)` -> `ColumnLoad` -> `Project`

The build side must have unique keys (`RowInTableLookup`), so it covers 1:1 and many-to-one - the INNER twin of the hash flavor of LEFT (`HashJoinExec`), differing only in dropping unmatched rows instead of null-filling. Both nodes are coordinator-only and non-serialized.

Stacked on #154365. PromQL translation does not emit `EqJoin` yet.
