### PR TITLE
[9.5] ES|QL: derive external read schema and split position once, not at each consumer (#154526)

### DIFF
--- a/docs/changelog/154526.yaml
+++ b/docs/changelog/154526.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154526
+summary: Honour the resolved schema and split position on external text reads
+type: bug

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -1743,13 +1743,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 // content and runs on EVERY split — macro-splits past the first stay correctly bound.
                 schemaFieldIndex = declaredPathFieldIndexes(readSchema, null, object);
             } else if (options.headerRow() && declaredPathBinding && context.firstSplit() == false) {
-                // The split gate (declaredNameBindingNeedsFileStart) must keep a headered by-name read whole-file;
-                // if a non-first split reaches here the gate failed, so fail loudly rather than mis-bind positionally.
-                throw new IllegalStateException(
-                    "headered path-bound read of ["
-                        + object.path()
-                        + "] reached a non-first split; the declared-name split gate did not hold"
-                );
+                // This read does not own the file's start, so the header is not in front of it. Bind by name
+                // against the header columns whoever cut the file up read once and passed down. Without them
+                // there is no way to know what this chunk's fields are called, and binding by position would
+                // shift every column silently — so fail loudly instead.
+                List<String> headerColumns = context.fileHeaderColumns();
+                if (headerColumns == null) {
+                    throw new IllegalStateException(
+                        "headered path-bound read of ["
+                            + object.path()
+                            + "] reached a non-first split without the file's header columns; cannot bind the declared "
+                            + "schema by name"
+                    );
+                }
+                schemaFieldIndex = bindDeclaredToHeaderNames(headerColumns.toArray(new String[0]), readSchema, object);
             }
             warnAbsentDeclaredColumns(schemaFieldIndex, readSchema, context.informationalWarningSink());
             effectiveSchema = readSchema;
@@ -1913,6 +1920,25 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
+     * Binds a declared schema to a file's columns by name, given the header column names rather than the
+     * header line itself. Used by a read that cannot see the header — a chunk after the first — where the
+     * names were read once from the file's start and passed down. Identical binding to the first-chunk path,
+     * including duplicate-header rejection, so the two cannot drift apart.
+     */
+    private int[] bindDeclaredToHeaderNames(String[] headerNames, List<Attribute> readSchema, StorageObject object) {
+        // Normalise here rather than trusting the caller: a read that owns the file's start derives these names
+        // from the header line, while a later chunk gets them from the reader's own metadata, and the two
+        // derivations trimmed surrounding whitespace differently. A header cell of [" value "] then bound on the
+        // first chunk and null-filled on every other one — the same column, read two ways, in one file.
+        String[] normalised = new String[headerNames.length];
+        for (int i = 0; i < headerNames.length; i++) {
+            normalised[i] = headerNames[i] == null ? null : headerNames[i].trim();
+        }
+        rejectDuplicateHeaderNames(normalised, object);
+        return declaredPathFieldIndexes(readSchema, normalised, object);
+    }
+
+    /**
      * Width tripwire for an externally-supplied (declared) positional schema against the file's actual header.
      *
      * <p>A declared schema binds text columns <b>positionally</b>: the declared names replace the header's names in
@@ -1935,9 +1961,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
         String[] fields = splitFieldsForOptions(headerLine, options);
         if (declaredPathBinding) {
-            String[] headerNames = headerColumnNames(headerLine, fields);
-            rejectDuplicateHeaderNames(headerNames, object);
-            return declaredPathFieldIndexes(readSchema, headerNames, object);
+            return bindDeclaredToHeaderNames(headerColumnNames(headerLine, fields), readSchema, object);
         }
         if (readSchema.size() > fields.length) {
             throw new IllegalArgumentException(

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDeclaredHeaderMultiChunkTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDeclaredHeaderMultiChunkTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A declared schema over a headered CSV binds its columns by name against the header, and only the first
+ * chunk of a file can see that header. Every later chunk used to fail outright, so any declared headered
+ * file large enough to be read in more than one chunk failed every query that was not limit-pushed —
+ * which at a 1 MiB chunk size and default parallelism is every real file.
+ *
+ * <p>This drives the real reader through the real coordinator over a genuinely multi-chunk stream, which is
+ * the closest this layer gets to the failing query. The reader-level halves are pinned in
+ * {@link CsvFormatReaderTests}; this pins that the two halves actually meet.
+ */
+public class CsvDeclaredHeaderMultiChunkTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setUpBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testDeclaredHeaderedCsvReadsAcrossChunkBoundaries() throws Exception {
+        // The streaming coordinator chunks at the reader's minimum segment size, so the content has to
+        // exceed it to produce a second chunk at all — below that the read never leaves chunk 0 and the
+        // test would pass without the fix.
+        long chunkSize = new CsvFormatReader(blockFactory).minimumSegmentSize();
+        StringBuilder csv = new StringBuilder("emp_no,first_name,salary\n");
+        int rows = 0;
+        while (csv.length() < chunkSize * 2) {
+            csv.append(rows).append(",name").append(rows).append(',').append(rows * 2L).append('\n');
+            rows++;
+        }
+        assertTrue("fixture must span more than one chunk to exercise the defect", csv.length() > chunkSize);
+
+        // Declared narrower than the file and in a different order, so a positional bind would be visibly wrong.
+        List<Attribute> declared = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "first_name", DataType.KEYWORD)
+        );
+
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", true))
+            .withDeclaredPathBinding(true)
+            .withSchema(declared);
+
+        InputStream stream = new ByteArrayInputStream(csv.toString().getBytes(StandardCharsets.UTF_8));
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        long seenRows = 0;
+        long salarySum = 0;
+        try (
+            CloseableIterator<Page> pages = StreamingParallelParsingCoordinator.parallelRead(
+                (SegmentableFormatReader) reader,
+                stream,
+                null,
+                List.of("salary", "first_name"),
+                1000,
+                4, // parallelism must exceed 1 or the serial path reads the whole file as one chunk
+                executor,
+                ErrorPolicy.STRICT,
+                declared,
+                0L,
+                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                null,
+                -1L,
+                StripeColumnScope.PROJECTED,
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
+            )
+        ) {
+            while (pages.hasNext()) {
+                Page page = pages.next();
+                try {
+                    LongBlock salary = (LongBlock) page.getBlock(0);
+                    BytesRefBlock name = (BytesRefBlock) page.getBlock(1);
+                    for (int i = 0; i < page.getPositionCount(); i++) {
+                        salarySum += salary.getLong(i);
+                        assertFalse("name column must not be null", name.isNull(i));
+                    }
+                    seenRows += page.getPositionCount();
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals("every data row must be read, across every chunk", rows, seenRows);
+        // salary is row*2 — binding by position instead of name would have read emp_no here and halved this.
+        assertEquals("salary must bind by name, not position", (long) (rows - 1) * rows, salarySum);
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -6520,6 +6520,151 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    /**
+     * The names a later chunk binds against come from this reader's own metadata, read from the file's first
+     * chunk. They must be the file's columns in the file's order — not the declared schema's, and not
+     * reordered to match it.
+     * <p>
+     * Nothing else pins this. If metadata ever short-circuited to the configured schema — a plausible
+     * optimisation — every column of every multi-chunk declared headered file would bind to the wrong field,
+     * silently, and no other test would notice.
+     */
+    public void testMetadataReturnsFileOrderNamesForADeclaredConfiguredReader() throws Exception {
+        // File order deliberately differs from the declared order below.
+        StorageObject object = createStorageObject("first_name,emp_no,salary\nAlice,1,100\n");
+        List<Attribute> declared = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "emp_no", DataType.LONG)
+        );
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", true))
+            .withDeclaredPathBinding(true)
+            .withSchema(declared);
+
+        List<String> names = reader.metadata(object).schema().stream().map(Attribute::name).toList();
+        assertEquals("metadata must describe the file, not the declaration", List.of("first_name", "emp_no", "salary"), names);
+    }
+
+    /**
+     * A chunk after the first cannot see the file's header, but it can still bind a declared schema by name
+     * when the header columns are handed to it. Without this a declared headered file large enough to be read
+     * in chunks fails every query.
+     */
+    public void testNonFirstChunkBindsDeclaredSchemaFromCarriedHeaderColumns() throws Exception {
+        // A chunk from the middle of the file: data rows only, no header in front of it.
+        StorageObject object = createStorageObject("1,Alice\n2,Bob\n");
+        List<Attribute> readSchema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "first_name", DataType.KEYWORD),
+            new ReferenceAttribute(Source.EMPTY, null, "emp_no", DataType.LONG)
+        );
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", true))
+            .withDeclaredPathBinding(true);
+        try (
+            CloseableIterator<Page> it = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .firstSplit(false)
+                    .recordAligned(true)
+                    .batchSize(10)
+                    .readSchema(readSchema)
+                    .fileHeaderColumns(List.of("emp_no", "first_name"))
+                    .build()
+            )
+        ) {
+            Page page = it.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals("Alice", ((BytesRefBlock) page.getBlock(0)).getBytesRef(0, new BytesRef()).utf8ToString());
+            assertEquals(1L, ((LongBlock) page.getBlock(1)).getLong(0));
+            assertEquals("Bob", ((BytesRefBlock) page.getBlock(0)).getBytesRef(1, new BytesRef()).utf8ToString());
+            assertEquals(2L, ((LongBlock) page.getBlock(1)).getLong(1));
+            page.releaseBlocks();
+        }
+    }
+
+    /**
+     * A header cell padded inside its quotes binds the same way on a later chunk as on the first.
+     * <p>
+     * The first chunk derives its header names from the header line and trims them; a later chunk is handed
+     * names the reader's own metadata produced, which did not. A declaration for {@code value} then matched on
+     * the first chunk and silently null-filled on every other one — the same column read two ways in one file.
+     */
+    public void testCarriedHeaderColumnsAreNormalisedLikeTheFirstChunk() throws Exception {
+        StorageObject object = createStorageObject("1\n");
+        List<Attribute> readSchema = List.of(new ReferenceAttribute(Source.EMPTY, null, "value", DataType.LONG));
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", true))
+            .withDeclaredPathBinding(true);
+        try (
+            CloseableIterator<Page> it = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .firstSplit(false)
+                    .recordAligned(true)
+                    .batchSize(10)
+                    .readSchema(readSchema)
+                    .fileHeaderColumns(List.of(" value "))
+                    .build()
+            )
+        ) {
+            Page page = it.next();
+            try {
+                assertFalse("a padded header name must still bind the declared column", page.getBlock(0).isNull(0));
+                assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    /**
+     * Binding is by name, not position: a declaration must follow its column even when the file orders the
+     * columns differently. Getting this wrong shifts every value into the wrong column silently.
+     */
+    public void testCarriedHeaderColumnsBindByNameNotPosition() throws Exception {
+        // File order is first_name,emp_no — the reverse of the declaration's order.
+        StorageObject object = createStorageObject("Alice,1\n");
+        List<Attribute> readSchema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "emp_no", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "first_name", DataType.KEYWORD)
+        );
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", true))
+            .withDeclaredPathBinding(true);
+        try (
+            CloseableIterator<Page> it = reader.read(
+                object,
+                FormatReadContext.builder()
+                    .firstSplit(false)
+                    .recordAligned(true)
+                    .batchSize(10)
+                    .readSchema(readSchema)
+                    .fileHeaderColumns(List.of("first_name", "emp_no"))
+                    .build()
+            )
+        ) {
+            Page page = it.next();
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals("Alice", ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()).utf8ToString());
+            page.releaseBlocks();
+        }
+    }
+
+    /**
+     * With no header columns to bind against there is nothing to fall back on but position, which would shift
+     * every column. Failing loudly is the correct outcome, and stays so.
+     */
+    public void testNonFirstChunkWithoutCarriedHeaderColumnsFailsLoudly() throws Exception {
+        StorageObject object = createStorageObject("1,Alice\n");
+        List<Attribute> readSchema = List.of(new ReferenceAttribute(Source.EMPTY, null, "emp_no", DataType.LONG));
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", true))
+            .withDeclaredPathBinding(true);
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> reader.read(
+                object,
+                FormatReadContext.builder().firstSplit(false).recordAligned(true).batchSize(10).readSchema(readSchema).build()
+            )
+        );
+        assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("without the file's header columns"));
+    }
+
     /** A narrow declaration may name a column far to the right of a wide file — the classic ClickBench shape. */
     public void testDeclaredPathBindsColumnBeyondDeclarationWidth() throws Exception {
         StorageObject object = createStorageObject("a,b,c,d,e,f,g,h,i,999\n");

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -305,17 +305,34 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Resolve the effective schema when the planner has bound a read schema. When the
-     * coordinator-side projection ({@code resolvedSchema}) is unavailable, the bound schema is used
-     * as-is. Otherwise the bound schema's column order is preserved and projection types/nullability
-     * overlay matching names — same semantics as {@link #mergeInferredWithPreferred}, just with the
-     * planner-supplied schema standing in for the per-file inference result.
+     * Resolve the effective schema when the planner has bound a read schema for this file.
+     * <p>
+     * <b>The bound schema wins on type.</b> It is the planner's read contract — a declared type, or a type
+     * reconciled across every file of the dataset — and the reader-level {@code projection} may be nothing
+     * more than what this file's own values happened to look like. Letting the projection's type win means a
+     * column declared {@code long} is read as {@code int} because the values in view were small, and the
+     * resulting block fails to cast in a compute engine still expecting {@code long}.
+     * <p>
+     * Inference never has more information than the planner here: the planner saw the declaration, or saw
+     * every file. A value that does not fit the bound type is the error policy's business at parse time, not
+     * grounds to retype the column.
+     * <p>
+     * The projection still supplies nullability for matching names, and contributes any column the bound
+     * schema does not mention. Bound column order is preserved.
      */
     private static List<Attribute> mergeBoundWithProjection(List<Attribute> bound, List<Attribute> projection) {
         if (projection == null || projection.isEmpty()) {
             return bound;
         }
-        return mergeInferredWithPreferred(bound, projection);
+        Map<String, Attribute> byName = new LinkedHashMap<>();
+        for (Attribute a : bound) {
+            byName.put(a.name(), a);
+        }
+        for (Attribute p : projection) {
+            Attribute existing = byName.get(p.name());
+            byName.put(p.name(), existing == null ? p : existing.withNullability(p.nullable()));
+        }
+        return List.copyOf(byName.values());
     }
 
     /**
@@ -468,6 +485,11 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         ErrorPolicy errorPolicy = context.errorPolicy() != null ? context.errorPolicy() : defaultErrorPolicy();
         // Bound read schema wins when non-null; null falls through to per-file inference.
         // Prevents cross-file type drift on multi-file globs (e.g. y:LONG vs file-with-1.5 y:DOUBLE).
+        //
+        // A bound schema is used as given. It must NOT be supplemented by inferring here: this method is
+        // handed storage that may be a single-use stream, and opening it again for inference both breaks
+        // that contract and re-reads the file on every chunk. Whoever owns the file's leading bytes resolves
+        // any facts the projection does not carry before the read starts.
         List<Attribute> effectiveSchema = context.readSchema() == null
             ? inferSchemaIfNeeded(resolvedSchema, object, skipFirstLine)
             : mergeBoundWithProjection(context.readSchema(), resolvedSchema);

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonBoundSchemaPrecedenceTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonBoundSchemaPrecedenceTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * When the planner has bound a read schema for a file, that schema decides each column's type — not
+ * whatever the reader happens to know locally.
+ *
+ * <p>The reader-level schema can be a per-file or per-chunk inference: what the values in view looked
+ * like. The bound schema is the planner's contract, either declared or reconciled across every file of
+ * the dataset. Inference never has more information, so letting it win retypes a column behind the
+ * compute engine's back and the resulting block fails to cast. That is the defect behind the compressed
+ * NDJSON read crashes; these tests pin the rule that prevents it recurring.
+ */
+public class NdJsonBoundSchemaPrecedenceTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setUpBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * The crash shape: a column declared {@code long} whose values are all int-sized. Inference calls it
+     * {@code integer}; the engine expects {@code long}.
+     */
+    public void testBoundTypeWinsOverInferredType() throws Exception {
+        FormatReader reader = new NdJsonFormatReader(null, blockFactory).withSchema(List.of(ref("v", DataType.INTEGER)));
+
+        try (CloseableIterator<Page> pages = read(reader, "{\"v\":1}\n{\"v\":2}\n", List.of(ref("v", DataType.LONG)))) {
+            assertTrue("expected a page", pages.hasNext());
+            Page page = pages.next();
+            try {
+                Block block = page.getBlock(0);
+                assertThat(
+                    "the planner declared [long]; the reader must not retype the column from its own values",
+                    block,
+                    org.hamcrest.Matchers.instanceOf(LongBlock.class)
+                );
+                LongBlock longs = (LongBlock) block;
+                assertEquals(1L, longs.getLong(0));
+                assertEquals(2L, longs.getLong(1));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    /** A column the bound schema does not mention is still contributed by the projection. */
+    public void testProjectionOnlyColumnIsStillRead() throws Exception {
+        FormatReader reader = new NdJsonFormatReader(null, blockFactory).withSchema(
+            List.of(ref("v", DataType.LONG), ref("w", DataType.LONG))
+        );
+
+        try (CloseableIterator<Page> pages = read(reader, "{\"v\":1,\"w\":7}\n", List.of(ref("v", DataType.LONG)))) {
+            assertTrue("expected a page", pages.hasNext());
+            Page page = pages.next();
+            try {
+                assertEquals("bound column plus the projection-only column", 2, page.getBlockCount());
+                assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+                assertEquals(7L, ((LongBlock) page.getBlock(1)).getLong(0));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    /** Bound column order survives the merge — the projection must not reorder the page's channels. */
+    public void testBoundColumnOrderIsPreserved() throws Exception {
+        FormatReader reader = new NdJsonFormatReader(null, blockFactory).withSchema(
+            List.of(ref("b", DataType.LONG), ref("a", DataType.LONG))
+        );
+
+        try (
+            CloseableIterator<Page> pages = read(reader, "{\"a\":10,\"b\":20}\n", List.of(ref("a", DataType.LONG), ref("b", DataType.LONG)))
+        ) {
+            assertTrue("expected a page", pages.hasNext());
+            Page page = pages.next();
+            try {
+                assertEquals("channel 0 is the bound schema's first column [a]", 10L, ((LongBlock) page.getBlock(0)).getLong(0));
+                assertEquals("channel 1 is the bound schema's second column [b]", 20L, ((LongBlock) page.getBlock(1)).getLong(0));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    private CloseableIterator<Page> read(FormatReader reader, String ndjson, List<Attribute> boundSchema) throws Exception {
+        StorageObject object = new BytesStorageObject("file:///test.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        return reader.read(object, FormatReadContext.builder().batchSize(10).readSchema(boundSchema).build());
+    }
+
+    private static Attribute ref(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, name, type);
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonDottedPrefixChunkConsistencyTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonDottedPrefixChunkConsistencyTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Every chunk of one file must decide the flat-versus-nested question the same way.
+ *
+ * <p>A flat dotted key {@code "a.b"} decodes as one field only when the file also has a column {@code "a"};
+ * otherwise it is read as the nested path {@code a -> b}. Answering that per chunk lets two chunks of the
+ * same file disagree whenever the sibling column is not present in every record — the chunks that happen not
+ * to see it read the column as a nested path and produce nulls, so the same query returns different data
+ * depending on where the chunk boundaries fell. The file's schema is therefore resolved once, before any
+ * chunk is dispatched, and every chunk decodes against that one answer.
+ *
+ * <p>The sibling here appears only in the first part of the file, which is what makes a per-chunk answer
+ * wrong for every chunk after it.
+ */
+public class NdJsonDottedPrefixChunkConsistencyTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setUpBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testSiblingColumnAbsentFromLaterChunksStillDecodesFlatKey() throws Exception {
+        Settings settings = segmentSize64Kb();
+        long chunkSize = new NdJsonFormatReader(settings, blockFactory).minimumSegmentSize();
+
+        StringBuilder ndjson = new StringBuilder();
+        int rows = 0;
+        while (ndjson.length() < chunkSize * 3) {
+            if (ndjson.length() < chunkSize / 2) {
+                // Only these early records carry the sibling scalar that makes "languages.long" a flat key.
+                ndjson.append("{\"languages\":\"en\",\"languages.long\":").append((long) rows).append("}\n");
+            } else {
+                ndjson.append("{\"languages.long\":").append((long) rows).append("}\n");
+            }
+            rows++;
+        }
+        assertTrue("fixture must span several chunks", ndjson.length() > chunkSize * 2);
+
+        List<Attribute> bound = List.of(new ReferenceAttribute(Source.EMPTY, "languages.long", DataType.LONG));
+        NdJsonFormatReader reader = new NdJsonFormatReader(settings, blockFactory).withSchema(bound);
+
+        InputStream stream = new ByteArrayInputStream(ndjson.toString().getBytes(StandardCharsets.UTF_8));
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        long seenRows = 0;
+        long nulls = 0;
+        long sum = 0;
+        try (
+            CloseableIterator<Page> pages = StreamingParallelParsingCoordinator.parallelRead(
+                (SegmentableFormatReader) reader,
+                stream,
+                null,
+                List.of("languages.long"),
+                1000,
+                4, // parallelism must exceed 1 or the whole file is read as a single chunk
+                executor,
+                ErrorPolicy.STRICT,
+                bound,
+                0L,
+                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                null,
+                -1L,
+                StripeColumnScope.PROJECTED,
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
+            )
+        ) {
+            while (pages.hasNext()) {
+                Page page = pages.next();
+                try {
+                    LongBlock block = (LongBlock) page.getBlock(0);
+                    for (int i = 0; i < page.getPositionCount(); i++) {
+                        if (block.isNull(i)) {
+                            nulls++;
+                        } else {
+                            sum += block.getLong(i);
+                        }
+                    }
+                    seenRows += page.getPositionCount();
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals("every row must be read", rows, seenRows);
+        assertEquals("a chunk whose records omit the sibling must still decode the flat key, not null it", 0, nulls);
+        assertEquals("sum of languages.long", (long) (rows - 1) * rows / 2, sum);
+    }
+
+    private static Settings segmentSize64Kb() {
+        return Settings.builder().put("esql.datasource.ndjson.segment_size", "64kb").build();
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonDottedPrefixStreamingTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonDottedPrefixStreamingTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinator;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StripeColumnScope;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A flat dotted key such as {@code "languages.long"} is decoded as a single JSON field only when its
+ * prefix column ({@code "languages"}) is also in the effective schema; otherwise the decoder reads it as
+ * the nested path {@code languages -> long}. On a file that carries both the flat key and a sibling scalar
+ * {@code "languages"}, that nested reading walks into the scalar as if it were an object, which fails the
+ * query under a strict policy and null-fills the column under a lenient one.
+ *
+ * <p>The prefix reaches the effective schema on the streaming path only if the coordinator infers the
+ * file's schema from its first chunk. When the planner has bound a read schema that lists the dotted leaf
+ * but not the prefix, the coordinator skips that inference, so the prefix is absent and the flat key is
+ * misread. This drives the real reader through the real streaming coordinator over a genuinely multi-chunk
+ * stream to state the contract: the bound dotted-leaf column must still decode to its flat-key value.
+ */
+public class NdJsonDottedPrefixStreamingTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setUpBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testBoundDottedLeafDecodesFlatKeyAcrossChunks() throws Exception {
+        long chunkSize = new NdJsonFormatReader(segmentSize64Kb(), blockFactory).minimumSegmentSize();
+
+        // Flat dotted key "languages.long" beside a sibling scalar "languages". The sibling is what makes
+        // a first-chunk inference produce the "languages" prefix column, and what turns the misread into a
+        // hard scalar-vs-object failure rather than a silent null.
+        StringBuilder ndjson = new StringBuilder();
+        int rows = 0;
+        while (ndjson.length() < chunkSize * 2) {
+            ndjson.append("{\"languages\":\"en\",\"languages.long\":").append((long) rows).append("}\n");
+            rows++;
+        }
+        assertTrue("fixture must span more than one chunk", ndjson.length() > chunkSize);
+
+        // The planner-bound schema and the reader's configured schema both project only the dotted leaf,
+        // without the "languages" prefix.
+        List<Attribute> bound = List.of(new ReferenceAttribute(Source.EMPTY, "languages.long", DataType.LONG));
+        NdJsonFormatReader reader = new NdJsonFormatReader(segmentSize64Kb(), blockFactory).withSchema(bound);
+
+        InputStream stream = new ByteArrayInputStream(ndjson.toString().getBytes(StandardCharsets.UTF_8));
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        long seenRows = 0;
+        long nulls = 0;
+        long sum = 0;
+        try (
+            CloseableIterator<Page> pages = StreamingParallelParsingCoordinator.parallelRead(
+                (SegmentableFormatReader) reader,
+                stream,
+                null,
+                List.of("languages.long"),
+                1000,
+                4, // parallelism must exceed 1 or the serial path reads the whole file as one chunk
+                executor,
+                ErrorPolicy.STRICT,
+                bound,
+                0L,
+                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                null,
+                -1L,
+                StripeColumnScope.PROJECTED,
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
+            )
+        ) {
+            while (pages.hasNext()) {
+                Page page = pages.next();
+                try {
+                    LongBlock block = (LongBlock) page.getBlock(0);
+                    for (int i = 0; i < page.getPositionCount(); i++) {
+                        if (block.isNull(i)) {
+                            nulls++;
+                        } else {
+                            sum += block.getLong(i);
+                        }
+                    }
+                    seenRows += page.getPositionCount();
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals("every row must be read across every chunk", rows, seenRows);
+        assertEquals("the bound dotted leaf must decode its flat-key value, not null", 0, nulls);
+        assertEquals("sum of languages.long", (long) (rows - 1) * rows / 2, sum);
+    }
+
+    private static Settings segmentSize64Kb() {
+        return Settings.builder().put("esql.datasource.ndjson.segment_size", "64kb").build();
+    }
+}

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUnterminatedRecordTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUnterminatedRecordTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A file whose last line has no trailing newline still ends with a complete record, and a read that
+ * owns the file's end must return it.
+ *
+ * <p>Dropping a trailing partial record is correct only for a split that is <em>not</em> the file's
+ * last — the next split re-reads those bytes. A whole-file read has no next split, so the same
+ * behaviour silently loses the final row while {@code COUNT(*)} still counts it. These tests state
+ * the contract from the reader's side; whether a given split is actually marked as the file's last is
+ * decided by the split producer and pinned in {@code FileSplitProviderTests}.
+ */
+public class NdJsonUnterminatedRecordTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setUpBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testSingleRecordWithNoTrailingNewlineIsRead() throws Exception {
+        assertIds("{\"id\":1}", List.of(1));
+    }
+
+    public void testLastRecordWithNoTrailingNewlineIsRead() throws Exception {
+        assertIds("{\"id\":1}\n{\"id\":2}\n{\"id\":3}", List.of(1, 2, 3));
+    }
+
+    public void testTrailingNewlineDoesNotYieldAPhantomRecord() throws Exception {
+        assertIds("{\"id\":1}\n{\"id\":2}\n", List.of(1, 2));
+    }
+
+    public void testCarriageReturnTerminatedLastLineIsRead() throws Exception {
+        assertIds("{\"id\":1}\r\n{\"id\":2}\r\n", List.of(1, 2));
+    }
+
+    public void testCarriageReturnTerminatorWithUnterminatedLastRecord() throws Exception {
+        assertIds("{\"id\":1}\r\n{\"id\":2}", List.of(1, 2));
+    }
+
+    /**
+     * The other side of the contract: a split that is not the file's last drops its trailing partial
+     * record, because the following split re-reads those bytes. Marking a whole-file read this way is
+     * what lost the final row.
+     */
+    public void testNonLastSplitStillDropsItsTrailingPartialRecord() throws Exception {
+        List<Integer> ids = readIds("{\"id\":1}\n{\"id\":2}", false);
+        assertEquals("a non-last split leaves its trailing partial record to the next split", List.of(1), ids);
+    }
+
+    private void assertIds(String ndjson, List<Integer> expected) throws Exception {
+        assertEquals(expected, readIds(ndjson, true));
+    }
+
+    private List<Integer> readIds(String ndjson, boolean lastSplit) throws Exception {
+        StorageObject object = new BytesStorageObject("file:///eof.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        FormatReadContext context = FormatReadContext.builder()
+            .projectedColumns(List.of("id"))
+            .batchSize(10)
+            .firstSplit(true)
+            .lastSplit(lastSplit)
+            .recordAligned(false)
+            .build();
+
+        List<Integer> ids = new ArrayList<>();
+        try (CloseableIterator<Page> pages = new NdJsonFormatReader(null, blockFactory).read(object, context)) {
+            while (pages.hasNext()) {
+                Page page = pages.next();
+                try {
+                    IntBlock block = (IntBlock) page.getBlock(0);
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        ids.add(block.getInt(i));
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        return ids;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -2001,7 +2001,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 StorageObject obj = FileSplitProvider.storageObjectForSplit(storageProvider, fileSplit);
                 attachStorageMetrics(obj); // before any read — see note at the single-object dispatch above
                 boolean recordAlignedMacro = FileSplitProvider.isRecordAlignedMacroSplit(fileSplit);
-                boolean firstSplit = fileSplit.offset() == 0 || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+                boolean firstSplit = FileSplitProvider.isFirstInFile(fileSplit);
                 if (cols.isEmpty() && recordAlignedMacro && firstSplit == false) {
                     // COUNT(*)/empty-projection path on a non-leading record-aligned macro-split:
                     // bind schema from the full file (header-bearing formats like CSV need file-leading bytes).
@@ -2034,11 +2034,9 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     withoutRowPosition.remove(compressedRowPosSlot);
                     readerCols = withoutRowPosition;
                 }
-                // A record-aligned macro-split that owns the file's trailing bytes is file-final; a genuine
-                // whole-file read (offset 0, not record-aligned, last split) is also file-final. Either way the
-                // last split's trailing segment may close its last stripe to EOF.
-                boolean splitIsFileFinal = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY))
-                    || (recordAlignedMacro == false && firstSplit && fileSplit.offset() == 0);
+                // Owning the file's trailing bytes means the last segment may close its last stripe to EOF.
+                // Same fact as the reader's lastSplit below — one derivation, so the two cannot disagree.
+                boolean splitIsFileFinal = FileSplitProvider.isLastInFile(fileSplit);
                 pages = openWithParallelism(
                     fileReader,
                     obj,
@@ -2056,14 +2054,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     bufferedInformationalWarningSink(state.buffer)
                 );
                 if (pages == null) {
-                    boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
                     FormatReadContext ctx = FormatReadContext.builder()
                         .projectedColumns(PhysicalNames.translateNames(readerCols, renames))
                         .batchSize(batchSize)
                         .rowLimit(FormatReader.NO_LIMIT)
                         .errorPolicy(errorPolicy)
                         .firstSplit(firstSplit)
-                        .lastSplit(lastSplit)
+                        .lastSplit(splitIsFileFinal)
                         .recordAligned(recordAlignedMacro)
                         .readSchema(PhysicalNames.translateSchema(perFileReadSchema, renames))
                         .splitStartByte(fileSplit.offset())

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactory.java
@@ -307,8 +307,8 @@ public class ExternalSourceOperatorFactory implements SourceOperator.SourceOpera
             if (split instanceof FileSplit fileSplit) {
                 currentSplitPath = fileSplit.path();
                 StorageObject obj = FileSplitProvider.storageObjectForSplit(storageProvider, fileSplit);
-                boolean firstSplit = fileSplit.offset() == 0 || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
-                boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+                boolean firstSplit = FileSplitProvider.isFirstInFile(fileSplit);
+                boolean lastSplit = FileSplitProvider.isLastInFile(fileSplit);
 
                 ColumnMapping columnMapping = fileSplit.columnMapping();
                 List<String> effectiveProjection = projectedColumns;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -111,6 +111,25 @@ public class FileSplitProvider implements SplitProvider {
     static final String FIRST_SPLIT_KEY = "_first_split";
     static final String LAST_SPLIT_KEY = "_last_split";
 
+    /**
+     * Config for a split that covers an entire file, so it is both the first and the last split of that file.
+     * <p>
+     * Readers run a split-boundary protocol off these flags: a non-first split drops its leading partial
+     * record and a non-last split drops its trailing one, because the neighbouring split owns those bytes.
+     * A whole-file split has no neighbours, so leaving the flags unstamped makes a reader discard a final
+     * record that is not newline-terminated — no other split will read it. Multi-split paths stamp the same
+     * keys on their edge splits, so after this every line-oriented split states its own position rather than
+     * leaving a whole-file read to be inferred from an absent key. Range splits are the exception: they share
+     * one config across all ranges and carry no position keys, because byte ranges are not a record-boundary
+     * protocol and their readers never consult these flags.
+     */
+    private static Map<String, Object> wholeFileSplitConfig(Map<String, Object> config) {
+        Map<String, Object> splitConfig = new HashMap<>(config);
+        splitConfig.put(FIRST_SPLIT_KEY, "true");
+        splitConfig.put(LAST_SPLIT_KEY, "true");
+        return splitConfig;
+    }
+
     static final String RANGE_SPLIT_KEY = "_range_split";
     static final String FILE_LENGTH_KEY = "_file_length";
     public static final String CONFIG_TARGET_SPLIT_SIZE = "target_split_size";
@@ -475,7 +494,7 @@ public class FileSplitProvider implements SplitProvider {
                     0,
                     task.fileLength(),
                     task.format(),
-                    task.config(),
+                    wholeFileSplitConfig(task.config()),
                     task.partitionValues(),
                     task.columnMapping(),
                     task.readSchema()
@@ -547,7 +566,17 @@ public class FileSplitProvider implements SplitProvider {
 
         // Whole-file split when macro splitting does not apply (small files, unsupported formats, or single aligned span).
         fileSplits.add(
-            FileSplit.withReadSchema("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping, readSchema)
+            FileSplit.withReadSchema(
+                "file",
+                filePath,
+                0,
+                fileLength,
+                format,
+                wholeFileSplitConfig(config),
+                partitionValues,
+                columnMapping,
+                readSchema
+            )
         );
         return fileSplits;
     }
@@ -692,7 +721,17 @@ public class FileSplitProvider implements SplitProvider {
 
             if (boundaries.length == 0) {
                 splits.add(
-                    FileSplit.withReadSchema("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping, readSchema)
+                    FileSplit.withReadSchema(
+                        "file",
+                        filePath,
+                        0,
+                        fileLength,
+                        format,
+                        wholeFileSplitConfig(config),
+                        partitionValues,
+                        columnMapping,
+                        readSchema
+                    )
                 );
                 return true;
             }
@@ -954,6 +993,51 @@ public class FileSplitProvider implements SplitProvider {
     }
 
     /**
+     * Whether this split covers the start of its file, and so owns the file's leading bytes (a header line,
+     * a leading partial record that belongs to no predecessor).
+     * <p>
+     * Position — where a split sits in its file — is stamped by this class on every split it produces and read
+     * back through this method and {@link #isLastInFile}. Deriving it anywhere else risks the two answers
+     * drifting apart, which is precisely how a whole-file read came to be treated as "not the last split" and
+     * discarded its final record.
+     */
+    public static boolean isFirstInFile(FileSplit split) {
+        return split != null && ("true".equals(split.config().get(FIRST_SPLIT_KEY)) || split.offset() == 0);
+    }
+
+    /**
+     * Whether this split covers the end of its file, and so owns the file's trailing bytes. Readers key their
+     * record-boundary protocol off this: a split that is not last drops its trailing partial record because the
+     * next split re-reads those bytes, while a last split must keep it — nothing else will read it.
+     * <p>
+     * See {@link #isFirstInFile} on why position is derived here and nowhere else.
+     */
+    public static boolean isLastInFile(FileSplit split) {
+        return split != null && ("true".equals(split.config().get(LAST_SPLIT_KEY)) || legacyUnstampedWholeFile(split));
+    }
+
+    /**
+     * Recognises a whole-file split produced before this class stamped position keys, so a data node still reads
+     * such a split correctly during a rolling upgrade. Splits are built on the coordinator and sent to data nodes,
+     * so an older coordinator emits no position keys at all.
+     * <p>
+     * This is the only place an absent LAST-position key is interpreted, and it is BWC-only: delete it once no
+     * supported coordinator predates the stamping. (An absent FIRST key is read from {@code offset() == 0}
+     * permanently and by design — range splits carry no position keys at all and rely on it.) It recognises
+     * legacy shapes by ruling out every protocol that
+     * implies a split covers part of a file, which is sound only because that list is closed over the producers
+     * in this class as of the stamping change — <b>a new split shape must stamp its position keys</b> rather than
+     * rely on being absent from this list.
+     */
+    private static boolean legacyUnstampedWholeFile(FileSplit split) {
+        Map<String, Object> config = split.config();
+        return split.offset() == 0
+            && "true".equals(config.get(RECORD_ALIGNED_MACRO_SPLIT_KEY)) == false
+            && "true".equals(config.get(COMPRESSED_OFFSET_SPLIT_KEY)) == false
+            && "true".equals(config.get(RANGE_SPLIT_KEY)) == false;
+    }
+
+    /**
      * Absolute byte offsets where each macro-split starts (always begins with {@code 0}), mirroring
      * {@link ParallelParsingCoordinator#computeSegments} stride semantics with {@code targetStrideBytes}.
      */
@@ -1073,7 +1157,17 @@ public class FileSplitProvider implements SplitProvider {
             List<FrameIndex.FrameEntry> frames = index.frames();
             if (frames.isEmpty()) {
                 splits.add(
-                    FileSplit.withReadSchema("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping, readSchema)
+                    FileSplit.withReadSchema(
+                        "file",
+                        filePath,
+                        0,
+                        fileLength,
+                        format,
+                        wholeFileSplitConfig(config),
+                        partitionValues,
+                        columnMapping,
+                        readSchema
+                    )
                 );
                 return true;
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -482,6 +482,13 @@ public final class ParallelParsingCoordinator {
             .batchSize(batchSize)
             .errorPolicy(effectivePolicy)
             .firstSplit(splitIncludesFileLeader)
+            // lastSplit is deliberately left to the builder default (true) and not set from splitIsFileFinal.
+            // This context is used two ways: as the single-threaded fallback below, which reads the whole
+            // storage object and so genuinely owns its trailing bytes, and as the base for per-segment
+            // contexts, which each set lastSplit themselves from their segment index. Setting it here from
+            // splitIsFileFinal breaks the first use, because the convenience overloads that assume a
+            // whole-file read (splitIncludesFileLeader=true) do not make the matching claim about the
+            // file's end. Reconciling those defaults is worth doing on its own, not as a side effect.
             .recordAligned(splitStartsAtRecordBoundary)
             .readSchema(readSchema)
             .splitStartByte(baseFileOffset)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -149,8 +149,14 @@ public final class StreamingParallelParsingCoordinator {
     /**
      * Variant that propagates the planner-resolved {@code readSchema}. Mirrors the same parameter on
      * {@link ParallelParsingCoordinator#parallelRead}; the streaming path must thread it so multi-file
-     * globs over gzip/zstd/bz2 inputs honor the planner's typing instead of re-inferring per file.
-     * Pass {@code null} when no read schema is bound.
+     * globs over stream-only compressed inputs honor the planner's typing instead of re-inferring per
+     * file. Pass {@code null} when no read schema is bound.
+     * <p>
+     * Stream-only compressed means any non-splittable codec (gzip, zstd), plus a splittable or indexed
+     * codec whose reader binds declared names from the file start — see
+     * {@code AsyncExternalSourceOperatorFactory#resolveDispatchMode}. A splittable codec without that
+     * constraint (bzip2 over a self-describing format) is block-aligned into compressed-offset macro-splits
+     * read one at a time instead, and never reaches here.
      *
      * @param baseFileOffset file-global byte offset added to each chunk's decompressed start byte before it
      *                       is handed to the reader as {@link FormatReadContext#splitStartByte()}. Stream-only
@@ -357,6 +363,13 @@ public final class StreamingParallelParsingCoordinator {
         /** See {@link FormatReadContext#readSchema()}. {@code null} = per-file inference. */
         @Nullable
         private final List<Attribute> readSchema;
+        /**
+         * The file's column names in file order, read from chunk 0 by {@link #captureFileHeaderColumns}.
+         * Written on the segmentator thread before any chunk is dispatched and read by parser threads;
+         * {@code volatile} for that publication. {@code null} whenever no chunk needs it.
+         */
+        @Nullable
+        private volatile List<String> fileHeaderColumns;
         /** Added to each chunk's decompressed start byte; see {@link #parallelRead}'s {@code baseFileOffset}. */
         private final long baseFileOffset;
         /**
@@ -717,7 +730,7 @@ public final class StreamingParallelParsingCoordinator {
                     if (lastNewline < 0) {
                         if (isEof) {
                             if (chunkIndex == 0) {
-                                bindSchemaFromFirstChunk(buf, totalBytes);
+                                prepareFromFirstChunk(buf, totalBytes);
                             }
                             if (dispatchChunk(chunkIndex, coverageStart, buf, totalBytes, true)) {
                                 chunkIndex++;
@@ -743,7 +756,7 @@ public final class StreamingParallelParsingCoordinator {
                             int grownNewline = result.boundary();
                             if (grownNewline < 0) {
                                 if (chunkIndex == 0) {
-                                    bindSchemaFromFirstChunk(grown, grown.length);
+                                    prepareFromFirstChunk(grown, grown.length);
                                 }
                                 if (dispatchChunk(chunkIndex, coverageStart, grown, grown.length, true)) {
                                     chunkIndex++;
@@ -758,7 +771,7 @@ public final class StreamingParallelParsingCoordinator {
                                 carry = new byte[carryLen];
                                 System.arraycopy(grown, validLen, carry, 0, carryLen);
                                 if (chunkIndex == 0) {
-                                    bindSchemaFromFirstChunk(grown, validLen);
+                                    prepareFromFirstChunk(grown, validLen);
                                 }
                                 if (dispatchChunk(chunkIndex, coverageStart, grown, validLen, false)) {
                                     chunkIndex++;
@@ -782,7 +795,7 @@ public final class StreamingParallelParsingCoordinator {
                     }
 
                     if (chunkIndex == 0) {
-                        bindSchemaFromFirstChunk(buf, validLen);
+                        prepareFromFirstChunk(buf, validLen);
                     }
                     if (dispatchChunk(chunkIndex, coverageStart, buf, validLen, isEof)) {
                         chunkIndex++;
@@ -827,11 +840,32 @@ public final class StreamingParallelParsingCoordinator {
         }
 
         /**
-         * Infers the schema from the first chunk and swaps {@link #reader} for the schema-bound
-         * variant returned by {@link FormatReader#withSchema(List)}; parser threads thereafter
-         * skip per-chunk inference. Same approach as ClickHouse / DuckDB / Spark.
+         * Does the once-per-file work that needs the file's leading bytes, before any chunk is dispatched.
+         * <p>
+         * The file's schema is inferred and bound onto the reader so chunks 1..N parse against one answer
+         * rather than re-inferring per chunk (or, for CSV, reading a data row as a header). This runs whether
+         * or not the planner resolved a schema: where it did, the reader merges the two and the bound schema
+         * wins on type, so the inference cannot retype a column — it only contributes columns the projection
+         * does not name, which some readers need in order to decode the ones it does.
+         * <p>
+         * A header-bearing file whose declared schema binds by name additionally has to tell later chunks what
+         * its columns are called, since only chunk 0 can see the header.
          */
-        private void bindSchemaFromFirstChunk(byte[] buffer, int length) throws IOException {
+        private void prepareFromFirstChunk(byte[] buffer, int length) throws IOException {
+            // Capture before binding: the header names must come from the reader as the planner configured it,
+            // not from one already swapped for a schema inferred from this chunk.
+            if (readSchema != null && readSchema.isEmpty() == false) {
+                captureFileHeaderColumns(buffer, length);
+            }
+            bindInferredSchema(buffer, length);
+        }
+
+        /**
+         * Infers the schema from the first chunk and swaps {@link #reader} for the schema-bound variant
+         * returned by {@link FormatReader#withSchema(List)}, so parser threads skip per-chunk inference.
+         * Same approach as ClickHouse / DuckDB / Spark.
+         */
+        private void bindInferredSchema(byte[] buffer, int length) throws IOException {
             ByteArrayStorageObject firstChunkObj = chunkStorageObject(0, buffer, 0, length);
             SourceMetadata metadata = reader.metadata(firstChunkObj);
             List<Attribute> schema = metadata == null ? null : metadata.schema();
@@ -847,6 +881,40 @@ public final class StreamingParallelParsingCoordinator {
             } else {
                 throw new IllegalStateException(
                     "FormatReader#withSchema returned a non-SegmentableFormatReader: " + bound.getClass().getName()
+                );
+            }
+        }
+
+        /**
+         * Reads the file's column names from chunk 0 so chunks 1..N can bind a declared schema by name.
+         * <p>
+         * Only a header-bearing format whose declared schema binds by name needs this, and only when the
+         * planner bound a schema — otherwise the reader either has no names to match or reads its own header.
+         * Chunk 0 always reads its own header and ignores what is captured here.
+         * <p>
+         * Runs on the segmentator thread before any chunk is dispatched, so every parser sees a fully
+         * populated value. Failure is not fatal: chunks 1..N then find no names and fail loudly rather than
+         * binding by position, which would shift every column silently.
+         */
+        private void captureFileHeaderColumns(byte[] buffer, int length) {
+            if (fileHeaderColumns != null || reader.declaredNameBindingNeedsFileStart() == false) {
+                return;
+            }
+            try {
+                SourceMetadata metadata = reader.metadata(chunkStorageObject(0, buffer, 0, length));
+                List<Attribute> schema = metadata == null ? null : metadata.schema();
+                if (schema != null && schema.isEmpty() == false) {
+                    fileHeaderColumns = schema.stream().map(Attribute::name).toList();
+                }
+            } catch (IOException | RuntimeException e) {
+                // Every later chunk will now fail with "no header columns", which says nothing about why they
+                // are missing. Log the real cause at WARN so the two can be connected — this is the only place
+                // it is visible.
+                logger.warn(
+                    () -> "could not read header columns from the first chunk of ["
+                        + (storageObject == null ? "<stream>" : storageObject.path())
+                        + "]",
+                    e
                 );
             }
         }
@@ -947,6 +1015,9 @@ public final class StreamingParallelParsingCoordinator {
                     .lastSplit(true)
                     .recordAligned(true)
                     .readSchema(readSchema)
+                    // Chunk 0 carries the file's header and reads it directly; later chunks cannot see it,
+                    // so hand them the names read from chunk 0 rather than leaving them to bind by position.
+                    .fileHeaderColumns(chunk.index == 0 ? null : fileHeaderColumns)
                     .splitStartByte(chunkFileGlobalStart)
                     .maxRecordBytes(maxRecordBytes)
                     .stats(chunkFileGlobalStart, statsStripeSize, chunk.last())

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -91,6 +91,12 @@ import java.util.function.Consumer;
  *                         {@code is_partial} flag (see {@code AsyncExternalSourceBuffer#recordWarning} for
  *                         the one warning that does) — so the warning is relayed back and re-emitted on
  *                         the correct thread instead of being silently dropped.
+ * @param fileHeaderColumns the file's own column names, in file order, read from its leading bytes.
+ *                         {@code null} for every read that owns the file's start, and for formats that do
+ *                         not name their columns in a header. Set only for a read that cannot see the
+ *                         header but still has to know what the columns are called — a chunk after the
+ *                         first of a header-bearing file whose declared schema binds by name. Binding such
+ *                         a chunk by position instead would shift every column silently.
  */
 public record FormatReadContext(
     List<String> projectedColumns,
@@ -107,7 +113,8 @@ public record FormatReadContext(
     long statsStripeSize,
     boolean statsFileFinal,
     StripeColumnScope statsColumnScope,
-    @Nullable Consumer<String> informationalWarningSink
+    @Nullable Consumer<String> informationalWarningSink,
+    @Nullable List<String> fileHeaderColumns
 ) {
 
     public FormatReadContext {
@@ -152,7 +159,8 @@ public record FormatReadContext(
             statsStripeSize,
             statsFileFinal,
             statsColumnScope,
-            informationalWarningSink
+            informationalWarningSink,
+            fileHeaderColumns
         );
     }
 
@@ -175,7 +183,8 @@ public record FormatReadContext(
             statsStripeSize,
             statsFileFinal,
             statsColumnScope,
-            informationalWarningSink
+            informationalWarningSink,
+            fileHeaderColumns
         );
     }
 
@@ -198,7 +207,8 @@ public record FormatReadContext(
             statsStripeSize,
             statsFileFinal,
             statsColumnScope,
-            informationalWarningSink
+            informationalWarningSink,
+            fileHeaderColumns
         );
     }
 
@@ -223,6 +233,8 @@ public record FormatReadContext(
         private int maxRecordBytes = SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES;
         private long statsBaseOffset = 0L;
         private long statsStripeSize = -1L;
+        @Nullable
+        private List<String> fileHeaderColumns = null;
         private boolean statsFileFinal = false;
         private StripeColumnScope statsColumnScope = StripeColumnScope.PROJECTED;
         @Nullable
@@ -318,6 +330,19 @@ public record FormatReadContext(
             return this;
         }
 
+        /**
+         * The file's own column names, in file order, read from its leading bytes.
+         * <p>
+         * Only set for a read that does NOT own the file's start but still needs to know what its columns
+         * are called — a chunk after the first of a header-bearing file whose declared schema binds by name.
+         * Such a chunk cannot see the header itself, and binding by position instead would silently shift
+         * every column. The component that cut the file into chunks reads the header once and states it here.
+         */
+        public Builder fileHeaderColumns(@Nullable List<String> fileHeaderColumns) {
+            this.fileHeaderColumns = fileHeaderColumns;
+            return this;
+        }
+
         public FormatReadContext build() {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive, got: " + batchSize);
@@ -337,7 +362,8 @@ public record FormatReadContext(
                 statsStripeSize,
                 statsFileFinal,
                 statsColumnScope,
-                informationalWarningSink
+                informationalWarningSink,
+                fileHeaderColumns
             );
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -234,17 +234,23 @@ public interface FormatReader extends Closeable {
     }
 
     /**
-     * Returns a format reader configured with the schema attributes.
+     * Returns a format reader configured with the schema attributes, letting the reader skip
+     * re-reading/inferring the schema from the file header on every read — especially important for
+     * split-based reads where the split may start mid-file (no header available).
      * <p>
-     * The schema is determined during the planning phase (via {@link #metadata(StorageObject)})
-     * and is constant for all files/splits in a query. Passing it here allows the reader to skip
-     * re-reading/inferring the schema from the file header on every read, which is especially
-     * important for split-based reads where the split may start mid-file (no header available).
+     * <b>This carries no authority.</b> Callers use it for two different things: the planning-phase
+     * schema, constant for the query ({@code FileSourceFactory}), and a schema just inferred from one
+     * file or even one chunk ({@code AsyncExternalSourceOperatorFactory},
+     * {@code ParallelParsingCoordinator}, {@code StreamingParallelParsingCoordinator}). A reader cannot
+     * tell the two apart from this call. So where a reader also receives
+     * {@link FormatReadContext#readSchema()} — the planner's per-file read contract — <b>that is the
+     * authority and must win on type</b>; whatever arrives here may be a guess. Letting the guess win
+     * is what produced the compressed-read type-cast crashes.
      * <p>
      * Formats with embedded schemas (Parquet, ORC) may ignore this since they always read
      * the schema from the file metadata.
      *
-     * @param schema the planning-phase schema attributes, or null to clear
+     * @param schema the schema attributes, or null to clear. NOT necessarily planning-phase — see above.
      * @return a new reader with the schema set, or {@code this} if the schema is not needed
      */
     default FormatReader withSchema(List<Attribute> schema) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -1038,6 +1038,66 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         assertSame(sliceQueue, factory.sliceQueue());
     }
 
+    /**
+     * A whole-file split reaches the reader marked as its file's last, so the reader keeps a final record with
+     * no trailing terminator. Splits built before the position keys existed carry no markers at all, and this
+     * is the path that recognises them — on the factory that production actually uses.
+     */
+    public void testLegacyUnstampedWholeFileSplitReachesTheReaderAsFileFinal() throws Exception {
+        FileSplit split = new FileSplit(
+            "test",
+            StoragePath.of("s3://bucket/whole.ndjson"),
+            0,
+            1024,
+            "ndjson",
+            Map.of(), // no position keys — as produced before they were stamped
+            Map.of()
+        );
+
+        List<StorageObject> capturedObjects = new ArrayList<>();
+        List<Boolean> capturedSkipFirstLine = new ArrayList<>();
+        SplitCapturingFormatReader formatReader = new SplitCapturingFormatReader(capturedObjects, capturedSkipFirstLine);
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            new StubMultiFileStorageProvider(),
+            formatReader,
+            StoragePath.of("s3://bucket/whole.ndjson"),
+            List.of(
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "value",
+                    new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+                )
+            ),
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).sliceQueue(new ExternalSliceQueue(List.of(split))).build();
+
+        SourceOperator operator = factory.get(driverContext);
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                page.releaseBlocks();
+            }
+        }
+
+        assertEquals(1, formatReader.capturedLastSplit().size());
+        assertTrue(
+            "a split covering the whole file owns its trailing bytes, so the reader must be told it is the file's last",
+            formatReader.capturedLastSplit().get(0)
+        );
+        // Same fact, second consumer: it closes the file's trailing stats stripe. Derived from one place so the
+        // two cannot disagree — they used to, and a mid-file stripe was closed as if it were the file's last.
+        assertTrue("a whole-file read closes the file's final stats stripe", formatReader.capturedStatsFileFinal().get(0));
+    }
+
     public void testSliceQueueWithNonZeroOffsetWrapsWithRangeStorageObject() throws Exception {
         long splitOffset = 500;
         long splitLength = 300;
@@ -3389,10 +3449,20 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
 
         private final List<StorageObject> capturedObjects;
         private final List<Boolean> capturedSkipFirstLine;
+        private final List<Boolean> capturedLastSplit = new ArrayList<>();
+        private final List<Boolean> capturedStatsFileFinal = new ArrayList<>();
 
         SplitCapturingFormatReader(List<StorageObject> capturedObjects, List<Boolean> capturedSkipFirstLine) {
             this.capturedObjects = capturedObjects;
             this.capturedSkipFirstLine = capturedSkipFirstLine;
+        }
+
+        List<Boolean> capturedLastSplit() {
+            return capturedLastSplit;
+        }
+
+        List<Boolean> capturedStatsFileFinal() {
+            return capturedStatsFileFinal;
         }
 
         @Override
@@ -3404,6 +3474,8 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
             capturedObjects.add(object);
             capturedSkipFirstLine.add(context.firstSplit() == false);
+            capturedLastSplit.add(context.lastSplit());
+            capturedStatsFileFinal.add(context.statsFileFinal());
             return singlePageIterator();
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceOperatorFactoryTests.java
@@ -170,6 +170,63 @@ public class ExternalSourceOperatorFactoryTests extends ESTestCase {
         .breaker(new NoopCircuitBreaker("none"))
         .build();
 
+    /**
+     * A whole-file split reaches the reader marked as its file's last, so the reader keeps a final record
+     * that has no trailing terminator. Splits built before the position keys existed carry no marks at all,
+     * and this is the path that recognises them.
+     * <p>
+     * Nothing else covers the factory's half of that chain: the split producer stamping the mark and the
+     * reader honouring it are each pinned elsewhere, but if the factory stopped deriving it the record would
+     * be dropped again with every other test still green.
+     */
+    public void testLegacyUnstampedWholeFileSplitReachesTheReaderAsFileFinal() throws Exception {
+        FileSplit split = new FileSplit(
+            "file",
+            StoragePath.of("s3://bucket/whole.csv"),
+            0,
+            1024,
+            ".csv",
+            Map.of(), // no position keys — as produced before they were stamped
+            Map.of()
+        );
+        List<Boolean> capturedSkipFirstLine = new ArrayList<>();
+        SplitCapturingFormatReader formatReader = new SplitCapturingFormatReader(new ArrayList<>(), capturedSkipFirstLine);
+
+        BlockFactory blockFactory = Mockito.mock(BlockFactory.class);
+        DriverContext driverContext = Mockito.mock(DriverContext.class);
+        Mockito.when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+        ExternalSourceOperatorFactory factory = new ExternalSourceOperatorFactory(
+            new StubStorageProvider(),
+            formatReader,
+            StoragePath.of("s3://bucket/whole.csv"),
+            List.of(
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "value",
+                    new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+                )
+            ),
+            100,
+            FormatReader.NO_LIMIT,
+            new ExternalSliceQueue(List.of(split))
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                page.releaseBlocks();
+            }
+        }
+
+        assertEquals(1, formatReader.capturedLastSplit().size());
+        assertTrue(
+            "a split covering the whole file owns its trailing bytes, so the reader must be told it is the file's last",
+            formatReader.capturedLastSplit().get(0)
+        );
+    }
+
     public void testSliceQueueWithNonZeroOffsetWrapsWithRangeStorageObject() throws Exception {
         long splitOffset = 500;
         long splitLength = 300;
@@ -428,9 +485,15 @@ public class ExternalSourceOperatorFactoryTests extends ESTestCase {
         private final List<StorageObject> capturedObjects;
         private final List<Boolean> capturedSkipFirstLine;
 
+        private final List<Boolean> capturedLastSplit = new ArrayList<>();
+
         SplitCapturingFormatReader(List<StorageObject> capturedObjects, List<Boolean> capturedSkipFirstLine) {
             this.capturedObjects = capturedObjects;
             this.capturedSkipFirstLine = capturedSkipFirstLine;
+        }
+
+        List<Boolean> capturedLastSplit() {
+            return capturedLastSplit;
         }
 
         @Override
@@ -442,6 +505,7 @@ public class ExternalSourceOperatorFactoryTests extends ESTestCase {
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
             capturedObjects.add(object);
             capturedSkipFirstLine.add(context.firstSplit() == false);
+            capturedLastSplit.add(context.lastSplit());
             return singlePageIterator();
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -282,7 +282,13 @@ public class FileSplitProviderTests extends ESTestCase {
         List<ExternalSplit> splits = provider.discoverSplits(ctx).splits();
 
         assertEquals(1, splits.size());
-        assertEquals(config, ((FileSplit) splits.get(0)).config());
+        Map<String, Object> splitConfig = ((FileSplit) splits.get(0)).config();
+        // Every caller-supplied entry reaches the split untouched. The split config is a superset, not a
+        // copy: the provider also stamps this split's position in its file (here, a whole-file split, so
+        // both first and last), which readers need for the record-boundary protocol.
+        assertEquals("https://s3.example.com", splitConfig.get("endpoint"));
+        assertEquals("true", splitConfig.get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", splitConfig.get(FileSplitProvider.LAST_SPLIT_KEY));
     }
 
     public void testSingleSplitProvider() {
@@ -671,8 +677,12 @@ public class FileSplitProviderTests extends ESTestCase {
         FileSplit whole = (FileSplit) splits.get(0);
         assertEquals(0, whole.offset());
         assertEquals(fileSize, whole.length());
-        assertNull(whole.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
-        assertNull(whole.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+        // A whole-file split states its position explicitly: it is both the first and the last split of
+        // the file. Readers run the split-boundary protocol off these flags — a non-last split drops its
+        // trailing partial record because the next split re-reads those bytes — so leaving them unstamped
+        // made a whole-file read discard a final record that no other split would ever read.
+        assertEquals("true", whole.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", whole.config().get(FileSplitProvider.LAST_SPLIT_KEY));
     }
 
     public void testNewlineMacroSplitCandidateExtensionsIncludeCsvAndTsv() {
@@ -2377,6 +2387,122 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals(Boolean.TRUE, FileSplitProvider.evaluateFilter(new GreaterThan(SRC, intLiteral(2024), fieldAttr("year")), values));
         // 2024 < year -> 2024 < 2020 -> FALSE (the file cannot match, and may be pruned)
         assertEquals(Boolean.FALSE, FileSplitProvider.evaluateFilter(new LessThan(SRC, intLiteral(2024), fieldAttr("year")), values));
+    }
+
+    /**
+     * A compressed file whose codec finds no block boundaries falls back to one whole-file split, and that
+     * split still states its position.
+     * <p>
+     * Pinned at the producer rather than through the position helpers: a whole-file split with no keys is
+     * currently rescued by the compatibility path for splits from older coordinators, so an unstamped
+     * producer looks correct until that path is deleted — at which point the file's final record would go
+     * missing again with every other test still green.
+     */
+    public void testCompressedFallbackWithNoBoundariesStampsPosition() {
+        assertWholeFileSplitStamped(splitsFromCompressedFallback());
+    }
+
+    private static List<ExternalSplit> splitsFromCompressedFallback() {
+        // A codec that reports no block boundaries at all sends the provider down its whole-file fallback.
+        DecompressionCodecRegistry codecRegistry = new DecompressionCodecRegistry();
+        codecRegistry.register(new FakeSplittableCodec(new long[0]));
+        FileSplitProvider splitter = new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            codecRegistry,
+            createMockStorageRegistry(),
+            new FormatReaderRegistry(codecRegistry),
+            Settings.EMPTY
+        );
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/noboundaries.ndjson.bz2"), 1_000_000L, Instant.EPOCH);
+        return splitter.discoverSplits(
+            new SplitDiscoveryContext(
+                null,
+                GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson.bz2"),
+                Map.of(),
+                PartitionMetadata.EMPTY,
+                List.of()
+            )
+        ).splits();
+    }
+
+    private static void assertWholeFileSplitStamped(List<ExternalSplit> splits) {
+        assertEquals("the fallback emits exactly one whole-file split", 1, splits.size());
+        FileSplit whole = (FileSplit) splits.get(0);
+        assertEquals(0, whole.offset());
+        assertEquals("true", whole.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+        assertEquals("true", whole.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+    }
+
+    /**
+     * Every shape of split this class can produce, with the position it must report.
+     * <p>
+     * Split position used to be re-derived at each consumer under differing rules, so a whole-file read
+     * answered "first" in one place and "not last" in another — and readers discarded its final record.
+     * This table is the single statement of the contract. <b>A new split shape must add a row here.</b>
+     */
+    public void testSplitPositionAcrossEveryProducibleShape() {
+        StoragePath p = StoragePath.of("s3://b/f.ndjson");
+
+        // Whole file: owns both ends.
+        assertPosition("stamped whole-file", split(p, 0, 100, Map.of("_first_split", "true", "_last_split", "true")), true, true);
+
+        // Newline-aligned macro-splits: the edges are stamped, the middle is stamped as neither.
+        Map<String, Object> ram = Map.of("_record_aligned_macro_split", "true");
+        assertPosition("newline macro first", split(p, 0, 40, withKeys(ram, "_first_split")), true, false);
+        assertPosition("newline macro middle", split(p, 40, 40, ram), false, false);
+        assertPosition("newline macro last", split(p, 80, 20, withKeys(ram, "_last_split")), false, true);
+
+        // Compressed block-aligned macro-splits. The first starts at offset 0, so an offset-based rule
+        // would call it whole-file; its protocol key is what rules it out.
+        Map<String, Object> cos = Map.of("_compressed_offset_split", "true");
+        assertPosition("compressed macro first", split(p, 0, 40, withKeys(cos, "_first_split")), true, false);
+        assertPosition("compressed macro middle", split(p, 40, 40, cos), false, false);
+        assertPosition("compressed macro last", split(p, 80, 20, withKeys(cos, "_last_split")), false, true);
+
+        // Range splits carry no position keys by design — byte ranges are not a record-boundary protocol.
+        Map<String, Object> range = Map.of("_range_split", "true");
+        assertPosition("range split at offset 0", split(p, 0, 40, range), true, false);
+        assertPosition("range split mid-file", split(p, 40, 40, range), false, false);
+
+        // A split from a coordinator that predates position stamping: recognised by the BWC belt.
+        assertPosition("legacy unstamped whole-file", split(p, 0, 100, Map.of()), true, true);
+    }
+
+    /** The belt must recognise only genuine whole-file splits — anything covering part of a file is excluded. */
+    public void testLegacyBeltExcludesEveryPartialFileShape() {
+        StoragePath p = StoragePath.of("s3://b/f.ndjson");
+        assertFalse("mid-file offset is never whole-file", FileSplitProvider.isLastInFile(split(p, 500, 40, Map.of())));
+        assertFalse(
+            "record-aligned macro at offset 0 is not whole-file",
+            FileSplitProvider.isLastInFile(split(p, 0, 40, Map.of("_record_aligned_macro_split", "true")))
+        );
+        assertFalse(
+            "compressed macro at offset 0 is not whole-file",
+            FileSplitProvider.isLastInFile(split(p, 0, 40, Map.of("_compressed_offset_split", "true")))
+        );
+        assertFalse(
+            "range split at offset 0 is not whole-file",
+            FileSplitProvider.isLastInFile(split(p, 0, 40, Map.of("_range_split", "true")))
+        );
+        // An explicit stamp always wins over the belt's inference.
+        assertTrue(FileSplitProvider.isLastInFile(split(p, 500, 40, Map.of("_last_split", "true"))));
+    }
+
+    private static void assertPosition(String shape, FileSplit split, boolean first, boolean last) {
+        assertEquals(shape + ": isFirstInFile", first, FileSplitProvider.isFirstInFile(split));
+        assertEquals(shape + ": isLastInFile", last, FileSplitProvider.isLastInFile(split));
+    }
+
+    private static FileSplit split(StoragePath path, long offset, long length, Map<String, Object> config) {
+        return new FileSplit("file", path, offset, length, ".ndjson", config, Map.of());
+    }
+
+    private static Map<String, Object> withKeys(Map<String, Object> base, String... extra) {
+        Map<String, Object> out = new HashMap<>(base);
+        for (String k : extra) {
+            out.put(k, "true");
+        }
+        return out;
     }
 
     // -- helpers --


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ES|QL: derive external read schema and split position once, not at each consumer (#154526)](https://github.com/elastic/elasticsearch/pull/154526)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)