### PR TITLE
[ESQL] Unmute noTypeConflictKeywordKeepTriggersLoadInlineStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -718,9 +718,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=search.vectors/41_knn_search_half_byte_quantized_bfloat16/Knn search with mip}
   issue: https://github.com/elastic/elasticsearch/issues/154355
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
-  issue: https://github.com/elastic/elasticsearch/issues/154377
 - class: org.elasticsearch.xpack.esql.action.ExternalParquetCoercionWarningFloodIT
   method: testDeclaredCoercionWarningsStayBoundedAcrossFanOut
   issue: https://github.com/elastic/elasticsearch/issues/154023


### PR DESCRIPTION
Look like this was fixed by #154466. Confirmed the test fails without the fix and passes with it.

Resolves #154377.