### PR TITLE
ESQL: Fix request breaker leak in lookup queries

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -610,12 +610,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
   method: testMaxExpressionDepth_nestedAbs_minOverflow {default}
   issue: https://github.com/elastic/elasticsearch/issues/154341
-- class: org.elasticsearch.xpack.esql.plugin.MatchFunctionIT
-  method: testMatchInLookupJoinWithKeywordJoinField
-  issue: https://github.com/elastic/elasticsearch/issues/154357
-- class: org.elasticsearch.xpack.esql.plugin.MatchFunctionIT
-  method: testMatchRuntimeEvalWithIncompatibleIntegerValueThrowsError
-  issue: https://github.com/elastic/elasticsearch/issues/154359
 - class: org.elasticsearch.index.rankeval.RankEvalRequestIT
   method: testIndicesOptions
   issue: https://github.com/elastic/elasticsearch/issues/154360

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -861,6 +861,8 @@ public abstract class AbstractLookupService<R extends AbstractLookupService.Requ
                 searchContext.getSearchExecutionContext(),
                 QueryWarnings.NOOP
             );
+            // Queries built via the wrapper charge its own accounting pool, which nothing else drains.
+            searchContext.addReleasable(esqlCtx::releaseQueryConstructionMemory);
             return new LookupShardContext(
                 new EsPhysicalOperationProviders.DefaultShardContext(0, searchContext, esqlCtx, searchContext.request().getAliasFilter()),
                 esqlCtx,


### PR DESCRIPTION
LookupShardContext.fromSearchContext wraps the SearchExecutionContext in an EsqlSearchExecutionContext (since #154186). The drain SearchService registers only covers the inner context, so the wrapper's pool was never released, leaking request breaker bytes whenever the lookup built a query through it.

Register the wrapper's releaseQueryConstructionMemory as a releasable on the SearchContext, mirroring ComputeSearchContext.

Unmutes MatchFunctionIT tests muted for this leak.

Closes #154357
Closes #154358
Closes #154359
Closes #154339
