### PR TITLE
Pass timestamp filters to field-caps

### DIFF
--- a/docs/changelog/154663.yaml
+++ b/docs/changelog/154663.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154663
+summary: Pass timestamp filters to field-caps
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-class FieldCapabilitiesNodeResponse extends ActionResponse implements Writeable {
+public class FieldCapabilitiesNodeResponse extends ActionResponse implements Writeable {
     private final List<FieldCapabilitiesIndexResponse> indexResponses;
     private final Map<ShardId, Exception> failures;
     private final Set<ShardId> unmatchedShardIds;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesNodeResponse;
+import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -22,6 +25,8 @@ import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.cluster.routing.allocation.mapper.DataTierFieldMapper;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
@@ -87,6 +92,8 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .get();
         try {
             var queriedIndices = captureQueriedIndices();
+            var fieldCapsIndices = captureFieldCapsResponseIndices();
+
             try (
                 EsqlQueryResponse resp = run(
                     syncEsqlQueryRequest("from events_*").pragmas(randomPragmas())
@@ -96,11 +103,16 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(4));
                 assertThat(queriedIndices, equalTo(Set.of("events_2023")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2023")));
+                fieldCapsIndices.clear();
             }
+            // date_parse is not foldable at extraction time
             try (EsqlQueryResponse resp = run("from events_* | WHERE @timestamp >= date_parse(\"yyyy-MM-dd\", \"2023-01-01\")")) {
                 assertThat(getValuesList(resp), hasSize(4));
                 assertThat(queriedIndices, equalTo(Set.of("events_2023")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022", "events_2023")));
+                fieldCapsIndices.clear();
             }
 
             try (
@@ -112,11 +124,15 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(3));
                 assertThat(queriedIndices, equalTo(Set.of("events_2022")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022")));
+                fieldCapsIndices.clear();
             }
             try (EsqlQueryResponse resp = run("from events_* | WHERE @timestamp < date_parse(\"yyyy-MM-dd\", \"2023-01-01\")")) {
                 assertThat(getValuesList(resp), hasSize(3));
                 assertThat(queriedIndices, equalTo(Set.of("events_2022")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022", "events_2023")));
+                fieldCapsIndices.clear();
             }
 
             try (
@@ -128,6 +144,8 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(7));
                 assertThat(queriedIndices, equalTo(Set.of("events_2022", "events_2023")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022", "events_2023")));
+                fieldCapsIndices.clear();
             }
             try (
                 EsqlQueryResponse resp = run(
@@ -139,6 +157,8 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(7));
                 assertThat(queriedIndices, equalTo(Set.of("events_2022", "events_2023")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022", "events_2023")));
+                fieldCapsIndices.clear();
             }
 
             try (
@@ -150,6 +170,8 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(0));
                 assertThat(queriedIndices, empty());
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, empty());
+                fieldCapsIndices.clear();
             }
             try (
                 EsqlQueryResponse resp = run(
@@ -161,6 +183,9 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(0));
                 assertThat(queriedIndices, empty());
                 queriedIndices.clear();
+                // date_parse is not supported
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022", "events_2023")));
+                fieldCapsIndices.clear();
             }
 
             try (EsqlQueryResponse resp = run(syncEsqlQueryRequest("""
@@ -171,6 +196,9 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(4));
                 assertThat(queriedIndices, equalTo(Set.of("events_2023")));
                 queriedIndices.clear();
+                // date_parse is not supported
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2022", "events_2023")));
+                fieldCapsIndices.clear();
             }
             try (
                 EsqlQueryResponse resp = run(
@@ -182,6 +210,25 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 assertThat(getValuesList(resp), hasSize(4));
                 assertThat(queriedIndices, equalTo(Set.of("events_2023")));
                 queriedIndices.clear();
+                assertThat(fieldCapsIndices, equalTo(Set.of("events_2023")));
+                fieldCapsIndices.clear();
+            }
+
+            long nowMillis = System.currentTimeMillis();
+            assertAcked(client().admin().indices().prepareCreate("ts_old").setMapping("@timestamp", "type=date", "uid", "type=keyword"));
+            client().prepareBulk("ts_old")
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .add(new IndexRequest().source("@timestamp", nowMillis - 3L * 365 * 24 * 60 * 60 * 1000, "uid", "old"))
+                .get();
+            assertAcked(client().admin().indices().prepareCreate("ts_recent").setMapping("@timestamp", "type=date", "uid", "type=keyword"));
+            client().prepareBulk("ts_recent")
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .add(new IndexRequest().source("@timestamp", nowMillis - 180L * 24 * 60 * 60 * 1000, "uid", "recent"))
+                .get();
+            try (EsqlQueryResponse resp = run("FROM ts_old,ts_recent | WHERE @timestamp >= NOW() - 1 year")) {
+                assertThat(getValuesList(resp), hasSize(1));
+                assertThat(fieldCapsIndices, equalTo(Set.of("ts_recent")));
+                assertThat(queriedIndices, equalTo(Set.of("ts_recent")));
             }
         } finally {
             cleanAllTransportRules();
@@ -451,6 +498,38 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             );
         }
         return queriedIndices;
+    }
+
+    protected static Set<String> captureFieldCapsResponseIndices() {
+        Set<String> matchingIndices = ConcurrentCollections.newConcurrentSet();
+        for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
+            as(transportService, MockTransportService.class).addRequestHandlingBehavior(
+                TransportFieldCapabilitiesAction.ACTION_NODE_NAME,
+                (handler, request, channel, task) -> handler.messageReceived(request, new TransportChannel() {
+                    @Override
+                    public String getProfileName() {
+                        return channel.getProfileName();
+                    }
+
+                    @Override
+                    public void sendResponse(TransportResponse response) {
+                        FieldCapabilitiesNodeResponse nodeResponse = (FieldCapabilitiesNodeResponse) response;
+                        for (FieldCapabilitiesIndexResponse indexResponse : nodeResponse.getIndexResponses()) {
+                            if (indexResponse.canMatch()) {
+                                matchingIndices.add(indexResponse.getIndexName());
+                            }
+                        }
+                        channel.sendResponse(response);
+                    }
+
+                    @Override
+                    public void sendResponse(Exception exception) {
+                        channel.sendResponse(exception);
+                    }
+                }, task)
+            );
+        }
+        return matchingIndices;
     }
 
     private static void cleanAllTransportRules() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -73,6 +73,7 @@ import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtract
 import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.core.util.Queries;
 import org.elasticsearch.xpack.esql.datasources.DatasetResolver;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
@@ -141,6 +142,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -155,6 +157,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.toSet;
+import static org.elasticsearch.xpack.esql.core.util.Queries.Clause.FILTER;
 import static org.elasticsearch.xpack.esql.session.SessionUtils.checkPagesBelowSize;
 
 /**
@@ -439,12 +442,21 @@ public class EsqlSession {
         final Configuration finalConfiguration = configurationToUse;
         final FoldContext foldContext = finalConfiguration.newFoldContext();
 
+        QueryBuilder timestampFilters = TimestampIndexFilterExtractor.extract(plan, configuration);
+        QueryBuilder requestFilter = request.filter();
+        if (timestampFilters != null) {
+            if (requestFilter == null) {
+                requestFilter = timestampFilters;
+            } else {
+                requestFilter = Queries.combine(FILTER, Arrays.asList(requestFilter, timestampFilters));
+            }
+        }
         analyzedPlan(
             plan,
             QuerySettings.UNMAPPED_FIELDS.get(finalConfiguration.resolvedSettings()),
             finalConfiguration,
             executionInfo,
-            request.filter(),
+            requestFilter,
             new EsqlCCSUtils.CssPartialErrorsActionListener(finalConfiguration, executionInfo, listener) {
                 @Override
                 public void onResponse(Versioned<LogicalPlan> analyzedPlan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/TimestampIndexFilterExtractor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/TimestampIndexFilterExtractor.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.session;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.Queries;
+import org.elasticsearch.xpack.esql.expression.function.UnresolvedFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.date.Now;
+import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
+import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
+import org.elasticsearch.xpack.esql.plan.QuerySettings;
+import org.elasticsearch.xpack.esql.plan.logical.Drop;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.Fork;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
+import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
+import org.elasticsearch.xpack.esql.plan.logical.Rename;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+
+import java.time.Duration;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.core.expression.MetadataAttribute.TIMESTAMP_FIELD;
+import static org.elasticsearch.xpack.esql.core.util.Queries.Clause.FILTER;
+
+/**
+ * Extracts timestamp filters from an unresolved plan for use as index-filter in field-caps.
+ */
+final class TimestampIndexFilterExtractor {
+
+    private static final long MILLIS_IN_SECOND = 1_000L;
+    private static final long MILLIS_IN_MINUTE = 60_000L;
+    private static final long MILLIS_IN_HOUR = 3_600_000L;
+
+    private TimestampIndexFilterExtractor() {}
+
+    @Nullable
+    static QueryBuilder extract(LogicalPlan plan, Configuration configuration) {
+        return combine(collect(plan, new ArrayList<>(), configuration));
+    }
+
+    private static Set<QueryBuilder> collect(LogicalPlan node, List<Expression> filters, Configuration configuration) {
+        if (node instanceof Fork fork) {
+            List<LogicalPlan> subPlans = fork.children();
+            if (subPlans.isEmpty()) {
+                return Set.of();
+            }
+            Set<QueryBuilder> common = new LinkedHashSet<>(collect(subPlans.getFirst(), new ArrayList<>(), configuration));
+            for (int i = 1; i < subPlans.size(); i++) {
+                if (common.isEmpty()) {
+                    break;
+                }
+                Set<QueryBuilder> other = collect(subPlans.get(i), new ArrayList<>(), configuration);
+                common.removeIf(q -> other.contains(q) == false);
+            }
+            common.addAll(toTimestampQueries(filters, configuration));
+            return common;
+        }
+        if (node instanceof UnresolvedRelation) {
+            return toTimestampQueries(filters, configuration);
+        }
+        if (filterPassthrough(node)) {
+            Set<String> shadowed = shadowedNames(node);
+            if (shadowed.isEmpty() == false && filters.isEmpty() == false) {
+                filters.removeIf(c -> referencesAny(c, shadowed));
+            }
+        } else {
+            filters.clear();
+        }
+        if (node instanceof Filter filter) {
+            filters.addAll(Predicates.splitAnd(filter.condition()));
+        }
+        Set<QueryBuilder> result = new LinkedHashSet<>();
+        for (LogicalPlan child : node.children()) {
+            result.addAll(collect(child, new ArrayList<>(filters), configuration));
+        }
+        return result;
+    }
+
+    /**
+     * Nodes a filter may move past without changing results
+     */
+    static boolean filterPassthrough(LogicalPlan plan) {
+        return plan instanceof Filter
+            || plan instanceof OrderBy
+            || plan instanceof Eval
+            || plan instanceof RegexExtract
+            || plan instanceof Rename
+            || plan instanceof Project // includes KEEP
+            || plan instanceof Drop
+            || plan instanceof Enrich
+            || plan instanceof MvExpand;
+    }
+
+    static Set<String> shadowedNames(LogicalPlan plan) {
+        Set<String> names = new HashSet<>();
+        if (plan instanceof GeneratingPlan<?> generating) {
+            for (Attribute attr : generating.generatedAttributes()) {
+                names.add(attr.name());
+            }
+        }
+        if (plan instanceof Eval eval) {
+            for (Alias alias : eval.fields()) {
+                names.add(alias.name());
+            }
+        }
+        if (plan instanceof Rename rename) {
+            for (Alias alias : rename.renamings()) {
+                names.add(alias.name());
+            }
+        }
+        if (plan instanceof MvExpand mvExpand) {
+            Attribute expanded = mvExpand.expanded();
+            if (expanded != null) {
+                names.add(expanded.name());
+            }
+        }
+        return names;
+    }
+
+    private static boolean referencesAny(Expression expression, Set<String> names) {
+        return expression.anyMatch(e -> e instanceof Attribute attr && names.contains(attr.name()));
+    }
+
+    private static Set<QueryBuilder> toTimestampQueries(List<Expression> filters, Configuration configuration) {
+        Set<QueryBuilder> ranges = new LinkedHashSet<>();
+        for (Expression filter : filters) {
+            QueryBuilder range = toTimestampRange(filter, configuration);
+            if (range != null) {
+                ranges.add(range);
+            }
+        }
+        return ranges;
+    }
+
+    @Nullable
+    private static QueryBuilder combine(Set<QueryBuilder> queries) {
+        if (queries.isEmpty()) {
+            return null;
+        }
+        if (queries.size() == 1) {
+            return queries.iterator().next();
+        }
+        return Queries.combine(FILTER, new ArrayList<>(queries));
+    }
+
+    private static QueryBuilder toTimestampRange(Expression expr, Configuration configuration) {
+        if (expr instanceof EsqlBinaryComparison comparison) {
+            return toTimestampRange(comparison, configuration);
+        }
+        return null;
+    }
+
+    private static QueryBuilder toTimestampRange(EsqlBinaryComparison comparison, Configuration configuration) {
+        Expression left = comparison.left();
+        Expression right = comparison.right();
+        boolean reversed = false;
+        UnresolvedAttribute timestampAttr = null;
+        Expression boundExpr = null;
+
+        if (left instanceof UnresolvedAttribute attr && TIMESTAMP_FIELD.equals(attr.name())) {
+            timestampAttr = attr;
+            boundExpr = right;
+        } else if (right instanceof UnresolvedAttribute attr && TIMESTAMP_FIELD.equals(attr.name())) {
+            timestampAttr = attr;
+            boundExpr = left;
+            reversed = true;
+        }
+        if (timestampAttr == null) {
+            return null;
+        }
+
+        // Expression must only reference @timestamp (+ foldable bound); no other field refs.
+        if (comparison.references().stream().anyMatch(a -> TIMESTAMP_FIELD.equals(a.name()) == false)) {
+            return null;
+        }
+
+        Object bound = foldTimestampBound(boundExpr);
+        if (bound == null) {
+            return null;
+        }
+
+        EsqlBinaryComparison.BinaryComparisonOperation op = comparison.getFunctionType();
+        if (reversed) {
+            op = reverse(op);
+        }
+
+        RangeQueryBuilder range = new RangeQueryBuilder(TIMESTAMP_FIELD);
+        Object rangeValue;
+        if (bound instanceof String dateMath) {
+            ZoneId zoneId = QuerySettings.TIME_ZONE.get(configuration.resolvedSettings());
+            range.timeZone(zoneId.getId());
+            rangeValue = dateMath;
+        } else if (bound instanceof Number n) {
+            rangeValue = n.longValue();
+        } else if (bound instanceof BytesRef br) {
+            rangeValue = BytesRefs.toString(br);
+        } else {
+            return null;
+        }
+        return applyBound(range, op, rangeValue);
+    }
+
+    private static EsqlBinaryComparison.BinaryComparisonOperation reverse(EsqlBinaryComparison.BinaryComparisonOperation op) {
+        return switch (op) {
+            case EQ -> EsqlBinaryComparison.BinaryComparisonOperation.EQ;
+            case NEQ -> EsqlBinaryComparison.BinaryComparisonOperation.NEQ;
+            case GT -> EsqlBinaryComparison.BinaryComparisonOperation.LT;
+            case GTE -> EsqlBinaryComparison.BinaryComparisonOperation.LTE;
+            case LT -> EsqlBinaryComparison.BinaryComparisonOperation.GT;
+            case LTE -> EsqlBinaryComparison.BinaryComparisonOperation.GTE;
+        };
+    }
+
+    private static QueryBuilder applyBound(RangeQueryBuilder range, EsqlBinaryComparison.BinaryComparisonOperation op, Object value) {
+        return switch (op) {
+            case GT -> range.gt(value);
+            case GTE -> range.gte(value);
+            case LT -> range.lt(value);
+            case LTE -> range.lte(value);
+            case EQ -> range.gte(value).lte(value);
+            case NEQ -> null; // cannot express safely as a single range for index pruning
+        };
+    }
+
+    static Object foldTimestampBound(Expression expr) {
+        if (expr instanceof Literal lit) {
+            Object value = lit.value();
+            if (value instanceof BytesRef || value instanceof String || value instanceof Number) {
+                return value;
+            }
+            return null;
+        }
+        if (isNow(expr)) {
+            return "now";
+        }
+        if (expr instanceof Sub sub && isNow(sub.left())) {
+            String unit = toDateMathUnit(foldTemporalAmount(sub.right()));
+            return unit != null ? "now-" + unit : null;
+        }
+        if (expr instanceof Add add) {
+            if (isNow(add.left())) {
+                String unit = toDateMathUnit(foldTemporalAmount(add.right()));
+                return unit != null ? "now+" + unit : null;
+            }
+            if (isNow(add.right())) {
+                String unit = toDateMathUnit(foldTemporalAmount(add.left()));
+                return unit != null ? "now+" + unit : null;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isNow(Expression expr) {
+        if (expr instanceof Now) {
+            return true;
+        }
+        if (expr instanceof UnresolvedFunction uf) {
+            return "now".equalsIgnoreCase(uf.name());
+        }
+        return false;
+    }
+
+    private static TemporalAmount foldTemporalAmount(Expression expr) {
+        if (expr instanceof Literal lit) {
+            DataType type = lit.dataType();
+            if ((type == DataType.TIME_DURATION || type == DataType.DATE_PERIOD) && lit.value() instanceof TemporalAmount amount) {
+                return amount;
+            }
+        }
+        return null;
+    }
+
+    static String toDateMathUnit(TemporalAmount amount) {
+        if (amount == null) {
+            return null;
+        }
+        if (amount instanceof Duration d) {
+            long millis = d.toMillis();
+            if (millis <= 0) {
+                return null;
+            }
+            if (millis % MILLIS_IN_HOUR == 0) {
+                return (millis / MILLIS_IN_HOUR) + "h";
+            }
+            if (millis % MILLIS_IN_MINUTE == 0) {
+                return (millis / MILLIS_IN_MINUTE) + "m";
+            }
+            if (millis % MILLIS_IN_SECOND == 0) {
+                return (millis / MILLIS_IN_SECOND) + "s";
+            }
+            return null; // sub-second precision is not useful for index pruning
+        }
+        if (amount instanceof Period p) {
+            int years = p.getYears();
+            int months = p.getMonths();
+            int days = p.getDays();
+            if (years > 0 && months == 0 && days == 0) return years + "y";
+            if (months > 0 && years == 0 && days == 0) return months + "M";
+            if (days > 0 && years == 0 && months == 0) {
+                if (days % 7 == 0) return (days / 7) + "w";
+                return days + "d";
+            }
+        }
+        return null;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/TimestampIndexFilterExtractorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/TimestampIndexFilterExtractorTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.session;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.plan.QuerySettings;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.time.Duration;
+import java.time.Period;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.configuration;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TimestampIndexFilterExtractorTests extends ESTestCase {
+
+    public void testExtractNowMinusIntervalAboveDrop() {
+        Configuration configuration = configuration("FROM logs*");
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | DROP lost.*
+            | WHERE @timestamp >= NOW() - 15 minutes AND @timestamp <= NOW()
+            | LIMIT 1
+            """);
+
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, configuration);
+        assertThat(filter, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder bool = (BoolQueryBuilder) filter;
+        assertThat(bool.filter().size(), equalTo(2));
+
+        RangeQueryBuilder lower = (RangeQueryBuilder) bool.filter().get(0);
+        RangeQueryBuilder upper = (RangeQueryBuilder) bool.filter().get(1);
+        assertDateMathRange(lower, "now-15m", true, null, false, configuration);
+        assertDateMathRange(upper, null, false, "now", true, configuration);
+    }
+
+    public void testExtractDateStringLiteral() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs* | WHERE @timestamp >= "2024-01-01T00:00:00Z" AND @timestamp < "2024-02-01T00:00:00Z"
+            """);
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, TEST_CFG);
+        assertThat(filter, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder bool = (BoolQueryBuilder) filter;
+        RangeQueryBuilder lower = (RangeQueryBuilder) bool.filter().get(0);
+        RangeQueryBuilder upper = (RangeQueryBuilder) bool.filter().get(1);
+        assertThat(lower.fieldName(), equalTo("@timestamp"));
+        assertThat(lower.from(), equalTo("2024-01-01T00:00:00Z"));
+        assertThat(lower.includeLower(), equalTo(true));
+        assertThat(lower.timeZone(), nullValue());
+        assertThat(upper.to(), equalTo("2024-02-01T00:00:00Z"));
+        assertThat(upper.includeUpper(), equalTo(false));
+    }
+
+    public void testExtractPastKeepAndDrop() {
+        Configuration configuration = configuration("FROM logs*");
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | WHERE @timestamp >= NOW() - 1 hour
+            | DROP lost.*
+            | KEEP @timestamp, message
+            """);
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, configuration);
+        assertThat(filter, instanceOf(RangeQueryBuilder.class));
+        assertDateMathRange((RangeQueryBuilder) filter, "now-1h", true, null, false, configuration);
+    }
+
+    public void testExtractNowMinusDaySetsTimeZone() {
+        Configuration configuration = configuration("FROM logs*");
+        LogicalPlan plan = TEST_PARSER.parseQuery("FROM logs* | WHERE @timestamp >= NOW() - 1 day");
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, configuration);
+        assertThat(filter, instanceOf(RangeQueryBuilder.class));
+        assertDateMathRange((RangeQueryBuilder) filter, "now-1d", true, null, false, configuration);
+    }
+
+    public void testNoExtractAboveLimit() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | LIMIT 10
+            | WHERE @timestamp >= "2024-01-01"
+            """);
+        assertThat(TimestampIndexFilterExtractor.extract(plan, TEST_CFG), nullValue());
+    }
+
+    public void testNoExtractWhenTimestampShadowedByEval() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | EVAL @timestamp = 1
+            | WHERE @timestamp >= "2024-01-01"
+            """);
+        assertThat(TimestampIndexFilterExtractor.extract(plan, TEST_CFG), nullValue());
+    }
+
+    public void testExtractWhenTimestampFilterBelowEvalShadow() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | WHERE @timestamp >= "2024-01-01"
+            | EVAL @timestamp = 1
+            """);
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, TEST_CFG);
+        assertThat(filter, instanceOf(RangeQueryBuilder.class));
+        assertThat(((RangeQueryBuilder) filter).from(), equalTo("2024-01-01"));
+    }
+
+    public void testIgnoresNonTimestampPredicates() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | WHERE status == "error" AND @timestamp >= "2024-01-01"
+            """);
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, TEST_CFG);
+        assertThat(filter, instanceOf(RangeQueryBuilder.class));
+        assertThat(((RangeQueryBuilder) filter).from(), equalTo("2024-01-01"));
+    }
+
+    public void testNoExtractWithoutTimestamp() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("FROM logs* | WHERE status == \"error\"");
+        assertThat(TimestampIndexFilterExtractor.extract(plan, TEST_CFG), nullValue());
+    }
+
+    public void testForkKeepsCommonTimestampFilter() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | FORK
+                (WHERE @timestamp >= "2024-01-01" AND status == "a")
+                (WHERE @timestamp >= "2024-01-01" AND status == "b")
+            | LIMIT 1
+            """);
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, TEST_CFG);
+        assertThat(filter, instanceOf(RangeQueryBuilder.class));
+        assertThat(((RangeQueryBuilder) filter).from(), equalTo("2024-01-01"));
+    }
+
+    public void testForkKeepsPartialCommonTimestampFilters() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | FORK
+                (WHERE @timestamp >= "2024-01-01" AND @timestamp < "2024-06-01")
+                (WHERE @timestamp >= "2024-01-01" AND @timestamp < "2025-01-01")
+            | LIMIT 1
+            """);
+        QueryBuilder filter = TimestampIndexFilterExtractor.extract(plan, TEST_CFG);
+        assertThat(filter, instanceOf(RangeQueryBuilder.class));
+        assertThat(((RangeQueryBuilder) filter).from(), equalTo("2024-01-01"));
+        assertThat(((RangeQueryBuilder) filter).to(), nullValue());
+    }
+
+    public void testForkSkipsWhenTimestampFiltersDiffer() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | FORK
+                (WHERE @timestamp >= "2024-01-01")
+                (WHERE @timestamp >= "2023-01-01")
+            | LIMIT 1
+            """);
+        assertThat(TimestampIndexFilterExtractor.extract(plan, TEST_CFG), nullValue());
+    }
+
+    public void testForkSkipsWhenOneBranchHasNoTimestampFilter() {
+        LogicalPlan plan = TEST_PARSER.parseQuery("""
+            FROM logs*
+            | FORK
+                (WHERE @timestamp >= "2024-01-01")
+                (WHERE status == "error")
+            | LIMIT 1
+            """);
+        assertThat(TimestampIndexFilterExtractor.extract(plan, TEST_CFG), nullValue());
+    }
+
+    public void testToDateMathUnit() {
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Duration.ofMinutes(15)), equalTo("15m"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Duration.ofHours(1)), equalTo("1h"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Duration.ofHours(24)), equalTo("24h"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Duration.ofHours(48)), equalTo("48h"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Duration.ofSeconds(30)), equalTo("30s"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Period.ofDays(1)), equalTo("1d"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Period.ofWeeks(2)), equalTo("2w"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Period.ofMonths(3)), equalTo("3M"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Period.ofYears(1)), equalTo("1y"));
+        assertThat(TimestampIndexFilterExtractor.toDateMathUnit(Duration.ofMillis(500)), nullValue());
+    }
+
+    private static void assertDateMathRange(
+        RangeQueryBuilder range,
+        String from,
+        boolean includeLower,
+        String to,
+        boolean includeUpper,
+        Configuration configuration
+    ) {
+        assertThat(range.fieldName(), equalTo("@timestamp"));
+        assertThat(range.format(), nullValue());
+        assertThat(range.timeZone(), equalTo(QuerySettings.TIME_ZONE.get(configuration.resolvedSettings()).getId()));
+        if (from != null) {
+            assertThat(range.from(), equalTo(from));
+            assertThat(range.includeLower(), equalTo(includeLower));
+        }
+        if (to != null) {
+            assertThat(range.to(), equalTo(to));
+            assertThat(range.includeUpper(), equalTo(includeUpper));
+        }
+    }
+}


### PR DESCRIPTION
Today, we pass the filter parameter as index_filter to field-caps, which can eliminate non-matching indices on the coordinator. However, we don't extract timestamp filters from the WHERE commands, so queries like:

```
FROM logging-*:logs-motel-*,logging-*:logs-hosted-otel-controller* METADATA _id, _index
| WHERE @timestamp >= NOW() - 15 minutes AND @timestamp <= NOW()
```

field-caps will return many thousands of indices instead of indices with data in the latest 15 minutes only.

Since we don't have resolved types yet, we do a best-effort extraction of the timestamp filter and convert it to query DSL for use as index_filter. We may want to apply the same approach to other important filters such as _tier in the future.