### PR TITLE
Adding feature flag check for newly introduced shard analyzer tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -55,6 +55,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class AnalysisRegistryTests extends ESTestCase {
+    private static final String SHARED_ANALYZERS_REQUIRED = "shared analyzers feature flag must be enabled";
+
     private AnalysisRegistry emptyRegistry;
     private AnalysisRegistry nonEmptyRegistry;
 
@@ -126,6 +128,7 @@ public class AnalysisRegistryTests extends ESTestCase {
      * analyzer into many indices with arbitrary names.
      */
     public void testCustomAnalyzerSharedAcrossDifferentLocalNames() throws IOException {
+        assumeTrue(SHARED_ANALYZERS_REQUIRED, AnalysisRegistry.SHARED_ANALYZERS_FEATURE_FLAG.isEnabled());
         Settings sA = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put("index.analysis.analyzer.my_name_a.tokenizer", "standard")
@@ -151,6 +154,7 @@ public class AnalysisRegistryTests extends ESTestCase {
      * StopTokenFilterFactory overrides sharingKey to compare (stopWords, ignoreCase, removeTrailing).
      */
     public void testUserDefinedFilterSharesWhenSharingKeyMatches() throws IOException {
+        assumeTrue(SHARED_ANALYZERS_REQUIRED, AnalysisRegistry.SHARED_ANALYZERS_FEATURE_FLAG.isEnabled());
         Settings sA = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put("index.analysis.filter.my_stop.type", "stop")
@@ -218,6 +222,7 @@ public class AnalysisRegistryTests extends ESTestCase {
      * on a hot path.
      */
     public void testSharingKeyIsStableAcrossCalls() throws IOException {
+        assumeTrue(SHARED_ANALYZERS_REQUIRED, AnalysisRegistry.SHARED_ANALYZERS_FEATURE_FLAG.isEnabled());
         Settings s = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put("index.analysis.analyzer.a.tokenizer", "standard")
@@ -242,6 +247,7 @@ public class AnalysisRegistryTests extends ESTestCase {
      * underlying. After Index A closes, Index B's analyzer must remain functional.
      */
     public void testIndexCloseDoesNotKillSharedAnalyzer() throws IOException {
+        assumeTrue(SHARED_ANALYZERS_REQUIRED, AnalysisRegistry.SHARED_ANALYZERS_FEATURE_FLAG.isEnabled());
         Settings s = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
             .put("index.analysis.analyzer.a.tokenizer", "standard")
@@ -270,6 +276,7 @@ public class AnalysisRegistryTests extends ESTestCase {
      * encode it in their own {@code sharingKey}, which {@code FactorySharingKeyTests} covers.
      */
     public void testVersionInvariantAnalyzersShareAcrossVersions() throws IOException {
+        assumeTrue(SHARED_ANALYZERS_REQUIRED, AnalysisRegistry.SHARED_ANALYZERS_FEATURE_FLAG.isEnabled());
         Settings sA = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
         Settings sB = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersionUtils.getPreviousVersion(IndexVersion.current()))

--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalyzerRefcountTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalyzerRefcountTests.java
@@ -67,6 +67,7 @@ public class AnalyzerRefcountTests extends ESTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        assumeTrue("shared analyzers feature flag must be enabled", AnalysisRegistry.SHARED_ANALYZERS_FEATURE_FLAG.isEnabled());
         Settings nodeSettings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
         AnalysisModule module = new AnalysisModule(
             TestEnvironment.newEnvironment(nodeSettings),
@@ -78,6 +79,10 @@ public class AnalyzerRefcountTests extends ESTestCase {
 
     @Override
     public void tearDown() throws Exception {
+        if (registry == null) {
+            super.tearDown();
+            return;
+        }
         try {
             // Opt-in strict leak check: every test in this class must drain the cache before
             // teardown. Any IndexAnalyzers built without being closed shows up here, attributed


### PR DESCRIPTION
Adding a guard before executing tests in `AnalysisRegistryTests` and `AnalyzerRefcountTests` to ensure that the `SHARED_ANALYZERS_FEATURE_FLAG` feature flag is enabled introduced in https://github.com/elastic/elasticsearch/pull/151755

Closes https://github.com/elastic/elasticsearch/issues/154653 and https://github.com/elastic/elasticsearch/issues/154654 . 