### PR TITLE
[9.5] Update query settings for unmapped fields (#154645)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/commands/settings/unmapped_fields.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/commands/settings/unmapped_fields.md
@@ -3,7 +3,7 @@
 ### `unmapped_fields` [esql-unmapped_fields]
 ```{applies_to}
 serverless: ga
-stack: ga 9.5+, preview 9.3-9.4
+stack: ga preview 9.3-9.4, ga 9.5+
 ```
 Determines how unmapped fields are treated.
 For a conceptual overview and use cases, including performance considerations, refer to

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -83,9 +83,9 @@ public final class QuerySettings {
         .build();
 
     @Param(name = "unmapped_fields", type = { "keyword" }, since = "preview 9.3-9.4, ga 9.5+", description = """
-            Determines how unmapped fields are treated.
-            For a conceptual overview and use cases, including performance considerations, refer to
-            [Unmapped fields](/reference/query-languages/esql/esql-unmapped-fields.md).
+        Determines how unmapped fields are treated.
+        For a conceptual overview and use cases, including performance considerations, refer to
+        [Unmapped fields](/reference/query-languages/esql/esql-unmapped-fields.md).
 
         Possible values are:
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Update query settings for unmapped fields (#154645)