### PR TITLE
Semantic field - generalize inference ID update tests

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/AbstractSemanticMapperTestCase.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/AbstractSemanticMapperTestCase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.IndexMode;
@@ -83,6 +84,7 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.SEARCH_
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.TEXT_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getChunksFieldName;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getEmbeddingsFieldName;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -256,6 +258,110 @@ abstract class AbstractSemanticMapperTestCase<T extends SemanticFieldMapper, U e
     /** Whether the field type under test uses the legacy {@code semantic_text} storage format. */
     protected boolean useLegacyFormat() {
         return false;
+    }
+
+    public void testUpdateInferenceId_GivenNoModelSettings() throws IOException {
+        for (int randomizedRun = 0; randomizedRun < 10; randomizedRun++) {
+            String fieldName = randomAlphaOfLengthBetween(5, 15);
+            String oldInferenceId = randomAlphaOfLengthBetween(5, 15);
+
+            TestModel oldModel = null;
+            if (randomBoolean()) {
+                oldModel = createRandomSupportedModel();
+                givenModelSettings(oldInferenceId, new MinimalServiceSettings(oldModel));
+            }
+
+            var mapperService = createSemanticMapperService(semanticMapping(fieldName, oldInferenceId));
+
+            assertInferenceEndpoints(mapperService, fieldName, oldInferenceId, oldInferenceId);
+            assertSemanticField(mapperService, fieldName, false, null, null);
+            if (oldModel != null) {
+                assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, oldModel);
+            }
+
+            String newInferenceId = randomValueOtherThan(oldInferenceId, () -> randomAlphaOfLengthBetween(5, 15));
+            TestModel newModel = null;
+            if (randomBoolean()) {
+                newModel = createRandomSupportedModel();
+                givenModelSettings(newInferenceId, new MinimalServiceSettings(newModel));
+            }
+
+            merge(mapperService, semanticMapping(fieldName, newInferenceId));
+
+            assertInferenceEndpoints(mapperService, fieldName, newInferenceId, newInferenceId);
+            assertSemanticField(mapperService, fieldName, false, null, null);
+            if (newModel != null) {
+                assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, newModel);
+            }
+        }
+    }
+
+    public void testUpdateInferenceId_GivenModelSettings() throws IOException {
+        for (int randomizedRun = 0; randomizedRun < 20; randomizedRun++) {
+            final String fieldName = randomAlphaOfLengthBetween(5, 15);
+            final String oldInferenceId = randomAlphaOfLengthBetween(5, 15);
+            final String newInferenceId = randomValueOtherThan(oldInferenceId, () -> randomAlphaOfLengthBetween(5, 15));
+
+            final TestModel oldModel = createRandomSupportedModel();
+            final MinimalServiceSettings previousModelSettings = new MinimalServiceSettings(oldModel);
+            givenModelSettings(oldInferenceId, previousModelSettings);
+
+            final MapperService mapperService = createSemanticMapperService(
+                semanticMapping(fieldName, oldInferenceId, previousModelSettings)
+            );
+            final SemanticIndexOptions currentIndexOptions = extractCurrentIndexOptions(mapperService, fieldName);
+            assertInferenceEndpoints(mapperService, fieldName, oldInferenceId, oldInferenceId);
+            assertSemanticField(mapperService, fieldName, true, null, currentIndexOptions);
+            assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, oldModel);
+
+            final CheckedRunnable<IOException> mergeRunner = () -> merge(mapperService, semanticMapping(fieldName, newInferenceId));
+
+            if (randomBoolean()) {
+                // Compatible: new endpoint has identical task type / dimensions / similarity / element type
+                TestModel newModel = createCompatibleModel(newInferenceId, oldModel);
+                MinimalServiceSettings newModelSettings = new MinimalServiceSettings(newModel);
+                givenModelSettings(newInferenceId, newModelSettings);
+
+                mergeRunner.run();
+                assertInferenceEndpoints(mapperService, fieldName, newInferenceId, newInferenceId);
+                assertSemanticField(mapperService, fieldName, true, null, currentIndexOptions);
+                assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, newModel);
+            } else {
+                final TestModel incompatibleModel = createIncompatibleModel(newInferenceId, oldModel);
+                final String expectedErrorMessage;
+                if (incompatibleModel == null) {
+                    // Incompatible: new endpoint does not exist
+                    expectedErrorMessage = "Cannot update ["
+                        + contentType()
+                        + "] field ["
+                        + fieldName
+                        + "] because inference endpoint ["
+                        + newInferenceId
+                        + "] does not exist.";
+                } else {
+                    // Incompatible: new endpoint exists but its model settings are incompatible
+                    MinimalServiceSettings incompatibleModelSettings = new MinimalServiceSettings(incompatibleModel);
+                    givenModelSettings(newInferenceId, incompatibleModelSettings);
+
+                    expectedErrorMessage = "Cannot update ["
+                        + contentType()
+                        + "] field ["
+                        + fieldName
+                        + "] because inference endpoint ["
+                        + oldInferenceId
+                        + "] with model settings ["
+                        + previousModelSettings
+                        + "] is not compatible with new inference endpoint ["
+                        + newInferenceId
+                        + "] with model settings ["
+                        + incompatibleModelSettings
+                        + "]";
+                }
+
+                IllegalArgumentException exc = assertThrows(IllegalArgumentException.class, mergeRunner::run);
+                assertThat(exc.getMessage(), containsString(expectedErrorMessage));
+            }
+        }
     }
 
     protected XContentBuilder semanticMapping(String fieldName, String inferenceId) throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/AbstractSemanticMapperTestCase.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/AbstractSemanticMapperTestCase.java
@@ -38,6 +38,7 @@ import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.MinimalServiceSettings;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
@@ -60,6 +61,7 @@ import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +71,9 @@ import java.util.function.Supplier;
 import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.index.IndexVersions.NEW_SPARSE_VECTOR;
 import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BFLOAT16;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BBQ_MIN_DIMS;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTestUtils.getSupportedSimilarities;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTestUtils.randomCompatibleDimensions;
 import static org.elasticsearch.xpack.inference.mapper.SemanticFieldMapper.INDEX_OPTIONS_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_EMBEDDINGS_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKING_SETTINGS_FIELD;
@@ -116,6 +121,15 @@ abstract class AbstractSemanticMapperTestCase<T extends SemanticFieldMapper, U e
         protected XPackLicenseState getLicenseState() {
             return licenseState;
         }
+    }
+
+    /** The kinds of incompatibility that can exist between two inference endpoint model settings. */
+    protected enum IncompatibilityKind {
+        TASK_TYPE,
+        DIMENSIONS,
+        SIMILARITY,
+        ELEMENT_TYPE,
+        DOES_NOT_EXIST
     }
 
     protected final License.OperationMode operationMode;
@@ -584,6 +598,122 @@ abstract class AbstractSemanticMapperTestCase<T extends SemanticFieldMapper, U e
 
     protected void givenModelSettings(String inferenceId, MinimalServiceSettings modelSettings) {
         when(globalModelRegistry.getMinimalServiceSettings(inferenceId)).thenReturn(modelSettings);
+    }
+
+    /**
+     * Creates a {@link TestModel} that is compatible with {@code baseModel} (same task type, dimensions,
+     * similarity, and element type) but with a distinct service, task settings, and secrets, registered
+     * under the given inference ID. Compatible models can be substituted via an inference-ID update.
+     */
+    protected TestModel createCompatibleModel(String inferenceId, TestModel baseModel) {
+        return new TestModel(
+            inferenceId,
+            baseModel.getTaskType(),
+            randomAlphaOfLength(4),
+            new TestModel.TestServiceSettings(
+                randomAlphaOfLength(4),
+                baseModel.getServiceSettings().dimensions(),
+                baseModel.getServiceSettings().similarity(),
+                baseModel.getServiceSettings().elementType()
+            ),
+            new TestModel.TestTaskSettings(randomInt(3)),
+            new TestModel.TestSecretSettings(randomAlphaOfLength(4))
+        );
+    }
+
+    /**
+     * Creates a {@link TestModel} that is NOT compatible with {@code baseModel}, choosing uniformly among the
+     * applicable kinds of incompatibility: task type, dimensions, similarity, element type, or the endpoint not
+     * existing. Setting-based perturbations (dimensions/similarity/element type) only apply to dense base models;
+     * a sparse base model has null dimensions/similarity/element type, so only task-type and does-not-exist apply.
+     *
+     * @return an incompatible model to register under {@code inferenceId}, or {@code null} to indicate the
+     *         caller should NOT register an endpoint (the does-not-exist case).
+     */
+    protected TestModel createIncompatibleModel(String inferenceId, TestModel baseModel) {
+        final TestModel.TestServiceSettings baseServiceSettings = baseModel.getServiceSettings();
+        final DenseVectorFieldMapper.ElementType baseElementType = baseServiceSettings.elementType();
+
+        List<IncompatibilityKind> applicable = new ArrayList<>();
+        if (supportedTaskTypes().size() > 1) {
+            applicable.add(IncompatibilityKind.TASK_TYPE);
+        }
+        applicable.add(IncompatibilityKind.DOES_NOT_EXIST);
+        if (baseModel.getTaskType() != TaskType.SPARSE_EMBEDDING) {
+            applicable.add(IncompatibilityKind.DIMENSIONS);
+            applicable.add(IncompatibilityKind.ELEMENT_TYPE);
+            // SIMILARITY only when the element type supports more than one option to perturb to
+            if (getSupportedSimilarities(baseElementType).size() > 1) {
+                applicable.add(IncompatibilityKind.SIMILARITY);
+            }
+        }
+
+        TaskType taskType = baseModel.getTaskType();
+        Integer dimensions = baseServiceSettings.dimensions();
+        SimilarityMeasure similarity = baseServiceSettings.similarity();
+        DenseVectorFieldMapper.ElementType elementType = baseElementType;
+        boolean returnNull = false;
+
+        switch (randomFrom(applicable)) {
+            case DOES_NOT_EXIST -> returnNull = true;
+            case TASK_TYPE -> {
+                taskType = randomValueOtherThan(taskType, () -> randomFrom(supportedTaskTypes()));
+                if (taskType != TaskType.SPARSE_EMBEDDING && baseModel.getTaskType() == TaskType.SPARSE_EMBEDDING) {
+                    // Sparse -> dense: populate required dense settings from a fresh random dense model
+                    TestModel randomDenseModel = TestModel.createRandomInstance(taskType);
+                    dimensions = randomDenseModel.getServiceSettings().dimensions();
+                    similarity = randomDenseModel.getServiceSettings().similarity();
+                    elementType = randomDenseModel.getServiceSettings().elementType();
+                } else if (taskType == TaskType.SPARSE_EMBEDDING) {
+                    // Dense -> sparse: clear dense-only settings
+                    dimensions = null;
+                    similarity = null;
+                    elementType = null;
+                }
+            }
+            case DIMENSIONS -> dimensions = randomValueOtherThan(
+                dimensions,
+                () -> randomCompatibleDimensions(baseElementType, BBQ_MIN_DIMS * 2)
+            );
+            case SIMILARITY -> similarity = randomValueOtherThan(similarity, () -> randomFrom(getSupportedSimilarities(baseElementType)));
+            case ELEMENT_TYPE -> {
+                elementType = randomValueOtherThan(
+                    elementType,
+                    () -> randomFrom(
+                        DenseVectorFieldMapper.ElementType.FLOAT,
+                        DenseVectorFieldMapper.ElementType.BYTE,
+                        DenseVectorFieldMapper.ElementType.BIT
+                    )
+                );
+                // Regenerate dimensions and similarity compatible with the new element type
+                dimensions = randomCompatibleDimensions(elementType, BBQ_MIN_DIMS * 2);
+                similarity = randomFrom(getSupportedSimilarities(elementType));
+            }
+        }
+
+        if (returnNull) {
+            return null;
+        }
+
+        return buildModel(baseModel, inferenceId, taskType, elementType, dimensions, similarity);
+    }
+
+    protected static TestModel buildModel(
+        TestModel baseModel,
+        String inferenceId,
+        TaskType taskType,
+        @Nullable DenseVectorFieldMapper.ElementType elementType,
+        @Nullable Integer dimensions,
+        @Nullable SimilarityMeasure similarity
+    ) {
+        return new TestModel(
+            inferenceId,
+            taskType,
+            baseModel.getConfigurations().getService(),
+            new TestModel.TestServiceSettings(baseModel.getServiceSettings().model(), dimensions, similarity, elementType),
+            baseModel.getTaskSettings(),
+            baseModel.getSecretSettings()
+        );
     }
 
     protected static String randomFieldName(int numLevel) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersion;
@@ -745,110 +744,6 @@ public class SemanticTextFieldMapperTests extends AbstractSemanticMapperTestCase
                 b.endObject();
             })));
             assertThat(e.getMessage(), containsString("is already used by another field"));
-        }
-    }
-
-    public void testUpdateInferenceId_GivenNoModelSettings() throws IOException {
-        for (int randomizedRun = 0; randomizedRun < 10; randomizedRun++) {
-            String fieldName = randomAlphaOfLengthBetween(5, 15);
-            String oldInferenceId = randomAlphaOfLengthBetween(5, 15);
-
-            TestModel oldModel = null;
-            if (randomBoolean()) {
-                oldModel = createRandomSupportedModel();
-                givenModelSettings(oldInferenceId, new MinimalServiceSettings(oldModel));
-            }
-
-            var mapperService = createSemanticMapperService(semanticMapping(fieldName, oldInferenceId));
-
-            assertInferenceEndpoints(mapperService, fieldName, oldInferenceId, oldInferenceId);
-            assertSemanticField(mapperService, fieldName, false, null, null);
-            if (oldModel != null) {
-                assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, oldModel);
-            }
-
-            String newInferenceId = randomValueOtherThan(oldInferenceId, () -> randomAlphaOfLengthBetween(5, 15));
-            TestModel newModel = null;
-            if (randomBoolean()) {
-                newModel = createRandomSupportedModel();
-                givenModelSettings(newInferenceId, new MinimalServiceSettings(newModel));
-            }
-
-            merge(mapperService, semanticMapping(fieldName, newInferenceId));
-
-            assertInferenceEndpoints(mapperService, fieldName, newInferenceId, newInferenceId);
-            assertSemanticField(mapperService, fieldName, false, null, null);
-            if (newModel != null) {
-                assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, newModel);
-            }
-        }
-    }
-
-    public void testUpdateInferenceId_GivenModelSettings() throws IOException {
-        for (int randomizedRun = 0; randomizedRun < 20; randomizedRun++) {
-            final String fieldName = randomAlphaOfLengthBetween(5, 15);
-            final String oldInferenceId = randomAlphaOfLengthBetween(5, 15);
-            final String newInferenceId = randomValueOtherThan(oldInferenceId, () -> randomAlphaOfLengthBetween(5, 15));
-
-            final TestModel oldModel = createRandomSupportedModel();
-            final MinimalServiceSettings previousModelSettings = new MinimalServiceSettings(oldModel);
-            givenModelSettings(oldInferenceId, previousModelSettings);
-
-            final MapperService mapperService = createSemanticMapperService(
-                semanticMapping(fieldName, oldInferenceId, previousModelSettings)
-            );
-            final SemanticIndexOptions currentIndexOptions = extractCurrentIndexOptions(mapperService, fieldName);
-            assertInferenceEndpoints(mapperService, fieldName, oldInferenceId, oldInferenceId);
-            assertSemanticField(mapperService, fieldName, true, null, currentIndexOptions);
-            assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, oldModel);
-
-            final CheckedRunnable<IOException> mergeRunner = () -> merge(mapperService, semanticMapping(fieldName, newInferenceId));
-
-            if (randomBoolean()) {
-                // Compatible: new endpoint has identical task type / dimensions / similarity / element type
-                TestModel newModel = createCompatibleModel(newInferenceId, oldModel);
-                MinimalServiceSettings newModelSettings = new MinimalServiceSettings(newModel);
-                givenModelSettings(newInferenceId, newModelSettings);
-
-                mergeRunner.run();
-                assertInferenceEndpoints(mapperService, fieldName, newInferenceId, newInferenceId);
-                assertSemanticField(mapperService, fieldName, true, null, currentIndexOptions);
-                assertEmbeddingsFieldMapperMatchesModel(mapperService, fieldName, newModel);
-            } else {
-                final TestModel incompatibleModel = createIncompatibleModel(newInferenceId, oldModel);
-                final String expectedErrorMessage;
-                if (incompatibleModel == null) {
-                    // Incompatible: new endpoint does not exist
-                    expectedErrorMessage = "Cannot update ["
-                        + SemanticTextFieldMapper.CONTENT_TYPE
-                        + "] field ["
-                        + fieldName
-                        + "] because inference endpoint ["
-                        + newInferenceId
-                        + "] does not exist.";
-                } else {
-                    // Incompatible: new endpoint exists but its model settings are incompatible
-                    MinimalServiceSettings incompatibleModelSettings = new MinimalServiceSettings(incompatibleModel);
-                    givenModelSettings(newInferenceId, incompatibleModelSettings);
-
-                    expectedErrorMessage = "Cannot update ["
-                        + SemanticTextFieldMapper.CONTENT_TYPE
-                        + "] field ["
-                        + fieldName
-                        + "] because inference endpoint ["
-                        + oldInferenceId
-                        + "] with model settings ["
-                        + previousModelSettings
-                        + "] is not compatible with new inference endpoint ["
-                        + newInferenceId
-                        + "] with model settings ["
-                        + incompatibleModelSettings
-                        + "]";
-                }
-
-                IllegalArgumentException exc = assertThrows(IllegalArgumentException.class, mergeRunner::run);
-                assertThat(exc.getMessage(), containsString(expectedErrorMessage));
-            }
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -100,10 +100,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.IndexSettings.DENSE_VECTOR_EXPERIMENTAL_FEATURES_SETTING;
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BBQ_MIN_DIMS;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTestUtils.defaultDenseVectorIndexOptions;
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTestUtils.getSupportedSimilarities;
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapperTestUtils.randomCompatibleDimensions;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldTypeTests.randomIndexOptionsAll;
 import static org.elasticsearch.index.mapper.vectors.SparseVectorFieldTypeTests.randomSparseVectorIndexOptions;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKS_FIELD;
@@ -853,129 +850,6 @@ public class SemanticTextFieldMapperTests extends AbstractSemanticMapperTestCase
                 assertThat(exc.getMessage(), containsString(expectedErrorMessage));
             }
         }
-    }
-
-    /**
-     * Creates a {@link TestModel} that is compatible with {@code baseModel} (same task type, dimensions,
-     * similarity, and element type) but with a distinct service, task settings, and secrets, registered
-     * under the given inference ID. Compatible models can be substituted via an inference-ID update.
-     */
-    private static TestModel createCompatibleModel(String inferenceId, TestModel baseModel) {
-        return new TestModel(
-            inferenceId,
-            baseModel.getTaskType(),
-            randomAlphaOfLength(4),
-            new TestModel.TestServiceSettings(
-                randomAlphaOfLength(4),
-                baseModel.getServiceSettings().dimensions(),
-                baseModel.getServiceSettings().similarity(),
-                baseModel.getServiceSettings().elementType()
-            ),
-            new TestModel.TestTaskSettings(randomInt(3)),
-            new TestModel.TestSecretSettings(randomAlphaOfLength(4))
-        );
-    }
-
-    /** The kinds of incompatibility that can exist between two inference endpoint model settings. */
-    private enum IncompatibilityKind {
-        TASK_TYPE,
-        DIMENSIONS,
-        SIMILARITY,
-        ELEMENT_TYPE,
-        DOES_NOT_EXIST
-    }
-
-    /**
-     * Creates a {@link TestModel} that is NOT compatible with {@code baseModel}, choosing uniformly among the
-     * applicable kinds of incompatibility: task type, dimensions, similarity, element type, or the endpoint not
-     * existing. Setting-based perturbations (dimensions/similarity/element type) only apply to dense base models;
-     * a sparse base model has null dimensions/similarity/element type, so only task-type and does-not-exist apply.
-     *
-     * @return an incompatible model to register under {@code inferenceId}, or {@code null} to indicate the
-     *         caller should NOT register an endpoint (the does-not-exist case).
-     */
-    private static TestModel createIncompatibleModel(String inferenceId, TestModel baseModel) {
-        final TestModel.TestServiceSettings baseServiceSettings = baseModel.getServiceSettings();
-        final DenseVectorFieldMapper.ElementType baseElementType = baseServiceSettings.elementType();
-
-        List<IncompatibilityKind> applicable = new ArrayList<>();
-        applicable.add(IncompatibilityKind.TASK_TYPE);
-        applicable.add(IncompatibilityKind.DOES_NOT_EXIST);
-        if (baseModel.getTaskType() != TaskType.SPARSE_EMBEDDING) {
-            applicable.add(IncompatibilityKind.DIMENSIONS);
-            applicable.add(IncompatibilityKind.ELEMENT_TYPE);
-            // SIMILARITY only when the element type supports more than one option to perturb to
-            if (getSupportedSimilarities(baseElementType).size() > 1) {
-                applicable.add(IncompatibilityKind.SIMILARITY);
-            }
-        }
-
-        TaskType taskType = baseModel.getTaskType();
-        Integer dimensions = baseServiceSettings.dimensions();
-        SimilarityMeasure similarity = baseServiceSettings.similarity();
-        DenseVectorFieldMapper.ElementType elementType = baseElementType;
-        boolean returnNull = false;
-
-        switch (randomFrom(applicable)) {
-            case DOES_NOT_EXIST -> returnNull = true;
-            case TASK_TYPE -> {
-                taskType = randomValueOtherThan(taskType, () -> randomFrom(Set.of(TaskType.SPARSE_EMBEDDING, TaskType.TEXT_EMBEDDING)));
-                if (taskType == TaskType.TEXT_EMBEDDING) {
-                    // Sparse -> dense: populate required dense settings from a fresh random dense model
-                    TestModel randomDenseModel = TestModel.createRandomInstance(TaskType.TEXT_EMBEDDING);
-                    dimensions = randomDenseModel.getServiceSettings().dimensions();
-                    similarity = randomDenseModel.getServiceSettings().similarity();
-                    elementType = randomDenseModel.getServiceSettings().elementType();
-                } else {
-                    // Dense -> sparse: clear dense-only settings
-                    dimensions = null;
-                    similarity = null;
-                    elementType = null;
-                }
-            }
-            case DIMENSIONS -> dimensions = randomValueOtherThan(
-                dimensions,
-                () -> randomCompatibleDimensions(baseElementType, BBQ_MIN_DIMS * 2)
-            );
-            case SIMILARITY -> similarity = randomValueOtherThan(similarity, () -> randomFrom(getSupportedSimilarities(baseElementType)));
-            case ELEMENT_TYPE -> {
-                elementType = randomValueOtherThan(
-                    elementType,
-                    () -> randomFrom(
-                        DenseVectorFieldMapper.ElementType.FLOAT,
-                        DenseVectorFieldMapper.ElementType.BYTE,
-                        DenseVectorFieldMapper.ElementType.BIT
-                    )
-                );
-                // Regenerate dimensions and similarity compatible with the new element type
-                dimensions = randomCompatibleDimensions(elementType, BBQ_MIN_DIMS * 2);
-                similarity = randomFrom(getSupportedSimilarities(elementType));
-            }
-        }
-
-        if (returnNull) {
-            return null;
-        }
-
-        return buildModel(baseModel, inferenceId, taskType, elementType, dimensions, similarity);
-    }
-
-    private static TestModel buildModel(
-        TestModel baseModel,
-        String inferenceId,
-        TaskType taskType,
-        @Nullable DenseVectorFieldMapper.ElementType elementType,
-        @Nullable Integer dimensions,
-        @Nullable SimilarityMeasure similarity
-    ) {
-        return new TestModel(
-            inferenceId,
-            taskType,
-            baseModel.getConfigurations().getService(),
-            new TestModel.TestServiceSettings(baseModel.getServiceSettings().model(), dimensions, similarity, elementType),
-            baseModel.getTaskSettings(),
-            baseModel.getSecretSettings()
-        );
     }
 
     public void testDynamicUpdate() throws IOException {


### PR DESCRIPTION
Moves the inference ID update tests and associated util methods to `AbstractSemanticMapperTestCase` so that they also run in `SemanticFieldMapperTests`.
