### PR TITLE
[9.5] Fix view+alias data deduplication in ViewResolver (#154694)

### DIFF
--- a/docs/changelog/154694.yaml
+++ b/docs/changelog/154694.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154694
+summary: Fix view+alias data deduplication in `ViewResolver`
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -370,6 +370,7 @@ public class CsvTestsDataLoader {
         new ViewConfig("employees_not_rehired"),
         new ViewConfig("employees_all"),
         new ViewConfig("employees_extra"),
+        new ViewConfig("employees_via_alias"),
         new ViewConfig("partial_mapping_view"),
         new ViewConfig("partial_mapping_view_message_wildcard"),
         new ViewConfig("partial_mapping_mv_view"),
@@ -394,6 +395,15 @@ public class CsvTestsDataLoader {
         new ViewConfig("employees_in_subquery_disjunction_view", List.of(WHERE_IN_SUBQUERY_WITH_VIEW)),
         new ViewConfig("employees_in_subquery_nested_view", List.of(WHERE_IN_SUBQUERY_WITH_VIEW))
     ).collect(toMap(ViewConfig::name, Function.identity()));
+
+    /**
+     * Index aliases created unconditionally alongside the main test indices. These are not tied
+     * to view support — any csv-spec test may reference them. Non-view tests that use wildcard
+     * patterns (e.g. {@code FROM employees*}) are unaffected because Elasticsearch field-caps
+     * deduplicates an alias and its backing index into a single logical source.
+     */
+    public static final Map<String, AliasConfig> ALIAS_CONFIGS = Stream.of(new AliasConfig("employees_alias", "employees"))
+        .collect(toMap(AliasConfig::aliasName, Function.identity()));
 
     /**
      * <p>
@@ -514,6 +524,9 @@ public class CsvTestsDataLoader {
                 }
                 if (policies) {
                     loadEnrichPolicies(client);
+                }
+                if (indexes) {
+                    loadAliasesIntoEs(client);
                 }
                 if (views) {
                     loadViewsIntoEs(client);
@@ -650,6 +663,7 @@ public class CsvTestsDataLoader {
                 loadEnrichPolicies(client);
             }
         }
+        loadAliasesIntoEs(client, indicesToLoad);
     }
 
     /**
@@ -744,6 +758,37 @@ public class CsvTestsDataLoader {
             }
         } else {
             logger.info("Skipping loading views as the cluster does not support views");
+        }
+    }
+
+    private static void loadAliasesIntoEs(RestClient client) throws IOException {
+        loadAliasesIntoEs(client, null);
+    }
+
+    /**
+     * Creates index aliases from {@link #ALIAS_CONFIGS}. When {@code indicesToLoad} is non-null,
+     * only aliases whose backing index is in that list are created — aliases for indices that were
+     * not loaded in this run are skipped to avoid {@code index_not_found_exception}.
+     */
+    private static void loadAliasesIntoEs(RestClient client, @Nullable List<String> indicesToLoad) throws IOException {
+        logger.info("Loading aliases");
+        for (var alias : ALIAS_CONFIGS.values()) {
+            if (indicesToLoad != null && indicesToLoad.contains(alias.indexName()) == false) {
+                logger.debug("Skipping alias [{}] -> [{}]: backing index not in indicesToLoad", alias.aliasName(), alias.indexName());
+                continue;
+            }
+            Request request = new Request("POST", "/_aliases");
+            request.setJsonEntity(
+                "{\"actions\":[{\"add\":{\"index\":\"" + alias.indexName() + "\",\"alias\":\"" + alias.aliasName() + "\"}}]}"
+            );
+            try {
+                client.performRequest(request);
+            } catch (ResponseException e) {
+                // Alias may already exist (idempotent re-load); ignore 400
+                if (e.getResponse().getStatusLine().getStatusCode() != 400) {
+                    throw e;
+                }
+            }
         }
     }
 
@@ -1547,6 +1592,9 @@ public class CsvTestsDataLoader {
             return getResourceString("/views/" + name + ".esql");
         }
     }
+
+    /** An index alias to create alongside the main test indices. */
+    public record AliasConfig(String aliasName, String indexName) {}
 
     private interface IndexCreator {
         void createIndex(RestClient client, String indexName, String mapping, Settings indexSettings) throws IOException;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
@@ -666,6 +666,40 @@ count:long
 200
 ;
 
+compactedViewWithAliasGivesTwoCopies
+required_capability: views_with_branching
+required_capability: views_crud_as_index_actions
+required_capability: views_alias_deduplication_bugfix
+
+// FROM alias, view where the view expands to the same index as the alias should give two copies.
+// employees_alias is an index alias pointing to employees; employees_all is a view defined as "FROM employees".
+// The result must contain 200 rows (two independent copies of the 100-row employees index),
+// not 100 rows (which would indicate the alias and view were incorrectly merged and deduplicated).
+FROM employees_alias, employees_all
+| STATS count=COUNT(emp_no)
+;
+
+count:long
+200
+;
+
+compactedViewWithAliasInBodyGivesTwoCopies
+required_capability: views_with_branching
+required_capability: views_crud_as_index_actions
+required_capability: views_alias_deduplication_bugfix
+
+// FROM index, view where the view body references an alias pointing to that index should give two copies.
+// employees_via_alias is a view defined as "FROM employees_alias"; employees_alias is an index alias pointing to employees.
+// The result must contain 200 rows (two independent copies of the 100-row employees index),
+// not 100 rows (which would indicate the alias inside the view body was incorrectly merged with the direct index reference).
+FROM employees, employees_via_alias
+| STATS count=COUNT(emp_no)
+;
+
+count:long
+200
+;
+
 wildcardExcludeEmployeeViewsNoFalseCircularReference
 required_capability: views_with_branching
 required_capability: views_crud_as_index_actions

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views/employees_via_alias.esql
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views/employees_via_alias.esql
@@ -1,0 +1,1 @@
+FROM employees_alias

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -114,6 +114,7 @@ import static org.elasticsearch.xpack.esql.CsvTestUtils.assumeFalseLogging;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.assumeTrueLogging;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.loadCsvSpecValues;
+import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.ALIAS_CONFIGS;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.CSV_DATASET;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.INFERENCE_CONFIGS;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
@@ -449,7 +450,10 @@ public class CsvIT extends ESTestCase {
                 @Override
                 protected boolean apply(String action, ActionRequest request, ActionListener<?> listener) {
                     switch (action) {
-                        case EsqlQueryAction.NAME -> loadViews();
+                        case EsqlQueryAction.NAME -> {
+                            loadViews();
+                            loadAliases();
+                        }
                         case EsqlResolveFieldsAction.NAME -> loadIndices((FieldCapabilitiesRequest) request);
                         case GetInferenceModelAction.NAME -> loadInference((GetInferenceModelAction.Request) request);
                     }
@@ -516,6 +520,18 @@ public class CsvIT extends ESTestCase {
         }
     }
 
+    private static void loadAliases() {
+        if ("views".equals(currentGroupName)) {
+            ALIAS_CONFIGS.forEach((name, alias) -> {
+                var backing = CSV_DATASET.get(alias.indexName());
+                if (backing != null) {
+                    indices.maybeLoad(backing.indexName(), backing);
+                }
+                aliases.maybeLoad(alias.aliasName(), alias);
+            });
+        }
+    }
+
     private static void loadIndices(FieldCapabilitiesRequest request) {
         Stream.of(request.indices()).flatMap(pattern -> {
             assert pattern.contains("<") == false : "Date-math is not supported in test";
@@ -543,6 +559,16 @@ public class CsvIT extends ESTestCase {
                 }
                 return CSV_DATASET.values().stream().filter(ds -> ds.indexName().startsWith(prefix));
             } else {
+                var aliasConfig = ALIAS_CONFIGS.get(pattern);
+                if (aliasConfig != null) {
+                    // Load the backing index first, then create the alias.
+                    var backing = CSV_DATASET.get(aliasConfig.indexName());
+                    if (backing != null) {
+                        indices.maybeLoad(backing.indexName(), backing);
+                    }
+                    aliases.maybeLoad(aliasConfig.aliasName(), aliasConfig);
+                    return Stream.empty();
+                }
                 return Stream.of(CSV_DATASET.get(pattern));
             }
         })
@@ -668,6 +694,20 @@ public class CsvIT extends ESTestCase {
                         DeleteViewAction.INSTANCE,
                         new DeleteViewAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, new String[] { name })
                     )
+            );
+        }
+    };
+
+    private static ResourceLoader<CsvTestsDataLoader.AliasConfig> aliases = new ResourceLoader<>() {
+        @Override
+        protected void load(CsvTestsDataLoader.AliasConfig alias) {
+            logger.info("Loading alias [{}] -> [{}]", alias.aliasName(), alias.indexName());
+            assertAcked(
+                cluster.client()
+                    .admin()
+                    .indices()
+                    .prepareAliases(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                    .addAlias(alias.indexName(), alias.aliasName())
             );
         }
     };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1496,8 +1496,13 @@ public class EsqlCapabilities {
         /**
          * Fixed a bug where views are incorrectly de-duplicated.
          */
-
         VIEWS_DEDUPLICATION_BUGFIX,
+        /**
+         * Fixed a bug where a view and an index alias pointing to the same underlying index were
+         * not correctly identified as overlapping, causing field-caps to deduplicate the alias into
+         * the concrete index and silently drop one branch of data.
+         */
+        VIEWS_ALIAS_DEDUPLICATION_BUGFIX,
         /**
          * Fixed false circular view reference errors when multiple sibling views are resolved together.
          * See https://github.com/elastic/elasticsearch/issues/146208

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewCompaction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewCompaction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.view;
 
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
@@ -25,6 +26,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.util.set.Sets.haveNonEmptyIntersection;
 
 /**
  * Compacts the nested plan produced by {@link ViewResolver} into the form expected by the rest
@@ -64,6 +69,15 @@ public class ViewCompaction extends Rule<LogicalPlan, LogicalPlan> {
      * {@link #postIndexResolution(LogicalPlan)}. Production code calls the two phases separately;
      * tests that exercise the compaction logic without going through the full analyzer call
      * this to get the same end state as the live pipeline produces.
+     * <p>
+     * TODO: this skips {@code ResolveTable} between the two phases, so {@link #postIndexResolution}
+     * sees {@link UnresolvedRelation}s rather than {@code EsRelation}s. This causes
+     * {@link #mergeUnresolvedRelationEntries} in {@link #compactNestedViewUnionAlls} to perform
+     * cross-level UR merging that never happens in the production pipeline (where all URs are
+     * already resolved by the time {@link #postIndexResolution} runs). Tests using this method
+     * therefore diverge slightly from production; fix in a follow-up by having test helpers
+     * replicate the full pipeline (view resolution → {@link #preIndexResolution} → ResolveTable →
+     * {@link #postIndexResolution}) instead of using this shortcut.
      */
     @Override
     public LogicalPlan apply(LogicalPlan plan) {
@@ -267,10 +281,17 @@ public class ViewCompaction extends Rule<LogicalPlan, LogicalPlan> {
             }
         }
 
-        // Always attempt to merge bare UnresolvedRelation siblings — the strip step earlier in this
-        // rule may have just exposed entries that were previously hidden inside a ViewUnionAll
-        // wrapping shadows + strict; without an unconditional merge here those exposed siblings
-        // would stay as separate branches even when their patterns are mergeable.
+        // Merge bare UnresolvedRelation siblings that ended up at the same level after
+        // flattening. ViewResolver.buildPlanFromBranches only merges URs within a single
+        // nesting level; after nested ViewUnionAlls are hoisted into this flat map, URs from
+        // different levels may become adjacent and mergeable.
+        //
+        // No alias resolver is available here, so alias-vs-backing-index overlap is not
+        // detected. This is safe in the production pipeline: by the time postIndexResolution
+        // runs, ResolveTable has already converted every UnresolvedRelation to an EsRelation,
+        // making the merge loop a no-op. The gap only exists in the apply() test convenience
+        // (which runs both phases without ResolveTable in between), and only for the
+        // multi-level nesting variant of the alias scenario — not a production concern.
         mergeUnresolvedRelationEntries(flat);
 
         if (flat.size() > Fork.MAX_BRANCHES) {
@@ -298,9 +319,11 @@ public class ViewCompaction extends Rule<LogicalPlan, LogicalPlan> {
     }
 
     /**
-     * Merges bare {@link UnresolvedRelation} entries in the map into a single entry where possible.
-     * {@link UnresolvedRelation}s that share individual index names with the merged result are kept
-     * as separate entries to prevent IndexResolution from deduplicating them and losing data.
+     * Merges bare {@link UnresolvedRelation} entries in the map into a single entry where possible,
+     * using string-equality and wildcard overlap as guards. Called after nested {@link ViewUnionAll}s
+     * are flattened so that URs lifted from inner levels can be merged with sibling URs at the outer
+     * level. Alias-vs-backing-index overlap is not checked here (no alias resolver is available at
+     * this call site); see the comment at the call site for why that is safe in production.
      */
     private static void mergeUnresolvedRelationEntries(LinkedHashMap<String, LogicalPlan> flat) {
         List<String> urKeys = new ArrayList<>();
@@ -328,8 +351,22 @@ public class ViewCompaction extends Rule<LogicalPlan, LogicalPlan> {
         flat.put(firstKey, merged);
     }
 
-    /** Merge the unresolved relation unless the index patterns contain matching index names. */
-    static UnresolvedRelation mergeIfPossible(UnresolvedRelation main, UnresolvedRelation other) {
+    /**
+     * Merge the unresolved relation unless the index patterns contain matching index names, or
+     * unless alias resolution via {@code aliasResolver} reveals that patterns in {@code main} and
+     * {@code other} map to overlapping concrete indices (e.g. one pattern is an alias that points
+     * to the same index as a pattern in the other relation). Pass {@code null} to skip alias
+     * checking (the existing string-equality and wildcard checks still apply).
+     * <p>
+     * {@code aliasResolver} should map a local, non-wildcard index/alias name to the set of
+     * concrete index names it backs. For a concrete index {@code x} it should return {@code {x}};
+     * for an alias {@code a → x} it should return {@code {x}}.
+     */
+    static UnresolvedRelation mergeIfPossible(
+        UnresolvedRelation main,
+        UnresolvedRelation other,
+        @Nullable Function<String, Set<String>> aliasResolver
+    ) {
         for (String mainPattern : main.indexPattern().indexPattern().split(",")) {
             for (String otherPattern : other.indexPattern().indexPattern().split(",")) {
                 if (mainPattern.equals(otherPattern)) {
@@ -347,6 +384,18 @@ public class ViewCompaction extends Rule<LogicalPlan, LogicalPlan> {
                     && Regex.simpleMatch(otherPattern, mainPattern)) {
                     return null;
                 }
+                // Check alias resolution: two non-wildcard, non-remote patterns may point to the same
+                // concrete index via alias. Without this check, merging "source-index" and "source-alias"
+                // (where source-alias → source-index) produces UnresolvedRelation("source-index,source-alias")
+                // which field-caps deduplicates to a single copy, silently dropping one data branch.
+                if (aliasResolver != null
+                    && Regex.isSimpleMatchPattern(mainPattern) == false
+                    && Regex.isSimpleMatchPattern(otherPattern) == false
+                    && RemoteClusterAware.isRemoteIndexName(mainPattern) == false
+                    && RemoteClusterAware.isRemoteIndexName(otherPattern) == false
+                    && haveNonEmptyIntersection(aliasResolver.apply(mainPattern), aliasResolver.apply(otherPattern))) {
+                    return null;
+                }
             }
         }
         return new UnresolvedRelation(
@@ -357,6 +406,17 @@ public class ViewCompaction extends Rule<LogicalPlan, LogicalPlan> {
             main.indexMode(),
             main.unresolvedMessage()
         );
+    }
+
+    /**
+     * Merge the unresolved relation unless the index patterns overlap by string equality or wildcard.
+     * Alias resolution is not performed; this overload is used by {@link #mergeUnresolvedRelationEntries}
+     * after nested {@link ViewUnionAll} flattening, where no alias resolver is available. In the
+     * production pipeline this is always a no-op because {@code ResolveTable} has already converted
+     * every {@link UnresolvedRelation} to an {@code EsRelation} before {@link #postIndexResolution} runs.
+     */
+    static UnresolvedRelation mergeIfPossible(UnresolvedRelation main, UnresolvedRelation other) {
+        return mergeIfPossible(main, other, null);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -12,6 +12,8 @@ import org.elasticsearch.action.ResolvedIndexExpression;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.metadata.View;
 import org.elasticsearch.cluster.metadata.ViewMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
@@ -19,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -55,7 +58,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.RestUtils.REST_MASTER_TIMEOUT_DEFAULT;
 
@@ -89,8 +94,8 @@ public class ViewResolver {
 
     protected Logger log = LogManager.getLogger(getClass());
     private final Executor executor;
-    private final ClusterService clusterService;
-    private final ProjectResolver projectResolver;
+    protected final ClusterService clusterService;
+    protected final ProjectResolver projectResolver;
     private final CrossProjectModeDecider crossProjectModeDecider;
     private volatile int maxViewDepth;
     private final Client client;
@@ -136,6 +141,19 @@ public class ViewResolver {
 
     ViewMetadata getMetadata() {
         return projectResolver.getProjectMetadata(clusterService.state()).custom(ViewMetadata.TYPE, ViewMetadata.EMPTY);
+    }
+
+    /**
+     * Returns the current {@link ProjectMetadata}, or {@code null} when the resolver is in NOOP mode
+     * (i.e. the {@code projectResolver} was not injected). Subclasses may override this to supply
+     * project metadata from a different source (e.g. in-memory test infrastructure).
+     */
+    @Nullable
+    protected ProjectMetadata getCurrentProjectMetadata() {
+        if (projectResolver == null || clusterService == null) {
+            return null;
+        }
+        return projectResolver.getProjectMetadata(clusterService.state());
     }
 
     // TODO: Remove this function entirely if we no longer need to do micro-benchmarks on views enabled/disabled
@@ -787,7 +805,7 @@ public class ViewResolver {
         // here keeps the resolved plan compact: a wide branching level (e.g. {@code FROM v1, v2, ... v9}
         // of compactable views) folds into a single {@link UnresolvedRelation} entry rather than a
         // ViewUnionAll that would later trip {@link Fork#MAX_BRANCHES} at post-analysis verification.
-        mergeCompatibleUnresolvedRelations(plans);
+        mergeCompatibleUnresolvedRelations(plans, buildAliasResolver());
 
         if (plans.size() == 1) {
             return plans.values().iterator().next();
@@ -797,13 +815,39 @@ public class ViewResolver {
     }
 
     /**
+     * Builds a function that maps a local, non-wildcard index or alias name to the set of concrete
+     * index names it backs. Concrete indices map to a singleton containing themselves; aliases map to
+     * the set of their backing indices. Returns {@code null} when project metadata is unavailable
+     * (NOOP resolver mode), in which case alias-aware merge checking is skipped.
+     */
+    @Nullable
+    private Function<String, Set<String>> buildAliasResolver() {
+        ProjectMetadata projectMetadata = getCurrentProjectMetadata();
+        if (projectMetadata == null) {
+            return null;
+        }
+        Map<String, IndexAbstraction> indicesLookup = projectMetadata.getIndicesLookup();
+        return name -> {
+            IndexAbstraction abstraction = indicesLookup.get(name);
+            if (abstraction == null || abstraction.getType() != IndexAbstraction.Type.ALIAS) {
+                return Set.of(name);
+            }
+            Set<String> backingIndices = abstraction.getIndices().stream().map(Index::getName).collect(Collectors.toSet());
+            return backingIndices.isEmpty() ? Set.of(name) : backingIndices;
+        };
+    }
+
+    /**
      * Merges bare UnresolvedRelation entries that don't share index patterns into a single entry.
      * Those that cannot be merged are wrapped in NamedSubquery nodes to preserve data duplication
      * semantics. The full broader-scope compaction lives in {@link ViewCompaction}; this is the
      * per-level merge that keeps the resolved tree small enough to pass {@link Fork#MAX_BRANCHES}
      * at post-analysis verification.
      */
-    private static void mergeCompatibleUnresolvedRelations(LinkedHashMap<String, LogicalPlan> plans) {
+    private static void mergeCompatibleUnresolvedRelations(
+        LinkedHashMap<String, LogicalPlan> plans,
+        @Nullable Function<String, Set<String>> aliasResolver
+    ) {
         List<String> urKeys = new ArrayList<>();
         for (Map.Entry<String, LogicalPlan> entry : plans.entrySet()) {
             if (entry.getValue() instanceof UnresolvedRelation ur && ur.indexMode() == IndexMode.STANDARD) {
@@ -820,7 +864,7 @@ public class ViewResolver {
         for (int i = 1; i < urKeys.size(); i++) {
             String key = urKeys.get(i);
             UnresolvedRelation ur = (UnresolvedRelation) plans.get(key);
-            UnresolvedRelation result = mergeIfPossible(merged, ur);
+            UnresolvedRelation result = mergeIfPossible(merged, ur, aliasResolver);
             if (result != null) {
                 merged = result;
                 plans.remove(key);
@@ -832,8 +876,12 @@ public class ViewResolver {
         plans.put(firstKey, merged);
     }
 
-    private static UnresolvedRelation mergeIfPossible(UnresolvedRelation main, UnresolvedRelation other) {
-        return ViewCompaction.mergeIfPossible(main, other);
+    private static UnresolvedRelation mergeIfPossible(
+        UnresolvedRelation main,
+        UnresolvedRelation other,
+        @Nullable Function<String, Set<String>> aliasResolver
+    ) {
+        return ViewCompaction.mergeIfPossible(main, other, aliasResolver);
     }
 
     private static void assertNamesMatch(String message, String left, String right) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewResolver.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewResolver.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.ViewMetadata;
 import org.elasticsearch.cluster.project.DefaultProjectResolver;
-import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -30,24 +29,19 @@ import static org.mockito.Mockito.mock;
 public class InMemoryViewResolver extends ViewResolver {
     protected Supplier<ViewMetadata> metadata;
     protected IndexNameExpressionResolver indexNameExpressionResolver;
-    protected ClusterService clusterService;
-    protected ProjectResolver projectResolver;
 
     public InMemoryViewResolver(
         ClusterService clusterService,
         Supplier<ViewMetadata> metadata,
         CrossProjectModeDecider crossProjectModeDecider
     ) {
-        super(null, clusterService, null, null, crossProjectModeDecider);
-        this.projectResolver = DefaultProjectResolver.INSTANCE;
+        super(null, clusterService, DefaultProjectResolver.INSTANCE, null, crossProjectModeDecider);
         this.indexNameExpressionResolver = new IndexNameExpressionResolver(
             new ThreadContext(Settings.EMPTY),
             EmptySystemIndices.INSTANCE,
             projectResolver
         );
         this.metadata = metadata;
-        this.clusterService = clusterService;
-
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewService.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewService.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
@@ -52,6 +53,8 @@ public class InMemoryViewService extends ViewService implements Closeable {
     private final ThreadPool threadPool;
     private ViewMetadata viewMetadata;
     private final List<String> indices = new ArrayList<>();
+    /** Maps alias name → target index name for aliases added via {@link #addAlias}. */
+    private final Map<String, String> aliasToIndex = new HashMap<>();
 
     private static final Set<Setting<?>> ALL_SETTINGS;
     static {
@@ -109,9 +112,7 @@ public class InMemoryViewService extends ViewService implements Closeable {
             existingViews.put(request.view().name(), request.view());
             viewMetadata = new ViewMetadata(existingViews);
             var projectBuilder = ProjectMetadata.builder(projectId).putCustom(ViewMetadata.TYPE, viewMetadata);
-            indices.forEach(
-                index -> projectBuilder.put(IndexMetadata.builder(index).settings(indexSettings(IndexVersion.current(), 1, 0)))
-            );
+            rebuildProjectMetadata(projectBuilder);
             ClusterServiceUtils.setState(
                 clusterService,
                 new ClusterState.Builder(clusterService.state()).putProjectMetadata(projectBuilder).build()
@@ -125,11 +126,37 @@ public class InMemoryViewService extends ViewService implements Closeable {
     public void addIndex(ProjectId projectId, String name) {
         var projectBuilder = ProjectMetadata.builder(projectId).putCustom(ViewMetadata.TYPE, viewMetadata);
         indices.add(name);
-        indices.forEach(index -> projectBuilder.put(IndexMetadata.builder(index).settings(indexSettings(IndexVersion.current(), 1, 0))));
+        rebuildProjectMetadata(projectBuilder);
         ClusterServiceUtils.setState(
             clusterService,
             new ClusterState.Builder(clusterService.state()).putProjectMetadata(projectBuilder).build()
         );
+    }
+
+    /**
+     * Adds an index alias {@code aliasName} pointing to {@code indexName} in the cluster state.
+     * The target index must have been added via {@link #addIndex} before calling this.
+     */
+    public void addAlias(ProjectId projectId, String aliasName, String indexName) {
+        aliasToIndex.put(aliasName, indexName);
+        var projectBuilder = ProjectMetadata.builder(projectId).putCustom(ViewMetadata.TYPE, viewMetadata);
+        rebuildProjectMetadata(projectBuilder);
+        ClusterServiceUtils.setState(
+            clusterService,
+            new ClusterState.Builder(clusterService.state()).putProjectMetadata(projectBuilder).build()
+        );
+    }
+
+    private void rebuildProjectMetadata(ProjectMetadata.Builder projectBuilder) {
+        indices.forEach(index -> {
+            var builder = IndexMetadata.builder(index).settings(indexSettings(IndexVersion.current(), 1, 0));
+            aliasToIndex.forEach((alias, targetIndex) -> {
+                if (targetIndex.equals(index)) {
+                    builder.putAlias(AliasMetadata.builder(alias).build());
+                }
+            });
+            projectBuilder.put(builder);
+        });
     }
 
     @Override
@@ -169,6 +196,7 @@ public class InMemoryViewService extends ViewService implements Closeable {
     void clearAllViewsAndIndices() {
         viewMetadata = ViewMetadata.EMPTY;
         indices.clear();
+        aliasToIndex.clear();
     }
 
     public InMemoryViewResolver getViewResolver() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -1710,6 +1710,60 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
     }
 
     /**
+     * Reproduces an issue when a view expands to a concrete index (e.g. {@code my-view = FROM source-index}) and the
+     * same query also references an alias that points to the same index (e.g. {@code source-alias}),
+     * the two branches must NOT be merged into a single {@link UnresolvedRelation} — doing so
+     * would cause field-caps to deduplicate {@code source-alias} into {@code source-index} and
+     * silently drop one copy of the data.
+     */
+    public void testViewAndAliasPointingToSameIndexProduceTwoCopies() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        assumeTrue("Requires views alias deduplication bugfix", EsqlCapabilities.Cap.VIEWS_ALIAS_DEDUPLICATION_BUGFIX.isEnabled());
+        addIndex("source-index");
+        addAlias("source-alias", "source-index");
+        addView("my-view", "FROM source-index");
+        // FROM my-view, source-alias: my-view expands to FROM source-index.
+        // source-alias is an alias for source-index, so both branches point to the same underlying
+        // index. Merging them into a single UnresolvedRelation would cause field-caps to deduplicate
+        // the data (1 copy instead of 2). The fix keeps them as separate branches.
+        //
+        // We test the state AFTER view-resolution + phase-1 compaction (preIndexResolution), which
+        // is exactly what EsqlSession feeds to PreAnalyzer / field-caps. Phase-2 compaction
+        // (postIndexResolution) only runs after ResolveTable, at which point UnresolvedRelations
+        // have already become EsRelations and the merge step is a no-op.
+        LogicalPlan resolved = replaceViewsWithoutCompaction(query("FROM my-view, source-alias"), viewResolver);
+        LogicalPlan compacted = ViewCompaction.preIndexResolution(resolved);
+        // Before the fix, compacted was a single UR("source-index,source-alias") — the two branches
+        // were merged and field-caps would deduplicate them. After the fix it must be a ViewUnionAll
+        // with two separate children.
+        assertThat(compacted, instanceOf(ViewUnionAll.class));
+        assertThat(compacted.children().size(), equalTo(2));
+    }
+
+    /**
+     * Variant of {@link #testViewAndAliasPointingToSameIndexProduceTwoCopies} where it is the
+     * <em>view body</em> that references the alias, not the outer query.
+     * <p>
+     * Query: {@code FROM source-index, my-view} where {@code my-view = FROM source-alias} and
+     * {@code source-alias → source-index}. After view resolution {@code my-view} expands to
+     * {@code FROM source-alias}, so the query's two branches are {@code source-index} and
+     * {@code source-alias}. These must NOT be merged — merging would produce a single
+     * {@link UnresolvedRelation} whose field-caps call deduplicates the alias into the backing index
+     * and silently returns only one copy of the data.
+     */
+    public void testIndexAndViewWithAliasBodyPointingToSameIndexProduceTwoCopies() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        assumeTrue("Requires views alias deduplication bugfix", EsqlCapabilities.Cap.VIEWS_ALIAS_DEDUPLICATION_BUGFIX.isEnabled());
+        addIndex("source-index");
+        addAlias("source-alias", "source-index");
+        addView("my-view", "FROM source-alias");
+        LogicalPlan resolved = replaceViewsWithoutCompaction(query("FROM source-index, my-view"), viewResolver);
+        LogicalPlan compacted = ViewCompaction.preIndexResolution(resolved);
+        assertThat(compacted, instanceOf(ViewUnionAll.class));
+        assertThat(compacted.children().size(), equalTo(2));
+    }
+
+    /**
      * Tests a 12x10 matrix of nesting depth x branching width with compactable views.
      * Compactable views are simple aliases (just {@code FROM <target>}), which the ViewResolver
      * compacts into a single FROM clause, eliminating any FORK branching.
@@ -2586,6 +2640,10 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
 
     private void addIndex(String name) {
         viewService.addIndex(projectId, name);
+    }
+
+    private void addAlias(String aliasName, String indexName) {
+        viewService.addAlias(projectId, aliasName, indexName);
     }
 
     private void addDateMathIndex(String prefix) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix view+alias data deduplication in ViewResolver (#154694)