### PR TITLE
ESQL: replay listed keys in compact file listings, fixing Hive path doubling

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
@@ -246,6 +246,68 @@ public class ExternalCsvHivePartitionedIT extends AbstractExternalDataSourceIT {
         Files.writeString(p2025.resolve("data.csv"), "id,value,year\n3,gamma,1999\n4,delta,1999\n", StandardCharsets.UTF_8);
     }
 
+    /**
+     * The exact layout from the public report (elastic/elasticsearch#154289): the standard AWS S3 log tree
+     * {@code AWSLogs/aws-account-id=<id>/aws-service=vpcflowlogs/aws-region=<r>/year=<y>/month=<m>/day=<d>/…}
+     * under {@code schema_resolution: first_file_wins}. The registered resource's pattern prefix ends at
+     * {@code aws-service=vpcflowlogs/}, so {@code aws-account-id=} and {@code aws-service=} are BOTH inside
+     * the base path AND claimed as partition columns. On {@code main} the compacted listing re-appended
+     * them, doubling the prefix, and the read hit {@code NoSuchKey}. The zero-padded {@code month=06} also
+     * trips the typed-value sibling defect ({@code month=06} → integer {@code 6} → {@code month=6}), so this
+     * one end-to-end query covers both the prefix-doubling and the value-spelling bugs; red on {@code main}.
+     *
+     * <p>The glob uses {@code **} so the local provider descends recursively and no {@code key=*} segment is
+     * spelled, so {@code WHERE month == 6} must prune from the reconstructed listing's partition values —
+     * which only line up when the reconstructed key equals the listed one.
+     */
+    public void testAwsVpcFlowLogLayoutFirstFileWinsRoundTrips() throws Exception {
+        Path root = createTempDir().resolve("aws_vpcflow_csv");
+        Path prefix = root.resolve("AWSLogs").resolve("aws-account-id=123456789012").resolve("aws-service=vpcflowlogs");
+        Path region = prefix.resolve("aws-region=us-east-1").resolve("year=2024");
+        writeCsv(region.resolve("month=06").resolve("day=01").resolve("flow-0001.csv"), "id,val\n1,a\n2,b\n");
+        writeCsv(region.resolve("month=12").resolve("day=15").resolve("flow-0002.csv"), "id,val\n3,c\n");
+
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(prefix) + "/**/*.csv";
+        String dataset = registerDataset(
+            "aws_vpcflow_csv",
+            glob,
+            Map.of("hive_partitioning", true, "schema_resolution", "first_file_wins")
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | KEEP id, val"))) {
+            assertThat(getValuesList(response).size(), is(3));
+        }
+        try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | WHERE month == 6 | KEEP id, val"))) {
+            assertThat(getValuesList(response).size(), is(2));
+        }
+    }
+
+    /**
+     * A comma-separated resource has no glob metacharacter, so its pattern prefix is the whole comma string
+     * and no listed key starts with it. On {@code main} the compacted listing prepended that base to each
+     * key; the round-trip guard now discards such an encoding and keeps the raw listing, so the reads
+     * succeed. Red on {@code main}. {@code first_file_wins} routes through the compactor (the default
+     * {@code union_by_name} never compacts).
+     */
+    public void testCommaSeparatedResourceFirstFileWinsRoundTrips() throws Exception {
+        Path root = createTempDir().resolve("comma_ffw_csv");
+        writeCsv(root.resolve("x.csv"), "id,val\n1,a\n");
+        writeCsv(root.resolve("y.csv"), "id,val\n2,b\n");
+
+        String uri = StoragePath.fileUri(root) + "/x.csv," + StoragePath.fileUri(root) + "/y.csv";
+        String dataset = registerDataset("comma_ffw_csv", uri, Map.of("schema_resolution", "first_file_wins"));
+
+        try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | KEEP id, val"))) {
+            assertThat(getValuesList(response).size(), is(2));
+        }
+    }
+
+    private static void writeCsv(Path file, String content) throws Exception {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+    }
+
     private static void writePartitionedCsvFiles(Path root) throws Exception {
         Path month01 = root.resolve("year=2024").resolve("month=01");
         Path month02 = root.resolve("year=2024").resolve("month=02");

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
@@ -247,14 +247,14 @@ public class ExternalCsvHivePartitionedIT extends AbstractExternalDataSourceIT {
     }
 
     /**
-     * The exact layout from the public report (elastic/elasticsearch#154289): the standard AWS S3 log tree
+     * The standard AWS S3 log tree
      * {@code AWSLogs/aws-account-id=<id>/aws-service=vpcflowlogs/aws-region=<r>/year=<y>/month=<m>/day=<d>/…}
      * under {@code schema_resolution: first_file_wins}. The registered resource's pattern prefix ends at
-     * {@code aws-service=vpcflowlogs/}, so {@code aws-account-id=} and {@code aws-service=} are BOTH inside
-     * the base path AND claimed as partition columns. On {@code main} the compacted listing re-appended
-     * them, doubling the prefix, and the read hit {@code NoSuchKey}. The zero-padded {@code month=06} also
-     * trips the typed-value sibling defect ({@code month=06} → integer {@code 6} → {@code month=6}), so this
-     * one end-to-end query covers both the prefix-doubling and the value-spelling bugs; red on {@code main}.
+     * {@code aws-service=vpcflowlogs/}, so {@code aws-account-id=} and {@code aws-service=} sit BOTH inside
+     * the base path AND are claimed as partition columns — a compact listing that re-appends partition
+     * columns to the base emits them twice and reads a key that does not exist. The zero-padded
+     * {@code month=06} additionally pins value spelling ({@code month=06} must not come back as
+     * {@code month=6}), so this one end-to-end query covers both duplication and spelling.
      *
      * <p>The glob uses {@code **} so the local provider descends recursively and no {@code key=*} segment is
      * spelled, so {@code WHERE month == 6} must prune from the reconstructed listing's partition values —
@@ -285,9 +285,9 @@ public class ExternalCsvHivePartitionedIT extends AbstractExternalDataSourceIT {
 
     /**
      * A comma-separated resource has no glob metacharacter, so its pattern prefix is the whole comma string
-     * and no listed key starts with it. On {@code main} the compacted listing prepended that base to each
-     * key; the round-trip guard now discards such an encoding and keeps the raw listing, so the reads
-     * succeed. Red on {@code main}. {@code first_file_wins} routes through the compactor (the default
+     * and no listed key starts with it. A compact encoding that prepends that base to each key reads objects
+     * that do not exist; the round-trip guard discards such an encoding and keeps the raw listing, so the
+     * reads succeed. {@code first_file_wins} routes through the compactor (the default
      * {@code union_by_name} never compacts).
      */
     public void testCommaSeparatedResourceFirstFileWinsRoundTrips() throws Exception {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvHivePartitionedIT.java
@@ -254,7 +254,7 @@ public class ExternalCsvHivePartitionedIT extends AbstractExternalDataSourceIT {
      * the base path AND are claimed as partition columns — a compact listing that re-appends partition
      * columns to the base emits them twice and reads a key that does not exist. The zero-padded
      * {@code month=06} additionally pins value spelling ({@code month=06} must not come back as
-     * {@code month=6}), so this one end-to-end query covers both duplication and spelling.
+     * {@code month=6}), so these queries cover both duplication and spelling.
      *
      * <p>The glob uses {@code **} so the local provider descends recursively and no {@code key=*} segment is
      * spelled, so {@code WHERE month == 6} must prune from the reconstructed listing's partition values —

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/DirectoryGroupedFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/DirectoryGroupedFileList.java
@@ -14,14 +14,14 @@ import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 /**
- * Directory-grouped file listing for Hive-partitioned data. Each file carries the index of the
- * relative directory it was listed under; {@link #path(int)} replays {@code basePath + directory +
- * leaf} verbatim, so the reconstructed key is byte-for-byte the one that was listed — value spelling,
- * segment order, and any non-partition directories all survive. Grouping on the directory string
- * (rather than on typed partition values) is what keeps the round-trip exact. Created by
- * {@link FileListCompactor} only when Hive partition metadata was detected.
+ * Compact file listing that groups files by the relative directory they were listed under. Each file
+ * carries the index of its directory; {@link #path(int)} replays {@code basePath + directory + leaf}
+ * verbatim, so the reconstructed key is byte-for-byte the one that was listed — value spelling, segment
+ * order, and any non-partition directories all survive, because nothing is re-derived from parsed
+ * partition values. Beats {@link DictionaryFileList} on layouts with many files per directory and few
+ * distinct directories; created by {@link FileListCompactor}.
  */
-final class HiveFileList implements FileList {
+final class DirectoryGroupedFileList implements FileList {
 
     private final String basePath;
     private final String[] groupDirs;
@@ -47,7 +47,7 @@ final class HiveFileList implements FileList {
     @Nullable
     private final FileSetFingerprint fileSetFingerprint;
 
-    HiveFileList(
+    DirectoryGroupedFileList(
         String basePath,
         String[] groupDirs,
         short[] fileGroups,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -51,13 +51,13 @@ final class FileListCompactor {
         }
         String normalizedBase = normalizeBase(basePath);
         PartitionMetadata pm = raw.partitionMetadata();
-        if (pm != null && pm.isEmpty() == false) {
-            FileList hive = verified(tryHive(normalizedBase, raw), raw);
-            if (hive != null) {
-                return hive;
-            }
-        }
+        FileList hive = pm != null && pm.isEmpty() == false ? verified(tryHive(normalizedBase, raw), raw) : null;
         FileList dict = verified(tryDictionary(normalizedBase, raw), raw);
+        // The Hive encoding stores one string per directory while the dictionary shares path segments
+        // across files, so which is smaller depends on the layout; keep whichever actually weighs less.
+        if (hive != null && (dict == null || hive.estimatedBytes() <= dict.estimatedBytes())) {
+            return hive;
+        }
         if (dict != null) {
             return dict;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -19,15 +19,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Compresses a {@link GenericFileList} into a compact representation.
- * Tries Hive-partitioned encoding first (if partition metadata exists),
- * then falls back to segment-dictionary encoding, and finally returns
- * the original list unchanged if neither encoding fits.
+ * Compresses a {@link GenericFileList} into a compact representation. Builds a
+ * {@link DirectoryGroupedFileList} (when partition metadata was detected) and a {@link DictionaryFileList},
+ * verifies each one replays the listed keys exactly, and keeps whichever verified candidate weighs less —
+ * falling back to the original list if neither fits.
  * <p>
- * Every candidate encoding is verified to replay the listed keys exactly before it is returned
- * (see {@link #verified}); one that cannot is discarded so the caller falls through to the next
- * encoding or the raw list. This keeps every compact representation faithful even for layouts an
- * encoding does not anticipate.
+ * The round-trip verification (see {@link #verified}) is the single point that keeps every compact
+ * representation faithful, even for a layout no encoding anticipates.
  */
 final class FileListCompactor {
 
@@ -36,14 +34,14 @@ final class FileListCompactor {
     private FileListCompactor() {}
 
     /**
-     * Compacts a raw file list into the most efficient representation available.
-     * Returns the original list when compaction is not applicable or overflows.
+     * Compacts a raw file list into the smallest faithful representation available, or returns the
+     * original list when compaction does not apply or overflows.
      * <p>
-     * The hive-partitioning flag is not passed explicitly; instead, the presence
-     * of {@link PartitionMetadata} on the raw list serves as the signal.
-     * When {@code hivePartitioning=false} upstream, {@link GlobExpander} never
-     * attaches partition metadata so the Hive branch here is skipped automatically
-     * and we go straight to dictionary encoding.
+     * The directory-grouped encoding is only built when {@link PartitionMetadata} was detected — not
+     * because it needs the partition values (it does not read them), but as a cost heuristic: that is
+     * the signal a layout has repeated directories worth grouping. {@link GlobExpander} attaches no
+     * partition metadata when hive partitioning is off, so such listings take the dictionary encoding
+     * directly.
      */
     static FileList compact(String basePath, GenericFileList raw) {
         if (raw == null || raw.isResolved() == false || raw.fileCount() == 0) {
@@ -51,12 +49,12 @@ final class FileListCompactor {
         }
         String normalizedBase = normalizeBase(basePath);
         PartitionMetadata pm = raw.partitionMetadata();
-        FileList hive = pm != null && pm.isEmpty() == false ? verified(tryHive(normalizedBase, raw), raw) : null;
+        FileList grouped = pm != null && pm.isEmpty() == false ? verified(tryDirectoryGrouped(normalizedBase, raw), raw) : null;
         FileList dict = verified(tryDictionary(normalizedBase, raw), raw);
-        // The Hive encoding stores one string per directory while the dictionary shares path segments
-        // across files, so which is smaller depends on the layout; keep whichever actually weighs less.
-        if (hive != null && (dict == null || hive.estimatedBytes() <= dict.estimatedBytes())) {
-            return hive;
+        // The directory-grouped encoding stores one string per directory while the dictionary shares path
+        // segments across files, so which is smaller depends on the layout; keep whichever weighs less.
+        if (grouped != null && (dict == null || grouped.estimatedBytes() <= dict.estimatedBytes())) {
+            return grouped;
         }
         if (dict != null) {
             return dict;
@@ -65,12 +63,27 @@ final class FileListCompactor {
     }
 
     /**
-     * Returns the candidate only if it reconstructs every listed path exactly; otherwise {@code null},
-     * so the caller falls through to the next encoding or the raw list. This is the chokepoint that
-     * keeps every compact representation faithful even for a layout no encoding anticipates — e.g. a
-     * base path that is not a prefix of the listed keys, as a comma-separated resource produces on the
-     * first_file_wins rail. The reconstruction is compared as a string; a candidate whose reconstructed
-     * key does not even parse is treated as a mismatch rather than allowed to throw.
+     * Strips {@code normalizedBase} from a listed key when it is genuinely a prefix, leaving the relative
+     * path both encodings reconstruct from. When the base is not a prefix — e.g. a comma-separated resource
+     * whose pattern prefix is the whole comma string — the full key is returned unchanged; the encoding
+     * then reconstructs a wrong key and is discarded by {@link #verified}. Owning this rule in one place
+     * keeps both encodings' notion of "relative" identical.
+     */
+    private static String relativize(String normalizedBase, String fullPath) {
+        if (normalizedBase.isEmpty() == false && fullPath.startsWith(normalizedBase)) {
+            return fullPath.substring(normalizedBase.length());
+        }
+        return fullPath;
+    }
+
+    /**
+     * Returns the candidate only if it reproduces every listed file exactly — path, size and modification
+     * time; otherwise {@code null}, so the caller falls through to the next encoding or the raw list. This
+     * is the chokepoint that keeps every compact representation faithful even for a layout no encoding
+     * anticipates — e.g. a base path that is not a prefix of the listed keys, as a comma-separated resource
+     * produces on the first_file_wins rail. Path is compared as a string; a candidate whose reconstructed
+     * key does not even parse is treated as a mismatch rather than allowed to throw. Size and mtime are
+     * checked too because an encoding may collapse them per group (see {@link DirectoryGroupedFileList}).
      */
     private static FileList verified(FileList candidate, GenericFileList raw) {
         if (candidate == null) {
@@ -84,7 +97,9 @@ final class FileListCompactor {
             } catch (IllegalArgumentException e) {
                 actual = null;
             }
-            if (expected.equals(actual) == false) {
+            if (expected.equals(actual) == false
+                || candidate.size(i) != raw.size(i)
+                || candidate.lastModifiedMillis(i) != raw.lastModifiedMillis(i)) {
                 logger.debug(
                     "discarding {} for pattern [{}]: listed file [{}] reconstructs as [{}]",
                     candidate.getClass().getSimpleName(),
@@ -107,18 +122,18 @@ final class FileListCompactor {
     }
 
     // ------------------------------------------------------------------
-    // Hive-partitioned encoding
+    // Directory-grouped encoding
     // ------------------------------------------------------------------
 
     /**
-     * Groups files by the relative directory they were listed under, in original listing order, and
-     * keeps one directory string per group. {@link HiveFileList#path(int)} then replays each file's
-     * exact listed key. Grouping on the directory string — not on typed partition values — is what
-     * makes the round-trip faithful: value spelling, segment order, non-partition directories, and a
-     * base path unrelated to the keys all survive, since none of them is re-derived from the parsed
-     * partition metadata.
+     * Groups files by the relative directory they were listed under, in original listing order, keeping
+     * one directory string per group. {@link DirectoryGroupedFileList#path(int)} then replays each file's
+     * exact listed key. Grouping on the directory string — not on typed partition values — is what makes
+     * the round-trip faithful: value spelling, segment order and non-partition directories all survive,
+     * since none of them is re-derived. Returns {@code null} when the directory count overflows the group
+     * index.
      */
-    private static FileList tryHive(String normalizedBase, GenericFileList raw) {
+    private static FileList tryDirectoryGrouped(String normalizedBase, GenericFileList raw) {
         List<StorageEntry> files = raw.files();
         int count = files.size();
 
@@ -136,11 +151,7 @@ final class FileListCompactor {
             sizes[f] = entry.length();
             mtimes[f] = entry.lastModified().toEpochMilli();
 
-            String fullPath = entry.path().toString();
-            String relative = fullPath;
-            if (normalizedBase.isEmpty() == false && fullPath.startsWith(normalizedBase)) {
-                relative = fullPath.substring(normalizedBase.length());
-            }
+            String relative = relativize(normalizedBase, entry.path().toString());
             int lastSlash = relative.lastIndexOf('/');
             String dir = lastSlash >= 0 ? relative.substring(0, lastSlash + 1) : "";
             String leaf = lastSlash >= 0 ? relative.substring(lastSlash + 1) : relative;
@@ -188,7 +199,7 @@ final class FileListCompactor {
             }
         }
 
-        return new HiveFileList(
+        return new DirectoryGroupedFileList(
             normalizedBase,
             dirs.toArray(new String[0]),
             fileGroups,
@@ -225,11 +236,7 @@ final class FileListCompactor {
             sizes[f] = entry.length();
             mtimes[f] = entry.lastModified().toEpochMilli();
 
-            String fullPath = entry.path().toString();
-            String relative = fullPath;
-            if (normalizedBase.isEmpty() == false && fullPath.startsWith(normalizedBase)) {
-                relative = fullPath.substring(normalizedBase.length());
-            }
+            String relative = relativize(normalizedBase, entry.path().toString());
 
             String leaf = relative;
             int lastSlash = relative.lastIndexOf('/');
@@ -268,11 +275,7 @@ final class FileListCompactor {
             List<short[]> rebuiltTokens = new ArrayList<>(count);
             for (int f = 0; f < count; f++) {
                 StorageEntry entry = files.get(f);
-                String fullPath = entry.path().toString();
-                String relative = fullPath;
-                if (normalizedBase.isEmpty() == false && fullPath.startsWith(normalizedBase)) {
-                    relative = fullPath.substring(normalizedBase.length());
-                }
+                String relative = relativize(normalizedBase, entry.path().toString());
 
                 String[] segments = relative.split("/");
                 String lastSeg = segments[segments.length - 1];

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasources.glob;
 
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
@@ -21,8 +23,15 @@ import java.util.Map;
  * Tries Hive-partitioned encoding first (if partition metadata exists),
  * then falls back to segment-dictionary encoding, and finally returns
  * the original list unchanged if neither encoding fits.
+ * <p>
+ * Every candidate encoding is verified to replay the listed keys exactly before it is returned
+ * (see {@link #verified}); one that cannot is discarded so the caller falls through to the next
+ * encoding or the raw list. This keeps every compact representation faithful even for layouts an
+ * encoding does not anticipate.
  */
 final class FileListCompactor {
+
+    private static final Logger logger = LogManager.getLogger(FileListCompactor.class);
 
     private FileListCompactor() {}
 
@@ -43,16 +52,50 @@ final class FileListCompactor {
         String normalizedBase = normalizeBase(basePath);
         PartitionMetadata pm = raw.partitionMetadata();
         if (pm != null && pm.isEmpty() == false) {
-            FileList hive = tryHive(normalizedBase, raw);
+            FileList hive = verified(tryHive(normalizedBase, raw), raw);
             if (hive != null) {
                 return hive;
             }
         }
-        FileList dict = tryDictionary(normalizedBase, raw);
+        FileList dict = verified(tryDictionary(normalizedBase, raw), raw);
         if (dict != null) {
             return dict;
         }
         return raw;
+    }
+
+    /**
+     * Returns the candidate only if it reconstructs every listed path exactly; otherwise {@code null},
+     * so the caller falls through to the next encoding or the raw list. This is the chokepoint that
+     * keeps every compact representation faithful even for a layout no encoding anticipates — e.g. a
+     * base path that is not a prefix of the listed keys, as a comma-separated resource produces on the
+     * first_file_wins rail. The reconstruction is compared as a string; a candidate whose reconstructed
+     * key does not even parse is treated as a mismatch rather than allowed to throw.
+     */
+    private static FileList verified(FileList candidate, GenericFileList raw) {
+        if (candidate == null) {
+            return null;
+        }
+        for (int i = 0; i < raw.fileCount(); i++) {
+            String expected = raw.path(i).toString();
+            String actual;
+            try {
+                actual = candidate.path(i).toString();
+            } catch (IllegalArgumentException e) {
+                actual = null;
+            }
+            if (expected.equals(actual) == false) {
+                logger.debug(
+                    "discarding {} for pattern [{}]: listed file [{}] reconstructs as [{}]",
+                    candidate.getClass().getSimpleName(),
+                    raw.originalPattern(),
+                    expected,
+                    actual
+                );
+                return null;
+            }
+        }
+        return candidate;
     }
 
     private static String extractExtension(String leafSegment) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -51,9 +51,9 @@ final class FileListCompactor {
         PartitionMetadata pm = raw.partitionMetadata();
         FileList groupedCandidate = pm != null && pm.isEmpty() == false ? tryDirectoryGrouped(normalizedBase, raw) : null;
         FileList dictCandidate = tryDictionary(normalizedBase, raw);
-        // Materialise the listed keys once: both candidates verify against the same strings, so rendering
-        // them per candidate would pay the whole listing's string cost twice. Skipped entirely when neither
-        // encoding fits (both overflowed) — that is the largest listing there is, and nothing needs checking.
+        // Collect the listed keys once so both candidates verify against one array instead of walking the raw
+        // entries again per candidate. These are stored strings; the reconstruction cost sits on the candidate
+        // side. Skipped when neither encoding was built, since then there is nothing to verify.
         String[] listedPaths = groupedCandidate != null || dictCandidate != null ? listedPaths(raw) : null;
         FileList grouped = verified(groupedCandidate, raw, listedPaths);
         FileList dict = verified(dictCandidate, raw, listedPaths);
@@ -68,7 +68,7 @@ final class FileListCompactor {
         return raw;
     }
 
-    /** Renders every listed key once, so several candidate encodings can be verified against one rendering. */
+    /** Collects the listed keys once so several candidate encodings verify against a single walk of the raw entries. */
     private static String[] listedPaths(GenericFileList raw) {
         String[] paths = new String[raw.fileCount()];
         for (int i = 0; i < paths.length; i++) {
@@ -99,8 +99,8 @@ final class FileListCompactor {
      * produces on the first_file_wins rail. Path is compared as a string; a candidate whose reconstructed
      * key does not even parse is treated as a mismatch rather than allowed to throw. Size and mtime are
      * checked too because an encoding may collapse them per group (see {@link DirectoryGroupedFileList}).
-     * {@code listedPaths} carries the raw listing's keys already rendered, so verifying several candidates
-     * renders them once rather than once per candidate.
+     * {@code listedPaths} carries the raw listing's keys, collected once so verifying several candidates walks
+     * the raw entries once.
      */
     private static FileList verified(FileList candidate, GenericFileList raw, String[] listedPaths) {
         if (candidate == null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -49,16 +49,14 @@ final class FileListCompactor {
         }
         String normalizedBase = normalizeBase(basePath);
         PartitionMetadata pm = raw.partitionMetadata();
+        FileList groupedCandidate = pm != null && pm.isEmpty() == false ? tryDirectoryGrouped(normalizedBase, raw) : null;
+        FileList dictCandidate = tryDictionary(normalizedBase, raw);
         // Materialise the listed keys once: both candidates verify against the same strings, so rendering
-        // them per candidate would pay the whole listing's string cost twice.
-        String[] listedPaths = new String[raw.fileCount()];
-        for (int i = 0; i < listedPaths.length; i++) {
-            listedPaths[i] = raw.path(i).toString();
-        }
-        FileList grouped = pm != null && pm.isEmpty() == false
-            ? verified(tryDirectoryGrouped(normalizedBase, raw), raw, listedPaths)
-            : null;
-        FileList dict = verified(tryDictionary(normalizedBase, raw), raw, listedPaths);
+        // them per candidate would pay the whole listing's string cost twice. Skipped entirely when neither
+        // encoding fits (both overflowed) — that is the largest listing there is, and nothing needs checking.
+        String[] listedPaths = groupedCandidate != null || dictCandidate != null ? listedPaths(raw) : null;
+        FileList grouped = verified(groupedCandidate, raw, listedPaths);
+        FileList dict = verified(dictCandidate, raw, listedPaths);
         // The directory-grouped encoding stores one string per directory while the dictionary shares path
         // segments across files, so which is smaller depends on the layout; keep whichever weighs less.
         if (grouped != null && (dict == null || grouped.estimatedBytes() <= dict.estimatedBytes())) {
@@ -68,6 +66,15 @@ final class FileListCompactor {
             return dict;
         }
         return raw;
+    }
+
+    /** Renders every listed key once, so several candidate encodings can be verified against one rendering. */
+    private static String[] listedPaths(GenericFileList raw) {
+        String[] paths = new String[raw.fileCount()];
+        for (int i = 0; i < paths.length; i++) {
+            paths[i] = raw.path(i).toString();
+        }
+        return paths;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -49,8 +49,16 @@ final class FileListCompactor {
         }
         String normalizedBase = normalizeBase(basePath);
         PartitionMetadata pm = raw.partitionMetadata();
-        FileList grouped = pm != null && pm.isEmpty() == false ? verified(tryDirectoryGrouped(normalizedBase, raw), raw) : null;
-        FileList dict = verified(tryDictionary(normalizedBase, raw), raw);
+        // Materialise the listed keys once: both candidates verify against the same strings, so rendering
+        // them per candidate would pay the whole listing's string cost twice.
+        String[] listedPaths = new String[raw.fileCount()];
+        for (int i = 0; i < listedPaths.length; i++) {
+            listedPaths[i] = raw.path(i).toString();
+        }
+        FileList grouped = pm != null && pm.isEmpty() == false
+            ? verified(tryDirectoryGrouped(normalizedBase, raw), raw, listedPaths)
+            : null;
+        FileList dict = verified(tryDictionary(normalizedBase, raw), raw, listedPaths);
         // The directory-grouped encoding stores one string per directory while the dictionary shares path
         // segments across files, so which is smaller depends on the layout; keep whichever weighs less.
         if (grouped != null && (dict == null || grouped.estimatedBytes() <= dict.estimatedBytes())) {
@@ -84,13 +92,15 @@ final class FileListCompactor {
      * produces on the first_file_wins rail. Path is compared as a string; a candidate whose reconstructed
      * key does not even parse is treated as a mismatch rather than allowed to throw. Size and mtime are
      * checked too because an encoding may collapse them per group (see {@link DirectoryGroupedFileList}).
+     * {@code listedPaths} carries the raw listing's keys already rendered, so verifying several candidates
+     * renders them once rather than once per candidate.
      */
-    private static FileList verified(FileList candidate, GenericFileList raw) {
+    private static FileList verified(FileList candidate, GenericFileList raw, String[] listedPaths) {
         if (candidate == null) {
             return null;
         }
         for (int i = 0; i < raw.fileCount(); i++) {
-            String expected = raw.path(i).toString();
+            String expected = listedPaths[i];
             String actual;
             try {
                 actual = candidate.path(i).toString();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -7,15 +7,12 @@
 
 package org.elasticsearch.xpack.esql.datasources.glob;
 
-import org.elasticsearch.xpack.esql.datasources.HivePartitionDetector;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
-import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +43,7 @@ final class FileListCompactor {
         String normalizedBase = normalizeBase(basePath);
         PartitionMetadata pm = raw.partitionMetadata();
         if (pm != null && pm.isEmpty() == false) {
-            FileList hive = tryHive(normalizedBase, raw, pm);
+            FileList hive = tryHive(normalizedBase, raw);
             if (hive != null) {
                 return hive;
             }
@@ -56,23 +53,6 @@ final class FileListCompactor {
             return dict;
         }
         return raw;
-    }
-
-    /**
-     * Returns the path-encoded representation of a partition value, restoring Hive's
-     * {@code __HIVE_DEFAULT_PARTITION__} sentinel when {@link HivePartitionDetector} has decoded
-     * the value to {@code null}. This is required so {@link HiveFileList#path(int)} can reconstruct
-     * the original on-disk directory name.
-     */
-    private static String pathEncodedValue(Map<String, Object> partVals, String column) {
-        if (partVals == null) {
-            return "";
-        }
-        if (partVals.containsKey(column) == false) {
-            return "";
-        }
-        Object raw = partVals.get(column);
-        return raw == null ? HivePartitionDetector.HIVE_DEFAULT_PARTITION : raw.toString();
     }
 
     private static String extractExtension(String leafSegment) {
@@ -87,140 +67,92 @@ final class FileListCompactor {
     // Hive-partitioned encoding
     // ------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
-    private static FileList tryHive(String normalizedBase, GenericFileList raw, PartitionMetadata pm) {
+    /**
+     * Groups files by the relative directory they were listed under, in original listing order, and
+     * keeps one directory string per group. {@link HiveFileList#path(int)} then replays each file's
+     * exact listed key. Grouping on the directory string — not on typed partition values — is what
+     * makes the round-trip faithful: value spelling, segment order, non-partition directories, and a
+     * base path unrelated to the keys all survive, since none of them is re-derived from the parsed
+     * partition metadata.
+     */
+    private static FileList tryHive(String normalizedBase, GenericFileList raw) {
         List<StorageEntry> files = raw.files();
         int count = files.size();
-        String[] colNames = pm.partitionColumns().keySet().toArray(new String[0]);
-        int numCols = colNames.length;
 
-        Map<String, Short>[] colValMaps = (Map<String, Short>[]) new Map<?, ?>[numCols];
-        List<String>[] colValLists = (List<String>[]) new List<?>[numCols];
-        for (int c = 0; c < numCols; c++) {
-            colValMaps[c] = new HashMap<>();
-            colValLists[c] = new ArrayList<>();
-        }
-
-        Map<String, List<Integer>> groupMap = new LinkedHashMap<>();
-
-        for (int f = 0; f < count; f++) {
-            StoragePath sp = files.get(f).path();
-            Map<String, Object> partVals = pm.filePartitionValues().get(sp);
-            StringBuilder keyBuilder = new StringBuilder();
-            for (int c = 0; c < numCols; c++) {
-                String val = pathEncodedValue(partVals, colNames[c]);
-                Short idx = colValMaps[c].get(val);
-                if (idx == null) {
-                    if (colValLists[c].size() >= 65535) {
-                        return null;
-                    }
-                    idx = (short) colValLists[c].size();
-                    colValMaps[c].put(val, idx);
-                    colValLists[c].add(val);
-                }
-                if (c > 0) {
-                    keyBuilder.append('\0');
-                }
-                keyBuilder.append((int) idx);
-            }
-            String gk = keyBuilder.toString();
-            groupMap.computeIfAbsent(gk, k -> new ArrayList<>()).add(f);
-        }
-
-        int numGroups = groupMap.size();
-        short[][] groupValIndices = new short[numGroups][numCols];
-        int[] groupFileStarts = new int[numGroups + 1];
-
-        long[] orderedSizes = new long[count];
-        String[] orderedLeafNames = new String[count];
-        long[] orderedMtimes = new long[count];
-
+        Map<String, Short> dirIndex = new HashMap<>();
+        List<String> dirs = new ArrayList<>();
+        short[] fileGroups = new short[count];
+        long[] sizes = new long[count];
+        long[] mtimes = new long[count];
+        String[] leafNames = new String[count];
         String sharedExt = null;
         boolean extChecked = false;
 
-        int filePos = 0;
-        int groupIdx = 0;
-        for (Map.Entry<String, List<Integer>> gEntry : groupMap.entrySet()) {
-            List<Integer> fileIndices = gEntry.getValue();
-            groupFileStarts[groupIdx] = filePos;
+        for (int f = 0; f < count; f++) {
+            StorageEntry entry = files.get(f);
+            sizes[f] = entry.length();
+            mtimes[f] = entry.lastModified().toEpochMilli();
 
-            int firstFile = fileIndices.get(0);
-            StoragePath firstPath = files.get(firstFile).path();
-            Map<String, Object> firstPartVals = pm.filePartitionValues().get(firstPath);
-            for (int c = 0; c < numCols; c++) {
-                String val = pathEncodedValue(firstPartVals, colNames[c]);
-                groupValIndices[groupIdx][c] = colValMaps[c].get(val);
+            String fullPath = entry.path().toString();
+            String relative = fullPath;
+            if (normalizedBase.isEmpty() == false && fullPath.startsWith(normalizedBase)) {
+                relative = fullPath.substring(normalizedBase.length());
             }
+            int lastSlash = relative.lastIndexOf('/');
+            String dir = lastSlash >= 0 ? relative.substring(0, lastSlash + 1) : "";
+            String leaf = lastSlash >= 0 ? relative.substring(lastSlash + 1) : relative;
 
-            for (int fi : fileIndices) {
-                StorageEntry entry = files.get(fi);
-                orderedSizes[filePos] = entry.length();
-                orderedMtimes[filePos] = entry.lastModified().toEpochMilli();
-
-                String fullPath = entry.path().toString();
-                String relative = fullPath;
-                if (normalizedBase.isEmpty() == false && fullPath.startsWith(normalizedBase)) {
-                    relative = fullPath.substring(normalizedBase.length());
+            Short idx = dirIndex.get(dir);
+            if (idx == null) {
+                if (dirs.size() >= 65535) {
+                    return null;
                 }
-                String leaf = relative;
-                int lastSlash = relative.lastIndexOf('/');
-                if (lastSlash >= 0) {
-                    leaf = relative.substring(lastSlash + 1);
-                }
-
-                String ext = extractExtension(leaf);
-                if (extChecked == false) {
-                    sharedExt = ext;
-                    extChecked = true;
-                } else if (sharedExt != null && (ext == null || sharedExt.equals(ext) == false)) {
-                    sharedExt = null;
-                }
-
-                orderedLeafNames[filePos] = leaf;
-                filePos++;
+                idx = (short) dirs.size();
+                dirIndex.put(dir, idx);
+                dirs.add(dir);
             }
-            groupIdx++;
+            fileGroups[f] = idx;
+
+            String ext = extractExtension(leaf);
+            if (extChecked == false) {
+                sharedExt = ext;
+                extChecked = true;
+            } else if (sharedExt != null && (ext == null || sharedExt.equals(ext) == false)) {
+                sharedExt = null;
+            }
+            leafNames[f] = leaf;
         }
-        groupFileStarts[numGroups] = filePos;
 
         if (sharedExt != null) {
             for (int i = 0; i < count; i++) {
-                if (orderedLeafNames[i].endsWith(sharedExt)) {
-                    orderedLeafNames[i] = orderedLeafNames[i].substring(0, orderedLeafNames[i].length() - sharedExt.length());
+                if (leafNames[i].endsWith(sharedExt)) {
+                    leafNames[i] = leafNames[i].substring(0, leafNames[i].length() - sharedExt.length());
                 }
             }
         }
 
-        boolean uniformMtimes = true;
+        int numGroups = dirs.size();
         long[] gMtimes = new long[numGroups];
-        outer: for (int g = 0; g < numGroups; g++) {
-            int start = groupFileStarts[g];
-            int end = groupFileStarts[g + 1];
-            long groupMtime = orderedMtimes[start];
-            gMtimes[g] = groupMtime;
-            for (int i = start + 1; i < end; i++) {
-                if (orderedMtimes[i] != groupMtime) {
-                    uniformMtimes = false;
-                    break outer;
-                }
+        boolean[] groupSeen = new boolean[numGroups];
+        boolean uniformMtimes = true;
+        for (int f = 0; f < count && uniformMtimes; f++) {
+            int g = Short.toUnsignedInt(fileGroups[f]);
+            if (groupSeen[g] == false) {
+                groupSeen[g] = true;
+                gMtimes[g] = mtimes[f];
+            } else if (gMtimes[g] != mtimes[f]) {
+                uniformMtimes = false;
             }
-        }
-
-        String[][] colValDicts = new String[numCols][];
-        for (int c = 0; c < numCols; c++) {
-            colValDicts[c] = colValLists[c].toArray(new String[0]);
         }
 
         return new HiveFileList(
             normalizedBase,
-            colNames,
-            colValDicts,
-            groupValIndices,
-            groupFileStarts,
-            orderedSizes,
-            uniformMtimes ? null : orderedMtimes,
+            dirs.toArray(new String[0]),
+            fileGroups,
+            sizes,
+            uniformMtimes ? null : mtimes,
             uniformMtimes ? gMtimes : null,
-            orderedLeafNames,
+            leafNames,
             sharedExt,
             raw.originalPattern(),
             raw.partitionMetadata(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -71,7 +71,7 @@ public final class GlobExpander {
 
     /**
      * Expands a glob/comma pattern and compresses the result into a compact representation
-     * (DictionaryFileList or HiveFileList). This is the primary entry point for the resolver.
+     * (DictionaryFileList or DirectoryGroupedFileList). This is the primary entry point for the resolver.
      */
     public static FileList expandAndCompact(
         String path,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/HiveFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/HiveFileList.java
@@ -14,17 +14,18 @@ import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 /**
- * Partition-grouped file listing for Hive-partitioned data. Stores column value
- * dictionaries and groups files by partition, reducing memory to ~32 bytes/file
- * vs ~52 bytes for DictionaryFileList. Created by {@link FileListCompactor}.
+ * Directory-grouped file listing for Hive-partitioned data. Each file carries the index of the
+ * relative directory it was listed under; {@link #path(int)} replays {@code basePath + directory +
+ * leaf} verbatim, so the reconstructed key is byte-for-byte the one that was listed — value spelling,
+ * segment order, and any non-partition directories all survive. Grouping on the directory string
+ * (rather than on typed partition values) is what keeps the round-trip exact. Created by
+ * {@link FileListCompactor} only when Hive partition metadata was detected.
  */
 final class HiveFileList implements FileList {
 
     private final String basePath;
-    private final String[] partitionColumnNames;
-    private final String[][] columnValueDicts;
-    private final short[][] groupValueIndices;
-    private final int[] groupFileStarts;
+    private final String[] groupDirs;
+    private final short[] fileGroups;
     private final long[] sizes;
     @Nullable
     private final long[] mtimesMillis;
@@ -48,10 +49,8 @@ final class HiveFileList implements FileList {
 
     HiveFileList(
         String basePath,
-        String[] partitionColumnNames,
-        String[][] columnValueDicts,
-        short[][] groupValueIndices,
-        int[] groupFileStarts,
+        String[] groupDirs,
+        short[] fileGroups,
         long[] sizes,
         @Nullable long[] mtimesMillis,
         @Nullable long[] groupMtimes,
@@ -63,10 +62,8 @@ final class HiveFileList implements FileList {
         @Nullable FileSetFingerprint fileSetFingerprint
     ) {
         this.basePath = basePath;
-        this.partitionColumnNames = partitionColumnNames;
-        this.columnValueDicts = columnValueDicts;
-        this.groupValueIndices = groupValueIndices;
-        this.groupFileStarts = groupFileStarts;
+        this.groupDirs = groupDirs;
+        this.fileGroups = fileGroups;
         this.sizes = sizes;
         this.mtimesMillis = mtimesMillis;
         this.groupMtimes = groupMtimes;
@@ -84,20 +81,6 @@ final class HiveFileList implements FileList {
         return fileSetFingerprint;
     }
 
-    private int findGroup(int fileIndex) {
-        int lo = 0;
-        int hi = groupFileStarts.length - 2;
-        while (lo < hi) {
-            int mid = (lo + hi + 1) >>> 1;
-            if (groupFileStarts[mid] <= fileIndex) {
-                lo = mid;
-            } else {
-                hi = mid - 1;
-            }
-        }
-        return lo;
-    }
-
     @Override
     public int fileCount() {
         return fileCount;
@@ -105,13 +88,8 @@ final class HiveFileList implements FileList {
 
     @Override
     public StoragePath path(int i) {
-        int group = findGroup(i);
         StringBuilder sb = new StringBuilder(basePath);
-        for (int c = 0; c < partitionColumnNames.length; c++) {
-            sb.append(partitionColumnNames[c]).append('=');
-            sb.append(columnValueDicts[c][Short.toUnsignedInt(groupValueIndices[group][c])]);
-            sb.append('/');
-        }
+        sb.append(groupDirs[Short.toUnsignedInt(fileGroups[i])]);
         sb.append(leafNames[i]);
         if (sharedExtension != null) {
             sb.append(sharedExtension);
@@ -127,7 +105,7 @@ final class HiveFileList implements FileList {
     @Override
     public long lastModifiedMillis(int i) {
         if (groupMtimes != null) {
-            return groupMtimes[findGroup(i)];
+            return groupMtimes[Short.toUnsignedInt(fileGroups[i])];
         }
         return mtimesMillis[i];
     }
@@ -160,15 +138,13 @@ final class HiveFileList implements FileList {
         long bytes = 64;
         // basePath String
         bytes += basePath.length() * (long) Character.BYTES;
-        for (String[] dict : columnValueDicts) {
-            for (String v : dict) {
-                // per-String: ~40B object overhead + char data
-                bytes += 40 + v.length() * (long) Character.BYTES;
-            }
+        // one String per distinct relative directory; the group keys are distinct by construction
+        for (String dir : groupDirs) {
+            // per-String: ~40B object overhead + char data
+            bytes += 40 + dir.length() * (long) Character.BYTES;
         }
-        // partition value indices: groups × columns × short
-        bytes += (long) groupValueIndices.length * partitionColumnNames.length * Short.BYTES;
-        bytes += (long) groupFileStarts.length * Integer.BYTES;
+        // per-file group index
+        bytes += fileGroups.length * (long) Short.BYTES;
         bytes += sizes.length * (long) Long.BYTES;
         if (mtimesMillis != null) {
             bytes += mtimesMillis.length * (long) Long.BYTES;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FileSetFingerprint;
+import org.elasticsearch.xpack.esql.datasources.HivePartitionDetector;
 import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
@@ -2203,7 +2204,6 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
     private static FileList testHiveGenericFileList() {
         Instant now = Instant.now();
         List<StorageEntry> entries = new ArrayList<>();
-        Map<StoragePath, Map<String, Object>> filePartitions = new LinkedHashMap<>();
 
         String[] years = { "2024", "2025" };
         String[] months = { "01", "06", "12" };
@@ -2215,20 +2215,14 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
                         "s3://bucket/data/year=" + year + "/month=" + month + "/part-" + Strings.format("%05d", fileIdx) + ".parquet"
                     );
                     entries.add(new StorageEntry(path, 1024L * (fileIdx + 1), now));
-                    Map<String, Object> pv = new LinkedHashMap<>();
-                    pv.put("year", year);
-                    pv.put("month", month);
-                    filePartitions.put(path, pv);
                     fileIdx++;
                 }
             }
         }
 
-        Map<String, DataType> partitionColumns = new LinkedHashMap<>();
-        partitionColumns.put("year", DataType.KEYWORD);
-        partitionColumns.put("month", DataType.KEYWORD);
-        PartitionMetadata pm = new PartitionMetadata(partitionColumns, filePartitions);
-
+        // Detect partitions the way production does, so the fixture exercises the real typing and
+        // percent-decoding rather than the on-disk spelling a hand-built PartitionMetadata would carry.
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries, Map.of());
         return GlobExpander.fileListOf(entries, "s3://bucket/data/*" + "*/*.parquet", pm);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
@@ -183,7 +183,7 @@ public class FileListCompactorTests extends ESTestCase {
             base,
             listOf(base + "**/*.parquet", base + "x=1/a.parquet", base + "x=1/b-01/f.parquet", base + "x=1/z.parquet")
         );
-        assertThat(compact, Matchers.instanceOf(HiveFileList.class));
+        assertThat(compact, Matchers.instanceOf(DirectoryGroupedFileList.class));
     }
 
     /** The cross-file key check is order-insensitive, so a listing may mix directory orders. */
@@ -205,14 +205,15 @@ public class FileListCompactorTests extends ESTestCase {
     public void testCommaSeparatedResourceBaseMismatch() {
         String base = "s3://b/x.parquet,s3://b/y.parquet/";
         GenericFileList raw = listOf("s3://b/x.parquet,s3://b/y.parquet", "s3://b/x.parquet", "s3://b/y.parquet");
-        assertRoundTrip(base, raw);
+        // No encoding can reconstruct these keys from this base, so the guard falls all the way to raw.
+        assertSame(raw, FileListCompactor.compact(base, raw));
     }
 
     /** Same defect on the hive rail: a base unrelated to the listed keys must not be prepended. */
     public void testAlienBaseWithPartitionsIsNotPrepended() {
         String base = "s3://other/data/";
         GenericFileList raw = listOf("s3://b/*" + "*/*.parquet", "s3://b/year=2024/f.parquet", "s3://b/year=2025/f.parquet");
-        assertRoundTrip(base, raw);
+        assertSame(raw, FileListCompactor.compact(base, raw));
     }
 
     // ------------------------------------------------------------------
@@ -256,11 +257,12 @@ public class FileListCompactorTests extends ESTestCase {
     // ------------------------------------------------------------------
 
     /**
-     * A classic layout with many files per partition directory and unique leaf names favours the Hive
-     * encoding: the directory string is shared by every file in it, so the per-file cost is a single
-     * group index, whereas the dictionary must also store a segment index per directory level per file.
+     * A classic layout with many files per partition directory and unique leaf names favours the
+     * directory-grouped encoding: the directory string is shared by every file in it, so the per-file
+     * cost is a single group index, whereas the dictionary must also store a segment index per directory
+     * level per file.
      */
-    public void testManyFilesPerDirectoryPicksHive() {
+    public void testManyFilesPerDirectoryPicksDirectoryGrouped() {
         String base = "s3://b/data/";
         List<String> keys = new ArrayList<>();
         int fileId = 0;
@@ -272,7 +274,7 @@ public class FileListCompactorTests extends ESTestCase {
             }
         }
         FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", keys.toArray(new String[0])));
-        assertThat(compact, Matchers.instanceOf(HiveFileList.class));
+        assertThat(compact, Matchers.instanceOf(DirectoryGroupedFileList.class));
     }
 
     /**
@@ -290,5 +292,119 @@ public class FileListCompactorTests extends ESTestCase {
         }
         FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", keys.toArray(new String[0])));
         assertThat(compact, Matchers.instanceOf(DictionaryFileList.class));
+    }
+
+    // ------------------------------------------------------------------
+    // Modification-time fidelity (uniform vs per-file)
+    // ------------------------------------------------------------------
+
+    /**
+     * Files in one directory sharing a modification time exercise the group-collapsed {@code groupMtimes}
+     * path; the reconstructed mtime must still equal the listed one.
+     */
+    public void testUniformMtimesWithinDirectory() {
+        String base = "s3://b/data/";
+        long mtime = 1_700_000_000_000L;
+        GenericFileList raw = listOfMtimes(
+            base + "*" + "*/*.parquet",
+            new String[] { base + "month=06/a.parquet", base + "month=06/b.parquet" },
+            new long[] { mtime, mtime }
+        );
+        FileList compact = assertRoundTrip(base, raw);
+        assertThat(compact, Matchers.instanceOf(DirectoryGroupedFileList.class));
+    }
+
+    /**
+     * Files in one directory with differing modification times force the per-file mtime array rather than
+     * the group collapse; every file's mtime must survive.
+     */
+    public void testNonUniformMtimesWithinDirectory() {
+        String base = "s3://b/data/";
+        GenericFileList raw = listOfMtimes(
+            base + "*" + "*/*.parquet",
+            new String[] { base + "month=06/a.parquet", base + "month=06/b.parquet" },
+            new long[] { 1_700_000_000_000L, 1_700_000_050_000L }
+        );
+        FileList compact = assertRoundTrip(base, raw);
+        assertThat(compact, Matchers.instanceOf(DirectoryGroupedFileList.class));
+    }
+
+    // ------------------------------------------------------------------
+    // Overflow and non-partitioned fall-through
+    // ------------------------------------------------------------------
+
+    /**
+     * More distinct directories than the group index can hold: the directory-grouped encoding overflows
+     * to {@code null}, the dictionary's token table overflows too, and the raw list is returned unchanged.
+     */
+    public void testDirectoryCountOverflowFallsBackToRaw() {
+        String base = "s3://b/data/";
+        String[] keys = new String[65536];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = base + "p=" + i + "/f.parquet";
+        }
+        GenericFileList raw = listOf(base + "*" + "*/*.parquet", keys);
+        assertSame(raw, FileListCompactor.compact(base, raw));
+    }
+
+    /**
+     * Flat files with no partition directories carry no partition metadata, so only the dictionary
+     * encoding is built; it must round-trip a leaf that sits directly under the base.
+     */
+    public void testFlatNonPartitionedListingUsesDictionary() {
+        String base = "s3://b/data/";
+        FileList compact = assertRoundTrip(base, listOf(base + "*.parquet", base + "a.parquet", base + "b.parquet"));
+        assertThat(compact, Matchers.instanceOf(DictionaryFileList.class));
+    }
+
+    /**
+     * Many uniquely-named files in a handful of directories: the dictionary's token table overflows on
+     * the distinct leaf names while the directory-grouped encoding (a per-file leaf array, no leaf
+     * dictionary) fits — so the grouped encoding is kept even though the dictionary candidate is absent.
+     */
+    public void testDictionaryOverflowKeepsDirectoryGrouped() {
+        String base = "s3://b/data/";
+        String[] keys = new String[65536];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = base + "p=" + (i % 2) + "/file-" + i + ".parquet";
+        }
+        FileList compact = assertRoundTrip(base, listOf(base + "*" + "*/*.parquet", keys));
+        assertThat(compact, Matchers.instanceOf(DirectoryGroupedFileList.class));
+    }
+
+    // ------------------------------------------------------------------
+    // Additional layout fidelity
+    // ------------------------------------------------------------------
+
+    /** A percent-escaped sequence in the leaf name (not just a directory) must survive verbatim. */
+    public void testPercentEscapedLeafName() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "*" + "*/*.parquet", base + "month=06/a%20b.parquet"));
+    }
+
+    /** Three partition levels with many files per leaf directory round-trip through the grouped encoding. */
+    public void testThreeLevelPartitionsRoundTrip() {
+        String base = "s3://b/data/";
+        List<String> keys = new ArrayList<>();
+        int fileId = 0;
+        for (int day = 1; day <= 3; day++) {
+            for (int part = 0; part < 5; part++) {
+                keys.add(base + "year=2024/month=06/day=0" + day + "/part-" + (fileId++) + ".parquet");
+            }
+        }
+        assertRoundTrip(base, listOf(base + "**/*.parquet", keys.toArray(new String[0])));
+    }
+
+    /**
+     * Builds a raw listing with an explicit modification time per file, to drive the uniform / non-uniform
+     * modification-time branches deterministically.
+     */
+    private static GenericFileList listOfMtimes(String pattern, String[] keys, long[] mtimesMillis) {
+        List<StorageEntry> entries = new ArrayList<>(keys.length);
+        for (int i = 0; i < keys.length; i++) {
+            entries.add(new StorageEntry(StoragePath.of(keys[i]), 100L * (i + 1), Instant.ofEpochMilli(mtimesMillis[i])));
+        }
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries, Map.of());
+        return new GenericFileList(entries, pattern, pm == null || pm.isEmpty() ? null : pm);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
@@ -250,4 +250,45 @@ public class FileListCompactorTests extends ESTestCase {
             listOf("s3://b/data/*" + "*/*.parquet", "s3://b/data/month=06/f.parquet", "s3://b/data/month=12/f.parquet")
         );
     }
+
+    // ------------------------------------------------------------------
+    // Encoding selected by measured size
+    // ------------------------------------------------------------------
+
+    /**
+     * A classic layout with many files per partition directory and unique leaf names favours the Hive
+     * encoding: the directory string is shared by every file in it, so the per-file cost is a single
+     * group index, whereas the dictionary must also store a segment index per directory level per file.
+     */
+    public void testManyFilesPerDirectoryPicksHive() {
+        String base = "s3://b/data/";
+        List<String> keys = new ArrayList<>();
+        int fileId = 0;
+        for (int year = 2023; year <= 2024; year++) {
+            for (int month = 1; month <= 12; month++) {
+                for (int part = 0; part < 20; part++) {
+                    keys.add(base + "year=" + year + "/month=" + month + "/part-" + (fileId++) + ".parquet");
+                }
+            }
+        }
+        FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", keys.toArray(new String[0])));
+        assertThat(compact, Matchers.instanceOf(HiveFileList.class));
+    }
+
+    /**
+     * A layout with one file per deeply-nested directory favours the dictionary encoding: whole
+     * directory strings share nothing, while the segment dictionary shares the repeated year/month
+     * tokens across every file.
+     */
+    public void testOneFilePerDirectoryPicksDictionary() {
+        String base = "s3://b/data/";
+        List<String> keys = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            for (int day = 1; day <= 28; day++) {
+                keys.add(base + "year=2024/month=" + month + "/day=" + day + "/data.parquet");
+            }
+        }
+        FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", keys.toArray(new String[0])));
+        assertThat(compact, Matchers.instanceOf(DictionaryFileList.class));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.glob;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.HivePartitionDetector;
+import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
+import org.elasticsearch.xpack.esql.datasources.StorageEntry;
+import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.hamcrest.Matchers;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Round-trip characterization of {@link FileListCompactor}.
+ * <p>
+ * Compaction re-encodes a listing to save memory; it must not change what the listing <em>means</em>.
+ * The single invariant asserted throughout is that a compacted list is indistinguishable from the raw
+ * list it came from — same file count, and for every index the same path, size and modification time.
+ * The listed object key is the only thing that identifies an object in the store, so a representation
+ * that cannot replay it exactly produces reads against keys that do not exist.
+ * <p>
+ * Fixtures route through the real {@link HivePartitionDetector} rather than hand-building
+ * {@link PartitionMetadata}: hand-built metadata carries the on-disk value spelling verbatim and so
+ * cannot exercise the typing and percent-decoding that the detector applies.
+ */
+public class FileListCompactorTests extends ESTestCase {
+
+    /**
+     * Builds a raw listing the way production does — entries first, then partition detection over
+     * those entries. Passes {@code null} metadata when nothing was detected, matching
+     * {@link GlobExpander}'s behaviour when hive partitioning is off or finds no partitions.
+     */
+    private static GenericFileList listOf(String pattern, String... keys) {
+        Instant mtime = Instant.ofEpochMilli(1_700_000_000_000L);
+        List<StorageEntry> entries = new ArrayList<>(keys.length);
+        for (int i = 0; i < keys.length; i++) {
+            entries.add(new StorageEntry(StoragePath.of(keys[i]), 100L * (i + 1), mtime));
+        }
+        PartitionMetadata pm = HivePartitionDetector.INSTANCE.detect(entries, Map.of());
+        return new GenericFileList(entries, pattern, pm == null || pm.isEmpty() ? null : pm);
+    }
+
+    /** Asserts the compacted list replays the raw listing exactly, and returns it for further pinning. */
+    private static FileList assertRoundTrip(String basePath, GenericFileList raw) {
+        FileList compact = FileListCompactor.compact(basePath, raw);
+        assertEquals("file count", raw.fileCount(), compact.fileCount());
+        for (int i = 0; i < raw.fileCount(); i++) {
+            assertEquals("path at " + i, raw.path(i).toString(), compact.path(i).toString());
+            assertEquals("size at " + i, raw.size(i), compact.size(i));
+            assertEquals("mtime at " + i, raw.lastModifiedMillis(i), compact.lastModifiedMillis(i));
+        }
+        return compact;
+    }
+
+    private static void assertPathsDistinct(FileList list) {
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < list.fileCount(); i++) {
+            String path = list.path(i).toString();
+            assertTrue("duplicate reconstructed path [" + path + "] at index " + i, seen.add(path));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Partition columns embedded in the pattern prefix
+    // ------------------------------------------------------------------
+
+    /**
+     * The reported failure: a pattern prefix containing {@code key=value} segments is the standard AWS
+     * S3 log layout. Those segments live in the base path AND are claimed as partition columns, so a
+     * reconstruction that appends partition columns to the base emits them twice.
+     */
+    public void testPrefixEmbeddedPartitionColumns() {
+        String base = "s3://b/env=prod/year=2024/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "month=06/part-0.parquet", base + "month=12/part-0.parquet"));
+    }
+
+    // ------------------------------------------------------------------
+    // Value spelling — the detector types and decodes, reconstruction must not re-spell
+    // ------------------------------------------------------------------
+
+    /** Zero-padded month directories are the Hive writer convention; typing to an integer drops the pad. */
+    public void testZeroPaddedPartitionValue() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "month=06/a.parquet", base + "month=06/b.parquet"));
+    }
+
+    /** Percent-escaped directory names are decoded on the way in and must be re-escaped on the way out. */
+    public void testPercentEscapedPartitionValue() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "ts=a%3Ab/k=a%20b/f.parquet"));
+    }
+
+    /** Scientific notation types to a double, whose toString is a different string. */
+    public void testScientificNotationPartitionValue() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "x=1e5/f.parquet"));
+    }
+
+    /**
+     * A {@code key=value} segment whose value contains a dot is not treated as a partition column
+     * ({@link HivePartitionDetector} excludes dotted segments), so the listing carries no partition
+     * metadata and compacts through the segment dictionary, which replays the value verbatim. This
+     * pins that the dotted-value exclusion keeps such layouts faithful without the Hive encoding.
+     */
+    public void testDottedPartitionValueFallsBackToDictionary() {
+        String base = "s3://b/data/";
+        FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", base + "x=2.50/f.parquet"));
+        assertThat(compact, Matchers.instanceOf(DictionaryFileList.class));
+    }
+
+    /** Boolean casing is normalized by typing. */
+    public void testBooleanPartitionValueCasing() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "flag=True/f.parquet"));
+    }
+
+    /**
+     * Two directories whose values type to the same object must stay two directories. Grouping on the
+     * typed value collapses them and reconstructs both files under one spelling.
+     */
+    public void testMixedValueSpellingDoesNotCollapse() {
+        String base = "s3://b/data/";
+        FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", base + "month=06/a.parquet", base + "month=6/b.parquet"));
+        assertPathsDistinct(compact);
+    }
+
+    /** A partition key colliding with a metadata name surfaces renamed; the directory on disk did not. */
+    public void testReservedPartitionKeyKeepsOnDiskName() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "_index=foo/f.parquet"));
+    }
+
+    /** The Hive null sentinel is a real directory name and must survive verbatim. */
+    public void testHiveDefaultPartitionSentinel() {
+        String base = "s3://b/data/";
+        assertRoundTrip(
+            base,
+            listOf(base + "**/*.parquet", base + "year=__HIVE_DEFAULT_PARTITION__/f.parquet", base + "year=2024/f.parquet")
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Directory structure — not every directory is a partition
+    // ------------------------------------------------------------------
+
+    /**
+     * Real CloudTrail layouts interleave partition directories with plain ones. A reconstruction built
+     * only from partition columns cannot re-emit the plain directories, so distinct objects collapse
+     * onto a single key.
+     */
+    public void testNonPartitionDirectoriesSurvive() {
+        String base = "s3://b/data/";
+        FileList compact = assertRoundTrip(
+            base,
+            listOf(base + "**/*.parquet", base + "year=2024/batch-01/f.parquet", base + "year=2024/batch-02/f.parquet")
+        );
+        assertPathsDistinct(compact);
+    }
+
+    /**
+     * A listing sorted by key interleaves a subdirectory's files between its parent's files. Any encoding
+     * that stores files grouped by directory in contiguous ranges permutes them relative to the listing.
+     */
+    public void testInterleavedDirectoriesKeepListingOrder() {
+        String base = "s3://b/d/";
+        FileList compact = assertRoundTrip(
+            base,
+            listOf(base + "**/*.parquet", base + "x=1/a.parquet", base + "x=1/b-01/f.parquet", base + "x=1/z.parquet")
+        );
+        assertThat(compact, Matchers.instanceOf(HiveFileList.class));
+    }
+
+    /** The cross-file key check is order-insensitive, so a listing may mix directory orders. */
+    public void testMixedDirectoryOrder() {
+        String base = "s3://b/d/";
+        FileList compact = assertRoundTrip(base, listOf(base + "**/*.parquet", base + "a=1/b=2/f1.parquet", base + "b=2/a=1/f2.parquet"));
+        assertPathsDistinct(compact);
+    }
+
+    // ------------------------------------------------------------------
+    // Base path that is not a prefix of the listed keys
+    // ------------------------------------------------------------------
+
+    /**
+     * A comma-separated resource has no glob metacharacter, so the pattern prefix is the whole comma
+     * string. No listed key starts with it, and an encoding that prepends the base regardless produces
+     * a key built from the entire resource specification.
+     */
+    public void testCommaSeparatedResourceBaseMismatch() {
+        String base = "s3://b/x.parquet,s3://b/y.parquet/";
+        GenericFileList raw = listOf("s3://b/x.parquet,s3://b/y.parquet", "s3://b/x.parquet", "s3://b/y.parquet");
+        assertRoundTrip(base, raw);
+    }
+
+    /** Same defect on the hive rail: a base unrelated to the listed keys must not be prepended. */
+    public void testAlienBaseWithPartitionsIsNotPrepended() {
+        String base = "s3://other/data/";
+        GenericFileList raw = listOf("s3://b/*" + "*/*.parquet", "s3://b/year=2024/f.parquet", "s3://b/year=2025/f.parquet");
+        assertRoundTrip(base, raw);
+    }
+
+    // ------------------------------------------------------------------
+    // Shared-extension factoring and edges
+    // ------------------------------------------------------------------
+
+    /** A leaf with an interior dot yields a compound shared extension. */
+    public void testDottedLeafNames() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "year=2024/a.b.parquet", base + "year=2024/c.b.parquet"));
+    }
+
+    /** A hidden file alongside a normal one disables extension sharing. */
+    public void testHiddenFileDisablesSharedExtension() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "year=2024/.hidden", base + "year=2024/f.parquet"));
+    }
+
+    /** Single-file listings skip fingerprinting; the path must still replay. */
+    public void testSingleFileListing() {
+        String base = "s3://b/data/";
+        assertRoundTrip(base, listOf(base + "**/*.parquet", base + "month=06/f.parquet"));
+    }
+
+    /** An empty listing is returned unchanged regardless of base normalization. */
+    public void testEmptyListingReturnedUnchanged() {
+        GenericFileList raw = listOf("s3://b/data/*" + "*/*.parquet");
+        assertSame(raw, FileListCompactor.compact("s3://b/data", raw));
+    }
+
+    /** A base without a trailing slash is normalized before stripping. */
+    public void testBaseWithoutTrailingSlash() {
+        assertRoundTrip(
+            "s3://b/data",
+            listOf("s3://b/data/*" + "*/*.parquet", "s3://b/data/month=06/f.parquet", "s3://b/data/month=12/f.parquet")
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactorTests.java
@@ -140,6 +140,10 @@ public class FileListCompactorTests extends ESTestCase {
     public void testReservedPartitionKeyKeepsOnDiskName() {
         String base = "s3://b/data/";
         assertRoundTrip(base, listOf(base + "**/*.parquet", base + "_index=foo/f.parquet"));
+        assertWarnings(
+            "Partition columns shadowing reserved metadata names were renamed; reference them by the _partition.* name.",
+            "partition column [_index] surfaced as [_partition._index]"
+        );
     }
 
     /** The Hive null sentinel is a real directory name and must survive verbatim. */


### PR DESCRIPTION
## What this is about

`FROM <dataset>` hard-fails on a Hive-partitioned dataset whose pattern prefix contains `key=value` segments — the standard AWS S3 log layout (`AWSLogs/aws-account-id=…/aws-service=…/**/*.parquet`). Reported in #154289 on `9.5.0-SNAPSHOT`, 100% reproducible. Only `schema_resolution: first_file_wins` and strict declared-schema datasets are affected; the default `union_by_name` never compacts, which is why the reporter got a clean A/B.

## Root cause

Listing compaction re-encodes the expanded file list to save coordinator memory. The Hive encoding discarded the listed key and rebuilt it from the parsed partition values: `basePath + name=value/… + leaf`. That reconstruction is not the listed key whenever the parse was lossy — and the parse is lossy in several independent ways. The reconstructed key then names a nonexistent object, and the read fails.

Concretely, the parse:
- **doubles** any `key=value` segment that lives inside `basePath` (the pattern prefix), because the detector claims it as a partition column and reconstruction appends it again — the reported failure;
- **re-spells** typed values: `month=06` → `month=6`, `x=1e5` → `x=100000.0`, `flag=True` → `flag=true`, `k=a%20b` → `k=a b`;
- **drops** intermediate non-`key=value` directories entirely (real CloudTrail layouts mix them), so two files can reconstruct to the same key;
- **loses** per-file directory order.

## What this PR does

Stops re-deriving the key. The compact encoding now groups files by the relative **directory string** and replays `basePath + directory + leaf` verbatim, so the reconstructed key is byte-for-byte the one that was listed — value spelling, segment order and non-partition directories all survive because nothing is parsed back out.

A round-trip guard at the single compaction chokepoint verifies every candidate encoding reproduces the listed path, size and mtime exactly, and discards one that cannot — falling through directory-grouped → dictionary → raw. This is what covers a base path that is not a prefix of the listed keys (a comma-separated resource on the `first_file_wins` rail) and any layout no encoding anticipates. The two encodings are then chosen by measured size, so neither is ever the larger one.

No wire, SPI or transport-version change: the listing is coordinator-only, in-memory, and never serialized.

## Does it work?

- New `FileListCompactorTests` — a round-trip property (`compact(raw).path(i) == raw.path(i)`, plus size and mtime) over the adversarial corpus above, built through the real `HivePartitionDetector`. Red on `main`.
- Fixed the blind spot: `ExternalSourceCacheServiceTests.testHiveFileListRoundTrip` asserted the right invariant but hand-built `PartitionMetadata`, bypassing the detector, so it stayed green through the bug. It now routes through the detector and is red on `main`.
- `ExternalCsvHivePartitionedIT` (existing hive CSV IT) gains two end-to-end cases on `file://`: the exact AWS VPC-flow S3 log layout (`AWSLogs/aws-account-id=…/aws-service=vpcflowlogs/…`, zero-padded `month=06`) under `first_file_wins`, and a comma-separated resource. Both red on `main`.

## What's in the diff

`DirectoryGroupedFileList` (renamed from `HiveFileList` — the mechanism is directory grouping, not partition-value replay) and `FileListCompactor` carry the fix; `FileListCompactorTests` (new) and two cases folded into the existing `ExternalCsvHivePartitionedIT` carry the coverage. The base-strip rule the fix protects lives in one `relativize` helper rather than three copies.

## What's out of scope

- Unifying the `first_file_wins` and strict rails' comma-list handling (the strict rail already expands comma lists uncompacted). The guard makes the FFW rail correct; making the two rails agree is a separate change.
- `COUNT(*)` over a Hive-partitioned external dataset trips an unrelated `fullOutput cannot be null or empty` in `VirtualColumnIterator` — a pre-existing bug on `main`, surfaced while writing the IT (the ITs project data columns to avoid it). Tracked separately.

Closes #154289
