### PR TITLE
Flakiness detection: fix yaml-suite tests.rest.suite clash

### DIFF
--- a/.buildkite/scripts/flakiness-detection/detectors/yaml-explicit-paths.test.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/yaml-explicit-paths.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+
+import type { ClassifiedTest } from "../domain.ts";
+
+import { generateBatchCommand } from "../commands.ts";
+import { DEFAULT_BATCHING_CONFIG } from "../domain.ts";
+import { reclassifyExplicitYamlSuites, usesExplicitYamlRestPaths, type FileReader } from "./yaml-explicit-paths.ts";
+
+// An in-memory reader keyed by repo-relative path.
+function reader(files: Record<string, string>): FileReader {
+  return (p) => (p in files ? files[p] : null);
+}
+
+const WATCHER_RUNNER = "x-pack/plugin/watcher/src/yamlRestTest/java/org/elasticsearch/smoketest/WatcherYamlRestIT.java";
+const WATCHER_SRC = `
+@ParametersFactory
+public static Iterable<Object[]> parameters() throws Exception {
+    return createParameters("mustache", "painless", "watcher");
+}`;
+
+// A default runner that reads tests.rest.suite (unaffected).
+const REINDEX_RUNNER = "modules/reindex/src/yamlRestTest/java/org/elasticsearch/reindex/ReindexClientYamlTestSuiteIT.java";
+const REINDEX_SRC = `
+@ParametersFactory
+public static Iterable<Object[]> parameters() throws Exception {
+    return ESClientYamlSuiteTestCase.createParameters();
+}`;
+
+describe("usesExplicitYamlRestPaths", () => {
+  test("true when a runner in the project's yamlRestTest source set uses explicit paths", () => {
+    const read = reader({ [WATCHER_RUNNER]: WATCHER_SRC });
+    expect(usesExplicitYamlRestPaths(":x-pack:plugin:watcher", [WATCHER_RUNNER], read)).toBe(true);
+  });
+
+  test("false for a default runner that honours tests.rest.suite", () => {
+    const read = reader({ [REINDEX_RUNNER]: REINDEX_SRC });
+    expect(usesExplicitYamlRestPaths(":modules:reindex", [REINDEX_RUNNER], read)).toBe(false);
+  });
+
+  test("false when the project has no yamlRestTest source files", () => {
+    expect(usesExplicitYamlRestPaths(":server", ["server/src/test/java/org/elasticsearch/FooTests.java"], reader({}))).toBe(false);
+  });
+
+  test("only scans the target project's yamlRestTest source set", () => {
+    // An explicit-paths runner in a *different* project must not leak in.
+    const read = reader({ [WATCHER_RUNNER]: WATCHER_SRC });
+    expect(usesExplicitYamlRestPaths(":modules:reindex", [WATCHER_RUNNER], read)).toBe(false);
+  });
+});
+
+describe("reclassifyExplicitYamlSuites", () => {
+  const suite = (gradleProject: string, suitePath: string): ClassifiedTest => ({
+    gradleProject,
+    kind: "yamlRestTestSuite",
+    sourceSet: "yamlRestTest",
+    suitePath,
+  });
+
+  test("maps an explicit-paths project's suite to a whole-task runner (no suitePath)", () => {
+    const read = reader({ [WATCHER_RUNNER]: WATCHER_SRC });
+    const out = reclassifyExplicitYamlSuites([suite(":x-pack:plugin:watcher", "painless")], [WATCHER_RUNNER], read);
+    expect(out).toEqual([{ gradleProject: ":x-pack:plugin:watcher", kind: "yamlRestTestRunner", sourceSet: "yamlRestTest" }]);
+  });
+
+  test("leaves a default project's suite untouched", () => {
+    const read = reader({ [REINDEX_RUNNER]: REINDEX_SRC });
+    const input = [suite(":modules:reindex", "reindex/10_basic")];
+    expect(reclassifyExplicitYamlSuites(input, [REINDEX_RUNNER], read)).toEqual(input);
+  });
+
+  test("passes non-suite kinds through unchanged", () => {
+    const unit: ClassifiedTest = { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "a.FooTests" };
+    expect(reclassifyExplicitYamlSuites([unit], [], reader({}))).toEqual([unit]);
+  });
+
+  test("scans each project's source set at most once", () => {
+    const reads: string[] = [];
+    const read: FileReader = (p) => {
+      reads.push(p);
+      return p === WATCHER_RUNNER ? WATCHER_SRC : null;
+    };
+    reclassifyExplicitYamlSuites(
+      [suite(":x-pack:plugin:watcher", "painless"), suite(":x-pack:plugin:watcher", "watcher")],
+      [WATCHER_RUNNER],
+      read,
+    );
+    // One scan for the single project despite two suites.
+    expect(reads).toEqual([WATCHER_RUNNER]);
+  });
+
+  test("end-to-end: a reclassified suite generates a whole-task rerun with no tests.rest.suite", () => {
+    const read = reader({ [WATCHER_RUNNER]: WATCHER_SRC });
+    const [reclassified] = reclassifyExplicitYamlSuites([suite(":x-pack:plugin:watcher", "painless")], [WATCHER_RUNNER], read);
+    const command = generateBatchCommand([reclassified], DEFAULT_BATCHING_CONFIG);
+    expect(command).toContain(":x-pack:plugin:watcher:yamlRestTest --rerun");
+    expect(command).not.toContain("tests.rest.suite");
+  });
+});

--- a/.buildkite/scripts/flakiness-detection/detectors/yaml-explicit-paths.ts
+++ b/.buildkite/scripts/flakiness-detection/detectors/yaml-explicit-paths.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import type { ClassifiedTest } from "../domain.ts";
+
+// A yaml REST test runner declares its suites in one of two ways. The default
+// `ESClientYamlSuiteTestCase.createParameters()` / `createParameters(registry)`
+// overloads read the suite set from the `tests.rest.suite` system property. The
+// "explicit paths" overloads - `createParameters("watcher")`,
+// `createParameters("gpu/supported")`, ... - hard-wire the suite dirs in code and
+// THROW `IllegalArgumentException("The 'tests.rest.suite' system property is not
+// supported with explicit test paths.")` if that property is set (including the
+// per-task scoped form `tests.rest.suite.<taskPath>`).
+//
+// The `yamlRestTestSuite` command sets exactly that scoped property, so on a
+// project whose runner uses explicit paths every re-run iteration fails in
+// `initializationError` and is recorded as a false `flaky_detected`. We detect
+// such projects statically and re-run their whole `yamlRestTest` task instead
+// (see reclassifyExplicitYamlSuites).
+//
+// Heuristic: a `createParameters(` call whose first argument is a string literal.
+// This matches every explicit-paths runner in the repo today. Known blind spots
+// (none present today): a @ParametersFactory inherited from a parent in another
+// module, and a non-literal path argument.
+const EXPLICIT_PATHS_CALL = /createParameters\(\s*"/;
+
+// Reads a repo-relative file, returning its text or null when it cannot be read.
+// Injected so the detector stays pure and unit-testable without the filesystem.
+export type FileReader = (repoRelativePath: string) => string | null;
+
+export function defaultFileReader(repoRoot: string): FileReader {
+  return (repoRelativePath) => {
+    try {
+      return readFileSync(join(repoRoot, repoRelativePath), "utf8");
+    } catch {
+      return null;
+    }
+  };
+}
+
+// Repo-relative source dir of a project's yamlRestTest Java source set, e.g.
+// `:x-pack:plugin:watcher` -> `x-pack/plugin/watcher/src/yamlRestTest/java/`.
+function yamlRestTestSrcPrefix(gradleProject: string): string {
+  const dir = gradleProject.replace(/^:/, "").split(":").join("/");
+  return `${dir}/src/yamlRestTest/java/`;
+}
+
+/**
+ * True when any concrete runner in the project's yamlRestTest source set uses the
+ * explicit-paths `createParameters(...)` overload, so its `yamlRestTest` task
+ * rejects the `tests.rest.suite` system property. One such runner is enough: the
+ * task runs all its runner classes, so a single explicit-paths runner fails the
+ * whole invocation when the property is set.
+ */
+export function usesExplicitYamlRestPaths(gradleProject: string, repoFiles: string[], read: FileReader): boolean {
+  const prefix = yamlRestTestSrcPrefix(gradleProject);
+  for (const f of repoFiles) {
+    if (!f.startsWith(prefix) || !f.endsWith(".java")) continue;
+    const src = read(f);
+    if (src !== null && EXPLICIT_PATHS_CALL.test(src)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Reclassify each `yamlRestTestSuite` whose project cannot accept
+ * `tests.rest.suite` into a whole-task `yamlRestTestRunner` run (which emits
+ * `:proj:yamlRestTest --rerun`, with no suite property). Every other entry passes
+ * through unchanged. The per-project decision is cached so each source set is
+ * scanned at most once.
+ */
+export function reclassifyExplicitYamlSuites(tests: ClassifiedTest[], repoFiles: string[], read: FileReader): ClassifiedTest[] {
+  const cache = new Map<string, boolean>();
+  return tests.map((t) => {
+    if (t.kind !== "yamlRestTestSuite") return t;
+    let explicit = cache.get(t.gradleProject);
+    if (explicit === undefined) {
+      explicit = usesExplicitYamlRestPaths(t.gradleProject, repoFiles, read);
+      cache.set(t.gradleProject, explicit);
+    }
+    if (!explicit) return t;
+    // Whole-task rerun: drop the suite path and target the task directly.
+    return { gradleProject: t.gradleProject, kind: "yamlRestTestRunner", sourceSet: "yamlRestTest" };
+  });
+}

--- a/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 
 import { classifyChangedFiles } from "../detectors/changed-files.ts";
 import { findUnmutedTests, type UnmuteDetectionResult } from "../detectors/unmutes.ts";
+import { defaultFileReader, reclassifyExplicitYamlSuites } from "../detectors/yaml-explicit-paths.ts";
 import { buildCommands, dedupeTests } from "../commands.ts";
 import { uploadBuildkitePipeline } from "../runners/buildkite.ts";
 import { DEFAULT_AGENT_CONFIG, DEFAULT_BATCHING_CONFIG } from "../domain.ts";
@@ -39,7 +40,26 @@ export function resolveMergeBaseTarget(
 // timeout_in_minutes budget.
 const GIT_COMMAND_TIMEOUT_MS = 60_000;
 
-function detectUnmutedTests(mergeBase: string, projectRoot: string): UnmuteDetectionResult {
+// List the repo's tracked files once (git ls-files); shared by unmute detection
+// and the yaml explicit-paths reclassification.
+function listRepoFiles(projectRoot: string): string[] {
+  console.log("  Listing tracked files...");
+  const repoFilesOutput = execSync("git ls-files", {
+    cwd: projectRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: GIT_COMMAND_TIMEOUT_MS,
+    maxBuffer: 256 * 1024 * 1024,
+    encoding: "utf8",
+  });
+  const repoFiles = repoFilesOutput
+    .split("\n")
+    .map((f) => f.trim())
+    .filter((f) => f !== "");
+  console.log(`  Indexed ${repoFiles.length} tracked files`);
+  return repoFiles;
+}
+
+function detectUnmutedTests(mergeBase: string, projectRoot: string, repoFiles: string[]): UnmuteDetectionResult {
   console.log(`  Reading muted-tests.yml at ${mergeBase}...`);
   let oldYaml = "";
   try {
@@ -63,20 +83,6 @@ function detectUnmutedTests(mergeBase: string, projectRoot: string): UnmuteDetec
     // File was deleted in the PR; treat as empty.
   }
 
-  console.log("  Listing tracked files...");
-  const repoFilesOutput = execSync("git ls-files", {
-    cwd: projectRoot,
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: GIT_COMMAND_TIMEOUT_MS,
-    maxBuffer: 256 * 1024 * 1024,
-    encoding: "utf8",
-  });
-  const repoFiles = repoFilesOutput
-    .split("\n")
-    .map((f) => f.trim())
-    .filter((f) => f !== "");
-  console.log(`  Indexed ${repoFiles.length} tracked files`);
-
   return findUnmutedTests(oldYaml, newYaml, repoFiles);
 }
 
@@ -98,8 +104,10 @@ export function run(): void {
   const changedTests = classifyChangedFiles(changedFiles);
   console.log(`Found ${changedTests.length} changed test files`);
 
+  const repoFiles = listRepoFiles(PROJECT_ROOT);
+
   console.log("Detecting unmuted tests...");
-  const unmuted = detectUnmutedTests(mergeBase, PROJECT_ROOT);
+  const unmuted = detectUnmutedTests(mergeBase, PROJECT_ROOT, repoFiles);
   console.log(`Found ${unmuted.located.length} unmuted tests`);
   if (unmuted.unlocated.length > 0) {
     console.log(`Skipping ${unmuted.unlocated.length} unmuted tests whose class files no longer exist:`);
@@ -108,7 +116,14 @@ export function run(): void {
     }
   }
 
-  const tests = dedupeTests([...changedTests, ...unmuted.located]);
+  // Projects whose yamlRestTest runner uses explicit suite paths reject the
+  // `tests.rest.suite` property the yamlRestTestSuite command sets; re-run their
+  // whole task instead (yamlRestTestRunner).
+  const tests = reclassifyExplicitYamlSuites(
+    dedupeTests([...changedTests, ...unmuted.located]),
+    repoFiles,
+    defaultFileReader(PROJECT_ROOT),
+  );
   console.log(`Total tests to run: ${tests.length} (${changedTests.length} changed, ${unmuted.located.length} unmuted)`);
 
   if (tests.length === 0) {


### PR DESCRIPTION
## What

Fixes a flakiness-detection command-generation bug where re-running a changed yaml suite in certain projects fails during test initialization.

## Why

For a changed/added `.yml`, the detector emits a `yamlRestTestSuite` command that scopes the suite via `-Dtests.rest.suite.<task>=<path>`. But ~9 projects have yaml runners that call the **explicit-paths** `ESClientYamlSuiteTestCase.createParameters("…")` overload (e.g. `WatcherYamlRestIT` → `createParameters("mustache","painless","watcher")`). Those overloads throw when `tests.rest.suite` is set (including the per-task-scoped form):

```
java.lang.IllegalArgumentException: The 'tests.rest.suite' system property is not supported with explicit test paths.
```

So every re-run iteration fails in `initializationError` and the batch is recorded as a **false `flaky_detected`** - the highest-trust-damaging outcome (it looks like the pipeline caught real flakiness and would wrongly block the PR under hard-fail). All other ~80 yaml runners use the default overload and are unaffected.

Observed on build `elastic/elasticsearch-pull-request#163216` (branch `elastic:fix-watcher-tests`). Over the last 30 days, `yamlRestTestSuite` jobs were 355 clean / 11 `flaky_detected` / 5 infra_fail / 3 hang, and the 11 flaky are almost all these custom runners (`WatcherYamlRestIT`, `WatcherYamlRestWithSecurityIT`, `XPackRestIT`, `InferenceRestIT`, `DiskBBQClientYamlTestSuiteIT`).

## How

New `detectors/yaml-explicit-paths.ts`:
- `usesExplicitYamlRestPaths(gradleProject, repoFiles, read)` - scans the project's `src/yamlRestTest/java/**` for a `createParameters("…")` call (string-literal path). Not detectable from `build.gradle`; this static source scan is the reliable signal.
- `reclassifyExplicitYamlSuites(...)` - maps each `yamlRestTestSuite` on such a project to a whole-task `yamlRestTestRunner` (which emits `:proj:yamlRestTest --rerun`, with no `tests.rest.suite`). Other entries pass through unchanged; the per-project decision is cached.

Wired into `entrypoints/pr.ts` only. `manual.ts`/`local.ts` go through `classifyExplicitList`, which never yields `yamlRestTestSuite` (that comes only from a changed `.yml`), so they can't hit this and need no change.

Trade-off: for the affected projects the whole yaml source set is re-run rather than just the changed suite - coarser, but correct, and the affected set is small.

`--tests` case-targeting (the guard doesn't block `--tests`) was considered but not taken: it needs the concrete runner FQCN plus exact randomizedtesting display-name/escaping - fragile. Possible future optimization.

Independent of the other flakiness-detection PRs (#153803 / #153806 / #153807); it only adds a detector and a call in `pr.ts`.

Unit tests cover detection (explicit vs default runner, project scoping, single-scan caching) and reclassification (suite→runner only for affected projects; end-to-end command has no `tests.rest.suite`).
