### PR TITLE
[8.19] ESQL: Avoid MAX_INT loop on Repeat (#154295)

### DIFF
--- a/docs/changelog/154295.yaml
+++ b/docs/changelog/154295.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154295
+summary: Avoid MAX_INT loop on Repeat
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2091,6 +2091,26 @@ a:keyword | repeated:keyword
 cheese | ""
 ;
 
+// Large empty REPEAT used to loop needlessly
+repeatEmptyMaxInt
+required_capability: fn_repeat_fix_size_guard
+ROW repeated = REPEAT("", 2147483647);
+
+repeated:keyword
+""
+;
+
+// int length*count overflow used to bypass the size guard
+repeatLengthOverflowMaxInt
+required_capability: fn_repeat_fix_size_guard
+ROW repeated = REPEAT("ab", 2147483647);
+warning:Line 1:16: evaluation of [REPEAT(\"ab\", 2147483647)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:16: java.lang.IllegalArgumentException: Creating repeated strings with more than [1048576] bytes is not supported
+
+repeated:keyword
+null
+;
+
 repeatNegative
 required_capability: repeat 
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -186,6 +186,11 @@ public class EsqlCapabilities {
         REPEAT,
 
         /**
+         * Empty input used to loop {@code count} times; int length*count overflow used to bypass the size guard.
+         */
+        FN_REPEAT_FIX_SIZE_GUARD,
+
+        /**
          * Cast string literals to datetime in addition and subtraction when the other side is a date or time interval.
          */
         STRING_LITERAL_AUTO_CASTING_TO_DATETIME_ADD_SUB,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Repeat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Repeat.java
@@ -119,14 +119,19 @@ public class Repeat extends EsqlScalarFunction implements OptionalArgument {
     }
 
     static BytesRef processInner(BreakingBytesRefBuilder scratch, BytesRef str, int number) {
-        int repeatedLen = str.length * number;
+        scratch.clear();
+        // Empty input always yields an empty result; skip the loop so large counts cannot burn CPU.
+        if (str.length == 0 || number == 0) {
+            return scratch.bytesRefView();
+        }
+        // Use long so large length*count cannot overflow int and bypass the size guard.
+        long repeatedLen = (long) str.length * number;
         if (repeatedLen > MAX_BYTES_REF_RESULT_SIZE) {
             throw new IllegalArgumentException(
                 "Creating repeated strings with more than [" + MAX_BYTES_REF_RESULT_SIZE + "] bytes is not supported"
             );
         }
-        scratch.grow(repeatedLen);
-        scratch.clear();
+        scratch.grow((int) repeatedLen);
         for (int i = 0; i < number; ++i) {
             scratch.append(str);
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatStaticTests.java
@@ -62,6 +62,28 @@ public class RepeatStaticTests extends ESTestCase {
         );
     }
 
+    public void testEmptyStringLargeCount() {
+        assertThat(process("", Integer.MAX_VALUE), equalTo(""));
+    }
+
+    public void testLengthOverflowRejected() {
+        // int multiplication of length*count would overflow (2 * Integer.MAX_VALUE == -2) and skip the size guard
+        assertNull(process("ab", Integer.MAX_VALUE));
+        assertWarnings(
+            "Line -1:-1: java.lang.IllegalArgumentException: Creating repeated strings with more than [1048576] bytes is not supported",
+            "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded."
+        );
+    }
+
+    public void testLengthOverflowWrapsPositiveRejected() {
+        // 65536 * 65537 overflows int to +65536, which is under the size limit and would skip the guard
+        assertNull(process("a".repeat(65536), 65537));
+        assertWarnings(
+            "Line -1:-1: java.lang.IllegalArgumentException: Creating repeated strings with more than [1048576] bytes is not supported",
+            "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded."
+        );
+    }
+
     public String process(String str, int number) {
         try (
             var eval = AbstractScalarFunctionTestCase.evaluator(


### PR DESCRIPTION
Manual 8.19 backport of https://github.com/elastic/elasticsearch/pull/154295