### PR TITLE
Fix StatelessHollowIndexShardsIT testDataStreamStatsActionBroadcastedToSearchNodesOnly

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -133,9 +133,6 @@ tests:
 - class: org.elasticsearch.backwards.RareTermsIT
   method: testSingleValuedString
   issue: https://github.com/elastic/elasticsearch/issues/147853
-- class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
-  method: testDataStreamStatsActionBroadcastedToSearchNodesOnly
-  issue: https://github.com/elastic/elasticsearch/issues/147973
 - class: org.elasticsearch.search.aggregations.metrics.LargeTopHitsIT
   method: test500Queries
   issue: https://github.com/elastic/elasticsearch/issues/148056

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -2665,7 +2665,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
 
         // Wait until the backing index is hollowable. Use assertBusy because GetDataStreamAction runs
         // on whichever node the client routes to, and that node may not have applied the rollover
-        // cluster state yet even though the node that coordinated DataStreamsStatsAction above, already has.
+        // cluster state yet even though the node that coordinated DataStreamsStatsAction, in the above call, already has.
         final var hollowShardsService = internalCluster().getInstance(HollowShardsService.class, indexingNodeA);
         final AtomicReference<String> backingHollowIndex = new AtomicReference<>();
         assertBusy(() -> {

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -2663,27 +2663,30 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         };
         assertDataStreamsActionResponse.run();
 
-        // Wait until the backing index is hollowable
-        final var backingIndices = getBackingIndices(dataStreamName, false).stream().map(Index::getName).toList();
-        assertThat(backingIndices.size(), equalTo(2));
-        final var backingIndex = backingIndices.get(0);
+        // Wait until the backing index is hollowable. Use assertBusy because GetDataStreamAction runs
+        // on whichever node the client routes to, and that node may not have applied the rollover
+        // cluster state yet even though the node that coordinated DataStreamsStatsAction above, already has.
         final var hollowShardsService = internalCluster().getInstance(HollowShardsService.class, indexingNodeA);
+        final AtomicReference<String> backingHollowIndex = new AtomicReference<>();
         assertBusy(() -> {
-            final var indexShard = findIndexShard(backingIndex);
+            final var indices = getBackingIndices(dataStreamName, false).stream().map(Index::getName).toList();
+            assertThat(indices.size(), equalTo(2));
+            final var indexShard = findIndexShard(indices.get(0));
             assertThat(hollowShardsService.isHollowableIndexShard(indexShard), equalTo(true));
+            backingHollowIndex.set(indices.get(0));
         });
 
         // Start a new indexing node and relocate the index from the first indexing node to this one so it is hollowed
         final var indexingNodeB = startIndexNode(lowTtlSettings);
         ensureStableCluster(4);
         assertNodeDoesNotReceiveAction.accept(indexingNodeB);
-        updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexingNodeA), backingIndex);
-        internalCluster().awaitNodeVacated(backingIndex, indexingNodeA);
-        ensureGreen(backingIndex);
+        updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexingNodeA), backingHollowIndex.get());
+        internalCluster().awaitNodeVacated(backingHollowIndex.get(), indexingNodeA);
+        ensureGreen(backingHollowIndex.get());
 
         // Ensure the shard was hollowed
         final var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, indexingNodeB);
-        final var indexShard = findIndexShard(backingIndex);
+        final var indexShard = findIndexShard(backingHollowIndex.get());
         assertThat(hollowShardsServiceB.isHollowShard(indexShard.shardId()), equalTo(true));
 
         // Assert the action again on the hollow shard


### PR DESCRIPTION
The test failed at some point where it expected a datastream rollover to have happened, based on a previous call.

But both calls are for a `TransportLocalClusterStateAction` which only looks at the locally applied cluster state.
So, if the 2 calls target different nodes (in the 3 node cluster) and there is a delay in the cluster state applier,
the first call might observe the rollover while the second might not, yet.

The fix reuses an assert busy below, to also first wait for the rollover.

Fixes https://github.com/elastic/elasticsearch/issues/147973