### PR TITLE
[9.5] Fix TransformContinuousIT flake and unmute #153782

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -658,9 +658,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.ExternalCsvHivePartitionedIT
   method: testHivePartitionShadowWarningReachesClient
   issue: https://github.com/elastic/elasticsearch/issues/153780
-- class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
-  method: testContinuousEvents
-  issue: https://github.com/elastic/elasticsearch/issues/153782
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
   method: testParquetFile {delta_byte_array}
   issue: https://github.com/elastic/elasticsearch/issues/153841

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -120,6 +121,36 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
             logger.error("Search failed with an exception.", e);
             throw e;
         }
+    }
+
+    /**
+     * Raw histogram aggregations emit zero-doc_count buckets; composite group-by in transforms skips them.
+     */
+    protected Map<String, Object> nextNonEmptyAggregationBucket(Iterator<Map<String, Object>> bucketIterator, int iteration) {
+        assertTrue(
+            "source aggregation has fewer non-empty buckets than transform destination, iteration: " + iteration,
+            bucketIterator.hasNext()
+        );
+        Map<String, Object> bucket = bucketIterator.next();
+        while ((Integer) bucket.get("doc_count") == 0) {
+            assertTrue(
+                "source aggregation has fewer non-empty buckets than transform destination, iteration: " + iteration,
+                bucketIterator.hasNext()
+            );
+            bucket = bucketIterator.next();
+        }
+        return bucket;
+    }
+
+    protected void assertAggregationAndDestinationIteratorsExhausted(Iterator<?> sourceIterator, Iterator<?> destIterator, int iteration) {
+        assertFalse(
+            "source aggregation still has buckets not reflected in the transform destination, iteration: " + iteration,
+            sourceIterator.hasNext()
+        );
+        assertFalse(
+            "transform destination has documents not reflected in the source aggregation, iteration: " + iteration,
+            destIterator.hasNext()
+        );
     }
 
     private SyncConfig getSyncConfig() {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -134,7 +134,7 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
         Iterator<Map<String, Object>> destIterator = hits.iterator();
 
         while (sourceIterator.hasNext() && destIterator.hasNext()) {
-            var bucket = sourceIterator.next();
+            var bucket = nextNonEmptyAggregationBucket(sourceIterator, iteration);
             var searchHit = destIterator.next();
             var source = (Map<String, Object>) searchHit.get("_source");
 
@@ -148,12 +148,6 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
 
             if (transformBucketKey == null) {
                 transformBucketKey = MISSING_BUCKET_KEY;
-            }
-
-            // aggs return buckets with 0 doc_count while composite aggs skip over them
-            while ((Integer) bucket.get("doc_count") == 0) {
-                assertTrue(sourceIterator.hasNext());
-                bucket = sourceIterator.next();
             }
 
             // test correctness, the results from the aggregation and the results from the transform should be the same
@@ -188,7 +182,6 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
                 );
             }
         }
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
@@ -158,7 +158,7 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
         Iterator<Map<String, Object>> destIterator = hits.iterator();
 
         while (sourceIterator.hasNext() && destIterator.hasNext()) {
-            var bucket = sourceIterator.next();
+            var bucket = nextNonEmptyAggregationBucket(sourceIterator, iteration);
             var searchHit = destIterator.next();
             var source = (Map<String, Object>) searchHit.get("_source");
 
@@ -168,12 +168,6 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
                     .format(Instant.ofEpochMilli((Long) XContentMapValues.extractValue("second", source)));
             } else {
                 transformBucketKey = (String) XContentMapValues.extractValue("second", source);
-            }
-
-            // aggs return buckets with 0 doc_count while composite aggs skip over them
-            while ((Integer) bucket.get("doc_count") == 0) {
-                assertTrue(sourceIterator.hasNext());
-                bucket = sourceIterator.next();
             }
 
             // test correctness, the results from the aggregation and the results from the transform should be the same
@@ -206,8 +200,7 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
             );
 
         }
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 
     @SuppressWarnings("unchecked")
@@ -282,8 +275,7 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
                 is(lessThanOrEqualTo(2))
             );
         }
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 
     private static Map<String, Object> flattenedResult(String second, String event, int count) {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -108,17 +108,11 @@ public class HistogramGroupByIT extends ContinuousTestCase {
         var destIterator = hits.iterator();
 
         while (sourceIterator.hasNext() && destIterator.hasNext()) {
-            var bucket = sourceIterator.next();
+            var bucket = nextNonEmptyAggregationBucket(sourceIterator, iteration);
             var searchHit = destIterator.next();
             var source = (Map<String, Object>) searchHit.get("_source");
 
             long transformBucketKey = ((Integer) extractValue("metric", source)).longValue();
-
-            // aggs return buckets with 0 doc_count while composite aggs skip over them
-            while ((Integer) bucket.get("doc_count") == 0) {
-                assertTrue(sourceIterator.hasNext());
-                bucket = sourceIterator.next();
-            }
             long bucketKey = ((Double) bucket.get("key")).longValue();
 
             // test correctness, the results from the aggregation and the results from the transform should be the same
@@ -151,8 +145,7 @@ public class HistogramGroupByIT extends ContinuousTestCase {
             }
         }
 
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -164,8 +164,7 @@ public class LatestContinuousIT extends ContinuousTestCase {
                 assertThat(XContentMapValues.extractValue(INGEST_RUN_FIELD, source), is(not(equalTo(iteration))));
             }
         }
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 
     private String toJson(Map<String, Object> map) throws IOException {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsGroupByIT.java
@@ -170,7 +170,6 @@ public class TermsGroupByIT extends ContinuousTestCase {
                 equalTo(XContentMapValues.extractValue(MAX_RUN_FIELD, source))
             );
         }
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
@@ -184,7 +184,6 @@ public class TermsOnDateGroupByIT extends ContinuousTestCase {
                 equalTo(XContentMapValues.extractValue(MAX_RUN_FIELD, source))
             );
         }
-        assertFalse(sourceIterator.hasNext());
-        assertFalse(destIterator.hasNext());
+        assertAggregationAndDestinationIteratorsExhausted(sourceIterator, destIterator, iteration);
     }
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -204,6 +204,7 @@ public class TransformContinuousIT extends TransformRestTestCase {
 
             int numDocs = randomIntBetween(1000, 20000);
             Set<String> modifiedEvents = new HashSet<>();
+            Instant maxIngestedTimestamp = runDate;
             String action = Strings.format("""
                 {"create":{"_index":"%s"}}
                 """, sourceIndexName);
@@ -244,6 +245,12 @@ public class TransformContinuousIT extends TransformRestTestCase {
 
                 String dateString = ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC"))
                     .format(runDate.plusNanos(randomIntBetween(0, 999999)));
+                Instant docTimestamp = Instant.from(
+                    ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC")).parse(dateString)
+                );
+                if (docTimestamp.isAfter(maxIngestedTimestamp)) {
+                    maxIngestedTimestamp = docTimestamp;
+                }
 
                 source.append("\"timestamp\":\"").append(dateString).append("\",");
                 // for data streams
@@ -266,7 +273,7 @@ public class TransformContinuousIT extends TransformRestTestCase {
 
             // start all transforms, wait until the processed all data and stop them
             startTransforms();
-            waitUntilTransformsProcessedNewData(ContinuousTestCase.SYNC_DELAY, run);
+            waitUntilTransformsProcessedNewData(ContinuousTestCase.SYNC_DELAY, run, maxIngestedTimestamp);
             stopTransforms();
 
             // test the output
@@ -465,11 +472,12 @@ public class TransformContinuousIT extends TransformRestTestCase {
         assertThat(pipelineIds, containsInRelativeOrder(ContinuousTestCase.INGEST_PIPELINE));
     }
 
-    private void waitUntilTransformsProcessedNewData(TimeValue delay, int iteration) throws Exception {
-        Instant waitUntil = Instant.now().plusMillis(delay.getMillis());
+    private void waitUntilTransformsProcessedNewData(TimeValue delay, int iteration, Instant maxIngestedTimestamp) throws Exception {
+        Instant waitUntil = maxIngestedTimestamp.plusMillis(delay.getMillis());
         logger.info(
-            "wait until transform reaches timestamp_millis: {} (takes into account the delay: {}) iteration: {}",
+            "wait until transform reaches max ingested timestamp plus delay: {} (max ingested: {}, delay: {}) iteration: {}",
             ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC")).format(waitUntil),
+            ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC")).format(maxIngestedTimestamp),
             delay,
             iteration
         );
@@ -483,16 +491,18 @@ public class TransformContinuousIT extends TransformRestTestCase {
                     assertThat(
                         Strings.format(
                             "Timeout [%ds] waiting for transform [%s] to finish next checkpoint, "
-                                + "iteration [%d], state [%s], reason in case of failure [%s], last search time [%d]",
+                                + "iteration [%d], state [%s], reason in case of failure [%s], last search time [%d], "
+                                + "wait until max ingested plus delay [%s]",
                             MAX_WAIT_TIME_ONE_ITERATION_SECONDS,
                             testCase.getName(),
                             iteration,
                             stats.get("state"),
                             stats.get("reason"),
-                            lastSearchTime
+                            lastSearchTime,
+                            ContinuousTestCase.STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS.withZone(ZoneId.of("UTC")).format(waitUntil)
                         ),
                         Instant.ofEpochMilli(lastSearchTime),
-                        is(greaterThan(waitUntil))
+                        is(greaterThanOrEqualTo(waitUntil))
                     );
                     // assert a checkpoint isn't in progress
                     Object state = XContentMapValues.extractValue("state", stats);


### PR DESCRIPTION
## Summary

Backport of the https://github.com/elastic/elasticsearch/pull/154809 harness fix: wait for transforms to process up to the run's max ingested `timestamp` plus `SYNC_DELAY` before comparing aggregation output.

Unmutes `TransformContinuousIT.testContinuousEvents` on 9.5.

Closes #153782