### PR TITLE
Hide OTel REST endpoints when disabled

### DIFF
--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
@@ -77,12 +77,15 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        assert indexingPressure.get() != null : "indexing pressure must be set";
-        List<RestHandler> handlers = new ArrayList<>(3);
-        handlers.add(new OTLPMetricsRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));
-        handlers.add(new OTLPTracesRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));
-        handlers.add(new OTLPLogsRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));
-        return handlers;
+        if (enabled == false) {
+            assert indexingPressure.get() != null : "indexing pressure must be set";
+            List<RestHandler> handlers = new ArrayList<>(3);
+            handlers.add(new OTLPMetricsRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));
+            handlers.add(new OTLPTracesRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));
+            handlers.add(new OTLPLogsRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));
+            return handlers;
+        }
+        return List.of();
     }
 
     @Override

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
@@ -77,7 +77,7 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        if (enabled == false) {
+        if (enabled) {
             assert indexingPressure.get() != null : "indexing pressure must be set";
             List<RestHandler> handlers = new ArrayList<>(3);
             handlers.add(new OTLPMetricsRestAction(indexingPressure.get(), maxProtobufContentLengthBytes));


### PR DESCRIPTION
Following the same pattern as the [PrometheusPlugin](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusPlugin.java#L102) this hides the OTel plugin's REST endpoints when disabled. 