### PR TITLE
Skip merges during resharding handoff

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequest;
 import org.elasticsearch.action.admin.cluster.allocation.TransportClusterAllocationExplainAction;
@@ -85,6 +86,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.index.Index;
@@ -95,6 +97,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.plugins.Plugin;
@@ -109,6 +112,7 @@ import org.elasticsearch.test.disruption.BlockMasterServiceOnMaster;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponse;
@@ -125,6 +129,7 @@ import org.elasticsearch.xpack.stateless.action.TransportNewCommitNotificationAc
 import org.elasticsearch.xpack.stateless.commits.StatelessCompoundCommit;
 import org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService;
 import org.hamcrest.Matcher;
+import org.junit.Assert;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -4858,6 +4863,64 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         if (failure.get() != null) {
             throw failure.get();
         }
+    }
+
+    public void testMergesAreSkippedDuringHandoffPreparation() throws Exception {
+        String indexNode = startMasterAndIndexNode();
+        ensureStableCluster(1);
+
+        final String indexName = randomIndexName();
+        createIndex(indexName, indexSettings(1, 0).put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE).build());
+        ensureGreen(indexName);
+
+        final var index = resolveIndex(indexName);
+        final var shardId = new ShardId(index, 0);
+        final var sourceShard = findIndexShard(index, 0, indexNode);
+
+        // Take a permit to block handoff flush
+        final var nodeThreadPool = internalCluster().getInstance(ThreadPool.class, indexNode);
+        final var permitFuture = new PlainActionFuture<Releasable>();
+        sourceShard.acquirePrimaryOperationPermit(permitFuture, nodeThreadPool.generic());
+        var permit = safeGet(permitFuture);
+
+        var splitSourceService = internalCluster().getInstance(SplitSourceService.class, indexNode);
+
+        assertFalse(splitSourceService.isPreparingForHandoff(shardId));
+
+        final var preflushFinished = new CountDownLatch(1);
+
+        splitSourceService.setPreHandoffHook(() -> {
+            // assert that at the first flush after entering prehandoff merge cancellation is signalled
+            sourceShard.withEngine(engine -> {
+                final var currentLocation = engine.getTranslogLastWriteLocation();
+                final var nextLocation = new Translog.Location(currentLocation.generation() + 1, 0, 0);
+                // create something to flush
+                indexDocs(indexName, randomIntBetween(10, 100));
+                logger.info("waiting for preflush: {}, {}", currentLocation, nextLocation);
+                engine.addFlushListener(nextLocation, ActionListener.wrap(response -> {
+                    assertTrue(splitSourceService.isPreparingForHandoff(shardId));
+                    preflushFinished.countDown();
+                }, Assert::assertNull));
+                return null;
+            });
+        });
+
+        safeGet(client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)));
+        safeAwait(preflushFinished);
+        logger.info("preflush finished");
+
+        // unblock handoff
+        permit.close();
+        awaitClusterState(
+            clusterState -> indexMetadata(clusterState, index).getReshardingMetadata()
+                .getSplit()
+                .targetStates()
+                .allMatch(s -> s == IndexReshardingState.Split.TargetShardState.HANDOFF)
+        );
+        // and assert that after handoff merges are allowed again
+        assertFalse(splitSourceService.isPreparingForHandoff(shardId));
+
+        waitForReshardCompletion(indexName);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -974,7 +974,6 @@ public class StatelessPlugin extends Plugin
         );
         components.add(setAndGet(recoveryMetricsCollector, new StatelessRecoveryMetricsCollector(services.telemetryProvider())));
         documentParsingProvider.set(services.documentParsingProvider());
-        skipMerges.set(new ShouldSkipMerges(indicesService));
         if (hasMasterRole && USE_INDEX_REFRESH_BLOCK_SETTING.get(settings)) {
             components.add(new RemoveRefreshClusterBlockService(settings, clusterService, threadPool));
         }
@@ -1012,6 +1011,7 @@ public class StatelessPlugin extends Plugin
             )
         );
         components.add(splitSourceService);
+        skipMerges.set(new ShouldSkipMerges(indicesService, splitSourceService));
         // PIT relocation
         var pitRelocationMetrics = new PitRelocationMetrics(services.telemetryProvider().getMeterRegistry());
         components.add(pitRelocationMetrics);
@@ -2097,12 +2097,12 @@ public class StatelessPlugin extends Plugin
         return shardRouting.initializing() && shardRouting.recoverySource().getType() != RecoverySource.Type.PEER;
     }
 
-    private record ShouldSkipMerges(IndicesService indicesService) implements Predicate<ShardId> {
+    private record ShouldSkipMerges(IndicesService indicesService, SplitSourceService splitSourceService) implements Predicate<ShardId> {
 
         @Override
         public boolean test(ShardId shardId) {
             IndexShard indexShard = indicesService.getShardOrNull(shardId);
-            return indexShard == null || indexShard.routingEntry().relocating();
+            return indexShard == null || indexShard.routingEntry().relocating() || splitSourceService.isPreparingForHandoff(shardId);
         }
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
@@ -112,10 +112,20 @@ public class SplitSourceService {
     private final ConcurrentHashMap<IndexShard, SplitRequestState> activeTargetRequests = new ConcurrentHashMap<>();
     // Tracks source shard state machine that performs cleanup logic and moves source shard to DONE once all target shards are complete.
     private final ConcurrentHashMap<IndexShard, SourceShardStateMachine> activeSourceShards = new ConcurrentHashMap<>();
+    // Used to abort merges that complete just before handoff so that we don't block indexing waiting for them to upload
+    private final Set<ShardId> shardsPreparingForHandoff = ConcurrentHashMap.newKeySet();
 
     // ES-12460 for testing purposes, until pre-handoff logic (flush etc) is built out
     @Nullable
     private Runnable preHandoffHook;
+
+    /**
+     * Returns true if the given shard is about to enter handoff.
+     * Used by ShouldSkipMerges to abort merges during this window so they don't block indexing while they upload.
+     */
+    public boolean isPreparingForHandoff(ShardId shardId) {
+        return shardsPreparingForHandoff.contains(shardId);
+    }
 
     public SplitSourceService(
         Client client,
@@ -312,6 +322,7 @@ public class SplitSourceService {
                     // and there will be no new commits.
                     // We explicitly swallow this exception since the contract of `delegateResponse` is to not throw.
                 }
+                shardsPreparingForHandoff.remove(sourceShard.shardId());
                 activeTargetRequests.remove(sourceShard);
                 l.onFailure(e);
             }));
@@ -350,6 +361,8 @@ public class SplitSourceService {
             logger.debug("handoff: flushing {} for {} before acquiring permits", sourceShard.shardId(), targetShardId);
             // Similar to relocation, flush before blocking operations because we expect this to reduce the amount of work done by the
             // flush that happens while operations are blocked. NB the flush has force=false so may do nothing.
+            // Start cancelling completing merges at this point so that they don't delay flush during handoff.
+            shardsPreparingForHandoff.add(sourceShard.shardId());
             engine.flush(/* force */ false, /* waitIfOngoing */ true, afterFirstFlush);
             return null;
         }))
@@ -365,6 +378,7 @@ public class SplitSourceService {
                             // commits spontaneously even though indexing permits are held. These are harmless to copy.
                             logger.debug("handoff: stopping commit copy from {} to {}", sourceShard.shardId(), targetShardId);
                             stopCopyingNewCommits(targetShardId);
+                            shardsPreparingForHandoff.remove(sourceShard.shardId());
                             activeTargetRequests.remove(sourceShard);
                             afterSecondFlush.onResponse(permits);
                         }, e -> {
@@ -688,6 +702,7 @@ public class SplitSourceService {
     /// of this function and adding a new state machine to the `activeSourceShards` map.
     public void cancelSplits(IndexShard indexShard) {
         activeTargetRequests.remove(indexShard);
+        shardsPreparingForHandoff.remove(indexShard.shardId());
         var stateMachine = activeSourceShards.remove(indexShard);
         if (stateMachine != null) {
             stateMachine.cancel();


### PR DESCRIPTION
Relocation already has the machinery for this, so this change only needs to wire into ShouldSkipMerges. It does this by keeping track of shards that are between the pre-handoff flush and the handoff flush, and exposing that to ShouldSkipMerges.
