### PR TITLE
[8.19] [ML] Fix and unmute TransformGetAndGetStatsIT (#153764)

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -220,7 +220,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         transform = ((List<Map<String, Object>>) XContentMapValues.extractValue("transforms", stats)).get(0);
 
         // verify state exists
-        assertEquals("started", XContentMapValues.extractValue("state", transform));
+        assertThat(XContentMapValues.extractValue("state", transform), oneOf("started", "indexing"));
 
         // verify health exists
         assertEquals("green", XContentMapValues.extractValue("health.status", transform));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Fix and unmute TransformGetAndGetStatsIT (#153764)](https://github.com/elastic/elasticsearch/pull/153764)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)