### PR TITLE
[CI] Retry preempted upgrade test jobs

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -66,6 +66,11 @@ steps:
       - label: "bc-upgrade-tests-part{{matrix.PART}}"
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=${BC_VERSION} -Dtests.bwc.refspec.main=${BC_COMMIT_HASH} bcUpgradeTestPart{{matrix.PART}}
         timeout_in_minutes: 300
+        retry:
+          automatic:
+            - exit_status: 47
+              limit: 3
+              signal_reason: none
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -32,6 +32,11 @@ steps:
         - label: "pr-upgrade-part-{{matrix.PART}}"
           command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=${VERSION}-SNAPSHOT -Dtests.bwc.refspec.main=${BASE_COMMIT} bcUpgradeTestPart{{matrix.PART}}
           timeout_in_minutes: 300
+          retry:
+            automatic:
+              - exit_status: 47
+                limit: 3
+                signal_reason: none
           agents:
             provider: gcp
             image: family/elasticsearch-ubuntu-2404


### PR DESCRIPTION
Dynamically uploaded PR and BC upgrade test steps bypass the retry configuration injected into the main PR pipeline.
This adds automatic retries for exit status 47, used when a GCP spot instance is preempted. Each step can retry up to three times, matching the existing PR pipeline policy.

Example of the pull-request pipeline where retry wasn't triggered automatically:
https://buildkite.com/elastic/elasticsearch-pull-request/builds/166072#019f8ab1-711f-493b-bac3-8db020aae4b0

There is this log, but the job was not re-tried automatically:
```
GCP terminated this instance early.
It should automatically retry and pick up where it left off in a new step.
You should be able to ignore this failed step.
user command error: exit status 47
```