### PR TITLE
Fix flaky KMeansLocalTests#testComputeNeighbours

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -245,9 +245,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=search.vectors/260_knn_lookup_query_builder/Test error when document not found}
   issue: https://github.com/elastic/elasticsearch/issues/154242
-- class: org.elasticsearch.index.codec.vectors.cluster.KMeansLocalTests
-  method: testComputeNeighbours
-  issue: https://github.com/elastic/elasticsearch/issues/154321
 - class: org.elasticsearch.xpack.security.authc.ldap.OpenLdapUserSearchSessionFactoryTests
   method: testUserSearchWithBindUserOpenLDAP
   issue: https://github.com/elastic/elasticsearch/issues/152601

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocalTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocalTests.java
@@ -179,10 +179,16 @@ public class KMeansLocalTests extends ESTestCase {
                 vectors,
                 clustersPerNeighbour
             );
-            assertEquals(neighborHoodsGraph.length, neighborHoodsGraphConcurrent.length);
-            for (int i = 0; i < neighborHoodsGraph.length; i++) {
-                assertArrayEquals(neighborHoodsGraph[i].neighbors(), neighborHoodsGraphConcurrent[i].neighbors());
-                assertEquals(neighborHoodsGraph[i].maxIntraDistance(), neighborHoodsGraphConcurrent[i].maxIntraDistance(), 0f);
+            // The concurrent HNSW builder (HnswConcurrentMergeBuilder) is non-deterministic due to
+            // thread scheduling, so it may produce a different graph than the serial builder and
+            // therefore different (but equally valid) approximate neighbors. Verify against brute
+            // force instead of asserting exact equality with the serial result.
+            assertEquals(neighborHoodsBruteForce.length, neighborHoodsGraphConcurrent.length);
+            for (int i = 0; i < neighborHoodsGraphConcurrent.length; i++) {
+                assertEquals(neighborHoodsBruteForce[i].neighbors().length, neighborHoodsGraphConcurrent[i].neighbors().length);
+                int matched = compareNN(i, neighborHoodsBruteForce[i].neighbors(), neighborHoodsGraphConcurrent[i].neighbors());
+                double recall = (double) matched / neighborHoodsGraphConcurrent[i].neighbors().length;
+                assertThat(recall, greaterThanOrEqualTo(0.5));
             }
         }
     }
@@ -216,10 +222,12 @@ public class KMeansLocalTests extends ESTestCase {
         }
         int clustersPerNeighbour = randomIntBetween(32, 64);
 
-        // sequential version
-        NeighborHood[] neighborHoodsGraph = NeighborHood.computeNeighborhoodsGraph(vectors, clustersPerNeighbour);
+        // brute force as the ground truth reference
+        NeighborHood[] neighborHoodsBruteForce = NeighborHood.computeNeighborhoodsBruteForce(vectors, clustersPerNeighbour);
 
-        // multiple concurrent executions for consistency
+        // multiple concurrent executions: each must have good recall against brute force;
+        // exact equality with the serial build is not guaranteed due to non-deterministic thread
+        // scheduling in HnswConcurrentMergeBuilder
         for (int iter = 0; iter < 50; iter++) {
             int numThreads = randomIntBetween(2, 8);
             try (ExecutorService executorService = Executors.newFixedThreadPool(numThreads)) {
@@ -231,18 +239,14 @@ public class KMeansLocalTests extends ESTestCase {
                     clustersPerNeighbour
                 );
 
-                assertEquals(neighborHoodsGraph.length, neighborHoodsGraphConcurrent.length);
-                for (int i = 0; i < neighborHoodsGraph.length; i++) {
-                    assertArrayEquals(
-                        "Iteration " + iter + ", thread count " + numThreads + ": Different neighbors at index " + i,
-                        neighborHoodsGraph[i].neighbors(),
-                        neighborHoodsGraphConcurrent[i].neighbors()
-                    );
-                    assertEquals(
-                        "Iteration " + iter + ", thread count " + numThreads + ": Different maxIntraDistance at index " + i,
-                        neighborHoodsGraph[i].maxIntraDistance(),
-                        neighborHoodsGraphConcurrent[i].maxIntraDistance(),
-                        1e-5f
+                assertEquals(neighborHoodsBruteForce.length, neighborHoodsGraphConcurrent.length);
+                for (int i = 0; i < neighborHoodsGraphConcurrent.length; i++) {
+                    int matched = compareNN(i, neighborHoodsBruteForce[i].neighbors(), neighborHoodsGraphConcurrent[i].neighbors());
+                    double recall = (double) matched / neighborHoodsGraphConcurrent[i].neighbors().length;
+                    assertThat(
+                        "Iteration " + iter + ", thread count " + numThreads + ": recall too low at index " + i,
+                        recall,
+                        greaterThanOrEqualTo(0.5)
                     );
                 }
             }


### PR DESCRIPTION
HnswConcurrentMergeBuilder is non-deterministic: thread scheduling affects which worker processes which batch, so the concurrent graph differs from the serial one. Replace assertArrayEquals against the serial result with recall >= 0.5 checks against brute force, matching the pattern already used for the serial graph. Same fix applied to testComputeNeighboursThreadSafety. Remove mute.

Note, this test was renamed to FloatLloydKMeansLocalTests.java  on 9.5 and main, and on these branches this test is not muted, and we have not seen failures yet. That's why addressing only on 9.4 for now.

Closes https://github.com/elastic/elasticsearch/issues/154321