### PR TITLE
docs: note Enterprise subscription for ES|QL approximation

### DIFF
--- a/docs/reference/query-languages/esql/esql-query-approximation.md
+++ b/docs/reference/query-languages/esql/esql-query-approximation.md
@@ -9,6 +9,7 @@ mapped_pages:
 # Approximate `STATS` queries
 
 ::::{admonition} Requirements
+:applies_to: { ess:, ece:, eck:, self: }
 For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions).
 ::::
 

--- a/docs/reference/query-languages/esql/esql-query-approximation.md
+++ b/docs/reference/query-languages/esql/esql-query-approximation.md
@@ -8,9 +8,9 @@ mapped_pages:
 ---
 # Approximate `STATS` queries
 
-**Requirements**
-
-- For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions).
+::::{admonition} Requirements
+For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions).
+::::
 
 {{esql}} [`STATS`](/reference/query-languages/esql/commands/stats-by.md) commands summarize large volumes of data into aggregated statistics. For many analytics workloads, exact results are not strictly necessary — approximate results with known error bounds are sufficient, and can be computed dramatically faster. The `approximation` setting enables this: {{esql}} rewrites your query to use random sampling and extrapolation, returning estimates together with confidence intervals and a certification flag.
 

--- a/docs/reference/query-languages/esql/esql-query-approximation.md
+++ b/docs/reference/query-languages/esql/esql-query-approximation.md
@@ -8,6 +8,10 @@ mapped_pages:
 ---
 # Approximate `STATS` queries
 
+**Requirements**
+
+- For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions).
+
 {{esql}} [`STATS`](/reference/query-languages/esql/commands/stats-by.md) commands summarize large volumes of data into aggregated statistics. For many analytics workloads, exact results are not strictly necessary — approximate results with known error bounds are sufficient, and can be computed dramatically faster. The `approximation` setting enables this: {{esql}} rewrites your query to use random sampling and extrapolation, returning estimates together with confidence intervals and a certification flag.
 
 Approximation breaks the dependency between performance and dataset size. Accuracy depends principally on the data characteristics and the query itself, not on how many rows are in the source index. This means the performance advantage grows as your data grows.


### PR DESCRIPTION
## Summary

- **`docs/reference/query-languages/esql/esql-query-approximation.md`**: Add a **Requirements** note at the top of the page stating that approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions) on Elastic Cloud Hosted, ECE, ECK, and self-managed clusters.

Verified against `EsqlLicenseChecker.checkQueryApproximation` ([#147097](https://github.com/elastic/elasticsearch/pull/147097)): `"A valid Enterprise license is required to use ES|QL query approximation."`

Companion Kibana UI docs PR: [elastic/docs-content#7482](https://github.com/elastic/docs-content/pull/7482) (docs-content issue [#7481](https://github.com/elastic/docs-content/issues/7481)). Related product UI work: [elastic/kibana#279718](https://github.com/elastic/kibana/issues/279718) (not closed by this PR).

## Test plan

- [ ] Confirm the Requirements note renders at the top of Approximate STATS queries
- [ ] Confirm `{{ech}}` / `{{ece}}` / `{{eck}}` substitutions resolve


Made with [Cursor](https://cursor.com)