### PR TITLE
Delete the old index pattern for the SML

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -746,11 +746,6 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // For connectors telemetry. Will be removed once we switched to connectors API
                 RoleDescriptor.IndicesPrivileges.builder().indices(".elastic-connectors*").privileges("read").build(),
-                // TODO: Remove after SML swaps to the below ai-index* pattern
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".ai-index-idx-sml-data", ".ai-index-idx-sml-data-*")
-                    .privileges("all")
-                    .build(),
                 // Context Engine's SML storage. A regular (non-system) index that Kibana
                 // creates and manages itself at startup, including its alias.
                 RoleDescriptor.IndicesPrivileges.builder()


### PR DESCRIPTION
Blocked by https://github.com/elastic/kibana/pull/279954
Follow-up on https://github.com/elastic/elasticsearch/pull/154623

We realized that the AI Index pattern couldn't be dot-prefixed in Serverless. The prior PR added the new pattern, and once Kibana switches to using the new pattern, this PR can remove the old one. 