### PR TITLE
[9.5] Gate TO_TEXT conditional csv-specs on fn_to_text (#154474)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -752,30 +752,6 @@ tests:
   method: test {csv-spec:conditional.singleCondition}
   issue: https://github.com/elastic/elasticsearch/issues/154436
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldTrailingTextArmKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154437
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldMultivalueTextKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154449
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldTextArmNullElseKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154450
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldKeywordIsGroupable}
-  issue: https://github.com/elastic/elasticsearch/issues/154451
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldMultivalueTextKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154452
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldTrailingTextArmKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154454
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldKeywordIsGroupable}
-  issue: https://github.com/elastic/elasticsearch/issues/154456
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.casePartialFoldTextArmNullElseKeepsKeyword}
-  issue: https://github.com/elastic/elasticsearch/issues/154457
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
   method: test {csv-spec:conditional.docsCaseSuccessRate}
   issue: https://github.com/elastic/elasticsearch/issues/154458
 - class: org.elasticsearch.blobcache.common.SparseFileTrackerTests

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -432,6 +432,7 @@ CASE(y==2, 10, 1) * MIN(x):integer | y:integer
 
 casePartialFoldTrueToTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -448,6 +449,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldTrailingTextArmKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -464,6 +466,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldKeywordIsGroupable
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10005
@@ -479,6 +482,7 @@ c:long | g:keyword
 
 casePartialFoldMixedConditionsKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no >= 10001 AND emp_no <= 10003
@@ -495,6 +499,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldMultivalueTextKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no == 10001
@@ -508,6 +513,7 @@ emp_no:integer | x:keyword
 
 casePartialFoldTextArmNullElseKeepsKeyword
 required_capability: fix_case_partial_fold_keyword_type
+required_capability: fn_to_text
 
 FROM employees
 | WHERE emp_no == 10001


### PR DESCRIPTION
Backport of #154474 to `9.5`.

## What this is about

The `casePartialFold*` specs in `conditional.csv-spec` use `TO_TEXT`, a 9.5 function. They gate only on `fix_case_partial_fold_keyword_type`, and that capability is present on 9.4.x because the CASE fix was backported there. So the BWC multi-cluster and mixed-cluster runners ran the specs against 9.4.x remotes and shipped plan fragments containing `ToText` to nodes that cannot deserialize it. In assert-enabled builds the unknown-writeable assertion is fatal and takes the remote node down, which is why each failure dragged unrelated specs along as `connect_transport_exception` collateral.

9.5 has the same bug main did, and a bigger mute pile to show for it.

## What this PR does

Adds `required_capability: fn_to_text` to all six `casePartialFold*` specs. The runners already check `required_capability` against every participating cluster, so the specs skip whenever any cluster lacks the function. No new capability and no runner changes — `fn_to_text` is auto-registered from the function registry, and `ToText` is registered on 9.5.

Unmutes the eight `casePartialFold*` entries the root cause produced.

## What differs from the source PR

The `muted-tests.yml` hunk did not apply — 9.5 accumulated its own mute set for these specs rather than the one main carried. Resolved by hand: this drops the eight `casePartialFold*` mutes (#154437, #154449, #154450, #154451, #154452, #154454, #154456, #154457), covering four specs across `MultiClusterSpecConditionalIT` and `MixedClusterEsqlSpecConditionalIT`. All four are among the six now gated.

The `conditional.csv-spec` hunk cherry-picked clean.

## What is out of scope

Three mutes on the same two suites are left in place — `singleCondition` (#154436), `docsCaseSuccessRate` (#154458), `conditionIsNull` (#154473). These look like `connect_transport_exception` collateral from the downed remote and should clear once the gate lands, but they are separately filed and confirming against green CI beats unmuting on inference.
