### PR TITLE
[9.5] Gate TO_TEXT conditional csv-specs on fn_to_text capability (#154474)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -432,6 +432,7 @@ CASE(y==2, 10, 1) * MIN(x):integer | y:integer
 
 casePartialFoldTrueToTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -448,6 +449,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldTrailingTextArmKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -464,6 +466,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldKeywordIsGroupable
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10005
@@ -479,6 +482,7 @@ c:long | g:keyword
 
 casePartialFoldMixedConditionsKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -495,6 +499,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldMultivalueTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no == 10001
@@ -508,6 +513,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldTextArmNullElseKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no == 10001


### PR DESCRIPTION
Backports #154474 to 9.5 to unblock the branch's BWC/multi-cluster CI.

The `casePartialFold*` conditional csv-specs use `TO_TEXT` (a 9.5.0 preview function). In the mixed/multi-cluster BWC matrix they ran against 9.4.x remotes that cannot deserialize `ToText`, crashing the remote node on the unknown-writeable assertion and dragging unrelated specs down as `connect_transport_exception` collateral. Gating those specs on the `fn_to_text` capability makes them skip against remotes that lack it.

This is the capability-gate half of #154474. The `muted-tests.yml` portion of that PR was not carried over — 9.5 already mutes the affected conditional specs, and importing main's unrelated mute churn would be wrong; the gate is the substantive fix and stands alone.

Backport of #154474. Fixes the 9.5 side of #154471.
