### PR TITLE
Increase AzureStorageCleanupThirdPartyTests suite timeout to 40 min

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -19,7 +19,9 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.AccessTier;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobStorageException;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -76,6 +78,7 @@ import static org.hamcrest.Matchers.not;
  * These tests sometimes run against a genuine Azure endpoint with credentials obtained from Vault. These credentials expire periodically
  * and must be manually renewed; the process is in the onboarding/process docs.
  */
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyRepositoryTestCase {
     private static final Logger logger = LogManager.getLogger(AzureStorageCleanupThirdPartyTests.class);
     private static final boolean USE_FIXTURE = Booleans.parseBoolean(System.getProperty("test.azure.fixture", "true"));

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -77,6 +77,7 @@ import static org.hamcrest.Matchers.not;
 /**
  * These tests sometimes run against a genuine Azure endpoint with credentials obtained from Vault. These credentials expire periodically
  * and must be manually renewed; the process is in the onboarding/process docs.
+ * Most tests that run against a genuine Azure endpoint can take between 1 and 3 minutes, hence the large suite timeout.
  */
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyRepositoryTestCase {


### PR DESCRIPTION
Here are the tests duration in the 2 build failures:
* https://gradle-enterprise.elastic.co/s/mnon3io5tnr36 and
* https://gradle-enterprise.elastic.co/s/yvosmmest44bc

```
  ┌─────────────────────────────────────────────────┬──────────────────┬──────────────────┐
  │                      Test                       │  Log 1 duration  │  Log 2 duration  │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testAccessTierPerOperationPurpose               │ 3m 22s (9th)     │ 1m 27s (2nd)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testCleanup                                     │ 2m 44s (4th)     │ 3m 03s (4th)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testCopy                                        │ 2m 24s (1st)     │ 1m 21s (8th)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testCreateSnapshot                              │ not run (11th)   │ 1m 50s (5th)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testFailIfAlreadyExists                         │ 1m 30s (6th)     │ 1m 19s (6th)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testIndexLatest                                 │ abandoned (10th) │ abandoned (10th) │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testListChildren                                │ 1m 31s (8th)     │ 3m 04s (1st)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testMultiBlockUpload                            │ 2m 14s (5th)     │ 1m 41s (7th)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testReadFromPositionLargerThanBlobLength        │ 1m 47s (2nd)     │ not run (11th)   │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testReadFromPositionWithLength                  │ 1m 37s (7th)     │ 1m 11s (3rd)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ testSkipBeyondBlobLengthShouldThrowEOFException │ 0m 44s (3rd)     │ 3m 02s (9th)     │
  ├─────────────────────────────────────────────────┼──────────────────┼──────────────────┤
  │ Total before testIndexLatest                    │ 17m 53s          │ 17m 58s          │
  └─────────────────────────────────────────────────┴──────────────────┴──────────────────┘
```

It seems most tests typically take around 2 minutes (with high variability) using real Azure service credentials,
including the `testIndexLatest`, see the time span between the first and last log entry:
```
  1> [2026-07-12T01:04:24,452][INFO ][o.e.r.a.AzureStorageCleanupThirdPartyTests][testIndexLatest] before test
  1> [2026-07-12T01:05:52,253][INFO ][o.e.s.SnapshotsService   ][node_s_0][snapshot][T#1] snapshots [myjpvrplwily/KQY6l1PvTZ2u94RRayKfbA] deleted in repository [default/test-repo]
```
```
  1> [2026-07-12T01:04:24,105][INFO ][o.e.r.a.AzureStorageCleanupThirdPartyTests][testIndexLatest] before test
  1> [2026-07-12T01:05:51,826][INFO ][o.e.s.SnapshotsService   ][node_s_0][snapshot][T#1] snapshots [ikvxzatxkdmz/OiIe9cnNS6iw9FAg7GBaqQ] deleted in repository [default/test-repo]
```
Commit d13fb1c98cf8 ("Add azure third-party tests for access tier verification", June 22, 2026) added testAccessTierPerOperationPurpose to AzureStorageCleanupThirdPartyTests. That test  takes 1.5–3.5 minutes against real Azure. Combined with the other 9 tests, the suite now routinely approaches or exceeds the 20-minute limit — whichever test is last by random ordering gets abandoned.

The "fix" here increases the suite timeout.

Fixes https://github.com/elastic/elasticsearch/issues/153588
