### PR TITLE
[9.5] [Test] More robust future completion check for SparseFileTrackerTests (#154676)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -716,26 +716,6 @@ tests:
   method: testSnapshotRetentionWithMissingRepo
   issue: https://github.com/elastic/elasticsearch/issues/154353
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_half_byte_quantized_bfloat16/Knn search with mip}
-  issue: https://github.com/elastic/elasticsearch/issues/154355
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
-  issue: https://github.com/elastic/elasticsearch/issues/154377
-- class: org.elasticsearch.blobcache.common.SparseFileTrackerTests
-  method: testClaimedGapsDoNotExtendBeyondRequestedRangeWhenCaller2FillsFirst
-  issue: https://github.com/elastic/elasticsearch/issues/154462
-- class: org.elasticsearch.xpack.esql.action.ExternalParquetCoercionWarningFloodIT
-  method: testDeclaredCoercionWarningsStayBoundedAcrossFanOut
-  issue: https://github.com/elastic/elasticsearch/issues/154023
-- class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
-  method: testVirtualBatchedCompoundCommitChunksPressure
-  issue: https://github.com/elastic/elasticsearch/issues/154631
-- class: org.elasticsearch.xpack.esql.action.ExternalCsvHivePartitionedIT
-  method: testCommaSeparatedResourceFirstFileWinsRoundTrips
-  issue: https://github.com/elastic/elasticsearch/issues/154662
-- class: org.elasticsearch.blobcache.common.SparseFileTrackerTests
-  method: testClaimedGapsDoNotExtendBeyondRequestedRangeWhenCaller1FillsFirst
-  issue: https://github.com/elastic/elasticsearch/issues/154666
 - class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
   method: testLargeRequestIsNeverDispatched
   issue: https://github.com/elastic/elasticsearch/issues/154657

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -716,6 +716,20 @@ tests:
   method: testSnapshotRetentionWithMissingRepo
   issue: https://github.com/elastic/elasticsearch/issues/154353
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=search.vectors/41_knn_search_half_byte_quantized_bfloat16/Knn search with mip}
+  issue: https://github.com/elastic/elasticsearch/issues/154355
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeywordKeepTriggersLoadInlineStats}
+  issue: https://github.com/elastic/elasticsearch/issues/154377
+- class: org.elasticsearch.xpack.esql.action.ExternalParquetCoercionWarningFloodIT
+  method: testDeclaredCoercionWarningsStayBoundedAcrossFanOut
+  issue: https://github.com/elastic/elasticsearch/issues/154023
+- class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitsIT
+  method: testVirtualBatchedCompoundCommitChunksPressure
+  issue: https://github.com/elastic/elasticsearch/issues/154631
+- class: org.elasticsearch.xpack.esql.action.ExternalCsvHivePartitionedIT
+  method: testCommaSeparatedResourceFirstFileWinsRoundTrips
+  issue: https://github.com/elastic/elasticsearch/issues/154662
 - class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
   method: testLargeRequestIsNeverDispatched
   issue: https://github.com/elastic/elasticsearch/issues/154657

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/common/SparseFileTrackerTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/common/SparseFileTrackerTests.java
@@ -511,13 +511,18 @@ public class SparseFileTrackerTests extends ESTestCase {
 
         // Fill caller 2's gaps [30, 50) and [50, 80): future1 fires when B reaches 40;
         // future2 fires when the gap [50,80) reaches 70 (end of its subRange).
+        boolean future1ShouldBeDone = false;
         for (SparseFileTracker.Gap gap : gaps2List) {
             for (long i = gap.start(); i < gap.end(); i++) {
                 if (randomBoolean()) {
                     gap.onProgress(i + 1);
-                    if (i >= 40) {
-                        assertTrue(future1.isDone());
+                    // future1 is completed when gaps are filled to its upper boundary of 40. However, if the gap.onProgress is called
+                    // with the gap's end, i.e. 50, the gap's listeners are not invoked until gap.onCompletion is called. So we include
+                    // that in the condition check.
+                    if (i + 1 >= 40 && i + 1 != 50L) {
+                        future1ShouldBeDone = true;
                     }
+                    assertThat(future1.isDone(), equalTo(future1ShouldBeDone));
                 }
             }
             gap.onCompletion();
@@ -562,13 +567,18 @@ public class SparseFileTrackerTests extends ESTestCase {
         assertThat(gaps1List.get(0).end(), equalTo(30L));
 
         // Fill caller 2's gaps first: when B=[30,50) passes 40 the listener is not yet invoked
+        boolean future2ShouldBeDone = false;
         for (SparseFileTracker.Gap gap : gaps2List) {
             for (long i = gap.start(); i < gap.end(); i++) {
                 if (randomBoolean()) {
                     gap.onProgress(i + 1);
-                    if (i >= 70) {
-                        assertTrue(future2.isDone());
+                    // future2 is completed when gaps are filled to its upper boundary of 70. However, if the gap.onProgress is called
+                    // with the gap's end, i.e. 80, the gap's listeners are not invoked until gap.onCompletion is called. So we include
+                    // that in the condition check.
+                    if (i + 1 >= 70 && i + 1 != 80L) {
+                        future2ShouldBeDone = true;
                     }
+                    assertThat(future2.isDone(), equalTo(future2ShouldBeDone));
                 }
             }
             gap.onCompletion();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Test] More robust future completion check for SparseFileTrackerTests (#154676)](https://github.com/elastic/elasticsearch/pull/154676)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)