### PR TITLE
[9.5] [CI] DLMFrozenTransitionDisruptionIT testMasterFailoverDuringCleanup failing [#153174] - Take 2 (#153839)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -571,9 +571,6 @@ tests:
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testEachInstallOrRotationAddsExactlyOneNewKey
   issue: https://github.com/elastic/elasticsearch/issues/153024
-- class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
-  method: testDeleteMountedFrozenIndexBeforeSwap
-  issue: https://github.com/elastic/elasticsearch/issues/153040
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -571,6 +571,9 @@ tests:
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testEachInstallOrRotationAddsExactlyOneNewKey
   issue: https://github.com/elastic/elasticsearch/issues/153024
+- class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
+  method: testDeleteMountedFrozenIndexBeforeSwap
+  issue: https://github.com/elastic/elasticsearch/issues/153040
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
@@ -727,36 +730,6 @@ tests:
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testRotationCompletesWithMultipleHandlers
   issue: https://github.com/elastic/elasticsearch/issues/153747
-- class: org.elasticsearch.index.codec.tsdb.ES819DocValuesDuelTests
-  method: testDuel
-  issue: https://github.com/elastic/elasticsearch/issues/153763
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {yaml=ml/inference_crud/Test delete already-deleted model returns 404 not 409}
-  issue: https://github.com/elastic/elasticsearch/issues/153812
-- class: org.elasticsearch.xpack.esql.action.S3ManagedIdentityAuthIT
-  method: testManagedIdentityAuthReadsRowsAndUsesWorkloadIdentityCredential
-  issue: https://github.com/elastic/elasticsearch/issues/153820
-- class: org.elasticsearch.xpack.esql.action.S3ManagedIdentityAuthIT
-  method: testQueryFailsWhenWrongCredentialIsUsed
-  issue: https://github.com/elastic/elasticsearch/issues/153821
-- class: org.elasticsearch.action.RejectionActionIT
-  method: testSimulatedSearchRejectionLoad
-  issue: https://github.com/elastic/elasticsearch/issues/153848
-- class: org.elasticsearch.xpack.stateless.StatelessAbortRunningMergesOnRelocationIT
-  method: testConcurrentForceMergeIsNotAborted
-  issue: https://github.com/elastic/elasticsearch/issues/153854
-- class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
-  method: testGetVirtualBatchedCompoundCommitChunkFailureWhenIndexCloses
-  issue: https://github.com/elastic/elasticsearch/issues/153888
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
-  method: testMixedOperationsDuringSplitWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/153891
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecUnmappedLoadIT
-  method: test {csv-spec:unmapped-load.replaceUnmappedFieldFromEmptyMapping}
-  issue: https://github.com/elastic/elasticsearch/issues/153892
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFuseIT
-  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
-  issue: https://github.com/elastic/elasticsearch/issues/153902
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterWhere}
   issue: https://github.com/elastic/elasticsearch/issues/152591
@@ -787,66 +760,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalParquetCoercionWarningFloodIT
   method: testDeclaredCoercionWarningsStayBoundedAcrossFanOut
   issue: https://github.com/elastic/elasticsearch/issues/154023
-- class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
-  method: testSeqNoPartiallyRetainedByCcrLease
-  issue: https://github.com/elastic/elasticsearch/issues/152498
-- class: org.elasticsearch.xpack.stateless.cache.SearchShardRecoveryWarmingTests
-  method: testSearchRecoveryWarmingListenerRecordsTimedOutOutcome
-  issue: https://github.com/elastic/elasticsearch/issues/154033
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
-  issue: https://github.com/elastic/elasticsearch/issues/154062
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateInManyThreads {TestCase=field: <random mv DEDUPLICATED_AND_SORTED_ASCENDING doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/154070
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateInManyThreads {TestCase=field: <random mv SORTED_ASCENDING doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/154071
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateInManyThreads {TestCase=field: <random mv DEDUPLICATED_UNORDERD doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/154072
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateInManyThreads {TestCase=field: <random mv UNORDERED doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/154073
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
-  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/154157
-- class: org.elasticsearch.xpack.esql.action.FromDatasetIT
-  method: testWildcardSpanningIndexAndDatasetSucceeds
-  issue: https://github.com/elastic/elasticsearch/issues/154200
-- class: org.elasticsearch.reindex.ReindexerTests
-  method: testRemoteReindexClosesRemoteInfoOnEarlyFailure
-  issue: https://github.com/elastic/elasticsearch/issues/154237
-- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
-  method: testMaxExpressionDepth_nestedAbs_minOverflow {default}
-  issue: https://github.com/elastic/elasticsearch/issues/154341
-- class: org.elasticsearch.index.rankeval.RankEvalRequestIT
-  method: testIndicesOptions
-  issue: https://github.com/elastic/elasticsearch/issues/154360
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/151923
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testClusterDetailsAfterCCSWithFailuresOnOneShardOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
-  issue: https://github.com/elastic/elasticsearch/issues/154363
-- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
-  method: testMaxExpressionDepth_nestedAbs_maxAllowed {default}
-  issue: https://github.com/elastic/elasticsearch/issues/154380
-- class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
-  method: testControllerSpawnGatedBySettings
-  issue: https://github.com/elastic/elasticsearch/issues/154291
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: multiple sub-objects with all three supported dynamic values}"
-  issue: https://github.com/elastic/elasticsearch/issues/154464
-- class: org.elasticsearch.reindex.ReindexerTests
-  method: testRemoteReindexClosesRemoteInfoOnNormalCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/154294
-- class: org.elasticsearch.xpack.esql.action.CrossClusterEnrichUnavailableClustersIT
-  method: testEnrichRemoteWithVendor
-  issue: https://github.com/elastic/elasticsearch/issues/154532
-- class: org.elasticsearch.xpack.esql.action.CrossClusterEnrichUnavailableClustersIT
-  method: testEnrichWithHostsPolicyAndDisconnectedRemotesWithSkipUnavailableFalse
-  issue: https://github.com/elastic/elasticsearch/issues/154533
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: "test {yaml=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
-  issue: https://github.com/elastic/elasticsearch/issues/154537
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
+  method: test {csv-spec:conditional.conditionIsNull}
+  issue: https://github.com/elastic/elasticsearch/issues/154473

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -571,9 +571,6 @@ tests:
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testEachInstallOrRotationAddsExactlyOneNewKey
   issue: https://github.com/elastic/elasticsearch/issues/153024
-- class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionDisruptionIT
-  method: testDeleteMountedFrozenIndexBeforeSwap
-  issue: https://github.com/elastic/elasticsearch/issues/153040
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
@@ -730,6 +727,36 @@ tests:
 - class: org.elasticsearch.xpack.encryption.KeyRotationIT
   method: testRotationCompletesWithMultipleHandlers
   issue: https://github.com/elastic/elasticsearch/issues/153747
+- class: org.elasticsearch.index.codec.tsdb.ES819DocValuesDuelTests
+  method: testDuel
+  issue: https://github.com/elastic/elasticsearch/issues/153763
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {yaml=ml/inference_crud/Test delete already-deleted model returns 404 not 409}
+  issue: https://github.com/elastic/elasticsearch/issues/153812
+- class: org.elasticsearch.xpack.esql.action.S3ManagedIdentityAuthIT
+  method: testManagedIdentityAuthReadsRowsAndUsesWorkloadIdentityCredential
+  issue: https://github.com/elastic/elasticsearch/issues/153820
+- class: org.elasticsearch.xpack.esql.action.S3ManagedIdentityAuthIT
+  method: testQueryFailsWhenWrongCredentialIsUsed
+  issue: https://github.com/elastic/elasticsearch/issues/153821
+- class: org.elasticsearch.action.RejectionActionIT
+  method: testSimulatedSearchRejectionLoad
+  issue: https://github.com/elastic/elasticsearch/issues/153848
+- class: org.elasticsearch.xpack.stateless.StatelessAbortRunningMergesOnRelocationIT
+  method: testConcurrentForceMergeIsNotAborted
+  issue: https://github.com/elastic/elasticsearch/issues/153854
+- class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
+  method: testGetVirtualBatchedCompoundCommitChunkFailureWhenIndexCloses
+  issue: https://github.com/elastic/elasticsearch/issues/153888
+- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
+  method: testMixedOperationsDuringSplitWithDisruption
+  issue: https://github.com/elastic/elasticsearch/issues/153891
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecUnmappedLoadIT
+  method: test {csv-spec:unmapped-load.replaceUnmappedFieldFromEmptyMapping}
+  issue: https://github.com/elastic/elasticsearch/issues/153892
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFuseIT
+  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
+  issue: https://github.com/elastic/elasticsearch/issues/153902
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterWhere}
   issue: https://github.com/elastic/elasticsearch/issues/152591
@@ -760,6 +787,66 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalParquetCoercionWarningFloodIT
   method: testDeclaredCoercionWarningsStayBoundedAcrossFanOut
   issue: https://github.com/elastic/elasticsearch/issues/154023
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.conditionIsNull}
-  issue: https://github.com/elastic/elasticsearch/issues/154473
+- class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
+  method: testSeqNoPartiallyRetainedByCcrLease
+  issue: https://github.com/elastic/elasticsearch/issues/152498
+- class: org.elasticsearch.xpack.stateless.cache.SearchShardRecoveryWarmingTests
+  method: testSearchRecoveryWarmingListenerRecordsTimedOutOutcome
+  issue: https://github.com/elastic/elasticsearch/issues/154033
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
+  issue: https://github.com/elastic/elasticsearch/issues/154062
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateInManyThreads {TestCase=field: <random mv DEDUPLICATED_AND_SORTED_ASCENDING doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/154070
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateInManyThreads {TestCase=field: <random mv SORTED_ASCENDING doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/154071
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateInManyThreads {TestCase=field: <random mv DEDUPLICATED_UNORDERD doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/154072
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateInManyThreads {TestCase=field: <random mv UNORDERED doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/154073
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
+  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
+  issue: https://github.com/elastic/elasticsearch/issues/154157
+- class: org.elasticsearch.xpack.esql.action.FromDatasetIT
+  method: testWildcardSpanningIndexAndDatasetSucceeds
+  issue: https://github.com/elastic/elasticsearch/issues/154200
+- class: org.elasticsearch.reindex.ReindexerTests
+  method: testRemoteReindexClosesRemoteInfoOnEarlyFailure
+  issue: https://github.com/elastic/elasticsearch/issues/154237
+- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
+  method: testMaxExpressionDepth_nestedAbs_minOverflow {default}
+  issue: https://github.com/elastic/elasticsearch/issues/154341
+- class: org.elasticsearch.index.rankeval.RankEvalRequestIT
+  method: testIndicesOptions
+  issue: https://github.com/elastic/elasticsearch/issues/154360
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/151923
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testClusterDetailsAfterCCSWithFailuresOnOneShardOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
+  issue: https://github.com/elastic/elasticsearch/issues/154363
+- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
+  method: testMaxExpressionDepth_nestedAbs_maxAllowed {default}
+  issue: https://github.com/elastic/elasticsearch/issues/154380
+- class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
+  method: testControllerSpawnGatedBySettings
+  issue: https://github.com/elastic/elasticsearch/issues/154291
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: multiple sub-objects with all three supported dynamic values}"
+  issue: https://github.com/elastic/elasticsearch/issues/154464
+- class: org.elasticsearch.reindex.ReindexerTests
+  method: testRemoteReindexClosesRemoteInfoOnNormalCompletion
+  issue: https://github.com/elastic/elasticsearch/issues/154294
+- class: org.elasticsearch.xpack.esql.action.CrossClusterEnrichUnavailableClustersIT
+  method: testEnrichRemoteWithVendor
+  issue: https://github.com/elastic/elasticsearch/issues/154532
+- class: org.elasticsearch.xpack.esql.action.CrossClusterEnrichUnavailableClustersIT
+  method: testEnrichWithHostsPolicyAndDisconnectedRemotesWithSkipUnavailableFalse
+  issue: https://github.com/elastic/elasticsearch/issues/154533
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: "test {yaml=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
+  issue: https://github.com/elastic/elasticsearch/issues/154537

--- a/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionDisruptionIT.java
@@ -773,18 +773,21 @@ public class DLMFrozenTransitionDisruptionIT extends ESIntegTestCase {
                 ActionListener listener,
                 BiConsumer<ActionRequest, ActionListener> proceed
             ) {
-                if (latch.getCount() > 0) {
+                if (disruptionDone.compareAndSet(false, true)) {
                     logger.info("--> intercepted [{}], running disruption action now", actionName);
-                    latch.countDown();
-                    if (disruptionDone.compareAndSet(false, true)) {
-                        if (async) {
-                            Thread t = new Thread(disruptionAction, "test-disruption-" + actionName);
-                            disruptionThreadsToJoin.add(t);
-                            t.start();
-                        } else {
-                            disruptionAction.run();
-                        }
+                    if (async) {
+                        Thread t = new Thread(disruptionAction, "test-disruption-" + actionName);
+                        disruptionThreadsToJoin.add(t);
+                        t.start();
+                    } else {
+                        disruptionAction.run();
                     }
+                    // Count down only after the disruption thread is started (or the sync action
+                    // completed): waitForStableCluster joins threads in disruptionThreadsToJoin
+                    // after awaiting this latch. Thread.join on a not-yet-started thread returns
+                    // immediately, so counting down before t.start() would let the test race ahead
+                    // while the master node is still being stopped.
+                    latch.countDown();
                 }
                 proceed.accept(request, listener);
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[CI] DLMFrozenTransitionDisruptionIT testMasterFailoverDuringCleanup failing [#153174] - Take 2 (#153839)](https://github.com/elastic/elasticsearch/pull/153839)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)