### PR TITLE
KnnIT - log per segment calibrated config when ac=true

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -16,13 +16,17 @@ import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.Sort;
@@ -31,12 +35,14 @@ import org.apache.lucene.util.NamedThreadFactory;
 import org.elasticsearch.cli.ProcessInfo;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.gpu.codec.ES92GpuHnswSQVectorsFormat;
 import org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat;
+import org.elasticsearch.index.codec.vectors.diskbbq.CalibrationAwareReader;
 import org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormat;
 import org.elasticsearch.index.codec.vectors.diskbbq.IvfAutoCalibration;
 import org.elasticsearch.index.codec.vectors.diskbbq.IvfFlushConfigSource;
@@ -73,6 +79,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -537,6 +545,9 @@ public class KnnIndexTester {
                 }
             }
             numSegments(indexPath, indexResults, sharedDir);
+            if (testConfiguration.autoCalibrate() && testConfiguration.indexType() == IndexType.IVF) {
+                logAutoCalibrationSegmentReport(indexPath, sharedDir);
+            }
 
             boolean hasQueries = testConfiguration.numQueries() > 0 && dataGenerator.numQueries() > 0;
             if (hasQueries) {
@@ -741,6 +752,104 @@ public class KnnIndexTester {
             result.numSegments = reader.leaves().size();
         } catch (IOException e) {
             throw new IOException("Failed to get segment count for dir: " + dir, e);
+        }
+    }
+
+    /**
+     * Logs a concise per-segment summary of the auto-calibrated IVF configuration: quantization
+     * encoding, rescore oversample factor, and whether preconditioning is active. Only meaningful
+     * when {@code auto_calibrate} is {@code true} and the index type is IVF.
+     */
+    static void logAutoCalibrationSegmentReport(Path indexPath, Directory sharedDir) throws IOException {
+        Directory dir = sharedDir != null ? sharedDir : KnnIndexer.getDirectory(indexPath);
+        boolean ownsDir = sharedDir == null;
+        try (IndexReader reader = DirectoryReader.open(dir)) {
+            List<LeafReaderContext> leaves = reader.leaves();
+            StringBuilder sb = new StringBuilder();
+            sb.append("Auto-calibration segment distribution [field=")
+                .append(KnnIndexer.VECTOR_FIELD)
+                .append(", ")
+                .append(leaves.size())
+                .append(" segment(s)]\n");
+            sb.append(
+                String.format(Locale.ROOT, "  %4s  %7s  %-22s  %10s  %12s%n", "seg", "docs", "quantization", "oversample", "precondition")
+            );
+            sb.append(
+                String.format(
+                    Locale.ROOT,
+                    "  %4s  %7s  %-22s  %10s  %12s%n",
+                    "---",
+                    "-------",
+                    "----------------------",
+                    "----------",
+                    "------------"
+                )
+            );
+
+            Map<String, Integer> encodingCounts = new LinkedHashMap<>();
+            List<Double> oversamples = new ArrayList<>();
+            int preconditionTrue = 0;
+            int calibrated = 0;
+
+            for (LeafReaderContext ctx : leaves) {
+                var lr = ctx.reader();
+                FieldInfo fi = lr.getFieldInfos().fieldInfo(KnnIndexer.VECTOR_FIELD);
+                if (fi == null) {
+                    sb.append(String.format(Locale.ROOT, "  %4d  %7d  (no vector field)%n", ctx.ord, lr.numDocs()));
+                    continue;
+                }
+                SegmentReader sr = Lucene.tryUnwrapSegmentReader(lr);
+                KnnVectorsReader vr = sr != null ? sr.getVectorReader() : null;
+                if (vr instanceof PerFieldKnnVectorsFormat.FieldsReader pfr) {
+                    vr = pfr.getFieldReader(KnnIndexer.VECTOR_FIELD);
+                }
+                if (vr instanceof CalibrationAwareReader car) {
+                    QuantEncoding enc = car.getQuantEncoding(fi);
+                    float oversample = car.getOversampleFactor(fi);
+                    boolean precondition = car.shouldPrecondition(fi);
+                    String encName = enc != null ? enc.name() : "n/a";
+                    String oversampleStr = Float.isFinite(oversample) ? String.format(Locale.ROOT, "%.2f", oversample) : "n/a";
+                    sb.append(
+                        String.format(
+                            Locale.ROOT,
+                            "  %4d  %7d  %-22s  %10s  %12b%n",
+                            ctx.ord,
+                            lr.numDocs(),
+                            encName,
+                            oversampleStr,
+                            precondition
+                        )
+                    );
+                    encodingCounts.merge(encName, 1, Integer::sum);
+                    if (Float.isFinite(oversample)) {
+                        oversamples.add((double) oversample);
+                    }
+                    if (precondition) {
+                        preconditionTrue++;
+                    }
+                    calibrated++;
+                } else {
+                    sb.append(String.format(Locale.ROOT, "  %4d  %7d  (no calibration data)%n", ctx.ord, lr.numDocs()));
+                }
+            }
+
+            if (calibrated > 0) {
+                DoubleSummaryStatistics stats = oversamples.stream().mapToDouble(Double::doubleValue).summaryStatistics();
+                sb.append("  Summary: encodings=");
+                encodingCounts.forEach((enc, count) -> sb.append(enc).append("×").append(count).append(" "));
+                if (oversamples.isEmpty() == false) {
+                    sb.append(
+                        String.format(Locale.ROOT, " oversample=[%.2f, %.2f] avg=%.2f", stats.getMin(), stats.getMax(), stats.getAverage())
+                    );
+                }
+                sb.append(String.format(Locale.ROOT, "  precondition=%d/%d segments", preconditionTrue, calibrated));
+            }
+
+            logger.info("{}", sb);
+        } finally {
+            if (ownsDir) {
+                dir.close();
+            }
         }
     }
 


### PR DESCRIPTION
Log information about calibrated segment distribution (quantization, oversampling, precondition), when auto_calibrate = true.

ann-gist-1M (force_merge=true)
```
2026-07-22T11:07:33.523767Z main INFO Auto-calibration segment distribution [field=vector, 1 segment(s)]
   seg     docs  quantization            oversample  precondition
   ---  -------  ----------------------  ----------  ------------
     0  1000000  FOUR_BIT_SYMMETRIC            2.00         false
  Summary: encodings=FOUR_BIT_SYMMETRIC×1  oversample=[2.00, 2.00] avg=2.00  precondition=0/1 segments
````

dbpedia-entity-arctic (force_merge=false)
```
2026-07-22T13:04:56.238888Z main INFO Auto-calibration segment distribution [field=vector, 13 segment(s)]
   seg     docs  quantization            oversample  precondition
   ---  -------  ----------------------  ----------  ------------
     0  1497435  TWO_BIT_4BIT_QUERY            1.50         false
     1   155650  ONE_BIT_4BIT_QUERY             n/a         false
     2   156180  ONE_BIT_4BIT_QUERY             n/a         false
     3   314911  ONE_BIT_4BIT_QUERY             n/a         false
     4  1470894  TWO_BIT_4BIT_QUERY            1.50         false
     5   197861  ONE_BIT_4BIT_QUERY             n/a         false
     6   205021  ONE_BIT_4BIT_QUERY             n/a         false
     7   228427  ONE_BIT_4BIT_QUERY             n/a         false
     8     6196  ONE_BIT_4BIT_QUERY             n/a         false
     9    10990  ONE_BIT_4BIT_QUERY             n/a         false
    10   164783  ONE_BIT_4BIT_QUERY             n/a         false
    11    77975  ONE_BIT_4BIT_QUERY             n/a         false
    12   149599  ONE_BIT_4BIT_QUERY             n/a         false
  Summary: encodings=TWO_BIT_4BIT_QUERY×2 ONE_BIT_4BIT_QUERY×11  oversample=[1.50, 1.50] avg=1.50  precondition=0/13 segments
```