### PR TITLE
Mute MultiCluster PromQL small-window test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -562,6 +562,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesPromqlIT
   method: test {csv-spec:k8s-timeseries-promql.rate_small_window_no_set_operator}
   issue: https://github.com/elastic/elasticsearch/issues/154609
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecK8sTimeseriesPromqlIT
+  method: test {csv-spec:k8s-timeseries-promql.rate_small_window_no_set_operator}
+  issue: https://github.com/elastic/elasticsearch/issues/154609
 - class: org.elasticsearch.blobcache.common.SparseFileTrackerTests
   method: testClaimedGapsDoNotExtendBeyondRequestedRangeWhenCaller2FillsFirst
   issue: https://github.com/elastic/elasticsearch/issues/154462


### PR DESCRIPTION
Mutes the `MultiClusterSpecK8sTimeseriesPromqlIT` variant of `rate_small_window_no_set_operator`. The mixed-cluster variant is already muted for the same `ReferenceAttribute` to `Bucket` failure.

Relates #154609.