### PR TITLE
Mute org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests #154350

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -652,3 +652,5 @@ tests:
 - class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
   method: testMasterFailoverDuringSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/154395
+- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
+  issue: https://github.com/elastic/elasticsearch/issues/154350


### PR DESCRIPTION
Muting the class: it fails frequently on `main` and across PRs (all six methods, both regular and `WithCranky` variants). Tracked in #154350.

Relates to #154350