### PR TITLE
[9.5] [Inference API] Fix SSE parsing across network read boundaries (#154155)

### DIFF
--- a/docs/changelog/154155.yaml
+++ b/docs/changelog/154155.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 153980
+pr: 154155
+summary: "[Inference API] Fix SSE parsing across network read boundaries"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/XContentUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/XContentUtils.java
@@ -9,9 +9,14 @@ package org.elasticsearch.xpack.inference.external.response;
 
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.core.Strings.format;
@@ -123,6 +128,36 @@ public class XContentUtils {
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, token, parser);
         return parser.floatValue();
+    }
+
+    /**
+     * Applies {@code objectParser} to every root JSON object contained in {@code data} and
+     * returns a stream of all results. A single SSE event's data may legally contain multiple
+     * JSON objects joined by newlines. This helper parses every root object and flat-maps the
+     * per-object results into one stream.
+     * <p>
+     * The parser passed to {@code objectParser} is positioned at a root {@code START_OBJECT} and
+     * <em>must</em> be fully consumed (left at the matching {@code END_OBJECT}) before returning.
+     * Parsers built on {@link org.elasticsearch.xcontent.ConstructingObjectParser} or
+     * {@link XContentParser#map()} already satisfy this contract. Token-navigation parsers
+     * that stop early should wrap the received parser in an
+     * {@link org.elasticsearch.xcontent.XContentSubParser} (whose {@code close()} drains to
+     * {@code END_OBJECT} regardless of nesting depth) and ensure any returned {@link Stream} is
+     * fully materialized before the subparser is closed.
+     */
+    public static <T> Stream<T> parseObjects(
+        XContentParserConfiguration parserConfig,
+        String data,
+        CheckedFunction<XContentParser, Stream<T>, IOException> objectParser
+    ) throws IOException {
+        var results = new ArrayList<T>();
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
+            while (parser.nextToken() != null) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+                objectParser.apply(parser).forEach(results::add);
+            }
+        }
+        return results.stream();
     }
 
     private XContentUtils() {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParser.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.external.response.streaming;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -28,43 +29,60 @@ public class ServerSentEventParser {
     private static final String TYPE_FIELD = "event";
     private static final String DATA_FIELD = "data";
     private final EventBuffer eventBuffer = new EventBuffer();
-    private volatile String previousTokens = "";
+    private final ByteArrayOutputStream pendingLine = new ByteArrayOutputStream();
+    private boolean previousByteWasCarriageReturn;
 
-    public Deque<ServerSentEvent> parse(byte[] bytes) {
+    /**
+     * Parses the given bytes and returns any complete SSE events found so far.
+     * Incomplete lines (no terminator yet) are retained internally and completed on the next call.
+     * An incomplete trailing line present when the stream ends is discarded per the SSE spec.
+     * <p>
+     * Successive calls for a single stream are serial but may execute on different threads.
+     * {@code synchronized} provides cross-thread visibility of the carry-over state
+     * ({@link #pendingLine}, {@link #previousByteWasCarriageReturn}, and the {@link EventBuffer})
+     * without requiring {@code volatile} on each field, and additionally guards against
+     * accidental concurrent access if the calling infrastructure ever changes.
+     */
+    public synchronized Deque<ServerSentEvent> parse(byte[] bytes) {
         if (bytes == null || bytes.length == 0) {
             return new ArrayDeque<>(0);
         }
 
-        var body = previousTokens + new String(bytes, StandardCharsets.UTF_8);
-        var lines = body.lines();
-
         var collector = new ArrayDeque<ServerSentEvent>();
-        lines.reduce((previousLine, nextLine) -> {
-            var line = previousLine.replace(BOM, "");
-
-            if (line.isEmpty()) {
-                eventBuffer.dispatch().ifPresent(collector::offer);
-            } else if (line.startsWith(":") == false) {
-                if (line.contains(":")) {
-                    fieldValueEvent(line);
-                } else if (DATA_FIELD.equals(line.toLowerCase(Locale.ROOT))) {
-                    eventBuffer.data("");
+        for (byte b : bytes) {
+            if (previousByteWasCarriageReturn) {
+                previousByteWasCarriageReturn = false;
+                if (b == '\n') {
+                    // CRLF: the CR already flushed the line; swallow the LF
+                    continue;
                 }
             }
-            return nextLine;
-        }).ifPresent(lastLine -> {
-            if (lastLine.isEmpty()) {
-                // if the last line is an empty line, then we dispatch the event and clear the previousToken cache
-                eventBuffer.dispatch().ifPresent(collector::offer);
-                previousTokens = "";
+            if (b == '\r') {
+                processPendingLine(collector);
+                previousByteWasCarriageReturn = true;
+            } else if (b == '\n') {
+                processPendingLine(collector);
             } else {
-                // we can sometimes get bytes for incomplete messages, so we save them for the next onNext invocation
-                // if we get an onComplete before we clear this cache, we follow the spec to treat it as an incomplete event and discard it
-                // since it was not followed by a blank line
-                previousTokens = lastLine;
+                pendingLine.write(b);
             }
-        });
+        }
         return collector;
+    }
+
+    private void processPendingLine(Deque<ServerSentEvent> collector) {
+        var line = pendingLine.toString(StandardCharsets.UTF_8);
+        pendingLine.reset();
+        line = line.replace(BOM, "");
+
+        if (line.isEmpty()) {
+            eventBuffer.dispatch().ifPresent(collector::offer);
+        } else if (line.startsWith(":") == false) {
+            if (line.contains(":")) {
+                fieldValueEvent(line);
+            } else if (DATA_FIELD.equals(line.toLowerCase(Locale.ROOT))) {
+                eventBuffer.data("");
+            }
+        }
     }
 
     private void fieldValueEvent(String lineWithColon) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessor.java
@@ -11,10 +11,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
 import org.elasticsearch.xpack.inference.common.DelegatingProcessor;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEvent;
@@ -28,6 +26,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.common.Strings.format;
+import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 
 /**
  * Chat Completions Streaming Processor for Anthropic provider
@@ -127,13 +126,13 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
                 logger.debug("Skipping event type [{}] for line [{}].", event.type(), event.data());
                 return Stream.empty();
             case MESSAGE_START_EVENT_TYPE:
-                return parseMessageStart(parserConfig, event.data());
+                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseMessageStart);
             case CONTENT_BLOCK_START_EVENT_TYPE:
-                return parseContentBlockStart(parserConfig, event.data());
+                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseContentBlockStart);
             case CONTENT_BLOCK_DELTA_EVENT_TYPE:
-                return parseContentBlockDelta(parserConfig, event.data());
+                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseContentBlockDelta);
             case MESSAGE_DELTA_EVENT_TYPE:
-                return parseMessageDelta(parserConfig, event.data());
+                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseMessageDelta);
             case MESSAGE_STOP_EVENT_TYPE:
                 return Stream.empty();
             case null, default:
@@ -164,33 +163,28 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      *     }
      * }
      * </code></pre>
-     * @param parserConfig the parser configuration
-     * @param data the event data
+     * @param parser the parser positioned at the root {@code START_OBJECT}
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageStart(
-        XContentParserConfiguration parserConfig,
-        String data
-    ) throws IOException {
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
-            var messageMap = extractInnerStringObjectMap(jsonParser.map(), MESSAGE_FIELD);
-            var model = extractMandatoryString(messageMap, MODEL_FIELD);
-            var id = extractMandatoryString(messageMap, ID_FIELD);
-            var role = extractMandatoryString(messageMap, ROLE_FIELD);
-            var finishReason = extractOptionalString(messageMap, STOP_REASON_FIELD);
-            var usageMap = extractInnerStringObjectMap(messageMap, USAGE_FIELD);
-            var promptTokens = extractMandatoryInteger(usageMap, INPUT_TOKENS_FIELD);
-            var completionTokens = extractMandatoryInteger(usageMap, OUTPUT_TOKENS_FIELD);
-            var totalTokens = completionTokens + promptTokens;
+    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageStart(XContentParser parser)
+        throws IOException {
+        var messageMap = extractInnerStringObjectMap(parser.map(), MESSAGE_FIELD);
+        var model = extractMandatoryString(messageMap, MODEL_FIELD);
+        var id = extractMandatoryString(messageMap, ID_FIELD);
+        var role = extractMandatoryString(messageMap, ROLE_FIELD);
+        var finishReason = extractOptionalString(messageMap, STOP_REASON_FIELD);
+        var usageMap = extractInnerStringObjectMap(messageMap, USAGE_FIELD);
+        var promptTokens = extractMandatoryInteger(usageMap, INPUT_TOKENS_FIELD);
+        var completionTokens = extractMandatoryInteger(usageMap, OUTPUT_TOKENS_FIELD);
+        var totalTokens = completionTokens + promptTokens;
 
-            var usage = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Usage(completionTokens, promptTokens, totalTokens);
-            var delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(null, null, role, null);
-            var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, finishReason, 0);
-            var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(id, List.of(choice), model, null, usage);
+        var usage = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Usage(completionTokens, promptTokens, totalTokens);
+        var delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(null, null, role, null);
+        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, finishReason, 0);
+        var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(id, List.of(choice), model, null, usage);
 
-            return Stream.of(chunk);
-        }
+        return Stream.of(chunk);
     }
 
     /**
@@ -218,42 +212,37 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      *     }
      * }
      * </code></pre>
-     * @param parserConfig the parser configuration
-     * @param data the event data
+     * @param parser the parser positioned at the root {@code START_OBJECT}
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockStart(
-        XContentParserConfiguration parserConfig,
-        String data
-    ) throws IOException {
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
-            var outerMap = jsonParser.map();
-            var index = extractMandatoryInteger(outerMap, INDEX_FIELD);
-            var contentBlockMap = extractInnerStringObjectMap(outerMap, CONTENT_BLOCK_FIELD);
-            var type = extractMandatoryString(contentBlockMap, TYPE_FIELD);
-            StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta delta;
-            if (type.equals(TEXT_TYPE)) {
-                var text = extractMandatoryString(contentBlockMap, TEXT_FIELD);
-                delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(text, null, null, null, null, null);
-            } else if (type.equals(TOOL_USE_TYPE)) {
-                var id = extractMandatoryString(contentBlockMap, ID_FIELD);
-                var name = extractMandatoryString(contentBlockMap, NAME_FIELD);
-                var input = extractOptionalField(contentBlockMap, INPUT_FIELD, Object.class);
-                var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function(
-                    input != null ? input.toString() : null,
-                    name
-                );
-                var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(0, id, function, null);
-                delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(null, null, null, List.of(toolCall));
-            } else {
-                logger.debug("Unknown content block start type [{}] for line [{}].", type, data);
-                return Stream.empty();
-            }
-            var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, index);
-            var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, null);
-            return Stream.of(chunk);
+    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockStart(XContentParser parser)
+        throws IOException {
+        var outerMap = parser.map();
+        var index = extractMandatoryInteger(outerMap, INDEX_FIELD);
+        var contentBlockMap = extractInnerStringObjectMap(outerMap, CONTENT_BLOCK_FIELD);
+        var type = extractMandatoryString(contentBlockMap, TYPE_FIELD);
+        StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta delta;
+        if (type.equals(TEXT_TYPE)) {
+            var text = extractMandatoryString(contentBlockMap, TEXT_FIELD);
+            delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(text, null, null, null, null, null);
+        } else if (type.equals(TOOL_USE_TYPE)) {
+            var id = extractMandatoryString(contentBlockMap, ID_FIELD);
+            var name = extractMandatoryString(contentBlockMap, NAME_FIELD);
+            var input = extractOptionalField(contentBlockMap, INPUT_FIELD, Object.class);
+            var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function(
+                input != null ? input.toString() : null,
+                name
+            );
+            var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(0, id, function, null);
+            delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(null, null, null, List.of(toolCall));
+        } else {
+            logger.debug("Unknown content block start type [{}] for line [{}].", type, outerMap);
+            return Stream.empty();
         }
+        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, index);
+        var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, null);
+        return Stream.of(chunk);
     }
 
     /**
@@ -279,49 +268,41 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      *     }
      * }
      * </code></pre>
-     * @param parserConfig the parser configuration
-     * @param data the event data
+     * @param parser the parser positioned at the root {@code START_OBJECT}
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockDelta(
-        XContentParserConfiguration parserConfig,
-        String data
-    ) throws IOException {
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
-            var outerMap = jsonParser.map();
-            var index = extractMandatoryInteger(outerMap, INDEX_FIELD);
-            var deltaMap = extractInnerStringObjectMap(outerMap, DELTA_FIELD);
-            var type = extractMandatoryString(deltaMap, TYPE_FIELD);
-            StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta delta;
-            if (type.equals(TEXT_DELTA_TYPE)) {
-                var text = extractMandatoryString(deltaMap, TEXT_FIELD);
-                delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(text, null, null, null, null, null);
-            } else if (type.equals(INPUT_JSON_DELTA_TYPE)) {
-                var partialJson = extractMandatoryString(deltaMap, PARTIAL_JSON_FIELD);
-                var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function(
-                    partialJson,
-                    null
-                );
-                var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(0, null, function, null);
-                delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(
-                    null,
-                    null,
-                    null,
-                    List.of(toolCall),
-                    null,
-                    null
-                );
-            } else {
-                logger.debug("Unknown content block delta type [{}] for line [{}].", type, data);
-                return Stream.empty();
-            }
-
-            var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, index);
-            var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, null);
-
-            return Stream.of(chunk);
+    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockDelta(XContentParser parser)
+        throws IOException {
+        var outerMap = parser.map();
+        var index = extractMandatoryInteger(outerMap, INDEX_FIELD);
+        var deltaMap = extractInnerStringObjectMap(outerMap, DELTA_FIELD);
+        var type = extractMandatoryString(deltaMap, TYPE_FIELD);
+        StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta delta;
+        if (type.equals(TEXT_DELTA_TYPE)) {
+            var text = extractMandatoryString(deltaMap, TEXT_FIELD);
+            delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(text, null, null, null, null, null);
+        } else if (type.equals(INPUT_JSON_DELTA_TYPE)) {
+            var partialJson = extractMandatoryString(deltaMap, PARTIAL_JSON_FIELD);
+            var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function(partialJson, null);
+            var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(0, null, function, null);
+            delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(
+                null,
+                null,
+                null,
+                List.of(toolCall),
+                null,
+                null
+            );
+        } else {
+            logger.debug("Unknown content block delta type [{}] for line [{}].", type, outerMap);
+            return Stream.empty();
         }
+
+        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, index);
+        var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, null);
+
+        return Stream.of(chunk);
     }
 
     /**
@@ -351,26 +332,21 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      *     }
      * }
      * </code></pre>
-     * @param parserConfig the parser configuration
-     * @param data the event data
+     * @param parser the parser positioned at the root {@code START_OBJECT}
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    public static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageDelta(
-        XContentParserConfiguration parserConfig,
-        String data
-    ) throws IOException {
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
-            var outerMap = jsonParser.map();
-            var deltaMap = extractInnerStringObjectMap(outerMap, DELTA_FIELD);
-            var finishReason = extractOptionalString(deltaMap, STOP_REASON_FIELD);
-            var usageMap = extractInnerStringObjectMap(outerMap, USAGE_FIELD);
-            var totalTokens = extractMandatoryInteger(usageMap, OUTPUT_TOKENS_FIELD);
+    public static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageDelta(XContentParser parser)
+        throws IOException {
+        var outerMap = parser.map();
+        var deltaMap = extractInnerStringObjectMap(outerMap, DELTA_FIELD);
+        var finishReason = extractOptionalString(deltaMap, STOP_REASON_FIELD);
+        var usageMap = extractInnerStringObjectMap(outerMap, USAGE_FIELD);
+        var totalTokens = extractMandatoryInteger(usageMap, OUTPUT_TOKENS_FIELD);
 
-            var chunk = buildChatCompletionChunk(totalTokens, finishReason);
+        var chunk = buildChatCompletionChunk(totalTokens, finishReason);
 
-            return Stream.of(chunk);
-        }
+        return Stream.of(chunk);
     }
 
     private static StreamingUnifiedChatCompletionResults.ChatCompletionChunk buildChatCompletionChunk(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicStreamingProcessor.java
@@ -14,6 +14,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
 import org.elasticsearch.xpack.inference.common.DelegatingProcessor;
@@ -25,7 +26,6 @@ import java.util.Deque;
 import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.xpack.inference.external.response.XContentUtils.moveToFirstToken;
 import static org.elasticsearch.xpack.inference.external.response.XContentUtils.positionParserAtTokenAfterField;
 
 public class AnthropicStreamingProcessor extends DelegatingProcessor<Deque<ServerSentEvent>, StreamingChatCompletionResults.Results> {
@@ -42,28 +42,8 @@ public class AnthropicStreamingProcessor extends DelegatingProcessor<Deque<Serve
         var results = new ArrayDeque<StreamingChatCompletionResults.Result>(item.size());
         for (var event : item) {
             if (event.hasData()) {
-                try (var parser = parser(event.data())) {
-                    var eventType = eventType(parser);
-                    switch (eventType) {
-                        case "error" -> {
-                            onError(parseError(parser));
-                            return;
-                        }
-                        case "content_block_start" -> {
-                            parseStartBlock(parser).ifPresent(results::offer);
-                        }
-                        case "content_block_delta" -> {
-                            parseMessage(parser).ifPresent(results::offer);
-                        }
-                        case "message_start", "message_stop", "message_delta", "content_block_stop", "ping" -> {
-                            log.debug("Skipping event type [{}] for line [{}].", eventType, item);
-                        }
-                        default -> {
-                            // "handle unknown events gracefully" https://docs.anthropic.com/en/api/messages-streaming#other-events
-                            // we'll ignore unknown events
-                            log.debug("Unknown event type [{}] for line [{}].", eventType, item);
-                        }
-                    }
+                try (var outerParser = parser(event.data())) {
+                    parseObjects(results, outerParser);
                 } catch (Exception e) {
                     log.warn("Failed to parse line {}", event);
                     throw e;
@@ -75,6 +55,37 @@ public class AnthropicStreamingProcessor extends DelegatingProcessor<Deque<Serve
             upstream().request(1);
         } else {
             downstream().onNext(new StreamingChatCompletionResults.Results(results));
+        }
+    }
+
+    private void parseObjects(Deque<StreamingChatCompletionResults.Result> results, XContentParser outerParser) throws IOException {
+        // Loop over all root JSON objects in the event data. Per the SSE spec, successive
+        // data: lines are joined with \n, so one event may legally carry multiple objects.
+        while (outerParser.nextToken() != null) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, outerParser.currentToken(), outerParser);
+            try (var objParser = new XContentSubParser(outerParser)) {
+                var eventType = eventType(objParser);
+                switch (eventType) {
+                    case "error" -> {
+                        onError(parseError(objParser));
+                        return;
+                    }
+                    case "content_block_start" -> {
+                        parseStartBlock(objParser).ifPresent(results::offer);
+                    }
+                    case "content_block_delta" -> {
+                        parseMessage(objParser).ifPresent(results::offer);
+                    }
+                    case "message_start", "message_stop", "message_delta", "content_block_stop", "ping" -> {
+                        log.debug("Skipping event type [{}].", eventType);
+                    }
+                    default -> {
+                        // "handle unknown events gracefully" https://docs.anthropic.com/en/api/messages-streaming#other-events
+                        // we'll ignore unknown events
+                        log.debug("Unknown event type [{}].", eventType);
+                    }
+                }
+            }
         }
     }
 
@@ -111,7 +122,6 @@ public class AnthropicStreamingProcessor extends DelegatingProcessor<Deque<Serve
     }
 
     private static String eventType(XContentParser parser) throws IOException {
-        moveToFirstToken(parser);
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         return parseString(parser, "type");
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioStreamingProcessor.java
@@ -11,10 +11,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.CheckedFunction;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
 import org.elasticsearch.xpack.inference.common.DelegatingProcessor;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEvent;
@@ -22,6 +21,9 @@ import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentE
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 
 class GoogleAiStudioStreamingProcessor extends DelegatingProcessor<Deque<ServerSentEvent>, StreamingChatCompletionResults.Results> {
     private static final Logger log = LogManager.getLogger(GoogleAiStudioStreamingProcessor.class);
@@ -37,9 +39,12 @@ class GoogleAiStudioStreamingProcessor extends DelegatingProcessor<Deque<ServerS
         var results = new ArrayDeque<StreamingChatCompletionResults.Result>(item.size());
         for (ServerSentEvent event : item) {
             if (event.hasData()) {
-                try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, event.data())) {
-                    var delta = content.apply(jsonParser);
-                    results.offer(new StreamingChatCompletionResults.Result(delta));
+                try {
+                    parseObjects(parserConfig, event.data(), p -> {
+                        try (var sub = new XContentSubParser(p)) {
+                            return Stream.of(new StreamingChatCompletionResults.Result(content.apply(sub)));
+                        }
+                    }).forEach(results::offer);
                 } catch (Exception e) {
                     log.warn("Failed to parse event from inference provider: {}", event);
                     throw e;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiStreamingProcessor.java
@@ -12,10 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
 import org.elasticsearch.xpack.inference.common.DelegatingProcessor;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEvent;
@@ -24,6 +21,8 @@ import java.io.IOException;
 import java.util.Deque;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 
 public class GoogleVertexAiStreamingProcessor extends DelegatingProcessor<Deque<ServerSentEvent>, InferenceServiceResults.Result> {
 
@@ -40,18 +39,17 @@ public class GoogleVertexAiStreamingProcessor extends DelegatingProcessor<Deque<
     }
 
     public static Stream<StreamingChatCompletionResults.Result> parse(XContentParserConfiguration parserConfig, ServerSentEvent event) {
-        String data = event.data();
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
-            var chunk = GoogleVertexAiUnifiedStreamingProcessor.GoogleVertexAiChatCompletionChunkParser.parse(jsonParser);
-
-            return chunk.choices()
-                .stream()
-                .map(choice -> choice.delta())
-                .filter(Objects::nonNull)
-                .map(delta -> delta.content())
-                .filter(content -> Strings.isNullOrEmpty(content) == false)
-                .map(StreamingChatCompletionResults.Result::new);
-
+        try {
+            return parseObjects(parserConfig, event.data(), p -> {
+                var chunk = GoogleVertexAiUnifiedStreamingProcessor.GoogleVertexAiChatCompletionChunkParser.parse(p);
+                return chunk.choices()
+                    .stream()
+                    .map(choice -> choice.delta())
+                    .filter(Objects::nonNull)
+                    .map(delta -> delta.content())
+                    .filter(content -> Strings.isNullOrEmpty(content) == false)
+                    .map(StreamingChatCompletionResults.Result::new);
+            });
         } catch (IOException e) {
             throw new ElasticsearchStatusException(
                 "Failed to parse event from inference provider: {}",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedStreamingProcessor.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.xpack.inference.external.response.XContentUtils.moveToFirstToken;
+import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 
 public class GoogleVertexAiUnifiedStreamingProcessor extends DelegatingProcessor<
     Deque<ServerSentEvent>,
@@ -93,17 +93,9 @@ public class GoogleVertexAiUnifiedStreamingProcessor extends DelegatingProcessor
         }
     }
 
-    private Iterator<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parse(
-        XContentParserConfiguration parserConfig,
-        String event
-    ) throws IOException {
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, event)) {
-            moveToFirstToken(jsonParser);
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, jsonParser.currentToken(), jsonParser);
-
-            StreamingUnifiedChatCompletionResults.ChatCompletionChunk chunk = GoogleVertexAiChatCompletionChunkParser.parse(jsonParser);
-            return Collections.singleton(chunk).iterator();
-        }
+    Iterator<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parse(XContentParserConfiguration parserConfig, String event)
+        throws IOException {
+        return parseObjects(parserConfig, event, p -> Stream.of(GoogleVertexAiChatCompletionChunkParser.parse(p))).iterator();
     }
 
     public static class GoogleVertexAiChatCompletionChunkParser {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiStreamingProcessor.java
@@ -13,16 +13,16 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
 import org.elasticsearch.xpack.inference.common.DelegatingProcessor;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEvent;
 
 import java.io.IOException;
 import java.util.Deque;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.parseList;
 import static org.elasticsearch.xpack.inference.external.response.XContentUtils.consumeUntilObjectEnd;
-import static org.elasticsearch.xpack.inference.external.response.XContentUtils.moveToFirstToken;
+import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 import static org.elasticsearch.xpack.inference.external.response.XContentUtils.positionParserAtTokenAfterField;
 
 /**
@@ -128,46 +128,17 @@ public class OpenAiStreamingProcessor extends DelegatingProcessor<Deque<ServerSe
             return Stream.empty();
         }
 
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, event.data())) {
-            moveToFirstToken(jsonParser);
+        try {
+            return parseObjects(parserConfig, event.data(), p -> {
+                try (var sub = new XContentSubParser(p)) {
+                    positionParserAtTokenAfterField(sub, CHOICES_FIELD, FAILED_TO_FIND_FIELD_TEMPLATE);
 
-            XContentParser.Token token = jsonParser.currentToken();
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, token, jsonParser);
-
-            positionParserAtTokenAfterField(jsonParser, CHOICES_FIELD, FAILED_TO_FIND_FIELD_TEMPLATE);
-
-            return parseList(jsonParser, parser -> {
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-
-                positionParserAtTokenAfterField(parser, DELTA_FIELD, FAILED_TO_FIND_FIELD_TEMPLATE);
-
-                var currentToken = parser.currentToken();
-
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, currentToken, parser);
-
-                currentToken = parser.nextToken();
-
-                // continue until the end of delta
-                while (currentToken != null && currentToken != XContentParser.Token.END_OBJECT) {
-                    if (currentToken == XContentParser.Token.START_OBJECT || currentToken == XContentParser.Token.START_ARRAY) {
-                        parser.skipChildren();
-                    }
-
-                    if (currentToken == XContentParser.Token.FIELD_NAME && parser.currentName().equals(CONTENT_FIELD)) {
-                        parser.nextToken();
-                        ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.currentToken(), parser);
-                        var content = parser.text();
-                        consumeUntilObjectEnd(parser); // end delta
-                        consumeUntilObjectEnd(parser); // end choices
-                        return content;
-                    }
-
-                    currentToken = parser.nextToken();
+                    return parseChoicesField(sub).stream()
+                        .filter(Objects::nonNull)
+                        .filter(Predicate.not(String::isEmpty))
+                        .map(StreamingChatCompletionResults.Result::new);
                 }
-
-                consumeUntilObjectEnd(parser); // end choices
-                return ""; // stopped
-            }).stream().filter(Objects::nonNull).filter(Predicate.not(String::isEmpty)).map(StreamingChatCompletionResults.Result::new);
+            });
         } catch (IOException e) {
             throw new ElasticsearchStatusException(
                 "Failed to parse event from inference provider: {}",
@@ -176,5 +147,40 @@ public class OpenAiStreamingProcessor extends DelegatingProcessor<Deque<ServerSe
                 event
             );
         }
+    }
+
+    private static List<String> parseChoicesField(XContentSubParser sub) throws IOException {
+        return parseList(sub, parser -> {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+
+            positionParserAtTokenAfterField(parser, DELTA_FIELD, FAILED_TO_FIND_FIELD_TEMPLATE);
+
+            var currentToken = parser.currentToken();
+
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, currentToken, parser);
+
+            currentToken = parser.nextToken();
+
+            // continue until the end of delta
+            while (currentToken != null && currentToken != XContentParser.Token.END_OBJECT) {
+                if (currentToken == XContentParser.Token.START_OBJECT || currentToken == XContentParser.Token.START_ARRAY) {
+                    parser.skipChildren();
+                }
+
+                if (currentToken == XContentParser.Token.FIELD_NAME && parser.currentName().equals(CONTENT_FIELD)) {
+                    parser.nextToken();
+                    ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.currentToken(), parser);
+                    var content = parser.text();
+                    consumeUntilObjectEnd(parser); // end delta
+                    consumeUntilObjectEnd(parser); // end choices
+                    return content;
+                }
+
+                currentToken = parser.nextToken();
+            }
+
+            consumeUntilObjectEnd(parser); // end choices
+            return ""; // stopped
+        });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedStreamingProcessor.java
@@ -13,10 +13,8 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.inference.completion.ReasoningDetail;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Usage.CompletionTokenDetails;
 import org.elasticsearch.xpack.inference.common.DelegatingProcessor;
@@ -29,13 +27,12 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.COMPLETION_TOKENS_DETAILS_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.REASONING_DETAILS_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.REASONING_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.REASONING_TOKENS_FIELD;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.xpack.inference.external.response.XContentUtils.moveToFirstToken;
+import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 
 public class OpenAiUnifiedStreamingProcessor extends DelegatingProcessor<
     Deque<ServerSentEvent>,
@@ -113,16 +110,7 @@ public class OpenAiUnifiedStreamingProcessor extends DelegatingProcessor<
         XContentParserConfiguration parserConfig,
         String data
     ) throws IOException {
-        try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, data)) {
-            moveToFirstToken(jsonParser);
-
-            XContentParser.Token token = jsonParser.currentToken();
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, token, jsonParser);
-
-            StreamingUnifiedChatCompletionResults.ChatCompletionChunk chunk = ChatCompletionChunkParser.parse(jsonParser);
-
-            return Stream.of(chunk);
-        }
+        return parseObjects(parserConfig, data, p -> Stream.of(ChatCompletionChunkParser.parse(p)));
     }
 
     public static class ChatCompletionChunkParser {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/XContentUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/XContentUtilsTests.java
@@ -11,13 +11,19 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentEOFException;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Locale;
+import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class XContentUtilsTests extends ESTestCase {
 
@@ -336,5 +342,76 @@ public class XContentUtilsTests extends ESTestCase {
             XContentUtils.positionParserAtTokenAfterField(parser, "key", errorFormat);
             expectThrows(ParsingException.class, () -> XContentUtils.parseFloat(parser));
         }
+    }
+
+    public void testParseObjects_SingleObject() throws IOException {
+        var data = """
+            {"key":"value"}
+            """;
+        var results = XContentUtils.parseObjects(XContentParserConfiguration.EMPTY, data, p -> Stream.of(p.map().get("key"))).toList();
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0), is("value"));
+    }
+
+    public void testParseObjects_TwoObjectsJoinedByNewline() throws IOException {
+        var data = """
+            {"key":"first"}
+            {"key":"second"}
+            {"key":"third",
+            "key2":"fourth"}
+            """;
+        var results = XContentUtils.parseObjects(
+            XContentParserConfiguration.EMPTY,
+            data,
+            p -> Stream.of(p.map().values()).flatMap(Collection::stream)
+        ).toList();
+        assertThat(results.size(), is(4));
+        assertThat(results, containsInAnyOrder("first", "second", "third", "fourth"));
+    }
+
+    public void testParseObjects_WithSubParser_EarlyStopBothObjectsConsumed() throws IOException {
+        // Verifies that when the objectParser wraps in XContentSubParser and stops early (does not
+        // read to END_OBJECT), XContentSubParser.close() drains the remainder so the outer loop
+        // correctly advances to the next root object.
+        var data = """
+            {"key":"first","other":"ignored"}
+            {"key":"second","other":"ignored"}
+            """;
+        var results = XContentUtils.parseObjects(XContentParserConfiguration.EMPTY, data, p -> {
+            try (var sub = new XContentSubParser(p)) {
+                XContentUtils.positionParserAtTokenAfterField(sub, "key", "Error: %s");
+                // Eagerly capture the text before the subparser closes and drains.
+                return Stream.of(sub.text());
+            }
+        }).toList();
+        assertThat(results.size(), is(2));
+        assertThat(results.get(0), is("first"));
+        assertThat(results.get(1), is("second"));
+    }
+
+    public void testParseObjects_EmptyData_ReturnsEmptyStream() throws IOException {
+        var results = XContentUtils.parseObjects(XContentParserConfiguration.EMPTY, "", p -> Stream.of("unreachable")).toList();
+        assertThat(results.size(), is(0));
+    }
+
+    public void testParseObjects_NonObjectRoot_Throws() {
+        expectThrows(
+            ParsingException.class,
+            () -> XContentUtils.parseObjects(XContentParserConfiguration.EMPTY, "[1,2,3]", p -> Stream.empty())
+        );
+    }
+
+    public void testParseObjects_FlatMapsAcrossObjects() throws IOException {
+        var data = """
+            {"emit":false}
+            {"emit":true}
+            {"emit":false}
+            """;
+        var results = XContentUtils.parseObjects(XContentParserConfiguration.EMPTY, data, p -> {
+            var map = p.map();
+            return Boolean.TRUE.equals(map.get("emit")) ? Stream.of("emitted") : Stream.empty();
+        }).toList();
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0), is("emitted"));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParserTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParserTests.java
@@ -10,12 +10,19 @@ package org.elasticsearch.xpack.inference.external.response.streaming;
 import org.elasticsearch.test.ESTestCase;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class ServerSentEventParserTests extends ESTestCase {
+    // Shared constants for mixed-terminator tests: the same values appear in both the
+    // input byte arrays and the expected ServerSentEvent results.
+    private static final String MIXED_TERM_EVENT_TYPE = "user_join";
+    private static final String MIXED_TERM_DATA = "{\"username\":\"Alice\"}";
+
     public void testRetryAndIdAreUnimplemented() {
         var payload = """
             id: 2
@@ -152,5 +159,114 @@ public class ServerSentEventParserTests extends ESTestCase {
             """.getBytes(StandardCharsets.UTF_8));
 
         assertEvents(events, List.of(new ServerSentEvent("test")));
+    }
+
+    public void testParsingIsIndependentOfNetworkReadBoundaries() {
+        var first = "first";
+        var second = "second";
+        for (var sep : new String[] { "\n", "\r", "\r\n" }) {
+            var payload = ("data: " + first + sep + sep + "data: " + second + sep + sep).getBytes(StandardCharsets.UTF_8);
+            for (int splitAt = 1; splitAt < payload.length; splitAt++) {
+                var parser = new ServerSentEventParser();
+                var allEvents = new ArrayDeque<ServerSentEvent>();
+                parser.parse(Arrays.copyOfRange(payload, 0, splitAt)).forEach(allEvents::offer);
+                parser.parse(Arrays.copyOfRange(payload, splitAt, payload.length)).forEach(allEvents::offer);
+                assertEvents(
+                    allEvents,
+                    List.of(new ServerSentEvent("message", first), new ServerSentEvent("message", second)),
+                    "separator=" + sep.replace("\r", "\\r").replace("\n", "\\n") + " splitAt=" + splitAt
+                );
+            }
+        }
+    }
+
+    public void testUtf8CharacterCanBeSplitAcrossNetworkReads() {
+        // U+1F389 PARTY POPPER — 4 bytes in UTF-8: 0xF0 0x9F 0x8E 0x89
+        var emoji = "🎉";
+        var payload = ("data: " + emoji + "\n\n").getBytes(StandardCharsets.UTF_8);
+        for (int splitAt = 1; splitAt < payload.length; splitAt++) {
+            var parser = new ServerSentEventParser();
+            var allEvents = new ArrayDeque<ServerSentEvent>();
+            parser.parse(Arrays.copyOfRange(payload, 0, splitAt)).forEach(allEvents::offer);
+            parser.parse(Arrays.copyOfRange(payload, splitAt, payload.length)).forEach(allEvents::offer);
+            assertEvents(allEvents, List.of(new ServerSentEvent("message", emoji)), "splitAt=" + splitAt);
+        }
+    }
+
+    public void testToolCallIdIsNotLostAcrossReadBoundary() {
+        // The event-separator \n\n is split across two network reads
+        // so the first \n ends read-1 and the second \n begins read-2.
+        // This ensures that events 1 and 2 are not merged.
+        var reasoningData = """
+            {"id":"1",\
+            "choices":[{"delta":{"content":"thinking"},"finish_reason":null,"index":0}],\
+            "model":"m","object":"chat.completion.chunk"}\
+            """;
+        var toolCallIdData = """
+            {"id":"2",\
+            "choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function"}]},"finish_reason":null,"index":0}],\
+            "model":"m","object":"chat.completion.chunk"}\
+            """;
+        var argsData = """
+            {"id":"3",\
+            "choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}","name":"fn"}}]},"finish_reason":null,"index":0}],\
+            "model":"m","object":"chat.completion.chunk"}\
+            """;
+
+        // Split so the first \n of the \n\n separator ends the first read
+        var firstRead = ("data: " + reasoningData + "\n").getBytes(StandardCharsets.UTF_8);
+        var secondRead = ("\ndata: " + toolCallIdData + "\n\ndata: " + argsData + "\n\n").getBytes(StandardCharsets.UTF_8);
+
+        var parser = new ServerSentEventParser();
+        var allEvents = new ArrayDeque<ServerSentEvent>();
+        parser.parse(firstRead).forEach(allEvents::offer);
+        parser.parse(secondRead).forEach(allEvents::offer);
+
+        assertThat(allEvents.size(), equalTo(3));
+    }
+
+    /**
+     * Verifies that event dispatch is triggered by an <em>empty line</em>, regardless of which
+     * terminator ({@code \n}, {@code \r}, or {@code \r\n}) ends each field line.
+     *
+     * <p>Key WHATWG rule (https://html.spec.whatwg.org/multipage/server-sent-events.html):
+     * an LF that is <em>preceded by a CR</em> is the second half of a CRLF pair and does
+     * <em>not</em> start a new line. So {@code data: ...\r\n} is one terminated line, not a
+     * data line plus a blank line — and therefore does not dispatch an event.
+     */
+    public void testMixedLineTerminatorsWithinSingleEvent() {
+        {
+            // Case 1: CRLF field line, then LF data line, then LF blank line → one event dispatched.
+            var scenario = ("event: " + MIXED_TERM_EVENT_TYPE + "\r\ndata: " + MIXED_TERM_DATA + "\n\n").getBytes(StandardCharsets.UTF_8);
+            var parser = new ServerSentEventParser();
+            assertEvents(parser.parse(scenario), List.of(new ServerSentEvent(MIXED_TERM_EVENT_TYPE, MIXED_TERM_DATA)));
+        }
+        {
+            // Case 2: the bytes end with \r\n — that is ONE CRLF terminator for the data line, NOT a
+            // data-line CR followed by a blank LF. No blank line arrives, so the event is not dispatched
+            // (incomplete trailing event is discarded per the spec).
+            var scenario = ("event: " + MIXED_TERM_EVENT_TYPE + "\ndata: " + MIXED_TERM_DATA + "\r\n").getBytes(StandardCharsets.UTF_8);
+            var parser = new ServerSentEventParser();
+            assertTrue(parser.parse(scenario).isEmpty());
+        }
+        {
+            // Case 3: CR terminates the data line; the second CR is an independent blank line → dispatched.
+            // This is the unambiguous contrast to Case 2: two CRs are two separate terminators.
+            var scenario = ("event: " + MIXED_TERM_EVENT_TYPE + "\ndata: " + MIXED_TERM_DATA + "\r\r").getBytes(StandardCharsets.UTF_8);
+            var parser = new ServerSentEventParser();
+            assertEvents(parser.parse(scenario), List.of(new ServerSentEvent(MIXED_TERM_EVENT_TYPE, MIXED_TERM_DATA)));
+        }
+        {
+            // Case 4: CRLF data line followed by a CRLF blank line → one event dispatched.
+            var scenario = ("event: " + MIXED_TERM_EVENT_TYPE + "\ndata: " + MIXED_TERM_DATA + "\r\n\r\n").getBytes(StandardCharsets.UTF_8);
+            var parser = new ServerSentEventParser();
+            assertEvents(parser.parse(scenario), List.of(new ServerSentEvent(MIXED_TERM_EVENT_TYPE, MIXED_TERM_DATA)));
+        }
+    }
+
+    private void assertEvents(Deque<ServerSentEvent> actualEvents, List<ServerSentEvent> expectedEvents, String context) {
+        assertThat(context, actualEvents.size(), equalTo(expectedEvents.size()));
+        var expectedEvent = expectedEvents.iterator();
+        actualEvents.forEach(event -> assertThat(context, event, equalTo(expectedEvent.next())));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessorTests.java
@@ -310,4 +310,22 @@ public class AnthropicChatCompletionStreamingProcessorTests extends ESTestCase {
             is("Field [model] in Anthropic chat completions response is of unexpected type [Integer]. Expected type is [String].")
         );
     }
+
+    public void testMultipleJsonObjectsInSingleEventAreParsed() {
+        var firstDelta = """
+            {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\
+            """;
+        var secondDelta = """
+            {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"World"}}\
+            """;
+        var item = events(List.of(Pair.of("content_block_delta", firstDelta + "\n" + secondDelta)));
+
+        var response = onNext(new AnthropicChatCompletionStreamingProcessor((noOp1, noOp2) -> {
+            fail("This should not be called");
+            return null;
+        }), item);
+        assertThat(response.chunks().size(), is(2));
+        assertContent(response, "Hello");
+        assertContent(response, "World");
+    }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicStreamingProcessorTests.java
@@ -130,6 +130,20 @@ public class AnthropicStreamingProcessorTests extends ESTestCase {
         verify(downstream, times(0)).onNext(any());
     }
 
+    public void testMultipleJsonObjectsInSingleEventAreParsed() {
+        var firstDelta = """
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}\
+            """;
+        var secondDelta = """
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": ", World"}}\
+            """;
+        var item = events(firstDelta + "\n" + secondDelta);
+
+        var response = onNext(new AnthropicStreamingProcessor(), item);
+        assertThat(response.results().size(), equalTo(2));
+        assertThat(response.results(), containsResults("Hello", ", World"));
+    }
+
     private static ElasticsearchStatusException onError(Deque<ServerSentEvent> item) {
         var processor = new AnthropicStreamingProcessor();
         var response = new AtomicReference<Throwable>();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioStreamingProcessorTests.java
@@ -139,6 +139,27 @@ public class GoogleAiStudioStreamingProcessorTests extends ESTestCase {
 
         var processor = new GoogleAiStudioStreamingProcessor(noOp -> { throw expectedException; });
 
-        assertThat(onError(processor, events("hi")), sameInstance(expectedException));
+        // Use a valid JSON object so parseObjects can tokenize and invoke the content function.
+        assertThat(onError(processor, events("{}")), sameInstance(expectedException));
+    }
+
+    public void testMultipleJsonObjectsInSingleEventAreParsed() {
+        var firstJson = """
+             {
+              "candidates": [{"content": {"parts": [{"text": "Hello"}], "role": "model"}, "finishReason": "STOP", "index": 0}],
+              "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 1}
+            }\
+            """;
+        var secondJson = """
+             {
+              "candidates": [{"content": {"parts": [{"text": ", World"}], "role": "model"}, "finishReason": "STOP", "index": 0}],
+              "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 1}
+            }\
+            """;
+        var item = events(firstJson + "\n" + secondJson);
+
+        var response = onNext(new GoogleAiStudioStreamingProcessor(GoogleAiStudioCompletionResponseEntity::content), item);
+        assertThat(response.results().size(), equalTo(2));
+        assertThat(response.results(), containsResults("Hello", ", World"));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiStreamingProcessorTests.java
@@ -59,6 +59,17 @@ public class GoogleVertexAiStreamingProcessorTests extends ESTestCase {
         assertThat(exception, instanceOf(XContentParseException.class));
     }
 
+    public void testMultipleJsonObjectsInSingleEventAreParsed() throws IOException {
+        var item = new ArrayDeque<ServerSentEvent>();
+        item.offer(new ServerSentEvent(vertexAiJsonResponse("hello", false) + vertexAiJsonResponse("world", true)));
+
+        var response = onNext(new GoogleVertexAiStreamingProcessor(), item);
+        var json = toJsonString(response);
+
+        assertThat(json, equalTo("""
+            {"completion":[{"delta":"hello"},{"delta":"world"}]}"""));
+    }
+
     private String vertexAiJsonResponse(String content, boolean includeFinishReason) {
         String finishReason = includeFinishReason ? "\"finishReason\": \"STOP\"," : "";
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedStreamingProcessorTests.java
@@ -15,6 +15,9 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.hamcrest.Matchers.is;
 
 public class GoogleVertexAiUnifiedStreamingProcessorTests extends ESTestCase {
 
@@ -214,5 +217,30 @@ public class GoogleVertexAiUnifiedStreamingProcessorTests extends ESTestCase {
         } catch (IOException e) {
             fail("IOException during test: " + e.getMessage());
         }
+    }
+
+    public void testMultipleJsonObjectsInSingleEventAreParsed() throws IOException {
+        var firstChunkData = """
+            {
+                "candidates": [],
+                "usageMetadata": {},
+                "modelVersion": "m",
+                "responseId": "r1"
+            }\
+            """;
+        var secondChunkData = """
+            {
+                "candidates": [],
+                "usageMetadata": {},
+                "modelVersion": "m",
+                "responseId": "r2"
+            }\
+            """;
+        var data = firstChunkData + "\n" + secondChunkData;
+        var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
+        var processor = new GoogleVertexAiUnifiedStreamingProcessor(RuntimeException::new);
+        var chunks = new ArrayList<>();
+        processor.parse(parserConfig, data).forEachRemaining(chunks::add);
+        assertThat(chunks.size(), is(2));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiStreamingProcessorTests.java
@@ -184,6 +184,56 @@ public class OpenAiStreamingProcessorTests extends ESTestCase {
         verify(downstream, times(0)).onNext(any());
     }
 
+    public void testMultipleJsonObjectsInSingleEventAreParsed() throws IOException {
+        var firstChunkData = """
+            {
+                "id":"1",
+                "object":"chat.completion.chunk",
+                "choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]
+            }\
+            """;
+        var secondChunkData = """
+            {
+                "id":"2",
+                "object":"chat.completion.chunk",
+                "choices":[{"index":0,"delta":{"content":"World"},"finish_reason":null}]
+            }\
+            """;
+        var item = new ArrayDeque<ServerSentEvent>();
+        item.offer(new ServerSentEvent(firstChunkData + "\n" + secondChunkData));
+
+        var response = onNext(new OpenAiStreamingProcessor(), item);
+        var json = toJsonString(response);
+
+        assertThat(json, equalTo("""
+            {"completion":[{"delta":"Hello"},{"delta":"World"}]}"""));
+    }
+
+    public void testMultipleJsonObjectsInSingleEvent_FinishChunkIsSkipped() throws IOException {
+        var contentChunkData = """
+            {
+                "id":"1",
+                "object":"chat.completion.chunk",
+                "choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]
+            }\
+            """;
+        var stopChunkData = """
+            {
+                "id":"2",
+                "object":"chat.completion.chunk",
+                "choices":[{"index":1,"delta":{},"finish_reason":"stop"}]
+            }\
+            """;
+        var item = new ArrayDeque<ServerSentEvent>();
+        item.offer(new ServerSentEvent(contentChunkData + "\n" + stopChunkData));
+
+        var response = onNext(new OpenAiStreamingProcessor(), item);
+        var json = toJsonString(response);
+
+        assertThat(json, equalTo("""
+            {"completion":[{"delta":"Hello"}]}"""));
+    }
+
     private String toJsonString(ChunkedToXContent chunkedToXContent) throws IOException {
         try (var builder = XContentFactory.jsonBuilder()) {
             chunkedToXContent.toXContentChunked(EMPTY_PARAMS).forEachRemaining(xContent -> {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedStreamingProcessorTests.java
@@ -576,4 +576,29 @@ public class OpenAiUnifiedStreamingProcessorTests extends ESTestCase {
             }
         }
     }
+
+    public void testMultipleJsonObjectsInSingleEventAreParsed() throws IOException {
+        var firstChunkData = """
+            {
+                "id": "1",
+                "choices": [],
+                "model": "m",
+                "object": "chat.completion.chunk"
+            }\
+            """;
+        var secondChunkData = """
+            {
+                "id": "2",
+                "choices": [],
+                "model": "m",
+                "object": "chat.completion.chunk"
+            }\
+            """;
+        var data = firstChunkData + "\n" + secondChunkData;
+        var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
+        var chunks = OpenAiUnifiedStreamingProcessor.parse(parserConfig, data).toList();
+        assertThat(chunks.size(), is(2));
+        assertThat(chunks.get(0).id(), is("1"));
+        assertThat(chunks.get(1).id(), is("2"));
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Inference API] Fix SSE parsing across network read boundaries (#154155)](https://github.com/elastic/elasticsearch/pull/154155)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)