### PR TITLE
[9.5] Add settings update consumer for stateless reader heap breaker (#154327)

### DIFF
--- a/docs/changelog/154327.yaml
+++ b/docs/changelog/154327.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 154327
+summary: Add settings update consumer for stateless reader heap breaker
+type: bug

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessPluginIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessPluginIT.java
@@ -7,6 +7,12 @@
 
 package org.elasticsearch.xpack.stateless;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.xpack.stateless.engine.StatelessReaderHeapBreaker;
+
+import static org.hamcrest.Matchers.equalTo;
+
 public class StatelessPluginIT extends AbstractStatelessPluginIntegTestCase {
 
     public void testCreateStatelessCluster() throws Exception {
@@ -20,6 +26,25 @@ public class StatelessPluginIT extends AbstractStatelessPluginIntegTestCase {
         final int numSearchNodes = randomIntBetween(0, 5);
         startSearchNodes(numSearchNodes);
         ensureStableCluster(1 + numIndexNodes + numSearchNodes);
+    }
+
+    public void testReaderHeapBreakerLimitIsDynamicallyUpdated() {
+        startMasterAndIndexNode();
+        final String searchNode = startSearchNode();
+
+        final var breakerService = internalCluster().getInstance(CircuitBreakerService.class, searchNode);
+        assertThat(breakerService.getBreaker(StatelessReaderHeapBreaker.NAME).getLimit(), equalTo(-1L));
+
+        updateClusterSettings(Settings.builder().put(StatelessReaderHeapBreaker.LIMIT_SETTING.getKey(), "100mb"));
+
+        final long expected = StatelessReaderHeapBreaker.LIMIT_SETTING.get(
+            Settings.builder().put(StatelessReaderHeapBreaker.LIMIT_SETTING.getKey(), "100mb").build()
+        ).getBytes();
+        assertThat(
+            "dynamic settings update must propagate to the live breaker limit",
+            breakerService.getBreaker(StatelessReaderHeapBreaker.NAME).getLimit(),
+            equalTo(expected)
+        );
     }
 
 }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -882,6 +882,7 @@ public class StatelessPlugin extends Plugin
             readerHeapMetrics,
             StatelessReaderHeapMetrics.register(services.telemetryProvider().getMeterRegistry(), readerHeapBreaker.get())
         );
+        StatelessReaderHeapBreaker.addLimitUpdateConsumer(clusterService.getClusterSettings(), readerHeapBreaker::get);
         components.add(hollowShardMetrics.get());
         components.add(new StatelessComponents(translogReplicator, objectStoreService));
         setAndGet(this.bccHeaderReadExecutor, new BCCHeaderReadExecutor(threadPool));

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/StatelessReaderHeapBreaker.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/StatelessReaderHeapBreaker.java
@@ -7,11 +7,16 @@
 
 package org.elasticsearch.xpack.stateless.engine;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.BreakerSettings;
+
+import java.util.function.Supplier;
 
 /**
  * Name and settings for the stateless {@code reader_heap} circuit breaker. Tracks heap reserved by the stateless
@@ -19,6 +24,8 @@ import org.elasticsearch.indices.breaker.BreakerSettings;
  * is exceeded the engine defers the refresh and re-evaluates on the next cycle.
  */
 public final class StatelessReaderHeapBreaker {
+
+    private static final Logger logger = LogManager.getLogger(StatelessReaderHeapBreaker.class);
 
     public static final String NAME = "stateless_reader_heap";
 
@@ -34,6 +41,13 @@ public final class StatelessReaderHeapBreaker {
     );
 
     private StatelessReaderHeapBreaker() {}
+
+    public static void addLimitUpdateConsumer(ClusterSettings clusterSettings, Supplier<CircuitBreaker> breakerSupplier) {
+        clusterSettings.addSettingsUpdateConsumer(LIMIT_SETTING, newLimit -> {
+            breakerSupplier.get().setLimitAndOverhead(newLimit.getBytes(), 1.0);
+            logger.info("Updated breaker settings {} limit: {}", NAME, newLimit);
+        });
+    }
 
     public static BreakerSettings breakerSettings(Settings settings) {
         return new BreakerSettings(


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Add settings update consumer for stateless reader heap breaker (#154327)