### PR TITLE
Tolerate scoped tests.rest.suite on explicit-paths yaml suites

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -252,9 +252,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param testPaths      list of paths to explicitly search for tests.
      */
     public static Iterable<Object[]> createParameters(Map<String, Object> yamlParameters, String... testPaths) throws Exception {
-        if (resolveRestTestsSuiteProperty() != null) {
-            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
-        }
+        checkRestTestsSuiteProperty();
         return createParameters(ExecutableSection.XCONTENT_REGISTRY, yamlParameters, testPaths);
     }
 
@@ -263,9 +261,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param testPaths list of paths to explicitly search for tests.
      */
     public static Iterable<Object[]> createParameters(String... testPaths) throws Exception {
-        if (resolveRestTestsSuiteProperty() != null) {
-            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
-        }
+        checkRestTestsSuiteProperty();
         return createParameters(ExecutableSection.XCONTENT_REGISTRY, Map.of(), testPaths);
     }
 
@@ -278,9 +274,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      */
     public static Iterable<Object[]> createParameters(NamedXContentRegistry executeableSectionRegistry, String... testPaths)
         throws Exception {
-        if (resolveRestTestsSuiteProperty() != null) {
-            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
-        }
+        checkRestTestsSuiteProperty();
         return createParameters(executeableSectionRegistry, Map.of(), testPaths);
     }
 
@@ -447,6 +441,43 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
             }
         }
         return System.getProperty(REST_TESTS_SUITE);
+    }
+
+    /**
+     * Guards the explicit-paths {@link #createParameters} overloads against the {@link #REST_TESTS_SUITE}
+     * system property, which a suite that declares its own paths cannot honor.
+     *
+     * <p>The per-task scoped form ({@code tests.rest.suite.<task path>}) is set by build tooling that
+     * targets one task among many - for example the flakiness-detection re-run pipeline, which re-runs a
+     * single changed suite by scoping the property to that task. An explicit-paths suite cannot restrict
+     * itself to the requested suite, but failing the whole run is hostile to such tooling, so the scoped
+     * property is logged and ignored (all of the suite's explicit paths run).
+     *
+     * <p>A bare, unscoped {@code tests.rest.suite} is almost always a mistake on an explicit-paths suite -
+     * the requested value would be silently dropped - so that still fails loudly.
+     */
+    private static void checkRestTestsSuiteProperty() {
+        String task = System.getProperty("tests.task");
+        String scoped = task == null ? null : System.getProperty(REST_TESTS_SUITE + "." + task);
+        checkRestTestsSuiteProperty(scoped, System.getProperty(REST_TESTS_SUITE));
+    }
+
+    // Visible for testing. `scopedValue` is the value of the per-task scoped property
+    // (tests.rest.suite.<task>) or null; `globalValue` is the bare tests.rest.suite or null.
+    static void checkRestTestsSuiteProperty(String scopedValue, String globalValue) {
+        if (scopedValue != null) {
+            Logger logger = LogManager.getLogger(ESClientYamlSuiteTestCase.class);
+            logger.warn(
+                "Ignoring the scoped '{}.<task>' system property [{}]: this suite declares explicit test paths, "
+                    + "so all of them run regardless of the requested suite.",
+                REST_TESTS_SUITE,
+                scopedValue
+            );
+            return;
+        }
+        if (globalValue != null) {
+            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
+        }
     }
 
     private static String[] resolveRestTestsSuitePaths() {

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
@@ -172,6 +172,32 @@ public class ESClientYamlSuiteTestCaseTests extends ESTestCase {
         assertThat(error.getMessage(), containsString("does not exist in any YAML test root"));
     }
 
+    /**
+     * A per-task scoped {@code tests.rest.suite.<task>} property (set by build tooling such as the
+     * flakiness-detection re-run pipeline) must not fail a suite that declares explicit test paths - it
+     * is logged and ignored so all of the suite's paths run.
+     */
+    public void testScopedSuitePropertyIsIgnoredForExplicitPaths() {
+        // scoped set, no global -> ignored, no throw
+        ESClientYamlSuiteTestCase.checkRestTestsSuiteProperty("painless", null);
+        // scoped takes precedence over a global value too
+        ESClientYamlSuiteTestCase.checkRestTestsSuiteProperty("painless", "watcher");
+        // neither set -> nothing to do
+        ESClientYamlSuiteTestCase.checkRestTestsSuiteProperty(null, null);
+    }
+
+    /**
+     * A bare, unscoped {@code tests.rest.suite} on an explicit-paths suite is still a hard error: the
+     * requested value would otherwise be silently dropped.
+     */
+    public void testGlobalSuitePropertyStillRejectedForExplicitPaths() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ESClientYamlSuiteTestCase.checkRestTestsSuiteProperty(null, "watcher")
+        );
+        assertThat(e.getMessage(), containsString("not supported with explicit test paths"));
+    }
+
     private static void assertSingleFile(Map<String, Set<Path>> yamlSuites, String dirName, String fileName) {
         assertThat(yamlSuites, notNullValue());
         assertThat(yamlSuites.size(), equalTo(1));


### PR DESCRIPTION
## What

`ESClientYamlSuiteTestCase`'s explicit-paths `createParameters(String... testPaths)` overloads currently throw `IllegalArgumentException("The 'tests.rest.suite' system property is not supported with explicit test paths.")` whenever `tests.rest.suite` is set - and the check also matches the per-task **scoped** form `tests.rest.suite.<task path>`.

This relaxes that guard: the **scoped** property is now logged and **ignored** (the suite's explicit paths all run), while a bare, unscoped `tests.rest.suite` still fails loudly.

## Why

The scoped `tests.rest.suite.<task>` property is set by build tooling that targets a single task among many. The flakiness-detection re-run pipeline uses exactly this to re-run one changed yaml suite - it emits `:proj:yamlRestTest --rerun -Dtests.rest.suite.<task>=<suite>`. On the ~9 projects whose runner declares explicit paths (e.g. `WatcherYamlRestIT` → `createParameters("mustache","painless","watcher")`), that currently throws during `@ParametersFactory`, so every re-run iteration fails in `initializationError`.

Failing the whole run is hostile to that (and any future) per-task tooling, and the value can't be honored by an explicit-paths suite anyway. Ignoring it (with a warning) lets the suite run its declared paths in full. A bare unscoped `tests.rest.suite` on such a suite remains a hard error, because there it is almost always a developer mistake - the requested value would be silently dropped.

## Change

`test/yaml-rest-runner/.../ESClientYamlSuiteTestCase.java`: the three explicit-paths `createParameters` overloads now call a shared `checkRestTestsSuiteProperty()` that distinguishes the scoped form (warn + ignore) from the bare global form (throw, as before). A package-private `checkRestTestsSuiteProperty(scopedValue, globalValue)` holds the testable decision.

Unit tests in `ESClientYamlSuiteTestCaseTests` cover both: scoped → no throw (incl. scoped-wins-over-global); global → still throws.

## Relationship to the flakiness-detection work

This is an **alternative** to #154347 (which fixes the same symptom entirely in the flakiness-detection TypeScript generator by detecting explicit-paths projects and re-running their whole task). If this framework change is taken, the generator needs **no** yaml special-casing - it can emit the scoped `tests.rest.suite` command for every project and this handles the explicit-paths ones. Only one of the two PRs is needed; opening this so the durable framework-side option can be compared. Independent of the other flakiness-detection PRs (#153803 / #153806 / #153807).

## Note

A stronger variant would *honor* the scoped property as a filter (run only the requested suite among the explicit paths) rather than ignoring it - more targeted, but a larger behavioral change to explicit-paths suites. Ignoring is the minimal, safe fix; happy to switch to filtering if preferred.
