### PR TITLE
[9.5] Ensure cancelled _field_caps tasks are removed from the tasks API (#153831)

### DIFF
--- a/docs/changelog/153831.yaml
+++ b/docs/changelog/153831.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 137475
+pr: 153831
+summary: Ensure cancelled `_field_caps` tasks are removed from the tasks API
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -852,6 +852,14 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             }, 30, TimeUnit.SECONDS);
             BlockingOnRewriteQueryBuilder.unblockOnRewrite();
             expectThrows(CancellationException.class, future::actionGet);
+            logger.info("--> waiting for cancelled field-caps tasks to be removed");
+            assertBusy(() -> {
+                List<TaskInfo> tasks = clusterAdmin().prepareListTasks()
+                    .setActions("indices:data/read/field_caps", "indices:data/read/field_caps[n]")
+                    .get()
+                    .getTasks();
+                assertThat(tasks, empty());
+            }, 30, TimeUnit.SECONDS);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/RequestDispatcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/RequestDispatcher.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
@@ -149,6 +150,10 @@ final class RequestDispatcher {
     }
 
     private void innerExecute() {
+        if (parentTask instanceof CancellableTask cancellableTask && cancellableTask.isCancelled()) {
+            onComplete.run();
+            return;
+        }
         final Map<String, List<ShardId>> nodeToSelectedShards = new HashMap<>();
         assert pendingRequests.get() == 0 : "pending requests = " + pendingRequests;
         final List<String> failedIndices = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -59,6 +59,7 @@ import org.elasticsearch.search.crossproject.CrossProjectIndexResolutionValidato
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.Transport;
@@ -671,6 +672,9 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         final Map<String, Map<String, FieldCapabilities.Builder>> fieldsBuilder = new HashMap<>();
         int lastPendingIndex = 0;
         for (int i = 1; i <= indexResponses.length; i++) {
+            if (i % 64 == 0) {
+                task.ensureNotCancelled();
+            }
             if (i == indexResponses.length || hasSameMappingHash(indexResponses[lastPendingIndex], indexResponses[i]) == false) {
                 final String[] subIndices;
                 if (lastPendingIndex == 0 && i == indexResponses.length) {
@@ -935,13 +939,15 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 } catch (TooComplexToDeterminizeException e) {
                     throw new IllegalArgumentException("The field names are too complex to process. " + e.getMessage());
                 }
+                final CancellableTask cancellableTask = (CancellableTask) task;
                 for (List<ShardId> shardIds : groupedShardIds.values()) {
+                    cancellableTask.ensureNotCancelled();
                     final Map<ShardId, Exception> failures = new HashMap<>();
                     final Set<ShardId> unmatched = new HashSet<>();
                     for (ShardId shardId : shardIds) {
                         try {
                             final FieldCapabilitiesIndexResponse response = fetcher.fetch(
-                                (CancellableTask) task,
+                                cancellableTask,
                                 shardId,
                                 fieldNameFilter,
                                 request.filters(),
@@ -961,6 +967,10 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                                 unmatched.add(shardId);
                             }
                         } catch (Exception e) {
+                            if (e instanceof TaskCancelledException) {
+                                throw e;
+                            }
+                            cancellableTask.ensureNotCancelled();
                             failures.put(shardId, e);
                         }
                     }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
@@ -54,7 +54,9 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelHelper;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
@@ -86,6 +88,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -679,6 +682,141 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
             dispatcher.execute();
             responseCollector.awaitCompletion();
             assertThat(responseCollector.failures.keySet(), equalTo(Sets.newHashSet(targetIndices)));
+        }
+    }
+
+    public void testStopDispatchingMidFlightWhenCancelled() throws Exception {
+        final List<String> allIndices = IntStream.rangeClosed(1, between(1, 5)).mapToObj(n -> "index_" + n).toList();
+        final ProjectId projectId = randomProjectIdOrDefault();
+        final ClusterState clusterState;
+        {
+            DiscoveryNodes.Builder discoNodes = DiscoveryNodes.builder();
+            discoNodes.add(newNode("node_0", VersionUtils.randomVersion(), IndexVersionUtils.randomVersion()));
+            ProjectMetadata.Builder metadata = ProjectMetadata.builder(projectId);
+            for (String index : allIndices) {
+                metadata.put(IndexMetadata.builder(index).settings(indexSettings(IndexVersions.MINIMUM_COMPATIBLE, 1, 0)));
+            }
+            clusterState = newClusterState(Metadata.builder().put(metadata).build(), discoNodes.build());
+        }
+        try (TestTransportService transportService = TestTransportService.newTestTransportService()) {
+            final CancellableTask parentTask = new CancellableTask(
+                0,
+                "type",
+                "action",
+                randomAlphaOfLength(10),
+                TaskId.EMPTY_TASK_ID,
+                Collections.emptyMap()
+            );
+            final boolean withFilter = false;
+            final ResponseCollector responseCollector = new ResponseCollector();
+            final RequestDispatcher dispatcher = new RequestDispatcher(
+                mockClusterService(clusterState),
+                transportService,
+                TestProjectResolvers.singleProject(projectId),
+                coordinatorRewriteContextProvider(),
+                parentTask,
+                randomFieldCapRequest(withFilter),
+                OriginalIndices.NONE,
+                randomNonNegativeLong(),
+                allIndices.toArray(new String[0]),
+                transportService.threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
+                responseCollector::addIndexResponse,
+                responseCollector::addIndexFailure,
+                responseCollector::onComplete
+            );
+            final RequestTracker requestTracker = new RequestTracker(dispatcher, clusterState.routingTable(), withFilter);
+            transportService.requestTracker.set(requestTracker);
+
+            final CountDownLatch round0RequestReceived = new CountDownLatch(1);
+            final AtomicReference<Runnable> heldResponder = new AtomicReference<>();
+            transportService.setTransportInterceptor(new TransportInterceptor.AsyncSender() {
+                @Override
+                public <T extends TransportResponse> void sendRequest(
+                    Transport.Connection connection,
+                    String action,
+                    TransportRequest request,
+                    TransportRequestOptions options,
+                    TransportResponseHandler<T> handler
+                ) {
+                    FieldCapabilitiesNodeRequest nodeReq = (FieldCapabilitiesNodeRequest) request;
+                    heldResponder.set(
+                        () -> transportService.sendResponse(
+                            handler,
+                            randomNodeResponse(Collections.emptySet(), nodeReq.shardIds(), Collections.emptySet())
+                        )
+                    );
+                    round0RequestReceived.countDown();
+                }
+            });
+
+            dispatcher.execute();
+            assertTrue("round-0 node request should be dispatched", round0RequestReceived.await(30, TimeUnit.SECONDS));
+            TaskCancelHelper.cancel(parentTask, "simulated mid-flight cancel");
+            heldResponder.get().run();
+
+            responseCollector.awaitCompletion();
+            assertThat("round-0 should dispatch exactly one node request", requestTracker.sentNodeRequests, hasSize(1));
+            assertThat(requestTracker.sentNodeRequests.get(0).round, equalTo(0));
+            assertThat(dispatcher.executionRound(), equalTo(1));
+            assertThat(responseCollector.responses, anEmptyMap());
+            assertThat(responseCollector.failures, anEmptyMap());
+        }
+    }
+
+    public void testStopDispatchingWhenCancelled() throws Exception {
+        final List<String> allIndices = IntStream.rangeClosed(1, 5).mapToObj(n -> "index_" + n).toList();
+        final ClusterState clusterState;
+        final ProjectId projectId = randomProjectIdOrDefault();
+        {
+            DiscoveryNodes.Builder discoNodes = DiscoveryNodes.builder();
+            int numNodes = randomIntBetween(1, 10);
+            for (int i = 0; i < numNodes; i++) {
+                discoNodes.add(newNode("node_" + i, VersionUtils.randomVersion(), IndexVersionUtils.randomVersion()));
+            }
+            ProjectMetadata.Builder metadata = ProjectMetadata.builder(projectId);
+            for (String index : allIndices) {
+                metadata.put(
+                    IndexMetadata.builder(index).settings(indexSettings(IndexVersions.MINIMUM_COMPATIBLE, between(1, 10), between(0, 2)))
+                );
+            }
+            clusterState = newClusterState(Metadata.builder().put(metadata).build(), discoNodes.build());
+        }
+        try (TestTransportService transportService = TestTransportService.newTestTransportService()) {
+            final List<String> indices = randomSubsetOf(between(1, allIndices.size()), allIndices);
+            final boolean withFilter = randomBoolean();
+            final ResponseCollector responseCollector = new ResponseCollector();
+            final CancellableTask parentTask = new CancellableTask(
+                0,
+                "type",
+                "action",
+                randomAlphaOfLength(10),
+                TaskId.EMPTY_TASK_ID,
+                Collections.emptyMap()
+            );
+            TaskCancelHelper.cancel(parentTask, "simulated");
+            final RequestDispatcher dispatcher = new RequestDispatcher(
+                mockClusterService(clusterState),
+                transportService,
+                TestProjectResolvers.singleProject(projectId),
+                coordinatorRewriteContextProvider(),
+                parentTask,
+                randomFieldCapRequest(withFilter),
+                OriginalIndices.NONE,
+                randomNonNegativeLong(),
+                indices.toArray(new String[0]),
+                transportService.threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
+                responseCollector::addIndexResponse,
+                responseCollector::addIndexFailure,
+                responseCollector::onComplete
+            );
+            final RequestTracker requestTracker = new RequestTracker(dispatcher, clusterState.routingTable(), withFilter);
+            transportService.requestTracker.set(requestTracker);
+            dispatcher.execute();
+            responseCollector.awaitCompletion();
+            assertThat("no node requests should be dispatched for a cancelled task", requestTracker.sentNodeRequests, hasSize(0));
+            assertThat("no rounds should be executed for a cancelled task", dispatcher.executionRound(), equalTo(0));
+            assertThat(responseCollector.responses, anEmptyMap());
+            assertThat(responseCollector.failures, anEmptyMap());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -10,30 +10,40 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.DummyQueryBuilder;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskCancelHelper;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class TransportFieldCapabilitiesActionTests extends ESTestCase {
 
@@ -50,8 +60,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
             .put("node.name", TransportFieldCapabilitiesActionTests.class.getSimpleName())
             .put(SearchService.CCS_VERSION_CHECK_SETTING.getKey(), "true")
             .build();
-        ActionFilters actionFilters = mock(ActionFilters.class);
-        when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
+        ActionFilters actionFilters = new ActionFilters(Set.of());
         TransportVersion transportVersion = TransportVersionUtils.getNextVersion(TransportVersion.minimumCCSVersion(), true);
         try {
             TransportService transportService = MockTransportService.createNewService(
@@ -71,19 +80,19 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
                 }
             });
 
-            IndicesService indicesService = mock(IndicesService.class);
             ClusterService clusterService = new ClusterService(
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 threadPool,
                 null
             );
+            // indicesService is not exercised on this path: the CCS compatibility check fails before any index is touched.
             TransportFieldCapabilitiesAction action = new TransportFieldCapabilitiesAction(
                 transportService,
                 clusterService,
                 threadPool,
                 actionFilters,
-                indicesService,
+                null,
                 null,
                 null,
                 CrossProjectModeDecider.NOOP
@@ -104,5 +113,79 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
         } finally {
             assertTrue(ESTestCase.terminate(threadPool));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testNodeHandlerAbortedWhenTaskCancelled() throws Exception {
+        ActionFilters actionFilters = new ActionFilters(Set.of());
+        ClusterService clusterService = new ClusterService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool,
+            null
+        );
+        TransportService transportService = MockTransportService.createNewService(
+            Settings.EMPTY,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
+        new TransportFieldCapabilitiesAction(
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            null,
+            null,
+            null,
+            CrossProjectModeDecider.NOOP
+        );
+
+        final TransportRequestHandler<FieldCapabilitiesNodeRequest> nodeHandler = (TransportRequestHandler<
+            FieldCapabilitiesNodeRequest>) transportService.getRequestHandler(TransportFieldCapabilitiesAction.ACTION_NODE_NAME)
+                .getHandler();
+
+        final CancellableTask cancelledTask = new CancellableTask(
+            0,
+            "transport",
+            TransportFieldCapabilitiesAction.ACTION_NODE_NAME,
+            "",
+            TaskId.EMPTY_TASK_ID,
+            Map.of()
+        );
+        TaskCancelHelper.cancel(cancelledTask, "test");
+
+        final FieldCapabilitiesNodeRequest request = new FieldCapabilitiesNodeRequest(
+            List.of(new ShardId("test_index", "_na_", 0)),
+            new String[] { "*" },
+            new String[0],
+            new String[0],
+            OriginalIndices.NONE,
+            null,
+            0L,
+            Map.of(),
+            true
+        );
+
+        final AtomicReference<Exception> channelError = new AtomicReference<>();
+        final TransportChannel channel = new TransportChannel() {
+            @Override
+            public String getProfileName() {
+                return "test";
+            }
+
+            @Override
+            public void sendResponse(TransportResponse response) {
+                fail("expected TaskCancelledException but got a successful response");
+            }
+
+            @Override
+            public void sendResponse(Exception exception) {
+                channelError.set(exception);
+            }
+        };
+
+        nodeHandler.messageReceived(request, channel, cancelledTask);
+        assertThat("pre-cancelled task must not fetch any shard data", channelError.get(), instanceOf(TaskCancelledException.class));
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Ensure cancelled _field_caps tasks are removed from the tasks API (#153831)