### PR TITLE
Keep sequence numbers on standalone columnar indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -1089,6 +1089,15 @@ public enum IndexMode {
             if (indexMode == LOOKUP) {
                 additionalSettings.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
             }
+            // Disable sequence numbers on columnar data-stream backing indices, whose append-only, time-based data does not need them,
+            // unless the setting was provided explicitly. Standalone columnar indices keep sequence numbers and support updates.
+            if (dataStreamName != null
+                && indexMode != null
+                && indexMode.isStrictColumnar()
+                && indexVersion.onOrAfter(IndexVersions.COLUMNAR_DISABLE_SEQUENCE_NUMBERS_DATA_STREAMS_ONLY)
+                && IndexSettings.DISABLE_SEQUENCE_NUMBERS.exists(indexTemplateAndCreateRequestSettings) == false) {
+                additionalSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), true);
+            }
             if (indexMode == VECTORDB_DOCUMENT) {
                 // Force index.mapping.exclude_source_vectors to true
                 String excludeSourceVectorsKey = IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey();

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1175,8 +1175,10 @@ public final class IndexSettings {
         IndexMode indexMode = IndexSettings.MODE.get(settings);
         if (indexMode.isStrictColumnar()) {
             var indexVersion = SETTING_INDEX_VERSION_CREATED.get(settings);
-            // Only enable by default if the index version supports it
-            if (indexVersion.onOrAfter(IndexVersions.DISABLE_SEQUENCE_NUMBERS)) {
+            // BWC only: columnar indices created before the gate disabled sequence numbers for all columnar indices. From the gate this
+            // is done per index at creation, for data-stream backing indices only (see IndexMode.IndexModeSettingsProvider).
+            if (indexVersion.onOrAfter(IndexVersions.DISABLE_SEQUENCE_NUMBERS)
+                && indexVersion.before(IndexVersions.COLUMNAR_DISABLE_SEQUENCE_NUMBERS_DATA_STREAMS_ONLY)) {
                 return Boolean.TRUE.toString();
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -267,6 +267,7 @@ public class IndexVersions {
     public static final IndexVersion DISK_BBQ_ES950_AUTO_CALIBRATE = def(9_105_0_00, Version.LUCENE_10_5_0);
     public static final IndexVersion TIME_SERIES_ES95_CODEC_DEFAULT = def(9_106_0_00, Version.LUCENE_10_5_0);
     public static final IndexVersion IGNORED_SOURCE_AS_DOC_VALUES_NO_FF = def(9_107_0_00, Version.LUCENE_10_5_0);
+    public static final IndexVersion COLUMNAR_DISABLE_SEQUENCE_NUMBERS_DATA_STREAMS_ONLY = def(9_108_0_00, Version.LUCENE_10_5_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1188,16 +1188,58 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         );
     }
 
+    public void testColumnarDataStreamBackingIndexKeepsExplicitDisableSequenceNumbers() {
+        // The injection only applies when the setting is absent, so an explicit request value must win.
+        boolean explicit = randomBoolean();
+        assertThat(
+            "an explicit [index.disable_sequence_numbers] on a columnar data-stream backing index must be preserved, not overridden",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(aggregateColumnarSettings("my-data-stream", IndexVersion.current(), explicit)),
+            equalTo(explicit)
+        );
+    }
+
+    public void testStandaloneColumnarIndexKeepsExplicitDisableSequenceNumbers() {
+        // The injection only fires for data streams, so an explicit value on a standalone columnar index is preserved untouched.
+        boolean explicit = randomBoolean();
+        assertThat(
+            "an explicit [index.disable_sequence_numbers] on a standalone columnar index must be preserved",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(aggregateColumnarSettings(null, IndexVersion.current(), explicit)),
+            equalTo(explicit)
+        );
+    }
+
+    public void testStandaloneColumnarIndexBeforeGateDisablesSequenceNumbers() {
+        // Below the gating version the override does not apply and a standalone columnar index disables sequence numbers. The lower bound
+        // is where the columnar disable-by-default begins.
+        IndexVersion beforeGate = IndexVersionUtils.randomVersionBetween(
+            IndexVersions.DISABLE_SEQUENCE_NUMBERS,
+            IndexVersionUtils.getPreviousVersion(IndexVersions.COLUMNAR_DISABLE_SEQUENCE_NUMBERS_DATA_STREAMS_ONLY)
+        );
+        assertTrue(
+            "a standalone columnar index below the gating version disables sequence numbers",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(aggregateColumnarSettings(null, beforeGate, null))
+        );
+    }
+
     private Settings aggregateColumnarSettings(@Nullable String dataStreamName) {
+        return aggregateColumnarSettings(dataStreamName, IndexVersion.current(), null);
+    }
+
+    private Settings aggregateColumnarSettings(
+        @Nullable String dataStreamName,
+        IndexVersion createdVersion,
+        @Nullable Boolean explicitDisableSequenceNumbers
+    ) {
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .putProjectMetadata(ProjectMetadata.builder(projectId).build())
             .build();
-        var request = new CreateIndexClusterStateUpdateRequest("create index", projectId, "idx", "idx").settings(
-            Settings.builder()
-                .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
-                .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
-                .build()
-        );
+        Settings.Builder indexSettings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, createdVersion);
+        if (explicitDisableSequenceNumbers != null) {
+            indexSettings.put(IndexSettings.DISABLE_SEQUENCE_NUMBERS.getKey(), explicitDisableSequenceNumbers);
+        }
+        var request = new CreateIndexClusterStateUpdateRequest("create index", projectId, "idx", "idx").settings(indexSettings.build());
         if (dataStreamName != null) {
             request.dataStreamName(dataStreamName);
         }
@@ -1210,7 +1252,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             Settings.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             randomShardLimitService(),
-            Collections.emptySet()
+            Set.of(new IndexMode.IndexModeSettingsProvider())
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1174,6 +1174,46 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         assertThat((Map<String, Object>) mappingsProperties.get("test"), hasValue("keyword"));
     }
 
+    public void testStandaloneColumnarIndexKeepsSequenceNumbers() {
+        assertFalse(
+            "a standalone columnar index should keep sequence numbers so that it supports updates",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(aggregateColumnarSettings(null))
+        );
+    }
+
+    public void testColumnarDataStreamBackingIndexDisablesSequenceNumbers() {
+        assertTrue(
+            "a columnar data-stream backing index disables sequence numbers by default",
+            IndexSettings.DISABLE_SEQUENCE_NUMBERS.get(aggregateColumnarSettings("my-data-stream"))
+        );
+    }
+
+    private Settings aggregateColumnarSettings(@Nullable String dataStreamName) {
+        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .putProjectMetadata(ProjectMetadata.builder(projectId).build())
+            .build();
+        var request = new CreateIndexClusterStateUpdateRequest("create index", projectId, "idx", "idx").settings(
+            Settings.builder()
+                .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+                .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                .build()
+        );
+        if (dataStreamName != null) {
+            request.dataStreamName(dataStreamName);
+        }
+        return aggregateIndexSettings(
+            clusterState,
+            request,
+            Settings.EMPTY,
+            null,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet()
+        );
+    }
+
     private static ClusterState clusterStateWithSettings(ProjectId projectId, Settings persistentSettings) {
         return ClusterState.builder(ClusterName.DEFAULT)
             .metadata(Metadata.builder().persistentSettings(persistentSettings).put(ProjectMetadata.builder(projectId)).build())

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -1252,33 +1252,38 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testDisableSequenceNumbersDefaultForColumnarModes() {
-        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.DISABLE_SEQUENCE_NUMBERS, IndexVersion.current());
-
-        // Test COLUMNAR mode
-        Settings columnarSettings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
-        IndexMetadata columnarMetadata = newIndexMeta("columnar-index", columnarSettings, indexVersion);
-        IndexSettings columnarIndexSettings = new IndexSettings(columnarMetadata, Settings.EMPTY);
-        assertThat("DISABLE_SEQUENCE_NUMBERS should be true for COLUMNAR mode", columnarIndexSettings.sequenceNumbersDisabled(), is(true));
-
-        // Test LOGSDB_COLUMNAR mode
-        Settings columnarLogsdbSettings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB_COLUMNAR.getName()).build();
-        IndexMetadata columnarLogsdbMetadata = newIndexMeta("columnar-logsdb-index", columnarLogsdbSettings, indexVersion);
-        IndexSettings columnarLogsdbIndexSettings = new IndexSettings(columnarLogsdbMetadata, Settings.EMPTY);
-        assertThat(
-            "DISABLE_SEQUENCE_NUMBERS should be true for LOGSDB_COLUMNAR mode",
-            columnarLogsdbIndexSettings.sequenceNumbersDisabled(),
-            is(true)
+        // BWC: below the gate, columnar modes disable sequence numbers by default.
+        IndexVersion beforeGate = IndexVersionUtils.randomVersionBetween(
+            IndexVersions.DISABLE_SEQUENCE_NUMBERS,
+            IndexVersionUtils.getPreviousVersion(IndexVersions.COLUMNAR_DISABLE_SEQUENCE_NUMBERS_DATA_STREAMS_ONLY)
         );
+        for (IndexMode columnarMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), columnarMode.getName()).build();
+            IndexSettings indexSettings = new IndexSettings(
+                newIndexMeta(columnarMode.getName() + "-index", settings, beforeGate),
+                Settings.EMPTY
+            );
+            assertThat(columnarMode + " disables sequence numbers below the gate", indexSettings.sequenceNumbersDisabled(), is(true));
+        }
 
-        // Test that STANDARD mode does not have sequence numbers disabled by default
+        // From the gate, columnar modes keep sequence numbers by default; only data-stream backing indices disable them (set at creation).
+        IndexVersion fromGate = IndexVersionUtils.randomVersionBetween(
+            IndexVersions.COLUMNAR_DISABLE_SEQUENCE_NUMBERS_DATA_STREAMS_ONLY,
+            IndexVersion.current()
+        );
+        for (IndexMode columnarMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), columnarMode.getName()).build();
+            IndexSettings indexSettings = new IndexSettings(
+                newIndexMeta(columnarMode.getName() + "-index", settings, fromGate),
+                Settings.EMPTY
+            );
+            assertThat(columnarMode + " keeps sequence numbers from the gate", indexSettings.sequenceNumbersDisabled(), is(false));
+        }
+
+        // STANDARD mode never disables sequence numbers by default.
         Settings standardSettings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.STANDARD.getName()).build();
-        IndexMetadata standardMetadata = newIndexMeta("standard-index", standardSettings, indexVersion);
-        IndexSettings standardIndexSettings = new IndexSettings(standardMetadata, Settings.EMPTY);
-        assertThat(
-            "DISABLE_SEQUENCE_NUMBERS should be false for STANDARD mode",
-            standardIndexSettings.sequenceNumbersDisabled(),
-            is(false)
-        );
+        IndexSettings standardIndexSettings = new IndexSettings(newIndexMeta("standard-index", standardSettings, fromGate), Settings.EMPTY);
+        assertThat(standardIndexSettings.sequenceNumbersDisabled(), is(false));
     }
 
     public void testDynamicStringsAutoTextDefaultByIndexMode() {


### PR DESCRIPTION
Only disable sequence numbers on columnar data-stream backing indices, so that non-time-based columnar indices keep them and can support updates.