### PR TITLE
Improve StatelessHollowIndexShardsIT.testStressWithRelocationOrObjectStoreFailures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -586,9 +586,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.HnswUtilsTests
   method: testNeighborhoodGraphSearchFindsSelf
   issue: https://github.com/elastic/elasticsearch/issues/154633
-- class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
-  method: testStressWithRelocationOrObjectStoreFailures
-  issue: https://github.com/elastic/elasticsearch/issues/154655
 - class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
   method: testLargeRequestIsNeverDispatched
   issue: https://github.com/elastic/elasticsearch/issues/154657

--- a/server/src/main/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContext.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.repositories.SnapshotShardContextHelper.withSnapshotIndexCommitRef;
 
 /**
@@ -148,7 +149,21 @@ public final class LocalPrimarySnapshotShardContext extends SnapshotShardContext
                 indexInput.readBytes(tmp, 0, tmp.length);
                 assert fileInfo.metadata().hash().bytesEquals(new BytesRef(tmp));
             } catch (IOException e) {
-                throw new AssertionError(e);
+                if (Lucene.isCorruptionException(e)) {
+                    throw new AssertionError(e);
+                }
+                // A transient I/O failure while re-reading the file to verify its hash does not indicate a mismatch. Rethrowing it
+                // as an AssertionError would escape the snapshot thread pool worker without ever completing the shard snapshot,
+                // leaving the snapshot in progress forever, so skip the verification instead.
+                logger.warn(
+                    () -> format(
+                        "[%s] [%s] failed to read [%s] to verify its hash, skipping verification",
+                        shardId(),
+                        snapshotId(),
+                        fileInfo.physicalName()
+                    ),
+                    e
+                );
             } finally {
                 store.decRef();
             }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/HollowShardsServiceUnhollowRaceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/HollowShardsServiceUnhollowRaceIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.PluginComponentBinding;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.stateless.commits.HollowShardsService;
+import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
+import org.elasticsearch.xpack.stateless.engine.HollowShardsMetrics;
+import org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+
+import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.SETTING_HOLLOW_INGESTION_TTL;
+import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
+
+public class HollowShardsServiceUnhollowRaceIT extends AbstractStatelessPluginIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        final var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(TestUtils.StatelessPluginWithTrialLicense.class);
+        plugins.add(RemoveHollowShardInterceptPlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings.Builder nodeSettings() {
+        // the base class randomly disables hollow shards, but this test requires them
+        return super.nodeSettings().put(STATELESS_HOLLOW_INDEX_SHARDS_ENABLED.getKey(), true);
+    }
+
+    /**
+     * Reproduces the race behind the {@code expect last commit hollow to be [false] but got [true]} failure of
+     * https://github.com/elastic/elasticsearch/issues/154655: the unhollowing flush listener in {@link HollowShardsService}
+     * asserts that the engine's last commit is not hollow. Until the listener calls {@code removeHollowShard}, the shard is in
+     * the hollow shards map and the ingestion op that triggered the unhollowing holds a primary permit, so nothing can hollow
+     * the engine concurrently. Once {@code removeHollowShard} has run, both protections are gone: the pending ingestion
+     * completes and releases its permit, and a relocation may then acquire all permits and re-hollow the very engine instance
+     * that the listener captured, via {@code IndexEngine#prepareForEngineReset} and {@code flushHollow}. The assertion must
+     * therefore run before {@code removeHollowShard}; this test fails with the assertion error above if it is moved after.
+     *
+     * The interleaving is forced deterministically: a {@link HollowShardsService} subclass parks the unhollowing listener
+     * thread right after {@code removeHollowShard}, and the test drives a re-hollowing relocation to completion before
+     * releasing the listener.
+     */
+    public void testUnhollowFlushListenerDoesNotRaceWithRehollowingRelocation() throws Exception {
+        startMasterOnlyNode();
+        final var indexNodeSettings = Settings.builder()
+            .put(disableIndexingDiskAndMemoryControllersNodeSettings())
+            .put(SETTING_HOLLOW_INGESTION_TTL.getKey(), TimeValue.timeValueMillis(1))
+            .build();
+        final String nodeA = startIndexNode(indexNodeSettings);
+        final String nodeB = startIndexNode(indexNodeSettings);
+
+        final var indexName = randomIdentifier();
+        createIndex(
+            indexName,
+            indexSettings(1, 0).put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeA).build()
+        );
+        ensureGreen(indexName);
+        indexDocs(indexName, randomIntBetween(8, 32));
+        flush(indexName);
+        final var index = resolveIndex(indexName);
+
+        // Relocate the shard to nodeB once it is hollowable, which hollows it
+        final var hollowShardsServiceA = internalCluster().getInstance(HollowShardsService.class, nodeA);
+        assertBusy(() -> assertTrue(hollowShardsServiceA.isHollowableIndexShard(findIndexShard(index, 0))));
+        updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeB), indexName);
+        internalCluster().awaitNodeVacated(indexName, nodeA);
+        ensureGreen(indexName);
+        final var shardId = findIndexShard(index, 0).shardId();
+        final var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, nodeB);
+        hollowShardsServiceB.ensureHollowShard(shardId, true);
+
+        // Park the unhollowing flush listener right after removeHollowShard, in the middle of the window in which a
+        // re-hollowing relocation can run concurrently
+        final var listenerParked = new CountDownLatch(1);
+        final var listenerReleased = new CountDownLatch(1);
+        findPlugin(nodeB, RemoveHollowShardInterceptPlugin.class).afterUnhollowRemoveHollowShard.put(shardId, () -> {
+            listenerParked.countDown();
+            safeAwait(listenerReleased, TimeValue.timeValueMinutes(1));
+        });
+
+        // Trigger unhollowing. The indexing completes as soon as removeHollowShard releases the ingestion blocker, i.e.
+        // while the unhollowing listener is still parked.
+        indexDocs(indexName, 1);
+        safeAwait(listenerParked, TimeValue.timeValueMinutes(1));
+        try {
+            // Relocate the shard back to nodeA. The source-side hollowing calls prepareForEngineReset -> flushHollow on the
+            // very IndexEngine instance the parked listener captured, making its last commit hollow again.
+            assertBusy(() -> assertTrue(hollowShardsServiceB.isHollowableIndexShard(findIndexShard(index, 0))));
+            updateIndexSettings(
+                Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeA),
+                indexName
+            );
+            internalCluster().awaitNodeVacated(indexName, nodeB);
+            ensureGreen(indexName);
+        } finally {
+            listenerReleased.countDown();
+        }
+
+        // With the assertion misplaced after removeHollowShard, the released listener now fails its assertion on nodeB and
+        // the test fails with an uncaught "expect last commit hollow to be [false] but got [true]" AssertionError.
+        // As a final sanity check, unhollow the shard on nodeA again by ingesting into it.
+        indexDocs(indexName, 1);
+        ensureGreen(indexName);
+    }
+
+    /**
+     * Installs a {@link HollowShardsService} whose {@code removeHollowShard} runs a one-shot per-shard hook after removing an
+     * unhollowed shard from the hollow shards map. Hooks only fire for the unhollowing flush listener's removal (identified by
+     * its reason), not for removals due to shard closure or failed unhollowing.
+     */
+    public static class RemoveHollowShardInterceptPlugin extends TestUtils.StatelessPluginWithTrialLicense {
+        final Map<ShardId, Runnable> afterUnhollowRemoveHollowShard = new ConcurrentHashMap<>();
+
+        public RemoveHollowShardInterceptPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public Collection<Object> createComponents(Plugin.PluginServices services) {
+            // The HollowShardsService subclass below is bound by its anonymous class, so it must be explicitly bound to
+            // HollowShardsService for the components that get it injected by that type.
+            final Collection<Object> components = super.createComponents(services);
+            components.add(
+                new PluginComponentBinding<>(
+                    HollowShardsService.class,
+                    (HollowShardsService) components.stream().filter(c -> c instanceof HollowShardsService).findFirst().orElseThrow()
+                )
+            );
+            return components;
+        }
+
+        @Override
+        protected HollowShardsService createHollowShardsService(
+            Settings settings,
+            ClusterService clusterService,
+            IndicesService indicesService,
+            ObjectStoreService objectStoreService,
+            StatelessCommitService commitService,
+            IndexShardCacheWarmer indexShardCacheWarmer,
+            ThreadPool threadPool,
+            HollowShardsMetrics metrics,
+            Executor bccHeaderReadExecutor
+        ) {
+            return new HollowShardsService(
+                settings,
+                clusterService,
+                indicesService,
+                objectStoreService,
+                commitService,
+                indexShardCacheWarmer,
+                threadPool,
+                metrics,
+                bccHeaderReadExecutor
+            ) {
+                @Override
+                public void removeHollowShard(IndexShard indexShard, String reason) {
+                    super.removeHollowShard(indexShard, reason);
+                    if (reason.startsWith("unhollowing gen")) {
+                        final var hook = afterUnhollowRemoveHollowShard.remove(indexShard.shardId());
+                        if (hook != null) {
+                            hook.run();
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteUtils;
@@ -3052,7 +3051,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
             thread.start();
         }
 
-        logger.info("Waiting for hollowRelocationsLatch ({} relocations needed)", hollowRelocationsLatch.getCount());
+        logger.info("Waiting for hollowRelocationsLatch");
         Throwable latchFailure = null;
         try {
             safeAwait(hollowRelocationsLatch, TimeValue.timeValueMinutes(10));
@@ -3065,29 +3064,6 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         // Always stop threads even if the latch wait times out, to avoid threads holding cluster resources
         // during test teardown and causing a suite-level timeout.
         stopThreads.set(true);
-        if (hollowRelocationsLatch.getCount() > 0) {
-            logger.warn(
-                "hollowRelocationsLatch timed out with {} relocations remaining; dumping thread stack traces and cluster state",
-                hollowRelocationsLatch.getCount()
-            );
-            for (Thread thread : threads) {
-                logger.warn(
-                    "Thread [{}] state [{}]:\n\tat {}",
-                    thread.getName(),
-                    thread.getState(),
-                    Arrays.stream(thread.getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining("\n\tat "))
-                );
-            }
-            try {
-                logger.warn(
-                    "cluster state at latch timeout:\n{}",
-                    safeGet(client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute()).getState()
-                );
-            } catch (Throwable t) {
-                // diagnostics are best-effort and must not replace the real failure
-                logger.warn("failed to fetch cluster state at latch timeout", t);
-            }
-        }
         // Join with a shared deadline so that a wedged stress thread produces a diagnosable failure here instead of
         // blocking the test until the suite timeout abandons it without any useful report.
         final long joinDeadline = System.currentTimeMillis() + TimeValue.timeValueMinutes(3).millis();
@@ -3552,64 +3528,51 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
     }
 
     private void ensureGreenViaMasterNode(String masterNode, String index, boolean waitForEvents) {
-        // Use assertBusy to retry health checks rather than relying on a single health request window.
-        // A single ~30-second health-request timeout is not always enough when the cluster is recovering
-        // from injected failures (e.g. object-store faults), which would kill the calling thread.
+        var healthRequest = client(masterNode).admin()
+            .cluster()
+            .prepareHealth(TEST_REQUEST_TIMEOUT, index)
+            .setWaitForStatus(ClusterHealthStatus.GREEN)
+            .setWaitForNoInitializingShards(true)
+            .setWaitForNoRelocatingShards(true);
+        if (waitForEvents) {
+            healthRequest = healthRequest.setWaitForEvents(Priority.LANGUID);
+        }
+        final var future = healthRequest.execute();
         long start = System.currentTimeMillis();
         try {
             assertBusy(() -> {
                 if (System.currentTimeMillis() - start > 10 * 1000) {
-                    try {
-                        logger.warn(
-                            "cluster state:\n{}",
-                            safeGet(client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute()).getState()
-                        );
-                        logger.warn("cluster pending tasks:\n{}", getClusterPendingTasks());
-                        logger.warn(
-                            "recoveries:\n{}",
-                            safeGet(client(masterNode).admin().indices().recoveries(new RecoveryRequest(index))).shardRecoveryStates()
-                                .entrySet()
-                                .stream()
-                                .map(
-                                    e -> e.getKey()
-                                        + ":"
-                                        + e.getValue()
-                                            .stream()
-                                            .map(rs -> rs.getShardId() + " - " + rs.getTimer().time())
-                                            .collect(Collectors.joining(","))
-                                )
-                                .toList()
-                        );
-                    } catch (Throwable t) {
-                        // diagnostics are best-effort and must not abort the health check retries
-                        logger.warn("failed to fetch cluster diagnostics", t);
-                    }
+                    logger.warn(
+                        "cluster state:\n{}",
+                        client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState()
+                    );
+                    logger.warn("cluster pending tasks:\n{}", getClusterPendingTasks());
+                    logger.warn(
+                        "recoveries:\n{}",
+                        client(masterNode).admin()
+                            .indices()
+                            .recoveries(new RecoveryRequest(index))
+                            .get()
+                            .shardRecoveryStates()
+                            .entrySet()
+                            .stream()
+                            .map(
+                                e -> e.getKey()
+                                    + ":"
+                                    + e.getValue()
+                                        .stream()
+                                        .map(rs -> rs.getShardId() + " - " + rs.getTimer().time())
+                                        .collect(Collectors.joining(","))
+                            )
+                            .toList()
+                    );
                 }
-                var healthRequest = client(masterNode).admin()
-                    .cluster()
-                    .prepareHealth(TEST_REQUEST_TIMEOUT, index)
-                    .setWaitForStatus(ClusterHealthStatus.GREEN)
-                    .setWaitForNoInitializingShards(true)
-                    .setWaitForNoRelocatingShards(true);
-                if (waitForEvents) {
-                    healthRequest = healthRequest.setWaitForEvents(Priority.LANGUID);
-                }
-                final ClusterHealthResponse healthResponse;
-                try {
-                    healthResponse = healthRequest.get();
-                } catch (Exception e) {
-                    // A transient failure of the health request itself (e.g. under injected object store failures) should be
-                    // retried like a non-green response rather than aborting the wait. assertBusy only retries AssertionErrors.
-                    throw new AssertionError("cluster health request failed", e);
-                }
-                assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
-            }, 5, TimeUnit.MINUTES);
-        } catch (Exception | AssertionError e) {
-            // assertBusy reports its timeout as an AssertionError, which the Exception-only catch used to miss
-            throw new AssertionError(
-                "cluster did not become GREEN within " + TimeValue.timeValueMillis(System.currentTimeMillis() - start),
-                e
-            );
+                assertThat(future.isDone(), equalTo(true));
+            }, 1, TimeUnit.MINUTES);
+            assertThat(future.get().getStatus(), equalTo(ClusterHealthStatus.GREEN));
+        } catch (Exception e) {
+            assert false : "unexpected exception: " + e;
+            throw new RuntimeException(e);
         }
     }
 

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -2699,6 +2699,8 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
             .put(disableIndexingDiskAndMemoryControllersNodeSettings())
             .put(SETTING_HOLLOW_INGESTION_TTL.getKey(), TimeValue.ZERO)
             .put(STATELESS_UPLOAD_MAX_AMOUNT_COMMITS.getKey(), 5) // so that relocations are fast in case of replaying translog
+            // Disable merge backlog throttling so the ForceMerge thread cannot cause indexing threads to block indefinitely
+            .put(IndexEngine.MERGE_BACKLOG_THROTTLE_FACTOR.getKey(), Integer.MAX_VALUE)
             .build();
         List<String> indexNodes = startIndexNodes(randomIntBetween(2, 4), indexNodeSettings);
         startSearchNode();
@@ -3027,17 +3029,55 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
             logger.info("exiting");
         }, "Snapshot"));
 
+        // Capture uncaught exceptions from all threads so they appear clearly in logs even when the
+        // test framework reports only "(No message provided)" for the test failure.
+        var uncaughtExceptions = new CopyOnWriteArrayList<Throwable>();
         for (Thread thread : threads) {
+            thread.setUncaughtExceptionHandler((t, e) -> {
+                logger.error("Thread [{}] died with uncaught exception", t.getName(), e);
+                uncaughtExceptions.add(e);
+            });
             thread.start();
         }
 
-        logger.info("Waiting for hollowRelocationsLatch");
-        safeAwait(hollowRelocationsLatch, TimeValue.timeValueMinutes(10));
-        logger.info("Waited for hollowRelocationsLatch");
-
-        stopThreads.set(true);
-        for (Thread thread : threads) {
-            thread.join();
+        logger.info("Waiting for hollowRelocationsLatch ({} relocations needed)", hollowRelocationsLatch.getCount());
+        try {
+            safeAwait(hollowRelocationsLatch, TimeValue.timeValueMinutes(10));
+            logger.info("Waited for hollowRelocationsLatch");
+        } finally {
+            // Always stop threads even if the latch wait times out, to avoid threads holding cluster resources
+            // during test teardown and causing a suite-level timeout.
+            stopThreads.set(true);
+            if (hollowRelocationsLatch.getCount() > 0) {
+                logger.warn(
+                    "hollowRelocationsLatch timed out with {} relocations remaining; dumping thread stack traces and cluster state",
+                    hollowRelocationsLatch.getCount()
+                );
+                for (Thread thread : threads) {
+                    logger.warn(
+                        "Thread [{}] state [{}]:\n\tat {}",
+                        thread.getName(),
+                        thread.getState(),
+                        Arrays.stream(thread.getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining("\n\tat "))
+                    );
+                }
+                logger.warn(
+                    "cluster state at latch timeout:\n{}",
+                    client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState()
+                );
+            }
+            for (Thread thread : threads) {
+                thread.join();
+            }
+            if (uncaughtExceptions.isEmpty() == false) {
+                var first = uncaughtExceptions.get(0);
+                AssertionError ae = new AssertionError(
+                    "One or more stress threads died with an uncaught exception: " + first.getMessage(),
+                    first
+                );
+                uncaughtExceptions.stream().skip(1).forEach(ae::addSuppressed);
+                throw ae;
+            }
         }
 
         logger.info("Waiting for ensureGreen");
@@ -3446,16 +3486,9 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
     }
 
     private void ensureGreenViaMasterNode(String masterNode, String index, boolean waitForEvents) {
-        var healthRequest = client(masterNode).admin()
-            .cluster()
-            .prepareHealth(TEST_REQUEST_TIMEOUT, index)
-            .setWaitForStatus(ClusterHealthStatus.GREEN)
-            .setWaitForNoInitializingShards(true)
-            .setWaitForNoRelocatingShards(true);
-        if (waitForEvents) {
-            healthRequest = healthRequest.setWaitForEvents(Priority.LANGUID);
-        }
-        final var future = healthRequest.execute();
+        // Use assertBusy to retry health checks rather than relying on a single health request window.
+        // A single ~30-second health-request timeout is not always enough when the cluster is recovering
+        // from injected failures (e.g. object-store faults), which would kill the calling thread.
         long start = System.currentTimeMillis();
         try {
             assertBusy(() -> {
@@ -3485,12 +3518,19 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
                             .toList()
                     );
                 }
-                assertThat(future.isDone(), equalTo(true));
-            }, 1, TimeUnit.MINUTES);
-            assertThat(future.get().getStatus(), equalTo(ClusterHealthStatus.GREEN));
+                var healthRequest = client(masterNode).admin()
+                    .cluster()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT, index)
+                    .setWaitForStatus(ClusterHealthStatus.GREEN)
+                    .setWaitForNoInitializingShards(true)
+                    .setWaitForNoRelocatingShards(true);
+                if (waitForEvents) {
+                    healthRequest = healthRequest.setWaitForEvents(Priority.LANGUID);
+                }
+                assertThat(healthRequest.get().getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            }, 5, TimeUnit.MINUTES);
         } catch (Exception e) {
-            assert false : "unexpected exception: " + e;
-            throw new RuntimeException(e);
+            throw new AssertionError("cluster did not become GREEN within 5 minutes", e);
         }
     }
 

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -9,10 +9,12 @@ package org.elasticsearch.xpack.stateless;
 
 import org.apache.lucene.index.MergePolicy;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteUtils;
@@ -2699,8 +2701,6 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
             .put(disableIndexingDiskAndMemoryControllersNodeSettings())
             .put(SETTING_HOLLOW_INGESTION_TTL.getKey(), TimeValue.ZERO)
             .put(STATELESS_UPLOAD_MAX_AMOUNT_COMMITS.getKey(), 5) // so that relocations are fast in case of replaying translog
-            // Disable merge backlog throttling so the ForceMerge thread cannot cause indexing threads to block indefinitely
-            .put(IndexEngine.MERGE_BACKLOG_THROTTLE_FACTOR.getKey(), Integer.MAX_VALUE)
             .build();
         List<String> indexNodes = startIndexNodes(randomIntBetween(2, 4), indexNodeSettings);
         startSearchNode();
@@ -2989,11 +2989,23 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
                 final var snapshotName = snapshotBaseName + snapshotNumber.getAndIncrement();
                 logger.info("--> creating snapshot [{}]", snapshotName);
 
-                final CreateSnapshotResponse response = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repos, snapshotName)
-                    .setIndices(indexName)
-                    .setWaitForCompletion(true)
-                    .setFeatureStates(org.elasticsearch.common.Strings.EMPTY_ARRAY)
-                    .get();
+                // Bound the wait-for-completion: a snapshot that never completes (e.g. because a shard snapshot died without
+                // reporting its status, see #154655) must fail this thread with a diagnosable error instead of blocking it
+                // forever and wedging the test into a suite-level timeout.
+                final CreateSnapshotResponse response;
+                try {
+                    response = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repos, snapshotName)
+                        .setIndices(indexName)
+                        .setWaitForCompletion(true)
+                        .setFeatureStates(org.elasticsearch.common.Strings.EMPTY_ARRAY)
+                        .execute()
+                        .actionGet(TimeValue.timeValueMinutes(2));
+                } catch (ElasticsearchTimeoutException e) {
+                    throw new AssertionError(
+                        "snapshot [" + snapshotName + "] did not complete within 2 minutes, its shard snapshots may be wedged",
+                        e
+                    );
+                }
 
                 final SnapshotInfo snapshotInfo = response.getSnapshotInfo();
                 assertThat(snapshotInfo.state(), Matchers.oneOf(SnapshotState.SUCCESS, SnapshotState.PARTIAL));
@@ -3041,43 +3053,97 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         }
 
         logger.info("Waiting for hollowRelocationsLatch ({} relocations needed)", hollowRelocationsLatch.getCount());
+        Throwable latchFailure = null;
         try {
             safeAwait(hollowRelocationsLatch, TimeValue.timeValueMinutes(10));
             logger.info("Waited for hollowRelocationsLatch");
-        } finally {
-            // Always stop threads even if the latch wait times out, to avoid threads holding cluster resources
-            // during test teardown and causing a suite-level timeout.
-            stopThreads.set(true);
-            if (hollowRelocationsLatch.getCount() > 0) {
+        } catch (Throwable t) {
+            // Captured rather than propagated so that the stress threads are always stopped and joined, and so that any
+            // uncaught exception from a stress thread (usually the root cause of a latch timeout) is reported alongside it.
+            latchFailure = t;
+        }
+        // Always stop threads even if the latch wait times out, to avoid threads holding cluster resources
+        // during test teardown and causing a suite-level timeout.
+        stopThreads.set(true);
+        if (hollowRelocationsLatch.getCount() > 0) {
+            logger.warn(
+                "hollowRelocationsLatch timed out with {} relocations remaining; dumping thread stack traces and cluster state",
+                hollowRelocationsLatch.getCount()
+            );
+            for (Thread thread : threads) {
                 logger.warn(
-                    "hollowRelocationsLatch timed out with {} relocations remaining; dumping thread stack traces and cluster state",
-                    hollowRelocationsLatch.getCount()
+                    "Thread [{}] state [{}]:\n\tat {}",
+                    thread.getName(),
+                    thread.getState(),
+                    Arrays.stream(thread.getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining("\n\tat "))
                 );
-                for (Thread thread : threads) {
-                    logger.warn(
-                        "Thread [{}] state [{}]:\n\tat {}",
-                        thread.getName(),
-                        thread.getState(),
-                        Arrays.stream(thread.getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining("\n\tat "))
-                    );
-                }
+            }
+            try {
                 logger.warn(
                     "cluster state at latch timeout:\n{}",
-                    client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState()
+                    safeGet(client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute()).getState()
+                );
+            } catch (Throwable t) {
+                // diagnostics are best-effort and must not replace the real failure
+                logger.warn("failed to fetch cluster state at latch timeout", t);
+            }
+        }
+        // Join with a shared deadline so that a wedged stress thread produces a diagnosable failure here instead of
+        // blocking the test until the suite timeout abandons it without any useful report.
+        final long joinDeadline = System.currentTimeMillis() + TimeValue.timeValueMinutes(3).millis();
+        var stuckThreads = new ArrayList<Thread>();
+        for (Thread thread : threads) {
+            thread.join(Math.max(1, joinDeadline - System.currentTimeMillis()));
+            if (thread.isAlive()) {
+                stuckThreads.add(thread);
+                logger.warn(
+                    "Thread [{}] did not exit after being told to stop; state [{}]:\n\tat {}",
+                    thread.getName(),
+                    thread.getState(),
+                    Arrays.stream(thread.getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining("\n\tat "))
                 );
             }
-            for (Thread thread : threads) {
-                thread.join();
+        }
+        // Snapshot the uncaught exceptions before interrupting stuck threads: the interrupts below typically make a stuck
+        // thread die with an uninteresting interrupt-induced exception that would otherwise pollute the failure report.
+        final var genuineUncaughtExceptions = List.copyOf(uncaughtExceptions);
+        if (stuckThreads.isEmpty() == false) {
+            // As a last resort interrupt the stuck threads so that they cannot also wedge the cluster teardown.
+            stuckThreads.forEach(Thread::interrupt);
+            for (Thread thread : stuckThreads) {
+                thread.join(TimeValue.timeValueSeconds(30).millis());
             }
-            if (uncaughtExceptions.isEmpty() == false) {
-                var first = uncaughtExceptions.get(0);
-                AssertionError ae = new AssertionError(
-                    "One or more stress threads died with an uncaught exception: " + first.getMessage(),
-                    first
-                );
-                uncaughtExceptions.stream().skip(1).forEach(ae::addSuppressed);
-                throw ae;
+        }
+        AssertionError failure = null;
+        if (genuineUncaughtExceptions.isEmpty() == false) {
+            // A dead stress thread is usually why the latch timed out, so report it as the primary failure and attach
+            // the other failures, if any, as suppressed.
+            var first = genuineUncaughtExceptions.get(0);
+            failure = new AssertionError("One or more stress threads died with an uncaught exception: " + first.getMessage(), first);
+            genuineUncaughtExceptions.stream().skip(1).forEach(failure::addSuppressed);
+        }
+        if (stuckThreads.isEmpty() == false) {
+            var stuckFailure = new AssertionError(
+                "Stress threads did not exit after being told to stop: "
+                    + stuckThreads.stream().map(Thread::getName).collect(Collectors.joining(", "))
+            );
+            if (failure == null) {
+                failure = stuckFailure;
+            } else {
+                failure.addSuppressed(stuckFailure);
             }
+        }
+        if (failure != null) {
+            if (latchFailure != null) {
+                failure.addSuppressed(latchFailure);
+            }
+            throw failure;
+        }
+        if (latchFailure != null) {
+            if (latchFailure instanceof Exception e) {
+                throw e;
+            }
+            throw (Error) latchFailure; // a Throwable is always either an Exception or an Error
         }
 
         logger.info("Waiting for ensureGreen");
@@ -3493,30 +3559,31 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         try {
             assertBusy(() -> {
                 if (System.currentTimeMillis() - start > 10 * 1000) {
-                    logger.warn(
-                        "cluster state:\n{}",
-                        client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState()
-                    );
-                    logger.warn("cluster pending tasks:\n{}", getClusterPendingTasks());
-                    logger.warn(
-                        "recoveries:\n{}",
-                        client(masterNode).admin()
-                            .indices()
-                            .recoveries(new RecoveryRequest(index))
-                            .get()
-                            .shardRecoveryStates()
-                            .entrySet()
-                            .stream()
-                            .map(
-                                e -> e.getKey()
-                                    + ":"
-                                    + e.getValue()
-                                        .stream()
-                                        .map(rs -> rs.getShardId() + " - " + rs.getTimer().time())
-                                        .collect(Collectors.joining(","))
-                            )
-                            .toList()
-                    );
+                    try {
+                        logger.warn(
+                            "cluster state:\n{}",
+                            safeGet(client(masterNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute()).getState()
+                        );
+                        logger.warn("cluster pending tasks:\n{}", getClusterPendingTasks());
+                        logger.warn(
+                            "recoveries:\n{}",
+                            safeGet(client(masterNode).admin().indices().recoveries(new RecoveryRequest(index))).shardRecoveryStates()
+                                .entrySet()
+                                .stream()
+                                .map(
+                                    e -> e.getKey()
+                                        + ":"
+                                        + e.getValue()
+                                            .stream()
+                                            .map(rs -> rs.getShardId() + " - " + rs.getTimer().time())
+                                            .collect(Collectors.joining(","))
+                                )
+                                .toList()
+                        );
+                    } catch (Throwable t) {
+                        // diagnostics are best-effort and must not abort the health check retries
+                        logger.warn("failed to fetch cluster diagnostics", t);
+                    }
                 }
                 var healthRequest = client(masterNode).admin()
                     .cluster()
@@ -3527,10 +3594,22 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
                 if (waitForEvents) {
                     healthRequest = healthRequest.setWaitForEvents(Priority.LANGUID);
                 }
-                assertThat(healthRequest.get().getStatus(), equalTo(ClusterHealthStatus.GREEN));
+                final ClusterHealthResponse healthResponse;
+                try {
+                    healthResponse = healthRequest.get();
+                } catch (Exception e) {
+                    // A transient failure of the health request itself (e.g. under injected object store failures) should be
+                    // retried like a non-green response rather than aborting the wait. assertBusy only retries AssertionErrors.
+                    throw new AssertionError("cluster health request failed", e);
+                }
+                assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             }, 5, TimeUnit.MINUTES);
-        } catch (Exception e) {
-            throw new AssertionError("cluster did not become GREEN within 5 minutes", e);
+        } catch (Exception | AssertionError e) {
+            // assertBusy reports its timeout as an AssertionError, which the Exception-only catch used to miss
+            throw new AssertionError(
+                "cluster did not become GREEN within " + TimeValue.timeValueMillis(System.currentTimeMillis() - start),
+                e
+            );
         }
     }
 

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotHashVerificationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotHashVerificationIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.snapshots;
+
+import org.apache.lucene.index.IndexCommit;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.common.lucene.FilterIndexCommit;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.plugins.IndexStorePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
+import org.elasticsearch.xpack.stateless.StatelessMockRepositoryPlugin;
+import org.elasticsearch.xpack.stateless.StatelessMockRepositoryStrategy;
+import org.elasticsearch.xpack.stateless.TestUtils;
+import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryTestUtils;
+import org.elasticsearch.xpack.stateless.lucene.IndexDirectory;
+import org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.oneOf;
+
+public class StatelessSnapshotHashVerificationIT extends AbstractStatelessPluginIntegTestCase {
+
+    @Override
+    protected boolean addMockFsRepository() {
+        // the object store is backed by StatelessMockRepositoryPlugin instead, which registers the same repository type
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        final var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(TestUtils.StatelessPluginWithTrialLicense.class);
+        plugins.add(SnapshotFileEnumerationInterceptPlugin.class);
+        plugins.add(StatelessMockRepositoryPlugin.class);
+        plugins.add(InternalSettingsPlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings.Builder nodeSettings() {
+        return super.nodeSettings()
+            // use the mock object store so that the test can inject read failures
+            .put(ObjectStoreService.TYPE_SETTING.getKey(), ObjectStoreService.ObjectStoreType.MOCK)
+            // disable hollow shards so that the relocated shard keeps a regular IndexEngine and the snapshot code path stays simple
+            .put(STATELESS_HOLLOW_INDEX_SHARDS_ENABLED.getKey(), false);
+    }
+
+    /**
+     * Reproduces the snapshot hang behind https://github.com/elastic/elasticsearch/issues/154655: during shard snapshotting,
+     * {@code BlobStoreRepository#doSnapshotShard} re-reads "virtual" files (files whose contents are stored in the shard-level
+     * metadata, i.e. {@code segments_N} and {@code .si} files) via
+     * {@code LocalPrimarySnapshotShardContext#assertFileContentsMatchHash} to verify their hash. On a stateless index node that
+     * bootstrapped the shard from the object store, that read goes through the shared blob cache and, on a cache miss, to the
+     * object store. A transient read failure there used to be rethrown as an {@link AssertionError}, which escaped the snapshot
+     * thread pool worker without ever completing the shard snapshot, leaving the snapshot in progress forever.
+     *
+     * The test recreates the failure deterministically: it relocates the shard (so its commit files are not on local disk),
+     * then uses an intercepted {@link IndexCommit#getFileNames()} — invoked by {@code doSnapshotShard} after loading the store
+     * metadata and right before the file enumeration loop — to evict the blob cache and start injecting object store read
+     * failures. The next read is the hash-verification read, which is then guaranteed to hit the object store and fail. The
+     * injected failures may legitimately fail the shard snapshot, but the create-snapshot call must always complete.
+     */
+    public void testTransientReadFailureDuringSnapshotFileVerification() throws Exception {
+        startMasterOnlyNode();
+        final var nodeA = startIndexNode();
+        final var nodeB = startIndexNode();
+
+        final var repoName = "test-repo";
+        createRepository(repoName, "fs");
+
+        final var indexName = randomIdentifier();
+        createIndex(
+            indexName,
+            indexSettings(1, 0)
+                // a merge after the relocation could rewrite the shard's files locally on the new node, and the test needs the
+                // snapshotted commit files to be readable only through the blob cache / object store
+                .put(InternalSettingsPlugin.MERGE_ENABLED.getKey(), false)
+                .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeA)
+                .build()
+        );
+        ensureGreen(indexName);
+        indexDocs(indexName, randomIntBetween(32, 128));
+        flush(indexName);
+
+        // Relocate the shard so that its commit files on the new node can only be read through the blob cache / object store
+        updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeB), indexName);
+        ensureGreen(indexName);
+
+        final var indexShard = findIndexShard(resolveIndex(indexName), 0);
+        assertThat(getNodeName(indexShard.routingEntry().currentNodeId()), equalTo(nodeB));
+        final var cacheService = BlobStoreCacheDirectoryTestUtils.getCacheService(
+            IndexDirectory.unwrapDirectory(indexShard.store().directory()).getBlobStoreCacheDirectory()
+        );
+
+        final var readFailuresInjected = new AtomicBoolean();
+        findPlugin(nodeB, SnapshotFileEnumerationInterceptPlugin.class).beforeSnapshotFileEnumeration.put(indexShard.shardId(), () -> {
+            if (readFailuresInjected.compareAndSet(false, true)) {
+                cacheService.forceEvict(cacheKey -> true);
+                setNodeRepositoryFailureStrategy(nodeB, true, false, Map.of(OperationPurpose.INDICES, ".*"));
+            }
+        });
+
+        try {
+            final var future = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, "test-snap")
+                .setIndices(indexName)
+                .setWaitForCompletion(true)
+                .execute();
+            final CreateSnapshotResponse response;
+            try {
+                response = future.get(60, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                throw new AssertionError(
+                    "create-snapshot did not complete, the shard snapshot likely failed without reporting its status",
+                    e
+                );
+            }
+            assertTrue("the test hook never ran, the snapshot never read the shard's file names", readFailuresInjected.get());
+            // The injected object store failures may legitimately fail the shard snapshot, but the snapshot must complete
+            assertThat(response.getSnapshotInfo().state(), oneOf(SnapshotState.SUCCESS, SnapshotState.PARTIAL));
+        } finally {
+            setNodeRepositoryStrategy(nodeB, StatelessMockRepositoryStrategy.DEFAULT);
+        }
+    }
+
+    private static String getNodeName(String id) {
+        return internalCluster().getInstance(ClusterService.class).state().nodes().get(id).getName();
+    }
+
+    /**
+     * Wraps the {@link IndexCommit} acquired for snapshotting so that a per-shard hook runs when the snapshot code calls
+     * {@link IndexCommit#getFileNames()}. In {@code BlobStoreRepository#doSnapshotShard} this happens after the store metadata
+     * has been loaded and immediately before the file enumeration loop that verifies virtual file hashes, which is the exact
+     * window this test needs to instrument.
+     */
+    public static class SnapshotFileEnumerationInterceptPlugin extends TestUtils.StatelessPluginWithTrialLicense {
+        final Map<ShardId, Runnable> beforeSnapshotFileEnumeration = new ConcurrentHashMap<>();
+
+        public SnapshotFileEnumerationInterceptPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+            return super.getEngineFactory(indexSettings).map(factory -> engineConfig -> {
+                final var delegate = engineConfig.getSnapshotCommitSupplier();
+                final var shardId = engineConfig.getShardId();
+                final IndexStorePlugin.SnapshotCommitSupplier wrappedCommitSupplier = engine -> {
+                    final var commitRef = delegate.acquireIndexCommitForSnapshot(engine);
+                    final var wrappedCommit = new FilterIndexCommit(commitRef.getIndexCommit()) {
+                        @Override
+                        public Collection<String> getFileNames() throws IOException {
+                            final var hook = beforeSnapshotFileEnumeration.get(shardId);
+                            if (hook != null) {
+                                hook.run();
+                            }
+                            return super.getFileNames();
+                        }
+                    };
+                    return new Engine.IndexCommitRef(wrappedCommit, commitRef::close);
+                };
+                final var wrappedConfig = EngineConfig.builder(engineConfig).snapshotCommitSupplier(wrappedCommitSupplier).build();
+                return factory.newReadWriteEngine(wrappedConfig);
+            });
+        }
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -916,7 +916,7 @@ public class StatelessPlugin extends Plugin
         // available on all nodes despite being useful only on indexing nodes
         var hollowShardsService = setAndGet(
             this.hollowShardsService,
-            new HollowShardsService(
+            createHollowShardsService(
                 settings,
                 clusterService,
                 indicesService,
@@ -1181,6 +1181,30 @@ public class StatelessPlugin extends Plugin
             cacheService,
             cacheWarmingService,
             telemetryProvider
+        );
+    }
+
+    protected HollowShardsService createHollowShardsService(
+        Settings settings,
+        ClusterService clusterService,
+        IndicesService indicesService,
+        ObjectStoreService objectStoreService,
+        StatelessCommitService commitService,
+        IndexShardCacheWarmer indexShardCacheWarmer,
+        ThreadPool threadPool,
+        HollowShardsMetrics metrics,
+        Executor bccHeaderReadExecutor
+    ) {
+        return new HollowShardsService(
+            settings,
+            clusterService,
+            indicesService,
+            objectStoreService,
+            commitService,
+            indexShardCacheWarmer,
+            threadPool,
+            metrics,
+            bccHeaderReadExecutor
         );
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/HollowShardsService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/HollowShardsService.java
@@ -434,11 +434,14 @@ public class HollowShardsService extends AbstractLifecycleComponent implements M
                                 assert engine instanceof IndexEngine : shardId + ": expected IndexEngine but was " + engine.getClass();
                                 engine.flush(true, true, ActionListener.wrap(flushResult -> {
                                     assert flushResult.skippedDueToCollision() == false : "Flush was skipped";
+                                    // Check hollow state before removeHollowShard: once the shard leaves the hollow map a
+                                    // concurrent relocation can call prepareForEngineReset → flushHollow on this engine,
+                                    // which would overwrite lastCommittedSegmentInfos and cause a spurious assertion failure.
+                                    assert assertIndexEngineLastCommitHollow(shardId, engine, false);
                                     removeHollowShard(indexShard, "unhollowing gen " + flushResult.generation());
                                     logger.info("{} unhollowed shard with gen {}", shardId, flushResult.generation());
                                     metrics.unhollowSuccessCounter().increment();
                                     metrics.unhollowTimeMs().record(relativeTimeSupplierInMillis.getAsLong() - startTime);
-                                    assert assertIndexEngineLastCommitHollow(shardId, engine, false);
                                 }, e -> failedUnhollowing(shardId, e)));
                                 return null;
                             });


### PR DESCRIPTION
This PR does a handful of things:

- Fixes a minor race condition in HollowShardsService
- Fixes the handling of transient IOExceptions in LocalPrimarySnapshotShardContext
- Improves ensureGreenViaMasterNode to not fail after a single 30-second timeout
- Prevents threads leftover after test timeouts from causing the whole test suite to timeout
- Logs additional diagnostic information so that we know more the next time it fails

Closes #154655
