### PR TITLE
[ES|QL] Skip CCS test for LOOKUP JOIN after STATS (#153178)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -379,9 +379,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testSourceRelocationAndTargetRestart
   issue: https://github.com/elastic/elasticsearch/issues/153173
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecApproximationIT
-  method: test {csv-spec:approximation.Lookup join before and after stats by}
-  issue: https://github.com/elastic/elasticsearch/issues/153178
 - class: org.elasticsearch.xpack.esql.action.FromDatasetIT
   method: testColumnarBadDateTokenNullsCellEagerAndDeferred
   issue: https://github.com/elastic/elasticsearch/issues/153187

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/csvSpecTest/java/org/elasticsearch/xpack/esql/ccq/AbstractMultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/csvSpecTest/java/org/elasticsearch/xpack/esql/ccq/AbstractMultiClusterSpecIT.java
@@ -162,7 +162,12 @@ public abstract class AbstractMultiClusterSpecIT extends EsqlSpecTestCase {
         // Lookup join after INLINE STATS (coordinator-only) is not supported in CCS yet
         "Inline stats by and lookup join",
         // Lookup join after STATS (coordinator-only) is not supported in CCS yet
-        "Lookup join after stats by"
+        "Lookup join after stats by",
+        // The second LOOKUP JOIN (after STATS) is not supported in CCS yet.
+        // Previously passed accidentally: before #152845, Join#replaceChildren dropped the isRemote flag,
+        // so postOptimizationVerification never saw isRemote=true on this join.
+        // #152845 fixed the flag propagation, exposing that CCS LOOKUP JOIN after STATS is unsupported.
+        "Lookup join before and after stats by"
     );
 
     @Override


### PR DESCRIPTION
Fixes: #153178 
The test "Lookup join before and after stats by" contains a second LOOKUP JOIN that follows a STATS command. In CCS mode the upstream EsRelation is remote, so the Analyzer stamps isRemote=true on that join. postOptimizationVerification then walks the join's subtree, finds the Aggregate (ExecutesOn.Coordinator), and throws:
  LOOKUP JOIN with remote indices can't be executed after [STATS ...]

Before #152845 this was silently passing: Join#replaceChildren was calling the no-isRemote constructor, resetting the flag to false on every plan transformation, so the validator never saw isRemote=true. #152845 made isRemote final and wired it through replaceChildren, which correctly preserved the flag and exposed the limitation.

The sibling test "Lookup join after stats by" was already excluded from CCS for the same reason. Add the new test to
NO_REMOTE_LOOKUP_JOIN_TESTS with the same treatment and remove the mute entry.