### PR TITLE
[8.19] [ML] Fix and unmute TransformTaskFailedStateIT (#153798)

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
@@ -179,7 +179,7 @@ public class TransformTaskFailedStateIT extends TransformRestTestCase {
 
         stopTransform(transformId, true);
 
-        assertThat(getTransformTasks(), is(empty()));
+        assertBusy(() -> assertThat(getTransformTasks(), is(empty())));
         assertThat(getTransformTasksFromClusterState(transformId), is(empty()));
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix and unmute TransformTaskFailedStateIT (#153798)](https://github.com/elastic/elasticsearch/pull/153798)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)