### PR TITLE
[9.5] ES|QL|DS Fix two-phase page-skip overshoot in PageColumnReader.skipRows (#154325)

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTwoPhasePageSkipCorrectnessIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetTwoPhasePageSkipCorrectnessIT.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.parquet;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.test.AzureReactorThreadFilter;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xpack.esql.datasources.AbstractFromDatasetSubqueryRestTestCase;
+import org.elasticsearch.xpack.esql.datasources.BackendFixture;
+import org.elasticsearch.xpack.esql.datasources.S3BackendFixture;
+import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.DataSourcesS3HttpFixture;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.WAREHOUSE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * End-to-end regression for the two-phase page-skip overshoot in {@code PageColumnReader.skipRows}:
+ * when a projection column's leading data page is fully excluded by the phase-1 survivor mask,
+ * {@code loadNextPage} jumps the physical cursor to the first surviving page via its
+ * {@code firstRowIndex}. If that jump overshoots the {@code skipRows} target and the surplus is
+ * discarded, the next skip over-advances into the survivor page and silently drops matching rows,
+ * surfacing as an undercounted grouped {@code COUNT(DISTINCT)} / {@code VALUES}.
+ *
+ * <p>The buggy path is reachable only under two-phase decoding, which the reader gates behind
+ * {@code StorageObject.supportsNativeAsync()}. A plain {@code file://} dataset takes the single-phase
+ * late-materialization path (projection readers get {@code RowRanges == null}) and cannot trigger it.
+ * This test therefore serves the fixture from the in-process S3 fixture (native-async), the same
+ * infrastructure the parquet csv-spec suites use, so the query runs through the real planner, the
+ * async external source operator and the two-phase iterator end to end.
+ *
+ * <p>Fixture geometry (the three conditions the bug needs, see {@code PageColumnReader.skipRows}):
+ * <ul>
+ *   <li>The projection column {@code v} is written with dictionary encoding disabled and a small page
+ *       size, so it spans many data pages of a predictable row count.</li>
+ *   <li>The predicate column {@code s} carries a single short {@code "hit"} cluster far into the row
+ *       group (row {@link #HIT_START}); every other row is {@code "bg"}. {@code WHERE s == "hit"} thus
+ *       yields a sparse survivor set (one run) so page filtering engages rather than being discarded.</li>
+ *   <li>{@link #HIT_START} sits well past the first projection page and past several row batches, so
+ *       draining the fully-filtered leading batches issues more than one {@code skipRows} across the
+ *       excluded pages. The banked overshoot must prevent later skips from advancing into survivor rows.</li>
+ * </ul>
+ *
+ * <p>{@code v} is unique per row, so the surviving group's {@code MV_COUNT(VALUES(v))} must equal the
+ * exact cluster size {@link #HIT_COUNT}. A dropped survivor makes it smaller.
+ */
+@ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
+public class ParquetTwoPhasePageSkipCorrectnessIT extends AbstractFromDatasetSubqueryRestTestCase {
+
+    private static final String DATA_SOURCE = "two_phase_skip_s3_ds";
+    private static final String DATASET = "two_phase_skip_s3";
+    private static final String BLOB_KEY = WAREHOUSE + "/standalone/two_phase_page_skip.parquet";
+
+    /** Total rows in the single row group. */
+    private static final int TOTAL_ROWS = 40_000;
+    /** First row of the sole {@code "hit"} cluster; deep past the leading (excluded) projection pages. */
+    private static final int HIT_START = 30_000;
+    /** Size of the {@code "hit"} cluster; the exact expected distinct-value count for the survivor group. */
+    private static final int HIT_COUNT = 17;
+
+    /** ~1,024 int64 values per page (8 KiB page / 8 bytes), so {@code v} spans ~40 pages. */
+    private static final int PAGE_SIZE_BYTES = 8 * 1024;
+    /** One row group for the whole file, so all pages live under a single {@code BlockMetaData}. */
+    private static final long ROW_GROUP_SIZE_BYTES = 1L << 30;
+
+    public static DataSourcesS3HttpFixture s3Fixture = new DataSourcesS3HttpFixture();
+    public static ElasticsearchCluster cluster = Clusters.testClusterWithEncryption(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(s3Fixture).around(cluster);
+
+    /**
+     * Pre-built fixture bytes. Computing 40K rows of Parquet data is not cheap; building it once
+     * and reusing the result keeps repeated test invocations ({@code -Dtests.iters=N}) fast.
+     */
+    private static final byte[] FIXTURE_BYTES;
+
+    static {
+        try {
+            FIXTURE_BYTES = twoPhasePageSkipParquetBytes();
+        } catch (IOException e) {
+            throw new AssertionError("failed to build fixture parquet bytes", e);
+        }
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    /**
+     * Deletes the test dataset and data source so they do not interfere with subsequent test
+     * classes that may register the same names against the same cluster.
+     */
+    @AfterClass
+    public static void cleanupRegistry() throws IOException {
+        deleteIgnoringMissing("/_query/dataset/" + DATASET);
+        deleteIgnoringMissing("/_query/data_source/" + DATA_SOURCE);
+    }
+
+    /**
+     * Verifies that {@code MV_COUNT(VALUES(v))} returns exactly {@link #HIT_COUNT} when the
+     * two-phase page-filtered iterator's {@code skipRows} crosses an excluded projection page and
+     * banks the overshoot surplus. When the surplus is not banked, a later skip advances into the
+     * survivor page and silently drops rows, making the count smaller than the cluster size.
+     *
+     * <p>This is an end-to-end sanity check that the real S3-backed two-phase path produces the
+     * correct aggregate; the deterministic regression guard for the {@code skipRows} accounting
+     * itself is {@code PageColumnReaderCorrectnessTests#testSkipCoveringExcludedPageLandsAtNextPageStart},
+     * which reproduces the overshoot directly without a fixture.
+     */
+    public void testGroupedDistinctSurvivesExcludedProjectionPageSkip() throws Exception {
+        BackendFixture s3Backend = new S3BackendFixture(s3Fixture);
+        s3Backend.uploadBlob(BLOB_KEY, FIXTURE_BYTES);
+        putDataSource(DATA_SOURCE, s3Backend.dataSourceType(), s3Backend.dataSourceSettings());
+        putDataset(DATASET, DATA_SOURCE, s3Backend.resourceUri(BLOB_KEY), Map.of());
+
+        // WHERE s == "hit" pushes as a late-materialization predicate (RECHECK), giving a sparse
+        // survivor mask; VALUES(v) makes v a projection-only column, which together with the S3
+        // (native-async) backend selects the two-phase page-filtered decode path under test.
+        String query = "FROM " + DATASET + " | WHERE s == \"hit\" | STATS u = MV_COUNT(VALUES(v)) BY s";
+
+        Map<String, Object> response = runQuery(query);
+        @SuppressWarnings("unchecked")
+        List<List<Object>> values = (List<List<Object>>) response.get("values");
+
+        assertThat("exactly one surviving group (s == \"hit\")", values, hasSize(1));
+        List<Object> row = values.get(0);
+        int uIdx = columnIndex(response, "u");
+        int sIdx = columnIndex(response, "s");
+        assertThat("group key must be the cluster value", row.get(sIdx).toString(), equalTo("hit"));
+        assertThat(
+            "distinct v over survivors must equal the exact cluster size; a smaller value means the "
+                + "excluded-page skip dropped surviving rows",
+            ((Number) row.get(uIdx)).intValue(),
+            equalTo(HIT_COUNT)
+        );
+    }
+
+    /**
+     * Builds the fixture described in the class Javadoc: {@code {s: keyword, v: long}} over
+     * {@link #TOTAL_ROWS} rows in one row group, {@code v} unique and dictionary-disabled with a small
+     * page size, {@code s} equal to {@code "hit"} only on {@code [HIT_START, HIT_START + HIT_COUNT)}.
+     */
+    private static byte[] twoPhasePageSkipParquetBytes() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("s")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("v")
+            .named("two_phase_page_skip");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = byteArrayOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                // Plain (non-dictionary) int64 pages so v's page boundaries are a predictable function
+                // of the byte page size, guaranteeing many full pages precede the survivor cluster.
+                .withDictionaryEncoding("v", false)
+                .withPageSize(PAGE_SIZE_BYTES)
+                .withRowGroupSize(ROW_GROUP_SIZE_BYTES)
+                .build()
+        ) {
+            for (int i = 0; i < TOTAL_ROWS; i++) {
+                Group g = factory.newGroup();
+                g.add("s", (i >= HIT_START && i < HIT_START + HIT_COUNT) ? "hit" : "bg");
+                g.add("v", (long) i);
+                writer.write(g);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private static OutputFile byteArrayOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return positionOutputStream(baos);
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int columnIndex(Map<String, Object> response, String columnName) {
+        List<Map<String, Object>> columns = (List<Map<String, Object>>) response.get("columns");
+        for (int i = 0; i < columns.size(); i++) {
+            if (columnName.equals(columns.get(i).get("name"))) {
+                return i;
+            }
+        }
+        throw new AssertionError("column '" + columnName + "' not found in response");
+    }
+
+    private static PositionOutputStream positionOutputStream(ByteArrayOutputStream baos) {
+        return new PositionOutputStream() {
+            private long position = 0;
+
+            @Override
+            public long getPos() {
+                return position;
+            }
+
+            @Override
+            public void write(int b) {
+                baos.write(b);
+                position++;
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                baos.write(b, off, len);
+                position += len;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -135,6 +135,20 @@ final class PageColumnReader implements Releasable {
     private long rowPositionInRowGroup;
     private boolean columnExhausted;
 
+    /**
+     * Source rows by which the physical cursor ({@link #rowPositionInRowGroup}) is ahead of the
+     * caller's coordinate space. When {@link #loadNextPage()} skips a survivor-excluded page it can
+     * jump the physical cursor PAST a {@link #skipRows} target; the surplus is recorded here and
+     * credited against subsequent skip requests rather than being discarded (which would leave the
+     * reader silently ahead and misread later survivor rows).
+     *
+     * <p>Only {@link #skipRows} spends this credit. The read entry point ({@link #readBatch}) requires
+     * it to be zero and throws {@link IllegalStateException} otherwise: a prejump only ever crosses
+     * survivor-excluded pages, so the caller always reaches the next survivor through a {@code skipRows}
+     * whose gap fully drains the surplus before any decode happens.
+     */
+    private long pendingPrejumped;
+
     PageColumnReader(PageReader pageReader, ColumnDescriptor descriptor, ColumnInfo info, RowRanges rowRanges) {
         this(pageReader, descriptor, info, rowRanges, null);
     }
@@ -166,6 +180,14 @@ final class PageColumnReader implements Releasable {
     }
 
     Block readBatch(int maxRows, BlockFactory blockFactory) {
+        // A banked pre-jump means the physical cursor is ahead of the caller's logical position; only
+        // skipRows may spend that credit. Decoding here would read from the wrong source rows and
+        // silently undercount an aggregate. The check is per-batch, so failing loudly costs nothing.
+        if (pendingPrejumped != 0) {
+            throw new IllegalStateException(
+                "readBatch called with " + pendingPrejumped + " banked pre-jump rows; physical cursor is ahead of logical position"
+            );
+        }
         loadDictionaryIfNeeded();
         // Declared-type coercion beyond the fused pairs: decode the column at the file's own type
         // with the arms below, then coerce the block to the declared type. Per-value failures
@@ -545,16 +567,38 @@ final class PageColumnReader implements Releasable {
     }
 
     void skipRows(int count) {
+        // Guard non-positive counts before the credit block below: a negative count would make
+        // Math.min(pendingPrejumped, count) negative, so `pendingPrejumped -= credited` would inflate
+        // the banked surplus instead of spending it, leaving the reader permanently ahead of the caller.
+        if (count <= 0) {
+            return;
+        }
+        // The physical cursor may already be ahead of the caller (a previous skip jumped a
+        // survivor-excluded page past its target). Spend that credit before touching the cursor,
+        // so a skip that lands entirely within the pre-jumped span is a no-op on the decoder.
+        if (pendingPrejumped > 0) {
+            long credited = Math.min(pendingPrejumped, count);
+            pendingPrejumped -= credited;
+            count -= (int) credited; // safe: credited <= count (int), so no overflow
+            if (count == 0) {
+                return;
+            }
+        }
+        // target must be computed after the credit block above: the banking below
+        // (pendingPrejumped += rowPositionInRowGroup - target) is only correct when
+        // target measures how far the caller wants to advance from the current cursor.
         long target = rowPositionInRowGroup + count;
         while (rowPositionInRowGroup < target) {
             if (ensurePage() == false) {
                 break;
             }
             if (rowPositionInRowGroup >= target) {
-                // ensurePage advanced past target via a firstRowIndex jump in loadNextPage
-                // (page-filtered prefetch with a survivor-range gap wider than `count`).
-                // Falling through would compute a negative fromPage and corrupt decoder /
-                // page-consumed state.
+                // ensurePage advanced past target via a firstRowIndex / excluded-page jump in
+                // loadNextPage (page-filtered prefetch with a survivor-range gap wider than
+                // `count`). Falling through would compute a negative fromPage and corrupt decoder /
+                // page-consumed state. Bank the surplus so the next skip credits it instead of the
+                // physical cursor advancing again, since the caller still counts those source rows.
+                pendingPrejumped += rowPositionInRowGroup - target;
                 break;
             }
             int fromPage = (int) Math.min(target - rowPositionInRowGroup, availableInPage());

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -19,6 +19,7 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -391,7 +392,7 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
      * closes the returned block.
      */
     private Block sparseRead(byte[] data, String column, DataType dataType, int[] survivors) throws IOException {
-        try (ParquetFileReader reader = openSparseReader(data)) {
+        try (ParquetFileReader reader = openReader(data)) {
             BlockMetaData block = reader.getRowGroups().getFirst();
             MessageType schema = reader.getFileMetaData().getSchema();
             ColumnDescriptor desc = schema.getColumnDescription(new String[] { column });
@@ -412,7 +413,7 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         }
     }
 
-    private ParquetFileReader openSparseReader(byte[] data) throws IOException {
+    private ParquetFileReader openReader(byte[] data) throws IOException {
         return ParquetFileReader.open(
             new ParquetStorageObjectAdapter(storageObject(data), blockFactory.arrowAllocator()),
             PlainParquetReadOptions.builder(codecFactory).build()
@@ -429,6 +430,109 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         assertFalse("position " + position + " must be non-null", block.isNull(position));
         IntBlock ib = (IntBlock) block;
         assertEquals(expected, ib.getInt(ib.getFirstValueIndex(position)));
+    }
+
+    // --- Two-phase page-filtered skip overshoot (skipRows) ---
+
+    private static final MessageType SKIP_OVERSHOOT_SCHEMA = Types.buildMessage().required(INT64).named("v").named("skip_overshoot_repro");
+
+    /**
+     * Exercises the two-phase page-filtered skip overshoot in {@link PageColumnReader#skipRows}.
+     *
+     * <p>When a projection reader carries a survivor {@link RowRanges} that EXCLUDES an early data
+     * page (zero survivors on that page) and survivors sit on a later page, {@code loadNextPage}
+     * skips the whole excluded page, jumping the physical cursor PAST the caller's skip target. If
+     * that overshoot is discarded, the reader is silently ahead of where the caller thinks it is and
+     * every later skip/read consumes real survivor rows.
+     *
+     * <p>The invariant asserted here is coordinate-space-exact and codec/geometry independent: two
+     * skip calls that together cover exactly the excluded first page must leave the reader on the
+     * first survivor row (source row == first-row-index of page 1), whose value equals its
+     * source-row index. With the overshoot bug the first skip jumps to the page boundary and
+     * discards the surplus, so the second skip eats into page 1 and the subsequent read returns a
+     * survivor row too far along.
+     */
+    public void testSkipCoveringExcludedPageLandsAtNextPageStart() throws IOException {
+        byte[] data = writeTwoPageFile();
+        try (ParquetFileReader reader = openReader(data)) {
+            BlockMetaData rg = reader.getRowGroups().getFirst();
+            long totalRows = rg.getRowCount();
+            OffsetIndex oi = reader.readOffsetIndex(rg.getColumns().getFirst());
+            assertNotNull("column must have an offset index", oi);
+            assertTrue("need at least two pages to reproduce", oi.getPageCount() >= 2);
+
+            // page 0 spans [0, firstPageRows); page 1 starts at firstPageRows.
+            int firstPageRows = Math.toIntExact(oi.getFirstRowIndex(1));
+            assertTrue(firstPageRows >= 2);
+
+            // Survivor RowRanges cover only page 1 onward, so page 0 is excluded (zero survivors)
+            // and survivors sit strictly after it, triggering the skip overshoot.
+            RowRanges survivorRanges = RowRanges.of(firstPageRows, totalRows, totalRows);
+
+            ColumnDescriptor desc = SKIP_OVERSHOOT_SCHEMA.getColumns().getFirst();
+            ColumnInfo info = new ColumnInfo(
+                desc,
+                desc.getPrimitiveType().getPrimitiveTypeName(),
+                DataType.LONG,
+                desc.getMaxDefinitionLevel(),
+                desc.getMaxRepetitionLevel(),
+                desc.getPrimitiveType().getLogicalTypeAnnotation()
+            );
+
+            PageReadStore store = reader.readNextRowGroup();
+            assertNotNull(store);
+
+            try (PageColumnReader pcr = new PageColumnReader(store.getPageReader(desc), desc, info, survivorRanges)) {
+                // The two-phase caller drains the fully-filtered leading batches with skipRows in
+                // source-row coordinates. Split the excluded page into two skips so the first one
+                // stops short of the page boundary (count < firstPageRows) and triggers the jump.
+                int firstSkip = firstPageRows / 2;
+                assertTrue(firstSkip > 0 && firstSkip < firstPageRows);
+                pcr.skipRows(firstSkip);
+                pcr.skipRows(firstPageRows - firstSkip);
+
+                // We have now skipped exactly the source rows of page 0. The next read must start
+                // at the first survivor row, whose value equals its source-row index.
+                LongBlock block = (LongBlock) pcr.readBatch(1, blockFactory);
+                try {
+                    assertEquals(1, block.getPositionCount());
+                    assertEquals(
+                        "reader must sit on the first survivor row after skipping the excluded page",
+                        (long) firstPageRows,
+                        block.getLong(0)
+                    );
+                } finally {
+                    block.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes a single-column {@code {v: long}} file over one row group with plain (dictionary-disabled)
+     * encoding and a tiny page size, so {@code v} spans several small data pages. {@code v} is unique
+     * per row and equals its source-row index, so a decoded value pins the reader's position.
+     */
+    private byte[] writeTwoPageFile() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(SKIP_OVERSHOOT_SCHEMA);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(codecFactory)
+                .withType(SKIP_OVERSHOOT_SCHEMA)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                // Plain encoding + a tiny page size forces several small pages within one row group.
+                .withDictionaryEncoding(false)
+                .withRowGroupSize(64L * 1024 * 1024)
+                .withPageSize(1024)
+                .build()
+        ) {
+            for (int i = 0; i < 4000; i++) {
+                writer.write(factory.newGroup().append("v", (long) i));
+            }
+        }
+        return out.toByteArray();
     }
 
     // --- Randomized test ---


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL|DS Fix two-phase page-skip overshoot in PageColumnReader.skipRows (#154325)](https://github.com/elastic/elasticsearch/pull/154325)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)