### PR TITLE
[9.3] Re-escape wildcard operators produced by the normalizer in wildcard queries (#153582)

### DIFF
--- a/docs/changelog/153582.yaml
+++ b/docs/changelog/153582.yaml
@@ -1,0 +1,6 @@
+pr: 153582
+summary: Fix wildcard queries on keyword fields whose normalizer rewrites wildcard characters
+area: Mapping
+type: bug
+issues:
+ - 150699

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.search.query;
 
+import org.apache.lucene.analysis.charfilter.MappingCharFilter;
+import org.apache.lucene.analysis.charfilter.NormalizeCharMap;
 import org.apache.lucene.analysis.pattern.PatternReplaceCharFilter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiTermQuery;
@@ -1754,11 +1756,44 @@ public class SearchQueryIT extends ESIntegTestCase {
         );
     }
 
+    public void testWildcardQueryNormalizationFullwidthOperators() {
+        // A normalizer that folds fullwidth forms emits ASCII wildcard operators for literal input (#150699): the
+        // fullwidth characters are data, so the emitted operators are re-escaped instead of changing the query.
+        assertAcked(
+            prepareCreate("test").setSettings(
+                Settings.builder()
+                    .put("index.analysis.char_filter.fullwidth_to_ascii.type", "mock_fullwidth_to_ascii")
+                    .put("index.analysis.normalizer.fullwidth_to_ascii.type", "custom")
+                    .put("index.analysis.normalizer.fullwidth_to_ascii.char_filter", "fullwidth_to_ascii")
+                    .build()
+            ).setMapping("field", "type=keyword,normalizer=fullwidth_to_ascii")
+        );
+        // the normalizer folds each fullwidth form, so the documents are indexed as foo*bar, foo?bar and foo\bar
+        prepareIndex("test").setId("1").setSource("field", "foo\uFF0Abar").get();
+        prepareIndex("test").setId("2").setSource("field", "foo\uFF1Fbar").get();
+        prepareIndex("test").setId("3").setSource("field", "foo\uFF3Cbar").get();
+        prepareIndex("test").setId("4").setSource("field", "foobar").get();
+        refresh();
+
+        // bare fullwidth characters are literal data and only match their own document
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\uFF0Abar")));
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\uFF1Fbar")));
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\uFF3Cbar")));
+        // escaped fullwidth characters are the same literals
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\\\uFF0Abar")));
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\\\uFF1Fbar")));
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\\\uFF3Cbar")));
+        // real ASCII operators keep their meaning: * spans all documents, ? exactly one character, \\ the backslash
+        assertHitCount(4L, prepareSearch().setQuery(wildcardQuery("field", "foo*bar")));
+        assertHitCount(3L, prepareSearch().setQuery(wildcardQuery("field", "foo?bar")));
+        assertHitCount(1L, prepareSearch().setQuery(wildcardQuery("field", "foo\\\\bar")));
+    }
+
     public static class MockAnalysisPlugin extends Plugin implements AnalysisPlugin {
 
         @Override
         public Map<String, AnalysisProvider<CharFilterFactory>> getCharFilters() {
-            return singletonMap("mock_pattern_replace", (indexSettings, env, name, settings) -> {
+            return Map.of("mock_pattern_replace", (indexSettings, env, name, settings) -> {
                 class Factory implements NormalizingCharFilterFactory {
 
                     private final Pattern pattern = Regex.compile("[\\*\\?]", null);
@@ -1771,6 +1806,25 @@ public class SearchQueryIT extends ESIntegTestCase {
                     @Override
                     public Reader create(Reader reader) {
                         return new PatternReplaceCharFilter(pattern, "", reader);
+                    }
+                }
+                return new Factory();
+            }, "mock_fullwidth_to_ascii", (indexSettings, env, name, settings) -> {
+                NormalizeCharMap.Builder mappings = new NormalizeCharMap.Builder();
+                mappings.add("\uFF0A", "*");
+                mappings.add("\uFF1F", "?");
+                mappings.add("\uFF3C", "\\");
+                NormalizeCharMap map = mappings.build();
+                class Factory implements NormalizingCharFilterFactory {
+
+                    @Override
+                    public String name() {
+                        return name;
+                    }
+
+                    @Override
+                    public Reader create(Reader reader) {
+                        return new MappingCharFilter(map, reader);
                     }
                 }
                 return new Factory();

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -57,7 +57,8 @@ import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
  */
 public abstract class StringFieldType extends TermBasedFieldType {
 
-    private static final Pattern WILDCARD_PATTERN = Pattern.compile("(\\\\.)|([?*]+)");
+    // DOTALL so an escape (\X) is recognised even when X is a line terminator, matching Lucene which escapes any code point.
+    private static final Pattern WILDCARD_PATTERN = Pattern.compile("(\\\\.)|([?*]+)", Pattern.DOTALL);
 
     public StringFieldType(String name, IndexType indexType, boolean isStored, TextSearchInfo textSearchInfo, Map<String, String> meta) {
         super(name, indexType, isStored, textSearchInfo, meta);
@@ -123,30 +124,64 @@ public abstract class StringFieldType extends TermBasedFieldType {
         if (normalizer == null) {
             return value;
         }
-        // we want to normalize everything except wildcard characters, e.g. F?o Ba* to f?o ba*, even if e.g there
-        // is a char_filter that would otherwise remove them
+        // Normalize the literal parts of the pattern but keep the ? and * operators, e.g. F?o Ba* to f?o ba*. Escapes
+        // (\X) are literal data, so we gather each contiguous literal run (across plain text and escapes) and normalize
+        // it as a whole; context-sensitive normalizers need the full run. Operators the normalizer emits are re-escaped.
         Matcher wildcardMatcher = WILDCARD_PATTERN.matcher(value);
         BytesRefBuilder sb = new BytesRefBuilder();
+        StringBuilder literal = new StringBuilder();
         int last = 0;
 
         while (wildcardMatcher.find()) {
-            if (wildcardMatcher.start() > 0) {
-                String chunk = value.substring(last, wildcardMatcher.start());
-
-                BytesRef normalized = normalizer.normalize(fieldname, chunk);
-                sb.append(normalized);
+            if (wildcardMatcher.start() > last) {
+                literal.append(value, last, wildcardMatcher.start());
             }
-            // append the matched group - without normalizing
-            sb.append(new BytesRef(wildcardMatcher.group()));
-
+            String escape = wildcardMatcher.group(1);
+            if (escape != null) {
+                // \X is an escape: the escaped character is literal data, so drop the backslash and keep X
+                literal.append(escape, 1, escape.length());
+            } else {
+                // operators: flush the accumulated literal run, then keep them verbatim
+                appendNormalizedLiteral(sb, normalizer, fieldname, literal.toString());
+                literal.setLength(0);
+                sb.append(new BytesRef(wildcardMatcher.group()));
+            }
             last = wildcardMatcher.end();
         }
         if (last < value.length()) {
-            String chunk = value.substring(last);
-            BytesRef normalized = normalizer.normalize(fieldname, chunk);
-            sb.append(normalized);
+            literal.append(value, last, value.length());
         }
+        appendNormalizedLiteral(sb, normalizer, fieldname, literal.toString());
         return sb.toBytesRef().utf8ToString();
+    }
+
+    /** Normalizes one literal run and appends it, re-escaping any {@code *}, {@code ?}, or backslash the normalizer produced. */
+    private static void appendNormalizedLiteral(BytesRefBuilder sb, Analyzer normalizer, String fieldname, String chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+        BytesRef normalized = normalizer.normalize(fieldname, chunk);
+        // The operators are ASCII and UTF-8 never uses bytes below 0x80 inside a multi-byte sequence, so scanning the
+        // raw bytes is safe. In the common case the normalizer emits no operator and the bytes are appended as-is.
+        int operators = 0;
+        for (int i = 0; i < normalized.length; i++) {
+            byte b = normalized.bytes[normalized.offset + i];
+            if (b == '*' || b == '?' || b == '\\') {
+                operators++;
+            }
+        }
+        if (operators == 0) {
+            sb.append(normalized);
+            return;
+        }
+        sb.grow(sb.length() + normalized.length + operators);
+        for (int i = 0; i < normalized.length; i++) {
+            byte b = normalized.bytes[normalized.offset + i];
+            if (b == '*' || b == '?' || b == '\\') {
+                sb.append((byte) '\\');
+            }
+            sb.append(b);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -113,6 +114,105 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         };
         MappedFieldType ft = new KeywordFieldType("field", new NamedAnalyzer("my_normalizer", AnalyzerScope.INDEX, normalizer));
         assertEquals(new TermQuery(new Term("field", "foo bar")), ft.termQuery("fOo BaR", MOCK_CONTEXT));
+    }
+
+    public void testNormalizeWildcardPatternReescapesOperators() {
+        // A normalizer can map fullwidth forms to the ASCII wildcard control characters (#150699). Operators the
+        // normalizer produces out of literal data are re-escaped, and escape contents are normalized like any literal.
+        Analyzer normalizer = new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                Tokenizer in = new WhitespaceTokenizer();
+                return new TokenStreamComponents(in, fullwidthToAsciiFilter(in));
+            }
+
+            @Override
+            protected TokenStream normalize(String fieldName, TokenStream in) {
+                return fullwidthToAsciiFilter(in);
+            }
+        };
+        NamedAnalyzer named = new NamedAnalyzer("fullwidth_nfkc", AnalyzerScope.INDEX, normalizer);
+
+        // An escaped fullwidth '＊' is normalized to an escaped ASCII '*': still the literal star.
+        assertEquals("foo\\*bar", StringFieldType.normalizeWildcardPattern("f", "foo\\＊bar", named));
+        // A bare fullwidth '＊' also normalizes to the literal star, not a wildcard operator.
+        assertEquals("foo\\*bar", StringFieldType.normalizeWildcardPattern("f", "foo＊bar", named));
+        // Same for the fullwidth '？'.
+        assertEquals("foo\\?bar", StringFieldType.normalizeWildcardPattern("f", "foo？bar", named));
+        // Real ASCII wildcard operators are preserved verbatim, including at the start and end of the pattern.
+        assertEquals("foo*bar", StringFieldType.normalizeWildcardPattern("f", "foo*bar", named));
+        assertEquals("foo?bar*", StringFieldType.normalizeWildcardPattern("f", "foo?bar*", named));
+        assertEquals("*bar", StringFieldType.normalizeWildcardPattern("f", "*bar", named));
+        assertEquals("foo*", StringFieldType.normalizeWildcardPattern("f", "foo*", named));
+        // A fullwidth backslash '＼' that normalizes to '\' is re-escaped to a literal backslash, whether the user
+        // wrote it bare or escaped.
+        assertEquals("foo\\\\bar", StringFieldType.normalizeWildcardPattern("f", "foo＼bar", named));
+        assertEquals("foo\\\\bar", StringFieldType.normalizeWildcardPattern("f", "foo\\＼bar", named));
+        // A trailing lone backslash is literal data and is re-escaped.
+        assertEquals("abc\\\\", StringFieldType.normalizeWildcardPattern("f", "abc\\", named));
+        // An escape before a line terminator is still an escape (WILDCARD_PATTERN is DOTALL): "a\<LF>b" is the literal
+        // "a<LF>b", and the backslash must not be re-introduced as a literal backslash.
+        assertEquals("a\nb", StringFieldType.normalizeWildcardPattern("f", "a\\\nb", named));
+    }
+
+    private static TokenFilter fullwidthToAsciiFilter(TokenStream in) {
+        // Mimics the ICU NFKC mapping of the wildcard control characters: ＊ -> *, ？ -> ?, ＼ -> \
+        return new TokenFilter(in) {
+            private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+
+            @Override
+            public boolean incrementToken() throws IOException {
+                if (input.incrementToken() == false) {
+                    return false;
+                }
+                String normalized = termAtt.toString().replace('＊', '*').replace('？', '?').replace('＼', '\\');
+                termAtt.setEmpty().append(normalized);
+                return true;
+            }
+        };
+    }
+
+    public void testNormalizeWildcardPatternNormalizesContiguousLiteralRunAcrossEscape() {
+        // Regression test for #150699: an escape sequence in the middle of a literal run must not split normalization.
+        // A context-sensitive normalizer (here a multi-character mapping "ab" -> "x") must see the whole run "ab",
+        // even when it is written as "a\b".
+        Analyzer normalizer = new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                Tokenizer in = new WhitespaceTokenizer();
+                return new TokenStreamComponents(in, mappingFilter(in));
+            }
+
+            @Override
+            protected TokenStream normalize(String fieldName, TokenStream in) {
+                return mappingFilter(in);
+            }
+        };
+        NamedAnalyzer named = new NamedAnalyzer("ab_to_x", AnalyzerScope.INDEX, normalizer);
+
+        // "a\b" is the literal "ab" in Lucene; normalizing the whole contiguous run yields "x".
+        assertEquals("x", StringFieldType.normalizeWildcardPattern("f", "a\\b", named));
+        // Adjacent escapes accumulate into the same run, so "\a\b" (also literal "ab") yields "x" too.
+        assertEquals("x", StringFieldType.normalizeWildcardPattern("f", "\\a\\b", named));
+        // A wildcard operator between the two characters keeps them in separate runs, so the mapping does not apply.
+        assertEquals("a*b", StringFieldType.normalizeWildcardPattern("f", "a*b", named));
+    }
+
+    private static TokenFilter mappingFilter(TokenStream in) {
+        // A deliberately context-sensitive normalizer: it only maps the two-character sequence "ab" to "x".
+        return new TokenFilter(in) {
+            private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+
+            @Override
+            public boolean incrementToken() throws IOException {
+                if (input.incrementToken() == false) {
+                    return false;
+                }
+                String normalized = termAtt.toString().replace("ab", "x");
+                termAtt.setEmpty().append(normalized);
+                return true;
+            }
+        };
     }
 
     public void testTermsQuery() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Re-escape wildcard operators produced by the normalizer in wildcard queries (#153582)](https://github.com/elastic/elasticsearch/pull/153582)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)