### PR TITLE
[9.5] ES|QL: fix COUNT(*) crash over Hive-partitioned text datasets (skip virtual-column wrap on empty output) (#154409)

### DIFF
--- a/docs/changelog/154409.yaml
+++ b/docs/changelog/154409.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154409
+summary: "[ESQLDS] Fix COUNT(*) over a Hive-partitioned text dataset crashing on a zero-column projection"
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -1728,10 +1728,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             // metadata and emit row-count-only pages instead of building a column iterator over
             // the entire file schema. Skipped when any predicate path is active (record filter,
             // FilterPredicate, or {@link ParquetPushedExpressions}) so we keep the row-group
-            // pruning and YES-conjunct re-evaluation the column iterator performs - in those
-            // cases the leak is plugged at the consumer side by
-            // {@link org.elasticsearch.xpack.esql.datasources.VirtualColumnIterator} releasing
-            // any surplus blocks the legacy "empty projection -> full schema" fallback emits.
+            // pruning and YES-conjunct re-evaluation the column iterator performs - the legacy
+            // "empty projection -> full schema" fallback then over-projects. Those surplus blocks
+            // are not leaked: a virtual-column wrap that narrows the page releases them
+            // ({@link org.elasticsearch.xpack.esql.datasources.VirtualColumnIterator}), and when
+            // no wrap is needed (a zero-output read such as a bare COUNT(*)) the page is forwarded
+            // whole, so every block stays owned by its page and is released downstream with it.
             if (projectedColumns != null
                 && projectedColumns.isEmpty()
                 && filterPredicate == null

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvAggregatePushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalCsvAggregatePushdownIT.java
@@ -87,6 +87,107 @@ public class ExternalCsvAggregatePushdownIT extends AbstractExternalDataSourceIT
     }
 
     /**
+     * The Hive-partitioned twin of {@link #testCountStarColdThenWarmShortCircuits}: a bare
+     * {@code STATS COUNT(*)} over a partitioned CSV dataset. {@code COUNT(*)} projects zero columns, so the
+     * source's output attribute list is empty, while the partition stamp keeps the effective
+     * partition-column set non-empty. Before this fix, the per-split virtual-column wrapper gated only on the
+     * dataset axis and constructed a {@code VirtualColumnIterator} with that empty list as its output,
+     * throwing {@code "fullOutput cannot be null or empty"} at construction — so the cold scan crashed and,
+     * because the stripe-stats warm cache is populated <em>by</em> that scan, every retry re-crashed. The
+     * output-axis guard forwards the reader's position-only pages unchanged, so the cold scan completes (its
+     * capture hook fills the cache) and the warm run folds to {@code LocalSourceExec} exactly like the
+     * unpartitioned path. Red without this fix.
+     */
+    public void testPartitionedCountStarColdThenWarmShortCircuits() throws Exception {
+        Path root = createTempDir().resolve("hive_csv_agg");
+        writePartitionedCsvFiles(root); // 4 rows across year=2024/month=01 (2) + month=02 (2)
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String dataset = registerDataset("hive_csv_agg", glob, Map.of("hive_partitioning", true));
+        String query = "FROM " + dataset + " | STATS c = COUNT(*)";
+
+        // Cold: red on main ("fullOutput cannot be null or empty"); with the fix, scans all 4 partitioned rows.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+            assertCount(response, 4);
+            assertThat("cold execution must scan every partitioned row", response.documentsFound(), equalTo(4L));
+        }
+        // Warm: the cold scan's capture hook populated the per-coordinator cache → LocalSourceExec, no data-node scan.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+            assertCount(response, 4);
+            assertNoPushdownBypass(response);
+            assertThat("warm partitioned COUNT(*) must not scan (LocalSourceExec)", response.documentsFound(), equalTo(0L));
+        }
+    }
+
+    /**
+     * Settles the ticket's disputed claim that {@code KEEP <data-col> | STATS COUNT(*)} sidesteps the crash.
+     * {@code CombineProjections} + {@code PruneColumns} collapse the KEEP-then-count shape to the identical
+     * zero-output plan as the bare query (the count references no columns), so before this fix it crashes the
+     * same way and must pass after it. Runs cold then warm, mirroring
+     * {@link #testPartitionedCountStarColdThenWarmShortCircuits}: the cold scan completes and fills the cache,
+     * the warm run folds to {@code LocalSourceExec}.
+     */
+    public void testPartitionedCountStarWithLeadingKeepIsSamePlan() throws Exception {
+        Path root = createTempDir().resolve("hive_csv_keep");
+        writePartitionedCsvFiles(root);
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String dataset = registerDataset("hive_csv_keep", glob, Map.of("hive_partitioning", true));
+        String query = "FROM " + dataset + " | KEEP id | STATS c = COUNT(*)";
+
+        // Cold: reduces to the same zero-output plan as the bare COUNT(*) and scans all 4 rows.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+            assertCount(response, 4);
+            assertThat("cold KEEP id | STATS COUNT(*) scans every partitioned row", response.documentsFound(), equalTo(4L));
+        }
+        // Warm: the cold scan filled the cache → LocalSourceExec, no data-node scan.
+        try (var response = run(syncEsqlQueryRequest(query).profile(true))) {
+            assertCount(response, 4);
+            assertNoPushdownBypass(response);
+            assertThat("warm KEEP id | STATS COUNT(*) must not scan (LocalSourceExec)", response.documentsFound(), equalTo(0L));
+        }
+    }
+
+    /**
+     * Guards against over-skipping the wrap: {@code STATS COUNT(*) BY month} projects the partition column
+     * {@code month}, so the source output is non-empty and the virtual-column wrap must still run to attach
+     * each row's partition value. This never-broken grouped shape stays green — the output-axis guard fires
+     * only when the output is genuinely empty.
+     */
+    public void testPartitionedCountStarByPartitionColumnStillWraps() throws Exception {
+        Path root = createTempDir().resolve("hive_csv_by");
+        writePartitionedCsvFiles(root);
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.csv";
+        String dataset = registerDataset("hive_csv_by", glob, Map.of("hive_partitioning", true));
+
+        try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | STATS c = COUNT(*) BY month | SORT month").profile(true))) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("two month partitions", rows.size(), equalTo(2));
+            // Output columns are [c, month]. Each of month=01 and month=02 carries exactly 2 rows; assert both
+            // the count and the injected partition value. month=01/02 cast to INTEGER 1/2 (leading zero stripped,
+            // per HivePartitionDetector.castValue) — pinning it proves the wrap still attaches partition values.
+            assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo(2L));
+            assertThat(rows.get(0).get(1), equalTo(1));
+            assertThat(((Number) rows.get(1).get(0)).longValue(), equalTo(2L));
+            assertThat(rows.get(1).get(1), equalTo(2));
+        }
+    }
+
+    /**
+     * Two-level Hive-style partition tree ({@code year=2024/month=01/data.csv} + {@code month=02/data.csv}),
+     * 2 rows per file, 4 rows total. Mirrors {@code ExternalCsvHivePartitionedIT#writePartitionedCsvFiles}.
+     */
+    private static void writePartitionedCsvFiles(Path root) throws IOException {
+        Path month01 = root.resolve("year=2024").resolve("month=01");
+        Path month02 = root.resolve("year=2024").resolve("month=02");
+        Files.createDirectories(month01);
+        Files.createDirectories(month02);
+        Files.writeString(month01.resolve("data.csv"), "id,value\n1,alpha\n2,beta\n", StandardCharsets.UTF_8);
+        Files.writeString(month02.resolve("data.csv"), "id,value\n3,gamma\n4,delta\n", StandardCharsets.UTF_8);
+    }
+
+    /**
      * The strict declared-schema twin of {@link #testCountStarColdThenWarmShortCircuits}. A strict
      * ({@code dynamic:false}) CSV dataset reads no file body at resolution, so it cannot harvest the row-count itself;
      * {@code ExternalSourceResolver.strictSingleFileMetadata} seeds a schema-cache entry that the cold scan's capture

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetHivePartitionedIT.java
@@ -131,4 +131,34 @@ public class ExternalParquetHivePartitionedIT extends AbstractExternalDataSource
             );
         }
     }
+
+    /**
+     * Immune-path regression pin for the partitioned-text {@code COUNT(*)} fix.
+     * A bare {@code COUNT(*)} over a Hive-partitioned <em>Parquet</em> dataset is served from footer/stripe
+     * row-count stats via {@code ComputeService.canSkipSplitDiscovery} → {@code resolveCount} with no scan
+     * operator at all — so unlike partitioned text it never reaches the virtual-column wrapper the fix
+     * touches. This asserts that path is undisturbed: the correct count with zero external scan operators,
+     * on the very first (cold) run. Green on main; the COUNT(*) shape (vs the COUNT(p) safe-miss above) was
+     * previously untested here.
+     */
+    public void testPartitionedCountStarServedFromStatsWithoutScan() throws Exception {
+        Path root = createTempDir().resolve("hive_parquet_countstar");
+        writeSingleColumnIdParquet(root.resolve("p=a"), 3); // ids 0,1,2
+        writeSingleColumnIdParquet(root.resolve("p=b"), 2); // ids 0,1
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        String glob = StoragePath.fileUri(root) + "/**/*.parquet";
+        String dataset = registerDataset("hive_parquet_countstar", glob, Map.of("hive_partitioning", true));
+
+        var request = syncEsqlQueryRequest("FROM " + dataset + " | STATS c = COUNT(*)");
+        request.profile(true);
+        try (var response = run(request)) {
+            assertTrue(
+                "partitioned Parquet COUNT(*) is served from footer stats with no external scan operator",
+                externalScanNodeNames(response).isEmpty()
+            );
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("COUNT(*) returns a single row", rows.size(), equalTo(1));
+            assertThat("COUNT(*) counts all 5 rows across both partitions", ((Number) rows.getFirst().getFirst()).longValue(), equalTo(5L));
+        }
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1092,7 +1092,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * partition / {@code _file.*} columns. The iterator allocates the constant blocks against
      * {@link #producerBlockFactory} when set (production: the node-level root factory) and
      * falls back to the driver context's factory otherwise (test convenience). Returns
-     * {@code pages} unchanged when there are no virtual columns to materialise.
+     * {@code pages} unchanged when there are no virtual columns to materialise — either the
+     * dataset is unpartitioned, or the query projects no output columns at all (a zero-projection
+     * {@code COUNT(*)} read, which forwards the reader's position-only pages untouched).
      */
     private CloseableIterator<Page> wrapWithVirtualColumns(
         CloseableIterator<Page> pages,
@@ -1116,7 +1118,19 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         StoragePath filePath
     ) {
-        if (partitionColumnNames.isEmpty()) {
+        // Two independent skip axes. The DATASET axis: an unpartitioned dataset has no virtual
+        // columns to materialise. The OUTPUT axis: a zero-projection read (a bare STATS COUNT(*),
+        // whose argument is a literal and so references no columns) has an empty output schema —
+        // there is no slot to render a partition column into, and the iterator's constructor
+        // rejects an empty fullOutput. In both cases forwarding the reader's pages unchanged is
+        // correct: the row count rides Page.getPositionCount(), and forwarding a page whole (rather
+        // than narrowing it, the only reason inject must release surplus blocks) keeps every block
+        // owned by its page, so nothing leaks even when a reader over-projects a zero projection to
+        // the full file schema. This is the same passthrough the unpartitioned arm has always taken.
+        // Testing `attributes` (the exact list handed to the iterator as fullOutput) rather than
+        // `queryDataSchema` is deliberate: COUNT(partition_col) / KEEP partition_col project the
+        // partition column, so `attributes` is non-empty there and the wrap still runs as required.
+        if (partitionColumnNames.isEmpty() || attributes.isEmpty()) {
             return pages;
         }
         BytesRef idPrefix = idColumnRequested ? ExternalRowIdentity.prefix(filePath, resolveMtimeMillis(partitionValuesForFile)) : null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -634,6 +634,69 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         }
     }
 
+    /**
+     * A zero-projection {@code STATS COUNT(*)} over a Hive-partitioned dataset. The query references no
+     * columns, so its output attribute list is empty, while the dataset's partition stamp keeps
+     * {@code partitionColumnNames} non-empty. Before the fix, {@code wrapWithVirtualColumns} gated only
+     * on the dataset axis and constructed a {@link VirtualColumnIterator} with the empty output as
+     * {@code fullOutput}, tripping the constructor's {@code "fullOutput cannot be null or empty"} check
+     * during {@code openNext*} — the exact partitioned-text {@code COUNT(*)} crash. The guard now also
+     * skips the wrap on the output axis, forwarding the reader's position-only pages unchanged so the
+     * row count rides {@code positionCount} to the count aggregator (mirroring the already-working
+     * unpartitioned path). This is the factory-level behavioral pin for the fix.
+     */
+    public void testZeroProjectionCountStarOverPartitionedSourceForwardsPositionOnlyPages() throws Exception {
+        StoragePath filePath = StoragePath.of("s3://bucket/data/year=2024/f1.parquet");
+        List<StorageEntry> entries = List.of(new StorageEntry(filePath, 100, Instant.EPOCH));
+        @SuppressWarnings("checkstyle:EmptyJavadoc") // the glob's '/**/' is misread as Javadoc
+        FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/data/**/*.parquet");
+
+        // COUNT(*) projects zero columns: the reader emits a position-only page (0 data blocks).
+        FormatReader formatReader = new SinglePageReader(() -> new Page(2));
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        // Empty output — the defining feature of a bare STATS COUNT(*) read — over a partitioned stamp.
+        List<Attribute> attributes = List.of();
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(TEST_BLOCK_FACTORY);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            formatReader,
+            filePath,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).fileList(fileList).partitionColumnNames(Set.of("year")).partitionValues(Map.of("year", 2024)).build();
+
+        SourceOperator operator = factory.get(driverContext);
+        assertNotNull(operator);
+
+        List<Page> pages = new ArrayList<>();
+        try {
+            while (operator.isFinished() == false) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                }
+            }
+
+            assertEquals("one page produced", 1, pages.size());
+            Page page = pages.get(0);
+            assertEquals("zero-projection read carries no data blocks", 0, page.getBlockCount());
+            assertEquals("the row count rides positionCount", 2, page.getPositionCount());
+        } finally {
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        }
+    }
+
     public void testMultiFileReadUnresolvedGenericFileListFallsBackToSingleFile() throws Exception {
         AtomicInteger readCount = new AtomicInteger(0);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL: fix COUNT(*) crash over Hive-partitioned text datasets (skip virtual-column wrap on empty output) (#154409)](https://github.com/elastic/elasticsearch/pull/154409)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)