### PR TITLE
[9.5] Increase AzureStorageCleanupThirdPartyTests suite timeout to 40 min (#154796)

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -19,7 +19,9 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.AccessTier;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobStorageException;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -75,7 +77,9 @@ import static org.hamcrest.Matchers.not;
 /**
  * These tests sometimes run against a genuine Azure endpoint with credentials obtained from Vault. These credentials expire periodically
  * and must be manually renewed; the process is in the onboarding/process docs.
+ * Most tests that run against a genuine Azure endpoint can take between 1 and 3 minutes, hence the large suite timeout.
  */
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyRepositoryTestCase {
     private static final Logger logger = LogManager.getLogger(AzureStorageCleanupThirdPartyTests.class);
     private static final boolean USE_FIXTURE = Booleans.parseBoolean(System.getProperty("test.azure.fixture", "true"));


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Increase AzureStorageCleanupThirdPartyTests suite timeout to 40 min (#154796)