### PR TITLE
[9.5] [ML] Fix and unmute TransformGetAndGetStatsIT (#153764)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -490,9 +490,6 @@ tests:
 - class: org.elasticsearch.gradle.internal.archunit.IsolatedProjectsArchUnitSpec
   method: the getRootProject baseline contains no stale entries
   issue: https://github.com/elastic/elasticsearch/issues/152341
-- class: org.elasticsearch.xpack.transform.integration.TransformGetAndGetStatsIT
-  method: testGetAndGetBasicStats
-  issue: https://github.com/elastic/elasticsearch/issues/152351
 - class: org.elasticsearch.test.apmintegration.OtelMetricsIT
   method: testExplicitMetrics
   issue: https://github.com/elastic/elasticsearch/issues/152379

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -214,7 +214,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         transform = ((List<Map<String, Object>>) XContentMapValues.extractValue("transforms", stats)).get(0);
 
         // verify state exists
-        assertEquals("started", XContentMapValues.extractValue("state", transform));
+        assertThat(XContentMapValues.extractValue("state", transform), oneOf("started", "indexing"));
 
         // verify health exists
         assertEquals("green", XContentMapValues.extractValue("health.status", transform));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[ML] Fix and unmute TransformGetAndGetStatsIT (#153764)](https://github.com/elastic/elasticsearch/pull/153764)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)