### PR TITLE
ILM Orphaned Artifact Cleanup Service

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleSettings.java
@@ -52,6 +52,13 @@ public class LifecycleSettings {
         Setting.Property.Dynamic,
         Setting.Property.IndexScope
     );
+    public static final String LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID = "index.lifecycle.force_merge_clone_source_uuid";
+    public static final Setting<String> LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID_SETTING = Setting.simpleString(
+        LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID,
+        Setting.Property.IndexScope,
+        Setting.Property.InternalIndex,
+        Setting.Property.NotCopyableOnResize
+    );
     public static final Setting<Boolean> LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING = Setting.boolSetting(
         LIFECYCLE_HISTORY_INDEX_ENABLED,
         true,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -236,6 +236,10 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
     String[] ignoredIndexSettings() {
         ArrayList<String> ignoredSettings = new ArrayList<>();
         ignoredSettings.add(LifecycleSettings.LIFECYCLE_NAME);
+        // Prevent the force-merge clone marker from propagating to the mounted searchable snapshot index.
+        // A mounted index that carries this marker could otherwise be deleted by IlmForceMergeCloneCleanupService
+        // if the action is interrupted after mounting but before the marker-bearing source is cleaned up.
+        ignoredSettings.add(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID);
         // if we are mounting a searchable snapshot in the hot phase, then we should not change the total_shards_per_node setting
         // if total_shards_per_node setting is specifically set for the frozen phase and not propagated from previous phase,
         // then it should not be ignored

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -89,7 +89,10 @@ public class SearchableSnapshotAction implements LifecycleAction {
         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
         .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, (String) null)
         .build();
-    private static final Function<IndexMetadata, Settings> CLONE_SETTINGS_SUPPLIER = indexMetadata -> CLONE_SETTINGS;
+    private static final Function<IndexMetadata, Settings> CLONE_SETTINGS_SUPPLIER = indexMetadata -> Settings.builder()
+        .put(CLONE_SETTINGS)
+        .put(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID, indexMetadata.getIndexUUID())
+        .build();
 
     private static final ConstructingObjectParser<SearchableSnapshotAction, Void> PARSER = new ConstructingObjectParser<>(
         NAME,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -205,7 +205,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 indexName,
                 RESTORED_INDEX_PREFIX,
                 indexName,
-                new String[] { LifecycleSettings.LIFECYCLE_NAME },
+                new String[] { LifecycleSettings.LIFECYCLE_NAME, LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID },
                 null,
                 0
             );
@@ -332,7 +332,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 indexName,
                 RESTORED_INDEX_PREFIX,
                 indexNameSnippet,
-                new String[] { LifecycleSettings.LIFECYCLE_NAME },
+                new String[] { LifecycleSettings.LIFECYCLE_NAME, LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID },
                 null,
                 0
             );
@@ -377,6 +377,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 indexName,
                 new String[] {
                     LifecycleSettings.LIFECYCLE_NAME,
+                    LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID,
                     ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey() },
                 null,
                 0
@@ -420,7 +421,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 indexName,
                 RESTORED_INDEX_PREFIX,
                 indexName,
-                new String[] { LifecycleSettings.LIFECYCLE_NAME },
+                new String[] { LifecycleSettings.LIFECYCLE_NAME, LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID },
                 null,
                 0
             );
@@ -466,7 +467,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 indexName,
                 RESTORED_INDEX_PREFIX,
                 indexName,
-                new String[] { LifecycleSettings.LIFECYCLE_NAME },
+                new String[] { LifecycleSettings.LIFECYCLE_NAME, LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID },
                 totalShardsPerNode,
                 replicas
             );
@@ -512,7 +513,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 indexName,
                 RESTORED_INDEX_PREFIX,
                 indexName,
-                new String[] { LifecycleSettings.LIFECYCLE_NAME },
+                new String[] { LifecycleSettings.LIFECYCLE_NAME, LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID },
                 totalShardsPerNode,
                 replicas
             );
@@ -526,6 +527,26 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 replicas
             );
             performActionAndWait(step, indexMetadata, state, null);
+        }
+    }
+
+    public void testIgnoredIndexSettingsAlwaysContainsForceMergeCloneSourceUuid() {
+        // Verify the marker is always excluded so a mounted index never inherits it.
+        for (String phase : List.of(TimeseriesLifecycleType.FROZEN_PHASE, TimeseriesLifecycleType.COLD_PHASE, "hot")) {
+            MountSnapshotStep step = new MountSnapshotStep(
+                new StepKey(phase, randomAlphaOfLength(5), randomAlphaOfLength(5)),
+                randomStepKey(),
+                null,
+                RESTORED_INDEX_PREFIX,
+                randomStorageType(),
+                null,
+                0
+            );
+            assertThat(
+                "ignoredIndexSettings for phase [" + phase + "] must exclude the force-merge clone marker",
+                List.of(step.ignoredIndexSettings()),
+                org.hamcrest.Matchers.hasItem(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID)
+            );
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -73,7 +73,8 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
     }
 
     /**
-     * Validate that the {@link ResizeIndexStep} used to clone the index for force merging configures the target index with 0 replicas.
+     * Validate that the {@link ResizeIndexStep} used to clone the index for force merging configures the target index with 0 replicas
+     * and stamps {@link LifecycleSettings#LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID} with the source index's UUID.
      */
     private void validateForceMergeClone(boolean isForceMergeIndex, Boolean isForceMergeOnClone, List<Step> steps) {
         if (isForceMergeIndex == false || (isForceMergeOnClone != null && isForceMergeOnClone == false)) {
@@ -89,6 +90,7 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
             .build();
         Settings cloneIndexSettings = cloneStep.getTargetIndexSettingsSupplier().apply(indexMetadata);
         assertThat(cloneIndexSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, -1), is(0));
+        assertThat(cloneIndexSettings.get(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID), is(indexMetadata.getIndexUUID()));
     }
 
     public void testPrefixAndStorageTypeDefaults() {

--- a/x-pack/plugin/ilm/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -155,6 +155,41 @@ public class SearchableSnapshotActionIT extends IlmESRestTestCase {
     }
 
     /**
+     * Verifies that {@link org.elasticsearch.xpack.ilm.IlmForceMergeCloneCleanupService} reclaims a force-merge clone that has
+     * become orphaned because its ILM policy was removed mid-action. We pause ILM on the clone step (by disabling allocation so
+     * the clone cannot go green), remove the policy to orphan the marker-bearing clone, and then assert the periodic cleanup
+     * service deletes it. Without the policy, ILM itself would never run {@code CleanupGeneratedIndexStep} for this clone again.
+     */
+    public void testOrphanedForceMergeCloneIsCleanedUp() throws Exception {
+        final int numberOfPrimaries = randomIntBetween(1, 3);
+        // The test suite runs with 4 nodes, so we can have up to 3 (allocated) replicas.
+        final int numberOfReplicas = randomIntBetween(1, 3);
+        final String phase = randomBoolean() ? "cold" : "frozen";
+        final String backingIndexName = prepareDataStreamWithDocs(phase, numberOfPrimaries, numberOfReplicas);
+
+        // Run the cleanup sweep aggressively so the test does not wait out the default one-day interval.
+        updateClusterSettings(Settings.builder().put("indices.lifecycle.force_merge_clone_cleanup.poll_interval", "1s").build());
+        try {
+            // Pause ILM on the clone step: the clone is created (carrying the marker) but its shards cannot allocate.
+            configureClusterAllocation(false);
+            updateIndexSettings(dataStream, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
+
+            // The clone exists and is stamped with the source index's UUID.
+            assertForceMergeCloneIndexSettings(backingIndexName, numberOfPrimaries);
+
+            // Removing the policy clears the source's execution state, orphaning the clone.
+            assertOK(client().performRequest(new Request("POST", "/" + backingIndexName + "/_ilm/remove")));
+
+            // The periodic cleanup service must delete the orphaned, marker-bearing clone.
+            awaitIndexDoesNotExist(FORCE_MERGE_CLONE_INDEX_PREFIX + "*" + backingIndexName, TimeValue.timeValueSeconds(30));
+        } finally {
+            // Re-enable allocation and restore the default interval so the remaining tests in the suite are not affected.
+            configureClusterAllocation(true);
+            updateClusterSettings(Settings.builder().putNull("indices.lifecycle.force_merge_clone_cleanup.poll_interval").build());
+        }
+    }
+
+    /**
      * Test that when we have a searchable snapshot action with force merge enabled and the source index has _zero_ replicas,
      * we perform the force merge on the _source_ index and snapshot the source index.
      */
@@ -1115,7 +1150,23 @@ public class SearchableSnapshotActionIT extends IlmESRestTestCase {
             final Map<String, Object> forceMergeIndexSettings = (Map<String, Object>) forceMergeIndexResponse.get("settings");
             assertThat(forceMergeIndexSettings.get("index.number_of_shards"), equalTo(String.valueOf(numberOfPrimaries)));
             assertThat(forceMergeIndexSettings.get("index.number_of_replicas"), equalTo("0"));
+            // The clone must be stamped with the source index's UUID so IlmForceMergeCloneCleanupService can prove its provenance.
+            assertThat(
+                forceMergeIndexSettings.get(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID),
+                equalTo(getIndexUUID(backingIndexName))
+            );
         });
+    }
+
+    private static String getIndexUUID(String indexName) throws Exception {
+        Request request = new Request("GET", "/" + indexName + "/_settings/index.uuid?flat_settings=true");
+        Response response = client().performRequest(request);
+        final Map<String, Object> indicesSettings = entityAsMap(response);
+        @SuppressWarnings("unchecked")
+        final var indexResponse = (Map<String, Object>) indicesSettings.get(indexName);
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> indexSettings = (Map<String, Object>) indexResponse.get("settings");
+        return (String) indexSettings.get("index.uuid");
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmForceMergeCloneCleanupService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmForceMergeCloneCleanupService.java
@@ -227,9 +227,11 @@ public class IlmForceMergeCloneCleanupService implements ClusterStateListener, C
             }
         } catch (Exception e) {
             logger.warn(
-                "ILM force-merge clone cleanup failed to delete orphaned indices [{}] in project [{}]",
-                indexNames,
-                project.id(),
+                () -> Strings.format(
+                    "ILM force-merge clone cleanup failed to delete orphaned indices [%s] in project [%s]",
+                    indexNames,
+                    project.id()
+                ),
                 e
             );
             if (e instanceof InterruptedException || ExceptionsHelper.unwrapCause(e) instanceof InterruptedException) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmForceMergeCloneCleanupService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmForceMergeCloneCleanupService.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ilm;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ilm.LifecycleOperationMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.OperationMode;
+import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Master-node service that periodically scans for orphaned ILM force-merge clone indices
+ * ({@code fm-clone-*}) and deletes them. A clone becomes an orphan when the ILM policy is
+ * removed and re-added mid-action, resetting the {@code LifecycleExecutionState} and losing
+ * the pointer to the clone.
+ *
+ * <p>Only indices stamped with {@link LifecycleSettings#LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID}
+ * are eligible for deletion, so only provably ILM-created clones are reclaimed. Clones created
+ * before this setting was introduced are left in place.
+ *
+ * <p>{@link #init()} must be called after construction to register this service as a
+ * {@link ClusterStateListener}; calling it from the constructor would publish a self-reference
+ * before the object is fully constructed.
+ */
+public class IlmForceMergeCloneCleanupService implements ClusterStateListener, Closeable {
+
+    private static final Logger logger = LogManager.getLogger(IlmForceMergeCloneCleanupService.class);
+
+    /**
+     * How often the service scans for and deletes orphaned force-merge clone indices. The floor
+     * is deliberately low (1 s) so integration tests can set a short interval without using
+     * internal APIs.
+     */
+    public static final Setting<TimeValue> POLL_INTERVAL_SETTING = Setting.timeSetting(
+        "indices.lifecycle.force_merge_clone_cleanup.poll_interval",
+        TimeValue.timeValueDays(1),
+        TimeValue.timeValueSeconds(1),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private static final IndicesOptions IGNORE_MISSING_OPTIONS = IndicesOptions.fromOptions(true, true, false, false);
+
+    private final ClusterService clusterService;
+    private final Client client;
+    private final long initialDelayMillis;
+    private final AtomicBoolean isMaster = new AtomicBoolean(false);
+    private final AtomicBoolean closing = new AtomicBoolean(false);
+    private volatile TimeValue pollInterval;
+    private ScheduledExecutorService schedulerThreadExecutor;
+
+    public IlmForceMergeCloneCleanupService(ClusterService clusterService, Client client) {
+        this.clusterService = clusterService;
+        this.client = client;
+        this.initialDelayMillis = Math.min(
+            TimeValue.timeValueMinutes(5).millis(),
+            POLL_INTERVAL_SETTING.get(clusterService.getSettings()).millis()
+        );
+        this.pollInterval = POLL_INTERVAL_SETTING.get(clusterService.getSettings());
+    }
+
+    // visible for testing
+    IlmForceMergeCloneCleanupService(ClusterService clusterService, Client client, long initialDelayMillis) {
+        this.clusterService = clusterService;
+        this.client = client;
+        this.initialDelayMillis = initialDelayMillis;
+        this.pollInterval = POLL_INTERVAL_SETTING.get(clusterService.getSettings());
+    }
+
+    /**
+     * Registers this service as a {@link ClusterStateListener} so that master election events trigger
+     * thread pool lifecycle. Must be called after construction to avoid publishing a self-reference
+     * from the constructor.
+     */
+    public void init() {
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(POLL_INTERVAL_SETTING, this::updatePollInterval);
+        clusterService.addListener(this);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (closing.get() || event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
+        boolean isNodeMaster = event.localNodeMaster();
+        if (isMaster.getAndSet(isNodeMaster) != isNodeMaster) {
+            if (isNodeMaster) {
+                startScheduler(initialDelayMillis);
+            } else {
+                stopScheduler();
+            }
+        }
+    }
+
+    private synchronized void startScheduler(long initialDelay) {
+        try {
+            if (closing.get() == false) {
+                assert schedulerThreadExecutor == null : "previous executor existed but it should not";
+                schedulerThreadExecutor = Executors.newSingleThreadScheduledExecutor(
+                    EsExecutors.daemonThreadFactory(clusterService.getSettings(), "ilm-fm-clone-cleanup")
+                );
+                schedulerThreadExecutor.scheduleWithFixedDelay(
+                    this::runWithErrorLogging,
+                    initialDelay,
+                    pollInterval.millis(),
+                    TimeUnit.MILLISECONDS
+                );
+            }
+        } catch (Exception e) {
+            logger.error("Unexpected exception while starting ILM force-merge clone cleanup scheduler", e);
+            stopScheduler();
+        }
+    }
+
+    private synchronized void stopScheduler() {
+        if (schedulerThreadExecutor != null) {
+            schedulerThreadExecutor.shutdownNow();
+            schedulerThreadExecutor = null;
+        }
+    }
+
+    private synchronized void updatePollInterval(TimeValue newInterval) {
+        this.pollInterval = newInterval;
+        if (schedulerThreadExecutor != null) {
+            // Restart with no initial delay so an operator lowering the interval to force a prompt sweep
+            // is not made to wait out the original (up to 5-minute) startup delay.
+            stopScheduler();
+            startScheduler(0L);
+        }
+    }
+
+    private void runWithErrorLogging() {
+        try {
+            cleanUpOrphanedForceMergeClones();
+        } catch (Exception e) {
+            logger.error("Unexpected exception in ILM force-merge clone cleanup task", e);
+        }
+    }
+
+    // visible for testing
+    void cleanUpOrphanedForceMergeClones() {
+        for (ProjectMetadata project : clusterService.state().metadata().projects().values()) {
+            if (Thread.currentThread().isInterrupted() || closing.get()) {
+                return;
+            }
+            if (LifecycleOperationMetadata.currentILMMode(project) != OperationMode.RUNNING) {
+                continue;
+            }
+            List<String> orphans = findOrphanedClones(project);
+            if (orphans.isEmpty() == false) {
+                deleteIndices(orphans, project);
+            }
+        }
+    }
+
+    // visible for testing
+    static List<String> findOrphanedClones(ProjectMetadata project) {
+        Set<String> referencedCloneNames = project.indices()
+            .values()
+            .stream()
+            .map(imd -> imd.getLifecycleExecutionState().forceMergeCloneIndexName())
+            .filter(Objects::nonNull)
+            .collect(Collectors.toUnmodifiableSet());
+
+        return project.indices()
+            .values()
+            .stream()
+            .filter(imd -> Strings.hasText(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID_SETTING.get(imd.getSettings())))
+            .filter(imd -> imd.isSearchableSnapshot() == false)
+            .filter(imd -> imd.getIndex().getName().startsWith(SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX))
+            .map(imd -> imd.getIndex().getName())
+            .filter(name -> referencedCloneNames.contains(name) == false)
+            .toList();
+    }
+
+    private void deleteIndices(List<String> orphans, ProjectMetadata project) {
+        DeleteIndexRequest request = new DeleteIndexRequest(orphans.toArray(String[]::new)).indicesOptions(IGNORE_MISSING_OPTIONS)
+            .masterNodeTimeout(TimeValue.MAX_VALUE);
+        String indexNames = String.join(",", orphans);
+        logger.debug("ILM force-merge clone cleanup issuing request to delete orphaned indices [{}]", indexNames);
+        try {
+            AcknowledgedResponse response = client.projectClient(project.id()).admin().indices().delete(request).get();
+            if (response.isAcknowledged()) {
+                logger.info(
+                    "ILM force-merge clone cleanup successfully deleted orphaned force-merge clone indices [{}] in project [{}]: "
+                        + "they carry [{}] but are not referenced by any lifecycle execution state",
+                    indexNames,
+                    project.id(),
+                    LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID
+                );
+            } else {
+                logger.warn(
+                    "ILM force-merge clone cleanup failed to acknowledge deletion of orphaned indices [{}] in project [{}]",
+                    indexNames,
+                    project.id()
+                );
+            }
+        } catch (Exception e) {
+            logger.warn(
+                "ILM force-merge clone cleanup failed to delete orphaned indices [{}] in project [{}]",
+                indexNames,
+                project.id(),
+                e
+            );
+            if (e instanceof InterruptedException || ExceptionsHelper.unwrapCause(e) instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closing.compareAndSet(false, true)) {
+            clusterService.removeListener(this);
+            if (schedulerThreadExecutor != null) {
+                ThreadPool.terminate(schedulerThreadExecutor, 10, TimeUnit.SECONDS);
+                schedulerThreadExecutor = null;
+            }
+        }
+    }
+
+    // visible for testing
+    synchronized boolean isSchedulerRunning() {
+        return schedulerThreadExecutor != null && schedulerThreadExecutor.isShutdown() == false;
+    }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -99,6 +99,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
     private final SetOnce<IndexLifecycleService> indexLifecycleInitialisationService = new SetOnce<>();
     private final SetOnce<ILMHistoryStore> ilmHistoryStore = new SetOnce<>();
     private final SetOnce<IlmHealthIndicatorService> ilmHealthIndicatorService = new SetOnce<>();
+    private final SetOnce<IlmForceMergeCloneCleanupService> forceMergeCloneCleanupService = new SetOnce<>();
     private final SetOnce<ReservedLifecycleAction> reservedLifecycleAction = new SetOnce<>();
     private final SetOnce<TimeSeriesEligibleWriteWindowLocatorWithIlm> timeSeriesEligibleWriteWindowLocator = new SetOnce<>();
     private final Settings settings;
@@ -126,7 +127,9 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
             RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING,
             IlmHealthIndicatorService.MAX_TIME_ON_ACTION_SETTING,
             IlmHealthIndicatorService.MAX_TIME_ON_STEP_SETTING,
-            IlmHealthIndicatorService.MAX_RETRIES_PER_STEP_SETTING
+            IlmHealthIndicatorService.MAX_RETRIES_PER_STEP_SETTING,
+            IlmForceMergeCloneCleanupService.POLL_INTERVAL_SETTING,
+            LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID_SETTING
         );
     }
 
@@ -200,6 +203,13 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
         );
         timeSeriesEligibleWriteWindowLocator.set(new TimeSeriesEligibleWriteWindowLocatorWithIlm());
         components.add(timeSeriesEligibleWriteWindowLocator.get());
+
+        var cleanupService = new IlmForceMergeCloneCleanupService(
+            services.clusterService(),
+            new OriginSettingClient(services.client(), INDEX_LIFECYCLE_ORIGIN)
+        );
+        cleanupService.init();
+        forceMergeCloneCleanupService.set(cleanupService);
 
         return components;
     }
@@ -312,7 +322,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
     @Override
     public void close() {
         try {
-            IOUtils.close(indexLifecycleInitialisationService.get(), ilmHistoryStore.get());
+            IOUtils.close(indexLifecycleInitialisationService.get(), ilmHistoryStore.get(), forceMergeCloneCleanupService.get());
         } catch (IOException e) {
             throw new ElasticsearchException("unable to close index lifecycle services", e);
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IlmForceMergeCloneCleanupServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IlmForceMergeCloneCleanupServiceTests.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ilm;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ilm.LifecycleOperationMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.OperationMode;
+import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import static org.elasticsearch.test.ClusterServiceUtils.setState;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+public class IlmForceMergeCloneCleanupServiceTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    private ClusterService clusterService;
+    private ProjectId projectId;
+
+    private CopyOnWriteArrayList<DeleteIndexRequest> capturedDeleteIndexRequests;
+    private AtomicReference<AcknowledgedResponse> mockDeleteIndexResponse;
+    private AtomicReference<Exception> mockDeleteIndexFailure;
+
+    @Before
+    public void setup() {
+        threadPool = new TestThreadPool(getTestName());
+        Set<Setting<?>> allSettings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        allSettings.add(IlmForceMergeCloneCleanupService.POLL_INTERVAL_SETTING);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, allSettings);
+        clusterService = createClusterService(threadPool, clusterSettings);
+        projectId = randomProjectIdOrDefault();
+
+        capturedDeleteIndexRequests = new CopyOnWriteArrayList<>();
+        mockDeleteIndexResponse = new AtomicReference<>(AcknowledgedResponse.of(true));
+        mockDeleteIndexFailure = new AtomicReference<>();
+    }
+
+    @After
+    public void cleanup() {
+        clusterService.close();
+        terminate(threadPool);
+    }
+
+    private NoOpClient createCapturingTestClient() {
+        return new NoOpClient(threadPool, TestProjectResolvers.usingRequestHeader(threadPool.getThreadContext())) {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> action,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                if (request instanceof DeleteIndexRequest req) {
+                    capturedDeleteIndexRequests.add(req);
+                    if (mockDeleteIndexFailure.get() != null) {
+                        listener.onFailure(mockDeleteIndexFailure.get());
+                    } else if (mockDeleteIndexResponse.get() != null) {
+                        listener.onResponse((Response) mockDeleteIndexResponse.get());
+                    }
+                } else {
+                    fail("Unexpected request type: " + request.getClass());
+                }
+            }
+        };
+    }
+
+    private IlmForceMergeCloneCleanupService createService() {
+        return new IlmForceMergeCloneCleanupService(clusterService, createCapturingTestClient(), TimeValue.timeValueDays(1).millis());
+    }
+
+    /**
+     * Builds an fm-clone index bearing the ILM marker pointing at {@code sourceUuid}.
+     */
+    private IndexMetadata createMarkedFmClone(String name, String sourceUuid) {
+        return IndexMetadata.builder(name)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID, sourceUuid).build())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+    }
+
+    /** Builds a source index (no marker). */
+    private IndexMetadata createSourceIndex(String name) {
+        return IndexMetadata.builder(name).settings(settings(IndexVersion.current())).numberOfShards(1).numberOfReplicas(0).build();
+    }
+
+    /** Builds a source index whose execution state tracks the given clone name. */
+    private IndexMetadata createSourceIndexWithTrackedClone(String name, String cloneName) {
+        LifecycleExecutionState state = LifecycleExecutionState.builder().setForceMergeCloneIndexName(cloneName).build();
+        return IndexMetadata.builder(name)
+            .settings(settings(IndexVersion.current()))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, state.asMap())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+    }
+
+    /** Builds a searchable-snapshot-backed index that also carries the marker (backstop scenario). */
+    private IndexMetadata createSearchableSnapshotWithMarker(String name, String sourceUuid) {
+        return IndexMetadata.builder(name)
+            .settings(
+                settings(IndexVersion.current()).put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), "snapshot")
+                    .put(LifecycleSettings.LIFECYCLE_FORCE_MERGE_CLONE_SOURCE_UUID, sourceUuid)
+                    .build()
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+    }
+
+    private void setClusterState(List<IndexMetadata> indices) {
+        setClusterState(indices, OperationMode.RUNNING);
+    }
+
+    private void setClusterState(List<IndexMetadata> indices, OperationMode ilmMode) {
+        ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(projectId);
+        for (IndexMetadata idx : indices) {
+            projectBuilder.put(idx, false);
+        }
+        if (ilmMode != OperationMode.RUNNING) {
+            projectBuilder.putCustom(LifecycleOperationMetadata.TYPE, new LifecycleOperationMetadata(ilmMode, OperationMode.RUNNING));
+        }
+        Metadata metadata = Metadata.builder().put(projectBuilder).build();
+        setState(clusterService, ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build());
+    }
+
+    /** Publishes a state where the local node is master and the given indices are present. */
+    private void becomeMasterWithIndices(List<IndexMetadata> indices) {
+        ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(projectId);
+        for (IndexMetadata idx : indices) {
+            projectBuilder.put(idx, false);
+        }
+        Metadata metadata = Metadata.builder().put(projectBuilder).build();
+        // Build a fresh state (no routing table) so the metadata's single project stays consistent, but carry over the
+        // discovery nodes from the current state and elect the local node as master to trigger the scheduler.
+        DiscoveryNodes nodes = clusterService.state().nodes();
+        setState(
+            clusterService,
+            ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).nodes(nodes.withMasterNodeId(nodes.getLocalNodeId())).build()
+        );
+    }
+
+    // ── core orphan-predicate tests ───────────────────────────────────────────
+
+    public void testOrphanedClone_deleted() {
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata orphan = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source",
+            source.getIndexUUID()
+        );
+        setClusterState(List.of(source, orphan));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests.size(), is(1));
+        assertThat(List.of(capturedDeleteIndexRequests.get(0).indices()), containsInAnyOrder(orphan.getIndex().getName()));
+    }
+
+    public void testMultipleOrphanedClones_allDeleted() {
+        IndexMetadata source = createSourceIndex("my-source");
+        String uuid = source.getIndexUUID();
+        IndexMetadata orphan1 = createMarkedFmClone(SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "aaa-my-source", uuid);
+        IndexMetadata orphan2 = createMarkedFmClone(SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "bbb-my-source", uuid);
+        setClusterState(List.of(source, orphan1, orphan2));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests.size(), is(1));
+        assertThat(
+            List.of(capturedDeleteIndexRequests.get(0).indices()),
+            containsInAnyOrder(orphan1.getIndex().getName(), orphan2.getIndex().getName())
+        );
+    }
+
+    public void testCloneTrackedBySourceIndex_notDeleted() {
+        String cloneName = SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source";
+        IndexMetadata source = createSourceIndexWithTrackedClone("my-source", cloneName);
+        IndexMetadata clone = createMarkedFmClone(cloneName, source.getIndexUUID());
+        setClusterState(List.of(source, clone));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    public void testCloneTrackedByRestoredIndex_notDeleted() {
+        // CopyExecutionStateStep copies the full execution state, including the clone pointer, onto the restored index.
+        String cloneName = SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source";
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata clone = createMarkedFmClone(cloneName, source.getIndexUUID());
+        // The restored index tracks the clone name in its execution state (copied by CopyExecutionStateStep)
+        LifecycleExecutionState restoredState = LifecycleExecutionState.builder().setForceMergeCloneIndexName(cloneName).build();
+        IndexMetadata restored = IndexMetadata.builder("restored-my-source")
+            .settings(settings(IndexVersion.current()))
+            .putCustom(ILM_CUSTOM_METADATA_KEY, restoredState.asMap())
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        setClusterState(List.of(source, clone, restored));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    public void testUnmarkedFmClone_notDeleted() {
+        // A legacy clone (created before this change) has no marker and must not be deleted.
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata unmarked = IndexMetadata.builder(SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        setClusterState(List.of(source, unmarked));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    public void testMarkerWithAnyUuid_deleted() {
+        // The UUID in the marker proves ILM provenance; it need not match any existing source index.
+        // A clone whose source was deleted (or recreated with a new UUID) is still an orphan.
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata orphan = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source",
+            randomAlphaOfLength(22)
+        );
+        setClusterState(List.of(source, orphan));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests.size(), is(1));
+        assertThat(List.of(capturedDeleteIndexRequests.get(0).indices()), containsInAnyOrder(orphan.getIndex().getName()));
+    }
+
+    public void testSearchableSnapshotWithMarker_notDeleted() {
+        // A mounted index that somehow inherited the marker (e.g. snapshot taken before MountSnapshotStep strips it).
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata mounted = createSearchableSnapshotWithMarker("restored-my-source", source.getIndexUUID());
+        setClusterState(List.of(source, mounted));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    public void testIlmStopped_nothingDeleted() {
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata orphan = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source",
+            source.getIndexUUID()
+        );
+        setClusterState(List.of(source, orphan), OperationMode.STOPPED);
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    public void testIlmStopping_nothingDeleted() {
+        // ILM transitions through STOPPING before STOPPED while in-flight steps drain; the service must
+        // stay quiet during that window too.
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata orphan = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source",
+            source.getIndexUUID()
+        );
+        setClusterState(List.of(source, orphan), OperationMode.STOPPING);
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    public void testDeleteFailure_doesNotPropagate() {
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata orphan = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source",
+            source.getIndexUUID()
+        );
+        setClusterState(List.of(source, orphan));
+        mockDeleteIndexFailure.set(new RuntimeException("simulated delete failure"));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            // Must complete without throwing
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests.size(), is(1));
+    }
+
+    // ── multi-project test ────────────────────────────────────────────────────
+
+    public void testMultipleProjects_eachProjectCleaned() {
+        ProjectId projectId2 = randomValueOtherThan(projectId, ESTestCase::randomProjectIdOrDefault);
+
+        IndexMetadata source1 = createSourceIndex("source-1");
+        IndexMetadata orphan1 = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "aaa-source-1",
+            source1.getIndexUUID()
+        );
+
+        IndexMetadata source2 = createSourceIndex("source-2");
+        IndexMetadata orphan2 = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "bbb-source-2",
+            source2.getIndexUUID()
+        );
+
+        ProjectMetadata.Builder project1Builder = ProjectMetadata.builder(projectId).put(source1, false).put(orphan1, false);
+        ProjectMetadata.Builder project2Builder = ProjectMetadata.builder(projectId2).put(source2, false).put(orphan2, false);
+        Metadata metadata = Metadata.builder().put(project1Builder).put(project2Builder).build();
+        setState(clusterService, ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build());
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests.size(), is(2));
+        List<String> allDeletedIndices = capturedDeleteIndexRequests.stream().flatMap(req -> Arrays.stream(req.indices())).toList();
+        assertThat(allDeletedIndices, containsInAnyOrder(orphan1.getIndex().getName(), orphan2.getIndex().getName()));
+    }
+
+    public void testMarkedNonClonePrefix_notDeleted() {
+        // A marked, non-searchable-snapshot index whose name lacks the fm-clone- prefix must be
+        // excluded by the prefix filter, independent of the searchable-snapshot filter.
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata marked = createMarkedFmClone("regular-index", source.getIndexUUID());
+        setClusterState(List.of(source, marked));
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.cleanUpOrphanedForceMergeClones();
+        }
+
+        assertThat(capturedDeleteIndexRequests, empty());
+    }
+
+    // ── scheduler lifecycle tests ─────────────────────────────────────────────
+
+    public void testSchedulerStartsOnMasterGainedAndStopsOnMasterLost() throws Exception {
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.init();
+            assertThat(service.isSchedulerRunning(), is(false));
+
+            // simulate becoming master
+            setState(
+                clusterService,
+                ClusterState.builder(clusterService.state())
+                    .nodes(clusterService.state().nodes().withMasterNodeId(clusterService.localNode().getId()))
+                    .build()
+            );
+            assertBusy(() -> assertThat(service.isSchedulerRunning(), is(true)));
+
+            // simulate losing mastership
+            setState(
+                clusterService,
+                ClusterState.builder(clusterService.state()).nodes(clusterService.state().nodes().withMasterNodeId(null)).build()
+            );
+            assertBusy(() -> assertThat(service.isSchedulerRunning(), is(false)));
+        }
+    }
+
+    public void testClose_terminatesScheduler() throws Exception {
+        IlmForceMergeCloneCleanupService service = createService();
+        try {
+            service.init();
+            // Force master state so the scheduler starts
+            setState(
+                clusterService,
+                ClusterState.builder(clusterService.state())
+                    .nodes(clusterService.state().nodes().withMasterNodeId(clusterService.localNode().getId()))
+                    .build()
+            );
+            assertBusy(() -> assertThat(service.isSchedulerRunning(), is(true)));
+
+            service.close();
+            assertThat(service.isSchedulerRunning(), is(false));
+        } finally {
+            // close() is idempotent; ensures the scheduler thread never leaks if an assertion above fails.
+            service.close();
+        }
+    }
+
+    public void testSchedulerDoesNotStartWhileStateNotRecovered() throws Exception {
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.init();
+
+            // Master elected but the cluster state has not recovered yet: the scheduler must stay down.
+            setState(
+                clusterService,
+                ClusterState.builder(clusterService.state())
+                    .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK))
+                    .nodes(clusterService.state().nodes().withMasterNodeId(clusterService.localNode().getId()))
+                    .build()
+            );
+            assertThat(service.isSchedulerRunning(), is(false));
+
+            // Once the recovery block clears, the scheduler starts.
+            setState(clusterService, ClusterState.builder(clusterService.state()).blocks(ClusterBlocks.builder().build()).build());
+            assertBusy(() -> assertThat(service.isSchedulerRunning(), is(true)));
+        }
+    }
+
+    public void testDynamicPollIntervalUpdateReschedulesAndRunsPromptly() throws Exception {
+        IndexMetadata source = createSourceIndex("my-source");
+        IndexMetadata orphan = createMarkedFmClone(
+            SearchableSnapshotAction.FORCE_MERGE_CLONE_INDEX_PREFIX + "abc-my-source",
+            source.getIndexUUID()
+        );
+
+        try (IlmForceMergeCloneCleanupService service = createService()) {
+            service.init();
+            // Scheduler starts on master election but with a 1-day initial delay, so no sweep fires yet.
+            becomeMasterWithIndices(List.of(source, orphan));
+            assertBusy(() -> assertThat(service.isSchedulerRunning(), is(true)));
+            assertThat(capturedDeleteIndexRequests, empty());
+
+            // Lowering the interval dynamically restarts the scheduler with a zero initial delay, so the
+            // pending orphan is swept promptly rather than after the original delay.
+            clusterService.getClusterSettings()
+                .applySettings(Settings.builder().put(IlmForceMergeCloneCleanupService.POLL_INTERVAL_SETTING.getKey(), "1s").build());
+
+            // The mock client does not mutate cluster state, so the 1s scheduler keeps sweeping; assert at
+            // least one prompt sweep happened rather than an exact count.
+            assertBusy(() -> assertThat(capturedDeleteIndexRequests.size(), greaterThanOrEqualTo(1)));
+            assertThat(List.of(capturedDeleteIndexRequests.get(0).indices()), containsInAnyOrder(orphan.getIndex().getName()));
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a periodic (Default 24 hours) service that detects and cleans up orphaned ILM fm-clone indices caused by interruptions to ILM during transition to the frozen tier.

It introduces a new hidden index setting that marks ILM created fm-clone indices along with their source to ensure that we only remove genuine orphaned resources and nothing user created.

It runs on the master in it's own thread following the pattern established by the sister DLM orphaned cleanup service.