### PR TITLE
[9.5] Account for deserialized SearchHit heap in chunked fetch breaker (#154408)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/SearchHitRamAccountingBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/SearchHitRamAccountingBenchmark.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.search;
+
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.ref.Reference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Thread)
+@SuppressWarnings("unused")
+public class SearchHitRamAccountingBenchmark {
+
+    private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
+
+    private static final long TARGET_FIELD_OBJECTS = 1_000_000L;
+    private static final int MIN_BATCH = 2_000;
+    private static final int MAX_BATCH = 100_000;
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    @Param({ "0", "1", "10", "100", "1000" })
+    public int fieldCount;
+
+    @Param({ "1" })
+    public int valuesPerField;
+
+    @Param({ "keyword", "long", "text" })
+    public String valueType;
+
+    @Param({ "0", "512" })
+    public int sourceBytes;
+
+    @Param({ "0", "5" })
+    public int innerHitCount;
+
+    private SearchHit[] timingHits;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        int batch = batchSize();
+
+        SearchHit[] hits = new SearchHit[batch];
+        long before = usedHeapAfterGc();
+        for (int i = 0; i < batch; i++) {
+            hits[i] = buildHit(i);
+        }
+        long after = usedHeapAfterGc();
+
+        long actualTotal = after - before;
+        long estimateTotal = 0L;
+        for (SearchHit hit : hits) {
+            estimateTotal += hit.ramBytesUsed();
+        }
+        Reference.reachabilityFence(hits);
+
+        double actualPerHit = (double) actualTotal / batch;
+        double estimatePerHit = (double) estimateTotal / batch;
+        double ratio = actualPerHit == 0 ? Double.NaN : estimatePerHit / actualPerHit;
+
+        System.out.println(
+            String.format(
+                Locale.ROOT,
+                "[accuracy] fields=%d valuesPerField=%d type=%s sourceBytes=%d innerHits=%d batch=%d "
+                    + "estimate/hit=%.1f B actual/hit=%.1f B estimate/actual=%.3f delta/hit=%.1f B",
+                fieldCount,
+                valuesPerField,
+                valueType,
+                sourceBytes,
+                innerHitCount,
+                batch,
+                estimatePerHit,
+                actualPerHit,
+                ratio,
+                estimatePerHit - actualPerHit
+            )
+        );
+
+        int timingCount = Math.min(batch, 256);
+        timingHits = new SearchHit[timingCount];
+        for (int i = 0; i < timingCount; i++) {
+            timingHits[i] = buildHit(i);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        timingHits = null;
+    }
+
+    @Benchmark
+    public long estimateRamBytesUsed() {
+        long total = 0L;
+        for (SearchHit hit : timingHits) {
+            total += hit.ramBytesUsed();
+        }
+        return total;
+    }
+
+    private int batchSize() {
+        int vpf = Math.max(1, valuesPerField);
+        long perHitObjects = Math.max(1L, (long) fieldCount * vpf + (long) innerHitCount * vpf);
+        long derived = TARGET_FIELD_OBJECTS / perHitObjects;
+        return (int) Math.max(MIN_BATCH, Math.min(MAX_BATCH, derived));
+    }
+
+    private SearchHit buildHit(int seq) {
+        SearchHit hit = SearchHit.unpooled(seq, "id-" + seq);
+        if (sourceBytes > 0) {
+            hit.sourceRef(new BytesArray(new byte[sourceBytes]));
+        }
+        if (fieldCount > 0) {
+            Map<String, DocumentField> docFields = new HashMap<>();
+            for (int f = 0; f < fieldCount; f++) {
+                String name = "field_" + f;
+                docFields.put(name, new DocumentField(name, buildValues(seq, f)));
+            }
+            hit.addDocumentFields(docFields, Map.of());
+        }
+        if (innerHitCount > 0) {
+            SearchHit[] inner = new SearchHit[innerHitCount];
+            for (int j = 0; j < innerHitCount; j++) {
+                SearchHit innerHit = SearchHit.unpooled(j, "inner-" + seq + "-" + j);
+                if (sourceBytes > 0) {
+                    innerHit.sourceRef(new BytesArray(new byte[sourceBytes]));
+                }
+                innerHit.setDocumentField(new DocumentField("inner_field", buildValues(seq, j)));
+                inner[j] = innerHit;
+            }
+            hit.setInnerHits(Map.of("nested", new SearchHits(inner, new TotalHits(innerHitCount, TotalHits.Relation.EQUAL_TO), 1f)));
+        }
+        return hit;
+    }
+
+    private List<Object> buildValues(int seq, int field) {
+        List<Object> values = new ArrayList<>(valuesPerField);
+        for (int v = 0; v < valuesPerField; v++) {
+            switch (valueType) {
+                case "keyword" -> values.add("kw-" + seq + "-" + field + "-" + v);
+                case "long" -> values.add(1_000_000L + (long) seq * 31 + (long) field * 7 + v);
+                case "text" -> values.add(text(seq, field, v));
+                default -> throw new IllegalArgumentException("unknown valueType [" + valueType + "]");
+            }
+        }
+        return values;
+    }
+
+    private static String text(int seq, int field, int v) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append("doc ").append(seq).append(" field ").append(field).append(" value ").append(v).append(' ');
+        while (sb.length() < 120) {
+            sb.append("lorem ipsum dolor sit amet ");
+        }
+        return sb.substring(0, 120);
+    }
+
+    private static long usedHeapAfterGc() {
+        long used = Long.MAX_VALUE;
+        for (int i = 0; i < 5; i++) {
+            System.gc();
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            used = Math.min(used, MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed());
+        }
+        return used;
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/SearchHitRamEstimateBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/SearchHitRamEstimateBenchmark.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.search;
+
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the runtime overhead of {@link SearchHit#ramBytesUsed()} (backed by
+ * {@code SearchHitRamUsageEstimator}). On the coordinator this method is invoked once per
+ * deserialized hit during a chunked fetch to charge the request circuit breaker, so its cost is
+ * paid on the hot fetch path. This benchmark reports the per-hit estimation latency across a matrix
+ * of hit shapes (field count, value type, source size, inner hits) to quantify that overhead.
+ *
+ * <p>Unlike {@code SearchHitRamAccountingBenchmark}, which focuses on the accuracy of the estimate
+ * versus the real retained heap, this benchmark isolates pure execution time.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Thread)
+@SuppressWarnings("unused")
+public class SearchHitRamEstimateBenchmark {
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    /** Number of chunk-sized hits estimated per {@link #estimateChunk} invocation. */
+    private static final int CHUNK_SIZE = 128;
+
+    @Param({ "0", "1", "10", "100", "1000" })
+    public int fieldCount;
+
+    @Param({ "1" })
+    public int valuesPerField;
+
+    @Param({ "keyword", "long", "text" })
+    public String valueType;
+
+    @Param({ "0", "512" })
+    public int sourceBytes;
+
+    @Param({ "0", "5" })
+    public int innerHitCount;
+
+    private SearchHit singleHit;
+    private SearchHit[] chunk;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        singleHit = buildHit(0);
+        chunk = new SearchHit[CHUNK_SIZE];
+        for (int i = 0; i < CHUNK_SIZE; i++) {
+            chunk[i] = buildHit(i);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        singleHit = null;
+        chunk = null;
+    }
+
+    /**
+     * Per-hit estimation latency. The returned value is consumed by JMH so the call cannot be
+     * eliminated as dead code.
+     */
+    @Benchmark
+    public long estimateSingleHit() {
+        return singleHit.ramBytesUsed();
+    }
+
+    /**
+     * Cost of estimating a full chunk of hits, mirroring the coordinator summing
+     * {@code ramBytesUsed()} over the hits in a received chunk before charging the breaker.
+     */
+    @Benchmark
+    public void estimateChunk(Blackhole bh) {
+        long total = 0L;
+        for (SearchHit hit : chunk) {
+            total += hit.ramBytesUsed();
+        }
+        bh.consume(total);
+    }
+
+    private SearchHit buildHit(int seq) {
+        SearchHit hit = SearchHit.unpooled(seq, "id-" + seq);
+        if (sourceBytes > 0) {
+            hit.sourceRef(new BytesArray(new byte[sourceBytes]));
+        }
+        if (fieldCount > 0) {
+            Map<String, DocumentField> docFields = new HashMap<>();
+            for (int f = 0; f < fieldCount; f++) {
+                String name = "field_" + f;
+                docFields.put(name, new DocumentField(name, buildValues(seq, f)));
+            }
+            hit.addDocumentFields(docFields, Map.of());
+        }
+        if (innerHitCount > 0) {
+            SearchHit[] inner = new SearchHit[innerHitCount];
+            for (int j = 0; j < innerHitCount; j++) {
+                SearchHit innerHit = SearchHit.unpooled(j, "inner-" + seq + "-" + j);
+                if (sourceBytes > 0) {
+                    innerHit.sourceRef(new BytesArray(new byte[sourceBytes]));
+                }
+                innerHit.setDocumentField(new DocumentField("inner_field", buildValues(seq, j)));
+                inner[j] = innerHit;
+            }
+            hit.setInnerHits(Map.of("nested", new SearchHits(inner, new TotalHits(innerHitCount, TotalHits.Relation.EQUAL_TO), 1f)));
+        }
+        return hit;
+    }
+
+    private List<Object> buildValues(int seq, int field) {
+        List<Object> values = new ArrayList<>(valuesPerField);
+        for (int v = 0; v < valuesPerField; v++) {
+            switch (valueType) {
+                case "keyword" -> values.add("kw-" + seq + "-" + field + "-" + v);
+                case "long" -> values.add(1_000_000L + (long) seq * 31 + (long) field * 7 + v);
+                case "text" -> values.add(text(seq, field, v));
+                default -> throw new IllegalArgumentException("unknown valueType [" + valueType + "]");
+            }
+        }
+        return values;
+    }
+
+    private static String text(int seq, int field, int v) {
+        StringBuilder sb = new StringBuilder(128);
+        sb.append("doc ").append(seq).append(" field ").append(field).append(" value ").append(v).append(' ');
+        while (sb.length() < 120) {
+            sb.append("lorem ipsum dolor sit amet ");
+        }
+        return sb.substring(0, 120);
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/ChunkedFetchPhaseCircuitBreakerTrippingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/ChunkedFetchPhaseCircuitBreakerTrippingIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -130,6 +131,63 @@ public class ChunkedFetchPhaseCircuitBreakerTrippingIT extends ESIntegTestCase {
             long currentBreaker = getRequestBreakerUsed(coordinatorNode);
             assertThat(
                 "Coordinator circuit breaker should be released even after tripping, current: "
+                    + currentBreaker
+                    + ", before: "
+                    + breakerBefore,
+                currentBreaker,
+                lessThanOrEqualTo(breakerBefore)
+            );
+        });
+    }
+
+    public void testCircuitBreakerTripsOnFieldGraphWithSourceDisabled() throws Exception {
+        internalCluster().startNode();
+        String coordinatorNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+
+        int numFields = 500;
+        int numDocs = 150;
+        createWideIndex(INDEX_NAME, numFields);
+        populateWideIndex(INDEX_NAME, numDocs, numFields);
+        ensureGreen(INDEX_NAME);
+
+        long breakerBefore = getRequestBreakerUsed(coordinatorNode);
+
+        ElasticsearchException exception = null;
+        SearchResponse resp = null;
+        try {
+            resp = internalCluster().client(coordinatorNode)
+                .prepareSearch(INDEX_NAME)
+                .setQuery(matchAllQuery())
+                .setSize(numDocs)
+                .setFetchSource(false)
+                .addFetchField("*")
+                .setAllowPartialSearchResults(false)
+                .addSort(SORT_FIELD, SortOrder.ASC)
+                .get();
+        } catch (ElasticsearchException e) {
+            exception = e;
+        } finally {
+            if (resp != null) {
+                resp.decRef();
+            }
+        }
+
+        assertNotNull("Search should have failed once the coordinator accumulated the field graph", exception);
+        assertThat(
+            "Circuit breaker should trip on the extracted field graph even with _source disabled",
+            containsCircuitBreakerException(exception),
+            equalTo(true)
+        );
+        assertThat(
+            "Circuit breaking should map to 429 TOO_MANY_REQUESTS",
+            ExceptionsHelper.status(exception),
+            equalTo(RestStatus.TOO_MANY_REQUESTS)
+        );
+
+        assertBusy(() -> {
+            long currentBreaker = getRequestBreakerUsed(coordinatorNode);
+            assertThat(
+                "Coordinator circuit breaker should be released after tripping on the field graph, current: "
                     + currentBreaker
                     + ", before: "
                     + breakerBefore,
@@ -363,6 +421,39 @@ public class ChunkedFetchPhaseCircuitBreakerTrippingIT extends ESIntegTestCase {
             }
             indexRandom(batch == 0, builders);
         }
+        refresh(indexName);
+    }
+
+    private void createWideIndex(String indexName, int numFields) {
+        String[] mapping = new String[2 + numFields * 2];
+        mapping[0] = SORT_FIELD;
+        mapping[1] = "type=long";
+        for (int f = 0; f < numFields; f++) {
+            mapping[2 + f * 2] = "f" + f;
+            mapping[3 + f * 2] = "type=keyword";
+        }
+        assertAcked(
+            prepareCreate(indexName).setSettings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put("index.mapping.total_fields.limit", numFields + 100)
+            ).setMapping(mapping)
+        );
+    }
+
+    private void populateWideIndex(String indexName, int numDocs, int numFields) throws IOException {
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            XContentBuilder source = jsonBuilder().startObject();
+            source.field(SORT_FIELD, i);
+            for (int f = 0; f < numFields; f++) {
+                source.field("f" + f, "value_" + i + "_" + f);
+            }
+            source.endObject();
+            builders.add(prepareIndex(indexName).setId(Integer.toString(i)).setSource(source));
+        }
+        indexRandom(true, builders);
         refresh(indexName);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -28,7 +28,6 @@ import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.SimpleRefCounted;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.rest.action.search.RestSearchAction;
@@ -294,7 +293,9 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         return new SearchHit(nestedTopDocId, id, nestedIdentity, ALWAYS_REFERENCED);
     }
 
-    private static final Text SINGLE_MAPPING_TYPE = new Text(MapperService.SINGLE_MAPPING_NAME);
+    public long ramBytesUsed() {
+        return SearchHitRamUsageEstimator.estimate(this);
+    }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/SearchHitRamUsageEstimator.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHitRamUsageEstimator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.document.DocumentField;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Conservative upper-bound estimator for the retained heap of a {@link SearchHit}
+ */
+public final class SearchHitRamUsageEstimator {
+
+    private static final long SEARCH_HIT_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SearchHit.class);
+    private static final long HASH_MAP_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(HashMap.class);
+    private static final long SEARCH_HITS_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SearchHits.class);
+    private static final long HASH_MAP_NODE_SIZE = RamUsageEstimator.alignObjectSize(
+        RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + 3L * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+    );
+
+    static final long RAM_BYTES_FLOOR = 512L;
+
+    private SearchHitRamUsageEstimator() {}
+
+    public static long estimate(SearchHit hit) {
+        long size = SEARCH_HIT_SHALLOW_SIZE + RAM_BYTES_FLOOR + hit.rawSourceLength();
+        size += estimateFields(hit.getDocumentFields());
+        size += estimateFields(hit.getMetadataFields());
+        Map<String, SearchHits> innerHits = hit.getInnerHits();
+        if (innerHits != null) {
+            size += HASH_MAP_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) innerHits.size() * (HASH_MAP_NODE_SIZE
+                + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+            for (Map.Entry<String, SearchHits> entry : innerHits.entrySet()) {
+                size += RamUsageEstimator.sizeOf(entry.getKey());
+                SearchHit[] innerHitsArray = entry.getValue().getHits();
+                size += SEARCH_HITS_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) innerHitsArray.length
+                    * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+                for (SearchHit innerHit : innerHitsArray) {
+                    size += estimate(innerHit);
+                }
+            }
+        }
+        return size;
+    }
+
+    private static long estimateFields(Map<String, DocumentField> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return 0L;
+        }
+        long size = HASH_MAP_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) fields.size() * (HASH_MAP_NODE_SIZE
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+        for (DocumentField field : fields.values()) {
+            size += field.ramBytesUsedEstimate();
+        }
+        return size;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseChunk.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseChunk.java
@@ -155,6 +155,20 @@ public class FetchPhaseResponseChunk implements Writeable, Releasable {
         drainDeserializedHits((hit, i) -> consumer.accept(hitPositions[i], hit));
     }
 
+    long estimatedRetainedBytes() throws IOException {
+        ensureDeserialized();
+        if (deserializedHits == null) {
+            return 0L;
+        }
+        long size = 0L;
+        for (SearchHit hit : deserializedHits) {
+            if (hit != null) {
+                size += hit.ramBytesUsed();
+            }
+        }
+        return size;
+    }
+
     /**
      * Walks {@code deserializedHits}, invoking {@code visitor} for each non-null slot and clearing
      * the slot afterwards so the same hit is never handed out twice. Shared by {@link #consumeHits}

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStream.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStream.java
@@ -97,10 +97,9 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
     void writeChunk(FetchPhaseResponseChunk chunk, Releasable releasable) {
         boolean success = false;
         try {
-            // Track memory usage
-            long bytesSize = chunk.getBytesLength();
-            circuitBreaker.addEstimateBytesAndMaybeBreak(bytesSize, "fetch_chunk_accumulation");
-            totalBreakerBytes.addAndGet(bytesSize);
+            long estimatedRetainedBytes = chunk.estimatedRetainedBytes();
+            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedRetainedBytes, "fetch_chunk_accumulation");
+            totalBreakerBytes.addAndGet(estimatedRetainedBytes);
 
             chunk.consumeHits((position, hit) -> queue.add(new SequencedHit(hit, position)));
 
@@ -185,7 +184,7 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
     /**
      * Tracks circuit breaker bytes without checking. Used when coordinator processes the embedded last chunk.
      */
-    void trackBreakerBytes(int bytes) {
+    void trackBreakerBytes(long bytes) {
         totalBreakerBytes.addAndGet(bytes);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationAction.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationAction.java
@@ -232,18 +232,17 @@ public class TransportFetchPhaseCoordinationAction extends HandledTransportActio
                     );
                 }
 
-                // Track memory usage
-                int bytesSize = lastChunkBytes.length();
-                circuitBreaker.addEstimateBytesAndMaybeBreak(bytesSize, "fetch_chunk_accumulation");
-                responseStream.trackBreakerBytes(bytesSize);
-
+                long estimatedRetainedBytes = 0L;
                 try (StreamInput in = new NamedWriteableAwareStreamInput(lastChunkBytes.streamInput(), namedWriteableRegistry)) {
                     for (int i = 0; i < hitCount; i++) {
                         int position = in.readVInt();
                         SearchHit hit = SearchHit.readFrom(in);
+                        estimatedRetainedBytes += hit.ramBytesUsed();
                         responseStream.addHitWithSequence(hit, position);
                     }
                 }
+                circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedRetainedBytes, "fetch_chunk_accumulation");
+                responseStream.trackBreakerBytes(estimatedRetainedBytes);
             }
 
             // Build final result from all accumulated hits

--- a/server/src/test/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStreamTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -251,34 +252,107 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
             long bytesBefore = breaker.getUsed();
             assertThat(bytesBefore, equalTo(0L));
 
-            FetchPhaseResponseChunk chunk1 = createChunkWithSourceSize(0, 5, 0, 1024);
-            long chunk1Bytes = chunk1.getBytesLength();
-            writeChunk(stream, chunk1);
+            long chunk1Bytes = estimatedRetainedBytesForSourceSize(0, 5, 1024);
+            writeChunk(stream, createChunkWithSourceSize(0, 5, 0, 1024));
 
             long bytesAfterChunk1 = breaker.getUsed();
-            assertThat("Circuit breaker should track chunk1 bytes", bytesAfterChunk1, equalTo(chunk1Bytes));
+            assertThat("Circuit breaker should track chunk1 retained bytes", bytesAfterChunk1, equalTo(chunk1Bytes));
 
-            FetchPhaseResponseChunk chunk2 = createChunkWithSourceSize(5, 5, 5, 1024);
-            long chunk2Bytes = chunk2.getBytesLength();
-            writeChunk(stream, chunk2);
+            long chunk2Bytes = estimatedRetainedBytesForSourceSize(5, 5, 1024);
+            writeChunk(stream, createChunkWithSourceSize(5, 5, 5, 1024));
 
             long bytesAfterChunk2 = breaker.getUsed();
-            assertThat("Circuit breaker should track both chunks' bytes", bytesAfterChunk2, equalTo(chunk1Bytes + chunk2Bytes));
+            assertThat("Circuit breaker should track both chunks' retained bytes", bytesAfterChunk2, equalTo(chunk1Bytes + chunk2Bytes));
         } finally {
             stream.decRef();
         }
+    }
+
+    public void testBreakerChargesRetainedFieldGraphNotSerializedSize() throws IOException {
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+        FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 5, breaker);
+
+        int fieldsPerHit = 500;
+        SearchHit[] hits = new SearchHit[5];
+        for (int i = 0; i < hits.length; i++) {
+            hits[i] = createHitWithManyFields(i, fieldsPerHit);
+        }
+        long serializedBytes;
+        long expectedRetained;
+        try {
+            expectedRetained = 0L;
+            for (SearchHit hit : hits) {
+                expectedRetained += hit.ramBytesUsed();
+            }
+            FetchPhaseResponseChunk chunk = new FetchPhaseResponseChunk(TEST_SHARD_ID, serializeHits(hits, 0), hits.length, 100, 0);
+            serializedBytes = chunk.getBytesLength();
+            writeChunk(stream, chunk);
+        } finally {
+            decRefSearchHits(hits);
+        }
+
+        try {
+            assertThat("Breaker should be charged the retained-heap estimate", breaker.getUsed(), equalTo(expectedRetained));
+            assertThat(
+                "Retained estimate must exceed the serialized size that previously priced the breaker",
+                breaker.getUsed(),
+                greaterThan(serializedBytes)
+            );
+        } finally {
+            stream.decRef();
+        }
+        assertThat("All breaker bytes should be released after close", breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testRetainedEstimateTripsBreakerWhereSerializedSizeWouldNot() throws IOException {
+        int fieldsPerHit = 500;
+        SearchHit[] hits = new SearchHit[5];
+        for (int i = 0; i < hits.length; i++) {
+            hits[i] = createHitWithManyFields(i, fieldsPerHit);
+        }
+
+        long serializedBytes;
+        long retainedBytes;
+        FetchPhaseResponseChunk chunk;
+        try {
+            retainedBytes = 0L;
+            for (SearchHit hit : hits) {
+                retainedBytes += hit.ramBytesUsed();
+            }
+            chunk = new FetchPhaseResponseChunk(TEST_SHARD_ID, serializeHits(hits, 0), hits.length, 100, 0);
+            serializedBytes = chunk.getBytesLength();
+        } finally {
+            decRefSearchHits(hits);
+        }
+
+        assertThat("retained estimate must exceed serialized size", retainedBytes, greaterThan(serializedBytes));
+
+        long limit = retainedBytes - 1;
+
+        CircuitBreaker serializedBasis = newLimitedBreaker(ByteSizeValue.ofBytes(limit));
+        serializedBasis.addEstimateBytesAndMaybeBreak(serializedBytes, "serialized_basis");
+        assertThat("serialized-size accounting would not have tripped at this limit", serializedBasis.getUsed(), equalTo(serializedBytes));
+        serializedBasis.addWithoutBreaking(-serializedBytes); // release the throwaway breaker used only for the comparison
+
+        CircuitBreaker retainedBasis = newLimitedBreaker(ByteSizeValue.ofBytes(limit));
+        FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, hits.length, retainedBasis);
+        try {
+            expectThrows(CircuitBreakingException.class, () -> writeChunk(stream, chunk));
+            assertThat("no bytes tracked after trip", retainedBasis.getUsed(), equalTo(0L));
+        } finally {
+            stream.decRef();
+        }
+        assertThat("all breaker bytes released after close", retainedBasis.getUsed(), equalTo(0L));
     }
 
     public void testCircuitBreakerBytesReleasedOnClose() throws IOException {
         CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 10, breaker);
 
-        FetchPhaseResponseChunk chunk1 = createChunkWithSourceSize(0, 5, 0, 1024);
-        FetchPhaseResponseChunk chunk2 = createChunkWithSourceSize(5, 5, 5, 1024);
-        long expectedBytes = chunk1.getBytesLength() + chunk2.getBytesLength();
+        long expectedBytes = estimatedRetainedBytesForSourceSize(0, 5, 1024) + estimatedRetainedBytesForSourceSize(5, 5, 1024);
 
-        writeChunk(stream, chunk1);
-        writeChunk(stream, chunk2);
+        writeChunk(stream, createChunkWithSourceSize(0, 5, 0, 1024));
+        writeChunk(stream, createChunkWithSourceSize(5, 5, 5, 1024));
 
         long bytesBeforeClose = breaker.getUsed();
         assertThat("Should have bytes tracked", bytesBeforeClose, equalTo(expectedBytes));
@@ -290,11 +364,9 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
     }
 
     public void testCircuitBreakerTrips() throws IOException {
-        FetchPhaseResponseChunk testChunk = createChunkWithSourceSize(0, 5, 0, 2048);
-        long chunkSize = testChunk.getBytesLength();
+        long estimatedBytes = estimatedRetainedBytesForSourceSize(0, 5, 2048);
 
-        // Set limit smaller than chunk size
-        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(chunkSize - 1));
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(estimatedBytes - 1));
         FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 10, breaker);
 
         try {
@@ -306,10 +378,8 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
     }
 
     public void testCircuitBreakerTripsOnSecondChunk() throws IOException {
-        FetchPhaseResponseChunk chunk1 = createChunkWithSourceSize(0, 5, 0, 1024);
-        FetchPhaseResponseChunk chunk2 = createChunkWithSourceSize(5, 5, 5, 1024);
-        long chunk1Size = chunk1.getBytesLength();
-        long chunk2Size = chunk2.getBytesLength();
+        long chunk1Size = estimatedRetainedBytesForSourceSize(0, 5, 1024);
+        long chunk2Size = estimatedRetainedBytesForSourceSize(5, 5, 1024);
 
         // Set limit to allow first chunk but not second
         long limit = chunk1Size + (chunk2Size / 2);
@@ -533,11 +603,9 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
     }
 
     public void testReleasableNotClosedOnFailure() throws IOException {
-        FetchPhaseResponseChunk testChunk = createChunkWithSourceSize(0, 5, 0, 10000);
-        long chunkSize = testChunk.getBytesLength();
+        long estimatedBytes = estimatedRetainedBytesForSourceSize(0, 5, 10000);
 
-        // Set limit smaller than chunk size to guarantee trip
-        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(chunkSize / 2));
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(estimatedBytes / 2));
         FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 5, breaker);
 
         try {
@@ -559,9 +627,9 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
 
     public void testWriteChunkWithCircuitBreakerTripPreservesAccountingAndPropagates() throws IOException {
         FetchPhaseResponseChunk chunk = createChunkWithSourceSize(0, 5, 0, 4096);
-        long chunkSize = chunk.getBytesLength();
+        long estimatedBytes = estimatedRetainedBytesForSourceSize(0, 5, 4096);
 
-        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(chunkSize - 1));
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(estimatedBytes - 1));
         FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 5, breaker);
         AtomicBoolean releasableClosed = new AtomicBoolean(false);
 
@@ -725,6 +793,22 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
         }
     }
 
+    private long estimatedRetainedBytesForSourceSize(int startId, int hitCount, int sourceSize) {
+        SearchHit[] hits = new SearchHit[hitCount];
+        for (int i = 0; i < hitCount; i++) {
+            hits[i] = createHitWithSourceSize(startId + i, sourceSize);
+        }
+        try {
+            long total = 0L;
+            for (SearchHit hit : hits) {
+                total += hit.ramBytesUsed();
+            }
+            return total;
+        } finally {
+            decRefSearchHits(hits);
+        }
+    }
+
     private SearchHit createHit(int id) {
         SearchHit hit = new SearchHit(id);
         hit.sourceRef(new BytesArray("{\"id\":" + id + "}"));
@@ -741,6 +825,15 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
         }
         sb.append("\"}");
         hit.sourceRef(new BytesArray(sb.toString()));
+        return hit;
+    }
+
+    private SearchHit createHitWithManyFields(int id, int fieldCount) {
+        SearchHit hit = new SearchHit(id);
+        hit.sourceRef(new BytesArray("{\"id\":" + id + "}"));
+        for (int f = 0; f < fieldCount; f++) {
+            hit.setDocumentField(new DocumentField("field_" + f, List.of("value_" + f)));
+        }
         return hit;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseResponseChunkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseResponseChunkActionTests.java
@@ -238,7 +238,7 @@ public class TransportFetchPhaseResponseChunkActionTests extends ESTestCase {
         ReleasableBytesReference wireBytes = null;
         try {
             chunk = new FetchPhaseResponseChunk(TEST_SHARD_ID, serializeHits(originalHit), 1, 1, 0L);
-            long expectedBytes = chunk.getBytesLength();
+            long expectedBytes = originalHit.ramBytesUsed();
             wireBytes = chunk.toReleasableBytesReference(coordinatingTaskId);
 
             PlainActionFuture<ActionResponse.Empty> future = sendChunk(wireBytes);


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Account for deserialized SearchHit heap in chunked fetch breaker (#154408)