### PR TITLE
Add OperationLocation to track rowIndex in a batch

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/IndexVersionValue.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/IndexVersionValue.java
@@ -18,16 +18,18 @@ final class IndexVersionValue extends VersionValue {
 
     private static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexVersionValue.class);
 
-    private final Translog.Location translogLocation;
+    private final Translog.OperationLocation operationLocation;
 
-    IndexVersionValue(Translog.Location translogLocation, long version, long seqNo, long term) {
+    IndexVersionValue(Translog.OperationLocation operationLocation, long version, long seqNo, long term) {
         super(version, seqNo, term);
-        this.translogLocation = translogLocation;
+        this.operationLocation = operationLocation;
     }
 
     @Override
     public long ramBytesUsed() {
-        return RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(translogLocation);
+        return RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(operationLocation) + RamUsageEstimator.shallowSizeOf(
+            operationLocation.location()
+        );
     }
 
     @Override
@@ -36,21 +38,21 @@ final class IndexVersionValue extends VersionValue {
         if (o == null || getClass() != o.getClass()) return false;
         if (super.equals(o) == false) return false;
         IndexVersionValue that = (IndexVersionValue) o;
-        return Objects.equals(translogLocation, that.translogLocation);
+        return Objects.equals(operationLocation, that.operationLocation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), translogLocation);
+        return Objects.hash(super.hashCode(), operationLocation);
     }
 
     @Override
     public String toString() {
-        return "IndexVersionValue{version=" + version + ", seqNo=" + seqNo + ", term=" + term + ", location=" + translogLocation + '}';
+        return "IndexVersionValue{version=" + version + ", seqNo=" + seqNo + ", term=" + term + ", location=" + operationLocation + '}';
     }
 
     @Override
-    public Translog.Location getLocation() {
-        return translogLocation;
+    public Translog.OperationLocation getOperationLocation() {
+        return operationLocation;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/IndexVersionValue.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/IndexVersionValue.java
@@ -27,9 +27,9 @@ final class IndexVersionValue extends VersionValue {
 
     @Override
     public long ramBytesUsed() {
-        return RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(operationLocation) + RamUsageEstimator.shallowSizeOf(
-            operationLocation.location()
-        );
+        return RAM_BYTES_USED + (operationLocation != null
+            ? RamUsageEstimator.shallowSizeOf(operationLocation) + RamUsageEstimator.shallowSizeOf(operationLocation.location())
+            : 0L);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -994,10 +994,11 @@ public class InternalEngine extends Engine {
                     );
                 }
                 if (get.isReadFromTranslog()) {
-                    if (versionValue.getLocation() != null) {
+                    final Translog.OperationLocation opLoc = versionValue.getOperationLocation();
+                    if (opLoc != null) {
                         try {
-                            // Translog.Location will contain a non-negative rowIndex when reading from a batch
-                            final Translog.Operation operation = translog.readOperation(versionValue.getLocation());
+                            // rowIndex >= 0 resolves a single row within a batch record; -1 reads a whole record
+                            final Translog.Operation operation = translog.readOperation(opLoc.location(), opLoc.rowIndex());
                             if (operation != null) {
                                 return getFromTranslog(get, (Translog.Index) operation, mappingLookup, documentParser, searcherWrapper);
                             }
@@ -1338,7 +1339,12 @@ public class InternalEngine extends Engine {
                     final Translog.Location translogLocation = trackTranslogLocation.get() ? indexResult.getTranslogLocation() : null;
                     versionMap.maybePutIndexUnderLock(
                         index.uid(),
-                        new IndexVersionValue(translogLocation, plan.versionForIndexing, index.seqNo(), index.primaryTerm())
+                        new IndexVersionValue(
+                            translogLocation == null ? null : new Translog.OperationLocation(translogLocation),
+                            plan.versionForIndexing,
+                            index.seqNo(),
+                            index.primaryTerm()
+                        )
                     );
                 }
                 localCheckpointTracker.markSeqNoAsProcessed(indexResult.getSeqNo());
@@ -1632,21 +1638,14 @@ public class InternalEngine extends Engine {
                 }
 
                 if (plan.indexIntoLucene && isSuccess) {
-                    final Translog.Location location = (trackTranslogLocation.get() && batchLocation != null)
-                        ? new Translog.Location(
-                            batchLocation.generation(),
-                            batchLocation.translogLocation(),
-                            batchLocation.size(),
-                            // same rowIndex recorded in Translog.IndexBatch.IndexOp for this document in the write loop above
-                            // because batch data retains every row
-                            i
-                        )
+                    // batchLocation is the whole-record Location; the row index lives in the OperationLocation wrapper
+                    final Translog.OperationLocation operationLocation = (trackTranslogLocation.get() && batchLocation != null)
+                        ? new Translog.OperationLocation(batchLocation, i)
                         : null;
                     versionMap.maybePutIndexUnderLock(
                         index.uid(),
-                        new IndexVersionValue(location, plan.versionForIndexing, index.seqNo(), index.primaryTerm())
+                        new IndexVersionValue(operationLocation, plan.versionForIndexing, index.seqNo(), index.primaryTerm())
                     );
-
                 }
                 // TODO: Batch Optimize the processed seqNo
                 localCheckpointTracker.markSeqNoAsProcessed(result.getSeqNo());

--- a/server/src/main/java/org/elasticsearch/index/engine/VersionValue.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/VersionValue.java
@@ -67,10 +67,12 @@ public abstract class VersionValue implements Accountable {
     }
 
     /**
-     * Returns the translog location for this version value or null. This is optional and might not be tracked all the time.
+     * Returns the operation location (translog location + optional batch row index) for this version
+     * value, or null. Optional and might not be tracked all the time. Consumed only by the realtime
+     * GET path.
      */
     @Nullable
-    public Translog.Location getLocation() {
+    public Translog.OperationLocation getOperationLocation() {
         return null;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
@@ -167,24 +167,27 @@ public abstract class BaseTranslogReader implements Comparable<BaseTranslogReade
         return Files.getLastModifiedTime(path).toMillis();
     }
 
-    /**
-     * Reads a single operation from the given location. If the record at that location is
-     * an {@link Translog.IndexBatch}, calls {@link Translog.IndexBatch#getIndexOp(int)} with the
-     * {@link Translog.Location#batchRowIndex()} to return the individual row's {@link Translog.Index}
-     * operation.
-     * If batchRowIndex is not set, the buffer is returned as a single operation
-     */
+    /** Reads a single non-batch operation. Throws if the record is a batch. */
     Translog.Operation read(Translog.Location location) throws IOException {
+        return read(location, -1);
+    }
+
+    /**
+     * Reads a single operation from the given location. If the record is an {@link Translog.IndexBatch}
+     * and {@code rowIndex >= 0}, returns that row's {@link Translog.Index} via
+     * {@link Translog.IndexBatch#getIndexOp(int)}. A batch record with {@code rowIndex < 0} throws.
+     */
+    Translog.Operation read(Translog.Location location, int rowIndex) throws IOException {
         assert location.generation() == this.generation : "generation mismatch expected: " + generation + " got: " + location.generation();
         ByteBuffer buffer = ByteBuffer.allocate(location.size());
         final Translog.Record record = readRecord(checksummedStream(buffer, location.translogLocation(), location.size(), null));
         if (record instanceof Translog.IndexBatch indexBatch) {
-            if (location.isBatchRow() == false) {
-                throw new IOException("Record at location is a batch; use a location with batchRowIndex to read a single row");
+            if (rowIndex < 0) {
+                throw new IOException("Record at location is a batch; provide a rowIndex to read a single row");
             }
-            return indexBatch.getIndexOp(location.batchRowIndex());
+            return indexBatch.getIndexOp(rowIndex);
         }
-        assert location.isBatchRow() == false : "Location set for a non batch record";
+        assert rowIndex < 0 : "rowIndex set for a non-batch record";
         return (Translog.Operation) record;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -854,6 +854,15 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * this method will return <code>null</code>.
      */
     public Operation readOperation(Location location) throws IOException {
+        return readOperation(location, -1);
+    }
+
+    /**
+     * Reads and returns the operation from the given location. If the record is an {@link IndexBatch}
+     * and {@code rowIndex >= 0}, returns that row's {@link Index} operation. A batch record with
+     * {@code rowIndex < 0} throws. Returns {@code null} if the generation is no longer available.
+     */
+    public Operation readOperation(Location location, int rowIndex) throws IOException {
         try {
             readLock.lock();
             try {
@@ -864,13 +873,13 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 if (current.generation == location.generation) {
                     // no need to fsync here the read operation will ensure that buffers are written to disk
                     // if they are still in RAM and we are reading onto that position
-                    return current.read(location);
+                    return current.read(location, rowIndex);
                 } else {
                     // read backwards - it's likely we need to read on that is recent
                     for (int i = readers.size() - 1; i >= 0; i--) {
                         TranslogReader translogReader = readers.get(i);
                         if (translogReader.generation == location.generation) {
-                            return translogReader.read(location);
+                            return translogReader.read(location, rowIndex);
                         }
                     }
                 }
@@ -1098,25 +1107,13 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         return deletionPolicy;
     }
 
-    public record Location(long generation, long translogLocation, int size, int batchRowIndex) implements Comparable<Location> {
+    public record Location(long generation, long translogLocation, int size) implements Comparable<Location> {
 
         public static final Location EMPTY = new Location(0, 0, 0);
 
-        public Location(long generation, long translogLocation, int size) {
-            this(generation, translogLocation, size, -1);
-        }
-
-        /**
-         * Whether this location pins a single document's row within a batch ({@link IndexBatch})
-         */
-        public boolean isBatchRow() {
-            return batchRowIndex >= 0;
-        }
-
         @Override
         public String toString() {
-            final String base = "[generation: " + generation + ", location: " + translogLocation + ", size: " + size;
-            return isBatchRow() ? base + ", batchRowIndex: " + batchRowIndex + "]" : base + "]";
+            return "[generation: " + generation + ", location: " + translogLocation + ", size: " + size + "]";
         }
 
         @Override
@@ -1127,6 +1124,37 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             }
 
             return result;
+        }
+    }
+
+    /**
+     * Pairs a {@link Location} with an optional batch row index for use by the live version map
+     * and the realtime GET path.
+     *
+     * <p>{@code rowIndex} is {@code -1} for a whole-record location and {@code >= 0}
+     * when it pins a single document's row within a batch.
+     */
+    public record OperationLocation(Location location, int rowIndex) {
+
+        /**
+         * Ensure that location is non-null
+         */
+        public OperationLocation {
+            Objects.requireNonNull(location, "location must not be null");
+        }
+
+        /**
+         * Creates a whole-record location that is not a batch row (i.e. {@code rowIndex == -1}).
+         */
+        public OperationLocation(Location location) {
+            this(location, -1);
+        }
+
+        /**
+         * Whether this location pins a single document's row within a batch ({@link IndexBatch}).
+         */
+        public boolean isBatchRow() {
+            return rowIndex >= 0;
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -8486,20 +8486,19 @@ public class InternalEngineTests extends EngineTestCase {
         assertEquals(Engine.Result.Type.SUCCESS, results.get(2).getResultType());
 
         final Map<BytesRef, VersionValue> versionMap = engine.getVersionMap();
-        final Translog.Location loc0 = versionMap.get(ops.get(0).uid()).getLocation();
-        final Translog.Location loc2 = versionMap.get(ops.get(2).uid()).getLocation();
+        final Translog.OperationLocation loc0 = versionMap.get(ops.get(0).uid()).getOperationLocation();
+        final Translog.OperationLocation loc2 = versionMap.get(ops.get(2).uid()).getOperationLocation();
 
         assertNotNull("0 must have a tracked batch-row location", loc0);
         assertTrue(loc0.isBatchRow());
-        assertEquals(0, loc0.batchRowIndex());
+        assertEquals(0, loc0.rowIndex());
 
         assertNotNull("2 must have a tracked batch-row location", loc2);
         assertTrue(loc2.isBatchRow());
-        assertEquals(2, loc2.batchRowIndex());   // crucially 2, not 1 — the failed row is not compacted
+        assertEquals(2, loc2.rowIndex());   // crucially 2, not 1 — the failed row is not compacted
 
-        // Both point at the same physical batch record (same generation + offset), differing only by row.
-        assertEquals(loc0.generation(), loc2.generation());
-        assertEquals(loc0.translogLocation(), loc2.translogLocation());
+        // Both wrap the same physical batch record, differing only by row.
+        assertEquals(loc0.location(), loc2.location());
         assertNotEquals(loc0, loc2);
     }
 
@@ -8521,14 +8520,15 @@ public class InternalEngineTests extends EngineTestCase {
         }
 
         // A single-document index (engine.index, NOT a batch) records a whole-record location:
-        // batchRowIndex == -1, i.e. not a batch row
+        // rowIndex == -1, i.e. not a batch row
         final Engine.Index op = indexForDoc(createParsedDoc("single", null));
         engine.index(op);
 
-        final Translog.Location loc = engine.getVersionMap().get(op.uid()).getLocation();
-        assertNotNull("single-doc index must have a tracked translog location", loc);
+        final Translog.OperationLocation loc = engine.getVersionMap().get(op.uid()).getOperationLocation();
+        assertNotNull("single-doc index must have a tracked operation location", loc);
+        assertNotNull("single-doc index must wrap a translog location", loc.location());
         assertFalse("single-doc location must not be a batch row", loc.isBatchRow());
-        assertEquals(-1, loc.batchRowIndex());
+        assertEquals(-1, loc.rowIndex());
     }
 
     public void testRealtimeGetServesBatchedDoc() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTestUtils.java
@@ -30,8 +30,13 @@ public class LiveVersionMapTestUtils {
         return new DeleteVersionValue(version, seqNo, term, time);
     }
 
-    public static IndexVersionValue newIndexVersionValue(Translog.Location location, long version, long seqNo, long term) {
-        return new IndexVersionValue(location, version, seqNo, term);
+    public static IndexVersionValue newIndexVersionValue(
+        Translog.OperationLocation operationLocation,
+        long version,
+        long seqNo,
+        long term
+    ) {
+        return new IndexVersionValue(operationLocation, version, seqNo, term);
     }
 
     public static VersionValue get(LiveVersionMap map, String id) {
@@ -71,14 +76,14 @@ public class LiveVersionMapTestUtils {
     }
 
     public static IndexVersionValue randomIndexVersionValue() {
-        return new IndexVersionValue(randomTranslogLocation(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
+        return new IndexVersionValue(randomOperationLocation(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
     }
 
-    public static Translog.Location randomTranslogLocation() {
+    public static Translog.OperationLocation randomOperationLocation() {
         if (randomBoolean()) {
             return null;
         } else {
-            return new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt());
+            return new Translog.OperationLocation(new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
@@ -36,7 +36,7 @@ import java.util.stream.IntStream;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency;
 import static org.elasticsearch.core.Tuple.tuple;
 import static org.elasticsearch.index.engine.LiveVersionMapTestUtils.randomIndexVersionValue;
-import static org.elasticsearch.index.engine.LiveVersionMapTestUtils.randomTranslogLocation;
+import static org.elasticsearch.index.engine.LiveVersionMapTestUtils.randomOperationLocation;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -106,7 +106,7 @@ public class LiveVersionMapTests extends ESTestCase {
     public void testBasics() throws IOException {
         LiveVersionMap map = new LiveVersionMap();
         try (Releasable r = map.acquireLock(uid("test"))) {
-            Translog.Location tlogLoc = randomTranslogLocation();
+            Translog.OperationLocation tlogLoc = randomOperationLocation();
             map.putIndexUnderLock(uid("test"), new IndexVersionValue(tlogLoc, 1, 1, 1));
             assertEquals(new IndexVersionValue(tlogLoc, 1, 1, 1), map.getUnderLock(uid("test")));
             map.beforeRefresh();
@@ -162,7 +162,12 @@ public class LiveVersionMapTests extends ESTestCase {
                         try (Releasable r = map.acquireLock(bytesRef)) {
                             VersionValue versionValue = values.computeIfAbsent(
                                 bytesRef,
-                                v -> new IndexVersionValue(randomTranslogLocation(), randomLong(), maxSeqNo.incrementAndGet(), randomLong())
+                                v -> new IndexVersionValue(
+                                    randomOperationLocation(),
+                                    randomLong(),
+                                    maxSeqNo.incrementAndGet(),
+                                    randomLong()
+                                )
                             );
                             boolean isDelete = versionValue instanceof DeleteVersionValue;
                             if (isDelete) {
@@ -180,7 +185,7 @@ public class LiveVersionMapTests extends ESTestCase {
                                 map.putDeleteUnderLock(bytesRef, (DeleteVersionValue) versionValue);
                             } else {
                                 versionValue = new IndexVersionValue(
-                                    randomTranslogLocation(),
+                                    randomOperationLocation(),
                                     versionValue.version + 1,
                                     maxSeqNo.incrementAndGet(),
                                     versionValue.term
@@ -342,7 +347,7 @@ public class LiveVersionMapTests extends ESTestCase {
         BytesRef uid = uid("1");
         VersionValue initialVersion;
         try (Releasable ignore = map.acquireLock(uid)) {
-            initialVersion = new IndexVersionValue(randomTranslogLocation(), version.incrementAndGet(), 1, 1);
+            initialVersion = new IndexVersionValue(randomOperationLocation(), version.incrementAndGet(), 1, 1);
             map.putIndexUnderLock(uid, (IndexVersionValue) initialVersion);
         }
         Thread t = new Thread(() -> {
@@ -359,7 +364,7 @@ public class LiveVersionMapTests extends ESTestCase {
                             underLock = nextVersionValue;
                         }
                         if (underLock.isDelete() || randomBoolean()) {
-                            nextVersionValue = new IndexVersionValue(randomTranslogLocation(), version.incrementAndGet(), 1, 1);
+                            nextVersionValue = new IndexVersionValue(randomOperationLocation(), version.incrementAndGet(), 1, 1);
                             map.putIndexUnderLock(uid, (IndexVersionValue) nextVersionValue);
                         } else {
                             nextVersionValue = new DeleteVersionValue(version.incrementAndGet(), 1, 1, 0);
@@ -428,7 +433,7 @@ public class LiveVersionMapTests extends ESTestCase {
                     versionMap.putDeleteUnderLock(uid, (DeleteVersionValue) latestVersion);
                     assertThat(versionMap.getUnderLock(uid), equalTo(latestVersion));
                 } else if (randomBoolean()) {
-                    latestVersion = new IndexVersionValue(randomTranslogLocation(), randomNonNegativeLong(), randomLong(), randomLong());
+                    latestVersion = new IndexVersionValue(randomOperationLocation(), randomNonNegativeLong(), randomLong(), randomLong());
                     versionMap.maybePutIndexUnderLock(uid, (IndexVersionValue) latestVersion);
                     if (versionMap.isSafeAccessRequired()) {
                         assertThat(versionMap.getUnderLock(uid), equalTo(latestVersion));

--- a/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
@@ -26,6 +26,11 @@ public class VersionValueTests extends ESTestCase {
         assertEquals(RamUsageTester.ramUsed(versionValue), versionValue.ramBytesUsed());
     }
 
+    public void testIndexRamBytesUsedNullLocation() {
+        IndexVersionValue versionValue = new IndexVersionValue(null, randomLong(), randomLong(), randomLong());
+        assertEquals(RamUsageTester.ramUsed(versionValue), versionValue.ramBytesUsed());
+    }
+
     public void testDeleteRamBytesUsed() {
         DeleteVersionValue versionValue = new DeleteVersionValue(randomLong(), randomLong(), randomLong(), randomLong());
         assertEquals(RamUsageTester.ramUsed(versionValue), versionValue.ramBytesUsed());

--- a/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
@@ -16,9 +16,11 @@ import org.elasticsearch.test.ESTestCase;
 public class VersionValueTests extends ESTestCase {
 
     public void testIndexRamBytesUsed() {
-        Translog.Location translogLoc = null;
+        Translog.OperationLocation translogLoc = null;
         if (randomBoolean()) {
-            translogLoc = new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt());
+            translogLoc = new Translog.OperationLocation(
+                new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt())
+            );
         }
         IndexVersionValue versionValue = new IndexVersionValue(translogLoc, randomLong(), randomLong(), randomLong());
         assertEquals(RamUsageTester.ramUsed(versionValue), versionValue.ramBytesUsed());

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogIndexBatchTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogIndexBatchTests.java
@@ -489,7 +489,7 @@ public class TranslogIndexBatchTests extends ESTestCase {
         final Translog.IndexBatch batch = buildBatch(List.of(Map.of("k", "v0"), Map.of("k", "v1")), XContentType.JSON, 0L, term);
         final Translog.Location location = translog.add(batch);
 
-        // readOperation will throw for batch records if batchRowIndex is not set in the location
+        // readOperation(location) with no rowIndex throws for batch records
         final IOException ex = expectThrows(IOException.class, () -> translog.readOperation(location));
         assertTrue("unexpected exception message: " + ex.getMessage(), ex.getMessage() != null && ex.getMessage().contains("batch"));
     }
@@ -541,17 +541,10 @@ public class TranslogIndexBatchTests extends ESTestCase {
             ops.add(new Translog.IndexBatch.IndexOp(1L, i, 100L + i, i, xContentType, Uid.encodeId("doc-" + i), null));
         }
         final Translog.Location batchLocation = translog.add(buildEscfBatch(sources, xContentType, primaryTerm.get(), ops));
-        assertFalse("add() returns a whole-record location. Should not contain batchRowIndex", batchLocation.isBatchRow());
 
         for (int i = 0; i < sources.size(); i++) {
-            // Mimic the LiveVersionMap by building a new Location with rowIndex
-            final Translog.Location rowLocation = new Translog.Location(
-                batchLocation.generation(),
-                batchLocation.translogLocation(),
-                batchLocation.size(),
-                i
-            );
-            final Translog.Operation op = translog.readOperation(rowLocation);
+            // Mimic the LiveVersionMap: plain whole-record Location + row index passed to the overload
+            final Translog.Operation op = translog.readOperation(batchLocation, i);
             assertTrue("expected Index op, got " + (op == null ? "null" : op.getClass()), op instanceof Translog.Index);
             final Translog.Index idx = (Translog.Index) op;
             assertEquals(i, idx.seqNo());
@@ -573,14 +566,8 @@ public class TranslogIndexBatchTests extends ESTestCase {
         );
         final Translog.Location opLocation = translog.add(single);
 
-        // explicitly set batchRowIndex to a non-negative value
-        final Translog.Location fakeLocation = new Translog.Location(
-            opLocation.generation(),
-            opLocation.translogLocation(),
-            opLocation.size(),
-            0
-        );
-        expectThrows(AssertionError.class, () -> translog.readOperation(fakeLocation));
+        // passing rowIndex >= 0 to a non-batch record throws
+        expectThrows(AssertionError.class, () -> translog.readOperation(opLocation, 0));
     }
 
 }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/StatelessLiveVersionMapTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/StatelessLiveVersionMapTests.java
@@ -50,7 +50,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         var archive = new StatelessLiveVersionMapArchive(preCommitGeneration::get);
         var map = newLiveVersionMap(archive);
         var id = "test";
-        Translog.Location loc = randomTranslogLocation();
+        Translog.OperationLocation loc = randomOperationLocation();
         var indexVersionValue = newIndexVersionValue(loc, 1, 1, 1);
         putIndex(map, id, indexVersionValue);
         assertEquals(indexVersionValue, get(map, id));
@@ -88,7 +88,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         deleteVersionValue = newDeleteVersionValue(2, 2, 2, 2);
         putDelete(map, id, deleteVersionValue);
         assertEquals(deleteVersionValue, get(map, id));
-        var indexValueVersion2 = newIndexVersionValue(randomTranslogLocation(), 3, 3, 1);
+        var indexValueVersion2 = newIndexVersionValue(randomOperationLocation(), 3, 3, 1);
         putIndex(map, id, indexValueVersion2);
         assertThat(archive.archivePerGeneration().size(), equalTo(0));
         refresh(map);
@@ -108,19 +108,19 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         var archive = new StatelessLiveVersionMapArchive(preCommitGeneration::get);
         var map = newLiveVersionMap(archive);
         var id = "test";
-        putIndex(map, id, newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        putIndex(map, id, newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         assertThat(archive.archivePerGeneration().size(), equalTo(0));
         refresh(map);
         assertThat(archive.archivePerGeneration().size(), equalTo(1));
         var archiveMap = archive.archivePerGeneration().get(preCommitGeneration.get() + 1);
         assertNotNull(archiveMap);
-        var update = newIndexVersionValue(randomTranslogLocation(), 2, 2, 1);
+        var update = newIndexVersionValue(randomOperationLocation(), 2, 2, 1);
         putIndex(map, id, update);
         refresh(map);
         assertEquals(update, get(map, id));
         flush(map, currentGeneration, preCommitGeneration);
         // while the commit if propagating to the unpromotables, a new update is added
-        var update2 = newIndexVersionValue(randomTranslogLocation(), 1, 1, 1);
+        var update2 = newIndexVersionValue(randomOperationLocation(), 1, 1, 1);
         putIndex(map, id, update2);
         assertEquals(update2, get(map, id));
         refresh(map);
@@ -148,7 +148,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         var map = newLiveVersionMap(archive);
         var id = "test";
         assertThat(archive.getMinDeleteTimestamp(), equalTo(Long.MAX_VALUE));
-        putIndex(map, id, newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        putIndex(map, id, newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         refresh(map);
         assertThat(archive.getMinDeleteTimestamp(), equalTo(Long.MAX_VALUE));
         var deleteVersionValue = newDeleteVersionValue(2, 2, 2, 2);
@@ -176,7 +176,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         var map = newLiveVersionMap(archive);
         assertEquals(archive.getMinDeleteTimestamp(), Long.MAX_VALUE);
         // the timestamp is not changed throughout refreshes that don't see deletes
-        putIndex(map, "1", newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        putIndex(map, "1", newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         refresh(map);
         assertThat(archive.getMinDeleteTimestamp(), equalTo(Long.MAX_VALUE));
 
@@ -192,7 +192,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         // New segment generation (flush on index shard)
         preCommitGeneration.incrementAndGet();
         currentGeneration.incrementAndGet();
-        putIndex(map, "3", newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        putIndex(map, "3", newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         putDelete(map, "3", newDeleteVersionValue(1, 1, 1, 3));
         refresh(map);
         assertThat(archive.getMinDeleteTimestamp(), equalTo(1L));
@@ -211,7 +211,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         var archive = new StatelessLiveVersionMapArchive(preCommitGeneration::get);
         var map = newLiveVersionMap(archive);
         assertFalse(isUnsafe(map));
-        maybePutIndex(map, "1", newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        maybePutIndex(map, "1", newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         assertTrue(isUnsafe(map));
         // A refresh moves the unsafe map from current to old and then to archive.
         // Do at least one refresh
@@ -239,7 +239,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         var archive = new StatelessLiveVersionMapArchive(preCommitGeneration::get);
         var map = newLiveVersionMap(archive);
         assertFalse(isUnsafe(map));
-        maybePutIndex(map, "1", newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        maybePutIndex(map, "1", newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         assertTrue(isUnsafe(map));
         // A commit happens (e.g. due to a switch from unsafe to safe when a get to an unsafe map is received)
         flush(map, currentGeneration, preCommitGeneration);
@@ -261,7 +261,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         AtomicLong preCommitGeneration = new AtomicLong();
         var archive = new StatelessLiveVersionMapArchive(preCommitGeneration::get);
         var map = newLiveVersionMap(archive);
-        maybePutIndex(map, "1", newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        maybePutIndex(map, "1", newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         // commit, hold on to unprmotable responses
         assertThat(archive.getMinSafeGeneration(), equalTo(-1L));
         flush(map, currentGeneration, preCommitGeneration);
@@ -269,7 +269,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         assertThat(minSafeGeneration, Matchers.equalTo(preCommitGeneration.get() + 1));
         assertTrue(isUnsafe(map));
         // while unpromotable refresh is happening, we index mode
-        maybePutIndex(map, "2", newIndexVersionValue(randomTranslogLocation(), 1, 1, 1));
+        maybePutIndex(map, "2", newIndexVersionValue(randomOperationLocation(), 1, 1, 1));
         refresh(map);
         assertThat(archive.getMinSafeGeneration(), Matchers.equalTo(preCommitGeneration.get() + 1));
         archive.afterUnpromotablesRefreshed(currentGeneration.get());
@@ -290,7 +290,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         AtomicLong preCommitGeneration = new AtomicLong();
         var archive = new StatelessLiveVersionMapArchive(preCommitGeneration::get);
         var map = newLiveVersionMap(archive);
-        maybePutIndex(map, "1", newIndexVersionValue(randomTranslogLocation(), 1, 0, 1));
+        maybePutIndex(map, "1", newIndexVersionValue(randomOperationLocation(), 1, 0, 1));
         assertTrue(isUnsafe(map));
         // Flush starts
         preCommitGeneration.set(currentGeneration.get() + 1);
@@ -298,7 +298,7 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         assertTrue(isUnsafe(map));
         int count = randomIntBetween(1, 3);
         for (int i = 0; i < count; i++) {
-            maybePutIndex(map, randomIdentifier(), newIndexVersionValue(randomTranslogLocation(), 1, i + 1, 1));
+            maybePutIndex(map, randomIdentifier(), newIndexVersionValue(randomOperationLocation(), 1, i + 1, 1));
             if (randomBoolean()) {
                 refresh(map);
             }
@@ -453,7 +453,9 @@ public class StatelessLiveVersionMapTests extends ESTestCase {
         }
     }
 
-    private Translog.Location randomTranslogLocation() {
-        return randomBoolean() ? null : new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt());
+    private Translog.OperationLocation randomOperationLocation() {
+        return randomBoolean()
+            ? null
+            : new Translog.OperationLocation(new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt()));
     }
 }


### PR DESCRIPTION
Remove the `batchRowIndex` from Location and track it using 
an additional abstraction called `OperationLocation` used 
only in the Live version map in `IndexVersionValue`

Since this is just a refactoring, existing tests cover regressions 
and no new tests are needed

