### PR TITLE
[9.5] ES|QL: name the column and declared type on a declared-read coercion failure (#154402)

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -1943,7 +1943,7 @@ public class OrcFormatReaderTests extends ESTestCase {
                 new RangeReadContext(List.of("ts"), 10, 0, orcData.length, plannerSchema, ErrorPolicy.STRICT)
             )
         ) {
-            expectThrows(IllegalArgumentException.class, () -> {
+            expectThrows(InvalidArgumentException.class, () -> {
                 while (it.hasNext()) {
                     it.next().releaseBlocks();
                 }
@@ -1996,7 +1996,7 @@ public class OrcFormatReaderTests extends ESTestCase {
                 new RangeReadContext(List.of("vals"), 10, 0, orcData.length, plannerSchema, ErrorPolicy.STRICT)
             )
         ) {
-            expectThrows(IllegalArgumentException.class, () -> {
+            expectThrows(InvalidArgumentException.class, () -> {
                 while (it.hasNext()) {
                     it.next().releaseBlocks();
                 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -231,6 +231,7 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         "long_csv_equiv",
         "long_parquet_equiv",
         "typed_strings_parquet",
+        "empty_string_double",
         "logs_deferred_coerce",
         "logs_bad_date_token",
         "logs_bad_date_failfast",
@@ -2014,6 +2015,65 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
         long parquetValue = readSingleLong("FROM long_parquet_equiv | SORT id | KEEP n | LIMIT 1");
         assertThat("text and columnar coerce the same token to the same long", parquetValue, equalTo(csvValue));
         assertThat(csvValue, equalTo(42L));
+    }
+
+    public void testEmptyStringDeclaredDoubleReproducesReportedFailureWithContext() throws Exception {
+        // Reproduces the exact reported failure end to end: a string column of EMPTY strings declared `double`.
+        // Double.parseDouble("") threw a bare `NumberFormatException: empty String` with no column or type, on the
+        // query that materialized the column. The read still fails under fail_fast, but the client-visible message
+        // now names the column and the declared type and points at error_mode -- the original `empty String` detail
+        // survives as context, no longer the whole story.
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        Path parquet = writeParquetEmptyStringFixture();
+        Map<String, DatasetFieldMapping> props = new LinkedHashMap<>();
+        props.put("id", new DatasetFieldMapping("long", null));
+        props.put("d", new DatasetFieldMapping("double", "s")); // s is the empty string ""
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "empty_string_double",
+                    "local_ds",
+                    parquet.toUri().toString(),
+                    null,
+                    new HashMap<>(Map.of("format", "parquet", "error_mode", "fail_fast")),
+                    new DatasetMapping(new DatasetMapping.Mappings(DatasetMapping.Dynamic.FALSE, props))
+                )
+            )
+        );
+        Exception e = expectThrows(
+            Exception.class,
+            () -> run(syncEsqlQueryRequest("FROM empty_string_double | KEEP d | LIMIT 10"), TIMEOUT).close()
+        );
+        String message = e.getMessage();
+        assertThat("the original symptom is retained as context", message, containsString("empty String"));
+        assertThat("the failing column is named", message, containsString("Column ["));
+        assertThat("the declared type is named", message, containsString("declared type [double]"));
+        assertThat("the tolerance path is pointed at", message, containsString("error_mode=null_field"));
+    }
+
+    private Path writeParquetEmptyStringFixture() throws IOException {
+        // One required UTF8 string column holding the empty string -- the exact value from the reported incident.
+        MessageType schema = MessageTypeParser.parseMessageType("message empties { required int64 id; required binary s (UTF8); }");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(baos))
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            Group g = factory.newGroup();
+            g.add("id", 1L);
+            g.add("s", "");
+            writer.write(g);
+        }
+        Path tempFile = createTempDir().resolve("empty_string.parquet");
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
     }
 
     private long readSingleLong(String query) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercions.java
@@ -362,6 +362,20 @@ public final class DeclaredTypeCoercions {
      * propagates and the read fails; with a live sink the caller nulls the cell/position and one
      * capped response {@code Warning} header records the reason. Callers append the null
      * themselves — this method only decides throw-vs-warn.
+     * <p>
+     * As the single decision point it also normalizes the strict failure. The coercers throw heterogeneous
+     * low-level exceptions ({@code NumberFormatException} from {@code Double.parseDouble}, a
+     * {@code DateTimeException} from a date parse, {@code InvalidArgumentException} from the reused {@code ::}
+     * engine), so re-raising them verbatim leaked a bare message (e.g. {@code empty String}) with no column
+     * or declared type on the paths that surface the exception directly (a direct {@link #castBlock}, the ORC
+     * fused arms), and a status only incidentally uniform — a leaked {@code DateTimeException} is not an
+     * {@link IllegalArgumentException} and would surface as a 500 rather than the numeric paths' 400. The
+     * strict branch instead re-raises one {@link InvalidArgumentException} (a client 400 that survives the
+     * data-node hop) naming the column, the declared type and the offending value, with the original chained
+     * as the cause and an {@code error_mode=null_field} pointer; readers that wrap a read failure in their own
+     * exception (the Parquet iterator) carry the enriched message in the cause. {@code columnName} is thus
+     * load-bearing in strict mode too (a {@code null} name degrades to {@code <unknown>}), and strict and
+     * lenient share one detail string so they cannot drift.
      */
     public static void onCoercionFailure(
         @Nullable String columnName,
@@ -370,20 +384,18 @@ public final class DeclaredTypeCoercions {
         RuntimeException e,
         @Nullable SkipWarnings warnings
     ) {
+        String detail = "Column ["
+            + (columnName == null ? "<unknown>" : columnName)
+            + "]: cannot coerce value from ["
+            + from.typeName()
+            + "] to declared type ["
+            + to.typeName()
+            + "]: "
+            + e.getMessage();
         if (warnings == null) {
-            throw e;
+            throw new InvalidArgumentException(e, detail + "; set error_mode=null_field to read failing values as null instead of failing");
         }
-        warnings.add(
-            "Column ["
-                + columnName
-                + "]: cannot coerce value from ["
-                + from.typeName()
-                + "] to declared type ["
-                + to.typeName()
-                + "]: "
-                + e.getMessage()
-                + "; returning null"
-        );
+        warnings.add(detail + "; returning null");
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DeclaredTypeCoercionsTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -530,7 +531,7 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
     public void testCastWholeNumberToDatetimeUnparseableTokenFollowsErrorPolicy() {
         DateFormatter yyyyMMdd = DateFormatter.forPattern("yyyyMMdd");
         try (Block src = blockFactory.newLongArrayVector(new long[] { 7L }, 1).asBlock()) {
-            expectThrows(IllegalArgumentException.class, () -> castStrict(src, DataType.LONG, DataType.DATETIME, yyyyMMdd).close());
+            expectThrows(InvalidArgumentException.class, () -> castStrict(src, DataType.LONG, DataType.DATETIME, yyyyMMdd).close());
         }
         List<String> warnings = new ArrayList<>();
         try (
@@ -590,7 +591,7 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
         }
         // a pre-epoch nanos instant has no millis representation here: it throws and follows the read's error policy
         try (Block src = blockFactory.newLongArrayVector(new long[] { -1L }, 1).asBlock()) {
-            expectThrows(IllegalArgumentException.class, () -> castStrict(src, DataType.DATE_NANOS, DataType.DATETIME).close());
+            expectThrows(InvalidArgumentException.class, () -> castStrict(src, DataType.DATE_NANOS, DataType.DATETIME).close());
         }
     }
 
@@ -613,7 +614,7 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
         }
         DateFormatter epochSecond = DateFormatter.forPattern("epoch_second");
         try (Block src = blockFactory.newDoubleArrayVector(new double[] { Double.NaN }, 1).asBlock()) {
-            expectThrows(IllegalArgumentException.class, () -> castStrict(src, DataType.DOUBLE, DataType.DATETIME, epochSecond).close());
+            expectThrows(InvalidArgumentException.class, () -> castStrict(src, DataType.DOUBLE, DataType.DATETIME, epochSecond).close());
         }
     }
 
@@ -723,7 +724,7 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
         // A genuinely unparseable token still fails (fail_fast throws).
         try (Block src = bytesBlock("notanumber")) {
             expectThrows(
-                IllegalArgumentException.class,
+                InvalidArgumentException.class,
                 () -> DeclaredTypeCoercions.castBlock(src, DataType.KEYWORD, DataType.DOUBLE, null, blockFactory, null, null).close()
             );
         }
@@ -993,7 +994,7 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
         assertThat(warnings.get(0), containsString("declared type [date_nanos]"));
         try (Block src = blockFactory.newLongArrayVector(new long[] { -1L }, 1).asBlock()) {
             expectThrows(
-                IllegalArgumentException.class,
+                InvalidArgumentException.class,
                 () -> DeclaredTypeCoercions.castBlock(src, DataType.LONG, DataType.DATE_NANOS, null, blockFactory, null, null).close()
             );
         }
@@ -1082,6 +1083,21 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
         assertThat(warnings.get(0), containsString("returning null"));
     }
 
+    /** The lenient branch degrades a null column name to {@code <unknown>} too, mirroring the strict path (shared detail). */
+    public void testLenientCoercionNullColumnDegrades() {
+        List<String> warnings = new ArrayList<>();
+        SkipWarnings sink = capturing(warnings);
+        try (Block source = bytesBlock("not-a-number")) {
+            try (Block cast = DeclaredTypeCoercions.castBlock(source, DataType.KEYWORD, DataType.LONG, null, blockFactory, null, sink)) {
+                assertTrue("the bad cell nulls under a live sink", cast.isNull(0));
+            }
+        }
+        assertThat(warnings, hasSize(1));
+        assertThat(warnings.get(0), containsString("Column [<unknown>]"));
+        assertThat(warnings.get(0), containsString("declared type [long]"));
+        assertThat(warnings.get(0), containsString("returning null"));
+    }
+
     public void testLenientOverflowNullsCellAndWarns() {
         List<String> warnings = new ArrayList<>();
         SkipWarnings sink = capturing(warnings);
@@ -1105,6 +1121,74 @@ public class DeclaredTypeCoercionsTests extends ESTestCase {
                 InvalidArgumentException.class,
                 () -> DeclaredTypeCoercions.castBlock(source, DataType.KEYWORD, DataType.LONG, null, blockFactory, null, null).close()
             );
+        }
+    }
+
+    /**
+     * A strict coercion failure names the column, the declared type and the offending value, points at
+     * {@code error_mode=null_field}, and is a client error (HTTP 400) — never the bare JDK parser exception
+     * with no column/type context that regressed diagnosability. The original exception is chained as the cause.
+     */
+    public void testStrictCoercionFailureNamesColumnTypeAndValue() {
+        try (Block src = bytesBlock("abc")) {
+            InvalidArgumentException e = expectThrows(
+                InvalidArgumentException.class,
+                () -> DeclaredTypeCoercions.castBlock(src, DataType.KEYWORD, DataType.DOUBLE, null, blockFactory, "views", null).close()
+            );
+            assertThat(e.getMessage(), containsString("Column [views]"));
+            assertThat(e.getMessage(), containsString("declared type [double]"));
+            assertThat("the offending value survives on the message", e.getMessage(), containsString("abc"));
+            assertThat(e.getMessage(), containsString("error_mode=null_field"));
+            assertThat("a coercion failure is a client error, not a 500", e.status(), equalTo(RestStatus.BAD_REQUEST));
+            assertNotNull("the low-level parser exception is preserved as the cause", e.getCause());
+        }
+    }
+
+    /**
+     * The reported incident: a column of empty strings declared {@code double} failed with a bare
+     * {@code NumberFormatException: empty String} naming neither the column nor the type. The retained
+     * message now leads with the column and declared type while still carrying the raw detail.
+     */
+    public void testStrictCoercionFailureOnEmptyStringNamesColumn() {
+        try (Block src = bytesBlock("")) {
+            InvalidArgumentException e = expectThrows(
+                InvalidArgumentException.class,
+                () -> DeclaredTypeCoercions.castBlock(src, DataType.KEYWORD, DataType.DOUBLE, null, blockFactory, "FlashMinor2", null)
+                    .close()
+            );
+            assertThat(e.getMessage(), containsString("Column [FlashMinor2]"));
+            assertThat(e.getMessage(), containsString("declared type [double]"));
+            assertThat("the raw JDK detail is retained, not discarded", e.getMessage(), containsString("empty String"));
+        }
+    }
+
+    /**
+     * The reused {@code ::} cast engine already throws {@link InvalidArgumentException} on an unparseable numeric
+     * token; the chokepoint re-wraps it with column + declared-type context. The outer type stays
+     * {@code InvalidArgumentException} (a client 400), the cast-engine exception is preserved as the cause, and the
+     * message reads cleanly without a duplicated clause.
+     */
+    public void testStrictCoercionFailureWrapsCastEngineException() {
+        try (Block src = bytesBlock("abc")) {
+            InvalidArgumentException e = expectThrows(
+                InvalidArgumentException.class,
+                () -> DeclaredTypeCoercions.castBlock(src, DataType.KEYWORD, DataType.LONG, null, blockFactory, "views", null).close()
+            );
+            assertThat(e.getMessage(), containsString("Column [views]"));
+            assertThat(e.getMessage(), containsString("declared type [long]"));
+            assertTrue("the cast-engine exception is preserved as the cause", e.getCause() instanceof InvalidArgumentException);
+        }
+    }
+
+    /** A reader that does not track a column name passes {@code null}; the message degrades to {@code <unknown>}, no NPE. */
+    public void testStrictCoercionFailureNullColumnDegrades() {
+        try (Block src = bytesBlock("abc")) {
+            InvalidArgumentException e = expectThrows(
+                InvalidArgumentException.class,
+                () -> DeclaredTypeCoercions.castBlock(src, DataType.KEYWORD, DataType.DOUBLE, null, blockFactory, null, null).close()
+            );
+            assertThat(e.getMessage(), containsString("Column [<unknown>]"));
+            assertThat(e.getMessage(), containsString("declared type [double]"));
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL: name the column and declared type on a declared-read coercion failure (#154402)](https://github.com/elastic/elasticsearch/pull/154402)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)