### PR TITLE
Mute org.elasticsearch.index.mapper.blockloader.KeywordFieldBlockLoaderTests #154349

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -633,6 +633,8 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/154395
 - class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
   issue: https://github.com/elastic/elasticsearch/issues/154350
+- class: org.elasticsearch.index.mapper.blockloader.KeywordFieldBlockLoaderTests
+  issue: https://github.com/elastic/elasticsearch/issues/154349
 - class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
   method: testControllerSpawnGatedBySettings
   issue: https://github.com/elastic/elasticsearch/issues/154291


### PR DESCRIPTION
Class-level mute; failing across the fleet since Jul 16 (681 failures/week), sibling `IpFieldBlockLoaderTests` was already muted for the same wave (#154350 / #154411).

Relates #154349

Made with [Cursor](https://cursor.com)