### PR TITLE
Bound min_hash filter params to prevent OOM

### DIFF
--- a/docs/changelog/154480.yaml
+++ b/docs/changelog/154480.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 154480
+summary: Bound `min_hash` filter params to prevent OOM
+type: bug

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MinHashTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MinHashTokenFilterFactory.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.analysis.common;
 
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.minhash.MinHashFilter;
 import org.apache.lucene.analysis.minhash.MinHashFilterFactory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -29,6 +30,28 @@ public class MinHashTokenFilterFactory extends AbstractTokenFilterFactory {
 
     MinHashTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(name);
+        int hashCount = settings.getAsInt("hash_count", MinHashFilter.DEFAULT_HASH_COUNT);
+        int bucketCount = settings.getAsInt("bucket_count", MinHashFilter.DEFAULT_BUCKET_COUNT);
+        int hashSetSize = settings.getAsInt("hash_set_size", MinHashFilter.DEFAULT_HASH_SET_SIZE);
+        long maxTokenCount = indexSettings.getMaxTokenCount();
+        long maxOutputTokens = (long) hashCount * bucketCount * hashSetSize;
+        if (maxOutputTokens > maxTokenCount) {
+            throw new IllegalArgumentException(
+                "The product of hash_count ["
+                    + hashCount
+                    + "], bucket_count ["
+                    + bucketCount
+                    + "], and hash_set_size ["
+                    + hashSetSize
+                    + "] is ["
+                    + maxOutputTokens
+                    + "], which exceeds the maximum token count limit ["
+                    + maxTokenCount
+                    + "]. This limit can be set by changing the ["
+                    + IndexSettings.MAX_TOKEN_COUNT_SETTING.getKey()
+                    + "] index level setting."
+            );
+        }
         minHashFilterFactory = new MinHashFilterFactory(convertSettings(settings));
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MinHashTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MinHashTokenFilterFactory.java
@@ -33,24 +33,29 @@ public class MinHashTokenFilterFactory extends AbstractTokenFilterFactory {
         int hashCount = settings.getAsInt("hash_count", MinHashFilter.DEFAULT_HASH_COUNT);
         int bucketCount = settings.getAsInt("bucket_count", MinHashFilter.DEFAULT_BUCKET_COUNT);
         int hashSetSize = settings.getAsInt("hash_set_size", MinHashFilter.DEFAULT_HASH_SET_SIZE);
-        long maxTokenCount = indexSettings.getMaxTokenCount();
-        long maxOutputTokens = (long) hashCount * bucketCount * hashSetSize;
-        if (maxOutputTokens > maxTokenCount) {
-            throw new IllegalArgumentException(
-                "The product of hash_count ["
-                    + hashCount
-                    + "], bucket_count ["
-                    + bucketCount
-                    + "], and hash_set_size ["
-                    + hashSetSize
-                    + "] is ["
-                    + maxOutputTokens
-                    + "], which exceeds the maximum token count limit ["
-                    + maxTokenCount
-                    + "]. This limit can be set by changing the ["
-                    + IndexSettings.MAX_TOKEN_COUNT_SETTING.getKey()
-                    + "] index level setting."
-            );
+        // Only validate when the user explicitly configured parameters; eager instantiation with
+        // default settings (empty Settings) is skipped so that an unrelated low max_token_count
+        // on an index that doesn't use min_hash does not cause index creation to fail.
+        if (settings.hasValue("hash_count") || settings.hasValue("bucket_count") || settings.hasValue("hash_set_size")) {
+            long maxTokenCount = indexSettings.getMaxTokenCount();
+            long maxOutputTokens = (long) hashCount * bucketCount * hashSetSize;
+            if (maxOutputTokens > maxTokenCount) {
+                throw new IllegalArgumentException(
+                    "The product of hash_count ["
+                        + hashCount
+                        + "], bucket_count ["
+                        + bucketCount
+                        + "], and hash_set_size ["
+                        + hashSetSize
+                        + "] is ["
+                        + maxOutputTokens
+                        + "], which exceeds the maximum token count limit ["
+                        + maxTokenCount
+                        + "]. This limit can be set by changing the ["
+                        + IndexSettings.MAX_TOKEN_COUNT_SETTING.getKey()
+                        + "] index level setting."
+                );
+            }
         }
         minHashFilterFactory = new MinHashFilterFactory(convertSettings(settings));
     }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MinHashFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MinHashFilterFactoryTests.java
@@ -97,4 +97,21 @@ public class MinHashFilterFactoryTests extends ESTokenStreamTestCase {
         // hash_set_size = 2 should give us two buckets
         assertStreamHasNumberOfTokens(tokenFilter.create(tokenizer), 2);
     }
+
+    public void testOversizedParametersRejected() {
+        // hash_count * bucket_count * hash_set_size far exceeds the default max_token_count (10000)
+        Settings settings = Settings.builder()
+            .put("index.analysis.filter.test_min_hash.type", "min_hash")
+            .put("index.analysis.filter.test_min_hash.hash_count", "2147483639")
+            .put("index.analysis.filter.test_min_hash.bucket_count", "2147483639")
+            .put("index.analysis.filter.test_min_hash.hash_set_size", "1")
+            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
+            .build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> AnalysisTestsHelper.createTestAnalysisFromSettings(settings, new CommonAnalysisPlugin())
+        );
+        assertThat(e.getMessage(), org.hamcrest.Matchers.containsString(IndexSettings.MAX_TOKEN_COUNT_SETTING.getKey()));
+    }
+
 }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MinHashFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MinHashFilterFactoryTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisTestsHelper;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.test.ESTestCase;


### PR DESCRIPTION
Validate that hash_count * bucket_count * hash_set_size does not exceed index.analyze.max_token_count before constructing the Lucene MinHashFilter. Without this check, extreme values near Integer.MAX_VALUE cause the filter constructor to allocate O(hash_count * bucket_count) TreeSet objects and exhaust heap at construction time, before any tokens are emitted.