### PR TITLE
Gate TO_TEXT conditional csv-specs on fn_to_text capability

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -636,15 +636,6 @@ tests:
 - class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
   method: testControllerSpawnGatedBySettings
   issue: https://github.com/elastic/elasticsearch/issues/154291
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldMixedConditionsKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154438
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldMixedConditionsKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154439
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldTrueToTextKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154440
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: multiple sub-objects with all three supported dynamic values}"
   issue: https://github.com/elastic/elasticsearch/issues/154464

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -432,6 +432,7 @@ CASE(y==2, 10, 1) * MIN(x):integer | y:integer
 
 casePartialFoldTrueToTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -448,6 +449,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldTrailingTextArmKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -464,6 +466,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldKeywordIsGroupable
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10005
@@ -479,6 +482,7 @@ c:long | g:keyword
 
 casePartialFoldMixedConditionsKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -495,6 +499,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldMultivalueTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no == 10001
@@ -508,6 +513,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldTextArmNullElseKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no == 10001


### PR DESCRIPTION
The `casePartialFold*` specs added in #154287 use `TO_TEXT`, a 9.5.0 preview function (#147103). Their `required_capability: fix_case_partial_fold_keyword_type` gate passes on 9.4.x remotes because the CASE fix was backported there, so BWC multi/mixed-cluster runners ran the specs and shipped plan fragments containing `ToText` to remotes that cannot deserialize it. In assert-enabled builds the unknown-writeable assertion is fatal and takes the remote node down, which is why each failure dragged unrelated specs along as `connect_transport_exception` collateral (full root-cause writeup: https://github.com/elastic/elasticsearch/issues/154471#issuecomment-5025609563).

Fix: additionally require the auto-registered `fn_to_text` capability on these six specs. The multi-cluster and mixed-cluster runners already check `required_capability` against every participating cluster, so the specs skip whenever any cluster lacks the function — no new capability or runner changes needed. Also removes the method-level mutes (#154438, #154439, #154440); the class-level mute for #154471 was never merged.

⭐Humans read: Relates #154471
