### PR TITLE
ESQL: Fix extra check

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
@@ -620,7 +620,7 @@ public abstract class GoldenTestCase extends ESTestCase {
     }
 
     private static Test.TestResult createNewOutput(Path output, QueryPlan<?> plan) throws IOException {
-        if (output.toString().contains("extra")) {
+        if (output.getFileName().toString().contains("extra")) {
             throw new IllegalStateException("Extra output files should not be created automatically:" + output);
         }
         String full = plan.toString(Node.NodeStringFormat.FULL);


### PR DESCRIPTION
The `GoldenTestCase` guards against accidentally creating "extra" files, but if your path has the characters `extra` in it, then nothing works. I had a worktree with `extract` in the name. Bad times.
