### PR TITLE
[9.5] ensure keystore always exists when testing security auto-config skip (#154288)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -2,12 +2,6 @@ tests:
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445
-- class: org.elasticsearch.packaging.test.ArchiveTests
-  method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
-  issue: https://github.com/elastic/elasticsearch/issues/118208
-- class: org.elasticsearch.packaging.test.ArchiveTests
-  method: test51AutoConfigurationWithPasswordProtectedKeystore
-  issue: https://github.com/elastic/elasticsearch/issues/118212
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -164,6 +164,7 @@ public class ArchiveTests extends PackagingTestCase {
         Platforms.onWindows(() -> {
             // auto-config requires that the archive owner and the process user be the same
             sh.chown(installation.config, installation.getOwner());
+            createKeystoreIfMissing();
             // prevent modifications to the config directory
             sh.run(
                 String.format(
@@ -178,7 +179,10 @@ public class ArchiveTests extends PackagingTestCase {
                 )
             );
         });
-        Platforms.onLinux(() -> { sh.run("chmod u-w " + installation.config); });
+        Platforms.onLinux(() -> {
+            createKeystoreIfMissing();
+            sh.run("chmod u-w " + installation.config);
+        });
         try {
             startElasticsearch();
             verifySecurityNotAutoConfigured(installation);
@@ -203,6 +207,13 @@ public class ArchiveTests extends PackagingTestCase {
             });
             Platforms.onLinux(() -> { sh.run("chmod u+w " + installation.config); });
             FileUtils.rm(installation.data);
+        }
+    }
+
+    private void createKeystoreIfMissing() {
+        if (Files.exists(installation.config("elasticsearch.keystore")) == false) {
+            final Installation.Executables bin = installation.executables();
+            bin.keystoreTool.run("create");
         }
     }
 
@@ -231,8 +242,12 @@ public class ArchiveTests extends PackagingTestCase {
         FileUtils.assertPathsDoNotExist(installation.data);
         final Installation.Executables bin = installation.executables();
         final String password = "some-keystore-password";
-        Platforms.onLinux(() -> bin.keystoreTool.run("passwd", password + "\n" + password + "\n"));
+        Platforms.onLinux(() -> {
+            createKeystoreIfMissing();
+            bin.keystoreTool.run("passwd", password + "\n" + password + "\n");
+        });
         Platforms.onWindows(() -> {
+            createKeystoreIfMissing();
             sh.run("Invoke-Command -ScriptBlock {echo '" + password + "'; echo '" + password + "'} | " + bin.keystoreTool + " passwd");
         });
         Shell.Result result = runElasticsearchStartCommand("some-wrong-password-here", false, false);
@@ -242,7 +257,7 @@ public class ArchiveTests extends PackagingTestCase {
             ServerUtils.addSettingToExistingConfiguration(installation, "node.name", "my-custom-random-node-name-here");
         }
         awaitElasticsearchStartup(runElasticsearchStartCommand(password, true, true));
-        verifySecurityAutoConfigured(installation);
+        verifySecurityAutoConfigured(installation, password);
 
         stopElasticsearch();
 

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -623,6 +623,10 @@ public abstract class PackagingTestCase extends Assert {
      * @param es the {@link Installation} to check
      */
     public void verifySecurityAutoConfigured(Installation es) throws Exception {
+        verifySecurityAutoConfigured(es, null);
+    }
+
+    public void verifySecurityAutoConfigured(Installation es, String keystorePassword) throws Exception {
         final String autoConfigDirName = "certs";
         final Settings settings;
         if (es.distribution.isArchive()) {
@@ -653,10 +657,7 @@ public abstract class PackagingTestCase extends Assert {
                 .forEach(
                     file -> assertThat(es.config(autoConfigDirName).resolve(file), FileMatcher.file(File, "root", "elasticsearch", p660))
                 );
-            assertThat(
-                sh.run(es.executables().keystoreTool + " list").stdout(),
-                Matchers.containsString("autoconfiguration.password_hash")
-            );
+            assertThat(listKeystoreEntries(es, keystorePassword), Matchers.containsString("autoconfiguration.password_hash"));
             settings = Settings.builder().loadFromPath(es.config("elasticsearch.yml")).build();
         }
         assertThat(settings.get("xpack.security.enabled"), equalTo("true"));
@@ -671,10 +672,14 @@ public abstract class PackagingTestCase extends Assert {
         }
 
         if (es.distribution.isArchive()) {
-            String keystoreEntries = es.executables().keystoreTool.run("list").stdout();
+            String keystoreEntries = listKeystoreEntries(es, keystorePassword);
             assertThat(keystoreEntries, Matchers.containsString("cluster.state.encryption.password.autoconfigured"));
             assertThat(keystoreEntries, Matchers.containsString("cluster.state.encryption.active_password_id"));
         }
+    }
+
+    private static String listKeystoreEntries(Installation es, String keystorePassword) {
+        return es.executables().keystoreTool.run("list", keystorePassword == null ? null : keystorePassword + "\n").stdout();
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ensure keystore always exists when testing security auto-config skip (#154288)