### PR TITLE
[Test] Drop reseting EncryptionServiceRegistry in internal cluster tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -547,12 +547,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: multiple sub-objects with all three supported dynamic values}"
   issue: https://github.com/elastic/elasticsearch/issues/154464
-- class: org.elasticsearch.xpack.esql.action.CrossClusterEnrichUnavailableClustersIT
-  method: testEnrichRemoteWithVendor
-  issue: https://github.com/elastic/elasticsearch/issues/154532
-- class: org.elasticsearch.xpack.esql.action.CrossClusterEnrichUnavailableClustersIT
-  method: testEnrichWithHostsPolicyAndDisconnectedRemotesWithSkipUnavailableFalse
-  issue: https://github.com/elastic/elasticsearch/issues/154533
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: "test {yaml=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
   issue: https://github.com/elastic/elasticsearch/issues/154537

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/datasource/TestEncryptionServicePlugin.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/datasource/TestEncryptionServicePlugin.java
@@ -26,10 +26,6 @@ public class TestEncryptionServicePlugin extends Plugin {
 
     public static final String TEST_KEY_ID = "test-key";
 
-    public TestEncryptionServicePlugin() {
-        EncryptionServiceRegistry.reset();
-    }
-
     @Override
     public Collection<?> createComponents(PluginServices services) {
         EncryptionService svc = new EncryptionService() {


### PR DESCRIPTION
The `AbstractMultiClustersTestCase` start clusters in parallel, so one cluster's node constructor would create `TestEncryptionServicePlugin` which sets `null` while others may already set it and attempted to read.

Since `TestEncryptionServicePlugin` is always referenced in internal cluster tests with the same bogus implementation, dropping the reset would avoid race condition and not change the correctness of these tests (as they don't care about encryption).

Resolves #154533
Resolves #154532

