### PR TITLE
[8.19] Fix `testLargeRequestIsNeverDispatched`

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -36,6 +36,7 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
@@ -123,6 +124,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -883,8 +885,18 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
             final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
             try (Netty4HttpClient client = new Netty4HttpClient()) {
                 Collection<FullHttpResponse> response = client.post(remoteAddress.address(), List.of(Tuple.tuple(uri, requestString)));
-                assertThat(response, hasSize(1));
-                assertThat(response.stream().findFirst().get().status(), is(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
+                // Sending body after close might yield RST, discarding response from TCP buffer before we read it:
+                assertThat(response, hasSize(lessThanOrEqualTo(1)));
+                assertTrue(response.stream().map(HttpResponse::status).allMatch(s -> s == HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
+
+                // Sending headers only yields no RST and triggers response because of Content-Length header
+                final var headersOnlyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri);
+                if (randomBoolean()) {
+                    HttpUtil.set100ContinueExpected(headersOnlyRequest, true);
+                }
+                HttpUtil.setContentLength(headersOnlyRequest, requestString.length());
+                final FullHttpResponse headersOnlyResponse = client.send(remoteAddress.address(), headersOnlyRequest);
+                assertThat(headersOnlyResponse.status(), is(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
             }
         }
     }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -313,6 +313,3 @@ tests:
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077
-- class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
-  method: testLargeRequestIsNeverDispatched
-  issue: https://github.com/elastic/elasticsearch/issues/154657


### PR DESCRIPTION
Continuing to send the request body after the server-side close might
yield a RST, discarding the response before Netty gets to see it, so we
have to weaken the assertion to permit zero responses. However, we can
be confident that if we send no body, just the headers, we see the
expected 413 response.

Closes #154657

Backport of #154677 to 8.19

