### PR TITLE
[8.19] Tighten up `Expect: 100-continue` handling

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -14,9 +14,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -31,6 +33,8 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -72,6 +76,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingDeque;
@@ -83,9 +88,12 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -317,25 +325,60 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         }
     }
 
-    // ensures that server reply 413-too-large on oversized request with expect-100-continue
+    // ensures that server reply 413-too-large on oversized request with expect-100-continue, and closes the connection
     public void test413TooLargeOnExpect100Continue() throws Exception {
         try (var ctx = setupClientCtx()) {
-            for (int reqNo = 0; reqNo < randomIntBetween(2, 10); reqNo++) {
-                var id = opaqueId(reqNo);
-                var oversized = MAX_CONTENT_LENGTH + 1;
+            final var request = httpRequest(opaqueId(0), MAX_CONTENT_LENGTH + 1);
+            HttpUtil.set100ContinueExpected(request, true);
 
-                // send request header and await 413 too large
-                var req = httpRequest(id, oversized);
-                HttpUtil.set100ContinueExpected(req, true);
-                ctx.clientChannel.writeAndFlush(req);
-                var resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
-                assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, resp.status());
-                resp.release();
+            var channel = ctx.clientChannel;
+            channel.writeAndFlush(request);
 
-                // terminate request
-                ctx.clientChannel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
-            }
+            final var response = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+            assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
+            assertEquals(CLOSE.toString(), response.headers().get(CONNECTION));
+            response.release();
+
+            safeAwait(l -> Netty4Utils.addListener(channel.closeFuture(), ignored -> l.onResponse(null)));
+            assertFalse("client connection must be closed", channel.isActive());
+            assertFalse("client connection must be closed", channel.isOpen());
         }
+    }
+
+    // ensures that requests after a 413-too-large reply are dropped
+    public void test413TooLargeOnExpect100ContinueWithSmuggledRequest() throws Exception {
+        try (
+            var ctx = setupClientCtx(
+                new HttpResponseDecoder() // manually encoding the requests because HttpClientCodec doesn't permit smuggling
+            )
+        ) {
+            final var request = httpRequest(opaqueId(0), MAX_CONTENT_LENGTH + 1);
+            HttpUtil.set100ContinueExpected(request, true);
+            final var followUpRequest = httpRequest(opaqueId(1), 0);
+
+            var channel = ctx.clientChannel;
+            var host = ((InetSocketAddress) channel.remoteAddress()).getHostString();
+
+            var out = Unpooled.compositeBuffer();
+            for (var httpRequest : List.of(request, followUpRequest)) {
+                var encoder = new EmbeddedChannel(new HttpRequestEncoder());
+                httpRequest.headers().set(HOST, host);
+                encoder.writeOutbound(httpRequest);
+                while (encoder.outboundMessages().isEmpty() == false) {
+                    out.addComponent(true, encoder.readOutbound());
+                }
+            }
+            channel.writeAndFlush(out);
+
+            final var response = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+            assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
+            assertEquals(CLOSE.toString(), response.headers().get(CONNECTION));
+            response.release();
+
+            safeAwait(l -> Netty4Utils.addListener(channel.closeFuture(), ignored -> l.onResponse(null)));
+            assertFalse("client connection must be closed", channel.isActive());
+            assertFalse("client connection must be closed", channel.isOpen());
+        } // close ensures no more responses available
     }
 
     // ensures that oversized chunked encoded request has maxContentLength limit and returns 413
@@ -539,14 +582,22 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
     }
 
     Ctx setupClientCtx() throws Exception {
+        return setupClientCtx(new HttpClientCodec());
+    }
+
+    Ctx setupClientCtx(ChannelHandler httpInboundCodec) throws Exception {
         var nodeName = internalCluster().getRandomNodeName();
         var clientRespQueue = new LinkedBlockingDeque<>(16);
-        var bootstrap = bootstrapClient(nodeName, clientRespQueue);
+        var bootstrap = bootstrapClient(nodeName, clientRespQueue, httpInboundCodec);
         var channel = bootstrap.connect().sync().channel();
         return new Ctx(getTestName(), nodeName, bootstrap, channel, clientRespQueue);
     }
 
     Bootstrap bootstrapClient(String node, BlockingQueue<Object> queue) {
+        return bootstrapClient(node, queue, new HttpClientCodec());
+    }
+
+    Bootstrap bootstrapClient(String node, BlockingQueue<Object> queue, ChannelHandler httpInboundCodec) {
         var httpServer = internalCluster().getInstance(HttpServerTransport.class, node);
         var remoteAddr = randomFrom(httpServer.boundAddress().boundAddresses());
         return new Bootstrap().group(new NioEventLoopGroup(1))
@@ -556,7 +607,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
                 @Override
                 protected void initChannel(SocketChannel ch) {
                     var p = ch.pipeline();
-                    p.addLast(new HttpClientCodec());
+                    p.addLast(httpInboundCodec);
                     p.addLast(new HttpObjectAggregator(4096));
                     p.addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
                         @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -36,7 +36,7 @@ public class Netty4HttpAggregator extends HttpObjectAggregator {
     public Netty4HttpAggregator(int maxContentLength, Predicate<HttpPreRequest> decider, HttpRequestDecoder decoder) {
         super(maxContentLength);
         this.decider = decider;
-        this.streamContentSizeHandler = new Netty4HttpContentSizeHandler(decoder, maxContentLength);
+        this.streamContentSizeHandler = new Netty4HttpContentSizeHandler(maxContentLength);
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpContentSizeHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpContentSizeHandler.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
@@ -39,11 +38,9 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
  * <br>
  * Replies {@code 100 Continue} to requests with allowed maxContentLength.
  * <br>
- * Replies {@code 413 Request Entity Too Large} when content size exceeds maxContentLength.
- *
- * Channel can be reused for requests with "Expect:100-Continue" header that exceed allowed content length,
- * as long as request does not include content. If oversized request already contains content then
- * we cannot safely proceed and connection will be closed.
+ * Replies {@code 413 Request Entity Too Large} when content size exceeds maxContentLength and closes the
+ * connection. Clients may send request bodies without waiting for {@code 100 Continue}, so early rejection
+ * must not reset HTTP framing and reuse the connection while body bytes remain owed.
  * <br><br>
  * TODO: move to RestController to allow content limits per RestHandler.
  *  Ideally we should be able to handle Continue and oversized request in the RestController.
@@ -80,22 +77,13 @@ public class Netty4HttpContentSizeHandler extends ChannelInboundHandlerAdapter {
         new DefaultHttpHeaders().add(CONTENT_LENGTH, 0).add(CONNECTION, HttpHeaderValues.CLOSE),
         EmptyHttpHeaders.INSTANCE
     );
-    static final FullHttpResponse TOO_LARGE = new DefaultFullHttpResponse(
-        HttpVersion.HTTP_1_1,
-        HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
-        Unpooled.EMPTY_BUFFER,
-        new DefaultHttpHeaders().add(CONTENT_LENGTH, 0),
-        EmptyHttpHeaders.INSTANCE
-    );
 
     private final int maxContentLength;
-    private final HttpRequestDecoder decoder; // need to reset decoder after sending 413
     private int currentContentLength; // chunked encoding does not provide content length, need to track actual length
     private boolean ignoreContent;
 
-    public Netty4HttpContentSizeHandler(HttpRequestDecoder decoder, int maxContentLength) {
+    public Netty4HttpContentSizeHandler(int maxContentLength) {
         this.maxContentLength = maxContentLength;
-        this.decoder = decoder;
     }
 
     @Override
@@ -129,13 +117,7 @@ public class Netty4HttpContentSizeHandler extends ChannelInboundHandlerAdapter {
 
         boolean isOversized = HttpUtil.getContentLength(request, -1) > maxContentLength;
         if (isOversized) {
-            if (isContinueExpected) {
-                // Client is allowed to send content without waiting for Continue.
-                // See https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1-11.3
-                // this content will result in HttpRequestDecoder failure and send downstream
-                decoder.reset();
-            }
-            ctx.writeAndFlush(TOO_LARGE.retainedDuplicate()).addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+            ctx.writeAndFlush(TOO_LARGE_CLOSE.retainedDuplicate()).addListener(ChannelFutureListener.CLOSE);
         } else {
             ignoreContent = false;
             currentContentLength = 0;

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpContentSizeHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpContentSizeHandlerTests.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class Netty4HttpContentSizeHandlerTests extends ESTestCase {
 
@@ -68,7 +69,7 @@ public class Netty4HttpContentSizeHandlerTests extends ESTestCase {
         super.setUp();
         var decoder = new HttpRequestDecoder();
         encoder = new EmbeddedChannel(new HttpRequestEncoder());
-        channel = new EmbeddedChannel(decoder, new Netty4HttpContentSizeHandler(decoder, MAX_CONTENT_LENGTH));
+        channel = new EmbeddedChannel(decoder, new Netty4HttpContentSizeHandler(MAX_CONTENT_LENGTH));
     }
 
     /**
@@ -138,22 +139,25 @@ public class Netty4HttpContentSizeHandlerTests extends ESTestCase {
         resp.release();
     }
 
+    private static void assertTooLargeResponseClosesConnection(FullHttpResponse resp, EmbeddedChannel channel) {
+        assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, resp.status());
+        assertEquals(HttpHeaderValues.CLOSE.toString(), resp.headers().get(HttpHeaderNames.CONNECTION));
+        assertFalse("should close channel", channel.isOpen());
+    }
+
     /**
      * Assert that handler returns 413 Request Entity Too Large for oversized request
-     * and does not close channel if following content is not present.
+     * and closes the connection.
      */
     public void testEntityTooLarge() {
-        for (var i = 0; i < REPS; i++) {
-            var sendRequest = httpRequest();
-            HttpUtil.set100ContinueExpected(sendRequest, true);
-            HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
-            channel.writeInbound(encode(sendRequest, LastHttpContent.EMPTY_LAST_CONTENT));
-            var resp = (FullHttpResponse) channel.readOutbound();
-            assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, resp.status());
-            assertNull("request should not pass", channel.readInbound());
-            assertTrue("should not close channel", channel.isOpen());
-            resp.release();
-        }
+        var sendRequest = httpRequest();
+        HttpUtil.set100ContinueExpected(sendRequest, true);
+        HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
+        channel.writeInbound(encode(sendRequest, LastHttpContent.EMPTY_LAST_CONTENT));
+        var resp = (FullHttpResponse) channel.readOutbound();
+        assertTooLargeResponseClosesConnection(resp, channel);
+        assertNull("request should not pass", channel.readInbound());
+        resp.release();
     }
 
     /**
@@ -168,44 +172,81 @@ public class Netty4HttpContentSizeHandlerTests extends ESTestCase {
                 HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
                 channel.writeInbound(encode(sendRequest));
                 var resp = (FullHttpResponse) channel.readOutbound();
-                assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, resp.status());
-                channel.writeInbound(encode(LastHttpContent.EMPTY_LAST_CONTENT)); // terminate
+                assertTooLargeResponseClosesConnection(resp, channel);
                 assertNull(channel.readInbound());
                 resp.release();
-            } else {
-                var normalSize = between(1, MAX_CONTENT_LENGTH);
-                HttpUtil.setContentLength(sendRequest, normalSize);
-                channel.writeInbound(encode(sendRequest));
-                var resp = (FullHttpResponse) channel.readOutbound();
-                assertEquals(HttpResponseStatus.CONTINUE, resp.status());
-                resp.release();
-                var sendContent = lastHttpContent(normalSize);
-                channel.writeInbound(encode(sendContent));
-                var recvRequest = (HttpRequest) channel.readInbound();
-                var recvContent = (LastHttpContent) channel.readInbound();
-                assertEquals("content length header should match", normalSize, HttpUtil.getContentLength(recvRequest));
-                assertFalse("should remove expect header", HttpUtil.is100ContinueExpected(recvRequest));
-                assertEquals("actual content size should match", normalSize, recvContent.content().readableBytes());
-                recvContent.release();
+                return; // channel is closed, no more to do
             }
+
+            var normalSize = between(1, MAX_CONTENT_LENGTH);
+            HttpUtil.setContentLength(sendRequest, normalSize);
+            channel.writeInbound(encode(sendRequest));
+            var resp = (FullHttpResponse) channel.readOutbound();
+            assertEquals(HttpResponseStatus.CONTINUE, resp.status());
+            resp.release();
+            var sendContent = lastHttpContent(normalSize);
+            channel.writeInbound(encode(sendContent));
+            var recvRequest = (HttpRequest) channel.readInbound();
+            var recvContent = (LastHttpContent) channel.readInbound();
+            assertEquals("content length header should match", normalSize, HttpUtil.getContentLength(recvRequest));
+            assertFalse("should remove expect header", HttpUtil.is100ContinueExpected(recvRequest));
+            assertEquals("actual content size should match", normalSize, recvContent.content().readableBytes());
+            recvContent.release();
         }
     }
 
     /**
-     * Assert that handler returns 413 Request Entity Too Large and skip following content.
+     * Assert that handler returns 413 Request Entity Too Large, skips following content, and closes the connection.
      */
     public void testEntityTooLargeWithContentWithoutExpect() {
-        for (int i = 0; i < REPS; i++) {
-            var sendRequest = httpRequest();
-            HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
-            var unexpectedContent = lastHttpContent(OVERSIZED_LENGTH);
-            channel.writeInbound(encode(sendRequest, unexpectedContent));
-            var resp = (FullHttpResponse) channel.readOutbound();
-            assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, resp.status());
-            resp.release();
-            assertNull("request and content should not pass", channel.readInbound());
-            assertTrue("should not close channel", channel.isOpen());
+        var sendRequest = httpRequest();
+        HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
+        var unexpectedContent = lastHttpContent(OVERSIZED_LENGTH);
+        channel.writeInbound(encode(sendRequest, unexpectedContent));
+        var resp = (FullHttpResponse) channel.readOutbound();
+        assertTooLargeResponseClosesConnection(resp, channel);
+        resp.release();
+        assertNull("request and content should not pass", channel.readInbound());
+    }
+
+    /**
+     * Oversized Expect requests must not repurpose owed body bytes as a new HTTP request when coalesced on the wire.
+     */
+    public void testEntityTooLargeExpectDoesNotParseSmuggledRequestCoalesced() {
+        var sendRequest = httpRequest();
+        HttpUtil.set100ContinueExpected(sendRequest, true);
+        HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
+        var followUpRequest = httpRequest();
+        HttpUtil.setContentLength(followUpRequest, 0);
+
+        var coalesced = Unpooled.compositeBuffer();
+        for (var httpRequest : List.of(sendRequest, followUpRequest)) {
+            var requestEncoder = new EmbeddedChannel(new HttpRequestEncoder());
+            httpRequest.headers().set(HttpHeaderNames.HOST, "localhost");
+            requestEncoder.writeOutbound(httpRequest);
+            while (requestEncoder.outboundMessages().isEmpty() == false) {
+                coalesced.addComponent(true, requestEncoder.readOutbound());
+            }
         }
+        channel.writeInbound(coalesced);
+        var resp = (FullHttpResponse) channel.readOutbound();
+        assertTooLargeResponseClosesConnection(resp, channel);
+        assertNull("smuggled request must not pass downstream", channel.readInbound());
+        resp.release();
+    }
+
+    /**
+     * Oversized Expect requests close the connection once the 413 is sent.
+     */
+    public void testEntityTooLargeExpectDoesNotParseSmuggledRequestAfterResponse() {
+        var sendRequest = httpRequest();
+        HttpUtil.set100ContinueExpected(sendRequest, true);
+        HttpUtil.setContentLength(sendRequest, OVERSIZED_LENGTH);
+        channel.writeInbound(encode(sendRequest));
+        var resp = (FullHttpResponse) channel.readOutbound();
+        assertTooLargeResponseClosesConnection(resp, channel);
+        assertNull("request must not pass downstream", channel.readInbound());
+        resp.release();
     }
 
     /**


### PR DESCRIPTION
There's no particular need to keep the connection open in this case, so
let's drop this special-case handling.

Backport of #154546 to 8.19