### PR TITLE
ESQL: Fix IVF/BBQ with single value query

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneOperator.java
@@ -222,7 +222,8 @@ public abstract class LuceneOperator extends SourceOperator {
                 taskConcurrency,
                 scoreModeFunction,
                 leafSplitGuard,
-                minDocsPerSlice
+                minDocsPerSlice,
+                singleValueQueryWarnings
             );
             this.taskConcurrency = Math.min(sliceQueue.totalSlices(), taskConcurrency);
             this.needsScore = needsScore;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSliceQueue.java
@@ -22,7 +22,9 @@ import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.lucene.PartialLeafReaderContext;
 import org.elasticsearch.compute.lucene.ShardContext;
+import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.codec.tsdb.PartitionedDocValues;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
@@ -296,6 +298,32 @@ public final class LuceneSliceQueue {
         LeafSplitGuard leafSplitGuard,
         int minDocsPerSlice
     ) {
+        return create(
+            contexts,
+            queryFunction,
+            dataPartitioning,
+            autoStrategy,
+            docThresholdForAutoStrategy,
+            taskConcurrency,
+            scoreModeFunction,
+            leafSplitGuard,
+            minDocsPerSlice,
+            QueryWarnings.NOOP
+        );
+    }
+
+    public static LuceneSliceQueue create(
+        IndexedByShardId<? extends ShardContext> contexts,
+        Function<ShardContext, List<QueryAndTags>> queryFunction,
+        DataPartitioning dataPartitioning,
+        BiFunction<ShardContext, Query, PartitioningStrategy> autoStrategy,
+        int docThresholdForAutoStrategy,
+        int taskConcurrency,
+        Function<ShardContext, ScoreMode> scoreModeFunction,
+        LeafSplitGuard leafSplitGuard,
+        int minDocsPerSlice,
+        QueryWarnings singleValueQueryWarnings
+    ) {
         List<LuceneSlice> slices = new ArrayList<>();
         Map<String, PartitioningStrategy> partitioningStrategies = new HashMap<>();
 
@@ -316,8 +344,20 @@ public final class LuceneSliceQueue {
                      * to do this before picking the partitioning strategy so we
                      * can pick more aggressive strategies when the query rewrites
                      * into MatchAll.
+                     *
+                    /*
+                     * Rewrite the query on the local index so things like fully
+                     * overlapping range queries become match all. It's important
+                     * to do this before picking the partitioning strategy so we
+                     * can pick more aggressive strategies when the query rewrites
+                     * into MatchAll.
+                     *
+                     * Sometimes (IVF/BBQ) rewrites run the whole query, and we
+                     * don't have a place to put warnings. So, for now, we use a
+                     * NOOP to discard any warnings we encounter. We'll change soon
+                     * to collect them.
                      */
-                    try {
+                    try (Releasable ignored = singleValueQueryWarnings.bindDiscarding()) {
                         query = ctx.searcher().rewrite(query);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/QueryWarnings.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/QueryWarnings.java
@@ -60,6 +60,11 @@ public class QueryWarnings {
         }
 
         @Override
+        public Releasable bindDiscarding() {
+            return () -> {};
+        }
+
+        @Override
         void registerException(SingleValueMatchQuery query, Class<? extends Exception> exceptionClass, String message) {}
     };
 
@@ -75,7 +80,7 @@ public class QueryWarnings {
      * {@link LuceneOperator#getOutput} calls. The {@link DriverContext} is {@code null} when
      * the caller supplies pre-built Warnings rather than requesting lazy creation.
      */
-    private record ThreadState(@Nullable DriverContext dc, IdentityHashMap<Query, Warnings> map) {}
+    private record ThreadState(@Nullable DriverContext dc, @Nullable IdentityHashMap<Query, Warnings> map, boolean discard) {}
 
     private final ThreadLocal<ThreadState> perThreadWarnings = new ThreadLocal<>();
 
@@ -96,7 +101,7 @@ public class QueryWarnings {
      *                                is reentering Lucene from within its own synchronous call
      */
     public Releasable bind(DriverContext dc, IdentityHashMap<Query, Warnings> map) {
-        return doBind(new ThreadState(dc, map));
+        return doBind(new ThreadState(dc, map, false));
     }
 
     /**
@@ -107,7 +112,22 @@ public class QueryWarnings {
      * @throws IllegalStateException if this thread already has a binding
      */
     public Releasable bind(Map<? extends Query, Warnings> prebuilt) {
-        return doBind(new ThreadState(null, new IdentityHashMap<>(prebuilt)));
+        return doBind(new ThreadState(null, new IdentityHashMap<>(prebuilt), false));
+    }
+
+    /**
+     * Bind a placeholder on the calling thread that silently discards any warnings raised while it's
+     * bound, without a {@link DriverContext} or a prebuilt map. Used when {@link Query}s reachable from
+     * this bridge (e.g. a {@link SingleValueMatchQuery} nested inside a kNN query's filter) may fire
+     * outside a driver's lifecycle -- for example while eagerly evaluating a filter during
+     * {@code IndexSearcher#rewrite}, which can happen before any {@link DriverContext}/driver exists to
+     * own the warning (see {@code LuceneSliceQueue#create}). There is currently no well-defined owner
+     * for warnings raised in that window, so they're dropped rather than attributed to a driver.
+     *
+     * @throws IllegalStateException if this thread already has a binding
+     */
+    public Releasable bindDiscarding() {
+        return doBind(new ThreadState(null, null, true));
     }
 
     private Releasable doBind(ThreadState state) {
@@ -132,6 +152,9 @@ public class QueryWarnings {
         ThreadState state = perThreadWarnings.get();
         if (state == null) {
             throw new IllegalStateException("no warnings bound on thread [" + Thread.currentThread().getName() + "] for [" + query + "]");
+        }
+        if (state.discard()) {
+            return;
         }
         Warnings w = state.map().computeIfAbsent(query, q -> {
             if (state.dc() == null) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/IvfKnnNestedFilterSingleValueWarningsTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/IvfKnnNestedFilterSingleValueWarningsTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.lucene.query;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.QueryBitSetProducer;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardIdFromList;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.querydsl.query.QueryWarnings;
+import org.elasticsearch.compute.querydsl.query.SingleValueMatchQuery;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.compute.test.TestWarningsSource;
+import org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormat;
+import org.elasticsearch.index.codec.vectors.diskbbq.IvfQueryConfigResolver;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.LeafFieldData;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatVectorQuery;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Adds a {@code single_value_match} pushdown used as the child filter of
+ * a nested/diversifying IVF (bbq_disk) kNN query and validates that we
+ * discard its warnings. We'll modify it before long to collect them.
+ */
+public class IvfKnnNestedFilterSingleValueWarningsTests extends ComputeTestCase {
+
+    /** Same trick as {@code LuceneOperatorSingleValueQueryWarningsTests}: report every doc as multi-valued
+     *  so the query survives rewrite() and fires registerMultiValueException() for every candidate doc. */
+    private static IndexFieldData<?> alwaysMultiValuedFieldData(String fieldName) {
+        IndexFieldData<?> fieldData = mock(IndexFieldData.class);
+        when(fieldData.getFieldName()).thenReturn(fieldName);
+        LeafFieldData leafFieldData = mock(LeafFieldData.class);
+        when(fieldData.load(any())).thenReturn(leafFieldData);
+        SortedBinaryDocValues sortedBinaryDocValues = mock(SortedBinaryDocValues.class);
+        when(leafFieldData.getBytesValues()).thenReturn(sortedBinaryDocValues);
+        when(sortedBinaryDocValues.getValueMode()).thenReturn(SortedBinaryDocValues.ValueMode.MULTI_VALUED);
+        try {
+            when(sortedBinaryDocValues.advanceExact(anyInt())).thenReturn(true);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        when(sortedBinaryDocValues.docValueCount()).thenReturn(2);
+        return fieldData;
+    }
+
+    private DriverContext driverContext() {
+        return new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, blockFactory(), null);
+    }
+
+    public void testIvfKnnQueryWithNestedFilterDoesNotThrowAndStillWarnsWhenScanned() throws IOException {
+        ES920DiskBBQVectorsFormat format = new ES920DiskBBQVectorsFormat(
+            ES920DiskBBQVectorsFormat.MIN_VECTORS_PER_CLUSTER,
+            ES920DiskBBQVectorsFormat.MIN_CENTROIDS_PER_PARENT_CLUSTER
+        );
+
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format)))) {
+                for (int group = 0; group < 5; group++) {
+                    for (int child = 0; child < 3; child++) {
+                        Document doc = new Document();
+                        doc.add(new KnnFloatVectorField("vector", new float[] { group, child }));
+                        writer.addDocument(doc);
+                    }
+                    Document parent = new Document();
+                    parent.add(new StringField("docType", "_parent", Field.Store.NO));
+                    writer.addDocument(parent);
+                }
+            }
+
+            try (IndexReader reader = DirectoryReader.open(dir)) {
+                LuceneSourceOperatorTests.MockShardContext shardContext = new LuceneSourceOperatorTests.MockShardContext(reader, 0);
+                BitSetProducer parentFilter = new QueryBitSetProducer(new TermQuery(new Term("docType", "_parent")));
+
+                QueryWarnings warnings = QueryWarnings.EMIT;
+                SingleValueMatchQuery singleValueMatchQuery = new SingleValueMatchQuery(
+                    alwaysMultiValuedFieldData("mv_nested_field"),
+                    warnings,
+                    new TestWarningsSource("test"),
+                    "single-value function encountered multi-value"
+                );
+                Query childFilter = new BooleanQuery.Builder().add(Queries.ALL_DOCS_INSTANCE, BooleanClause.Occur.FILTER)
+                    .add(singleValueMatchQuery, BooleanClause.Occur.FILTER)
+                    .build();
+
+                Query knnQuery = new DiversifyingChildrenIVFKnnFloatVectorQuery(
+                    "vector",
+                    new float[] { 0, 0 },
+                    3,
+                    3,
+                    childFilter,
+                    parentFilter,
+                    0f,
+                    IvfQueryConfigResolver.from(false, false, 4, 1.0f, null)
+                );
+
+                // Constructing the operator factory for this shard/query triggers exactly what
+                // LuceneSliceQueue.create() does for every LuceneOperator.Factory: it rewrites the
+                // pushed-down query against the shard searcher *before* any driver/DriverContext exists.
+                // Before the fix this threw IllegalStateException because QueryWarnings was never bound
+                // on this thread; now a placeholder binding is used around that rewrite, so construction
+                // completes normally (any warning raised strictly during this rewrite is discarded, per
+                // the TODO(154664) at the bind site).
+                LuceneSourceOperator.Factory factory = new LuceneSourceOperator.Factory(
+                    new IndexedByShardIdFromList<>(List.of(shardContext)),
+                    ctx -> List.of(new LuceneSliceQueue.QueryAndTags(knnQuery, List.of())),
+                    DataPartitioning.SHARD,
+                    DataPartitioning.AutoStrategy.DEFAULT,
+                    LuceneOperator.SMALL_INDEX_BOUNDARY,
+                    1,
+                    10,
+                    LuceneOperator.NO_LIMIT,
+                    false,
+                    () -> 0L,
+                    LuceneSliceQueue.MIN_DOCS_PER_SLICE,
+                    warnings
+                );
+
+                // Now prove that actually running a driver over this operator no longer throws either.
+                // For an IVF/BBQ kNN query, the ANN accept-docs bitset (and therefore the child filter,
+                // including our single_value_match node) is only evaluated once, eagerly, during the
+                // rewrite() above -- the real per-driver scan just walks the already-computed top-k doc
+                // set, it never re-invokes the filter's two-phase matcher. So the warning raised while
+                // building that bitset is -- per the TODO(154664) at the bind site -- silently discarded
+                // rather than surfacing on this driver; that's a known, documented gap for this query
+                // shape, not a regression. (Ordinary, non-kNN pushed-down filters visit
+                // single_value_match on every scored doc during the real per-driver scan, and correctly
+                // still emit warnings there -- see LuceneOperatorSingleValueQueryWarningsTests.)
+                LuceneSourceOperator op = (LuceneSourceOperator) factory.get(driverContext());
+                try {
+                    while (op.isFinished() == false) {
+                        Page page = op.getOutput();
+                        if (page != null) {
+                            page.releaseBlocks();
+                        }
+                    }
+                } finally {
+                    op.close();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Binds a QueryWarnings during rewrite so rewrites that evaluate the query have somewhere to write into. We discard the warnings for the moment.

Close #154664
