### PR TITLE
ESQL: extract hash base for joins

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/AbstractHashJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/AbstractHashJoin.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.join;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.SortPreserving;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Shared base for coordinator-only joins whose right ("build") side is an independent subquery that must be executed first, its result
+ * buffered into a {@link LocalRelation}, and only then joined against the streaming left ("probe") side. Concretely this covers
+ * the {@code field IN (subquery)} family ({@link AbstractSubqueryJoin} and its {@link SemiJoin}/{@link AntiJoin}/{@link MarkJoin}
+ * subtypes) and the PromQL vector-matching INNER equi-join ({@code EqJoin}).
+ * <p>
+ * Unlike {@link InlineJoin}, the right side does not embed the left via a {@code StubRelation}; it is a self-contained subquery, so no stub
+ * replacement or deep copy is needed and the node executed as the subplan is the very same instance held on the join's right.
+ * <p>
+ * The coordinator phase loop (see {@code EsqlSession}) drives this base directly: {@link #firstSubPlan} yields the next
+ * unmaterialized right subquery and the concrete join family substitutes the materialized result back into the plan.
+ * <p>
+ * These nodes are ephemeral: they are resolved away on the coordinator before the physical plan crosses the wire, so they are never
+ * serialized (see {@link #writeTo}).
+ */
+public abstract class AbstractHashJoin extends Join implements SortPreserving, ExecutesOn.Coordinator {
+
+    protected AbstractHashJoin(Source source, LogicalPlan left, LogicalPlan right, JoinConfig config) {
+        super(source, left, right, config, ExecuteLocation.ANY);
+    }
+
+    protected AbstractHashJoin(
+        Source source,
+        LogicalPlan left,
+        LogicalPlan right,
+        JoinType type,
+        List<Attribute> leftFields,
+        List<Attribute> rightFields
+    ) {
+        super(source, left, right, type, leftFields, rightFields, null, ExecuteLocation.ANY);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    /**
+     * Finds the first (bottom-up) join in the plan whose right subquery has not yet been replaced with results, and returns it as the next
+     * subplan to execute. Bottom-up ordering ensures nested subqueries are resolved before the outer ones that depend on them.
+     */
+    public static LogicalPlanTuple firstSubPlan(LogicalPlan optimizedPlan, Set<LocalRelation> subPlansResults) {
+        Holder<LogicalPlan> subPlanHolder = new Holder<>();
+        optimizedPlan.forEachUp(AbstractHashJoin.class, join -> {
+            if (subPlanHolder.get() == null) {
+                if (join.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) {
+                    return;
+                }
+                subPlanHolder.set(join.right());
+            }
+        });
+        LogicalPlan subPlan = subPlanHolder.get();
+        if (subPlan == null) {
+            return null;
+        }
+        subPlan.setOptimized();
+        // The subplan is the very same instance held on the join's right side, so it doubles as the identity key used to substitute the
+        // materialized result back into the main plan - hence both tuple slots are the same.
+        return new LogicalPlanTuple(subPlan, subPlan);
+    }
+
+    /**
+     * Build the terminal plan for a materialized hash-join path. The right side has already been wrapped in a {@link LocalRelation}.
+     * Subclasses can override this to keep different rows or append computed output, while sharing the common right-side materialization
+     * and subplan scheduling owned by this base class.
+     */
+    protected LogicalPlan buildHashJoinPathPlan(
+        LogicalPlan leftSide,
+        LocalRelation materializedRight,
+        JoinConfig leftJoinConfig,
+        Attribute sentinelAttr,
+        Source source,
+        boolean rightHadNulls
+    ) {
+        Join leftJoin = new Join(source, leftSide, materializedRight, leftJoinConfig, ExecuteLocation.ANY);
+        Filter filter = new Filter(source, leftJoin, sentinelFilterCondition(source, sentinelAttr));
+        List<NamedExpression> leftOutput = new ArrayList<>(left().output());
+        return new Project(source, filter, leftOutput);
+    }
+
+    /**
+     * Sentinel-column filter used by hash-join rewrites. The default keeps matched rows; subclasses can invert or replace this condition.
+     */
+    protected Expression sentinelFilterCondition(Source source, Attribute sentinel) {
+        return new IsNotNull(source, sentinel);
+    }
+
+    /**
+     * Whether NULL-keyed left rows should be removed before the materialized hash join. The default avoids treating NULL as a joinable
+     * key when the terminal plan filters after a LEFT join.
+     */
+    protected boolean filterNullLeftKeysBeforeHashJoin() {
+        return true;
+    }
+
+    /**
+     * Tuple holding the subplan to execute and the original plan node used as the identity key when substituting the result back.
+     */
+    public record LogicalPlanTuple(LogicalPlan subPlan, LogicalPlan originalSubPlan) {}
+
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/AbstractSubqueryJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/AbstractSubqueryJoin.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plan.logical.join;
 
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
@@ -30,24 +29,19 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSingleValueOrNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
-import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
-import org.elasticsearch.xpack.esql.plan.logical.SortPreserving;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
@@ -66,10 +60,10 @@ import static org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes.LEFT;
  * flips a couple of hooks for {@code NOT IN}, and {@link MarkJoin} returns Eval-based plans that preserve every left row and produce a
  * boolean mark attribute with three-valued logic.
  */
-public abstract class AbstractSubqueryJoin extends Join implements SortPreserving, ExecutesOn.Coordinator {
+public abstract class AbstractSubqueryJoin extends AbstractHashJoin {
 
     protected AbstractSubqueryJoin(Source source, LogicalPlan left, LogicalPlan right, JoinConfig config) {
-        super(source, left, right, config, ExecuteLocation.ANY);
+        super(source, left, right, config);
     }
 
     protected AbstractSubqueryJoin(
@@ -80,17 +74,38 @@ public abstract class AbstractSubqueryJoin extends Join implements SortPreservin
         List<Attribute> leftFields,
         List<Attribute> rightFields
     ) {
-        super(source, left, right, type, leftFields, rightFields, null, ExecuteLocation.ANY);
+        super(source, left, right, type, leftFields, rightFields);
     }
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("not serialized");
+    private LogicalPlan inlineSubPlanResult(
+        LocalRelation subPlanResult,
+        int hashJoinThreshold,
+        BlockFactory blockFactory,
+        AtomicReference<Page> pageHolder
+    ) {
+        return inlineData(this, subPlanResult, hashJoinThreshold, blockFactory, pageHolder);
     }
 
-    @Override
-    public String getWriteableName() {
-        throw new UnsupportedOperationException("not serialized");
+    /**
+     * Rebuilds the main plan after the right-side subquery has been materialized, applying the IN-subquery rewrite resources to the
+     * matching subquery join.
+     */
+    public static LogicalPlan newMainPlan(
+        LogicalPlan optimizedPlan,
+        LogicalPlanTuple subPlans,
+        LocalRelation resultWrapper,
+        int hashJoinThreshold,
+        BlockFactory blockFactory,
+        AtomicReference<Page> pageHolder
+    ) {
+        LogicalPlan newPlan = optimizedPlan.transformUp(
+            AbstractSubqueryJoin.class,
+            join -> join.right() == subPlans.originalSubPlan()
+                ? join.inlineSubPlanResult(resultWrapper, hashJoinThreshold, blockFactory, pageHolder)
+                : join
+        );
+        newPlan.setOptimized();
+        return newPlan;
     }
 
     @Override
@@ -170,49 +185,11 @@ public abstract class AbstractSubqueryJoin extends Join implements SortPreservin
     }
 
     /**
-     * Build the terminal plan for the large-dedup "hash-join" path. The deduplicated key column has already been wrapped in a
-     * {@link LocalRelation} alongside a constant TRUE sentinel column. SEMI/ANTI add a sentinel filter and Project that drops the
-     * right-side column; MarkJoin instead computes the mark via a CASE expression and projects the mark column out alongside the original
-     * left output.
-     */
-    protected LogicalPlan buildHashJoinPathPlan(
-        LogicalPlan leftSide,
-        LocalRelation deduplicatedData,
-        JoinConfig leftJoinConfig,
-        Attribute sentinelAttr,
-        Source source,
-        boolean rightHadNulls
-    ) {
-        Join leftJoin = new Join(source, leftSide, deduplicatedData, leftJoinConfig, ExecuteLocation.ANY);
-        Filter filter = new Filter(source, leftJoin, sentinelFilterCondition(source, sentinelAttr));
-        List<NamedExpression> leftOutput = new ArrayList<>(left().output());
-        return new Project(source, filter, leftOutput);
-    }
-
-    /**
      * Wraps the {@code In} expression built from the dedup keys for the inline-filter path. SEMI returns it as-is; ANTI wraps it in
      * {@code Not}.
      */
     protected Expression wrapInExpression(Source source, Expression in) {
         return in;
-    }
-
-    /**
-     * Sentinel-column filter that drives the hash-join path. SEMI keeps matched rows ({@code IS NOT NULL} on the sentinel); ANTI keeps
-     * unmatched rows ({@code IS NULL}).
-     */
-    protected Expression sentinelFilterCondition(Source source, Attribute sentinel) {
-        return new IsNotNull(source, sentinel);
-    }
-
-    /**
-     * Whether the hash-join path needs to drop NULL-keyed left rows before the join. SEMI/ANTI filter on the sentinel after the join;
-     * ANTI in particular would otherwise keep NULL-keyed rows (sentinel NULL → "no match") even though {@code NULL NOT IN (...)} should
-     * yield NULL. MARK keeps every left row and handles the NULL-key case explicitly inside the CASE expression that produces the mark,
-     * so it suppresses the filter.
-     */
-    protected boolean filterNullLeftKeysBeforeHashJoin() {
-        return true;
     }
 
     @Override
@@ -667,50 +644,4 @@ public abstract class AbstractSubqueryJoin extends Join implements SortPreservin
         }
         return input.filter(false, positions);
     }
-
-    /**
-     * Finds the first subquery join in the plan whose right side has not yet been replaced with results. Unlike InlineJoin, the right
-     * side is an independent subquery that doesn't use StubRelation, no replaceStub is needed, deep copy is not required.
-     */
-    public static LogicalPlanTuple firstSubPlan(LogicalPlan optimizedPlan, Set<LocalRelation> subPlansResults) {
-        Holder<LogicalPlan> subPlanHolder = new Holder<>();
-        optimizedPlan.forEachUp(AbstractSubqueryJoin.class, sj -> {
-            if (subPlanHolder.get() == null) {
-                if (sj.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) {
-                    return;
-                }
-                subPlanHolder.set(sj.right());
-            }
-        });
-        LogicalPlan subPlan = subPlanHolder.get();
-        if (subPlan == null) {
-            return null;
-        }
-        subPlan.setOptimized();
-        // Unlike InlineJoin there is no StubRelation deep copy here, so the node executed as the subplan is the very same instance held
-        // on the join's right side. It therefore doubles as the identity key that newMainPlan matches against, hence both tuple slots are
-        // the same.
-        return new LogicalPlanTuple(subPlan, subPlan);
-    }
-
-    public static LogicalPlan newMainPlan(
-        LogicalPlan optimizedPlan,
-        LogicalPlanTuple subPlans,
-        LocalRelation resultWrapper,
-        int hashJoinThreshold,
-        BlockFactory blockFactory,
-        AtomicReference<Page> pageHolder
-    ) {
-        LogicalPlan newPlan = optimizedPlan.transformUp(
-            AbstractSubqueryJoin.class,
-            sj -> sj.right() == subPlans.originalSubPlan() ? inlineData(sj, resultWrapper, hashJoinThreshold, blockFactory, pageHolder) : sj
-        );
-        newPlan.setOptimized();
-        return newPlan;
-    }
-
-    /**
-     * Tuple holding the subplan to execute and the original plan node for identity matching.
-     */
-    public record LogicalPlanTuple(LogicalPlan subPlan, LogicalPlan originalSubPlan) {}
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
@@ -87,6 +87,7 @@ import org.elasticsearch.xpack.esql.plan.logical.UnpackDims;
 import org.elasticsearch.xpack.esql.plan.logical.fuse.Fuse;
 import org.elasticsearch.xpack.esql.plan.logical.fuse.FuseScoreEval;
 import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.AbstractHashJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.AntiJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
@@ -189,6 +190,7 @@ public class ApproximationSupportTests extends ESTestCase {
         BinaryPlan.class,
         InferencePlan.class,
         CompoundOutputEval.class,
+        AbstractHashJoin.class,
         AbstractSubqueryJoin.class,
 
         // These plans don't occur in a correct analyzed/optimzed query.


### PR DESCRIPTION
## What

SEMI/ANTI/MARK `IN`-subquery joins and the upcoming coordinator-side INNER equi-join share the same plumbing: run the join's right side as an independent subquery, materialize it to a `LocalRelation`, and splice it back before the join runs. That lived in `AbstractSubqueryJoin`, mixed with the SEMI-specific `IN`-list / hash-join rewrite.

## How

Extract the shared machinery (`firstSubPlan`, `newMainPlan`, the coordinator phase-loop hooks, and a polymorphic `onMaterializedRight`) into a new `AbstractHashJoin` base, and rename `AbstractSubqueryJoin` to `SubqueryHashJoin` (the SEMI/ANTI/MARK family, which implements `onMaterializedRight` as the existing `inlineData` rewrite). `EsqlSession`'s phase loop now keys off `AbstractHashJoin`, so any subtype participates. Pure refactor, no behavior change.
