### PR TITLE
[9.3] Fix `testLargeRequestIsNeverDispatched`

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -36,6 +36,7 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
@@ -97,7 +98,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -125,6 +125,7 @@ import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -847,36 +848,45 @@ public class Netty4HttpServerTransportTests extends ESTestCase {
             + randomAlphaOfLengthBetween(4, 8)
             + "="
             + randomAlphaOfLengthBetween(4, 8);
-        final Settings settings = createBuilderWithPort().put(HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH.getKey(), "1mb")
-            .build();
         final String requestString = randomAlphaOfLength(2 * 1024 * 1024); // request size is twice the limit
-        final HttpServerTransport.Dispatcher dispatcher = new AggregatingDispatcher() {
-            @Override
-            public void dispatchAggregatedRequest(final RestRequest request, final RestChannel channel, final ThreadContext threadContext) {
-                throw new AssertionError("Request dispatched but shouldn't");
-            }
-
-            @Override
-            public void dispatchBadRequest(final RestChannel channel, final ThreadContext threadContext, final Throwable cause) {
-                throw new AssertionError("Request dispatched but shouldn't");
-            }
-        };
         try (
-            Netty4HttpServerTransport transport = getTestNetty4HttpServerTransport(
-                settings,
-                dispatcher,
+            var transport = getTestNetty4HttpServerTransport(
+                createBuilderWithPort().put(HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH.getKey(), "1mb").build(),
+                new AggregatingDispatcher() {
+                    @Override
+                    public void dispatchAggregatedRequest(
+                        final RestRequest request,
+                        final RestChannel channel,
+                        final ThreadContext threadContext
+                    ) {
+                        fail("should not have dispatched request");
+                    }
+
+                    @Override
+                    public void dispatchBadRequest(final RestChannel channel, final ThreadContext threadContext1, final Throwable cause) {
+                        fail("should not have dispatched request");
+                    }
+                },
                 (r, c, l) -> l.onResponse(null),
-                (restRequest, threadContext) -> {
-                    throw new AssertionError("Request dispatched but shouldn't");
-                }
+                (restRequest, threadContext) -> fail("should not have dispatched request")
             )
         ) {
             transport.start();
-            final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
+            final var remoteAddress = randomFrom(transport.boundAddress().boundAddresses()).address();
             try (Netty4HttpClient client = new Netty4HttpClient()) {
-                Collection<FullHttpResponse> response = client.post(remoteAddress.address(), List.of(Tuple.tuple(uri, requestString)));
-                assertThat(response, hasSize(1));
-                assertThat(response.stream().findFirst().get().status(), is(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
+                final var response = client.post(remoteAddress, List.of(Tuple.tuple(uri, requestString)));
+                // Sending body after close might yield RST, discarding response from TCP buffer before we read it:
+                assertThat(response, hasSize(lessThanOrEqualTo(1)));
+                assertTrue(response.stream().map(HttpResponse::status).allMatch(s -> s == HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
+
+                // Sending headers only yields no RST and triggers response because of Content-Length header
+                final var headersOnlyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri);
+                if (randomBoolean()) {
+                    HttpUtil.set100ContinueExpected(headersOnlyRequest, true);
+                }
+                HttpUtil.setContentLength(headersOnlyRequest, requestString.length());
+                final FullHttpResponse headersOnlyResponse = client.send(remoteAddress, headersOnlyRequest);
+                assertThat(headersOnlyResponse.status(), is(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
             }
         }
     }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -343,9 +343,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.CssSearchYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_bbq_flat_bfloat16/Vector rescoring has same scoring as exact search for kNN section}
   issue: https://github.com/elastic/elasticsearch/issues/154656
-- class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
-  method: testLargeRequestIsNeverDispatched
-  issue: https://github.com/elastic/elasticsearch/issues/154657
 
 # Examples:
 #


### PR DESCRIPTION
Continuing to send the request body after the server-side close might
yield a RST, discarding the response before Netty gets to see it, so we
have to weaken the assertion to permit zero responses. However, we can
be confident that if we send no body, just the headers, we see the
expected 413 response.

Closes #154657

Backport of #154677 to 9.3

