### PR TITLE
Flip Escf absent to validity bitset

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/AbstractFixed64Column.java
+++ b/server/src/main/java/org/elasticsearch/escf/AbstractFixed64Column.java
@@ -20,8 +20,8 @@ abstract class AbstractFixed64Column extends EscfColumn {
 
     protected final BytesReference data;
 
-    AbstractFixed64Column(int docCount, FixedBitSet absent, BytesReference data) {
-        super(docCount, absent);
+    AbstractFixed64Column(int docCount, FixedBitSet validity, BytesReference data) {
+        super(docCount, validity);
         this.data = data;
     }
 

--- a/server/src/main/java/org/elasticsearch/escf/AbstractVarColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/AbstractVarColumn.java
@@ -24,14 +24,14 @@ abstract class AbstractVarColumn extends EscfColumn {
     final BytesReference data;
     final IntsRef offsets;
 
-    AbstractVarColumn(int docCount, FixedBitSet absent, BytesReference data, IntsRef offsets) {
-        super(docCount, absent);
+    AbstractVarColumn(int docCount, FixedBitSet validity, BytesReference data, IntsRef offsets) {
+        super(docCount, validity);
         this.data = data;
         this.offsets = offsets;
         assert offsets.length == docCount + 1;
     }
 
-    abstract AbstractVarColumn newSlice(int count, FixedBitSet sliceAbsent, BytesReference sliceData, IntsRef sliceOffsets);
+    abstract AbstractVarColumn newSlice(int count, FixedBitSet sliceValidity, BytesReference sliceData, IntsRef sliceOffsets);
 
     @Override
     final BytesRef getBinaryValue(int row) {
@@ -42,13 +42,13 @@ abstract class AbstractVarColumn extends EscfColumn {
     @Override
     final EscfColumn sliceInternal(int from, int count) {
         // data is kept full/shared; the slice is expressed by adjusting dataOffsets.offset.
-        return newSlice(count, windowBitSet(absent, from, count), data, sliceOffsets(offsets, from, count));
+        return newSlice(count, windowValidity(validity, from, count), data, sliceOffsets(offsets, from, count));
     }
 
     @Override
     final EscfColumnData toColumnData() {
         BytesReference newData = sliceData(offsets, data, docCount);
         int[] newOffsets = rebasedOffsets(offsets, docCount);
-        return EscfColumnData.ofVarWidth(kind(), docCount, absent, newOffsets, newData);
+        return EscfColumnData.ofVarWidth(kind(), docCount, validity, newOffsets, newData);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfArrayColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfArrayColumn.java
@@ -25,8 +25,8 @@ final class EscfArrayColumn extends EscfColumn {
     private final EscfColumn child;
     private final IntsRef rowOffsets;
 
-    EscfArrayColumn(int docCount, FixedBitSet absent, EscfColumn child, IntsRef rowOffsets) {
-        super(docCount, absent);
+    EscfArrayColumn(int docCount, FixedBitSet validity, EscfColumn child, IntsRef rowOffsets) {
+        super(docCount, validity);
         this.child = child;
         this.rowOffsets = rowOffsets;
     }
@@ -51,7 +51,7 @@ final class EscfArrayColumn extends EscfColumn {
     @Override
     EscfColumn sliceInternal(int from, int count) {
         // Child stays full/unsliced — ColumnarArrayReader uses absolute element indices.
-        return new EscfArrayColumn(count, windowBitSet(absent, from, count), child, sliceOffsets(rowOffsets, from, count));
+        return new EscfArrayColumn(count, windowValidity(validity, from, count), child, sliceOffsets(rowOffsets, from, count));
     }
 
     @Override
@@ -61,6 +61,6 @@ final class EscfArrayColumn extends EscfColumn {
         int elemTo = intAt(rowOffsets, docCount);
         // Slice the child to the element range referenced by this window, then materialize it.
         EscfColumnData childData = child.sliceInternal(elemFrom, elemTo - elemFrom).toColumnData();
-        return EscfColumnData.ofArray(docCount, absent, newRowOffsets, childData);
+        return EscfColumnData.ofArray(docCount, validity, newRowOffsets, childData);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfBatch.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfBatch.java
@@ -154,7 +154,7 @@ public final class EscfBatch implements SourceBatch {
 
     /** Sums a column's own live storage plus, for ARRAY, its nested {@code child} column's storage. */
     private static long columnRamBytes(EscfColumnData col) {
-        long total = bitsetRam(col.absent()) + bitsetRam(col.values()) + (col.typeVector() != null ? col.typeVector().length : 0L) + (col
+        long total = bitsetRam(col.validity()) + bitsetRam(col.values()) + (col.typeVector() != null ? col.typeVector().length : 0L) + (col
             .offsets() != null ? col.offsets().length * 4L : 0L) + refLen(col.data());
         if (col.child() != null) {
             total += columnRamBytes(col.child());

--- a/server/src/main/java/org/elasticsearch/escf/EscfBatchCodec.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfBatchCodec.java
@@ -34,11 +34,11 @@ import java.util.List;
  * schema_offset(i32) column_index_offset(i32) data_offset(i32) total_size(i32)
  * [Schema]        non_leaf_count(u16) { parent(u16) name_len(u16) name }* leaf_count(u16) { parent(u16) name_len(u16) name }*
  * [Column Index]  per leaf: kind(u8) present_flags(u8) base_offset(i32)
- *                 absent_len(i32) typevec_len(i32) offsets_len(i32) data_len(i32)   [= 22 bytes]
- * [Column Data]   per leaf, present fields concatenated: [absent_bitset] [type_vector] [offsets] [data]
+ *                 validity_len(i32) typevec_len(i32) offsets_len(i32) data_len(i32)   [= 22 bytes]
+ * [Column Data]   per leaf, present fields concatenated: [validity_bitset] [type_vector] [offsets] [data]
  * </pre>
- * {@code present_flags} bit 0 = absent bitset, bit 1 = type vector, bit 2 = offsets; the data field is
- * always present. {@code base_offset} is relative to {@code data_offset}.
+ * {@code present_flags} bit 0 = Arrow-style validity bitset (bit set = present), bit 1 = type vector,
+ * bit 2 = offsets; the data field is always present. {@code base_offset} is relative to {@code data_offset}.
  */
 final class EscfBatchCodec {
 
@@ -49,7 +49,7 @@ final class EscfBatchCodec {
     private static final int HEADER_SIZE = 32;
     private static final int COLUMN_INDEX_ENTRY_SIZE = 22;
 
-    private static final int FLAG_ABSENT = 0x1;
+    private static final int FLAG_VALIDITY = 0x1;
     private static final int FLAG_TYPE_VECTOR = 0x2;
     private static final int FLAG_OFFSETS = 0x4;
 
@@ -93,9 +93,9 @@ final class EscfBatchCodec {
             int dataLen = data.getIntLE(entryBase + 18);
 
             int pos = base;
-            FixedBitSet absent = null;
-            if ((flags & FLAG_ABSENT) != 0) {
-                absent = bytesToFixedBitSet(data, pos, docCount);
+            FixedBitSet validity = null;
+            if ((flags & FLAG_VALIDITY) != 0) {
+                validity = bytesToFixedBitSet(data, pos, docCount);
                 pos += absentLen;
             }
             BytesRef typeVector = null;
@@ -111,25 +111,25 @@ final class EscfBatchCodec {
             // For BOOL the data field carries the value bitset; ARRAY carries a nested child column;
             // every other kind keeps its payload as a byte slice.
             columns[c] = switch (kind) {
-                case EscfColumnKind.BOOL -> EscfColumnData.ofBool(docCount, absent, bytesToFixedBitSet(data, pos, docCount));
+                case EscfColumnKind.BOOL -> EscfColumnData.ofBool(docCount, validity, bytesToFixedBitSet(data, pos, docCount));
                 case EscfColumnKind.ARRAY -> EscfColumnData.ofArray(
                     docCount,
-                    absent,
+                    validity,
                     offsets,
                     decodeArrayChild(data, pos, dataLen, offsets[docCount])
                 );
-                case EscfColumnKind.UNION -> EscfColumnData.ofUnion(docCount, absent, typeVector, offsets, data.slice(pos, dataLen));
+                case EscfColumnKind.UNION -> EscfColumnData.ofUnion(docCount, validity, typeVector, offsets, data.slice(pos, dataLen));
                 case EscfColumnKind.STRING, EscfColumnKind.BINARY -> EscfColumnData.ofVarWidth(
                     kind,
                     docCount,
-                    absent,
+                    validity,
                     offsets,
                     data.slice(pos, dataLen)
                 );
                 case EscfColumnKind.LONG, EscfColumnKind.DOUBLE -> EscfColumnData.ofFixed64(
                     kind,
                     docCount,
-                    absent,
+                    validity,
                     data.slice(pos, dataLen)
                 );
                 default -> throw new IllegalStateException("Unknown ESCF column kind: " + EscfColumnKind.name(kind));
@@ -154,7 +154,7 @@ final class EscfBatchCodec {
         BytesReference[] dataPart = new BytesReference[colCount];
         for (int c = 0; c < colCount; c++) {
             EscfColumnData col = columns[c];
-            absentPart[c] = col.absent() != null ? bitsetToRef(col.absent(), docCount) : null;
+            absentPart[c] = col.validity() != null ? bitsetToRef(col.validity(), docCount) : null;
             typeVecPart[c] = col.typeVector() != null
                 ? new BytesArray(col.typeVector().bytes, col.typeVector().offset, col.typeVector().length)
                 : null;
@@ -178,7 +178,7 @@ final class EscfBatchCodec {
             baseOffsets[c] = cumDataOffset;
             int f = 0;
             if (absentPart[c] != null) {
-                f |= FLAG_ABSENT;
+                f |= FLAG_VALIDITY;
                 cumDataOffset += absentPart[c].length();
             }
             if (typeVecPart[c] != null) {

--- a/server/src/main/java/org/elasticsearch/escf/EscfBinaryColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfBinaryColumn.java
@@ -20,8 +20,8 @@ import org.elasticsearch.sourcebatch.SourceValueType;
  */
 final class EscfBinaryColumn extends AbstractVarColumn {
 
-    EscfBinaryColumn(int docCount, FixedBitSet absent, BytesReference data, IntsRef offsets) {
-        super(docCount, absent, data, offsets);
+    EscfBinaryColumn(int docCount, FixedBitSet validity, BytesReference data, IntsRef offsets) {
+        super(docCount, validity, data, offsets);
     }
 
     @Override
@@ -35,7 +35,7 @@ final class EscfBinaryColumn extends AbstractVarColumn {
     }
 
     @Override
-    AbstractVarColumn newSlice(int count, FixedBitSet sliceAbsent, BytesReference sliceData, IntsRef sliceOffsets) {
-        return new EscfBinaryColumn(count, sliceAbsent, sliceData, sliceOffsets);
+    AbstractVarColumn newSlice(int count, FixedBitSet sliceValidity, BytesReference sliceData, IntsRef sliceOffsets) {
+        return new EscfBinaryColumn(count, sliceValidity, sliceData, sliceOffsets);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfBoolColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfBoolColumn.java
@@ -23,8 +23,8 @@ final class EscfBoolColumn extends EscfColumn {
      */
     private final FixedBitSet values;
 
-    EscfBoolColumn(int docCount, FixedBitSet absent, FixedBitSet values) {
-        super(docCount, absent);
+    EscfBoolColumn(int docCount, FixedBitSet validity, FixedBitSet values) {
+        super(docCount, validity);
         this.values = values;
     }
 
@@ -50,12 +50,12 @@ final class EscfBoolColumn extends EscfColumn {
 
     @Override
     EscfColumn sliceInternal(int from, int count) {
-        return new EscfBoolColumn(count, windowBitSet(absent, from, count), windowBitSet(values, from, count));
+        return new EscfBoolColumn(count, windowValidity(validity, from, count), windowBitSet(values, from, count));
     }
 
     @Override
     EscfColumnData toColumnData() {
-        // absent and values are already windowed and zero-based; return them directly.
-        return EscfColumnData.ofBool(docCount, absent, values);
+        // validity and values are already windowed and zero-based; return them directly.
+        return EscfColumnData.ofBool(docCount, validity, values);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
@@ -29,12 +29,15 @@ abstract class EscfColumn implements SliceableColumn {
 
     final int docCount;
 
-    /** Absent set (bit set = absent), or {@code null} when every document is present (dense). */
-    final FixedBitSet absent;
+    /**
+     * Validity bitset (bit set = present/valid), or {@code null} when every document is
+     * present (dense). Always zero-based and covers {@code [0, docCount)} when non-null.
+     */
+    final FixedBitSet validity;
 
-    EscfColumn(int docCount, FixedBitSet absent) {
+    EscfColumn(int docCount, FixedBitSet validity) {
         this.docCount = docCount;
-        this.absent = absent;
+        this.validity = validity;
     }
 
     /** The column kind (see {@link EscfColumnKind}). */
@@ -43,24 +46,22 @@ abstract class EscfColumn implements SliceableColumn {
     /** Builds the typed column view for {@code col}, dispatching on its kind. The fields are already native. */
     static EscfColumn from(EscfColumnData col) {
         int docCount = col.docCount();
-        // Normalize the absent bitset to [0, docCount): windowBitSet returns null when no bits
-        // are set (same semantics) and a properly-sized FixedBitSet otherwise.
-        FixedBitSet absent = windowBitSet(col.absent(), 0, docCount);
+        FixedBitSet validity = windowValidity(col.validity(), 0, docCount);
         return switch (col.kind()) {
-            case EscfColumnKind.LONG -> new EscfLongColumn(docCount, absent, col.data());
-            case EscfColumnKind.DOUBLE -> new EscfDoubleColumn(docCount, absent, col.data());
-            case EscfColumnKind.BOOL -> new EscfBoolColumn(docCount, absent, windowBitSet(col.values(), 0, docCount));
-            case EscfColumnKind.STRING -> new EscfStringColumn(docCount, absent, col.data(), new IntsRef(col.offsets(), 0, docCount + 1));
-            case EscfColumnKind.BINARY -> new EscfBinaryColumn(docCount, absent, col.data(), new IntsRef(col.offsets(), 0, docCount + 1));
+            case EscfColumnKind.LONG -> new EscfLongColumn(docCount, validity, col.data());
+            case EscfColumnKind.DOUBLE -> new EscfDoubleColumn(docCount, validity, col.data());
+            case EscfColumnKind.BOOL -> new EscfBoolColumn(docCount, validity, windowBitSet(col.values(), 0, docCount));
+            case EscfColumnKind.STRING -> new EscfStringColumn(docCount, validity, col.data(), new IntsRef(col.offsets(), 0, docCount + 1));
+            case EscfColumnKind.BINARY -> new EscfBinaryColumn(docCount, validity, col.data(), new IntsRef(col.offsets(), 0, docCount + 1));
             case EscfColumnKind.ARRAY -> new EscfArrayColumn(
                 docCount,
-                absent,
+                validity,
                 from(col.child()),
                 new IntsRef(col.offsets(), 0, docCount + 1)
             );
             case EscfColumnKind.UNION -> new EscfUnionColumn(
                 docCount,
-                absent,
+                validity,
                 col.typeVector(),
                 new IntsRef(col.offsets(), 0, docCount + 1),
                 col.data()
@@ -73,8 +74,9 @@ abstract class EscfColumn implements SliceableColumn {
         if (row < 0 || row >= docCount) {
             return true;
         }
-        // absent is always null or a FixedBitSet covering [0, docCount), so no length guard is needed.
-        return absent != null && absent.get(row);
+        // validity is always null (all-present) or a FixedBitSet covering [0, docCount), so no length guard needed.
+        // A set bit means present; a clear bit or null means all-present (dense).
+        return validity != null && validity.get(row) == false;
     }
 
     final byte getTypeByte(int row) {
@@ -149,10 +151,35 @@ abstract class EscfColumn implements SliceableColumn {
     abstract EscfColumnData toColumnData();
 
     /**
+     * Extracts a {@code count}-bit window of an validity bitset (bit set = present) starting
+     * at {@code base} from {@code src}, re-indexed to {@code [0, count)}. Returns {@code null} when
+     * {@code src} is {@code null} (all-present / dense) or when every bit in the window is set (also
+     * all-present), preserving the invariant that a {@code null} validity means every document is present.
+     * Bits beyond {@code src.length()} are treated as absent (clear).
+     */
+    static FixedBitSet windowValidity(FixedBitSet src, int base, int count) {
+        if (src == null) {
+            return null;
+        }
+        FixedBitSet out = new FixedBitSet(Math.max(1, count));
+        int cap = src.length();
+        boolean anyAbsent = false;
+        for (int i = 0; i < count; i++) {
+            int idx = base + i;
+            if (idx < cap && src.get(idx)) {
+                out.set(i);
+            } else {
+                anyAbsent = true;
+            }
+        }
+        return anyAbsent ? out : null;
+    }
+
+    /**
      * Extracts a {@code count}-bit window starting at {@code base} from {@code src}, re-indexed to
-     * {@code [0, count)}. Returns {@code null} when {@code src} is {@code null} (dense) or when no
-     * bits in the window are set (also dense), preserving the invariant that a {@code null} absent set
-     * means every document is present.
+     * {@code [0, count)}. Returns {@code null} when {@code src} is {@code null} or when no bits in the
+     * window are set, preserving the invariant that a {@code null} bitset means all bits are clear.
+     * Used for the BOOL {@code values} bitset (bit set = {@code true}); not for validity.
      */
     static FixedBitSet windowBitSet(FixedBitSet src, int base, int count) {
         if (src == null) {

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
@@ -161,18 +161,23 @@ abstract class EscfColumn implements SliceableColumn {
         if (src == null) {
             return null;
         }
-        FixedBitSet out = new FixedBitSet(Math.max(1, count));
+        FixedBitSet out = null;
         int cap = src.length();
-        boolean anyAbsent = false;
         for (int i = 0; i < count; i++) {
             int idx = base + i;
-            if (idx < cap && src.get(idx)) {
-                out.set(i);
+            boolean present = idx < cap && src.get(idx);
+            if (present) {
+                if (out != null) {
+                    out.set(i);
+                }
             } else {
-                anyAbsent = true;
+                if (out == null) {
+                    out = new FixedBitSet(count);
+                    out.set(0, i); // backfill all prior docs in the window as present
+                }
             }
         }
-        return anyAbsent ? out : null;
+        return out;
     }
 
     /**
@@ -185,17 +190,18 @@ abstract class EscfColumn implements SliceableColumn {
         if (src == null) {
             return null;
         }
-        FixedBitSet out = new FixedBitSet(Math.max(1, count));
+        FixedBitSet out = null;
         int cap = src.length();
-        boolean anySet = false;
         for (int i = 0; i < count; i++) {
             int idx = base + i;
             if (idx < cap && src.get(idx)) {
+                if (out == null) {
+                    out = new FixedBitSet(count);
+                }
                 out.set(i);
-                anySet = true;
             }
         }
-        return anySet ? out : null;
+        return out;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
@@ -155,18 +155,14 @@ abstract class EscfColumn implements SliceableColumn {
      * at {@code base} from {@code src}, re-indexed to {@code [0, count)}. Returns {@code null} when
      * {@code src} is {@code null} (all-present / dense) or when every bit in the window is set (also
      * all-present), preserving the invariant that a {@code null} validity means every document is present.
-     * Bits beyond {@code src.length()} are treated as absent (clear).
      */
     static FixedBitSet windowValidity(FixedBitSet src, int base, int count) {
         if (src == null) {
             return null;
         }
         FixedBitSet out = null;
-        int cap = src.length();
         for (int i = 0; i < count; i++) {
-            int idx = base + i;
-            boolean present = idx < cap && src.get(idx);
-            if (present) {
+            if (src.get(base + i)) {
                 if (out != null) {
                     out.set(i);
                 }
@@ -175,6 +171,7 @@ abstract class EscfColumn implements SliceableColumn {
                     out = new FixedBitSet(count);
                     out.set(0, i); // backfill all prior docs in the window as present
                 }
+                // leave bit[i] clear — this doc is absent
             }
         }
         return out;

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnBuilder.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnBuilder.java
@@ -232,15 +232,39 @@ final class EscfColumnBuilder {
     private abstract static class BaseBuilder implements TypedBuilder {
 
         int count;
-        FixedBitSet absent;
+        FixedBitSet validity;
 
-        final void markAbsent() {
-            absent = absent == null ? new FixedBitSet(Math.max(64, count + 1)) : FixedBitSet.ensureCapacity(absent, count + 1);
-            absent.set(count);
+        /**
+         * Marks the current document (at {@code count}) as absent and advances {@code count}. On the first
+         * absence, the validity bitset is materialised and all prior documents are backfilled as present.
+         */
+        final void advanceAbsent() {
+            if (validity == null) {
+                // First absent: materialise and backfill all prior docs as present.
+                validity = new FixedBitSet(Math.max(64, count + 1));
+                validity.set(0, count); // [0, count) are present
+            } else {
+                validity = FixedBitSet.ensureCapacity(validity, count + 1);
+            }
+            // leave bit[count] clear — this document is absent
+            count++;
+        }
+
+        /**
+         * Marks the current document (at {@code count}) as present and advances {@code count}. A no-op on
+         * the validity bitset when the column is still dense (null), since all documents are implicitly
+         * present; once the bitset is materialised, the present bit is explicitly set.
+         */
+        final void advancePresent() {
+            if (validity != null) {
+                validity = FixedBitSet.ensureCapacity(validity, count + 1);
+                validity.set(count);
+            }
+            count++;
         }
 
         final boolean isAbsentAt(int d) {
-            return absent != null && absent.get(d);
+            return validity != null && validity.get(d) == false;
         }
 
         @Override
@@ -315,20 +339,19 @@ final class EscfColumnBuilder {
         @Override
         public void addLong(long value) {
             writeLongLE(data, value);
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addDouble(double value) {
             writeLongLE(data, Double.doubleToRawLongBits(value));
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addAbsent() {
-            markAbsent();
             writeLongLE(data, 0L);
-            count++;
+            advanceAbsent();
         }
 
         @Override
@@ -341,13 +364,13 @@ final class EscfColumnBuilder {
                 offsets[i] = i * 8;
             }
             offsets[count] = count * 8;
-            return new UnionBuilder(data, typeVec, offsets, count * 8, count, absent);
+            return new UnionBuilder(data, typeVec, offsets, count * 8, count, validity);
         }
 
         @Override
         public EscfColumnData finish(int docCount) {
             assert count == docCount : "builder count " + count + " != docCount " + docCount;
-            return EscfColumnData.ofFixed64(kind, docCount, absent, data.moveToBytesReference());
+            return EscfColumnData.ofFixed64(kind, docCount, validity, data.moveToBytesReference());
         }
 
         @Override
@@ -372,13 +395,12 @@ final class EscfColumnBuilder {
                 values = values == null ? new FixedBitSet(Math.max(64, count + 1)) : FixedBitSet.ensureCapacity(values, count + 1);
                 values.set(count);
             }
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addAbsent() {
-            markAbsent();
-            count++;
+            advanceAbsent();
         }
 
         @Override
@@ -391,13 +413,13 @@ final class EscfColumnBuilder {
                     typeVec[i] = (values != null && values.get(i)) ? SourceValueType.TRUE : SourceValueType.FALSE;
                 }
             }
-            return new UnionBuilder(newStream(recycler), typeVec, new int[count + 1], 0, count, absent);
+            return new UnionBuilder(newStream(recycler), typeVec, new int[count + 1], 0, count, validity);
         }
 
         @Override
         public EscfColumnData finish(int docCount) {
             assert count == docCount : "builder count " + count + " != docCount " + docCount;
-            return EscfColumnData.ofBool(docCount, absent, values);
+            return EscfColumnData.ofBool(docCount, validity, values);
         }
     }
 
@@ -432,14 +454,13 @@ final class EscfColumnBuilder {
             recordOffset();
             writeBytes(data, value.bytes(), value.offset(), value.length());
             dataLen += value.length();
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addAbsent() {
             recordOffset();
-            markAbsent();
-            count++;
+            advanceAbsent();
         }
 
         private void recordOffset() {
@@ -456,7 +477,7 @@ final class EscfColumnBuilder {
             }
             offsets = ensureIntCapacity(offsets, count + 1);
             offsets[count] = dataLen;
-            return new UnionBuilder(data, typeVec, offsets, dataLen, count, absent);
+            return new UnionBuilder(data, typeVec, offsets, dataLen, count, validity);
         }
 
         @Override
@@ -464,7 +485,7 @@ final class EscfColumnBuilder {
             assert count == docCount : "builder count " + count + " != docCount " + docCount;
             offsets = ensureIntCapacity(offsets, count + 1);
             offsets[count] = dataLen;
-            return EscfColumnData.ofVarWidth(kind, docCount, absent, Arrays.copyOf(offsets, docCount + 1), data.moveToBytesReference());
+            return EscfColumnData.ofVarWidth(kind, docCount, validity, Arrays.copyOf(offsets, docCount + 1), data.moveToBytesReference());
         }
 
         @Override
@@ -502,14 +523,13 @@ final class EscfColumnBuilder {
         @Override
         public void addColumnarArray(byte[] packed) {
             rows.add(packed);
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addAbsent() {
             rows.add(null);
-            markAbsent();
-            count++;
+            advanceAbsent();
         }
 
         @Override
@@ -592,7 +612,7 @@ final class EscfColumnBuilder {
             } catch (IOException e) {
                 throw new UncheckedIOException(e); // in-memory stream never performs IO
             }
-            return EscfColumnData.ofArray(docCount, absent, rowOffsets, child);
+            return EscfColumnData.ofArray(docCount, validity, rowOffsets, child);
         }
     }
 
@@ -607,13 +627,13 @@ final class EscfColumnBuilder {
             this.data = newStream(recycler);
         }
 
-        UnionBuilder(RecyclerBytesStreamOutput data, byte[] typeVec, int[] offsets, int dataLen, int count, FixedBitSet absent) {
+        UnionBuilder(RecyclerBytesStreamOutput data, byte[] typeVec, int[] offsets, int dataLen, int count, FixedBitSet validity) {
             this.data = data;
             this.typeVec = typeVec;
             this.offsets = offsets;
             this.dataLen = dataLen;
             this.count = count;
-            this.absent = absent;
+            this.validity = validity;
         }
 
         @Override
@@ -626,7 +646,7 @@ final class EscfColumnBuilder {
             prep(SourceValueType.LONG);
             writeLongLE(data, value);
             dataLen += 8;
-            count++;
+            advancePresent();
         }
 
         @Override
@@ -634,13 +654,13 @@ final class EscfColumnBuilder {
             prep(SourceValueType.DOUBLE);
             writeLongLE(data, Double.doubleToRawLongBits(value));
             dataLen += 8;
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addBoolean(boolean value) {
             prep(value ? SourceValueType.TRUE : SourceValueType.FALSE);
-            count++;
+            advancePresent();
         }
 
         @Override
@@ -648,7 +668,7 @@ final class EscfColumnBuilder {
             prep(SourceValueType.STRING);
             writeBytes(data, utf8.bytes(), utf8.offset(), utf8.length());
             dataLen += utf8.length();
-            count++;
+            advancePresent();
         }
 
         @Override
@@ -656,7 +676,7 @@ final class EscfColumnBuilder {
             prep(SourceValueType.BINARY);
             writeBytes(data, bytes.bytes(), bytes.offset(), bytes.length());
             dataLen += bytes.length();
-            count++;
+            advancePresent();
         }
 
         @Override
@@ -664,20 +684,19 @@ final class EscfColumnBuilder {
             prep(arrayType);
             writeBytes(data, packed, 0, packed.length);
             dataLen += packed.length;
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addNull() {
             prep(SourceValueType.NULL);
-            count++;
+            advancePresent();
         }
 
         @Override
         public void addAbsent() {
             prep(SourceValueType.ABSENT);
-            markAbsent();
-            count++;
+            advanceAbsent();
         }
 
         private void prep(byte type) {
@@ -699,7 +718,7 @@ final class EscfColumnBuilder {
             offsets[count] = dataLen;
             return EscfColumnData.ofUnion(
                 docCount,
-                absent,
+                validity,
                 new BytesRef(Arrays.copyOf(typeVec, docCount)),
                 Arrays.copyOf(offsets, docCount + 1),
                 data.moveToBytesReference()

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnData.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnData.java
@@ -20,7 +20,7 @@ import org.elasticsearch.sourcebatch.SourceValueType;
  * A single ESCF column held in its <b>native</b> in-memory representation — the metadata factors are
  * live arrays/bitsets rather than pre-serialized bytes
  * <ul>
- *   <li>{@code absent} — validity bitset (bit set = absent); {@code null} when every document is present.</li>
+ *   <li>{@code validity} — Validity bitset (bit set = present); {@code null} when every document is present (dense).</li>
  *   <li>{@code values} — the BOOL value bitset (bit set = {@code true}); {@code null} for every other kind.</li>
  *   <li>{@code typeVector} — one {@link SourceValueType} byte per document as a windowed {@link BytesRef};
  *       {@code null} for kinds whose per-document type is implied by {@link #kind} (everything except UNION).</li>
@@ -39,7 +39,7 @@ import org.elasticsearch.sourcebatch.SourceValueType;
 record EscfColumnData(
     byte kind,
     int docCount,
-    FixedBitSet absent,
+    FixedBitSet validity,
     FixedBitSet values,
     BytesRef typeVector,
     int[] offsets,
@@ -59,27 +59,27 @@ record EscfColumnData(
     }
 
     /** LONG or DOUBLE: a dense 8-byte-per-document value payload; no offsets or type vector. */
-    static EscfColumnData ofFixed64(byte kind, int docCount, FixedBitSet absent, BytesReference data) {
-        return new EscfColumnData(kind, docCount, absent, null, null, null, data, null);
+    static EscfColumnData ofFixed64(byte kind, int docCount, FixedBitSet validity, BytesReference data) {
+        return new EscfColumnData(kind, docCount, validity, null, null, null, data, null);
     }
 
     /** BOOL: the value bitset directly; no byte payload. */
-    static EscfColumnData ofBool(int docCount, FixedBitSet absent, FixedBitSet values) {
-        return new EscfColumnData(EscfColumnKind.BOOL, docCount, absent, values, null, null, null, null);
+    static EscfColumnData ofBool(int docCount, FixedBitSet validity, FixedBitSet values) {
+        return new EscfColumnData(EscfColumnKind.BOOL, docCount, validity, values, null, null, null, null);
     }
 
     /** STRING or BINARY: an offset vector plus a dense byte payload. */
-    static EscfColumnData ofVarWidth(byte kind, int docCount, FixedBitSet absent, int[] offsets, BytesReference data) {
-        return new EscfColumnData(kind, docCount, absent, null, null, offsets, data, null);
+    static EscfColumnData ofVarWidth(byte kind, int docCount, FixedBitSet validity, int[] offsets, BytesReference data) {
+        return new EscfColumnData(kind, docCount, validity, null, null, offsets, data, null);
     }
 
     /** ARRAY: per-row element-range offsets over a native primitive {@code child} sub-column. */
-    static EscfColumnData ofArray(int docCount, FixedBitSet absent, int[] offsets, EscfColumnData child) {
-        return new EscfColumnData(EscfColumnKind.ARRAY, docCount, absent, null, null, offsets, null, child);
+    static EscfColumnData ofArray(int docCount, FixedBitSet validity, int[] offsets, EscfColumnData child) {
+        return new EscfColumnData(EscfColumnKind.ARRAY, docCount, validity, null, null, offsets, null, child);
     }
 
     /** UNION: a per-document type vector, an offset vector, and a dense value payload. */
-    static EscfColumnData ofUnion(int docCount, FixedBitSet absent, BytesRef typeVector, int[] offsets, BytesReference data) {
-        return new EscfColumnData(EscfColumnKind.UNION, docCount, absent, null, typeVector, offsets, data, null);
+    static EscfColumnData ofUnion(int docCount, FixedBitSet validity, BytesRef typeVector, int[] offsets, BytesReference data) {
+        return new EscfColumnData(EscfColumnKind.UNION, docCount, validity, null, typeVector, offsets, data, null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnKind.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnKind.java
@@ -21,9 +21,10 @@ import org.elasticsearch.sourcebatch.SourceValueType;
  * ARRAY:         offsets[(docCount+1) * 4] (per-row element ranges) | child_kind(1) | child_values
  * UNION:         type_vec[docCount] | offsets[(docCount+1) * 4] | dense_values
  * </pre>
- * A validity bitset (LE longs, bit set = absent) is prepended to any kind only when at least one
- * document is absent. ARRAY uses a columnar list layout: the {@code offsets} delimit each row's
- * element range within a single dense primitive {@code child} sub-column (never inline arrays).
+ * A validity bitset (LE longs, bit set = present/valid) is prepended to any kind only
+ * when at least one document is absent. ARRAY uses a columnar list layout: the {@code offsets}
+ * delimit each row's element range within a single dense primitive {@code child} sub-column
+ * (never inline arrays).
  */
 public final class EscfColumnKind {
 

--- a/server/src/main/java/org/elasticsearch/escf/EscfDoubleColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfDoubleColumn.java
@@ -16,8 +16,8 @@ import org.elasticsearch.sourcebatch.SourceValueType;
 /** An ESCF column whose values are all {@code double}s (JSON floats and doubles upcast to 64-bit raw bits). */
 final class EscfDoubleColumn extends AbstractFixed64Column {
 
-    EscfDoubleColumn(int docCount, FixedBitSet absent, BytesReference data) {
-        super(docCount, absent, data);
+    EscfDoubleColumn(int docCount, FixedBitSet validity, BytesReference data) {
+        super(docCount, validity, data);
     }
 
     @Override
@@ -37,11 +37,11 @@ final class EscfDoubleColumn extends AbstractFixed64Column {
 
     @Override
     EscfColumn sliceInternal(int from, int count) {
-        return new EscfDoubleColumn(count, windowBitSet(absent, from, count), data.slice(from * 8, count * 8));
+        return new EscfDoubleColumn(count, windowValidity(validity, from, count), data.slice(from * 8, count * 8));
     }
 
     @Override
     EscfColumnData toColumnData() {
-        return EscfColumnData.ofFixed64(kind(), docCount, absent, data);
+        return EscfColumnData.ofFixed64(kind(), docCount, validity, data);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfLongColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfLongColumn.java
@@ -16,8 +16,8 @@ import org.elasticsearch.sourcebatch.SourceValueType;
 /** An ESCF column whose values are all {@code long}s (JSON ints and longs upcast to 64-bit). */
 final class EscfLongColumn extends AbstractFixed64Column {
 
-    EscfLongColumn(int docCount, FixedBitSet absent, BytesReference data) {
-        super(docCount, absent, data);
+    EscfLongColumn(int docCount, FixedBitSet validity, BytesReference data) {
+        super(docCount, validity, data);
     }
 
     @Override
@@ -37,11 +37,11 @@ final class EscfLongColumn extends AbstractFixed64Column {
 
     @Override
     EscfColumn sliceInternal(int from, int count) {
-        return new EscfLongColumn(count, windowBitSet(absent, from, count), data.slice(from * 8, count * 8));
+        return new EscfLongColumn(count, windowValidity(validity, from, count), data.slice(from * 8, count * 8));
     }
 
     @Override
     EscfColumnData toColumnData() {
-        return EscfColumnData.ofFixed64(kind(), docCount, absent, data);
+        return EscfColumnData.ofFixed64(kind(), docCount, validity, data);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfStringColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfStringColumn.java
@@ -20,8 +20,8 @@ import org.elasticsearch.xcontent.XContentString;
 /** An ESCF column whose values are all UTF-8 strings (variable-length layout: offset vector + dense byte payload). */
 final class EscfStringColumn extends AbstractVarColumn {
 
-    EscfStringColumn(int docCount, FixedBitSet absent, BytesReference data, IntsRef offsets) {
-        super(docCount, absent, data, offsets);
+    EscfStringColumn(int docCount, FixedBitSet validity, BytesReference data, IntsRef offsets) {
+        super(docCount, validity, data, offsets);
     }
 
     @Override
@@ -41,7 +41,7 @@ final class EscfStringColumn extends AbstractVarColumn {
     }
 
     @Override
-    AbstractVarColumn newSlice(int count, FixedBitSet sliceAbsent, BytesReference sliceData, IntsRef sliceOffsets) {
-        return new EscfStringColumn(count, sliceAbsent, sliceData, sliceOffsets);
+    AbstractVarColumn newSlice(int count, FixedBitSet sliceValidity, BytesReference sliceData, IntsRef sliceOffsets) {
+        return new EscfStringColumn(count, sliceValidity, sliceData, sliceOffsets);
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfUnionColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfUnionColumn.java
@@ -33,8 +33,8 @@ final class EscfUnionColumn extends EscfColumn {
     private final IntsRef offsets;
     private final BytesReference data;
 
-    EscfUnionColumn(int docCount, FixedBitSet absent, BytesRef typeVec, IntsRef offsets, BytesReference data) {
-        super(docCount, absent);
+    EscfUnionColumn(int docCount, FixedBitSet validity, BytesRef typeVec, IntsRef offsets, BytesReference data) {
+        super(docCount, validity);
         this.typeVec = typeVec;
         this.offsets = offsets;
         this.data = data;
@@ -108,7 +108,7 @@ final class EscfUnionColumn extends EscfColumn {
     EscfColumn sliceInternal(int from, int count) {
         return new EscfUnionColumn(
             count,
-            windowBitSet(absent, from, count),
+            windowValidity(validity, from, count),
             new BytesRef(typeVec.bytes, typeVec.offset + from, count),
             sliceOffsets(offsets, from, count),
             data
@@ -119,6 +119,6 @@ final class EscfUnionColumn extends EscfColumn {
     EscfColumnData toColumnData() {
         BytesReference newData = sliceData(offsets, data, docCount);
         int[] newOffsets = rebasedOffsets(offsets, docCount);
-        return EscfColumnData.ofUnion(docCount, absent, typeVec, newOffsets, newData);
+        return EscfColumnData.ofUnion(docCount, validity, typeVec, newOffsets, newData);
     }
 }

--- a/server/src/test/java/org/elasticsearch/escf/EscfColumnBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/escf/EscfColumnBuilderTests.java
@@ -28,7 +28,7 @@ public class EscfColumnBuilderTests extends ESTestCase {
         b.addLong(3);
         EscfColumnData data = b.finish(3);
         assertEquals(EscfColumnKind.LONG, data.kind());
-        assertNull("dense column has no validity bitset", data.absent());
+        assertNull("dense column has no validity bitset", data.validity());
         EscfColumn col = EscfColumn.from(data);
         assertEquals(1L, col.getLongValue(0));
         assertEquals(2L, col.getLongValue(1));
@@ -43,7 +43,7 @@ public class EscfColumnBuilderTests extends ESTestCase {
         b.addLong(30);
         EscfColumnData data = b.finish(3);
         assertEquals(EscfColumnKind.LONG, data.kind());
-        assertNotNull("a column with an absent row carries a validity bitset", data.absent());
+        assertNotNull("a column with an absent row carries a validity bitset", data.validity());
         EscfColumn col = EscfColumn.from(data);
         assertFalse(col.isAbsent(0));
         assertTrue(col.isAbsent(1));
@@ -116,6 +116,81 @@ public class EscfColumnBuilderTests extends ESTestCase {
         assertTrue(col.isAbsent(0));
         assertTrue(col.isAbsent(1));
         assertEquals(SourceValueType.ABSENT, col.getTypeByte(0));
+    }
+
+    public void testDenseColumnKeepsNullValidity() {
+        EscfColumnBuilder b = new EscfColumnBuilder();
+        b.addLong(1);
+        b.addLong(2);
+        b.addLong(3);
+        EscfColumnData data = b.finish(3);
+        assertNull("dense column must have null validity (all-present shortcut)", data.validity());
+
+        EscfColumn col = EscfColumn.from(data);
+        assertNull("after from(), dense column still has null validity", col.validity);
+
+        // Slice a dense column: the window must also be null.
+        EscfColumn slice = col.sliceInternal(1, 2);
+        assertNull("slicing a dense column produces a null validity", slice.validity);
+
+        // Round-trip through codec; the validity stays null.
+        EscfColumnData sliceData = slice.toColumnData();
+        assertNull("dense column data after toColumnData() has null validity", sliceData.validity());
+        EscfColumn reparsed = EscfColumn.from(sliceData);
+        assertNull("reparsed dense column has null validity", reparsed.validity);
+    }
+
+    public void testValidityBitsetBackfillOnFirstAbsent() {
+        // Pattern: 3 present, 1 absent, 1 present.
+        EscfColumnBuilder b = new EscfColumnBuilder();
+        b.addLong(10);
+        b.addLong(20);
+        b.addLong(30);
+        b.addAbsent();
+        b.addLong(50);
+        EscfColumnData data = b.finish(5);
+
+        assertNotNull("validity must be set once an absent appears", data.validity());
+        // Under Arrow validity, bit set = present.
+        assertTrue("doc 0 (present before absent) must have its bit set", data.validity().get(0));
+        assertTrue("doc 1 (present before absent) must have its bit set", data.validity().get(1));
+        assertTrue("doc 2 (present before absent) must have its bit set", data.validity().get(2));
+        assertFalse("doc 3 (absent) must have its bit clear", data.validity().get(3));
+        assertTrue("doc 4 (present after absent) must have its bit set", data.validity().get(4));
+
+        // The column view must agree with the validity bitset.
+        EscfColumn col = EscfColumn.from(data);
+        assertFalse(col.isAbsent(0));
+        assertFalse(col.isAbsent(1));
+        assertFalse(col.isAbsent(2));
+        assertTrue(col.isAbsent(3));
+        assertFalse(col.isAbsent(4));
+    }
+
+    public void testTrailingAbsentRoundTrip() {
+        EscfColumnBuilder b = new EscfColumnBuilder();
+        b.addLong(100);
+        b.addLong(200);
+        b.addAbsent(); // last doc
+        EscfColumnData data = b.finish(3);
+
+        assertNotNull(data.validity());
+        assertTrue(data.validity().get(0));
+        assertTrue(data.validity().get(1));
+        assertFalse(data.validity().get(2));
+
+        // Round-trip via EscfColumn.from (which calls windowValidity) and back to EscfColumnData.
+        EscfColumn col = EscfColumn.from(data);
+        assertFalse(col.isAbsent(0));
+        assertFalse(col.isAbsent(1));
+        assertTrue(col.isAbsent(2));
+
+        EscfColumnData roundTripped = col.toColumnData();
+        assertNotNull("trailing-absent column must keep a validity bitset", roundTripped.validity());
+        EscfColumn reparsed = EscfColumn.from(roundTripped);
+        assertFalse(reparsed.isAbsent(0));
+        assertFalse(reparsed.isAbsent(1));
+        assertTrue(reparsed.isAbsent(2));
     }
 
     private static XContentString.UTF8Bytes utf8(String s) {

--- a/server/src/test/java/org/elasticsearch/escf/EscfColumnSliceTests.java
+++ b/server/src/test/java/org/elasticsearch/escf/EscfColumnSliceTests.java
@@ -62,7 +62,7 @@ public class EscfColumnSliceTests extends ESTestCase {
         EscfColumn col = EscfColumn.from(data);
         EscfColumn slice = col.sliceInternal(2, 2);
 
-        assertNull("dense column slice has no absent bitset", sliceData(slice).absent());
+        assertNull("dense column slice has no validity bitset", sliceData(slice).validity());
         assertEquals(300L, slice.getLongValue(0));
         assertEquals(400L, slice.getLongValue(1));
     }
@@ -266,12 +266,8 @@ public class EscfColumnSliceTests extends ESTestCase {
         assertTrue(reparsed.isNull(2));
     }
 
-    /**
-     * Verifies that slicing a column whose absent bitset is sized to the last absent document
-     * (not the full column width) still correctly reports absence for the last document.
-     */
     public void testAbsentBitsetNormalizationOnFrom() {
-        // Build: 4 docs, absent at position 3 (last). The builder sizes the bitset to 4 (last_absent+1).
+        // Build: 4 docs, absent at position 3 (last).
         EscfColumnBuilder b = new EscfColumnBuilder();
         b.addLong(1);
         b.addLong(2);


### PR DESCRIPTION
Previously the ESCF absent bitset used "set bit = absent".
Switch to "set bit = present/valid", null = all-present (dense).
The physical LE-word layout is unchanged.

Builder accumulates validity directly: on the first absent doc the
bitset is materialised and all prior docs are backfilled as present;
every subsequent present add explicitly sets its bit.