### PR TITLE
[9.4] [ML] Wait for shards in tests (#148993)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1983,6 +1983,32 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     /**
+     * Waits for the given index (pattern) to be at least yellow with no shards initializing or relocating. This is the
+     * appropriate wait condition before querying for documents written prior to a restart or upgrade: yellow alone is
+     * satisfied as soon as the primary is STARTED, but searches routed to an INITIALIZING replica can return stale or
+     * empty results until peer recovery completes, which often surfaces as a 404 from APIs that translate "no hits" to
+     * "not found".
+     *
+     * Prefer this over a raw {@link #ensureHealth} call in any BWC, full-cluster-restart, or rolling-upgrade test that
+     * reads back data indexed before the restart/upgrade. {@link #ensureGreen} is unsuitable for the MIXED phase of
+     * rolling-upgrade tests on indices with {@code auto_expand_replicas=0-1}, since one node is offline at a time and
+     * the cluster legitimately stays yellow.
+     *
+     * @param index index pattern to check (use {@code ""} for cluster-wide health)
+     * @param timeout optional health-check timeout (e.g. {@code "120s"}); {@code null} uses the server default
+     */
+    public static void ensureYellowAndNoInitializingShards(String index, String timeout) throws IOException {
+        ensureHealth(index, (request) -> {
+            request.addParameter("wait_for_status", "yellow");
+            request.addParameter("wait_for_no_relocating_shards", "true");
+            request.addParameter("wait_for_no_initializing_shards", "true");
+            if (timeout != null) {
+                request.addParameter("timeout", timeout);
+            }
+        });
+    }
+
+    /**
      * waits until all shard initialization is completed. This is a handy alternative to ensureGreen as it relates to all shards
      * in the cluster and doesn't require to know how many nodes/replica there are.
      */

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -469,13 +469,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             assertRollUpJob("rollup-job-test");
 
         } else {
-
-            final Request clusterHealthRequest = new Request("GET", "/_cluster/health");
-            clusterHealthRequest.addParameter("wait_for_status", "yellow");
-            clusterHealthRequest.addParameter("wait_for_no_relocating_shards", "true");
-            clusterHealthRequest.addParameter("wait_for_no_initializing_shards", "true");
-            Map<String, Object> clusterHealthResponse = entityAsMap(client().performRequest(clusterHealthRequest));
-            assertThat(clusterHealthResponse.get("timed_out"), equalTo(Boolean.FALSE));
+            ensureYellowAndNoInitializingShards("", null);
 
             assertRollUpJob("rollup-job-test");
         }
@@ -710,13 +704,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
     }
 
     private void waitForYellow(String indexName) throws IOException {
-        Request request = new Request("GET", "/_cluster/health/" + indexName);
-        request.addParameter("wait_for_status", "yellow");
-        request.addParameter("timeout", "30s");
-        request.addParameter("wait_for_no_relocating_shards", "true");
-        request.addParameter("wait_for_no_initializing_shards", "true");
-        Map<String, Object> response = entityAsMap(client().performRequest(request));
-        assertThat(response.get("timed_out"), equalTo(Boolean.FALSE));
+        ensureYellowAndNoInitializingShards(indexName, "30s");
     }
 
     private void waitForHits(String indexName, int expectedHits) throws Exception {

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -115,10 +115,7 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
                 }
             }, 90, TimeUnit.SECONDS);
         } else {
-            ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                request.addParameter("wait_for_status", "yellow");
-                request.addParameter("timeout", "120s");
-            }));
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
             waitForDeploymentStarted(modelId);
             assertBusy(() -> {
                 try {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -107,10 +107,7 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                 assertInfer(modelId);
             }
             case MIXED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
                 waitForDeploymentStarted(modelId);
                 // attempt inference on new and old nodes multiple times
                 for (int i = 0; i < 10; i++) {
@@ -118,10 +115,7 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                 }
             }
             case UPGRADED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
 
                 waitForDeploymentStarted(modelId);
                 assertInfer(modelId);
@@ -140,17 +134,11 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                 assertInfer(modelId);
             }
             case MIXED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
                 stopDeployment(modelId);
             }
             case UPGRADED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
                 assertThatTrainedModelAssignmentMetadataIsEmpty(modelId);
             }
             default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -85,10 +85,7 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
                 assertNewMemoryFormat("new_memory_format");
             }
             case MIXED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
                 waitForDeploymentStarted("old_memory_format");
                 waitForDeploymentStarted("new_memory_format");
 
@@ -97,10 +94,7 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
                 assertNewMemoryFormat("new_memory_format");
             }
             case UPGRADED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
                 waitForDeploymentStarted("old_memory_format");
                 waitForDeploymentStarted("new_memory_format");
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
@@ -67,10 +67,7 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
                 testInfer(oldModels);
             }
             case MIXED, UPGRADED -> {
-                ensureHealth(".ml-inference-*,.ml-config*", (request -> {
-                    request.addParameter("wait_for_status", "yellow");
-                    request.addParameter("timeout", "70s");
-                }));
+                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
                 List<String> modelIds = getTrainedModels();
                 // Test that stats are serializable and can be gathered
                 getTrainedModelStats();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ML] Wait for shards in tests (#148993)](https://github.com/elastic/elasticsearch/pull/148993)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)