### PR TITLE
Increasing lower bound for graph connections in HnswUtilsTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -622,9 +622,6 @@ tests:
 - class: org.elasticsearch.upgrades.TokenBackwardsCompatibilityIT
   method: testTokensStayInvalidatedInUpgradedCluster
   issue: https://github.com/elastic/elasticsearch/issues/154627
-- class: org.elasticsearch.index.codec.vectors.HnswUtilsTests
-  method: testNeighborhoodGraphSearchFindsSelf
-  issue: https://github.com/elastic/elasticsearch/issues/154633
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithRelocationOrObjectStoreFailures
   issue: https://github.com/elastic/elasticsearch/issues/154655

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/HnswUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/HnswUtilsTests.java
@@ -26,6 +26,8 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.lucene.util.hnsw.HnswGraphBuilder.DEFAULT_MAX_CONN;
+
 public class HnswUtilsTests extends ESTestCase {
 
     public void testGraphSerialization() throws IOException {
@@ -154,7 +156,7 @@ public class HnswUtilsTests extends ESTestCase {
             }
         }
         var sim = VectorSimilarityFunction.EUCLIDEAN;
-        int m = random().nextInt(8, 32);
+        int m = random().nextInt(DEFAULT_MAX_CONN, 32);
         int candidates = Math.min(numVectors - 1, 64);
         var neighborhoods = NeighborHood.computeNeighborhoods(CentroidOps.FLOAT, vectors, candidates);
         HnswUtils.MultiLevelAdjacency built = HnswUtils.buildMultiLevelFromNeighborhoods(neighborhoods, floatScorer(vectors, sim), m, 42L);


### PR DESCRIPTION
Seems that because vectors were quite dense (few dims/vectors) in some cases we needed to significantly increase the exploration in order to actually find the query vector. This is just a test artifact so there are a couple of options: either increase graph density, or increase exploration. This PR changes the lwoer bound for `m` to be the default `m` for HNSW which is 16 (from 8). 

Closes https://github.com/elastic/elasticsearch/issues/154633