### PR TITLE
Add index refresh after forced merge

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
@@ -791,6 +791,10 @@ setup:
         max_num_segments: 1
 
   - do:
+      indices.refresh:
+        index: test_index
+
+  - do:
       search:
         index: test_index
         body:
@@ -936,6 +940,10 @@ setup:
       indices.forcemerge:
         index: test_index
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: test_index
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/210_knn_search_profile.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/210_knn_search_profile.yml
@@ -85,6 +85,10 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: bbq_hnsw
 ---
 "Profile rescored knn search":
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
@@ -465,6 +465,10 @@ setup:
         max_num_segments: 1
 
   - do:
+      indices.refresh:
+        index: bbq_flat_nested
+
+  - do:
       search:
         index: bbq_flat_nested
         body:


### PR DESCRIPTION
Similar to #154272, this PR adds an `indices.refresh` call after an `indices.forcemerge` call.

This will fix an issue in serverless:
https://github.com/elastic/elasticsearch-serverless/issues/7310

The root cause was the `42_knn...` file, but I asked Claude to go through other files in the search.vectors directory and fix this pattern as well.
