### PR TITLE
[9.5] fix(mapper): accept subobjects: false as no-op in columnar mode (#154675)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -117,6 +117,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.keyword.doc_values_case_insensitive_regexp"
     );
     public static final NodeFeature COLUMNAR_REJECTS_RUNTIME_DYNAMIC = new NodeFeature("mapper.columnar_rejects_runtime_dynamic");
+    public static final NodeFeature COLUMNAR_ACCEPTS_SUBOBJECTS_FALSE = new NodeFeature("mapper.columnar.accepts_subobjects_false");
     static final NodeFeature COLUMNAR_MAINTAIN_ARRAY_ORDER = new NodeFeature("mapper.columnar.maintain_array_order");
     static final NodeFeature KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY = new NodeFeature(
         "mapper.keyword.columnar_default_high_cardinality"
@@ -212,6 +213,7 @@ public class MapperFeatures implements FeatureSpecification {
             KEYWORD_DV_CASE_INSENSITIVE_REGEXP,
             COLUMNAR_MAINTAIN_ARRAY_ORDER,
             COLUMNAR_REJECTS_RUNTIME_DYNAMIC,
+            COLUMNAR_ACCEPTS_SUBOBJECTS_FALSE,
             KEYWORD_COLUMNAR_DEFAULT_HIGH_CARDINALITY,
             TEXT_FIELDS_ENABLE_DOC_VALUES_BY_DEFAULT_IN_COLUMNAR_MODE,
             COLUMNAR_MAINTAIN_ARRAY_ORDER_IP_TEXT,

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -675,13 +675,17 @@ public class ObjectMapper extends Mapper {
         }
 
         protected static Explicit<Subobjects> parseSubobjects(Map<String, Object> node, MappingParserContext parserContext) {
-            boolean strictColumnar = IndexSettings.MODE.get(parserContext.getSettings()).isStrictColumnar();
-            Object subobjectsNode = node.remove("subobjects");
+            final boolean strictColumnar = IndexSettings.MODE.get(parserContext.getSettings()).isStrictColumnar();
+            final Object subobjectsNode = node.remove("subobjects");
             if (subobjectsNode != null) {
+                final Subobjects requested = Subobjects.from(subobjectsNode);
                 if (strictColumnar) {
-                    throw new MapperParsingException("subobjects params are not supported in columnar mode");
+                    if (requested != Subobjects.DISABLED) {
+                        throw new MapperParsingException("subobjects [true] is not supported in columnar mode");
+                    }
+                    return Defaults.SUBOBJECTS_COLUMNAR;
                 }
-                return Explicit.of(Subobjects.from(subobjectsNode));
+                return Explicit.of(requested);
             }
             if (strictColumnar) {
                 return Defaults.SUBOBJECTS_COLUMNAR;

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -837,13 +837,14 @@ public class ObjectMapperTests extends MapperServiceTestCase {
                 }
                 b.endObject();
             }));
+            assertEquals(ObjectMapper.Subobjects.DISABLED, mapperService.documentMapper().mapping().getRoot().subobjects());
             assertNotNull(mapperService.fieldType("metrics.time"));
             assertNotNull(mapperService.fieldType("metrics.count"));
             assertNull(mapperService.mappingLookup().objectMappers().get("metrics"));
         }
     }
 
-    public void testStrictColumnarModesRejectSubobjectsParam() {
+    public void testStrictColumnarModesRejectSubobjectsTrueOnObjectField() {
         for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
             Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
             MapperParsingException e = expectThrows(MapperParsingException.class, () -> createMapperService(settings, mapping(b -> {
@@ -856,7 +857,26 @@ public class ObjectMapperTests extends MapperServiceTestCase {
                 }
                 b.endObject();
             })));
-            assertThat(e.getMessage(), containsString("subobjects params are not supported in columnar mode"));
+            assertThat(e.getMessage(), containsString("subobjects [true] is not supported in columnar mode"));
+        }
+    }
+
+    public void testStrictColumnarModesAcceptSubobjectsFalseOnObjectFieldAsNoOp() throws Exception {
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            final Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            final MapperService mapperService = createMapperService(settings, mapping(b -> {
+                b.startObject("metrics");
+                {
+                    b.field("subobjects", false);
+                    b.startObject("properties");
+                    b.startObject("time").field("type", "long").endObject();
+                    b.endObject();
+                }
+                b.endObject();
+            }));
+            assertEquals(ObjectMapper.Subobjects.DISABLED, mapperService.documentMapper().mapping().getRoot().subobjects());
+            assertNotNull(mapperService.fieldType("metrics.time"));
+            assertNull(mapperService.mappingLookup().objectMappers().get("metrics"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -681,14 +681,22 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
         }
     }
 
-    public void testStrictColumnarModesRejectSubobjectsParam() {
+    public void testStrictColumnarModesRejectSubobjectsTrueAtRoot() {
         for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
             Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
             MapperParsingException e = expectThrows(
                 MapperParsingException.class,
                 () -> createMapperService(settings, topMapping(b -> b.field("subobjects", true)))
             );
-            assertThat(e.getMessage(), containsString("subobjects params are not supported in columnar mode"));
+            assertThat(e.getMessage(), containsString("subobjects [true] is not supported in columnar mode"));
+        }
+    }
+
+    public void testStrictColumnarModesAcceptSubobjectsFalseAtRootAsNoOp() throws Exception {
+        for (IndexMode indexMode : List.of(IndexMode.COLUMNAR, IndexMode.LOGSDB_COLUMNAR)) {
+            final Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), indexMode.getName()).build();
+            final MapperService mapperService = createMapperService(settings, topMapping(b -> b.field("subobjects", false)));
+            assertEquals(ObjectMapper.Subobjects.DISABLED, mapperService.documentMapper().mapping().getRoot().subobjects());
         }
     }
 

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
@@ -664,4 +664,5 @@ public class LogsdbRestIT extends ESRestTestCase {
             containsString("mapping-level runtime fields are not allowed in index using [logsdb_columnar] index mode")
         );
     }
+
 }

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/35_columnar_subobjects_false.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/35_columnar_subobjects_false.yml
@@ -1,0 +1,188 @@
+---
+setup:
+  - requires:
+      test_runner_features: [ capabilities, allowed_warnings ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ columnar_index_modes ]
+      cluster_features: [ "mapper.columnar.accepts_subobjects_false" ]
+      reason: "columnar index modes must accept subobjects: false as a no-op"
+
+---
+"logsdb_columnar standalone index accepts subobjects: false at root":
+  - do:
+      indices.create:
+        index: test_logsdb_columnar_subobjects_false_root
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            subobjects: false
+            properties:
+              "@timestamp":
+                type: date
+              log.level:
+                type: keyword
+
+  - do:
+      indices.get_mapping:
+        index: test_logsdb_columnar_subobjects_false_root
+  - match: { test_logsdb_columnar_subobjects_false_root.mappings.properties.log\.level.type: keyword }
+
+---
+"logsdb_columnar standalone index accepts subobjects: false on object field":
+  - do:
+      indices.create:
+        index: test_logsdb_columnar_subobjects_false_object
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              host:
+                type: object
+                subobjects: false
+                properties:
+                  name:
+                    type: keyword
+
+  - do:
+      indices.get_mapping:
+        index: test_logsdb_columnar_subobjects_false_object
+  - match: { test_logsdb_columnar_subobjects_false_object.mappings.properties.host\.name.type: keyword }
+  - is_false: test_logsdb_columnar_subobjects_false_object.mappings.properties.host.properties
+
+---
+"logsdb_columnar data stream accepts subobjects: false at root via index template":
+  - do:
+      indices.put_index_template:
+        name: cl-subobjects-root-template
+        body:
+          index_patterns: [ logs-cl-subobjects-root-* ]
+          data_stream: {}
+          priority: 1000
+          template:
+            settings:
+              index.mode: logsdb_columnar
+            mappings:
+              subobjects: false
+              properties:
+                "@timestamp":
+                  type: date
+                log.level:
+                  type: keyword
+      allowed_warnings:
+        - "index template [cl-subobjects-root-template] has index patterns [logs-cl-subobjects-root-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-subobjects-root-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: logs-cl-subobjects-root-dev
+  - is_true: acknowledged
+
+---
+"logsdb_columnar data stream accepts subobjects: false on object field via component template":
+  - do:
+      cluster.put_component_template:
+        name: cl-subobjects-object-component
+        body:
+          template:
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                host:
+                  type: object
+                  subobjects: false
+                  properties:
+                    name:
+                      type: keyword
+
+  - do:
+      indices.put_index_template:
+        name: cl-subobjects-object-template
+        body:
+          index_patterns: [ logs-cl-subobjects-object-* ]
+          data_stream: {}
+          priority: 1000
+          composed_of: [ cl-subobjects-object-component ]
+          template:
+            settings:
+              index.mode: logsdb_columnar
+      allowed_warnings:
+        - "index template [cl-subobjects-object-template] has index patterns [logs-cl-subobjects-object-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [cl-subobjects-object-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: logs-cl-subobjects-object-dev
+  - is_true: acknowledged
+
+  - do:
+      indices.get_data_stream:
+        name: logs-cl-subobjects-object-dev
+  - set: { data_streams.0.indices.0.index_name: backing_index }
+
+  - do:
+      indices.get_mapping:
+        index: $backing_index
+  - match: { .$backing_index.mappings.properties.host\.name.type: keyword }
+  - is_false: .$backing_index.mappings.properties.host.properties
+
+---
+"logsdb_columnar index still rejects subobjects: true":
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_logsdb_columnar_subobjects_true
+        body:
+          settings:
+            index.mode: logsdb_columnar
+          mappings:
+            subobjects: true
+
+  - match: { error.type: "mapper_parsing_exception" }
+  - match: { error.reason: "Failed to parse mapping: subobjects [true] is not supported in columnar mode" }
+
+---
+"logsdb_columnar index accepts PUT mapping with subobjects: false":
+  - do:
+      indices.create:
+        index: test_logsdb_columnar_put_mapping
+        body:
+          settings:
+            index.mode: logsdb_columnar
+
+  - do:
+      indices.put_mapping:
+        index: test_logsdb_columnar_put_mapping
+        body:
+          subobjects: false
+          properties:
+            log.level:
+              type: keyword
+
+  - do:
+      indices.get_mapping:
+        index: test_logsdb_columnar_put_mapping
+  - match: { test_logsdb_columnar_put_mapping.mappings.properties.log\.level.type: keyword }
+
+---
+"logsdb_columnar index still rejects PUT mapping with subobjects: true":
+  - do:
+      indices.create:
+        index: test_logsdb_columnar_put_mapping_true
+        body:
+          settings:
+            index.mode: logsdb_columnar
+
+  - do:
+      catch: bad_request
+      indices.put_mapping:
+        index: test_logsdb_columnar_put_mapping_true
+        body:
+          subobjects: true
+
+  - match: { error.type: "mapper_parsing_exception" }
+  - match: { error.reason: "Failed to parse mapping: subobjects [true] is not supported in columnar mode" }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - fix(mapper): accept subobjects: false as no-op in columnar mode (#154675)