### PR TITLE
[8.19] Force merge sparse_vector test index to stabilize pruning (#146447)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -81,6 +81,17 @@ setup:
           {"index": { "_id": 6 }}
           {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
 
+  # Force merge to a single segment so that term statistics used by token pruning
+  # (averageTokenFreqRatio) are deterministic regardless of how many segments the
+  # bulk index produced. Without this, the per-segment max unique token count varies
+  # and borderline pruning decisions can flip between runs.
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.forcemerge:
+        index: index-with-sparse-vector
+        max_num_segments: 1
+
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Force merge sparse_vector test index to stabilize pruning (#146447)](https://github.com/elastic/elasticsearch/pull/146447)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)