### PR TITLE
Adding ensureGreen check in RankEvalRequestIT to ensure all indices are available

### DIFF
--- a/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
+++ b/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
@@ -58,9 +58,11 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         prepareIndex(TEST_INDEX).setId("6").setSource("id", 6, "text", "amsterdam", "population", 851573).get();
 
         // add another index for testing closed indices etc...
+        createIndex("test2");
+        ensureGreen();
+
         prepareIndex("test2").setId("7").setSource("id", 7, "text", "amsterdam", "population", 851573).get();
         refresh();
-        ensureGreen();
 
         // set up an alias that can also be used in tests
         assertAcked(

--- a/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
+++ b/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
@@ -60,6 +60,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         // add another index for testing closed indices etc...
         prepareIndex("test2").setId("7").setSource("id", 7, "text", "amsterdam", "population", 851573).get();
         refresh();
+        ensureGreen();
 
         // set up an alias that can also be used in tests
         assertAcked(

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -529,9 +529,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
   method: testMaxExpressionDepth_nestedAbs_minOverflow {default}
   issue: https://github.com/elastic/elasticsearch/issues/154341
-- class: org.elasticsearch.index.rankeval.RankEvalRequestIT
-  method: testIndicesOptions
-  issue: https://github.com/elastic/elasticsearch/issues/154360
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/151923


### PR DESCRIPTION
The assertion was thrown when trying to acknowledge that the index was closed, so we add an additional check during setup to ensure that all shards are available for all nodes for the said index. 

Closes https://github.com/elastic/elasticsearch/issues/154360