### PR TITLE
Remove duplicate muted test entries for GenerativeIT#SUBQUERIES

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -292,12 +292,6 @@ tests:
 - class: org.elasticsearch.upgrades.MlMappingsUpgradeIT
   method: testMappingsUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/152115
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test {feature:SUBQUERIES}
-  issue: https://github.com/elastic/elasticsearch/issues/149681
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test {feature:SUBQUERIES}
-  issue: https://github.com/elastic/elasticsearch/issues/149681
 - class: org.elasticsearch.xpack.esql.action.ExternalSourceProfileIT
   method: testCsvCountStarScansColdThenSkipsWarm
   issue: https://github.com/elastic/elasticsearch/issues/152132


### PR DESCRIPTION
Entries for `single_node.GenerativeIT` and `multi_node.GenerativeIT` with test {feature:SUBQUERIES} (issue #149681) 
were each listed twice. Remaining entries are now at line 262 and line 265 now.
