### PR TITLE
[9.5] Unmute conditional csv-spec collateral tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -742,18 +742,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
   issue: https://github.com/elastic/elasticsearch/issues/154377
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.singleCondition}
-  issue: https://github.com/elastic/elasticsearch/issues/154436
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecConditionalIT
-  method: test {csv-spec:conditional.docsCaseSuccessRate}
-  issue: https://github.com/elastic/elasticsearch/issues/154458
 - class: org.elasticsearch.blobcache.common.SparseFileTrackerTests
   method: testClaimedGapsDoNotExtendBeyondRequestedRangeWhenCaller2FillsFirst
   issue: https://github.com/elastic/elasticsearch/issues/154462
 - class: org.elasticsearch.xpack.esql.action.ExternalParquetCoercionWarningFloodIT
   method: testDeclaredCoercionWarningsStayBoundedAcrossFanOut
   issue: https://github.com/elastic/elasticsearch/issues/154023
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecConditionalIT
-  method: test {csv-spec:conditional.conditionIsNull}
-  issue: https://github.com/elastic/elasticsearch/issues/154473


### PR DESCRIPTION
Follow-up to #154516 (per https://github.com/elastic/elasticsearch/pull/154474#issuecomment-5030715825): these three were left muted pending confirmation, but main already provides it — they were never muted there and run green with the `fn_to_text` gate in place. They only ever failed as `connect_transport_exception` collateral of the remote node deaths root-caused in #154471.

Closes #154436
Closes #154458
Closes #154473

Made with [Cursor](https://cursor.com)