### PR TITLE
[9.5] [Test] Fix race in reindex tests introduced in #154133 (#154322)

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
@@ -1177,9 +1178,11 @@ public class ReindexerTests extends ESTestCase {
                 request -> request.setRemoteInfo(remoteInfoWithPassword(server, password)),
                 initFuture -> {
                     assertNotNull(initFuture.actionGet());
-                    assertThat(
-                        expectThrows(IllegalStateException.class, password::getChars).getMessage(),
-                        containsString("SecureString has already been closed")
+                    assertBusy(
+                        () -> assertThat(
+                            expectThrows(IllegalStateException.class, password::getChars).getMessage(),
+                            containsString("SecureString has already been closed")
+                        )
                     );
                 }
             );
@@ -1208,9 +1211,11 @@ public class ReindexerTests extends ESTestCase {
                 request.setRemoteInfo(remoteInfoWithPassword(server, password));
             }, initFuture -> {
                 expectThrows(ElasticsearchStatusException.class, initFuture::actionGet);
-                assertThat(
-                    expectThrows(IllegalStateException.class, password::getChars).getMessage(),
-                    containsString("SecureString has already been closed")
+                assertBusy(
+                    () -> assertThat(
+                        expectThrows(IllegalStateException.class, password::getChars).getMessage(),
+                        containsString("SecureString has already been closed")
+                    )
                 );
             });
         } finally {
@@ -3034,8 +3039,8 @@ public class ReindexerTests extends ESTestCase {
     private void runRemotePitTestWithMockServer(
         HttpServer server,
         Consumer<ReindexRequest> requestConfigurer,
-        Consumer<PlainActionFuture<BulkByPaginatedSearchResponse>> assertions
-    ) {
+        CheckedConsumer<PlainActionFuture<BulkByPaginatedSearchResponse>, Exception> assertions
+    ) throws Exception {
         runRemotePitTestWithMockServer(server, requestConfigurer, assertions, Settings.EMPTY);
     }
 
@@ -3047,9 +3052,9 @@ public class ReindexerTests extends ESTestCase {
     private void runRemotePitTestWithMockServer(
         HttpServer server,
         Consumer<ReindexRequest> requestConfigurer,
-        Consumer<PlainActionFuture<BulkByPaginatedSearchResponse>> assertions,
+        CheckedConsumer<PlainActionFuture<BulkByPaginatedSearchResponse>, Exception> assertions,
         Settings pitKeepAliveLayerSettings
-    ) {
+    ) throws Exception {
         BytesArray matchAll = new BytesArray("{\"match_all\":{}}");
         RemoteInfo remoteInfo = new RemoteInfo(
             "http",

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -712,9 +712,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.renameDerivedGroupingPrune [ndjson.bz/HTTP]}
   issue: https://github.com/elastic/elasticsearch/issues/154238
-- class: org.elasticsearch.reindex.ReindexerTests
-  method: testRemoteReindexClosesRemoteInfoOnNormalCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/154294
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesIT
   method: test {csv-spec:k8s-timeseries.firstAndLastWithNullSort}
   issue: https://github.com/elastic/elasticsearch/issues/153565
@@ -736,9 +733,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=search.vectors/41_knn_search_half_byte_quantized_bfloat16/Knn search with mip}
   issue: https://github.com/elastic/elasticsearch/issues/154355
-- class: org.elasticsearch.reindex.ReindexerTests
-  method: testRemoteReindexClosesRemoteInfoOnEarlyFailure
-  issue: https://github.com/elastic/elasticsearch/issues/154237
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
   issue: https://github.com/elastic/elasticsearch/issues/154377


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Test] Fix race in reindex tests introduced in #154133 (#154322)](https://github.com/elastic/elasticsearch/pull/154322)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)