### PR TITLE
[9.4] Bug fix: default AMD value resolution in FromAggregateMetricDouble (#153805)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java
@@ -15,9 +15,12 @@ import org.elasticsearch.compute.data.AggregateMetricDoubleBlock;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -147,12 +150,20 @@ public class FromAggregateMetricDouble extends EsqlScalarFunction implements Con
             public ExpressionEvaluator get(DriverContext context) {
                 final ExpressionEvaluator eval = fieldEvaluator.get(context);
                 final int subFieldIndex = ((Number) subfieldIndex.fold(FoldContext.small())).intValue();
-                return new Evaluator(context.blockFactory(), eval, subFieldIndex);
+                return new Evaluator(
+                    context.blockFactory(),
+                    eval,
+                    subFieldIndex,
+                    // We use this factory method to be compatible with the AvgBlockLoader
+                    Warnings.createOnlyWarnings(context.warningsMode(), source())
+                );
             }
         };
     }
 
-    private record Evaluator(BlockFactory blockFactory, ExpressionEvaluator eval, int subFieldIndex) implements ExpressionEvaluator {
+    private record Evaluator(BlockFactory blockFactory, ExpressionEvaluator eval, int subFieldIndex, Warnings warnings)
+        implements
+            ExpressionEvaluator {
 
         private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Evaluator.class);
 
@@ -163,9 +174,13 @@ public class FromAggregateMetricDouble extends EsqlScalarFunction implements Con
                 if (block.areAllValuesNull()) {
                     return blockFactory.newConstantNullBlock(block.getPositionCount());
                 }
-                Block resultBlock = ((AggregateMetricDoubleBlock) block).getMetricBlock(subFieldIndex);
-                resultBlock.incRef();
-                return resultBlock;
+                if (subFieldIndex == AggregateMetricDoubleBlockBuilder.Metric.DEFAULT.getIndex()) {
+                    return evaluateDefaultBlock((AggregateMetricDoubleBlock) block);
+                } else {
+                    Block resultBlock = ((AggregateMetricDoubleBlock) block).getMetricBlock(subFieldIndex);
+                    resultBlock.incRef();
+                    return resultBlock;
+                }
             } finally {
                 block.close();
             }
@@ -184,6 +199,39 @@ public class FromAggregateMetricDouble extends EsqlScalarFunction implements Con
         @Override
         public String toString() {
             return "FromAggregateMetricDoubleEvaluator[field=" + eval + ",subfieldIndex=" + subFieldIndex + "]";
+        }
+
+        private Block evaluateDefaultBlock(AggregateMetricDoubleBlock block) {
+            int positionCount = block.getPositionCount();
+            DoubleBlock sumBlock = block.sumBlock();
+            IntBlock countBlock = block.countBlock();
+            if (sumBlock.areAllValuesNull() || countBlock.areAllValuesNull()) {
+                return blockFactory().newConstantNullBlock(positionCount);
+            }
+            try (DoubleBlock.Builder builder = blockFactory().newDoubleBlockBuilder(positionCount)) {
+                for (int p = 0; p < positionCount; p++) {
+                    if (sumBlock.isNull(p) || countBlock.isNull(p)) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    int sumFirstValueIndex = sumBlock.getFirstValueIndex(p);
+                    int countFirstValueIndex = countBlock.getFirstValueIndex(p);
+                    double sum = sumBlock.getDouble(sumFirstValueIndex);
+                    int count = countBlock.getInt(countFirstValueIndex);
+                    if (count <= 0) {
+                        warnings.registerException(
+                            IllegalArgumentException.class,
+                            "[aggregate_metric_double] fields has a non-positive count [value_count="
+                                + count
+                                + "], so it cannot fallback to a single average value, treating result as null"
+                        );
+                        builder.appendNull();
+                    } else {
+                        builder.appendDouble(sum / count);
+                    }
+                }
+                return builder.build();
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDoubleTests.java
@@ -67,6 +67,81 @@ public class FromAggregateMetricDoubleTests extends AbstractScalarFunctionTestCa
             }));
         }
 
+        // The DEFAULT metric (index 4) has no dedicated sub-block; it's computed on the fly as sum / count.
+        suppliers.add(new TestCaseSupplier(List.of(dataType, DataType.INTEGER), () -> {
+            double sum = randomDoubleBetween(-1000, 1000, true);
+            int count = randomIntBetween(1, 1000);
+            var agg_metric = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
+                randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                sum,
+                count
+            );
+            int index = AggregateMetricDoubleBlockBuilder.Metric.DEFAULT.getIndex();
+            double expectedValue = sum / count;
+
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(agg_metric, dataType, "agg_metric"),
+                    new TestCaseSupplier.TypedData(index, DataType.INTEGER, "subfield_index").forceLiteral()
+                ),
+                "FromAggregateMetricDoubleEvaluator[field=Attribute[channel=0],subfieldIndex=" + index + "]",
+                DataType.DOUBLE,
+                Matchers.closeTo(expectedValue, Math.abs(expectedValue * 0.00001))
+            );
+        }));
+
+        // DEFAULT metric with count == 0: result is null and a warning is logged.
+        suppliers.add(new TestCaseSupplier(List.of(dataType, DataType.INTEGER), () -> {
+            int index = AggregateMetricDoubleBlockBuilder.Metric.DEFAULT.getIndex();
+            var agg_metric = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
+                randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                randomDoubleBetween(-1000, 1000, true),
+                0
+            );
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(agg_metric, dataType, "agg_metric"),
+                    new TestCaseSupplier.TypedData(index, DataType.INTEGER, "subfield_index").forceLiteral()
+                ),
+                "FromAggregateMetricDoubleEvaluator[field=Attribute[channel=0],subfieldIndex=" + index + "]",
+                DataType.DOUBLE,
+                Matchers.nullValue()
+            ).withWarning("Line 1:1: warnings during evaluation of [source]. Only first 20 failures recorded.")
+                .withWarning(
+                    "Line 1:1: java.lang.IllegalArgumentException: [aggregate_metric_double] fields has a non-positive count"
+                        + " [value_count=0], so it cannot fallback to a single average value, treating result as null"
+                );
+        }));
+
+        // DEFAULT metric with count < 0: result is null and a warning is logged.
+        suppliers.add(new TestCaseSupplier(List.of(dataType, DataType.INTEGER), () -> {
+            int index = AggregateMetricDoubleBlockBuilder.Metric.DEFAULT.getIndex();
+            int count = randomIntBetween(-100, -1);
+            var agg_metric = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
+                randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                randomDoubleBetween(-1000, 1000, true),
+                count
+            );
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(agg_metric, dataType, "agg_metric"),
+                    new TestCaseSupplier.TypedData(index, DataType.INTEGER, "subfield_index").forceLiteral()
+                ),
+                "FromAggregateMetricDoubleEvaluator[field=Attribute[channel=0],subfieldIndex=" + index + "]",
+                DataType.DOUBLE,
+                Matchers.nullValue()
+            ).withWarning("Line 1:1: warnings during evaluation of [source]. Only first 20 failures recorded.")
+                .withWarning(
+                    "Line 1:1: java.lang.IllegalArgumentException: [aggregate_metric_double] fields has a non-positive count"
+                        + " [value_count="
+                        + count
+                        + "], so it cannot fallback to a single average value, treating result as null"
+                );
+        }));
+
         return parameterSuppliersFromTypedData(
             anyNullIsNull(
                 suppliers,

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -583,6 +583,8 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
             BlockLoaderFunctionConfig cfg = blContext.blockLoaderFunctionConfig();
             if (cfg != null) {
                 return switch (cfg.function()) {
+                    // After an AggregateMetricDoubleBlock is loaded, we do not have anymore the single metric
+                    // information, this is why in the context of ES|QL we always default to average.
                     case AMD_DEFAULT -> new AggregateMetricDoubleBlockLoader.AvgBlockLoader(metricFields, blContext.warnings());
                     case AMD_COUNT -> getIndividualBlockLoader(Metric.value_count);
                     case AMD_MAX -> getIndividualBlockLoader(Metric.max);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Bug fix: default AMD value resolution in FromAggregateMetricDouble (#153805)](https://github.com/elastic/elasticsearch/pull/153805)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)