### PR TITLE
Fixed IpFieldBlockLoaderTests test failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -631,10 +631,6 @@ tests:
 - class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
   method: testMasterFailoverDuringSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/154395
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  issue: https://github.com/elastic/elasticsearch/issues/154350
-- class: org.elasticsearch.index.mapper.blockloader.KeywordFieldBlockLoaderTests
-  issue: https://github.com/elastic/elasticsearch/issues/154349
 - class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
   method: testControllerSpawnGatedBySettings
   issue: https://github.com/elastic/elasticsearch/issues/154291

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -344,14 +344,13 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             return ESTestCase.randomBoolean();
         }
 
-        // doc_values can't be disabled here.
+        // doc_values can't be disabled here; multi_value:false is exercised separately by SingleValueDocValuesDataSourceHandler.
         return ESTestCase.randomFrom(
             List.of(
                 true,
                 Map.of("multi_value", true),
                 Map.of("on_failure", ESTestCase.randomFrom("fail", "ignore")),
                 Map.of("multi_value", true, "on_failure", ESTestCase.randomFrom("fail", "ignore")),
-                Map.of("multi_value", false, "on_failure", "ignore"),
                 Map.of("nullability", false, "on_failure", "ignore")
             )
         );


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/154024 we introduced a new mapping parameter combo into [DefaultMappingParametersHandler](https://github.com/elastic/elasticsearch/blob/794939efe99a4d953fdc152ea428e945e2047b48/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java#L354): `{multi_value = false, on_failure = ignore}`. Whenever the underlying data generator generates more than one value, `multi_value = false` would reject that and throw. However, with `on_failure = ignore` set, this failure is swallowed. This is a correct test, but its undermined by the fact that `DefaultMappingParametersHandler`'s data generator may generate multiple values in a single-value context (`multi_value = false`). This is a problem because the tests expect to get those multiple values back, but due to `multi_value = false`, only one value is returned.

This problem is addressed by `SingleValueDocValuesDataSourceHandler`, which exercises `multi_value = false`.

Hence, I believe we shouldn't generate `multi_value = false` in `DefaultMappingParametersHandler`.

Closes https://github.com/elastic/elasticsearch/issues/154350, https://github.com/elastic/elasticsearch/issues/154349

Note, the `multi_value = false` + `on_failure = ignore` + multiple values is [covered](https://github.com/elastic/elasticsearch/blob/794939efe99a4d953fdc152ea428e945e2047b48/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java#L653) by unit tests.