### PR TITLE
Fix VotingOnlyNodePluginTests.testBootstrapOnlyVotingOnlyNodes 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -535,9 +535,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/154058
-- class: org.elasticsearch.cluster.coordination.votingonly.VotingOnlyNodePluginTests
-  method: testBootstrapOnlyVotingOnlyNodes
-  issue: https://github.com/elastic/elasticsearch/issues/154563
 - class: org.elasticsearch.search.fetch.chunk.TransportFetchPhaseCoordinationActionTests
   method: testDoExecuteReleasesRegistrationOnLastChunkDeserializationFailure
   issue: https://github.com/elastic/elasticsearch/issues/154568

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1014,7 +1014,11 @@ public abstract class ESIntegTestCase extends ESTestCase {
         // The cluster health API always runs on the master node, and the master only completes cluster state publication when all nodes
         // in the cluster have accepted the new cluster state. By waiting for all events to have finished on the master node, we ensure
         // that the whole cluster has a consistent view of which node is the master.
-        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setTimeout(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setTimeout(TEST_REQUEST_TIMEOUT)
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForNodes(Integer.toString(internalCluster().size()))
+            .get();
     }
 
     /**

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -117,10 +117,15 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         );
     }
 
-    public void testBootstrapOnlyVotingOnlyNodes() {
+    public void testBootstrapOnlyVotingOnlyNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)), Settings.EMPTY, Settings.EMPTY);
-        ensureStableCluster(3);
+        assertBusy(
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
+        );
         awaitMasterNode();
         assertThat(
             VotingOnlyNodePlugin.isVotingOnlyNode(

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -117,15 +117,10 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         );
     }
 
-    public void testBootstrapOnlyVotingOnlyNodes() throws Exception {
+    public void testBootstrapOnlyVotingOnlyNodes() {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)), Settings.EMPTY, Settings.EMPTY);
-        assertBusy(
-            () -> assertThat(
-                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds().size(),
-                equalTo(3)
-            )
-        );
+        ensureStableCluster(3);
         awaitMasterNode();
         assertThat(
             VotingOnlyNodePlugin.isVotingOnlyNode(


### PR DESCRIPTION
In the failed test execution logs, we can see that node_t1 joins the cluster **after the test cleanup has already started**.                                                                                                                                                                                                

Added `.setWaitForNodes(Integer.toString(internalCluster().size()))` in the `awaitMasterNode()` to wait for the cluster to stabilize.

Closes #154563 