### PR TITLE
[9.5] Golden guard was reading tea leaves, not paths (#154329)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/GoldenTestCase.java
@@ -619,7 +619,7 @@ public abstract class GoldenTestCase extends ESTestCase {
     }
 
     private static Test.TestResult createNewOutput(Path output, QueryPlan<?> plan) throws IOException {
-        if (output.toString().contains("extra")) {
+        if (output.getFileName().toString().contains("extra")) {
             throw new IllegalStateException("Extra output files should not be created automatically:" + output);
         }
         String full = plan.toString(Node.NodeStringFormat.FULL);


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Golden guard was reading tea leaves, not paths (#154329)