### PR TITLE
[9.4] ESQL: guard ROUND_TO to fields coming from indices in the physical optimizer (#154317)

### DIFF
--- a/docs/changelog/154317.yaml
+++ b/docs/changelog/154317.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154315
+pr: 154317
+summary: Guard ROUND_TO to fields coming from indices in the physical optimized
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -918,6 +918,93 @@ COUNT(*):long | salary:integer
             8 | 70000
 ;
 
+
+roundToOverFunctionArgument
+required_capability: round_to
+required_capability: fix_round_to_query_and_tags_over_function
+FROM employees
+| STATS COUNT(*) BY salary=ROUND_TO(
+    ABS(salary),
+    0,
+    20000,
+    25000,
+    30000,
+    40000,
+    50000,
+    70000,
+    90000
+)
+| SORT salary ASC
+;
+
+COUNT(*):long | salary:integer
+            9 | 25000
+           27 | 30000
+           22 | 40000
+           34 | 50000
+            8 | 70000
+;
+
+roundToOverFunctionArgumentInsideAggFunction
+required_capability: round_to
+required_capability: fix_round_to_query_and_tags_over_function
+FROM employees
+| STATS s = SUM(ROUND_TO(
+    ABS(salary),
+    0,
+    20000,
+    25000,
+    30000,
+    40000,
+    50000,
+    70000,
+    90000
+))
+;
+
+s:long
+4175000
+;
+
+roundToOverFunctionArgumentInsideMinMax
+required_capability: round_to
+required_capability: fix_round_to_query_and_tags_over_function
+FROM employees
+| STATS mn = MIN(ROUND_TO(ABS(salary), 0, 20000, 25000, 30000, 40000, 50000, 70000, 90000)),
+        mx = MAX(ROUND_TO(ABS(salary), 0, 20000, 25000, 30000, 40000, 50000, 70000, 90000))
+;
+
+mn:integer | mx:integer
+     25000 | 70000
+;
+
+roundToOverFunctionArgumentInEval
+required_capability: round_to
+required_capability: fix_round_to_query_and_tags_over_function
+FROM employees
+| EVAL bucket = ROUND_TO(
+    GREATEST(salary, 0),
+    0,
+    20000,
+    25000,
+    30000,
+    40000,
+    50000,
+    70000,
+    90000
+)
+| STATS COUNT(*) BY bucket
+| SORT bucket ASC
+;
+
+COUNT(*):long | bucket:integer
+            9 | 25000
+           27 | 30000
+           22 | 40000
+           34 | 50000
+            8 | 70000
+;
+
 roundToNanos
 required_capability: round_to
 FROM sample_data_ts_nanos

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2646,6 +2646,13 @@ public class EsqlCapabilities {
          */
         SPATIAL_BBOX_VALIDATION_FIX,
 
+        /**
+         * Fix {@code ReplaceRoundToWithQueryAndTags} throwing a {@code ClassCastException} when {@code ROUND_TO}'s first argument
+         * is a function (e.g. {@code ROUND_TO(BYTE_LENGTH(field), ...)}) rather than a bare field.
+         * See <a href="https://github.com/elastic/elasticsearch/issues/154315">#154315</a>
+         */
+        FIX_ROUND_TO_QUERY_AND_TAGS_OVER_FUNCTION,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceRoundToWithQueryAndTags.java
@@ -307,6 +307,9 @@ public class ReplaceRoundToWithQueryAndTags extends PhysicalOptimizerRules.Param
             // It is not clear how to push down multiple RoundTos, dealing with multiple RoundTos is out of the scope of this PR.
             if (roundTos.size() == 1) {
                 RoundTo roundTo = roundTos.get(0);
+                if (roundTo.field() instanceof FieldAttribute == false) {
+                    return evalExec;
+                }
                 int count = roundTo.points().size();
                 int roundingPointsUpperLimit = adjustedRoundingPointsThreshold(
                     ctx.searchStats(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToTests.java
@@ -1027,6 +1027,30 @@ public class SubstituteRoundToTests extends AbstractLocalPhysicalPlanOptimizerTe
         }
     }
 
+    // Test fix for issue https://github.com/elastic/elasticsearch/issues/154315
+    public void testRoundToOnNonFieldNotTransformToQueryAndTags() {
+        for (String expression : List.of("round_to(abs(long), 1, 2, 3, 4)", "round_to(long + 1, 1, 2, 3, 4)")) {
+            String query = LoggerMessageFormat.format(null, """
+                from test
+                | stats count(*) by x = {}
+                """, expression);
+
+            ExchangeExec exchange = validatePlanBeforeExchange(query, DataType.LONG);
+            AggregateExec agg = as(exchange.child(), AggregateExec.class);
+            EvalExec eval = as(agg.child(), EvalExec.class);
+            assertEquals(1, eval.fields().size());
+            RoundTo roundTo = as(eval.fields().getFirst().child(), RoundTo.class);
+            assertThat(roundTo.field(), not(instanceOf(FieldAttribute.class)));
+
+            FieldExtractExec fieldExtract = as(eval.child(), FieldExtractExec.class);
+            EsQueryExec esQuery = as(fieldExtract.child(), EsQueryExec.class);
+            List<EsQueryExec.QueryBuilderAndTags> queryBuilderAndTags = esQuery.queryBuilderAndTags();
+            assertEquals(1, queryBuilderAndTags.size());
+            assertNull(queryBuilderAndTags.getFirst().query());
+            assertTrue(queryBuilderAndTags.getFirst().tags().isEmpty());
+        }
+    }
+
     private static SearchStats searchStats() {
         // create a SearchStats with min and max in milliseconds
         Map<String, Object> minValue = Map.of("date", 1697804103360L); // 2023-10-20T12:15:03.360Z


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [ESQL: guard ROUND_TO to fields coming from indices in the physical optimizer (#154317)](https://github.com/elastic/elasticsearch/pull/154317)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)