### PR TITLE
[9.5] ES|QL|DS: floor external split coalescing at read parallelism (#154196)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCoordinatorOnlyGatherIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCoordinatorOnlyGatherIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * End-to-end guard for the gather-boundary decision in {@code ComputeService.applyExternalDistributionStrategy}. Under
+ * the {@code external_distribution=coordinator_only} pragma the scan is kept off data nodes, so an ungrouped {@code STATS}
+ * that runs several parallel partial-aggregation scan drivers on the coordinator must gather those partials into a single
+ * final row. Dropping the gather boundary (collapsing the external exchange instead) would emit one row per parallel
+ * driver, so this test pins the correct single-row result.
+ *
+ * <p>The scenario is made deterministic rather than left to the host: the number of parallel scan drivers is
+ * {@code min(splitCount, task_concurrency)}, so both knobs are fixed. {@code task_concurrency} is pinned to {@value
+ * #TASK_CONCURRENCY} (the class-load default is derived from the host processor count and can collapse to 1), and the
+ * file count is kept below the split-coalescing threshold so every file stays its own split ({@code splitCount ==
+ * fileCount}) instead of being coalesced down to a host-dependent group count. Both together guarantee more than one
+ * parallel partial-aggregation driver, which the test also asserts from the query profile so the multi-driver gather path
+ * cannot be silently skipped.
+ */
+public class ExternalParquetCoordinatorOnlyGatherIT extends AbstractExternalDataSourceIT {
+
+    private static final int TASK_CONCURRENCY = 4;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(ParquetDataSourcePlugin.class);
+    }
+
+    public void testUngroupedStatsGathersToSingleRowUnderCoordinatorOnly() throws Exception {
+        // Below the split-coalescing threshold (32), so the files are never coalesced and splitCount == fileCount. With
+        // task_concurrency pinned to 4, the scan runs min(fileCount, 4) = 4 parallel partial-aggregation drivers whose
+        // partials must be gathered.
+        int fileCount = 8;
+        Path dir = createTempDir().resolve("coordinator_only_gather");
+        Files.createDirectories(dir);
+        // One single-row file per split; file i carries value=i.
+        for (int i = 0; i < fileCount; i++) {
+            int value = i;
+            writeParquet(
+                dir.resolve("f" + i + ".parquet"),
+                "message test { required int32 value; }",
+                1,
+                1024,
+                (g, r) -> g.add("value", value)
+            );
+        }
+        String glob = StoragePath.fileUri(dir) + "/*.parquet";
+        String dataset = registerDataset("coordinator_only_gather", glob, Map.of());
+
+        QueryPragmas pragmas = new QueryPragmas(
+            Settings.builder()
+                .put(QueryPragmas.EXTERNAL_DISTRIBUTION.getKey(), "coordinator_only")
+                .put(QueryPragmas.TASK_CONCURRENCY.getKey(), TASK_CONCURRENCY)
+                .build()
+        );
+        // SUM is not metadata-pushable, so split discovery runs and every file becomes its own split; the ungrouped STATS
+        // then depends on the gather boundary to merge the parallel drivers' partials into a single row.
+        String query = "FROM " + dataset + " | STATS s = SUM(value), c = COUNT(*)";
+        var request = syncEsqlQueryRequest(query).pragmas(pragmas);
+        request.acceptedPragmaRisks(true); // pragmas are rejected on non-snapshot builds without this
+        request.profile(true);
+
+        try (var response = run(request)) {
+            // Keeps the single-row assertion below from passing vacuously. Each parallel scan driver emits its own
+            // partial aggregation into the exchange, so with a single driver there is nothing to gather and a missing
+            // gather boundary would still yield one row. Requiring >= 2 scan drivers means the exchange has >= 2 partials
+            // to merge, so a dropped gather boundary surfaces as >= 2 rows below rather than going undetected.
+            assertThat(
+                "expected more than one parallel partial-aggregation scan driver to feed the gather",
+                externalScanStatuses(response).size(),
+                greaterThanOrEqualTo(2)
+            );
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat("ungrouped STATS must gather to exactly one row, not one per parallel driver", rows.size(), equalTo(1));
+            long expectedSum = (long) fileCount * (fileCount - 1) / 2;
+            assertThat(
+                "SUM must aggregate every file across all parallel drivers",
+                ((Number) rows.get(0).get(0)).longValue(),
+                equalTo(expectedSum)
+            );
+            assertThat(
+                "COUNT must total every file across all parallel drivers",
+                ((Number) rows.get(0).get(1)).longValue(),
+                equalTo((long) fileCount)
+            );
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescer.java
@@ -12,12 +12,17 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.PriorityQueue;
 
 /**
- * Groups many small {@link ExternalSplit}s into {@link CoalescedSplit}s to
- * reduce scheduling overhead. Uses greedy bin-packing by size when all splits
- * report a positive {@code estimatedSizeInBytes()}, and falls back to
- * count-based grouping otherwise.
+ * Groups many small {@link ExternalSplit}s into {@link CoalescedSplit}s to reduce scheduling overhead. Uses greedy
+ * bin-packing by size when every split reports a known (non-negative) {@code estimatedSizeInBytes()}, and falls back
+ * to count-based grouping otherwise. When either packing yields fewer groups than the caller's {@code minGroupCount}
+ * floor, the splits are re-binned to meet that floor so read parallelism is not collapsed onto one schedulable unit.
+ *
+ * <p>This class is the sole owner of the grouping policy: whether a scan is worth coalescing at all
+ * ({@link #shouldCoalesce}), how splits are packed, and how the floor is met. Callers supply budgets and the floor;
+ * they do not re-implement any part of the decision.
  */
 public final class SplitCoalescer {
 
@@ -27,22 +32,82 @@ public final class SplitCoalescer {
 
     private SplitCoalescer() {}
 
+    /**
+     * Whether a scan holding {@code splitCount} splits is worth grouping at all. This is the single home of that
+     * rule — callers ask here rather than comparing against {@link #COALESCING_THRESHOLD} themselves, so the
+     * decision cannot drift between this class and the code that drives it.
+     */
+    public static boolean shouldCoalesce(int splitCount) {
+        return splitCount > COALESCING_THRESHOLD;
+    }
+
+    /**
+     * Whether a split already fills the size budget on its own and therefore stays a standalone group rather than
+     * being packed with others. Shared by {@link #packBySize} and {@link #floorGroups} so the two agree by
+     * construction: {@link #floorGroups} reserves one group per standalone split and spreads the rest across what
+     * is left, which only leaves room for the remainder because {@link #packBySize} gave those same splits their
+     * own bin. If the two predicates diverged, the floor could be asked for more groups than it has splits to fill.
+     */
+    private static boolean isStandalone(ExternalSplit split, long targetGroupSizeBytes) {
+        return split.estimatedSizeInBytes() >= targetGroupSizeBytes;
+    }
+
+    /**
+     * Coalesces with the default size and count budgets and no minimum group floor; equivalent to
+     * {@link #coalesce(List, long, int, int)} with {@code minGroupCount=1}.
+     */
     public static List<ExternalSplit> coalesce(List<ExternalSplit> splits) {
         return coalesce(splits, DEFAULT_TARGET_GROUP_SIZE_BYTES, DEFAULT_TARGET_GROUP_COUNT);
     }
 
+    /**
+     * Coalesces with the given size and count budgets and no minimum group floor; equivalent to
+     * {@link #coalesce(List, long, int, int)} with {@code minGroupCount=1}.
+     */
     public static List<ExternalSplit> coalesce(List<ExternalSplit> splits, long targetGroupSizeBytes, int targetGroupCount) {
+        return coalesce(splits, targetGroupSizeBytes, targetGroupCount, 1);
+    }
+
+    /**
+     * Coalesces with the default size and count budgets and a floor of {@code minGroupCount} groups (clamped to
+     * the number of input splits), so a scan over many small files keeps at least that many schedulable units.
+     */
+    public static List<ExternalSplit> coalesce(List<ExternalSplit> splits, int minGroupCount) {
+        return coalesce(splits, DEFAULT_TARGET_GROUP_SIZE_BYTES, DEFAULT_TARGET_GROUP_COUNT, minGroupCount);
+    }
+
+    /**
+     * Coalesces with a floor of {@code minGroupCount} on the number of produced groups, clamped to the number of
+     * input splits. A scan over many small files therefore stays spread across at least
+     * {@code min(splitCount, minGroupCount)} independently schedulable units, so read concurrency is not collapsed
+     * to a single unit when tiny files would otherwise bin-pack into one group. The size budget still raises the
+     * group count above the floor when the data needs more bins to stay under {@code targetGroupSizeBytes}; the
+     * floor only ever adds groups, never merges past the size budget.
+     *
+     * <p>The returned list is always the coalescer's own, never {@code splits} itself, including when the input is
+     * too small to be worth grouping. Callers replace the contents of the list they passed in, so handing theirs
+     * back would make them clear the list they are copying from and silently empty the scan.
+     */
+    public static List<ExternalSplit> coalesce(
+        List<ExternalSplit> splits,
+        long targetGroupSizeBytes,
+        int targetGroupCount,
+        int minGroupCount
+    ) {
         if (splits == null) {
             throw new IllegalArgumentException("splits cannot be null");
-        }
-        if (splits.size() <= COALESCING_THRESHOLD) {
-            return splits;
         }
         if (targetGroupCount <= 0) {
             throw new IllegalArgumentException("targetGroupCount must be positive, got: " + targetGroupCount);
         }
         if (targetGroupSizeBytes <= 0) {
             throw new IllegalArgumentException("targetGroupSizeBytes must be positive, got: " + targetGroupSizeBytes);
+        }
+        if (minGroupCount < 1) {
+            throw new IllegalArgumentException("minGroupCount must be positive, got: " + minGroupCount);
+        }
+        if (shouldCoalesce(splits.size()) == false) {
+            return new ArrayList<>(splits);
         }
 
         boolean allHaveSize = true;
@@ -53,13 +118,16 @@ public final class SplitCoalescer {
             }
         }
 
-        if (allHaveSize) {
-            return coalesceBySizeGreedy(splits, targetGroupSizeBytes);
+        List<List<ExternalSplit>> bins = allHaveSize ? packBySize(splits, targetGroupSizeBytes) : packByCount(splits, targetGroupCount);
+
+        int targetGroups = Math.min(splits.size(), minGroupCount);
+        if (bins.size() < targetGroups) {
+            bins = floorGroups(splits, targetGroups, targetGroupSizeBytes, allHaveSize);
         }
-        return coalesceByCount(splits, targetGroupCount);
+        return buildResult(bins);
     }
 
-    private static List<ExternalSplit> coalesceBySizeGreedy(List<ExternalSplit> splits, long targetGroupSizeBytes) {
+    private static List<List<ExternalSplit>> packBySize(List<ExternalSplit> splits, long targetGroupSizeBytes) {
         List<ExternalSplit> sorted = new ArrayList<>(splits);
         sorted.sort(Comparator.comparingLong(ExternalSplit::estimatedSizeInBytes).reversed());
 
@@ -68,7 +136,7 @@ public final class SplitCoalescer {
 
         for (ExternalSplit split : sorted) {
             long size = split.estimatedSizeInBytes();
-            if (size >= targetGroupSizeBytes) {
+            if (isStandalone(split, targetGroupSizeBytes)) {
                 bins.add(new ArrayList<>(List.of(split)));
                 binSizes.add(size);
                 continue;
@@ -93,10 +161,10 @@ public final class SplitCoalescer {
             }
         }
 
-        return buildResult(bins);
+        return bins;
     }
 
-    private static List<ExternalSplit> coalesceByCount(List<ExternalSplit> splits, int targetGroupCount) {
+    private static List<List<ExternalSplit>> packByCount(List<ExternalSplit> splits, int targetGroupCount) {
         int groupSize = Math.max(1, (splits.size() + targetGroupCount - 1) / targetGroupCount);
         List<List<ExternalSplit>> bins = new ArrayList<>();
 
@@ -105,7 +173,121 @@ public final class SplitCoalescer {
             bins.add(new ArrayList<>(splits.subList(i, end)));
         }
 
-        return buildResult(bins);
+        return bins;
+    }
+
+    /**
+     * Re-bins the splits into exactly {@code targetGroups} groups when the size/count packing produced fewer,
+     * so the number of schedulable units meets the read-parallelism floor. When sizes are known, splits at or
+     * above the size budget stay standalone and the rest are spread across the leftover groups balanced by leaf
+     * count with the size budget as a cap, which shares the per-file open cost evenly without a straggler group.
+     * When sizes are unknown, all splits are spread by leaf count.
+     */
+    private static List<List<ExternalSplit>> floorGroups(
+        List<ExternalSplit> splits,
+        int targetGroups,
+        long targetGroupSizeBytes,
+        boolean allHaveSize
+    ) {
+        List<List<ExternalSplit>> groups = new ArrayList<>(targetGroups);
+        List<ExternalSplit> small = new ArrayList<>(splits.size());
+        if (allHaveSize) {
+            for (ExternalSplit split : splits) {
+                if (isStandalone(split, targetGroupSizeBytes)) {
+                    groups.add(new ArrayList<>(List.of(split)));
+                } else {
+                    small.add(split);
+                }
+            }
+        } else {
+            small.addAll(splits);
+        }
+
+        int smallGroups = targetGroups - groups.size();
+        groups.addAll(spreadLeastLoaded(small, smallGroups, allHaveSize, targetGroupSizeBytes));
+        return groups;
+    }
+
+    /**
+     * Distributes {@code leaves} across exactly {@code groupCount} groups. The largest leaves seed the groups
+     * one-per-group, then each remaining leaf goes to the group holding the fewest leaves, so groups stay balanced
+     * by count and the per-file open cost (which dominates many-small-file scans) is spread evenly rather than
+     * concentrated in one group. Byte load only breaks ties between groups with an equal leaf count, and a group
+     * that has already reached {@code targetGroupSizeBytes} is skipped while any other group still has room, so a
+     * group is never grown past the size budget while a lighter group is available. Seeding the groups up front
+     * guarantees {@code groupCount} non-empty groups even when several leaves report a zero (or unknown) size.
+     * When {@code bySize} is false the leaves have no known size, so the budget and byte tie-break do not apply and
+     * leaves are spread purely by count.
+     *
+     * <p>Precondition: {@code 1 <= groupCount <= leaves.size()}, guaranteed by {@link #floorGroups} because
+     * {@link #isStandalone} splits off exactly the groups {@link #packBySize} had already given their own bin.
+     * Violating it throws: {@code groupCount > leaves.size()} runs the seed phase off the end of the list
+     * ({@link IndexOutOfBoundsException}), and {@code groupCount < 1} with leaves left to place is rejected by the
+     * priority queue's capacity ({@link IllegalArgumentException}).
+     */
+    private static List<List<ExternalSplit>> spreadLeastLoaded(
+        List<ExternalSplit> leaves,
+        int groupCount,
+        boolean bySize,
+        long targetGroupSizeBytes
+    ) {
+        List<ExternalSplit> sorted = new ArrayList<>(leaves);
+        if (bySize) {
+            sorted.sort(Comparator.comparingLong(ExternalSplit::estimatedSizeInBytes).reversed());
+        }
+
+        List<List<ExternalSplit>> groups = new ArrayList<>(groupCount);
+        long[] loads = new long[groupCount];
+        int[] leafCounts = new int[groupCount];
+        for (int i = 0; i < groupCount; i++) {
+            ExternalSplit leaf = sorted.get(i);
+            List<ExternalSplit> group = new ArrayList<>();
+            group.add(leaf);
+            groups.add(group);
+            loads[i] = bySize ? leaf.estimatedSizeInBytes() : 1;
+            leafCounts[i] = 1;
+        }
+
+        if (sorted.size() > groupCount) {
+            PriorityQueue<Integer> pq = new PriorityQueue<>(
+                groupCount,
+                (a, b) -> compareGroups(leafCounts, loads, a, b, bySize, targetGroupSizeBytes)
+            );
+            for (int i = 0; i < groupCount; i++) {
+                pq.offer(i);
+            }
+            for (int i = groupCount; i < sorted.size(); i++) {
+                ExternalSplit leaf = sorted.get(i);
+                int target = pq.poll();
+                groups.get(target).add(leaf);
+                leafCounts[target]++;
+                loads[target] += bySize ? leaf.estimatedSizeInBytes() : 1;
+                pq.offer(target);
+            }
+        }
+        return groups;
+    }
+
+    /**
+     * Three-way comparator for group selection: returns negative when {@code a} is a better target than {@code b},
+     * positive when {@code b} is better, zero when equal priority. A group still under the size budget is preferred
+     * over one that has reached it, so no group grows past the budget while another has room. Among groups on the
+     * same side of the budget, the one holding fewer leaves wins (count balance), and byte load only separates
+     * groups with an equal leaf count. Budget and byte load are ignored when {@code bySize} is false.
+     */
+    private static int compareGroups(int[] leafCounts, long[] loads, int a, int b, boolean bySize, long targetGroupSizeBytes) {
+        if (bySize) {
+            boolean aHasRoom = loads[a] < targetGroupSizeBytes;
+            boolean bHasRoom = loads[b] < targetGroupSizeBytes;
+            if (aHasRoom != bHasRoom) {
+                return aHasRoom ? -1 : 1;
+            }
+        }
+        int countDiff = Integer.compare(leafCounts[a], leafCounts[b]);
+        if (countDiff != 0) {
+            return countDiff;
+        }
+        return bySize ? Long.compare(loads[a], loads[b]) : 0;
     }
 
     private static List<ExternalSplit> buildResult(List<List<ExternalSplit>> bins) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AdaptiveStrategy.java
@@ -56,7 +56,7 @@ public final class AdaptiveStrategy implements ExternalDistributionStrategy {
             return ExternalDistributionPlan.LOCAL;
         }
 
-        boolean hasPipelineBreaker = plan.anyMatch(n -> n instanceof AggregateExec || n instanceof TopNExec);
+        boolean hasPipelineBreaker = ExternalDistributionStrategy.needsGatherBoundary(plan);
         boolean manySplits = splits.size() > nodes.size();
 
         if (hasPipelineBreaker || manySplits) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -115,6 +115,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -191,6 +192,7 @@ public class ComputeService {
     private final OperatorFactoryRegistry operatorFactoryRegistry;
     private final FormatReaderRegistry formatReaderRegistry;
     private final Executor searchExecutor;
+    private final ThreadPool threadPool;
     // Single shared instance, refreshed in place whenever the dynamic setting changes, rather than
     // re-resolving it from ClusterSettings for every query.
     private final AtomicReference<MatcherWatchdog> grokMatcherWatchdog = new AtomicReference<>();
@@ -212,6 +214,7 @@ public class ComputeService {
         this.bigArrays = bigArrays.withCircuitBreaking();
         this.blockFactory = blockFactory;
         this.searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
+        this.threadPool = threadPool;
         this.driverRunner = new DriverTaskRunner(transportService, searchExecutor);
         this.enrichLookupService = enrichLookupService;
         this.lookupFromIndexService = lookupFromIndexService;
@@ -266,7 +269,7 @@ public class ComputeService {
                 isCancelled
             );
             recordExternalScanStats(execInfo, result);
-            return coalesceSplits(result.plan());
+            return coalesceSplits(result.plan(), () -> externalCoalesceFloor(configuration));
         } catch (TaskCancelledException e) {
             // Cancellation is not a discovery failure — propagate it without the warn.
             throw e;
@@ -287,18 +290,57 @@ public class ComputeService {
         }
     }
 
-    static PhysicalPlan coalesceSplits(PhysicalPlan plan) {
+    /**
+     * Applies the coalescing floor to every external source in the plan. The floor is resolved through a supplier and
+     * at most once per plan, because resolving it reads cluster state and thread-pool info while the overwhelming
+     * majority of queries carry no external source that needs coalescing at all.
+     */
+    static PhysicalPlan coalesceSplits(PhysicalPlan plan, IntSupplier minGroupCount) {
+        // externalCoalesceFloor never returns less than one, so zero is a safe "not yet resolved" marker.
+        int[] resolvedFloor = new int[1];
         return plan.transformUp(ExternalSourceExec.class, exec -> {
             List<ExternalSplit> splits = exec.splits();
-            if (splits.size() <= SplitCoalescer.COALESCING_THRESHOLD) {
+            if (SplitCoalescer.shouldCoalesce(splits.size()) == false) {
                 return exec;
             }
-            List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
-            if (coalesced == splits) {
-                return exec;
+            if (resolvedFloor[0] == 0) {
+                resolvedFloor[0] = minGroupCount.getAsInt();
             }
-            return exec.withSplits(coalesced);
+            return exec.withSplits(SplitCoalescer.coalesce(splits, resolvedFloor[0]));
         });
+    }
+
+    private int externalCoalesceFloor(Configuration configuration) {
+        int taskConcurrency = configuration.pragmas().taskConcurrency();
+        // The TASK_CONCURRENCY default is computed from Settings.EMPTY at class-load time and therefore ignores
+        // node.processors. On a K8s node with node.processors=4 on a 64-CPU host the default is 97 while the
+        // esql_worker pool has only 7 threads. Cap against the pool size so the floor never creates more groups
+        // than there are workers to drain them. ThreadPool#info returns null for a pool this node did not register,
+        // in which case there is no pool size to cap against and the pragma value stands on its own.
+        ThreadPool.Info computePoolInfo = threadPool.info(EsqlPlugin.computePool());
+        int effectiveConcurrency = computePoolInfo == null ? taskConcurrency : Math.min(taskConcurrency, computePoolInfo.getMax());
+        int eligibleNodes = Math.max(1, NodeEligibilityStrategy.DATA_NODES_ONLY.eligibleNodes(clusterService.state().nodes()).size());
+        return externalCoalesceFloor(effectiveConcurrency, eligibleNodes);
+    }
+
+    /**
+     * The minimum number of coalesced groups to keep for an external scan, so read parallelism is not collapsed
+     * to a single unit. It is the per-node driver cap ({@code task_concurrency}) times the number of eligible
+     * data nodes: after distribution each node receives about {@code task_concurrency} groups and runs that many
+     * scan drivers. {@link SplitCoalescer} clamps the result to the input split count. The value is held at or
+     * above one (a degenerate {@code task_concurrency} of zero or below still leaves the scan coalescible) and at
+     * or below {@link Integer#MAX_VALUE} on an implausibly wide cluster.
+     *
+     * <p>Deliberately counts the whole cluster even for a scan that ends up staying local: coalescing runs before
+     * the distribution decision, and the group count is itself an input to that decision
+     * ({@code AdaptiveStrategy} weighs splits against nodes). A local scan therefore gets more groups than its one
+     * node can occupy. That overshoot is harmless — the groups become slices in a shared queue and the driver count
+     * is still capped at {@code min(groupCount, task_concurrency)} — whereas undershooting would leave a
+     * distributable scan unable to fill the cluster.
+     */
+    static int externalCoalesceFloor(int taskConcurrency, int eligibleNodeCount) {
+        long floor = (long) taskConcurrency * eligibleNodeCount;
+        return (int) Math.max(1, Math.min(floor, Integer.MAX_VALUE));
     }
 
     static ExternalDistributionStrategy resolveExternalDistributionStrategy(QueryPragmas pragmas) {
@@ -350,6 +392,22 @@ public class ComputeService {
             return new ExternalDistributionResult(resolvedPlan, distributionPlan, List.of());
         }
 
+        // Staying local but a gather is required: preserve the exchange and run the partial-aggregation stage on the local
+        // (coordinator) node via the same path the distributed modes use, so the parallel per-group drivers are gathered into a
+        // single final aggregation. Collapsing here instead would drop the gather boundary and emit one row per split group.
+        // Restricted to plans that actually hold an operator unsafe to replicate per driver: a collapsed scan is the cheaper
+        // path (no exchange, no self transport hop), and it stays correct for everything else — notably a limit-only plan,
+        // where all drivers share one Limiter. Widening this would reroute queries that were never broken.
+        if (externalSplits.size() > 1
+            && ExternalDistributionStrategy.needsGatherBoundary(resolvedPlan)
+            && hasCollapsibleExternalExchange(resolvedPlan)) {
+            ExternalDistributionPlan localNodePlan = new ExternalDistributionPlan(
+                Map.of(clusterService.localNode().getId(), externalSplits),
+                true
+            );
+            return new ExternalDistributionResult(resolvedPlan, localNodePlan, List.of());
+        }
+
         return new ExternalDistributionResult(collapseExternalSourceExchanges(resolvedPlan), null, externalSplits);
     }
 
@@ -385,12 +443,12 @@ public class ComputeService {
                 recordExternalWarmAggregates(execInfo, plan);
             } else {
                 PhysicalPlan rewritten = discoverSplitsFromFragments(plan, splits, maxRecordBytes(configuration), execInfo, isCancelled);
-                if (splits.size() > SplitCoalescer.COALESCING_THRESHOLD) {
-                    List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
-                    if (coalesced != splits) {
-                        splits.clear();
-                        splits.addAll(coalesced);
-                    }
+                if (SplitCoalescer.shouldCoalesce(splits.size())) {
+                    // coalesce always returns a list of its own, so replacing the contents of `splits` in place
+                    // cannot clear the list being copied from.
+                    List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits, externalCoalesceFloor(configuration));
+                    splits.clear();
+                    splits.addAll(coalesced);
                 }
                 return new CollectedSplits(rewritten, splits);
             }
@@ -577,13 +635,7 @@ public class ComputeService {
 
     static PhysicalPlan collapseExternalSourceExchanges(PhysicalPlan plan) {
         PhysicalPlan collapsed = plan.transformUp(ExchangeExec.class, exchange -> {
-            if (exchange.child() instanceof ExternalSourceExec) {
-                return exchange.child();
-            }
-            if (exchange.child() instanceof FragmentExec fragment && fragment.fragment().anyMatch(ExternalRelation.class::isInstance)) {
-                return exchange.child();
-            }
-            return exchange;
+            return isCollapsibleExchange(exchange) ? exchange.child() : exchange;
         });
         return collapsed.transformUp(TopNExec.class, topN -> {
             if (topN.inputOrdering() != InputOrdering.NOT_SORTED && topN.child() instanceof FragmentExec) {
@@ -591,6 +643,28 @@ public class ComputeService {
             }
             return topN;
         });
+    }
+
+    /**
+     * Whether the plan contains an {@link ExchangeExec} that {@link #collapseExternalSourceExchanges} would remove, i.e. an
+     * exchange sitting directly above an external source. Such an exchange is the gather boundary between the parallel
+     * partial-aggregation drivers and the single final-aggregation driver, so it must be preserved when the external source
+     * runs with more than one split group.
+     */
+    static boolean hasCollapsibleExternalExchange(PhysicalPlan plan) {
+        return plan.anyMatch(p -> p instanceof ExchangeExec exchange && isCollapsibleExchange(exchange));
+    }
+
+    /**
+     * Whether {@code exchange} is one that sits directly above an external source — either a top-level
+     * {@link ExternalSourceExec} or a {@link FragmentExec} wrapping an {@link ExternalRelation}. Both
+     * {@link #collapseExternalSourceExchanges} and {@link #hasCollapsibleExternalExchange} use this predicate
+     * so the two stay in sync: if either ever diverges, a multi-split-group STATS query would silently emit
+     * one row per split group instead of a single merged row.
+     */
+    private static boolean isCollapsibleExchange(ExchangeExec exchange) {
+        return exchange.child() instanceof ExternalSourceExec
+            || (exchange.child() instanceof FragmentExec fragment && fragment.fragment().anyMatch(ExternalRelation.class::isInstance));
     }
 
     public void execute(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionStrategy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionStrategy.java
@@ -7,6 +7,10 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+
 /**
  * Decides whether an external source query should be distributed across data nodes
  * or executed locally on the coordinator.
@@ -14,4 +18,22 @@ package org.elasticsearch.xpack.esql.plugin;
 public interface ExternalDistributionStrategy {
 
     ExternalDistributionPlan planDistribution(ExternalDistributionContext context);
+
+    /**
+     * Whether the plan contains an operator that cannot simply be replicated across parallel scan drivers, because
+     * each driver would run it over its own slice of the input and emit its own result: an aggregation would produce
+     * one row per driver instead of one merged row, and a {@code TopN} its own top-N per driver. Such a plan needs a
+     * gather boundary above the scan.
+     *
+     * <p>A {@code LIMIT} is deliberately not in this set: {@code LimitOperator.Factory} builds a single
+     * {@code Limiter} and hands that same instance to every driver it creates, so a limit is already enforced
+     * across all of them and stays correct without a gather.
+     *
+     * <p>Single home for the rule, shared by {@link AdaptiveStrategy} (deciding whether the scan is worth
+     * distributing) and {@link ComputeService} (deciding whether a scan staying local must still keep its exchange).
+     * If the two diverged, a plan could be collapsed onto parallel drivers by one and assumed gathered by the other.
+     */
+    static boolean needsGatherBoundary(PhysicalPlan plan) {
+        return plan.anyMatch(n -> n instanceof AggregateExec || n instanceof TopNExec);
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitCoalescerTests.java
@@ -34,12 +34,29 @@ public class SplitCoalescerTests extends ESTestCase {
 
     public void testBelowThresholdReturnsUnchanged() {
         List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD - 1);
-        assertSame(splits, SplitCoalescer.coalesce(splits));
+        assertEquals(splits, SplitCoalescer.coalesce(splits));
     }
 
     public void testExactlyAtThresholdReturnsUnchanged() {
         List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD);
-        assertSame(splits, SplitCoalescer.coalesce(splits));
+        assertEquals(splits, SplitCoalescer.coalesce(splits));
+    }
+
+    public void testCoalesceNeverReturnsTheCallersList() {
+        // Callers replace the contents of the list they passed in. Handing back that same list would make them
+        // clear the list they are copying from, silently emptying the scan, so declining to group must still
+        // produce a list of our own.
+        List<ExternalSplit> belowThreshold = makeSplits(COALESCING_THRESHOLD - 1);
+        assertNotSame(belowThreshold, SplitCoalescer.coalesce(belowThreshold));
+        List<ExternalSplit> aboveThreshold = makeSplits(COALESCING_THRESHOLD + 1);
+        assertNotSame(aboveThreshold, SplitCoalescer.coalesce(aboveThreshold));
+    }
+
+    public void testShouldCoalesceOwnsTheThresholdRule() {
+        assertFalse(SplitCoalescer.shouldCoalesce(0));
+        assertFalse(SplitCoalescer.shouldCoalesce(COALESCING_THRESHOLD - 1));
+        assertFalse(SplitCoalescer.shouldCoalesce(COALESCING_THRESHOLD));
+        assertTrue(SplitCoalescer.shouldCoalesce(COALESCING_THRESHOLD + 1));
     }
 
     public void testSizeBasedGrouping() {
@@ -124,6 +141,224 @@ public class SplitCoalescerTests extends ESTestCase {
     public void testInvalidTargetGroupSizeBytesThrows() {
         List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD + 1);
         expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(splits, 0, 8));
+    }
+
+    public void testParallelismFloorSpreadsTinyFiles() {
+        int count = 100;
+        int parallelism = 14;
+        // 1 KB files all fit one 128 MB bin, so without a floor they collapse to a single group.
+        List<ExternalSplit> splits = makeSplits(count, 1024);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, parallelism);
+
+        assertEquals("tiny files must be spread across at least the parallelism floor", parallelism, result.size());
+        assertEquals(count, countTotalLeaves(result));
+    }
+
+    public void testParallelismFloorCappedBySplitCount() {
+        int count = COALESCING_THRESHOLD + 8; // above the threshold so coalescing runs
+        int parallelism = 100;                // more than the number of files
+        List<ExternalSplit> splits = makeSplits(count, 1024);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, parallelism);
+
+        assertEquals("floor cannot exceed the number of input splits", count, result.size());
+        assertEquals(count, countTotalLeaves(result));
+    }
+
+    public void testSizeRaisesGroupCountAboveParallelismFloor() {
+        int count = 100;
+        long fileSize = 10 * 1024 * 1024;  // 10 MB
+        long target = 128 * 1024 * 1024;   // ~12 files per bin -> ~8 bins by size alone
+        int parallelism = 4;               // lower than the size-required bin count
+        List<ExternalSplit> splits = makeSplits(count, fileSize);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, target, 8, parallelism);
+
+        int sizeBins = (int) Math.ceil((count * (double) fileSize) / target);
+        assertTrue("size must raise the group count above the parallelism floor", result.size() >= sizeBins);
+        assertEquals(count, countTotalLeaves(result));
+        for (ExternalSplit split : result) {
+            if (split instanceof CoalescedSplit coalesced) {
+                assertTrue("size budget must still be respected under the floor", coalesced.estimatedSizeInBytes() <= target + fileSize);
+            }
+        }
+    }
+
+    public void testParallelismFloorPreservesAllChildren() {
+        int count = 100;
+        int parallelism = 14;
+        List<ExternalSplit> splits = makeSplits(count, 1024);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, parallelism);
+
+        Set<ExternalSplit> originalSet = new HashSet<>(splits);
+        Set<ExternalSplit> resultLeaves = new HashSet<>();
+        for (ExternalSplit split : result) {
+            if (split instanceof CoalescedSplit coalesced) {
+                resultLeaves.addAll(coalesced.children());
+            } else {
+                resultLeaves.add(split);
+            }
+        }
+        assertEquals(originalSet, resultLeaves);
+    }
+
+    public void testParallelismFloorWithoutSizeInfo() {
+        int count = 100;
+        int parallelism = 14;
+        List<ExternalSplit> splits = makeSplitsWithoutSize(count);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, parallelism);
+
+        assertEquals("count-based grouping must also honor the parallelism floor", parallelism, result.size());
+        assertEquals(count, countTotalLeaves(result));
+    }
+
+    public void testFloorKeepsOversizedStandaloneAndSpreadsTiny() {
+        long target = 128 * 1024 * 1024;
+        int parallelism = 14;
+        List<ExternalSplit> splits = new ArrayList<>();
+        splits.add(makeFileSplit(0, 200L * 1024 * 1024)); // oversized
+        splits.add(makeFileSplit(1, 300L * 1024 * 1024)); // oversized
+        for (int i = 2; i < 100; i++) {
+            splits.add(makeFileSplit(i, 1024));
+        }
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, target, 8, parallelism);
+
+        assertEquals(parallelism, result.size());
+        assertEquals(100, countTotalLeaves(result));
+        int standaloneOversized = 0;
+        for (ExternalSplit split : result) {
+            if (split instanceof FileSplit fs && fs.length() >= target) {
+                standaloneOversized++;
+            }
+            if (split instanceof CoalescedSplit coalesced) {
+                assertTrue("coalesced groups must stay under the size budget", coalesced.estimatedSizeInBytes() <= target + 1024);
+            }
+        }
+        assertEquals("both oversized files stay standalone", 2, standaloneOversized);
+    }
+
+    public void testFloorProducesBalancedGroups() {
+        int count = 100;
+        int parallelism = 14;
+        List<ExternalSplit> splits = makeSplits(count, 1024);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, parallelism);
+
+        assertEquals(parallelism, result.size());
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (ExternalSplit split : result) {
+            int leaves = split instanceof CoalescedSplit coalesced ? coalesced.children().size() : 1;
+            min = Math.min(min, leaves);
+            max = Math.max(max, leaves);
+        }
+        assertTrue("groups should be balanced within one leaf, got min=" + min + " max=" + max, max - min <= 1);
+    }
+
+    public void testFloorSpreadsZeroSizedFilesEvenly() {
+        int count = 100;
+        int parallelism = 14;
+        // Zero-byte files all tie on load, so the least-loaded tie-break must still round-robin them across groups
+        // rather than piling every file after the seed into the first group.
+        List<ExternalSplit> splits = makeSplits(count, 0);
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, parallelism);
+
+        assertEquals(parallelism, result.size());
+        assertEquals(count, countTotalLeaves(result));
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (ExternalSplit split : result) {
+            int leaves = split instanceof CoalescedSplit coalesced ? coalesced.children().size() : 1;
+            min = Math.min(min, leaves);
+            max = Math.max(max, leaves);
+        }
+        assertTrue("zero-sized files should be balanced within one leaf, got min=" + min + " max=" + max, max - min <= 1);
+    }
+
+    public void testFloorBalancesFileCountAcrossMixedSizes() {
+        // A few larger files plus many tiny ones must not pile every tiny file into the single group seeded by a
+        // tiny file. Read parallelism over small files is bounded by per-file opens, so groups are balanced by leaf
+        // count, not by bytes: balancing by bytes alone would leave one group holding all 100 tiny files.
+        long target = 128 * 1024 * 1024;
+        int floor = 6;
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            splits.add(makeFileSplit(i, 10 * 1024 * 1024)); // 10 MB
+        }
+        for (int i = 5; i < 105; i++) {
+            splits.add(makeFileSplit(i, 1024)); // 1 KB
+        }
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, target, 8, floor);
+
+        assertEquals(floor, result.size());
+        assertEquals(105, countTotalLeaves(result));
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (ExternalSplit split : result) {
+            int leaves = split instanceof CoalescedSplit coalesced ? coalesced.children().size() : 1;
+            min = Math.min(min, leaves);
+            max = Math.max(max, leaves);
+        }
+        assertTrue("groups must be balanced by leaf count, got min=" + min + " max=" + max, max - min <= 1);
+    }
+
+    public void testFloorStopsFillingGroupsAtSizeBudget() {
+        // A near-budget file seeds one group. Balancing purely by leaf count would keep steering tiny files onto
+        // that group whenever its count is the smallest, pushing it far past the budget. The fill must stop once a
+        // group reaches the budget and send the remaining files to groups that still have room.
+        long target = 100L * 1024 * 1024; // 100 MB
+        long tiny = 1024 * 1024;          // 1 MB
+        int floor = 4;
+        List<ExternalSplit> splits = new ArrayList<>();
+        splits.add(makeFileSplit(0, 95L * 1024 * 1024)); // 95 MB, just under budget
+        for (int i = 1; i <= 105; i++) {
+            splits.add(makeFileSplit(i, tiny));
+        }
+
+        List<ExternalSplit> result = SplitCoalescer.coalesce(splits, target, 8, floor);
+
+        assertEquals(floor, result.size());
+        assertEquals(106, countTotalLeaves(result));
+        for (ExternalSplit split : result) {
+            assertTrue(
+                "no group may exceed the size budget by more than one file, got " + split.estimatedSizeInBytes(),
+                split.estimatedSizeInBytes() <= target + tiny
+            );
+        }
+    }
+
+    public void testFloorOfOneMatchesDefaultGrouping() {
+        int count = 100;
+        List<ExternalSplit> splits = makeSplits(count, 10 * 1024 * 1024);
+
+        List<ExternalSplit> defaultGrouping = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8);
+        List<ExternalSplit> floored = SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, 1);
+
+        assertEquals(defaultGrouping, floored);
+    }
+
+    public void testInvalidMinGroupCountThrows() {
+        List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD + 1);
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, 0));
+    }
+
+    public void testBelowThresholdIgnoresMinGroups() {
+        List<ExternalSplit> splits = makeSplits(COALESCING_THRESHOLD - 1);
+        assertEquals(splits, SplitCoalescer.coalesce(splits, 128 * 1024 * 1024, 8, 14));
+    }
+
+    public void testInvalidParamsThrowEvenBelowThreshold() {
+        // Validation must fire before the early-return size guard so the same invalid argument is always rejected.
+        List<ExternalSplit> belowThreshold = makeSplits(COALESCING_THRESHOLD - 1);
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(belowThreshold, 128 * 1024 * 1024, 8, 0));
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(belowThreshold, 0, 8, 1));
+        expectThrows(IllegalArgumentException.class, () -> SplitCoalescer.coalesce(belowThreshold, 128 * 1024 * 1024, 0, 1));
     }
 
     public void testMixedSizesProducesReasonableGroups() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExtendedDistributionPropertyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExtendedDistributionPropertyTests.java
@@ -147,7 +147,10 @@ public class ExtendedDistributionPropertyTests extends ESTestCase {
 
         List<ExternalSplit> result = SplitCoalescer.coalesce(original);
 
-        assertSame("Below threshold, coalescing must return the same list", original, result);
+        assertEquals("Below threshold, coalescing must leave the splits untouched", original, result);
+        // The no-op still hands back a list of the coalescer's own: callers replace the contents of the list they
+        // passed in, and returning that same list would make them clear the list they are copying from.
+        assertNotSame("Coalescing must never hand back the caller's own list", original, result);
     }
 
     public void testCoalescedSplitSizeEqualsChildrenSum() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ExternalDistributionTests.java
@@ -23,7 +23,9 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.SplitCoalescer;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -54,8 +56,11 @@ import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
 import org.elasticsearch.xpack.esql.session.Versioned;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
 
 public class ExternalDistributionTests extends ESTestCase {
 
@@ -336,6 +341,69 @@ public class ExternalDistributionTests extends ESTestCase {
         );
     }
 
+    // --- Gather-boundary detection tests ---
+
+    // Detecting the exchange that collapseExternalSourceExchanges would remove is what tells the local path a gather is
+    // still needed. When true and there is more than one split group, the exchange must be preserved and the partial
+    // aggregation run on the local node so the parallel per-group drivers merge into a single final aggregation.
+
+    public void testHasCollapsibleExternalExchangeDetectsFragmentExchange() {
+        ExternalRelation external = createExternalRelation();
+        Aggregate aggregate = new Aggregate(SRC, external, List.of(), List.of());
+
+        Mapper mapper = new Mapper();
+        PhysicalPlan physicalPlan = mapper.map(new Versioned<>(aggregate, TransportVersion.current()));
+
+        assertTrue(
+            "STATS over an external source must keep a collapsible exchange",
+            ComputeService.hasCollapsibleExternalExchange(physicalPlan)
+        );
+    }
+
+    public void testHasCollapsibleExternalExchangeDetectsDirectSourceExchange() {
+        ExternalSourceExec externalSource = createExternalSourceExec();
+        ExchangeExec exchange = new ExchangeExec(SRC, externalSource);
+        LimitExec limit = new LimitExec(SRC, exchange, new Literal(SRC, 10, DataType.INTEGER), null);
+
+        assertTrue(ComputeService.hasCollapsibleExternalExchange(limit));
+    }
+
+    public void testNeedsGatherBoundaryOnlyForPerDriverUnsafeOperators() {
+        ExternalRelation external = createExternalRelation();
+        Mapper mapper = new Mapper();
+
+        PhysicalPlan aggPlan = mapper.map(new Versioned<>(new Aggregate(SRC, external, List.of(), List.of()), TransportVersion.current()));
+        assertTrue(
+            "STATS emits one row per driver when replicated, so it needs a gather",
+            ExternalDistributionStrategy.needsGatherBoundary(aggPlan)
+        );
+
+        // A limit is enforced across drivers by a single shared Limiter, so replicating it stays correct and the
+        // scan must keep its cheaper collapsed path rather than being rerouted through an exchange.
+        PhysicalPlan limitPlan = mapper.map(
+            new Versioned<>(new Limit(SRC, new Literal(SRC, 10, DataType.INTEGER), external), TransportVersion.current())
+        );
+        assertFalse("a limit-only plan must not be rerouted through a gather", ExternalDistributionStrategy.needsGatherBoundary(limitPlan));
+    }
+
+    public void testHasCollapsibleExternalExchangeFalseWithoutExchange() {
+        ExternalSourceExec externalSource = createExternalSourceExec();
+        LimitExec limit = new LimitExec(SRC, externalSource, new Literal(SRC, 10, DataType.INTEGER), null);
+
+        assertFalse("A plain external scan without an exchange needs no gather", ComputeService.hasCollapsibleExternalExchange(limit));
+    }
+
+    public void testHasCollapsibleExternalExchangeFalseForNonExternalExchange() {
+        ExternalSourceExec externalSource = createExternalSourceExec();
+        AggregateExec agg = new AggregateExec(SRC, externalSource, List.of(), List.of(), AggregatorMode.INITIAL, List.of(), null);
+        ExchangeExec exchange = new ExchangeExec(SRC, agg);
+
+        assertFalse(
+            "An exchange whose child is not directly the external source is not collapsible",
+            ComputeService.hasCollapsibleExternalExchange(exchange)
+        );
+    }
+
     // --- localPlan expansion tests ---
 
     public void testLocalPlanExpandsFragmentExecToExternalSourceExec() {
@@ -472,10 +540,65 @@ public class ExternalDistributionTests extends ESTestCase {
             exec -> exec.splits().isEmpty() ? exec.withSplits(splits) : exec
         );
 
-        final List<ExternalSourceExec> sources = new java.util.ArrayList<>();
+        final List<ExternalSourceExec> sources = new ArrayList<>();
         withSplits.forEachDown(ExternalSourceExec.class, sources::add);
         assertFalse("Should have at least one ExternalSourceExec", sources.isEmpty());
         assertEquals("Splits should be injected", 2, sources.get(0).splits().size());
+    }
+
+    // --- Split coalescing floor wiring ---
+
+    public void testCoalesceSplitsFloorsTopLevelSplitCount() {
+        int fileCount = 200;
+        int minGroupCount = 14;
+        List<ExternalSplit> splits = new ArrayList<>(fileCount);
+        for (int i = 0; i < fileCount; i++) {
+            splits.add(
+                new FileSplit("parquet", StoragePath.of("s3://bucket/file" + i + ".parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+            );
+        }
+        ExternalSourceExec exec = createExternalSourceExec().withSplits(splits);
+
+        PhysicalPlan coalesced = ComputeService.coalesceSplits(exec, () -> minGroupCount);
+
+        List<ExternalSourceExec> sources = new ArrayList<>();
+        coalesced.forEachDown(ExternalSourceExec.class, sources::add);
+        assertEquals(1, sources.size());
+        List<ExternalSplit> result = sources.get(0).splits();
+        assertEquals("tiny files must stay spread across the floor, not collapse to one split", minGroupCount, result.size());
+        assertEquals("no leaves lost", fileCount, CoalescedSplit.flatten(result).size());
+    }
+
+    public void testCoalesceSplitsResolvesFloorAtMostOnceAndOnlyWhenNeeded() {
+        AtomicInteger resolutions = new AtomicInteger();
+        IntSupplier countingFloor = () -> {
+            resolutions.incrementAndGet();
+            return 14;
+        };
+
+        // Resolving the floor reads cluster state and thread-pool info, so a plan with nothing to coalesce must not
+        // pay for it: split discovery runs on every query, the overwhelming majority of which have no external source.
+        ComputeService.coalesceSplits(createExternalSourceExec(), countingFloor);
+        assertEquals("a plan with no coalescible external source must not resolve the floor", 0, resolutions.get());
+
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < SplitCoalescer.COALESCING_THRESHOLD + 1; i++) {
+            splits.add(
+                new FileSplit("parquet", StoragePath.of("s3://bucket/file" + i + ".parquet"), 0, 1024, ".parquet", Map.of(), Map.of())
+            );
+        }
+        ComputeService.coalesceSplits(createExternalSourceExec().withSplits(splits), countingFloor);
+        assertEquals("a coalescible external source resolves the floor exactly once", 1, resolutions.get());
+    }
+
+    public void testExternalCoalesceFloorIsTaskConcurrencyTimesNodes() {
+        assertEquals(14, ComputeService.externalCoalesceFloor(14, 1));
+        assertEquals(56, ComputeService.externalCoalesceFloor(14, 4));
+        // A degenerate task_concurrency must not drive the floor below one, which would make coalescing throw.
+        assertEquals(1, ComputeService.externalCoalesceFloor(0, 4));
+        assertEquals(1, ComputeService.externalCoalesceFloor(-3, 4));
+        // An implausibly wide cluster must clamp rather than overflow.
+        assertEquals(Integer.MAX_VALUE, ComputeService.externalCoalesceFloor(Integer.MAX_VALUE, 4));
     }
 
     // --- Field retention through local optimization tests ---


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ES|QL|DS: floor external split coalescing at read parallelism (#154196)

`RuntimeSearchExecutionContext` is not present on 9.5 — it arrives with the
HIGHLIGHT full-text work (#153313), which was not backported — so the source
commit's change to that file is dropped here. That change was a no-op refactor
(`getFieldType` delegating to `fieldType`, both already returning the same map
lookup), so nothing behavioural is lost.

Verified on this branch: `:x-pack:plugin:esql` compiles, and the
`datasources` + `plugin` unit test packages pass.
