### PR TITLE
ES|QL: Handle GROK timeout more gracefully

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -50,6 +51,7 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -60,6 +62,7 @@ import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.unsignedlong.UnsignedLongMapperPlugin;
 import org.elasticsearch.xpack.versionfield.VersionFieldPlugin;
@@ -2167,6 +2170,49 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
             assertEquals(10, getValuesList(results).size());
         } finally {
             clearPersistentSettings(AnalyzerSettings.QUERY_RESULT_TRUNCATION_MAX_SIZE);
+        }
+    }
+
+    public void testGrokTimeoutIsUserError() {
+        String indexName = "test_grok_timeout";
+        assertAcked(client().admin().indices().prepareCreate(indexName).setMapping("message", "type=keyword"));
+        client().prepareIndex(indexName)
+            .setSource(
+                "message",
+                "Bonsuche mit folgender Anfrage: Belegart->[EINGESCHRAENKTER_VERKAUF, VERKAUF, NACHERFASSUNG] "
+                    + "Zustand->ABGESCHLOSSEN Kassennummer->2 Bonnummer->6362 Datum->Mon Jan 08 00:00:00 UTC 2018"
+            )
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+        ensureYellow(indexName);
+
+        admin().cluster()
+            .updateSettings(
+                new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(
+                    Settings.builder().put(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME.getKey(), "200ms").build()
+                )
+            )
+            .actionGet();
+
+        try {
+            // This pattern causes catastrophic backtracking and reliably exceeds the 200 ms watchdog timeout.
+            // The same pattern is used in GrokTests.testExponentialExpressions.
+            var ex = expectThrows(
+                ElasticsearchException.class,
+                () -> run(
+                    "FROM "
+                        + indexName
+                        + " | GROK message \"\"\""
+                        + "Bonsuche mit folgender Anfrage: Belegart->\\[%{WORD:param2},(?<param5>(\\s*%{NOTSPACE})*)\\] "
+                        + "Zustand->ABGESCHLOSSEN Kassennummer->%{WORD:param9} Bonnummer->%{WORD:param10}"
+                        + " Datum->%{DATESTAMP_OTHER:param11}"
+                        + "\"\"\""
+                ).close()
+            );
+            assertThat(ex.status(), equalTo(RestStatus.BAD_REQUEST));
+            assertThat(ex.getMessage(), containsString("grok pattern matching was interrupted after"));
+        } finally {
+            clearPersistentSettings(EsqlPlugin.GROK_WATCHDOG_MAX_EXECUTION_TIME);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/command/GrokEvaluatorExtracter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/command/GrokEvaluatorExtracter.java
@@ -22,6 +22,7 @@ import org.elasticsearch.grok.FloatConsumer;
 import org.elasticsearch.grok.Grok;
 import org.elasticsearch.grok.GrokCaptureConfig;
 import org.elasticsearch.grok.GrokCaptureExtracter;
+import org.elasticsearch.xpack.esql.EsqlClientException;
 import org.joni.Region;
 
 import java.util.ArrayList;
@@ -211,7 +212,11 @@ public class GrokEvaluatorExtracter implements ColumnExtractOperator.Evaluator, 
         Arrays.fill(firstValues, null);
         for (int c = 0; c < valueCount; c++) {
             BytesRef input = inputBlock.getBytesRef(position + c, spare);
-            parser.match(input.bytes, input.offset, input.length, this);
+            try {
+                parser.match(input.bytes, input.offset, input.length, this);
+            } catch (RuntimeException e) {
+                throw new EsqlClientException(e.getMessage(), e);
+            }
         }
         for (int i = 0; i < firstValues.length; i++) {
             if (firstValues[i] == null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/GrokEvaluatorExtracterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/GrokEvaluatorExtracterTests.java
@@ -19,11 +19,14 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.grok.Grok;
 import org.elasticsearch.grok.GrokBuiltinPatterns;
+import org.elasticsearch.grok.MatcherWatchdog;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlClientException;
 import org.elasticsearch.xpack.esql.evaluator.command.GrokEvaluatorExtracter;
 
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -125,6 +128,51 @@ public class GrokEvaluatorExtracterTests extends ESTestCase {
         checkDoubleBlock(targetBlocks[3], new int[] { 4 }, 12.3F, 14.3F, 34.3F, 84.3F);
         checkDoubleBlock(targetBlocks[4], new int[] { 4 }, 15.5D, 16.5D, 36.5D, 86.5D);
         checkBooleanBlock(targetBlocks[5], new int[] { 4 }, false, true, true, false);
+    }
+
+    public void testTimeoutIsUserError() {
+        // This pattern causes catastrophic backtracking and will reliably exceed the 200 ms watchdog timeout.
+        // The same pattern is used in GrokTests.testExponentialExpressions.
+        String pattern = "Bonsuche mit folgender Anfrage: Belegart->\\[%{WORD:param2},(?<param5>(\\s*%{NOTSPACE})*)\\] "
+            + "Zustand->ABGESCHLOSSEN Kassennummer->%{WORD:param9} Bonnummer->%{WORD:param10} Datum->%{DATESTAMP_OTHER:param11}";
+        String logLine = "Bonsuche mit folgender Anfrage: Belegart->[EINGESCHRAENKTER_VERKAUF, VERKAUF, NACHERFASSUNG] "
+            + "Zustand->ABGESCHLOSSEN Kassennummer->2 Bonnummer->6362 Datum->Mon Jan 08 00:00:00 UTC 2018";
+
+        Map<String, Integer> keyToBlock = Map.of("param2", 0, "param5", 1, "param9", 2, "param10", 3, "param11", 4);
+        Map<String, ElementType> types = Map.of(
+            "param2",
+            ElementType.BYTES_REF,
+            "param5",
+            ElementType.BYTES_REF,
+            "param9",
+            ElementType.BYTES_REF,
+            "param10",
+            ElementType.BYTES_REF,
+            "param11",
+            ElementType.BYTES_REF
+        );
+
+        var builtinPatterns = GrokBuiltinPatterns.get(true);
+        Grok grok = new Grok(builtinPatterns, pattern, MatcherWatchdog.newInstance(200), logger::warn);
+        GrokEvaluatorExtracter extracter = new GrokEvaluatorExtracter.Factory(grok, pattern, keyToBlock, types).create(null);
+
+        BytesRefBlock inputBlock;
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(1)) {
+            builder.appendBytesRef(new BytesRef(logLine));
+            inputBlock = builder.build();
+        }
+        Block.Builder[] targetBlocks = {
+            blockFactory.newBytesRefBlockBuilder(1),
+            blockFactory.newBytesRefBlockBuilder(1),
+            blockFactory.newBytesRefBlockBuilder(1),
+            blockFactory.newBytesRefBlockBuilder(1),
+            blockFactory.newBytesRefBlockBuilder(1) };
+
+        EsqlClientException ex = expectThrows(
+            EsqlClientException.class,
+            () -> extracter.computeRow(inputBlock, 0, targetBlocks, new BytesRef())
+        );
+        assertThat(ex.getMessage(), containsString("grok pattern matching was interrupted after"));
     }
 
     private void checkStringBlock(Block.Builder builder, int[] itemsPerRow, String... expectedValues) {


### PR DESCRIPTION
Grok library throws `RuntimeException` in case of watchdog timeout.
In ES|QL, we want it to become a client exception

Fixes: https://github.com/elastic/elasticsearch/issues/154789