### PR TITLE
Grant write_fleet_secrets privilege to elastic/fleet-server service account

### DIFF
--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -114,6 +114,7 @@ public class ServiceAccountIT extends ESRestTestCase {
                 "monitor",
                 "manage_own_api_key",
                 "read_fleet_secrets",
+                "write_fleet_secrets",
                 "cluster:admin/xpack/connector/*"
               ],
               "indices": [

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -46,7 +46,12 @@ final class ElasticServiceAccounts {
         "fleet-server",
         new RoleDescriptor(
             NAMESPACE + "/fleet-server",
-            new String[] { "monitor", "manage_own_api_key", "read_fleet_secrets", "write_fleet_secrets", "cluster:admin/xpack/connector/*" },
+            new String[] {
+                "monitor",
+                "manage_own_api_key",
+                "read_fleet_secrets",
+                "write_fleet_secrets",
+                "cluster:admin/xpack/connector/*" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -46,7 +46,7 @@ final class ElasticServiceAccounts {
         "fleet-server",
         new RoleDescriptor(
             NAMESPACE + "/fleet-server",
-            new String[] { "monitor", "manage_own_api_key", "read_fleet_secrets", "cluster:admin/xpack/connector/*" },
+            new String[] { "monitor", "manage_own_api_key", "read_fleet_secrets", "write_fleet_secrets", "cluster:admin/xpack/connector/*" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -304,8 +304,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
 
         final TransportRequest request = mock(TransportRequest.class);
         assertThat(role.cluster().check("cluster:admin/fleet/secrets/get", request, authentication), is(true));
-        assertThat(role.cluster().check("cluster:admin/fleet/secrets/post", request, authentication), is(false));
-        assertThat(role.cluster().check("cluster:admin/fleet/secrets/delete", request, authentication), is(false));
+        assertThat(role.cluster().check("cluster:admin/fleet/secrets/post", request, authentication), is(true));
+        assertThat(role.cluster().check("cluster:admin/fleet/secrets/delete", request, authentication), is(true));
 
         final IndexAbstraction apmSampledTracesIndex = mockIndexAbstraction("traces-apm.sampled-" + randomAlphaOfLengthBetween(1, 20));
         assertThat(role.indices().allowedIndicesMatcher(TransportDeleteAction.NAME).test(apmSampledTracesIndex), is(true));


### PR DESCRIPTION
Adds `write_fleet_secrets` to the cluster privileges for the `elastic/fleet-server` built-in service account (`ElasticServiceAccounts.java`) and updates `ElasticServiceAccountsTests` accordingly.

## Motivation

Fleet Server needs to write output API key secrets to `.fleet-secrets` (via `POST /_fleet/secret`) so that the raw key material is no longer stored in plaintext in `.fleet-agents-7`. Currently the `kibana_system` role has broad read access to `.fleet-agents*`, which means any principal with `kibana_system` credentials can extract plaintext output API keys and use them to write to SIEM data streams.

A follow-up fleet-server PR ([elastic/fleet-server#7416](https://github.com/elastic/fleet-server/pull/7416)) changes `policy_output.go` to call `POST /_fleet/secret` when generating a new output API key, storing only a `$co.elastic.secret{id}` reference in `.fleet-agents-7` and resolving the reference at checkin time. `write_fleet_secrets` also covers `DELETE`, used by that same PR to clean up old secrets when output API keys are rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)