### PR TITLE
[9.5] Wait for green indices after restart in oldrepos tests (#154520)

### DIFF
--- a/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
+++ b/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
@@ -74,6 +74,7 @@ public class DocValueOnlyFieldsIT extends ESClientYamlSuiteTestCase {
     public void setupIndex() throws IOException {
         final boolean afterRestart = Booleans.parseBoolean(System.getProperty("tests.after_restart"));
         if (afterRestart) {
+            ensureGreen("test");
             return;
         }
 

--- a/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldMappingsIT.java
+++ b/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldMappingsIT.java
@@ -65,6 +65,13 @@ public class OldMappingsIT extends ESRestTestCase {
     public void setupIndex() throws IOException {
         final boolean afterRestart = Booleans.parseBoolean(System.getProperty("tests.after_restart"));
         if (afterRestart) {
+            List<String> indices = new ArrayList<>(List.of("filebeat", "custom", "nested", "standard_token_filter", "similarity"));
+            if (oldVersion.before(Version.fromString("6.0.0"))) {
+                indices.add("winlogbeat");
+            }
+            for (String index : indices) {
+                ensureGreen(index);
+            }
             return;
         }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Wait for green indices after restart in oldrepos tests (#154520)