### PR TITLE
[9.4] ESQL: Re-type a TEXT data type to KEYWORD to fulfill the CASE resolveType contract (#154287)

### DIFF
--- a/docs/changelog/154287.yaml
+++ b/docs/changelog/154287.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154278
+pr: 154287
+summary: Re-type a TEXT data type to KEYWORD to fulfill the CASE `resolveType` contract
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -429,3 +429,92 @@ CASE(y==2, 10, 1) * MIN(x):integer | y:integer
 10                                 | 2
 1                                  | 3
 ;
+
+casePartialFoldTrueToTextKeepsKeyword
+required_capability: fix_case_partial_fold_keyword_type
+
+FROM employees
+| WHERE emp_no >= 10001 AND emp_no <= 10003
+| EVAL x = CASE(true, TO_TEXT(first_name))
+| KEEP emp_no, x
+| SORT emp_no
+;
+
+emp_no:integer | x:keyword
+10001          | Georgi
+10002          | Bezalel
+10003          | Parto
+;
+
+casePartialFoldTrailingTextArmKeepsKeyword
+required_capability: fix_case_partial_fold_keyword_type
+
+FROM employees
+| WHERE emp_no >= 10001 AND emp_no <= 10003
+| EVAL x = CASE(false, "never", TO_TEXT(last_name))
+| KEEP emp_no, x
+| SORT emp_no
+;
+
+emp_no:integer | x:keyword
+10001          | Facello
+10002          | Simmel
+10003          | Bamford
+;
+
+casePartialFoldKeywordIsGroupable
+required_capability: fix_case_partial_fold_keyword_type
+
+FROM employees
+| WHERE emp_no >= 10001 AND emp_no <= 10005
+| EVAL g = CASE(true, TO_TEXT(gender))
+| STATS c = COUNT(*) BY g
+| SORT g
+;
+
+c:long | g:keyword
+1      | F
+4      | M
+;
+
+casePartialFoldMixedConditionsKeepsKeyword
+required_capability: fix_case_partial_fold_keyword_type
+
+FROM employees
+| WHERE emp_no >= 10001 AND emp_no <= 10003
+| EVAL x = CASE(false, "x", gender == "F", TO_TEXT(first_name), TO_TEXT(last_name))
+| KEEP emp_no, x
+| SORT emp_no
+;
+
+emp_no:integer | x:keyword
+10001          | Facello
+10002          | Bezalel
+10003          | Bamford
+;
+
+casePartialFoldMultivalueTextKeepsKeyword
+required_capability: fix_case_partial_fold_keyword_type
+
+FROM employees
+| WHERE emp_no == 10001
+| EVAL x = CASE(true, TO_TEXT(job_positions))
+| KEEP emp_no, x
+;
+
+emp_no:integer | x:keyword
+10001          | [Accountant, Senior Python Developer]
+;
+
+casePartialFoldTextArmNullElseKeepsKeyword
+required_capability: fix_case_partial_fold_keyword_type
+
+FROM employees
+| WHERE emp_no == 10001
+| EVAL x = CASE(false, TO_TEXT(first_name), null)
+| KEEP emp_no, x
+;
+
+emp_no:integer | x:keyword
+10001          | null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -433,41 +433,41 @@ CASE(y==2, 10, 1) * MIN(x):integer | y:integer
 casePartialFoldTrueToTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
 
-FROM employees
+FROM employees_gender_text
 | WHERE emp_no >= 10001 AND emp_no <= 10003
-| EVAL x = CASE(true, TO_TEXT(first_name))
+| EVAL x = CASE(true, gender)
 | KEEP emp_no, x
 | SORT emp_no
 ;
 
 emp_no:integer | x:keyword
-10001          | Georgi
-10002          | Bezalel
-10003          | Parto
+10001          | M
+10002          | F
+10003          | M
 ;
 
 casePartialFoldTrailingTextArmKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
 
-FROM employees
+FROM employees_gender_text
 | WHERE emp_no >= 10001 AND emp_no <= 10003
-| EVAL x = CASE(false, "never", TO_TEXT(last_name))
+| EVAL x = CASE(false, "never", gender)
 | KEEP emp_no, x
 | SORT emp_no
 ;
 
 emp_no:integer | x:keyword
-10001          | Facello
-10002          | Simmel
-10003          | Bamford
+10001          | M
+10002          | F
+10003          | M
 ;
 
 casePartialFoldKeywordIsGroupable
 required_capability: fix_case_partial_fold_keyword_type
 
-FROM employees
+FROM employees_gender_text
 | WHERE emp_no >= 10001 AND emp_no <= 10005
-| EVAL g = CASE(true, TO_TEXT(gender))
+| EVAL g = CASE(true, gender)
 | STATS c = COUNT(*) BY g
 | SORT g
 ;
@@ -480,38 +480,38 @@ c:long | g:keyword
 casePartialFoldMixedConditionsKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
 
-FROM employees
+FROM employees_gender_text
 | WHERE emp_no >= 10001 AND emp_no <= 10003
-| EVAL x = CASE(false, "x", gender == "F", TO_TEXT(first_name), TO_TEXT(last_name))
+| EVAL x = CASE(false, "x", emp_no == 10002, gender, "other")
 | KEEP emp_no, x
 | SORT emp_no
 ;
 
 emp_no:integer | x:keyword
-10001          | Facello
-10002          | Bezalel
-10003          | Bamford
+10001          | other
+10002          | F
+10003          | other
 ;
 
 casePartialFoldMultivalueTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
 
-FROM employees
-| WHERE emp_no == 10001
-| EVAL x = CASE(true, TO_TEXT(job_positions))
-| KEEP emp_no, x
+FROM mv_text
+| WHERE @timestamp == "2023-10-23T13:55:01.543Z"
+| EVAL x = CASE(true, message)
+| KEEP x
 ;
 
-emp_no:integer | x:keyword
-10001          | [Accountant, Senior Python Developer]
+x:keyword
+[Banana, Connected to 10.1.0.1]
 ;
 
 casePartialFoldTextArmNullElseKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
 
-FROM employees
+FROM employees_gender_text
 | WHERE emp_no == 10001
-| EVAL x = CASE(false, TO_TEXT(first_name), null)
+| EVAL x = CASE(false, gender, null)
 | KEEP emp_no, x
 ;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -396,6 +396,12 @@ public class EsqlCapabilities {
         CASE_FOLD_TEMPORAL_AMOUNT,
 
         /**
+         * Partial folding of {@code CASE} keeps the KEYWORD type declared at analysis time when the
+         * surviving branch is TEXT, instead of letting the plan output drift to TEXT. See #154278.
+         */
+        FIX_CASE_PARTIAL_FOLD_KEYWORD_TYPE,
+
+        /**
          * Support for loading values over enrich. This is supported by all versions of ESQL but not
          * the unit test CsvTests.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -364,17 +364,7 @@ public final class Case extends EsqlScalarFunction {
         return switch (newChildren.size()) {
             // CASE(false, a) -> NULL
             case 0 -> new Literal(source(), null, dataType());
-            /*
-             * CASE(false, a, b) -> b
-             *
-             * We *must* return something of dataType or downstream stuff will
-             * blow up. `b` can be:
-             *   - dataType - return as-is
-             *   - TEXT when dataType is keyword - return as-is - which is safe because
-             *     TEXT is the same as KEYWORD everywhere that matters downstream from here
-             *   - any NULL-typed expression — cast it to dataType so callers
-             *     see the right type (e.g. KEYWORD, not NULL)
-             */
+            // CASE(false, a, b) -> b, casting a NULL arm to dataType() so callers see KEYWORD, not NULL.
             case 1 -> {
                 Expression child = newChildren.getFirst();
                 if (child.dataType() == NULL && dataType() != NULL) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PartiallyFoldCase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PartiallyFoldCase.java
@@ -9,8 +9,11 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToString;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection.DOWN;
 
 /**
@@ -30,6 +33,11 @@ public final class PartiallyFoldCase extends OptimizerRules.OptimizerExpressionR
 
     @Override
     protected Expression rule(Case c, LogicalOptimizerContext ctx) {
-        return c.partiallyFold(ctx.foldCtx());
+        Expression folded = c.partiallyFold(ctx.foldCtx());
+        // obey the Case.resolveType() and resolveValueType() contract where a TEXT data type is never generated if the folding arm is TEXT
+        if (folded.dataType() == TEXT && c.dataType() == KEYWORD) {
+            return new ToString(folded.source(), folded, ctx.configuration());
+        }
+        return folded;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseExtraTests.java
@@ -193,9 +193,17 @@ public class CaseExtraTests extends ESTestCase {
         assertThat(c.dataType(), equalTo(DataType.KEYWORD));
         Expression result = c.partiallyFold(FoldContext.small());
         assertThat(result, equalToIgnoringIds(field("text_field", DataType.TEXT)));
-        // This should be KEYWORD so it lines up with the original value.
-        // It isn't because the conversion is difficult.
-        // But it's not likely to break anything as is.
+    }
+
+    public void testPartialFoldTrueConditionTextValue() {
+        Case c = new Case(
+            Source.synthetic("case"),
+            new Literal(Source.EMPTY, true, DataType.BOOLEAN),
+            List.of(field("text_field", DataType.TEXT))
+        );
+        assertThat(c.dataType(), equalTo(DataType.KEYWORD));
+        Expression result = c.partiallyFold(FoldContext.small());
+        assertThat(result, equalToIgnoringIds(field("text_field", DataType.TEXT)));
     }
 
     public void testPartialFoldTrailingKeywordLeadingText() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -6275,6 +6275,19 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(languages.name(), is("emp_no"));
     }
 
+    public void testPartiallyFoldCaseKeepsKeywordForTextArm() {
+        var plan = optimizedPlan("""
+              FROM test
+            | EVAL c = CASE(true, TO_TEXT(first_name))
+            """);
+
+        var eval = as(plan, Eval.class);
+        var alias = eval.expressions().get(0);
+        assertThat(alias.dataType(), is(DataType.KEYWORD));
+        var toString = as(Alias.unwrap(alias), ToString.class);
+        assertThat(toString.dataType(), is(DataType.KEYWORD));
+    }
+
     private EsqlBinaryComparison extractPlannedBinaryComparison(String expression) {
         LogicalPlan plan = planTypes("FROM types | WHERE " + expression);
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -6278,7 +6278,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     public void testPartiallyFoldCaseKeepsKeywordForTextArm() {
         var plan = optimizedPlan("""
               FROM test
-            | EVAL c = CASE(true, TO_TEXT(first_name))
+            | EVAL c = CASE(true, gender)
             """);
 
         var eval = as(plan, Eval.class);


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: Re-type a TEXT data type to KEYWORD to fulfill the CASE resolveType contract (#154287)