### PR TITLE
ES|QL Fix flaky testInvalidJoinPatternsExpressionJoin

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/LookupJoinParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/LookupJoinParserTests.java
@@ -311,7 +311,13 @@ public class LookupJoinParserTests extends AbstractStatementParserTests {
         {
             var fromPatterns = randomIndexPattern();
             // Generate a syntactically invalid (partially quoted) pattern.
-            var joinPattern = randomIdentifier() + ":" + quote(randomIndexPattern(without(CROSS_CLUSTER)));
+            // Exclude keywords active in JOIN_MODE (on, as, join, using): when tokenized as a keyword rather
+            // than UNQUOTED_SOURCE, ANTLR produces "mismatched input" instead of "no viable alternative at input".
+            var clusterPrefix = randomValueOtherThanMany(
+                s -> List.of("on", "as", "join", "using").contains(s),
+                ESTestCase::randomIdentifier
+            );
+            var joinPattern = clusterPrefix + ":" + quote(randomIndexPattern(without(CROSS_CLUSTER)));
             expectError(
                 "FROM " + fromPatterns + " | LOOKUP JOIN " + joinPattern + " ON " + onClause,
                 // Since the from pattern is partially quoted, we get an error at the beginning of the partially quoted


### PR DESCRIPTION
Closes #151705

## Problem

`testInvalidJoinPatternsExpressionJoin` generates a syntactically invalid
join pattern of the form `<identifier>:"<quoted-index>"` and asserts the
parser rejects it with `"no viable alternative at input"`. This worked
correctly unless `randomIdentifier()` happened to produce `on`, `as`,
`join`, or `using` — the four keywords active in ANTLR's `JOIN_MODE`
grammar (`Join.g4`).

When the cluster prefix matches a `JOIN_MODE` keyword, the ANTLR lexer
tokenizes it as a keyword token rather than `UNQUOTED_SOURCE`. The parser
then reports `"mismatched input 'on' expecting {QUOTED_STRING, UNQUOTED_SOURCE}"`
instead of `"no viable alternative at input"`, failing the assertion.

Failing query from CI (seed `AB90374578730E7`, ~5.9% observed fail rate):

```
FROM *m^.*9mda3jt2apw | LOOKUP JOIN on::failures ON odyyovpxcqpm!=lcjidupf
```

## Fix

Use `randomValueOtherThanMany` to exclude the four `JOIN_MODE` keywords
(`on`, `as`, `join`, `using`) from the generated cluster prefix. This
ensures the prefix always tokenizes as `UNQUOTED_SOURCE` and the expected
error message is stable across all random seeds.