### PR TITLE
ESQL: release match_phrase on runtime expressions

### DIFF
--- a/docs/changelog/153745.yaml
+++ b/docs/changelog/153745.yaml
@@ -1,5 +1,0 @@
-area: ES|QL
-issues: []
-pr: 153745
-summary: Match_phrase works on runtime text expressions
-type: enhancement

--- a/docs/changelog/154765.yaml
+++ b/docs/changelog/154765.yaml
@@ -1,0 +1,11 @@
+area: ES|QL
+highlight:
+  body: |-
+    Runtime search for match_phrase on non-index-mapped expressions is now
+    enabled in release builds.
+  notable: true
+  title: Release `match_phrase` on runtime expressions
+issues: []
+pr: 154765
+summary: Release `match_phrase` on runtime expressions
+type: enhancement

--- a/docs/changelog/154765.yaml
+++ b/docs/changelog/154765.yaml
@@ -1,11 +1,16 @@
 area: ES|QL
 highlight:
   body: |-
-    Runtime search for match_phrase on non-index-mapped expressions is now
-    enabled in release builds.
+    The `match_phrase` function can now work with runtime expressions; it
+    no longer needs to be pushed down as a Lucene query to the shard. When
+    matching on a runtime expression, the function is evaluated on-the-fly for
+    each row: a `text` expression is analyzed and matches when all query terms
+    appear in order at consecutive positions, while a `keyword` expression
+    must equal the query string exactly, preserving the term query semantics
+    of `match_phrase` on a mapped keyword field.
   notable: true
-  title: Release `match_phrase` on runtime expressions
+  title: match_phrase can now operate on runtime expressions
 issues: []
 pr: 154765
-summary: Release `match_phrase` on runtime expressions
+summary: match_phrase can now operate on runtime expressions
 type: enhancement

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetSubqueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetSubqueryIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhrase;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.view.DeleteViewAction;
 import org.elasticsearch.xpack.esql.view.PutViewAction;
@@ -918,22 +917,19 @@ public class FromDatasetSubqueryIT extends AbstractExternalDataSourceIT {
         }
     }
 
+    /**
+     * MATCH_PHRASE on a dataset (keyword) field works via runtime search, matching the exact value like the term
+     * query a pushed-down match_phrase on a keyword field rewrites to.
+     */
     public void testMatchPhraseOnDatasetField() {
         registerEmployees();
 
-        String query = "FROM (FROM employees | WHERE MATCH_PHRASE(first_name, \"Alice\"))";
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            try (var response = run(syncEsqlQueryRequest(query + " | KEEP first_name, last_name"), TIMEOUT)) {
-                assertColumnNames(response.columns(), List.of("first_name", "last_name"));
-                assertValues(response.values(), List.of(List.of("Alice", "Anderson")));
-            }
-        } else {
-            Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest(query), TIMEOUT));
-            assertCauseMessageContains(
-                ex,
-                "[MatchPhrase] function cannot operate on [first_name], which is not a field from an index mapping "
-                    + "(the source is a federated data source, not an index)"
-            );
+        try (var response = run(syncEsqlQueryRequest("""
+            FROM (FROM employees | WHERE MATCH_PHRASE(first_name, "Alice"))
+            | KEEP first_name, last_name
+            """), TIMEOUT)) {
+            assertColumnNames(response.columns(), List.of("first_name", "last_name"));
+            assertValues(response.values(), List.of(List.of("Alice", "Anderson")));
         }
     }
 
@@ -965,25 +961,20 @@ public class FromDatasetSubqueryIT extends AbstractExternalDataSourceIT {
         );
     }
 
+    /**
+     * MATCH_PHRASE after a subquery union of datasets works via runtime search, mirroring
+     * {@link #testMatchAfterSubquery}.
+     */
     public void testMatchPhraseAfterSubquery() {
         registerEmployees();
         registerEmployeesAlt();
 
-        String query = """
+        try (var response = run(syncEsqlQueryRequest("""
             FROM (FROM employees), (FROM employees_alt) | WHERE MATCH_PHRASE(first_name, "Alice")
-            """;
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            try (var response = run(syncEsqlQueryRequest(query + " | KEEP first_name, last_name"), TIMEOUT)) {
-                assertColumnNames(response.columns(), List.of("first_name", "last_name"));
-                assertValues(response.values(), List.of(List.of("Alice", "Anderson")));
-            }
-        } else {
-            Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest(query), TIMEOUT));
-            assertCauseMessageContains(
-                ex,
-                "[MatchPhrase] function cannot operate on [first_name], which is not a field from an index mapping "
-                    + "(the source is a federated data source, not an index)"
-            );
+            | KEEP first_name, last_name
+            """), TIMEOUT)) {
+            assertColumnNames(response.columns(), List.of("first_name", "last_name"));
+            assertValues(response.values(), List.of(List.of("Alice", "Anderson")));
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchPhraseFunctionIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.plugin;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhrase;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
@@ -27,14 +26,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     @Before
     public void setupIndex() {
         createAndPopulateIndices(this::ensureYellow);
-    }
-
-    /**
-     * Runtime match_phrase is gated behind a snapshot-only capability; in release builds the queries these tests
-     * run are rejected by the verifier instead.
-     */
-    private static void assumeRuntimeMatchPhraseEnabled() {
-        assumeTrue("requires runtime match_phrase", MatchPhrase.runtimeSearchEnabled());
     }
 
     public void testSimpleWhereMatchPhrase() {
@@ -217,7 +208,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereMatchPhraseEvalColumn() {
-        assumeRuntimeMatchPhraseEnabled();
         // to_upper produces a keyword, so runtime match_phrase compares the whole value exactly: the phrase-like
         // "BROWN FOX" query matches nothing, only the complete value does.
         var query = """
@@ -248,7 +238,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereMatchPhraseOverWrittenColumn() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | DROP content
@@ -305,7 +294,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereMatchPhraseWithRow() {
-        assumeRuntimeMatchPhraseEnabled();
         // A ROW string literal is a keyword: runtime match_phrase requires the exact value, not a phrase within it.
         var query = """
             ROW content = "a brown fox"
@@ -377,7 +365,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseAfterMvExpand() {
-        assumeRuntimeMatchPhraseEnabled();
         // After MV_EXPAND on the searched field, the expanded attribute is no longer a direct index field, so
         // runtime search takes over: the MV_EXPAND restriction is bypassed and the phrase is evaluated per row.
         var query = """
@@ -396,7 +383,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseAfterMvExpandWithIntermediateCommands() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | MV_EXPAND content
@@ -456,7 +442,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     // ---- runtime match_phrase: searching text expressions that are not index-mapped fields ----
 
     public void testSimpleWhereRuntimeMatchPhrase() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | WHERE match_phrase(to_text(concat(content, " extra")), "brown fox")
@@ -472,7 +457,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testRuntimeMatchPhraseOrderMatters() {
-        assumeRuntimeMatchPhraseEnabled();
         // Both tokens exist in ids 1 and 6, but never adjacent in this order, so a runtime phrase matches nothing.
         var query = """
             FROM test
@@ -489,7 +473,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereRuntimeMatchPhraseEvalTextColumn() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | EVAL text_content = content
@@ -506,7 +489,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereRuntimeMatchPhraseWithRow() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             ROW content = to_text("a brown fox")
             | WHERE match_phrase(content, "brown fox")
@@ -520,7 +502,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testWhereRuntimeMatchPhraseKeyword() {
-        assumeRuntimeMatchPhraseEnabled();
         // concat produces a keyword: runtime match_phrase preserves the pushed-down term-query semantics and
         // matches on the exact value.
         var query = """
@@ -558,7 +539,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
 
     public void testUnmappedWithIndexedText() {
         // to_text over a partially unmapped field is evaluated as a runtime expression.
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             SET unmapped_fields = "LOAD";
             FROM test, test_unmapped METADATA _index
@@ -577,7 +557,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
 
     public void testUnmappedWithIndexedTextAndKeyword() {
         // to_text over a partially unmapped field is evaluated as a runtime expression.
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             SET unmapped_fields = "LOAD";
             FROM test, test_keyword, test_unmapped METADATA _index
@@ -595,7 +574,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testSimpleWhereRuntimeMatchPhraseWithScore() {
-        assumeRuntimeMatchPhraseEnabled();
         // Runtime match_phrase does not contribute to the score, so matching rows keep a 0.0 score.
         var query = """
             FROM test METADATA _score
@@ -612,7 +590,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseRuntimeEvalWithOptionsThrowsError() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             FROM test
             | EVAL new_content = to_text(concat(content, " extra"))
@@ -627,7 +604,6 @@ public class MatchPhraseFunctionIT extends AbstractEsqlIntegTestCase {
     }
 
     public void testMatchPhraseRuntimeRowWithOptionsThrowsError() {
-        assumeRuntimeMatchPhraseEnabled();
         var query = """
             ROW content = to_text("a brown fox")
             | WHERE match_phrase(content, "brown fox", {"analyzer": "standard"})

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Build;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -72,9 +71,7 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
     );
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(MatchPhrase.class)
         .ternary(MatchPhrase::new)
-        .capabilities("unmapped_fields_pushdown_fix")
-        // in-development runtime search support; move to capabilities(...) when released
-        .snapshotCapabilities("runtime_filter")
+        .capabilities("runtime_filter", "unmapped_fields_pushdown_fix")
         .name("match_phrase");
     public static final Set<DataType> FIELD_DATA_TYPES = Set.of(KEYWORD, TEXT, NULL);
     public static final Set<DataType> QUERY_DATA_TYPES = Set.of(KEYWORD, TEXT);
@@ -255,21 +252,12 @@ public class MatchPhrase extends SingleFieldFullTextFunction implements Optional
         return new MatchPhraseQuery(source(), fieldName, queryAsObject(), matchPhraseQueryOptions());
     }
 
-    /**
-     * Runtime search on non-index-mapped expressions is under development and enabled in snapshot builds only,
-     * advertised through the snapshot-only {@code fn_match_phrase_runtime_filter} function capability declared on
-     * {@link #DEFINITION}.
-     */
-    public static boolean runtimeSearchEnabled() {
-        return Build.current().isSnapshot();
-    }
-
     @Override
     public boolean isRuntimeSearch() {
         FieldAttribute fieldAttribute = fieldAsFieldAttribute();
         if (fieldAttribute == null) {
-            // Runtime search on expressions is currently snapshot-only.
-            return runtimeSearchEnabled();
+            // This isn't a field in the index, so the expression is evaluated at runtime, row by row.
+            return true;
         }
         // A potentially unmapped field cannot be pushed down: the Lucene query would silently miss the rows of the
         // indices where the field is unmapped, so it is matched at runtime instead.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerExternalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerExternalTests.java
@@ -53,12 +53,10 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DENSE_VECTOR;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
 
 /**
  * Unit tests for analysis of external datasets reached via {@code FROM <dataset>}. All such analyzer tests belong
@@ -165,30 +163,16 @@ public class AnalyzerExternalTests extends ESTestCase {
     }
 
     /**
-     * MATCH_PHRASE can operate on external (non-index) keyword fields via runtime search (snapshot-only for now).
-     * In release builds it is rejected, and the message names the federated-source limitation.
+     * MATCH_PHRASE can operate on external (non-index) keyword fields via runtime search.
      */
     public void testWithMatchPhraseFunction() {
         assumeTrue("requires dataset-in-FROM support", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
 
-        String query = "FROM " + DATASET_NAME + " | WHERE MATCH_PHRASE(first_name, \"foo\")";
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            var plan = analyzeDataset(external(), S3_PATH, query);
-            Limit limit = as(plan, Limit.class);
-            Filter filter = as(limit.child(), Filter.class);
-            assertThat(filter.condition(), instanceOf(MatchPhrase.class));
-            assertThat(filter.child(), instanceOf(ExternalRelation.class));
-        } else {
-            datasetError(
-                external(),
-                S3_PATH,
-                query,
-                containsString(
-                    "function cannot operate on [first_name], which is not a field from an index mapping "
-                        + "(the source is a federated data source, not an index)"
-                )
-            );
-        }
+        var plan = analyzeDataset(external(), S3_PATH, "FROM " + DATASET_NAME + " | WHERE MATCH_PHRASE(first_name, \"foo\")");
+        Limit limit = as(plan, Limit.class);
+        Filter filter = as(limit.child(), Filter.class);
+        assertThat(filter.condition(), instanceOf(MatchPhrase.class));
+        assertThat(filter.child(), instanceOf(ExternalRelation.class));
     }
 
     /**
@@ -252,56 +236,29 @@ public class AnalyzerExternalTests extends ESTestCase {
     }
 
     /**
-     * MATCH_PHRASE runtime search also accepts a renamed external field (snapshot-only for now). In release builds
-     * the error still names the federated-source limitation - the federated-clause detection must follow the rename
-     * (by attribute identity) back to the {@link ExternalRelation}, not just compare the field's current name
-     * against its output.
+     * MATCH_PHRASE runtime search also accepts a renamed external field.
      */
     public void testWithMatchPhraseFunctionAfterRename() {
         assumeTrue("requires dataset-in-FROM support", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
 
-        String query = "FROM " + DATASET_NAME + " | RENAME first_name AS fname | WHERE MATCH_PHRASE(fname, \"foo\")";
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            analyzeDataset(external(), S3_PATH, query);
-        } else {
-            datasetError(
-                external(),
-                S3_PATH,
-                query,
-                containsString(
-                    "function cannot operate on [fname], which is not a field from an index mapping "
-                        + "(the source is a federated data source, not an index)"
-                )
-            );
-        }
+        analyzeDataset(external(), S3_PATH, "FROM " + DATASET_NAME + " | RENAME first_name AS fname | WHERE MATCH_PHRASE(fname, \"foo\")");
     }
 
     /**
-     * MATCH_PHRASE runtime search accepts EVAL-derived keyword fields (snapshot-only for now). In release builds,
-     * where it is rejected, a genuinely computed field - even one built from a federated field, and even after a
-     * subsequent rename - must not gain the federated-source clause: the value is no longer a direct reference to
-     * the federated field, so the plain "not a field from an index mapping" message applies.
+     * MATCH_PHRASE runtime search accepts EVAL-derived keyword fields, even ones built from a federated field and
+     * renamed afterwards.
      */
     public void testWithMatchPhraseFunctionOnEvalDerivedField() {
         assumeTrue("requires dataset-in-FROM support", EsqlCapabilities.Cap.DATASET_IN_FROM_COMMAND.isEnabled());
 
-        String query = "FROM "
-            + DATASET_NAME
-            + " | EVAL full_name = CONCAT(first_name, last_name) | RENAME full_name AS content "
-            + "| WHERE MATCH_PHRASE(content, \"foo\")";
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            analyzeDataset(external(), S3_PATH, query);
-        } else {
-            datasetError(
-                external(),
-                S3_PATH,
-                query,
-                allOf(
-                    containsString("function cannot operate on [content], which is not a field from an index mapping"),
-                    not(containsString("federated"))
-                )
-            );
-        }
+        analyzeDataset(
+            external(),
+            S3_PATH,
+            "FROM "
+                + DATASET_NAME
+                + " | EVAL full_name = CONCAT(first_name, last_name) | RENAME full_name AS content "
+                + "| WHERE MATCH_PHRASE(content, \"foo\")"
+        );
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1947,20 +1947,11 @@ public class VerifierTests extends ESTestCase {
 
         checkFieldBasedFunctionNotAllowedAfterCommands(":", "operator", "title : \"Meditation\"", true);
 
-        // MATCH_PHRASE supports runtime search (snapshot-only for now) on text and keyword expressions
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            fullText().query("from test | eval text = substring(title, 1) | where match_phrase(text, \"cat\")");
-            fullText().query("from test | eval text=concat(title, body) | where match_phrase(text, \"cat\")");
-            fullText().query("row n = null | eval text = n + 5 | where match_phrase(text::keyword, \"cat\")");
-        } else {
-            checkFieldBasedWithNonIndexedColumn("MatchPhrase", "match_phrase(text, \"cat\")", "function");
-        }
-        checkFieldBasedFunctionNotAllowedAfterCommands(
-            "MatchPhrase",
-            "function",
-            "match_phrase(title, \"Meditation\")",
-            MatchPhrase.runtimeSearchEnabled()
-        );
+        // MATCH_PHRASE supports runtime search on text and keyword expressions
+        fullText().query("from test | eval text = substring(title, 1) | where match_phrase(text, \"cat\")");
+        fullText().query("from test | eval text=concat(title, body) | where match_phrase(text, \"cat\")");
+        fullText().query("row n = null | eval text = n + 5 | where match_phrase(text::keyword, \"cat\")");
+        checkFieldBasedFunctionNotAllowedAfterCommands("MatchPhrase", "function", "match_phrase(title, \"Meditation\")", true);
 
         checkFieldBasedFunctionNotAllowedAfterCommands("KNN", "function", "knn(vector, [1, 2, 3])", false);
     }
@@ -2059,29 +2050,6 @@ public class VerifierTests extends ESTestCase {
                     + "| where title : \"data\"",
                 allOf(containsString("Found 1 problem"), containsString("[:] operator cannot be used after FORK"))
             );
-    }
-
-    private void checkFieldBasedWithNonIndexedColumn(String functionName, String functionInvocation, String functionType) {
-        fullText().error(
-            "from test | eval text = substring(title, 1) | where " + functionInvocation,
-            containsString(
-                "[" + functionName + "] " + functionType + " cannot operate on [text], which is not a field from an index mapping"
-            )
-        );
-        fullText().error(
-            "from test | eval text=concat(title, body) | where " + functionInvocation,
-            containsString(
-                "[" + functionName + "] " + functionType + " cannot operate on [text], which is not a field from an index mapping"
-            )
-        );
-        var keywordInvocation = functionInvocation.replace("text", "text::keyword");
-        fullText().error(
-            "row n = null | eval text = n + 5 | where " + keywordInvocation,
-            allOf(
-                containsString("[" + functionName + "] " + functionType + " cannot operate on"),
-                containsString("which is not a field from an index mapping")
-            )
-        );
     }
 
     public void testNonFieldBasedFullTextFunctionsNotAllowedAfterCommands() throws Exception {
@@ -2373,15 +2341,8 @@ public class VerifierTests extends ESTestCase {
         // match and : support runtime search and can operate on EVAL columns
         fullText().query("from test | eval name = title | where match(name, \"Meditation\")");
         fullText().query("from test | eval name = title | where name : \"Meditation\"");
-        // match_phrase supports runtime search (snapshot-only for now) on text EVAL columns
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            fullText().query("from test | eval name = title | where match_phrase(name, \"Meditation\")");
-        } else {
-            fullText().error(
-                "from test | eval name = title | where match_phrase(name, \"Meditation\")",
-                containsString("[MatchPhrase] function cannot operate on [name], which is not a field from an index mapping")
-            );
-        }
+        // match_phrase supports runtime search on text EVAL columns
+        fullText().query("from test | eval name = title | where match_phrase(name, \"Meditation\")");
     }
 
     /**
@@ -2409,45 +2370,17 @@ public class VerifierTests extends ESTestCase {
         fullText().query("from test | dissect title \"%{extracted}\" | rename extracted as x | where match(x, \"Meditation\")");
         fullText().query("from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match(y, \"Meditation\")");
 
-        // MATCH_PHRASE supports runtime search (snapshot-only for now) on renamed text expressions
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            fullText().query("from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")");
-        } else {
-            fullText().error(
-                "from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")",
-                containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
-            );
-        }
-
-        // MATCH_PHRASE runtime search also covers keyword expressions (concat, grok, dissect and substring all
-        // produce keyword); in release builds these still require a field from an index mapping
-        if (MatchPhrase.runtimeSearchEnabled()) {
-            fullText().query(
-                "from test | eval text = concat(title, body) | rename text as content | where match_phrase(content, \"Meditation\")"
-            );
-            fullText().query("from test | grok body \"%{WORD:extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")");
-            fullText().query("from test | dissect title \"%{extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")");
-            fullText().query(
-                "from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match_phrase(y, \"Meditation\")"
-            );
-        } else {
-            fullText().error(
-                "from test | eval text = concat(title, body) | rename text as content | where match_phrase(content, \"Meditation\")",
-                containsString("[MatchPhrase] function cannot operate on [content], which is not a field from an index mapping")
-            );
-            fullText().error(
-                "from test | grok body \"%{WORD:extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")",
-                containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
-            );
-            fullText().error(
-                "from test | dissect title \"%{extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")",
-                containsString("[MatchPhrase] function cannot operate on [x], which is not a field from an index mapping")
-            );
-            fullText().error(
-                "from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match_phrase(y, \"Meditation\")",
-                containsString("[MatchPhrase] function cannot operate on [y], which is not a field from an index mapping")
-            );
-        }
+        // MATCH_PHRASE supports runtime search on renamed text and keyword expressions (concat, grok, dissect and
+        // substring all produce keyword)
+        fullText().query("from test | eval name = title | rename name as x | where match_phrase(x, \"Meditation\")");
+        fullText().query(
+            "from test | eval text = concat(title, body) | rename text as content | where match_phrase(content, \"Meditation\")"
+        );
+        fullText().query("from test | grok body \"%{WORD:extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")");
+        fullText().query("from test | dissect title \"%{extracted}\" | rename extracted as x | where match_phrase(x, \"Meditation\")");
+        fullText().query(
+            "from test | eval text = substring(title, 1) | rename text as x | rename x as y | where match_phrase(y, \"Meditation\")"
+        );
     }
 
     public void testConditionalFunctionsWithMixedNumericTypes() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseRuntimeSearchEvaluatorTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.junit.Before;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
@@ -35,12 +34,6 @@ import static org.hamcrest.Matchers.instanceOf;
  * positions are exercised too.
  */
 public class MatchPhraseRuntimeSearchEvaluatorTests extends AbstractRuntimeSearchEvaluatorTests {
-
-    @Before
-    public void assumeRuntimeMatchPhraseEnabled() {
-        // Runtime match_phrase is gated behind a snapshot-only capability; there is nothing to test in release builds.
-        assumeTrue("requires runtime match_phrase", MatchPhrase.runtimeSearchEnabled());
-    }
 
     private static MatchPhrase runtimeMatchPhrase(String queryValue) {
         return runtimeMatchPhrase(TEXT, queryValue);


### PR DESCRIPTION
Runtime search for match_phrase on non-index-mapped expressions is now enabled in release builds.
