### PR TITLE
docs: Mark ES|QL views as available in serverless (#7437)

### DIFF
--- a/docs/reference/query-languages/esql/esql-multi.md
+++ b/docs/reference/query-languages/esql/esql-multi.md
@@ -14,7 +14,7 @@ data from multiple sources. Learn more in the following sections:
 * [Query across clusters](esql-cross-clusters.md)
 * [Query across {{serverless-short}} projects](esql-cross-serverless-projects.md) {applies_to}`serverless: preview`
 * [Combine result sets with subqueries](esql-subquery.md) {applies_to}`stack: preview 9.4.0` {applies_to}`serverless: preview`
-* [Define virtual indices using ES|QL views](esql-views.md) {applies_to}`stack: preview 9.4.0` {applies_to}`serverless: unavailable`
+* [Define virtual indices using ES|QL views](esql-views.md) {applies_to}`stack: preview 9.4.0` {applies_to}`serverless: preview`
 
 ::::{include} _snippets/common/query-performance-tip.md
 ::::

--- a/docs/reference/query-languages/esql/esql-views.md
+++ b/docs/reference/query-languages/esql/esql-views.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "Define virtual indices using ES|QL views"
 applies_to:
-  serverless: unavailable
+  serverless: preview
   stack: preview 9.4.0
 products:
   - id: elasticsearch


### PR DESCRIPTION
## Summary

This PR addresses elastic/docs-content#7437.

Elasticsearch now exposes the ES|QL views API in serverless: `RestPutViewAction`, `RestGetViewAction`, and `RestDeleteViewAction` (the `PUT`/`GET`/`DELETE /_query/view` routes) are all annotated `@ServerlessScope(Scope.PUBLIC)`, and the REST specs declare `stability: experimental` / `visibility: public`. On the Kibana side, [elastic/kibana#274819](https://github.com/elastic/kibana/pull/274819) removes the workaround that had suppressed the views API in serverless while Elasticsearch support was pending (the "monitoring" in that PR title refers to Kibana's internal error logging around the views API, not a user-facing feature).

Views remain a preview feature, but the availability metadata for the ES|QL Views reference still marked serverless as `unavailable`, which is now factually incorrect.

- **`docs/reference/query-languages/esql/esql-views.md`**: change the page-level `applies_to` from `serverless: unavailable` to `serverless: preview`. The Stack preview history (`stack: preview 9.4.0`) is unchanged.
- **`docs/reference/query-languages/esql/esql-multi.md`**: update the inline `applies_to` on the ES|QL views entry of the "Query multiple sources" list from `serverless: unavailable` to `serverless: preview`, matching the reference page and the sibling subqueries entry.

The body of the views page already documents serverless availability in the **Cross-cluster and serverless** section (via the `view_limitations` snippet), so no body change was needed there.

## Resolves

Closes elastic/docs-content#7437

---

> **AI-generated draft** — created with Claude (Opus 4.8).
> Review all generated content for factual accuracy before merging.