### PR TITLE
Reject unsupported dense vector index types when slicing is enabled

### DIFF
--- a/docs/changelog/154332.yaml
+++ b/docs/changelog/154332.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+ - 154020
+pr: 154332
+summary: Reject unsupported dense vector index types when index slicing is enabled
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -898,7 +898,7 @@ public final class DocumentParser {
             IndexSettings.DENSE_VECTOR_EXPERIMENTAL_FEATURES_SETTING.get(context.indexSettings().getSettings()),
             context.getVectorFormatProviders(),
             context.indexSettings().isIndexDisabledByDefault()
-        );
+        ).setSliceEnabled(context.indexSettings().isSliceEnabled());
         builder.dimensions(arraySize);
         context.updateDynamicMappers(fullFieldName, List.of(builder));
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -309,6 +309,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         private final List<VectorsFormatProvider> vectorsFormatProviders;
 
         private final boolean indexDisabledByDefault;
+        private boolean sliceEnabled;
 
         public Builder(
             String name,
@@ -552,6 +553,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
             return this;
         }
 
+        public Builder setSliceEnabled(boolean sliceEnabled) {
+            this.sliceEnabled = sliceEnabled;
+            return this;
+        }
+
         @Override
         public String contentType() {
             return CONTENT_TYPE;
@@ -562,6 +568,18 @@ public class DenseVectorFieldMapper extends FieldMapper {
             // Validate again here because the dimensions or element type could have been set programmatically,
             // which affects index option validity
             validate();
+            if (sliceEnabled && indexed.getValue() && indexOptions.getValue() instanceof BBQIVFIndexOptions == false) {
+                DenseVectorIndexOptions options = indexOptions.getValue();
+                throw new MapperParsingException(
+                    "Field ["
+                        + context.buildFullName(leafName())
+                        + "] uses dense vector index type ["
+                        + (options == null ? "default" : options.type)
+                        + "] which does not support ["
+                        + IndexSettings.SLICE_ENABLED.getKey()
+                        + "]"
+                );
+            }
             boolean isExcludeSourceVectorsFinal = context.isSourceSynthetic() == false && indexed.getValue() && isExcludeSourceVectors;
             return new DenseVectorFieldMapper(
                 leafName(),
@@ -584,7 +602,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 isExcludeSourceVectorsFinal,
                 experimentalFeaturesEnabled,
                 vectorsFormatProviders,
-                indexDisabledByDefault
+                indexDisabledByDefault,
+                sliceEnabled
             );
         }
     }
@@ -3114,7 +3133,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             IndexSettings.DENSE_VECTOR_EXPERIMENTAL_FEATURES_SETTING.get(c.getIndexSettings().getSettings()),
             c.getVectorsFormatProviders(),
             c.getIndexSettings().isIndexDisabledByDefault()
-        ),
+        ).setSliceEnabled(c.getIndexSettings().isSliceEnabled()),
         notInMultiFields(CONTENT_TYPE)
     );
 
@@ -3846,6 +3865,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
     private final boolean experimentalFeaturesEnabled;
     private final List<VectorsFormatProvider> extraVectorsFormatProviders;
     private final boolean indexDisabledByDefault;
+    private final boolean sliceEnabled;
 
     private DenseVectorFieldMapper(
         String simpleName,
@@ -3858,7 +3878,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
         boolean excludeSourceVectors,
         boolean experimentalFeaturesEnabled,
         List<VectorsFormatProvider> vectorsFormatProviders,
-        boolean indexDisabledByDefault
+        boolean indexDisabledByDefault,
+        boolean sliceEnabled
     ) {
         super(simpleName, mappedFieldType, params);
         this.indexOptions = indexOptions;
@@ -3869,6 +3890,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         this.experimentalFeaturesEnabled = experimentalFeaturesEnabled;
         this.extraVectorsFormatProviders = vectorsFormatProviders;
         this.indexDisabledByDefault = indexDisabledByDefault;
+        this.sliceEnabled = sliceEnabled;
     }
 
     @Override
@@ -3997,7 +4019,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             experimentalFeaturesEnabled,
             extraVectorsFormatProviders,
             indexDisabledByDefault
-        ).init(this);
+        ).setSliceEnabled(sliceEnabled).init(this);
     }
 
     private static DenseVectorIndexOptions parseIndexOptions(

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -1707,6 +1707,52 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
         );
     }
 
+    public void testSliceEnabledRejectsUnsupportedIndexType() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.SLICE_ENABLED.getKey(), true).build();
+        for (String indexType : List.of("hnsw", "int8_hnsw", "int4_hnsw", "bbq_hnsw", "flat", "int8_flat", "int4_flat", "bbq_flat")) {
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> createMapperService(settings, fieldMapping(b -> {
+                b.field("type", "dense_vector");
+                b.field("dims", 384);
+                b.startObject("index_options");
+                b.field("type", indexType);
+                b.endObject();
+            })));
+            assertThat(e.getMessage(), containsString("index type [" + indexType + "] which does not support [index.slice.enabled]"));
+        }
+    }
+
+    public void testSliceEnabledRejectsDefaultIndexType() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.SLICE_ENABLED.getKey(), true).build();
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(settings, fieldMapping(b -> b.field("type", "dense_vector").field("dims", 128)))
+        );
+        assertThat(e.getMessage(), containsString("does not support [index.slice.enabled]"));
+    }
+
+    public void testSliceEnabledAllowsBBQDisk() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.SLICE_ENABLED.getKey(), true).build();
+        MapperService mapperService = createMapperService(settings, fieldMapping(b -> {
+            b.field("type", "dense_vector");
+            b.field("dims", 384);
+            b.startObject("index_options");
+            b.field("type", "bbq_disk");
+            b.endObject();
+        }));
+        DenseVectorFieldMapper mapper = (DenseVectorFieldMapper) mapperService.mappingLookup().getMapper("field");
+        assertThat(mapper.fieldType().getIndexOptions(), instanceOf(DenseVectorFieldMapper.BBQIVFIndexOptions.class));
+    }
+
+    public void testSliceEnabledAllowsNonIndexedDenseVector() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.SLICE_ENABLED.getKey(), true).build();
+        MapperService mapperService = createMapperService(
+            settings,
+            fieldMapping(b -> b.field("type", "dense_vector").field("dims", 128).field("index", false))
+        );
+        DenseVectorFieldMapper mapper = (DenseVectorFieldMapper) mapperService.mappingLookup().getMapper("field");
+        assertNull(mapper.fieldType().getIndexOptions());
+    }
+
     private static float[] decodeDenseVector(IndexVersion indexVersion, BytesRef encodedVector) {
         int dimCount = VectorEncoderDecoder.denseVectorLength(indexVersion, encodedVector);
         float[] vector = new float[dimCount];

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldMapper.java
@@ -413,7 +413,7 @@ public class SemanticFieldMapper extends FieldMapper implements InferenceFieldMa
                 experimentalFeaturesEnabled,
                 vectorsFormatProviders,
                 false
-            );
+            ).setSliceEnabled(indexSettings.isSliceEnabled());
             ExtendedDenseVectorIndexOptions extendedIndexOptions = indexOptions.get() != null
                 ? getExtendedDenseVectorIndexOptions(indexOptions.get())
                 : null;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -299,7 +299,7 @@ public class SemanticTextFieldMapper extends SemanticFieldMapper {
                         experimentalFeaturesEnabled,
                         vectorsFormatProviders,
                         false
-                    );
+                    ).setSliceEnabled(indexSettings.isSliceEnabled());
                     ExtendedDenseVectorIndexOptions extendedIndexOptions = indexOptions.get() != null
                         ? getExtendedDenseVectorIndexOptions(indexOptions.get())
                         : null;


### PR DESCRIPTION
Closes #154020.

When index.slice.enabled is true, reject indexed dense_vector mappings unless they use the disk-backed BBQ index (bbq_disk). The validation is applied to explicit mappings, dynamically inferred dense vectors, semantic field embeddings, and merge builders. Non-indexed dense vectors remain valid.

Tests cover the default index type, every unsupported explicit index type, bbq_disk, and non-indexed vectors.

Validation:
- ./gradlew :server:test --tests org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTests
- ./gradlew :server:spotlessJavaCheck
- ./gradlew :x-pack:plugin:inference:compileJava
- ./gradlew :x-pack:plugin:inference:spotlessJavaCheck

This contribution was completed through openjobs.bot for listing 11b0a577-e813-42fa-bd39-5231132f43ba.

Source issue: https://github.com/elastic/elasticsearch/issues/154020