### PR TITLE
[9.5] Update Slack references: #es-delivery-alerts -> #es-core-infra-alerts and user group (#154730)

### DIFF
--- a/.buildkite/pipelines/ecs-dynamic-template-tests.yml
+++ b/.buildkite/pipelines/ecs-dynamic-template-tests.yml
@@ -8,7 +8,7 @@ steps:
       diskSizeGb: 350
       machineType: custom-32-98304
 notify:
-  - slack: "#es-delivery"
+  - slack: "#es-core-infra"
     if: build.state == "failed"
   - slack: "#es-storage-engine"
     if: build.state == "failed"

--- a/.buildkite/pipelines/version-bump-pipeline.yml
+++ b/.buildkite/pipelines/version-bump-pipeline.yml
@@ -1,14 +1,14 @@
 notify:
   - slack:
       channels:
-        - "#es-delivery-alerts"
-      message: "<!subteam^S08QCN4G2N4|es-delivery-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}"
+        - "#es-core-infra-alerts"
+      message: "<!subteam^S0BHJLCCDQX|es-core-infra-team> Version bump to ${NEW_VERSION} — ${BUILDKITE_BUILD_URL}"
     if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/) && (build.state == 'passed' || build.state == 'failed')
   - slack:
       channels:
-        - "#es-delivery-alerts"
+        - "#es-core-infra-alerts"
       message: |
-        <!subteam^S08QCN4G2N4|es-delivery-team>
+        <!subteam^S0BHJLCCDQX|es-core-infra-team>
         🚦 Pipeline waiting for approval 🚦
         Repo: `${REPO}`
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Update Slack references: #es-delivery-alerts -> #es-core-infra-alerts and user group (#154730)