### PR TITLE
Prevent BPF filter installation in Spawner tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -532,9 +532,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
   method: testMaxExpressionDepth_nestedAbs_maxAllowed {default}
   issue: https://github.com/elastic/elasticsearch/issues/154380
-- class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
-  method: testControllerSpawnGatedBySettings
-  issue: https://github.com/elastic/elasticsearch/issues/154291
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: multiple sub-objects with all three supported dynamic values}"
   issue: https://github.com/elastic/elasticsearch/issues/154464

--- a/qa/no-bootstrap-tests/build.gradle
+++ b/qa/no-bootstrap-tests/build.gradle
@@ -13,3 +13,8 @@
  */
 
 apply plugin: 'elasticsearch.standalone-test'
+
+tasks.withType(Test).configureEach {
+  // this module tests process spawning, which requires the system call filter to be disabled
+  systemProperty 'tests.system_call_filter', 'false'
+}


### PR DESCRIPTION
Fixes the `SpawnerNoBoostrapTests`. The failure comes from the `MockLog` class, which in the `awaitAllExpectationsMatched()` method loads the `ESTestCase`. The `ESTestCase` in the static initialization block calls `Elasticsearch#initializeNatives()`, which installs a BPF filter that blocks all `exec()`/`fork()` calls. This in turn makes the `posix_spawn()` function fail with `EACCES`:

```
posix_spawn failed, error: 13 (Permission denied)
```

This made `testControllerSpawnGatedBySettings()` fail non-deterministically: only when `testControllerSpawn()` (the test that calls `awaitAllExpectationsMatched()` was ordered first by the randomised runner.

It's worth noting that `EACCES` it not listed as a possible `errno` value for `posix_spawn()`.

Closes https://github.com/elastic/elasticsearch/issues/154291
