### PR TITLE
[9.5] [Inference API] Documenting SSE parser deviations and fix some issues (#154632)

### DIFF
--- a/docs/changelog/154632.yaml
+++ b/docs/changelog/154632.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 154632
+summary: "[Inference API] Documenting SSE parser deviations and fix some issues"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParser.java
@@ -15,14 +15,31 @@ import java.util.Locale;
 import java.util.Optional;
 
 /**
- * https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
- * Lines are separated by LF, CR, or CRLF.
- * If the line is empty, we do not dispatch the event since we do that automatically. Instead, we discard this event.
- * If the line starts with a colon, we discard this event.
- * If the line contains a colon, we process it into {@link ServerSentEvent} with a non-empty value.
- * If the line does not contain a colon, we process it into {@link ServerSentEvent}with an empty string value.
- * If the line's field is not one of (data, event), we discard this event. `id` and `retry` are not implemented, because we do not use them
- * and have no plans to use them.
+ * Parses a server-sent event stream according to the WHATWG SSE specification:
+ * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation">WHATWG SSE spec</a>
+ *
+ * <h2>Implemented behaviors</h2>
+ * <ul>
+ *   <li>Lines are separated by LF ({@code \n}), CR ({@code \r}), or CRLF ({@code \r\n}).</li>
+ *   <li>A leading U+FEFF BYTE ORDER MARK on the very first processed line is stripped (once only).</li>
+ *   <li>Lines starting with {@code :} are comments and are discarded.</li>
+ *   <li>Lines containing {@code :} are split into field name and value; exactly one leading space
+ *       in the value is removed if present.</li>
+ *   <li>Multiple {@code data:} lines in one event are concatenated with a LF between them.</li>
+ *   <li>An empty line dispatches the accumulated event if at least one {@code data} field was seen
+ *       (even if that field had an empty value).</li>
+ * </ul>
+ *
+ * <h2>Retained deviations from the WHATWG spec (knowingly kept)</h2>
+ * <ul>
+ *   <li><b>Case-insensitive field names</b> — field names are lower-cased before matching;
+ *       the spec matches them case-sensitively, so {@code DATA:} should be an unknown field.</li>
+ *   <li><b>No-colon lines only honored for {@code data}</b> — a bare {@code data} line
+ *       (no colon) is treated as {@code data} with an empty value; any other bare field name is
+ *       ignored. The spec treats any no-colon line as that field with an empty value.</li>
+ *   <li><b>{@code id} and {@code retry} are not implemented</b> — intentionally omitted;
+ *       we do not use reconnect state.</li>
+ * </ul>
  */
 public class ServerSentEventParser {
     private static final String BOM = "\uFEFF";
@@ -31,6 +48,7 @@ public class ServerSentEventParser {
     private final EventBuffer eventBuffer = new EventBuffer();
     private final ByteArrayOutputStream pendingLine = new ByteArrayOutputStream();
     private boolean previousByteWasCarriageReturn;
+    private boolean firstLine = true;
 
     /**
      * Parses the given bytes and returns any complete SSE events found so far.
@@ -72,7 +90,13 @@ public class ServerSentEventParser {
     private void processPendingLine(Deque<ServerSentEvent> collector) {
         var line = pendingLine.toString(StandardCharsets.UTF_8);
         pendingLine.reset();
-        line = line.replace(BOM, "");
+        // Spec: "one leading U+FEFF BYTE ORDER MARK character must be ignored if any are present" — once, at stream start.
+        if (firstLine) {
+            firstLine = false;
+            if (line.startsWith(BOM)) {
+                line = line.substring(BOM.length());
+            }
+        }
 
         if (line.isEmpty()) {
             eventBuffer.dispatch().ifPresent(collector::offer);
@@ -105,29 +129,30 @@ public class ServerSentEventParser {
         private static final String MESSAGE = "message";
         private StringBuilder type = new StringBuilder();
         private StringBuilder data = new StringBuilder();
-        private boolean appendLineFeed = false;
+        // True once at least one data field has been seen; used by dispatch() to distinguish
+        // "no data field" (drop event) from "data field with empty value" (dispatch empty event).
+        private boolean dataFieldSeen = false;
 
         private void type(String type) {
             this.type.append(type);
         }
 
         private void data(String data) {
-            // "Append the field value to the data buffer, then append a single U+000A LINE FEED (LF) character to the data buffer."
-            // But then we're told "If the data buffer's last character is a U+000A LINE FEED (LF) character,
-            // then remove the last character from the data buffer."
-            // Rather than add + remove for single-line data fields, we only append a LINE FEED on subsequent data lines.
-            if (appendLineFeed) {
+            // Spec: append value then a LF for every data field; we join lazily (LF before 2nd+ value),
+            // which yields the identical buffer after the trailing-LF strip in dispatch().
+            if (dataFieldSeen) {
                 this.data.append(LINE_FEED);
-            } else {
-                appendLineFeed = true;
             }
+            dataFieldSeen = true;
             this.data.append(data);
         }
 
         private Optional<ServerSentEvent> dispatch() {
-            // "If the data buffer is an empty string, set the data buffer and the event type buffer to the empty string and return."
-            // We don't process empty events anywhere, so we just drop the events.
-            if (data.isEmpty()) {
+            // Spec dispatch step 2: "If the data buffer is an empty string, return." runs before step 3's
+            // trailing-LF strip. A lone empty data field appends "" then LF → buffer "\n" → not empty →
+            // dispatches with data "". We emulate this correctly by checking dataFieldSeen: if no data
+            // field was ever seen the buffer is also "" but we must NOT dispatch.
+            if (dataFieldSeen == false) {
                 reset();
                 return Optional.empty();
             }
@@ -147,7 +172,7 @@ public class ServerSentEventParser {
         private void reset() {
             type = new StringBuilder();
             data = new StringBuilder();
-            appendLineFeed = false;
+            dataFieldSeen = false;
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParserTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/streaming/ServerSentEventParserTests.java
@@ -24,6 +24,9 @@ public class ServerSentEventParserTests extends ESTestCase {
     private static final String MIXED_TERM_DATA = "{\"username\":\"Alice\"}";
 
     public void testRetryAndIdAreUnimplemented() {
+        // Deliberate deviation #5: "id" would set the Last-Event-ID (used as a reconnect header on
+        // reconnect) and "retry" would set the reconnect interval in ms. We ignore both because we
+        // do not implement reconnect logic and ServerSentEvent carries neither.
         var payload = """
             id: 2
 
@@ -102,21 +105,29 @@ public class ServerSentEventParserTests extends ESTestCase {
         assertEvents(events, List.of(new ServerSentEvent("message", "hello\nthere")));
     }
 
-    private void assertEvents(Deque<ServerSentEvent> actualEvents, List<ServerSentEvent> expectedEvents) {
-        assertThat(actualEvents.size(), equalTo(expectedEvents.size()));
-        var expectedEvent = expectedEvents.iterator();
-        actualEvents.forEach(event -> assertThat(event, equalTo(expectedEvent.next())));
-    }
+    /**
+     * WHATWG SSE spec example (https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation):
+     * three {@code data:} lines in one event are concatenated with a single LF between each,
+     * yielding {@code "YHOO\n+2\n10"}. The leading space after each colon is stripped once per the spec.
+     */
+    public void testMultipleDataLinesConcatenatedPerSpecExample() {
+        var payload = """
+            data: YHOO
+            data: +2
+            data: 10
 
-    // by default, Java's UTF-8 decode does not remove the byte order mark
-    public void testByteOrderMarkIsRemoved() {
-        // these are the bytes for "<byte-order mark>data: hello\n\n"
-        var payload = new byte[] { -17, -69, -65, 100, 97, 116, 97, 58, 32, 104, 101, 108, 108, 111, 10, 10 };
+            """.getBytes(StandardCharsets.UTF_8);
 
         var parser = new ServerSentEventParser();
         var events = parser.parse(payload);
 
-        assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
+        assertEvents(events, List.of(new ServerSentEvent("message", "YHOO\n+2\n10")));
+    }
+
+    private void assertEvents(Deque<ServerSentEvent> actualEvents, List<ServerSentEvent> expectedEvents) {
+        assertThat(actualEvents.size(), equalTo(expectedEvents.size()));
+        var expectedEvent = expectedEvents.iterator();
+        actualEvents.forEach(event -> assertThat(event, equalTo(expectedEvent.next())));
     }
 
     public void testEmptyEventIsSetAsEmptyString() {
@@ -262,6 +273,162 @@ public class ServerSentEventParserTests extends ESTestCase {
             var parser = new ServerSentEventParser();
             assertEvents(parser.parse(scenario), List.of(new ServerSentEvent(MIXED_TERM_EVENT_TYPE, MIXED_TERM_DATA)));
         }
+    }
+
+    public void testLeadingSpaceAfterColonIsStrippedOnce() {
+        {
+            // One leading space stripped; interior spaces in the value are preserved.
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data: {\"foo\": \"bar baz\"}\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "{\"foo\": \"bar baz\"}")));
+        }
+        {
+            // Two leading spaces: only the first is stripped; the second is part of the value.
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data:  hello\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", " hello")));
+        }
+        {
+            // No leading space: value is taken verbatim.
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data:hello\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
+        }
+    }
+
+    public void testEventStateResetsBetweenMessages() {
+        // Proves reset() clears the type buffer: event 1 sets a custom type, event 2 omits it
+        // and must revert to the default "message".
+        var parser = new ServerSentEventParser();
+        var events = parser.parse("""
+            event: custom
+            data: hello
+
+            data: world
+
+            """.getBytes(StandardCharsets.UTF_8));
+        assertEvents(events, List.of(new ServerSentEvent("custom", "hello"), new ServerSentEvent("message", "world")));
+    }
+
+    public void testMultipleConsecutiveBlankLinesDispatchOnce() {
+        // Only the first blank line dispatches the event; subsequent blank lines find no data
+        // field accumulated and produce no additional event.
+        var parser = new ServerSentEventParser();
+        var events = parser.parse("data: hello\n\n\n\n".getBytes(StandardCharsets.UTF_8));
+        assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
+    }
+
+    public void testCommentInterleavedWithinEventIsIgnored() {
+        // A comment line between event: and data: lines does not interrupt accumulation;
+        // the event still dispatches correctly (extends the standalone-comment coverage).
+        var parser = new ServerSentEventParser();
+        var events = parser.parse("""
+            event: mytype
+            :this is a comment
+            data: hello
+
+            """.getBytes(StandardCharsets.UTF_8));
+        assertEvents(events, List.of(new ServerSentEvent("mytype", "hello")));
+    }
+
+    public void testUnknownFieldIsIgnoredButDataPreserved() {
+        // Unknown field names are silently skipped; the data field still accumulates normally.
+        var parser = new ServerSentEventParser();
+        var events = parser.parse("""
+            foo: bar
+            data: hello
+
+            """.getBytes(StandardCharsets.UTF_8));
+        assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
+    }
+
+    public void testLoneEmptyDataDispatchesEmptyEvent() {
+        // Spec dispatch step 2 ("If the data buffer is an empty string, return.") runs BEFORE
+        // step 3's trailing-LF strip. A lone "data:" appends "" + LF → buffer "\n" (not empty at
+        // step 2) → strip trailing LF → dispatch with data "". A "data" with no colon is equivalent.
+        {
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data:\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "")));
+        }
+        {
+            // A bare "data" line (no colon) is treated as data with an empty value — same result.
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "")));
+        }
+    }
+
+    /**
+     * WHATWG SSE spec example (https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation):
+     * the stream {@code "data\n\ndata\ndata\n\ndata:"} fires exactly two events — the first block dispatches
+     * an empty-string data event, the middle two-line block dispatches a single-newline ({@code "\n"}) data
+     * event — and the trailing {@code "data:"} block is discarded because it is not followed by a blank line.
+     */
+    public void testTwoEventsFireAndTrailingBlockIsDiscarded() {
+        var payload = "data\n\ndata\ndata\n\ndata:".getBytes(StandardCharsets.UTF_8);
+
+        var parser = new ServerSentEventParser();
+        var events = parser.parse(payload);
+
+        assertEvents(events, List.of(new ServerSentEvent("message", ""), new ServerSentEvent("message", "\n")));
+    }
+
+    // by default, Java's UTF-8 decode does not remove the byte order mark
+    public void testByteOrderMarkIsRemoved() {
+        // these are the bytes for "<byte-order mark>data: hello\n\n"
+        var payload = new byte[] { -17, -69, -65, 100, 97, 116, 97, 58, 32, 104, 101, 108, 108, 111, 10, 10 };
+
+        var parser = new ServerSentEventParser();
+        var events = parser.parse(payload);
+
+        assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
+    }
+
+    public void testByteOrderMarkOnlyStrippedAtStreamStart() {
+        {
+            // BOM mid-value: the character is inside the value, not at the start of the first line.
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data: he﻿llo\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "he﻿llo")));
+        }
+        {
+            // BOM at the start of a later event's data value: firstLine is already false, no strip.
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("data: first\n\ndata: ﻿second\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "first"), new ServerSentEvent("message", "﻿second")));
+        }
+    }
+
+    public void testFieldNamesAreCaseInsensitive_DeviatesFromSpec() {
+        // Deviation #3: we lower-case field names before matching. The WHATWG spec matches
+        // case-sensitively, so "DATA" and "EVENT" should be unknown fields yielding no event.
+        // We accept them as "data" and "event" (more lenient than spec).
+        {
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("DATA: hello\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
+        }
+        {
+            var parser = new ServerSentEventParser();
+            var events = parser.parse("EVENT: custom\nDATA: world\n\n".getBytes(StandardCharsets.UTF_8));
+            assertEvents(events, List.of(new ServerSentEvent("custom", "world")));
+        }
+    }
+
+    public void testNoColonLineOnlyHonorsDataField_DeviatesFromSpec() {
+        // Deviation #4: a no-colon line is only treated as a field when the bare name is "data".
+        // The spec would treat any no-colon line as that field with an empty value; so a bare
+        // "event" line should set the event type to "". We ignore it instead (observably equivalent
+        // for the fields we consume, but a deviation).
+        var parser = new ServerSentEventParser();
+        var events = parser.parse("""
+            event
+            data: hello
+
+            """.getBytes(StandardCharsets.UTF_8));
+        // The bare "event" line has no effect; the event type defaults to "message".
+        assertEvents(events, List.of(new ServerSentEvent("message", "hello")));
     }
 
     private void assertEvents(Deque<ServerSentEvent> actualEvents, List<ServerSentEvent> expectedEvents, String context) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Inference API] Documenting SSE parser deviations and fix some issues (#154632)