### PR TITLE
Add non-dot-prefixed pattern for AI Index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -746,10 +746,15 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // For connectors telemetry. Will be removed once we switched to connectors API
                 RoleDescriptor.IndicesPrivileges.builder().indices(".elastic-connectors*").privileges("read").build(),
+                // TODO: Remove after SML swaps to the below ai-index* pattern
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-*")
+                    .privileges("all")
+                    .build(),
                 // Context Engine's SML storage. A regular (non-system) index that Kibana
                 // creates and manages itself at startup, including its alias.
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-*")
+                    .indices("ai-index-idx-sml-data", "ai-index-idx-sml-data-*")
                     .privileges("all")
                     .build(),
                 // Significant events. Kibana system user manages index plumbing and document access.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1279,7 +1279,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Context Engine's SML storage: a regular (non-system) index that Kibana
         // creates and manages itself, including its alias.
-        Arrays.asList(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+        Arrays.asList("ai-index-idx-sml-data", "ai-index-idx-sml-data-" + randomAlphaOfLength(randomIntBetween(0, 13)))
             .forEach(index -> assertReadWriteAndManage(kibanaRole, index));
 
         // Agent Builder OTLP telemetry (traces + logs from span events)


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/154015, but removing the `.` prefix, after it was flagged that Serverless doesn't allow non-system indices to have `.` prefixes, without a special allow-list. Team determined that dropping the dot was the right path forward.

Related to https://github.com/elastic/kibana/pull/279660