### PR TITLE
[Test unmute] Unmute FullClusterRestartIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -29,15 +29,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:METRICS}
   issue: https://github.com/elastic/elasticsearch/issues/153507
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testClusterState {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/143800
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testOperationBasedRecovery {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/143801
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testOperationBasedRecovery {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/143802
 - class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
   method: testOpenAiEmbeddings {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/144440


### PR DESCRIPTION
Unmute since the failures were caused by temporary test orchestration/infrastructure issue. See also
https://github.com/elastic/elasticsearch/issues/143800#issuecomment-5042063731

Resolves #143800
Resolves #143801
Resolves #143802
