### PR TITLE
Don't read new max sequence numbers while refresh is being deferred

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
@@ -683,6 +683,8 @@ public class SearchEngine extends Engine {
             private void doUpdateInternalState(NewCommitNotification latestNotification, SegmentInfos current) throws IOException {
                 final StatelessCompoundCommit latestCommit = latestNotification.compoundCommit();
                 final SegmentInfos next = Lucene.readSegmentInfos(directory);
+                final long previousMaxSequenceNumber = maxSequenceNumber;
+                final long previousProcessedLocalCheckpoint = processedLocalCheckpoint;
                 setSequenceNumbers(next);
 
                 assert next.getGeneration() == latestCommit.generation();
@@ -701,11 +703,14 @@ public class SearchEngine extends Engine {
                     engineReadLock.unlock();
                 }
 
-                // The reader-heap breaker deferred the refresh: revert segmentInfosAndCommit so the (commit,
-                // reader) invariant holds, and schedule a retry tied to the index's refresh_interval so the
-                // refresh is attempted again without waiting for a fresh commit notification.
+                // The reader-heap breaker deferred the refresh: revert segmentInfosAndCommit, max seq no and
+                // local checkpoint so the (commit, reader, seq no) invariant holds, and schedule a retry tied to
+                // the index's refresh_interval so the refresh is attempted again without waiting for a fresh
+                // commit notification.
                 if (lastRefreshDeferred) {
                     segmentInfosAndCommit = previousSegmentInfosAndCommitSnapshot;
+                    maxSequenceNumber = previousMaxSequenceNumber;
+                    processedLocalCheckpoint = previousProcessedLocalCheckpoint;
                     scheduleDeferredRefreshRetry(latestNotification);
                     return;
                 }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/AbstractEngineTestCase.java
@@ -568,6 +568,7 @@ public abstract class AbstractEngineTestCase extends ESTestCase {
             .retentionLeasesSupplier(() -> {
                 throw new AssertionError();
             })
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
             .primaryTermSupplier(primaryTermSupplier)
             .engineResetLock(new EngineResetLock())
             .mergeMetrics(MergeMetrics.NOOP)

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/SearchEngineHeapBudgetTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/SearchEngineHeapBudgetTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 
 import java.io.IOException;
 
@@ -492,6 +493,49 @@ public class SearchEngineHeapBudgetTests extends AbstractEngineTestCase {
         }
 
         assertThat("reservation drains to zero after engine close even on the deferral path", trackingBreaker.getUsed(), equalTo(0L));
+        assertWarnings(
+            "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
+        );
+    }
+
+    public void testGetMaxSeqNoMatchesSeqNoStatsWhenRefreshIsDeferred() throws IOException {
+        // Pin the limit at 1 byte so the very first real refresh (bringing in d1's segment) defers.
+        trackingBreaker.setLimit(1L);
+
+        final var indexConfig = indexConfig();
+        final var searchTaskQueue = new DeterministicTaskQueue();
+
+        try (
+            var indexEngine = newIndexEngine(indexConfig);
+            var searchEngine = newSearchEngineFromIndexEngine(indexEngine, searchTaskQueue)
+        ) {
+            Engine.IndexResult result = indexEngine.index(randomDoc("d1"));
+            indexEngine.flush();
+            notifyCommits(indexEngine, searchEngine);
+            searchTaskQueue.runAllRunnableTasks();
+
+            assertThat("refresh must have been deferred", searchEngine.getRefreshDeferredCount(), equalTo(1L));
+            assertThat(
+                "getSeqNoStats() must still reflect the pre-d1 commit while the refresh is deferred",
+                searchEngine.getSeqNoStats(-1).getMaxSeqNo(),
+                equalTo(SequenceNumbers.NO_OPS_PERFORMED)
+            );
+            // getMaxSeqNo() is a separately cached field updated by setSequenceNumbers(); it must not race ahead
+            // of getSeqNoStats() while the corresponding commit isn't actually visible yet.
+            assertThat(searchEngine.getMaxSeqNo(), equalTo(searchEngine.getSeqNoStats(-1).getMaxSeqNo()));
+
+            // Release the pressure and let the retry apply the deferred commit; both accessors must then advance
+            // together to d1's seq no.
+            trackingBreaker.setLimit(Long.MAX_VALUE);
+            long retryDelayMillis = searchEngine.config().getIndexSettings().getRefreshInterval().millis() * 2L;
+            advancePast(searchTaskQueue, searchTaskQueue.getCurrentTimeMillis() + retryDelayMillis + 1L);
+
+            assertThat(searchEngine.getSeqNoStats(-1).getMaxSeqNo(), equalTo(result.getSeqNo()));
+            assertThat(searchEngine.getMaxSeqNo(), equalTo(searchEngine.getSeqNoStats(-1).getMaxSeqNo()));
+        }
+
+        assertThat("reservation drains to zero after engine close", trackingBreaker.getUsed(), equalTo(0L));
         assertWarnings(
             "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch and will be removed in a future release. "
                 + "See the breaking changes documentation for the next major version."


### PR DESCRIPTION
Extracted from https://github.com/elastic/elasticsearch/pull/153167 so that that PR can just be a tidying-up PR.

This fixes a scenario in SearchEngine where we could read a new max sequence number while the refresh is actively being deferred.