### PR TITLE
Improve ML Sandbox2 failure observability in Java layer

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1183,10 +1183,7 @@ public class MachineLearning extends Plugin
                 pyTorchProcessFactory = new NativePyTorchProcessFactory(environment, nativeController, clusterService);
                 mlController = nativeController;
             } catch (IOException e) {
-                // The low level cause of failure from the named pipe helper's perspective is almost never the real root cause, so
-                // only log this at the lowest level of detail. It's almost always "file not found" on a named pipe we expect to be
-                // able to connect to, but the thing we really need to know is what stopped the native process creating the named pipe.
-                logger.trace("Failed to connect to ML native controller", e);
+                logger.warn("Failed to connect to ML native controller", e);
                 throw new ElasticsearchException(
                     "Failure running machine learning native code. This could be due to running "
                         + "on an unsupported OS or distribution, missing OS libraries, or a problem with the temp directory. To "

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
@@ -97,7 +97,11 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
         try {
             process.start(executorService);
         } catch (IOException | EsRejectedExecutionException e) {
-            String msg = "Failed to connect to pytorch process for job " + task.getDeploymentId();
+            String msg = "Failed to connect to pytorch process for job "
+                + task.getDeploymentId()
+                + " ["
+                + processPipes.describeNamedPipes()
+                + "]";
             logger.error(msg, e);
             try {
                 IOUtils.close(process);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessPipes.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessPipes.java
@@ -282,4 +282,16 @@ public class ProcessPipes {
     public Duration getTimeout() {
         return timeout;
     }
+
+    public String describeNamedPipes() {
+        return String.format(
+            Locale.ROOT,
+            "logPipe=%s inputPipe=%s outputPipe=%s restorePipe=%s namedPipeConnectTimeout=%ss",
+            logPipeName,
+            processInPipeName,
+            processOutPipeName,
+            restorePipeName,
+            timeout.getSeconds()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Raise ML native controller connect failures from `trace` to `warn` so startup issues are visible in production logs.
- Include named-pipe paths and `namedPipeConnectTimeout` in pytorch process connect failure messages.
- Add `ProcessPipes.describeNamedPipes()` for structured pipe diagnostics.

[Companion to ml-cpp Sandbox2](https://github.com/elastic/ml-cpp/pull/2873) observability work: these Java-side signals correlate ES deployment symptoms (pipe timeouts, connect failures) with C++ controller spawn-context logs.