### PR TITLE
ES|QL: fix date_nanos time-series aggregations

### DIFF
--- a/docs/changelog/154547.yaml
+++ b/docs/changelog/154547.yaml
@@ -1,0 +1,5 @@
+area: TSDB
+issues: []
+pr: 154547
+summary: Fix `date_nanos` time-series aggregations
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -368,23 +368,28 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
             return;
         }
         Rounding.Prepared optimizedTimeBucket = optimizeRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp());
-        long maxBound = tsBlockHash.maxTimestamp();
+        // The hash keys are in the time resolution of the timestamp field (nanoseconds for date_nanos), while the
+        // roundings operate on milliseconds. Iterate the buckets in the millisecond domain and convert the resulting
+        // labels back to the hash resolution when creating groups.
+        long maxBoundMillis = timeResolution.roundDownToMillis(tsBlockHash.maxTimestamp());
         if (outputTimeBucket != null) {
-            maxBound = optimizeOutputRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp()).round(maxBound);
+            maxBoundMillis = optimizeOutputRoundingForTimeRange(tsBlockHash.minTimestamp(), tsBlockHash.maxTimestamp()).round(
+                maxBoundMillis
+            );
         }
         this.numGroupsBeforeExpanding = Math.toIntExact(numGroups);
         this.expandingGroups = new ExpandingGroups(driverContext.bigArrays());
         for (long groupId = 0; groupId < numGroups; groupId++) {
             int tsid = tsBlockHash.tsidForGroup(groupId);
-            long startTimestamp = tsBlockHash.timestampForGroup(groupId);
-            long effectiveEnd = Math.min(startTimestamp + timeResolution.convert(windowMillis), maxBound + 1);
-            long bucket = optimizedTimeBucket.nextRoundingValue(startTimestamp);
+            long startMillis = timeResolution.roundDownToMillis(tsBlockHash.timestampForGroup(groupId));
+            long effectiveEndMillis = Math.min(startMillis + windowMillis, maxBoundMillis + 1);
+            long bucketMillis = optimizedTimeBucket.nextRoundingValue(startMillis);
             // Fill the missing buckets between (timestamp - window, timestamp).
-            while (bucket < effectiveEnd) {
-                if (tsBlockHash.addExtraGroup(tsid, bucket) >= 0) {
+            while (bucketMillis < effectiveEndMillis) {
+                if (tsBlockHash.addExtraGroup(tsid, timeResolution.convert(bucketMillis)) >= 0) {
                     expandingGroups.addGroup(Math.toIntExact(groupId));
                 }
-                bucket = optimizedTimeBucket.nextRoundingValue(bucket);
+                bucketMillis = optimizedTimeBucket.nextRoundingValue(bucketMillis);
             }
         }
     }
@@ -512,7 +517,8 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                 var iterator = fastRounding.iterator(Math.max(rangeStartMillis, minMillis), rangeEndMillis);
                 while (iterator.next()) {
                     if (iterator.getRoundedFloor() >= rangeStartMillis) {
-                        long groupId = tsBlockHash.getGroupId(tsid, iterator.getRounded());
+                        // the hash keys are in the resolution of the timestamp field, the iterator yields milliseconds
+                        long groupId = tsBlockHash.getGroupId(tsid, timeResolution.convert(iterator.getRounded()));
                         if (groupId != -1 && groupId != startingGroupId) {
                             action.accept(Math.toIntExact(groupId));
                         }
@@ -549,7 +555,9 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
                     if (cacheIndex >= 0) {
                         nextBucketTs = nextTimestamps.indexGet(cacheIndex);
                     } else {
-                        nextBucketTs = fastRounding.nextRoundingValue(bucketTs);
+                        // both the map and the hash keys are in the resolution of the timestamp field, the rounding
+                        // operates on milliseconds
+                        nextBucketTs = timeResolution.convert(fastRounding.nextRoundingValue(timeResolution.roundDownToMillis(bucketTs)));
                         nextTimestamps.put(bucketTs, nextBucketTs);
                     }
                     int nextGroupId = Math.toIntExact(tsBlockHash.getGroupId(tsid, nextBucketTs));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -332,6 +332,8 @@ public class CsvTestsDataLoader {
             "metric_temporality-settings.json"
         ).withRequiredCapabilities(EsqlCapabilities.Cap.TSDB_TEMPORALITY_SUPPORT_V9),
         new TestDataset("ts_window", "ts_window-mappings.json", "ts_window.csv", "ts_window-settings.json"),
+        new TestDataset("ts_window", "ts_window-mappings.json", "ts_window.csv", "ts_window-settings.json").withIndex("ts_window_nanos")
+            .withTypeMapping(Map.of("@timestamp", "date_nanos")),
         new TestDataset("date_extract_fields", "mapping-date_extract_fields.json", "date_extract_fields.csv"),
         new TestDataset("trim_test")
     ).collect(toMap(TestDataset::indexName, Function.identity()));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -1172,19 +1172,20 @@ max:double | inc:double | time_bucket:datetime   | cluster:keyword
 dateNanosOneRateIncreaseWithBucketAndClusterThenFilter
 required_capability: ts_command_v0
 required_capability: ts_rate_datenanos_2
+required_capability: fix_time_series_date_nanos_mixed_rounding
 
 TS datenanos-k8s
 | WHERE cluster=="prod"
 | STATS max=max(rate(network.total_bytes_in)), inc=max(increase(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute), cluster
 | EVAL max=ROUND(max, 3), inc=ROUND(inc, 3)
 | KEEP max, inc, time_bucket, cluster
-| SORT time_bucket DESC 
+| SORT time_bucket DESC
 | LIMIT 3;
 
 max:double | inc:double | time_bucket:date_nanos   | cluster:keyword
-6.981      | 2094.198   | 2024-05-10T00:20:00.000Z | prod
-11.861     | 3558.242   | 2024-05-10T00:15:00.000Z | prod
-11.563     | 3468.821   | 2024-05-10T00:10:00.000Z | prod
+64.5       | 2287.441   | 2024-05-10T00:20:00.000Z | prod
+13.765     | 4129.556   | 2024-05-10T00:15:00.000Z | prod
+11.132     | 3339.653   | 2024-05-10T00:10:00.000Z | prod
 
 ;
 
@@ -1270,6 +1271,7 @@ required_capability: ts_command_v0
 required_capability: ts_linreg_derivative
 required_capability: ts_rate_datenanos_2
 required_capability: ts_deriv_datenanos
+required_capability: fix_time_series_date_nanos_mixed_rounding
 
 TS datenanos-k8s
 | STATS max_deriv = max(deriv(to_long(network.total_bytes_in))), max_rate = max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute), cluster
@@ -1280,11 +1282,11 @@ TS datenanos-k8s
 ;
 
 max_deriv:double | max_rate:double | time_bucket:date_nanos   | cluster:keyword
-19.6162          | 8.1208          | 2024-05-10T00:00:00.000Z | prod
-4.9885           | 6.4517          | 2024-05-10T00:05:00.000Z | prod
-8.9937           | 11.5627         | 2024-05-10T00:10:00.000Z | prod
-16.0871          | 11.8608         | 2024-05-10T00:15:00.000Z | prod
-10.2206          | 6.9807          | 2024-05-10T00:20:00.000Z | prod
+19.6162          | 8.0475          | 2024-05-10T00:00:00.000Z | prod
+4.9885           | 5.7361          | 2024-05-10T00:05:00.000Z | prod
+8.9937           | 11.1322         | 2024-05-10T00:10:00.000Z | prod
+16.0871          | 13.7652         | 2024-05-10T00:15:00.000Z | prod
+10.2206          | 64.5            | 2024-05-10T00:20:00.000Z | prod
 ;
 
 derivative_of_gauge_metric_promql

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ts-window-date_nanos.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ts-window-date_nanos.csv-spec
@@ -1,0 +1,394 @@
+###############################################
+# date_nanos twins of the ts-window.csv-spec tests.
+# The ts_window_nanos index holds the same data as ts_window,
+# with @timestamp mapped as date_nanos instead of date.
+# All timestamps are whole minutes, so every test must produce
+# the same values as its millisecond twin.
+#   dim a: val[m] = m + 1  (1..30)
+#   dim b: val[m] = (m+1)*10  (10..300)
+#   counter_val: cumulative sum of val
+# Timestamps: 2024-01-01T00:00..00:29
+###############################################
+
+###############################################
+# Window smaller than bucket: handled by WindowFilter
+###############################################
+
+sum_over_time_window_smaller_than_bucket_2m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_smaller_than_bucket
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS s = sum(sum_over_time(val, 2m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+s:long | dim:keyword | time_bucket:date_nanos
+9      | a           | 2024-01-01T00:00:00.000Z
+90     | b           | 2024-01-01T00:00:00.000Z
+19     | a           | 2024-01-01T00:05:00.000Z
+190    | b           | 2024-01-01T00:05:00.000Z
+29     | a           | 2024-01-01T00:10:00.000Z
+290    | b           | 2024-01-01T00:10:00.000Z
+39     | a           | 2024-01-01T00:15:00.000Z
+390    | b           | 2024-01-01T00:15:00.000Z
+49     | a           | 2024-01-01T00:20:00.000Z
+490    | b           | 2024-01-01T00:20:00.000Z
+59     | a           | 2024-01-01T00:25:00.000Z
+590    | b           | 2024-01-01T00:25:00.000Z
+;
+
+max_over_time_window_smaller_than_bucket_2m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_smaller_than_bucket
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS mx = sum(max_over_time(val, 2m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+mx:long | dim:keyword | time_bucket:date_nanos
+5      | a           | 2024-01-01T00:00:00.000Z
+50     | b           | 2024-01-01T00:00:00.000Z
+10     | a           | 2024-01-01T00:05:00.000Z
+100    | b           | 2024-01-01T00:05:00.000Z
+15     | a           | 2024-01-01T00:10:00.000Z
+150    | b           | 2024-01-01T00:10:00.000Z
+20     | a           | 2024-01-01T00:15:00.000Z
+200    | b           | 2024-01-01T00:15:00.000Z
+25     | a           | 2024-01-01T00:20:00.000Z
+250    | b           | 2024-01-01T00:20:00.000Z
+30     | a           | 2024-01-01T00:25:00.000Z
+300    | b           | 2024-01-01T00:25:00.000Z
+;
+
+###############################################
+# Window is an exact multiple of the bucket
+###############################################
+
+sum_over_time_exact_multiple_10m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_v1
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS s = sum(sum_over_time(val, 10m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+s:long | dim:keyword | time_bucket:date_nanos
+15     | a           | 2024-01-01T00:00:00.000Z
+150    | b           | 2024-01-01T00:00:00.000Z
+55     | a           | 2024-01-01T00:05:00.000Z
+550    | b           | 2024-01-01T00:05:00.000Z
+105    | a           | 2024-01-01T00:10:00.000Z
+1050   | b           | 2024-01-01T00:10:00.000Z
+155    | a           | 2024-01-01T00:15:00.000Z
+1550   | b           | 2024-01-01T00:15:00.000Z
+205    | a           | 2024-01-01T00:20:00.000Z
+2050   | b           | 2024-01-01T00:20:00.000Z
+255    | a           | 2024-01-01T00:25:00.000Z
+2550   | b           | 2024-01-01T00:25:00.000Z
+;
+
+###############################################
+# Non-multiple window/bucket combos (GCD-based sub-bucketing)
+###############################################
+
+sum_over_time_non_multiple_7m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS s = sum(sum_over_time(val, 7m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+s:long | dim:keyword | time_bucket:date_nanos
+1      | a           | 2024-01-01T00:00:00.000Z
+10     | b           | 2024-01-01T00:00:00.000Z
+21     | a           | 2024-01-01T00:05:00.000Z
+210    | b           | 2024-01-01T00:05:00.000Z
+56     | a           | 2024-01-01T00:10:00.000Z
+560    | b           | 2024-01-01T00:10:00.000Z
+91     | a           | 2024-01-01T00:15:00.000Z
+910    | b           | 2024-01-01T00:15:00.000Z
+126    | a           | 2024-01-01T00:20:00.000Z
+1260   | b           | 2024-01-01T00:20:00.000Z
+161    | a           | 2024-01-01T00:25:00.000Z
+1610   | b           | 2024-01-01T00:25:00.000Z
+;
+
+sum_over_time_non_multiple_11m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS s = sum(sum_over_time(val, 11m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+s:long | dim:keyword | time_bucket:date_nanos
+1      | a           | 2024-01-01T00:00:00.000Z
+10     | b           | 2024-01-01T00:00:00.000Z
+21     | a           | 2024-01-01T00:05:00.000Z
+210    | b           | 2024-01-01T00:05:00.000Z
+66     | a           | 2024-01-01T00:10:00.000Z
+660    | b           | 2024-01-01T00:10:00.000Z
+121    | a           | 2024-01-01T00:15:00.000Z
+1210   | b           | 2024-01-01T00:15:00.000Z
+176    | a           | 2024-01-01T00:20:00.000Z
+1760   | b           | 2024-01-01T00:20:00.000Z
+231    | a           | 2024-01-01T00:25:00.000Z
+2310   | b           | 2024-01-01T00:25:00.000Z
+;
+
+count_over_time_non_multiple_7m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS c = sum(count_over_time(val, 7m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+c:long | dim:keyword | time_bucket:date_nanos
+1      | a           | 2024-01-01T00:00:00.000Z
+1      | b           | 2024-01-01T00:00:00.000Z
+6      | a           | 2024-01-01T00:05:00.000Z
+6      | b           | 2024-01-01T00:05:00.000Z
+7      | a           | 2024-01-01T00:10:00.000Z
+7      | b           | 2024-01-01T00:10:00.000Z
+7      | a           | 2024-01-01T00:15:00.000Z
+7      | b           | 2024-01-01T00:15:00.000Z
+7      | a           | 2024-01-01T00:20:00.000Z
+7      | b           | 2024-01-01T00:20:00.000Z
+7      | a           | 2024-01-01T00:25:00.000Z
+7      | b           | 2024-01-01T00:25:00.000Z
+;
+
+min_over_time_non_multiple_7m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS mn = sum(min_over_time(val, 7m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+mn:long | dim:keyword | time_bucket:date_nanos
+1      | a           | 2024-01-01T00:00:00.000Z
+10     | b           | 2024-01-01T00:00:00.000Z
+1      | a           | 2024-01-01T00:05:00.000Z
+10     | b           | 2024-01-01T00:05:00.000Z
+5      | a           | 2024-01-01T00:10:00.000Z
+50     | b           | 2024-01-01T00:10:00.000Z
+10     | a           | 2024-01-01T00:15:00.000Z
+100    | b           | 2024-01-01T00:15:00.000Z
+15     | a           | 2024-01-01T00:20:00.000Z
+150    | b           | 2024-01-01T00:20:00.000Z
+20     | a           | 2024-01-01T00:25:00.000Z
+200    | b           | 2024-01-01T00:25:00.000Z
+;
+
+avg_over_time_non_multiple_7m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS a = sum(avg_over_time(val, 7m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+a:double | dim:keyword | time_bucket:date_nanos
+1.0      | a           | 2024-01-01T00:00:00.000Z
+10.0     | b           | 2024-01-01T00:00:00.000Z
+3.5      | a           | 2024-01-01T00:05:00.000Z
+35.0     | b           | 2024-01-01T00:05:00.000Z
+8.0      | a           | 2024-01-01T00:10:00.000Z
+80.0     | b           | 2024-01-01T00:10:00.000Z
+13.0     | a           | 2024-01-01T00:15:00.000Z
+130.0    | b           | 2024-01-01T00:15:00.000Z
+18.0     | a           | 2024-01-01T00:20:00.000Z
+180.0    | b           | 2024-01-01T00:20:00.000Z
+23.0     | a           | 2024-01-01T00:25:00.000Z
+230.0    | b           | 2024-01-01T00:25:00.000Z
+;
+
+sum_over_time_non_multiple_with_trange_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| WHERE TRANGE("2024-01-01T00:05:00.000Z", "2024-01-01T00:20:00.000Z")
+| STATS s = sum(sum_over_time(val, 7m)) BY dim, time_bucket = TBUCKET(5minute)
+| SORT time_bucket, dim
+| LIMIT 10;
+
+s:long | dim:keyword | time_bucket:date_nanos
+45     | a           | 2024-01-01T00:10:00.000Z
+450    | b           | 2024-01-01T00:10:00.000Z
+91     | a           | 2024-01-01T00:15:00.000Z
+910    | b           | 2024-01-01T00:15:00.000Z
+126    | a           | 2024-01-01T00:20:00.000Z
+1260   | b           | 2024-01-01T00:20:00.000Z
+;
+
+###############################################
+# Rate with non-multiple windows and interpolation
+###############################################
+
+rate_non_multiple_avg_rate_7m_window_5m_bucket_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: rate_with_interpolation
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| STATS r = avg(rate(counter_val, 7m)) BY dim, time_bucket = TBUCKET(5minute)
+| EVAL r = ROUND(r, 6)
+| SORT time_bucket, dim
+| LIMIT 20;
+
+dim:keyword | time_bucket:date_nanos   | r:double
+a           | 2024-01-01T00:00:00.000Z | null
+b           | 2024-01-01T00:00:00.000Z | null
+a           | 2024-01-01T00:05:00.000Z | 0.053968
+b           | 2024-01-01T00:05:00.000Z | 0.539683
+a           | 2024-01-01T00:10:00.000Z | 0.130102
+b           | 2024-01-01T00:10:00.000Z | 1.30102
+a           | 2024-01-01T00:15:00.000Z | 0.206633
+b           | 2024-01-01T00:15:00.000Z | 2.066327
+a           | 2024-01-01T00:20:00.000Z | 0.283163
+b           | 2024-01-01T00:20:00.000Z | 2.831633
+a           | 2024-01-01T00:25:00.000Z | 0.359694
+b           | 2024-01-01T00:25:00.000Z | 3.596939
+;
+
+rate_5m_tbucket_datenanos
+required_capability: ts_command_v0
+required_capability: rate_with_interpolation_v2
+required_capability: fix_time_series_date_nanos_mixed_rounding
+
+TS ts_window_nanos
+| WHERE dim == "a"
+| STATS r = rate(counter_val) BY time_bucket = TBUCKET(5minute)
+| EVAL r = ROUND(r, 6)
+| KEEP r, time_bucket
+| SORT time_bucket
+;
+
+r:double | time_bucket:date_nanos
+0.066667 | 2024-01-01T00:00:00.000Z
+0.15     | 2024-01-01T00:05:00.000Z
+0.233333 | 2024-01-01T00:10:00.000Z
+0.316667 | 2024-01-01T00:15:00.000Z
+0.4      | 2024-01-01T00:20:00.000Z
+0.418    | 2024-01-01T00:25:00.000Z
+;
+
+###############################################
+# TSTEP variants
+###############################################
+
+sum_over_time_non_multiple_7m_window_5m_tstep_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: tstep
+required_capability: fix_tstep_bucket_rounding
+required_capability: fix_time_series_date_nanos_mixed_rounding
+request_time_filter: 2024-01-01T00:00:00.000Z,2024-01-01T00:30:00.000Z
+
+TS ts_window_nanos
+| STATS s = sum(sum_over_time(val, 7m)) BY dim, time_bucket = TSTEP(5minute)
+| SORT time_bucket, dim
+| LIMIT 12;
+
+s:long | dim:keyword | time_bucket:date_nanos
+1      | a           | 2024-01-01T00:00:00.000Z
+10     | b           | 2024-01-01T00:00:00.000Z
+21     | a           | 2024-01-01T00:05:00.000Z
+210    | b           | 2024-01-01T00:05:00.000Z
+56     | a           | 2024-01-01T00:10:00.000Z
+560    | b           | 2024-01-01T00:10:00.000Z
+91     | a           | 2024-01-01T00:15:00.000Z
+910    | b           | 2024-01-01T00:15:00.000Z
+126    | a           | 2024-01-01T00:20:00.000Z
+1260   | b           | 2024-01-01T00:20:00.000Z
+161    | a           | 2024-01-01T00:25:00.000Z
+1610   | b           | 2024-01-01T00:25:00.000Z
+;
+
+sum_over_time_non_multiple_11m_window_5m_tstep_datenanos
+required_capability: ts_command_v0
+required_capability: time_series_window_non_multiple
+required_capability: fix_time_series_window_backward
+required_capability: tstep
+required_capability: fix_tstep_bucket_rounding
+required_capability: fix_time_series_date_nanos_mixed_rounding
+request_time_filter: 2024-01-01T00:00:00.000Z,2024-01-01T00:30:00.000Z
+
+TS ts_window_nanos
+| STATS s = sum(sum_over_time(val, 11m)) BY dim, time_bucket = TSTEP(5minute)
+| SORT time_bucket, dim
+| LIMIT 12;
+
+s:long | dim:keyword | time_bucket:date_nanos
+1      | a           | 2024-01-01T00:00:00.000Z
+10     | b           | 2024-01-01T00:00:00.000Z
+21     | a           | 2024-01-01T00:05:00.000Z
+210    | b           | 2024-01-01T00:05:00.000Z
+66     | a           | 2024-01-01T00:10:00.000Z
+660    | b           | 2024-01-01T00:10:00.000Z
+121    | a           | 2024-01-01T00:15:00.000Z
+1210   | b           | 2024-01-01T00:15:00.000Z
+176    | a           | 2024-01-01T00:20:00.000Z
+1760   | b           | 2024-01-01T00:20:00.000Z
+231    | a           | 2024-01-01T00:25:00.000Z
+2310   | b           | 2024-01-01T00:25:00.000Z
+;
+
+rate_5m_tstep_datenanos
+required_capability: ts_command_v0
+required_capability: rate_with_interpolation_v2
+required_capability: tstep
+required_capability: fix_tstep_bucket_rounding
+required_capability: fix_time_series_date_nanos_mixed_rounding
+request_time_filter: 2024-01-01T00:00:00.000Z,2024-01-01T00:30:00.000Z
+
+TS ts_window_nanos
+| WHERE dim == "a"
+| STATS r = rate(counter_val) BY time_bucket = TSTEP(5minute)
+| EVAL r = ROUND(r, 6)
+| KEEP r, time_bucket
+| SORT time_bucket
+;
+
+r:double | time_bucket:date_nanos
+null     | 2024-01-01T00:00:00.000Z
+0.066667 | 2024-01-01T00:05:00.000Z
+0.15     | 2024-01-01T00:10:00.000Z
+0.233333 | 2024-01-01T00:15:00.000Z
+0.316667 | 2024-01-01T00:20:00.000Z
+0.4      | 2024-01-01T00:25:00.000Z
+0.41625  | 2024-01-01T00:30:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/WindowFilterDateNanosEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/WindowFilterDateNanosEvaluator.java
@@ -1,0 +1,154 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function;
+
+import com.carrotsearch.hppc.LongLongHashMap;
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import java.util.function.Function;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.Rounding;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link WindowFilter}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class WindowFilterDateNanosEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(WindowFilterDateNanosEvaluator.class);
+
+  private final Source source;
+
+  private final long window;
+
+  private final Rounding.Prepared bucket;
+
+  private final LongLongHashMap nextTimestamps;
+
+  private final ExpressionEvaluator timestamp;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public WindowFilterDateNanosEvaluator(Source source, long window, Rounding.Prepared bucket,
+      LongLongHashMap nextTimestamps, ExpressionEvaluator timestamp, DriverContext driverContext) {
+    this.source = source;
+    this.window = window;
+    this.bucket = bucket;
+    this.nextTimestamps = nextTimestamps;
+    this.timestamp = timestamp;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (LongBlock timestampBlock = (LongBlock) timestamp.eval(page)) {
+      LongVector timestampVector = timestampBlock.asVector();
+      if (timestampVector == null) {
+        return eval(page.getPositionCount(), timestampBlock);
+      }
+      return eval(page.getPositionCount(), timestampVector).asBlock();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += timestamp.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public BooleanBlock eval(int positionCount, LongBlock timestampBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (timestampBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        long timestamp = timestampBlock.getLong(timestampBlock.getFirstValueIndex(p));
+        result.appendBoolean(WindowFilter.processDateNanos(this.window, this.bucket, this.nextTimestamps, timestamp));
+      }
+      return result.build();
+    }
+  }
+
+  public BooleanVector eval(int positionCount, LongVector timestampVector) {
+    try(BooleanVector.FixedBuilder result = driverContext.blockFactory().newBooleanVectorFixedBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        long timestamp = timestampVector.getLong(p);
+        result.appendBoolean(p, WindowFilter.processDateNanos(this.window, this.bucket, this.nextTimestamps, timestamp));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "WindowFilterDateNanosEvaluator[" + "window=" + window + ", bucket=" + bucket + ", nextTimestamps=" + nextTimestamps + ", timestamp=" + timestamp + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(timestamp);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final long window;
+
+    private final Rounding.Prepared bucket;
+
+    private final Function<DriverContext, LongLongHashMap> nextTimestamps;
+
+    private final ExpressionEvaluator.Factory timestamp;
+
+    public Factory(Source source, long window, Rounding.Prepared bucket,
+        Function<DriverContext, LongLongHashMap> nextTimestamps,
+        ExpressionEvaluator.Factory timestamp) {
+      this.source = source;
+      this.window = window;
+      this.bucket = bucket;
+      this.nextTimestamps = nextTimestamps;
+      this.timestamp = timestamp;
+    }
+
+    @Override
+    public WindowFilterDateNanosEvaluator get(DriverContext context) {
+      return new WindowFilterDateNanosEvaluator(source, window, bucket, nextTimestamps.apply(context), timestamp.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "WindowFilterDateNanosEvaluator[" + "window=" + window + ", bucket=" + bucket + ", nextTimestamps=" + nextTimestamps + ", timestamp=" + timestamp + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3462,6 +3462,14 @@ public class EsqlCapabilities {
          */
         PROMQL_TOPK,
 
+        /**
+         * Fix mixing of millisecond roundings with nanosecond timestamps in time-series aggregations over
+         * {@code date_nanos} indices. This covers window bucket expansion, the window merge in the final
+         * aggregation, the window row filter for windows smaller than the time bucket, and the neighbor-bucket
+         * lookup used by rate interpolation.
+         */
+        FIX_TIME_SERIES_DATE_NANOS_MIXED_ROUNDING,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/WindowFilter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/WindowFilter.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
@@ -29,6 +30,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
@@ -115,6 +117,15 @@ public class WindowFilter extends EsqlScalarFunction implements TimestampAware, 
         Duration foldedWindow = (Duration) window.fold(toEvaluator.foldCtx());
         Rounding.Prepared preparedRounding = bucketBucket.getDateRoundingOrNull(toEvaluator.foldCtx());
         var timestampFactory = toEvaluator.apply(timestamp);
+        if (timestamp.dataType() == DataType.DATE_NANOS) {
+            return new WindowFilterDateNanosEvaluator.Factory(
+                source(),
+                foldedWindow.toMillis(),
+                preparedRounding,
+                driverContext -> new LongLongHashMap(),
+                timestampFactory
+            );
+        }
         return new WindowFilterEvaluator.Factory(
             source(),
             foldedWindow.toMillis(),
@@ -162,5 +173,41 @@ public class WindowFilter extends EsqlScalarFunction implements TimestampAware, 
         long nextBucketId = lo == bucketId ? hi - window : hi - window + 1;
         nextTimestamps.indexInsert(idx, bucketId, nextBucketId);
         return timestamp >= nextBucketId;
+    }
+
+    @Evaluator(extraName = "DateNanos")
+    static boolean processDateNanos(
+        @Fixed long window,
+        @Fixed Rounding.Prepared bucket,
+        @Fixed(scope = Fixed.Scope.THREAD_LOCAL) LongLongHashMap nextTimestamps,
+        long timestamp
+    ) {
+        // The rounding operates on milliseconds while the timestamp is in nanoseconds. The bucket edges are whole
+        // milliseconds, so the boundary is derived exactly like in process() and only the comparison moves to the
+        // nanosecond domain. The map is keyed by the millisecond bucket label and stores the nanosecond boundary.
+        long timestampMillis = DateUtils.toMilliSeconds(timestamp);
+        long bucketId = bucket.round(timestampMillis);
+        int idx = nextTimestamps.indexOf(bucketId);
+        if (nextTimestamps.indexExists(idx)) {
+            return timestamp >= nextTimestamps.indexGet(idx);
+        }
+
+        long lo = bucket.roundingFloor(bucketId);
+        long hi = bucket.roundingCeiling(bucketId);
+        long windowStartMillis = hi - window;
+        // TimeUnit saturates an upper out-of-range boundary to Long.MAX_VALUE. That would incorrectly include the
+        // maximum date_nanos timestamp, so reject the bucket before converting the boundary to nanoseconds.
+        if (windowStartMillis > DateUtils.MAX_NANOSECOND_INSTANT.toEpochMilli()) {
+            return false;
+        }
+        long windowStartNanos = TimeUnit.MILLISECONDS.toNanos(windowStartMillis);
+        long nextTimestamp;
+        if (lo == bucketId) {
+            nextTimestamp = windowStartNanos;
+        } else {
+            nextTimestamp = windowStartNanos + 1;
+        }
+        nextTimestamps.indexInsert(idx, bucketId, nextTimestamp);
+        return timestamp >= nextTimestamp;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/WindowFilterEndLabeledTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/WindowFilterEndLabeledTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -85,6 +86,21 @@ public class WindowFilterEndLabeledTests extends AbstractConfigurationFunctionTe
         randomZoneCase(suppliers, "5m/1m random tz: 5m", 5, 1, minutes(5));
         randomZoneCase(suppliers, "5m/2m random tz: 3m", 5, 2, minutes(3));
 
+        // date_nanos timestamps: the left-open lower edge must be nudged by one nanosecond, not one millisecond,
+        // so a sample one nanosecond above the window's lower edge is already inside the window.
+        utcNanosCase(suppliers, "nanos 5m/1m: 4m excluded (window lower edge)", 5, 1, minuteNanos(4), false);
+        utcNanosCase(suppliers, "nanos 5m/1m: 4m plus 1ns included", 5, 1, minuteNanos(4) + 1, true);
+        utcNanosCase(suppliers, "nanos 5m/1m: 5m included (right edge)", 5, 1, minuteNanos(5), true);
+        // Bucket membership is decided on the truncated millisecond value, matching how TSTEP groups date_nanos rows
+        // (see DateTrunc#processDateNanos): a sample less than one millisecond above the right edge still belongs to
+        // this bucket and its trailing window, while a sample one millisecond above falls into the next bucket.
+        utcNanosCase(suppliers, "nanos 5m/1m: 5m plus 1ns included (truncated to right edge)", 5, 1, minuteNanos(5) + 1, true);
+        utcNanosCase(suppliers, "nanos 5m/1m: 5m plus 1ms excluded", 5, 1, minuteNanos(5) + TimeUnit.MILLISECONDS.toNanos(1), false);
+        utcNanosCase(suppliers, "nanos 5m/2m: 3m excluded (window lower edge)", 5, 2, minuteNanos(3), false);
+        utcNanosCase(suppliers, "nanos 5m/2m: 3m plus 1ns included", 5, 2, minuteNanos(3) + 1, true);
+        // The trailing minute of the final five-minute bucket starts after the date_nanos range.
+        utcNanosCase(suppliers, "nanos 5m/1m: maximum timestamp excluded", 5, 1, DateUtils.MAX_NANOSECOND, false);
+
         return parameterSuppliersFromTypedData(suppliers);
     }
 
@@ -107,6 +123,31 @@ public class WindowFilterEndLabeledTests extends AbstractConfigurationFunctionTe
             return new TestCaseSupplier.TestCase(
                 args,
                 Matchers.startsWith("WindowFilterEvaluator[window=" + window.toMillis()),
+                DataType.BOOLEAN,
+                equalTo(expected)
+            ).withConfiguration(TEST_SOURCE, configurationForTimezone(ZoneOffset.UTC));
+        }));
+    }
+
+    private static void utcNanosCase(
+        List<TestCaseSupplier> suppliers,
+        String name,
+        int bucketMinutes,
+        int windowMinutes,
+        long timestampNanos,
+        boolean expected
+    ) {
+        Duration window = Duration.ofMinutes(windowMinutes);
+        Duration bucket = Duration.ofMinutes(bucketMinutes);
+
+        suppliers.add(new TestCaseSupplier(name, List.of(DataType.TIME_DURATION, DataType.TIME_DURATION, DataType.DATE_NANOS), () -> {
+            List<TestCaseSupplier.TypedData> args = new ArrayList<>();
+            args.add(new TestCaseSupplier.TypedData(window, DataType.TIME_DURATION, "window").forceLiteral());
+            args.add(new TestCaseSupplier.TypedData(bucket, DataType.TIME_DURATION, "bucket").forceLiteral());
+            args.add(new TestCaseSupplier.TypedData(timestampNanos, DataType.DATE_NANOS, "@timestamp"));
+            return new TestCaseSupplier.TestCase(
+                args,
+                Matchers.startsWith("WindowFilterDateNanosEvaluator[window=" + window.toMillis()),
                 DataType.BOOLEAN,
                 equalTo(expected)
             ).withConfiguration(TEST_SOURCE, configurationForTimezone(ZoneOffset.UTC));
@@ -175,5 +216,9 @@ public class WindowFilterEndLabeledTests extends AbstractConfigurationFunctionTe
 
     private static long seconds(long s) {
         return TimeUnit.SECONDS.toMillis(s);
+    }
+
+    private static long minuteNanos(long m) {
+        return TimeUnit.MINUTES.toNanos(m);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/WindowFilterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/WindowFilterTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -102,6 +103,24 @@ public class WindowFilterTests extends AbstractConfigurationFunctionTestCase {
         randomZoneCase(suppliers, "1m/5m random tz: 6m", 1, 5, minutes(6));
         randomZoneCase(suppliers, "1m/5m random tz: 7m", 1, 5, minutes(7));
 
+        // date_nanos timestamps: the boundary is computed from the millisecond rounding but the comparison happens in
+        // the nanosecond domain, so sub-millisecond samples right around the window edge must be classified exactly.
+        // 5m bucket, 1m window: the window is [4m, 5m).
+        utcNanosCase(suppliers, "nanos 5m/1m: 0s excluded", 5, 1, 0L, false);
+        utcNanosCase(suppliers, "nanos 5m/1m: 4m minus 1ns excluded", 5, 1, minuteNanos(4) - 1, false);
+        utcNanosCase(suppliers, "nanos 5m/1m: 4m included", 5, 1, minuteNanos(4), true);
+        utcNanosCase(suppliers, "nanos 5m/1m: 4m plus 1ns included", 5, 1, minuteNanos(4) + 1, true);
+        utcNanosCase(suppliers, "nanos 5m/1m: 5m minus 1ns included", 5, 1, minuteNanos(5) - 1, true);
+        utcNanosCase(suppliers, "nanos 5m/1m: 5m excluded", 5, 1, minuteNanos(5), false);
+        // 5m bucket, 2m window: the window is [3m, 5m).
+        utcNanosCase(suppliers, "nanos 5m/2m: 3m minus 1ns excluded", 5, 2, minuteNanos(3) - 1, false);
+        utcNanosCase(suppliers, "nanos 5m/2m: 3m included", 5, 2, minuteNanos(3), true);
+        // Window larger than bucket: everything passes.
+        utcNanosCase(suppliers, "nanos 1m/5m: 0s included", 1, 5, 0L, true);
+        utcNanosCase(suppliers, "nanos 1m/5m: 30s plus 1ns included", 1, 5, minuteNanos(0) + TimeUnit.SECONDS.toNanos(30) + 1, true);
+        // The trailing minute of the final five-minute bucket starts after the date_nanos range.
+        utcNanosCase(suppliers, "nanos 5m/1m: maximum timestamp excluded", 5, 1, DateUtils.MAX_NANOSECOND, false);
+
         for (int i = 0; i < 10; i++) {
             fullyRandomCase(suppliers, "random case " + i);
         }
@@ -130,6 +149,31 @@ public class WindowFilterTests extends AbstractConfigurationFunctionTestCase {
                 Matchers.startsWith(
                     "WindowFilterEvaluator[window=" + window.toMillis() + ", bucket=Rounding[" + bucket.toMillis() + " in Z][fixed]"
                 ),
+                DataType.BOOLEAN,
+                equalTo(expected)
+            ).withConfiguration(TEST_SOURCE, configurationForTimezone(ZoneOffset.UTC));
+        }));
+    }
+
+    private static void utcNanosCase(
+        List<TestCaseSupplier> suppliers,
+        String name,
+        int bucketMinutes,
+        int windowMinutes,
+        long timestampNanos,
+        boolean expected
+    ) {
+        Duration window = Duration.ofMinutes(windowMinutes);
+        Duration bucket = Duration.ofMinutes(bucketMinutes);
+
+        suppliers.add(new TestCaseSupplier(name, List.of(DataType.TIME_DURATION, DataType.TIME_DURATION, DataType.DATE_NANOS), () -> {
+            List<TestCaseSupplier.TypedData> args = new ArrayList<>();
+            args.add(new TestCaseSupplier.TypedData(window, DataType.TIME_DURATION, "window").forceLiteral());
+            args.add(new TestCaseSupplier.TypedData(bucket, DataType.TIME_DURATION, "bucket").forceLiteral());
+            args.add(new TestCaseSupplier.TypedData(timestampNanos, DataType.DATE_NANOS, "@timestamp"));
+            return new TestCaseSupplier.TestCase(
+                args,
+                Matchers.startsWith("WindowFilterDateNanosEvaluator[window=" + window.toMillis()),
                 DataType.BOOLEAN,
                 equalTo(expected)
             ).withConfiguration(TEST_SOURCE, configurationForTimezone(ZoneOffset.UTC));
@@ -219,5 +263,9 @@ public class WindowFilterTests extends AbstractConfigurationFunctionTestCase {
 
     private static long seconds(long s) {
         return TimeUnit.SECONDS.toMillis(s);
+    }
+
+    private static long minuteNanos(long m) {
+        return TimeUnit.MINUTES.toNanos(m);
     }
 }


### PR DESCRIPTION
Time-series block hash keys are in the resolution of the @timestamp field, which is nanoseconds for date_nanos indices, but the time bucket roundings operate on milliseconds. Windowed aggregations mixed the two domains, so on a date_nanos index they either crashed or returned wrong results while the same query on a date index was correct.

Similar to https://github.com/elastic/elasticsearch/pull/153996
