### PR TITLE
[9.5] Add conditional loading of templates based on node features (#154567)

### DIFF
--- a/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistry.java
+++ b/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.apmdata;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -32,7 +33,8 @@ public class APMIndexTemplateRegistry extends YamlTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
         super(
             nodeSettings,
@@ -40,7 +42,9 @@ public class APMIndexTemplateRegistry extends YamlTemplateRegistry {
             threadPool,
             client,
             xContentRegistry,
-            templateFilter(isDataStreamsLifecycleOnlyMode(clusterService.getSettings()))
+            featureService,
+            templateFilter(isDataStreamsLifecycleOnlyMode(clusterService.getSettings())),
+            NODE_FEATURE_FILTERS
         );
     }
 

--- a/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMPlugin.java
+++ b/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMPlugin.java
@@ -48,7 +48,14 @@ public class APMPlugin extends Plugin implements ActionPlugin {
         Settings settings = services.environment().settings();
         ClusterService clusterService = services.clusterService();
         registry.set(
-            new APMIndexTemplateRegistry(settings, clusterService, services.threadPool(), services.client(), services.xContentRegistry())
+            new APMIndexTemplateRegistry(
+                settings,
+                clusterService,
+                services.threadPool(),
+                services.client(),
+                services.xContentRegistry(),
+                services.featureService()
+            )
         );
         if (enabled) {
             APMIndexTemplateRegistry registryInstance = registry.get();

--- a/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMDSLOnlyTests.java
+++ b/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMDSLOnlyTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -22,6 +23,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,7 +61,8 @@ public class APMDSLOnlyTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         apmIndexTemplateRegistry.setEnabled(true);
     }

--- a/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -91,7 +92,14 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
         client = new VerifyingClient(threadPool);
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, clusterSettings);
         stackTemplateRegistryAccessor = new StackTemplateRegistryAccessor(
-            new StackTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, NamedXContentRegistry.EMPTY)
+            new StackTemplateRegistry(
+                Settings.EMPTY,
+                clusterService,
+                threadPool,
+                client,
+                NamedXContentRegistry.EMPTY,
+                new FeatureService(List.of())
+            )
         );
 
         apmIndexTemplateRegistry = new APMIndexTemplateRegistry(
@@ -99,7 +107,8 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         apmIndexTemplateRegistry.setEnabled(true);
     }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryRolloverIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryRolloverIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -58,7 +59,8 @@ public class IndexTemplateRegistryRolloverIT extends ESIntegTestCase {
             clusterService.threadPool(),
             client,
             xContentRegistry(),
-            3L
+            3L,
+            new FeatureService(List.of())
         );
         registry.initialize();
         ensureGreen();

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/template/RolloverEnabledTestTemplateRegistry.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/template/RolloverEnabledTestTemplateRegistry.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
@@ -28,9 +29,10 @@ public class RolloverEnabledTestTemplateRegistry extends IndexTemplateRegistry {
         ThreadPool threadPool,
         Client client,
         NamedXContentRegistry xContentRegistry,
-        long version
+        long version,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.version = version;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -40,6 +40,8 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
@@ -66,6 +68,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.isDataStreamsLifecycleOnlyMode;
@@ -113,6 +117,15 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(IndexTemplateRegistry.class);
 
     private static final TimeValue REGISTRY_ACTION_TIMEOUT = TimeValue.THIRTY_SECONDS; // TODO should this be longer?
+    /**
+     * This map matches node features with predicates to detect when a template requires that feature.
+     * This allows the registry to install the template only after the cluster fully supports a feature.
+     */
+    protected static final Map<NodeFeature, Predicate<Template>> NODE_FEATURE_FILTERS = Map.of();
+    private final Map<NodeFeature, Predicate<Template>> nodeFeatureFilters;
+    // This flag short-circuits the node feature check, if all node features are supported.
+    private volatile boolean allFeaturesSupported = false;
+    private final FeatureService featureService;
 
     protected final Settings settings;
     protected final Client client;
@@ -127,13 +140,26 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         new ConcurrentHashMap<>();
     protected final List<LifecyclePolicy> lifecyclePolicies;
 
+    public IndexTemplateRegistry(
+        Settings nodeSettings,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
+    ) {
+        this(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService, NODE_FEATURE_FILTERS);
+    }
+
     @SuppressWarnings("this-escape")
     public IndexTemplateRegistry(
         Settings nodeSettings,
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService,
+        Map<NodeFeature, Predicate<Template>> nodeFeatureFilters
     ) {
         this.settings = nodeSettings;
         this.client = client;
@@ -147,6 +173,8 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         } else {
             this.lifecyclePolicies = List.of();
         }
+        this.featureService = featureService;
+        this.nodeFeatureFilters = nodeFeatureFilters;
     }
 
     /**
@@ -266,6 +294,53 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     }
 
     /**
+     * Retrieves return a list of {@link IndexTemplateConfig} that represents
+     * the component templates that are supported by all nodes of the cluster.
+     * Component templates are always installed prior composable templates, so they may
+     * be referenced by a composable template.
+     * @return The configurations for the templates that CAN be installed right now.
+     */
+    protected Map<String, ComponentTemplate> getComponentTemplatesReadyToInstall(ClusterState clusterState) {
+        return filterBasedOnFeatures(clusterState, getComponentTemplateConfigs(), ComponentTemplate::template);
+    }
+
+    /**
+     * Retrieves return a list of {@link IndexTemplateConfig} that represents
+     * the composable templates that are supported by all nodes of the cluster.
+     * @return The configurations for the templates that CAN be installed right now.
+     */
+    protected Map<String, ComposableIndexTemplate> getComposableTemplatesReadyToInstall(ClusterState clusterState) {
+        return filterBasedOnFeatures(clusterState, getComposableTemplateConfigs(), ComposableIndexTemplate::template);
+    }
+
+    /**
+     * Returns only templates that are supported by all nodes. This is useful during rolling upgrades
+     * to protect the cluster from installing templates that have features that are not supported by
+     * the nodes that haven't been upgraded yet.
+     * Visible for testing
+     */
+    <T> Map<String, T> filterBasedOnFeatures(ClusterState clusterState, Map<String, T> templates, Function<T, Template> templateExtractor) {
+        // Considering that allFeaturesSupported will be true eventually, we use this flag to
+        // short-circuit the check when the end state is reached.
+        if (allFeaturesSupported || templates.isEmpty()) {
+            return templates;
+        }
+        List<Predicate<Template>> unsupportedFeatures = nodeFeatureFilters.entrySet()
+            .stream()
+            .filter(entry -> featureService.clusterHasFeature(clusterState, entry.getKey()) == false)
+            .map(Map.Entry::getValue)
+            .toList();
+        if (unsupportedFeatures.isEmpty()) {
+            allFeaturesSupported = true;
+            return templates;
+        }
+        return templates.entrySet().stream().filter(entry -> {
+            Template template = templateExtractor.apply(entry.getValue());
+            return unsupportedFeatures.stream().noneMatch(p -> p.test(template));
+        }).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
      * Retrieves a list of {@link LifecyclePolicy} that represents the ILM
      * policies that should be installed and managed. Only called if ILM is enabled.
      * @return The lifecycle policies that should be installed.
@@ -342,7 +417,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         }
         for (ProjectMetadata project : event.state().metadata().projects().values()) {
             addIngestPipelinesIfMissing(project);
-            addTemplatesIfMissing(project);
+            addTemplatesIfMissing(event.state(), project);
             addIndexLifecyclePoliciesIfMissing(project);
         }
     }
@@ -364,10 +439,10 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         return false;
     }
 
-    private void addTemplatesIfMissing(ProjectMetadata project) {
+    private void addTemplatesIfMissing(ClusterState state, ProjectMetadata project) {
         addLegacyTemplatesIfMissing(project);
-        addComponentTemplatesIfMissing(project);
-        addComposableTemplatesIfMissing(project);
+        addComponentTemplatesIfMissing(state, project);
+        addComposableTemplatesIfMissing(state, project);
     }
 
     private void addLegacyTemplatesIfMissing(ProjectMetadata project) {
@@ -415,8 +490,8 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         }
     }
 
-    private void addComponentTemplatesIfMissing(ProjectMetadata project) {
-        final Map<String, ComponentTemplate> indexTemplates = getComponentTemplateConfigs();
+    private void addComponentTemplatesIfMissing(ClusterState state, ProjectMetadata project) {
+        final Map<String, ComponentTemplate> indexTemplates = getComponentTemplatesReadyToInstall(state);
         for (Map.Entry<String, ComponentTemplate> newTemplate : indexTemplates.entrySet()) {
             final String templateName = newTemplate.getKey();
             final AtomicBoolean creationCheck = templateCreationsInProgress.computeIfAbsent(project.id(), key -> new ConcurrentHashMap<>())
@@ -489,8 +564,8 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
         return true;
     }
 
-    private void addComposableTemplatesIfMissing(ProjectMetadata project) {
-        final Map<String, ComposableIndexTemplate> indexTemplates = getComposableTemplateConfigs();
+    private void addComposableTemplatesIfMissing(ClusterState state, ProjectMetadata project) {
+        final Map<String, ComposableIndexTemplate> indexTemplates = getComposableTemplatesReadyToInstall(state);
         for (Map.Entry<String, ComposableIndexTemplate> newTemplate : indexTemplates.entrySet()) {
             final String templateName = newTemplate.getKey();
             final AtomicBoolean creationCheck = templateCreationsInProgress.computeIfAbsent(project.id(), key -> new ConcurrentHashMap<>())
@@ -1024,5 +1099,10 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
             })
             .map(DataStream::getName)
             .collect(Collectors.toList());
+    }
+
+    // Visible for testing
+    protected boolean allFeaturesSupported() {
+        return allFeaturesSupported;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/YamlTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/YamlTemplateRegistry.java
@@ -13,10 +13,13 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -54,9 +57,10 @@ public abstract class YamlTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        this(nodeSettings, clusterService, threadPool, client, xContentRegistry, ignored -> true);
+        this(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService, ignored -> true, NODE_FEATURE_FILTERS);
     }
 
     @SuppressWarnings({ "unchecked", "this-escape" })
@@ -66,9 +70,11 @@ public abstract class YamlTemplateRegistry extends IndexTemplateRegistry {
         ThreadPool threadPool,
         Client client,
         NamedXContentRegistry xContentRegistry,
-        Predicate<String> templateFilter
+        FeatureService featureService,
+        Predicate<String> templateFilter,
+        Map<NodeFeature, Predicate<Template>> nodeFeatureFilters
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService, nodeFeatureFilters);
         try {
             final Map<String, Object> resources = XContentHelper.convertToMap(
                 YamlXContent.yamlXContent,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.admin.indices.template.put.TransportPutComposabl
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -28,6 +29,7 @@ import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -36,6 +38,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
@@ -62,6 +66,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -69,6 +74,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
@@ -79,12 +85,19 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class IndexTemplateRegistryTests extends ESTestCase {
+
+    // Matches the marker settings baked into the fixtures defined in TestRegistryWithNodeFeatureFilters.
+    private static final NodeFeature FEATURE_ONE = new NodeFeature("feature_one");
+    private static final NodeFeature FEATURE_TWO = new NodeFeature("feature_two");
+    private static final Predicate<Template> MATCHES_COMPONENT_TWO = t -> "1".equals(t.settings().get("index.number_of_replicas"));
+    private static final Predicate<Template> MATCHES_INDEX_TWO = t -> "2".equals(t.settings().get("index.number_of_shards"));
 
     private final ProjectId projectId = randomProjectIdOrDefault();
 
@@ -900,7 +913,8 @@ public class IndexTemplateRegistryTests extends ESTestCase {
                 clusterService,
                 threadPool,
                 client,
-                NamedXContentRegistry.EMPTY
+                NamedXContentRegistry.EMPTY,
+                new FeatureService(List.of())
             ) {
                 @Override
                 protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
@@ -940,7 +954,8 @@ public class IndexTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         ) {
             @Override
             protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
@@ -972,7 +987,8 @@ public class IndexTemplateRegistryTests extends ESTestCase {
                 clusterService,
                 threadPool,
                 client,
-                NamedXContentRegistry.EMPTY
+                NamedXContentRegistry.EMPTY,
+                new FeatureService(List.of())
             ) {
                 @Override
                 protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
@@ -1011,7 +1027,8 @@ public class IndexTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         ) {
             @Override
             protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
@@ -1071,7 +1088,292 @@ public class IndexTemplateRegistryTests extends ESTestCase {
         assertThat(IndexTemplateRegistry.findRolloverTargetDataStreams(project, "it5", it5), empty());
     }
 
-    // -------------
+    public void testNoFiltersReturnsAllTemplatesUnfiltered() {
+        TestRegistryWithNodeFeatureFilters registry = createRegistryWithFilters(Map.of());
+        ClusterState state = stateWithNodeFeatures();
+        Map<String, ComponentTemplate> componentTemplates = registry.getComponentTemplatesReadyToInstall(state);
+        Map<String, ComposableIndexTemplate> composableTemplates = registry.getComposableTemplatesReadyToInstall(state);
+        assertThat(componentTemplates.keySet(), containsInAnyOrder("test-one@component-template", "test-two@component-template"));
+        assertThat(composableTemplates.keySet(), containsInAnyOrder("test-index-one@template", "test-index-two@template"));
+        assertThat(registry.allFeaturesSupported(), equalTo(true));
+    }
+
+    public void testFeaturePresentOnAllNodesKeepsAllTemplates() {
+        TestRegistryWithNodeFeatureFilters registry = createRegistryWithFilters(Map.of(FEATURE_ONE, MATCHES_COMPONENT_TWO));
+        ClusterState state = stateWithNodeFeatures(FEATURE_ONE);
+        assertThat(
+            registry.getComponentTemplatesReadyToInstall(state).keySet(),
+            containsInAnyOrder("test-one@component-template", "test-two@component-template")
+        );
+        assertThat(
+            registry.getComposableTemplatesReadyToInstall(state).keySet(),
+            containsInAnyOrder("test-index-one@template", "test-index-two@template")
+        );
+        assertThat(registry.allFeaturesSupported(), equalTo(true));
+    }
+
+    public void testFeatureAbsentFiltersMatchingComponentTemplate() {
+        // FEATURE_ONE is not reported by any node, so templates matching its filter must be excluded.
+        TestRegistryWithNodeFeatureFilters registry = createRegistryWithFilters(Map.of(FEATURE_ONE, MATCHES_COMPONENT_TWO));
+        ClusterState state = stateWithNodeFeatures();
+        assertThat(registry.getComponentTemplatesReadyToInstall(state).keySet(), containsInAnyOrder("test-one@component-template"));
+        // Composable templates are unaffected, since the filter only matches component template "test-two@component-template".
+        assertThat(
+            registry.getComposableTemplatesReadyToInstall(state).keySet(),
+            containsInAnyOrder("test-index-one@template", "test-index-two@template")
+        );
+        assertThat(registry.allFeaturesSupported(), equalTo(false));
+    }
+
+    public void testFeatureAbsentFiltersMatchingComposableTemplate() {
+        TestRegistryWithNodeFeatureFilters registry = createRegistryWithFilters(Map.of(FEATURE_ONE, MATCHES_INDEX_TWO));
+        ClusterState state = stateWithNodeFeatures();
+        assertThat(
+            registry.getComponentTemplatesReadyToInstall(state).keySet(),
+            containsInAnyOrder("test-one@component-template", "test-two@component-template")
+        );
+        assertThat(registry.getComposableTemplatesReadyToInstall(state).keySet(), containsInAnyOrder("test-index-one@template"));
+        assertThat(registry.allFeaturesSupported(), equalTo(false));
+    }
+
+    public void testOnlyUnsupportedFeaturesFilterTemplates() {
+        // FEATURE_ONE is present cluster-wide so its filter is inert; FEATURE_TWO is absent so its filter applies.
+        TestRegistryWithNodeFeatureFilters registry = createRegistryWithFilters(
+            Map.of(FEATURE_ONE, MATCHES_COMPONENT_TWO, FEATURE_TWO, MATCHES_INDEX_TWO)
+        );
+        ClusterState stateWithFeatureOne = stateWithNodeFeatures(FEATURE_ONE);
+        assertThat(
+            registry.getComponentTemplatesReadyToInstall(stateWithFeatureOne).keySet(),
+            containsInAnyOrder("test-one@component-template", "test-two@component-template")
+        );
+        assertThat(
+            registry.getComposableTemplatesReadyToInstall(stateWithFeatureOne).keySet(),
+            containsInAnyOrder("test-index-one@template")
+        );
+        assertThat(registry.allFeaturesSupported(), equalTo(false));
+        // Second filter is also supported
+        ClusterState stateWithBothFeatures = stateWithNodeFeatures(FEATURE_ONE, FEATURE_TWO);
+        assertThat(
+            registry.getComponentTemplatesReadyToInstall(stateWithBothFeatures).keySet(),
+            containsInAnyOrder("test-one@component-template", "test-two@component-template")
+        );
+        assertThat(
+            registry.getComposableTemplatesReadyToInstall(stateWithBothFeatures).keySet(),
+            containsInAnyOrder("test-index-one@template", "test-index-two@template")
+        );
+        assertThat(registry.allFeaturesSupported(), equalTo(true));
+    }
+
+    public void testEmptyFilterMapReturnsSameMapInstance() {
+        TestRegistryWithNodeFeatureFilters registry = createRegistryWithFilters(Map.of());
+        ClusterState state = stateWithNodeFeatures();
+        // After the first call allFeaturesSupported is set to true; subsequent calls short-circuit
+        // and return the same backing map instance rather than building a new filtered copy.
+        Map<String, ComponentTemplate> first = registry.getComponentTemplatesReadyToInstall(state);
+        assertThat(registry.getComponentTemplatesReadyToInstall(state), sameInstance(first));
+        assertThat(registry.allFeaturesSupported(), equalTo(true));
+    }
+
+    /**
+     * Verifies the rolling-upgrade lifecycle of a feature-gated template:
+     * <ol>
+     *   <li>While the cluster is mixed (not all nodes report FEATURE_ONE), the composable template
+     *       that requires FEATURE_ONE is suppressed and only the unblocked template is installed.</li>
+     *   <li>Once all nodes report FEATURE_ONE the registry unblocks the gated template, installs it
+     *       on the next cluster-changed event, and marks {@code allFeaturesSupported} as {@code true}.</li>
+     * </ol>
+     */
+    public void testRollingUpgradeInstallsGatedTemplateAfterAllNodesUpgraded() throws Exception {
+        // Two-node cluster: local node is the master; otherNode is a second data node.
+        // Phase 1 simulates a rolling upgrade in progress: the local node has upgraded and reports
+        // FEATURE_ONE, but otherNode hasn't yet. The intersection across nodes is empty, so the
+        // feature is not considered cluster-wide and the gated template must stay suppressed.
+        DiscoveryNode localNode = clusterService.localNode();
+        DiscoveryNode otherNode = DiscoveryNodeUtils.create("other");
+        DiscoveryNodes twoNodes = DiscoveryNodes.builder()
+            .localNodeId(localNode.getId())
+            .masterNodeId(localNode.getId())
+            .add(localNode)
+            .add(otherNode)
+            .build();
+
+        Set<String> installedIndexTemplates = ConcurrentHashMap.newKeySet();
+        NoOpClient trackingClient = new NoOpClient(threadPool, TestProjectResolvers.usingRequestHeader(threadPool.getThreadContext())) {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected <Req extends ActionRequest, Resp extends ActionResponse> void doExecute(
+                ActionType<Resp> action,
+                Req request,
+                ActionListener<Resp> listener
+            ) {
+                if (action == TransportPutComposableIndexTemplateAction.TYPE) {
+                    installedIndexTemplates.add(((TransportPutComposableIndexTemplateAction.Request) request).name());
+                }
+                listener.onResponse((Resp) AcknowledgedResponse.TRUE);
+            }
+        };
+
+        // FEATURE_ONE gates test-index-two@template (matched by MATCHES_INDEX_TWO).
+        TestRegistryWithNodeFeatureFilters registry = new TestRegistryWithNodeFeatureFilters(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            trackingClient,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of()),
+            Map.of(FEATURE_ONE, MATCHES_INDEX_TWO)
+        );
+
+        // Phase 1: mixed cluster — local node reports FEATURE_ONE but otherNode does not.
+        // The feature intersection across all nodes is therefore empty, so test-index-two@template
+        // must be suppressed. The cluster state already has both component templates installed
+        // (prerequisite for composable templates) but no composable templates yet.
+        Map<String, Set<String>> mixedNodeFeatures = Map.of(localNode.getId(), Set.of(FEATURE_ONE.id()), otherNode.getId(), Set.of());
+        ClusterState phaseOneState = buildClusterStateForFeatureTest(
+            Map.of("test-one@component-template", 1L, "test-two@component-template", 1L),
+            Map.of(),
+            twoNodes,
+            mixedNodeFeatures
+        );
+        registry.clusterChanged(createClusterChangedEvent(twoNodes, phaseOneState));
+
+        assertBusy(() -> assertThat(installedIndexTemplates, containsInAnyOrder("test-index-one@template")));
+        assertThat(registry.allFeaturesSupported(), equalTo(false));
+
+        // Phase 2: otherNode has now upgraded — all nodes report FEATURE_ONE.
+        // The gated template must be installed on the next cluster-changed event.
+        // Cluster state reflects what was installed in phase 1: component templates and
+        // test-index-one@template are present, but test-index-two@template is still absent.
+        Map<String, Set<String>> allNodesUpgradedFeatures = Map.of(
+            localNode.getId(),
+            Set.of(FEATURE_ONE.id()),
+            otherNode.getId(),
+            Set.of(FEATURE_ONE.id())
+        );
+        ClusterState phaseTwoState = buildClusterStateForFeatureTest(
+            Map.of("test-one@component-template", 1L, "test-two@component-template", 1L),
+            Map.of("test-index-one@template", 1L),
+            twoNodes,
+            allNodesUpgradedFeatures
+        );
+        registry.clusterChanged(createClusterChangedEvent(twoNodes, phaseTwoState));
+
+        assertBusy(() -> assertThat(installedIndexTemplates, containsInAnyOrder("test-index-one@template", "test-index-two@template")));
+        assertThat(registry.allFeaturesSupported(), equalTo(true));
+    }
+
+    private ClusterState stateWithNodeFeatures(NodeFeature... features) {
+        DiscoveryNode localNode = clusterService.localNode();
+        Set<String> featureIds = Arrays.stream(features).map(NodeFeature::id).collect(Collectors.toUnmodifiableSet());
+        return ClusterState.builder(clusterService.state()).nodeFeatures(Map.of(localNode.getId(), featureIds)).build();
+    }
+
+    private TestRegistryWithNodeFeatureFilters createRegistryWithFilters(Map<NodeFeature, Predicate<Template>> nodeFeatureFilters) {
+        return new TestRegistryWithNodeFeatureFilters(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of()),
+            nodeFeatureFilters
+        );
+    }
+
+    private ClusterState buildClusterStateForFeatureTest(
+        Map<String, Long> componentTemplateVersions,
+        Map<String, Long> indexTemplateVersions,
+        DiscoveryNodes nodes,
+        Map<String, Set<String>> nodeFeaturesByNode
+    ) {
+        Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
+        for (Map.Entry<String, Long> entry : componentTemplateVersions.entrySet()) {
+            ComponentTemplate mockTemplate = mock(ComponentTemplate.class);
+            when(mockTemplate.version()).thenReturn(entry.getValue());
+            componentTemplates.put(entry.getKey(), mockTemplate);
+        }
+
+        ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(Metadata.DEFAULT_PROJECT_ID)
+            .componentTemplates(componentTemplates);
+        for (Map.Entry<String, Long> entry : indexTemplateVersions.entrySet()) {
+            ComposableIndexTemplate mockTemplate = mock(ComposableIndexTemplate.class);
+            when(mockTemplate.version()).thenReturn(entry.getValue());
+            projectBuilder.put(entry.getKey(), mockTemplate);
+        }
+
+        ClusterState.Builder stateBuilder = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().transientSettings(Settings.EMPTY).put(projectBuilder.build()).build())
+            .blocks(new ClusterBlocks.Builder().build())
+            .nodes(nodes);
+        if (nodeFeaturesByNode.isEmpty() == false) {
+            stateBuilder.nodeFeatures(nodeFeaturesByNode);
+        }
+        return stateBuilder.build();
+    }
+
+    /**
+     * Minimal {@link IndexTemplateRegistry} that provides two component templates and two composable
+     * templates with distinct settings, used to exercise node-feature-based template filtering.
+     * <p>
+     * The settings baked into the templates match the predicates {@link #MATCHES_COMPONENT_TWO} and
+     * {@link #MATCHES_INDEX_TWO}: {@code test-two@component-template} has
+     * {@code index.number_of_replicas=1} and {@code test-index-two@template} has
+     * {@code index.number_of_shards=2}.
+     */
+    static class TestRegistryWithNodeFeatureFilters extends IndexTemplateRegistry {
+
+        private final Map<String, ComponentTemplate> componentTemplates;
+        private final Map<String, ComposableIndexTemplate> composableTemplates;
+
+        TestRegistryWithNodeFeatureFilters(
+            Settings nodeSettings,
+            ClusterService clusterService,
+            ThreadPool threadPool,
+            Client client,
+            NamedXContentRegistry xContentRegistry,
+            FeatureService featureService,
+            Map<NodeFeature, Predicate<Template>> nodeFeatureFilters
+        ) {
+            super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService, nodeFeatureFilters);
+            componentTemplates = Map.of(
+                "test-one@component-template",
+                new ComponentTemplate(new Template(Settings.builder().put("index.number_of_replicas", 0).build(), null, null), 1L, null),
+                "test-two@component-template",
+                new ComponentTemplate(new Template(Settings.builder().put("index.number_of_replicas", 1).build(), null, null), 1L, null)
+            );
+            composableTemplates = Map.of(
+                "test-index-one@template",
+                ComposableIndexTemplate.builder()
+                    .indexPatterns(List.of("test-index-one-*"))
+                    .template(new Template(Settings.builder().put("index.number_of_shards", 1).build(), null, null))
+                    .componentTemplates(List.of("test-one@component-template"))
+                    .version(1L)
+                    .build(),
+                "test-index-two@template",
+                ComposableIndexTemplate.builder()
+                    .indexPatterns(List.of("test-index-two-*"))
+                    .template(new Template(Settings.builder().put("index.number_of_shards", 2).build(), null, null))
+                    .componentTemplates(List.of("test-two@component-template"))
+                    .version(1L)
+                    .build()
+            );
+        }
+
+        @Override
+        protected Map<String, ComponentTemplate> getComponentTemplateConfigs() {
+            return componentTemplates;
+        }
+
+        @Override
+        protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
+            return composableTemplates;
+        }
+
+        @Override
+        protected String getOrigin() {
+            return "test";
+        }
+    }
 
     /**
      * A client that delegates to a verifying function for action/request/listener

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/TestRegistryWithCustomPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/TestRegistryWithCustomPlugin.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
@@ -47,7 +48,7 @@ class TestRegistryWithCustomPlugin extends IndexTemplateRegistry {
         Client client,
         NamedXContentRegistry xContentRegistry
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, new FeatureService(List.of()));
         this.threadPool = threadPool;
     }
 

--- a/x-pack/plugin/core/src/test/resources/component-templates/test-one@component-template.yaml
+++ b/x-pack/plugin/core/src/test/resources/component-templates/test-one@component-template.yaml
@@ -1,0 +1,12 @@
+version: ${test.template.version}
+_meta:
+  description: Test component template one
+  managed: true
+template:
+  settings:
+    index:
+      number_of_replicas: 0
+  mappings:
+    properties:
+      field_one:
+        type: keyword

--- a/x-pack/plugin/core/src/test/resources/component-templates/test-two@component-template.yaml
+++ b/x-pack/plugin/core/src/test/resources/component-templates/test-two@component-template.yaml
@@ -1,0 +1,12 @@
+version: ${test.template.version}
+_meta:
+  description: Test component template two
+  managed: true
+template:
+  settings:
+    index:
+      number_of_replicas: 1
+  mappings:
+    properties:
+      field_two:
+        type: keyword

--- a/x-pack/plugin/core/src/test/resources/index-templates/test-index-one@template.yaml
+++ b/x-pack/plugin/core/src/test/resources/index-templates/test-index-one@template.yaml
@@ -1,0 +1,14 @@
+version: ${test.template.version}
+index_patterns: ["test-index-one-*"]
+priority: 100
+data_stream: {}
+allow_auto_create: true
+_meta:
+  description: Test index template one
+  managed: true
+composed_of:
+  - test-one@component-template
+template:
+  settings:
+    index:
+      number_of_shards: 1

--- a/x-pack/plugin/core/src/test/resources/index-templates/test-index-two@template.yaml
+++ b/x-pack/plugin/core/src/test/resources/index-templates/test-index-two@template.yaml
@@ -1,0 +1,14 @@
+version: ${test.template.version}
+index_patterns: ["test-index-two-*"]
+priority: 100
+data_stream: {}
+allow_auto_create: true
+_meta:
+  description: Test index template two
+  managed: true
+composed_of:
+  - test-two@component-template
+template:
+  settings:
+    index:
+      number_of_shards: 2

--- a/x-pack/plugin/core/src/test/resources/resources.yaml
+++ b/x-pack/plugin/core/src/test/resources/resources.yaml
@@ -1,0 +1,11 @@
+# Minimal template registry used by YamlTemplateRegistryTests to exercise
+# node-feature-based template filtering without pulling in a real plugin's resources.
+version: 1
+
+component-templates:
+  - test-one@component-template
+  - test-two@component-template
+
+index-templates:
+  - test-index-one@template
+  - test-index-two@template

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/Deprecation.java
@@ -72,7 +72,8 @@ public class Deprecation extends Plugin implements ActionPlugin {
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         templateRegistry.initialize();
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -45,9 +46,10 @@ public class DeprecationIndexingTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     private final Map<String, ComponentTemplate> componentTemplates = parseComponentTemplates(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -465,7 +465,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         analyticsTemplateRegistry.initialize();
 
@@ -474,7 +475,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         connectorTemplateRegistry.initialize();
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.UpdateForV10;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -89,9 +90,10 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+        super(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -127,9 +128,10 @@ public class ConnectorTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+        super(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -76,7 +77,13 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
         threadPool = new TestThreadPool(this.getClass().getName());
         client = new VerifyingClient(threadPool);
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        registry = new AnalyticsTemplateRegistry(clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+        registry = new AnalyticsTemplateRegistry(
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
+        );
     }
 
     @After

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistryTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -79,7 +80,13 @@ public class ConnectorTemplateRegistryTests extends ESTestCase {
         threadPool = new TestThreadPool(this.getClass().getName());
         client = new VerifyingClient(threadPool);
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        registry = new ConnectorTemplateRegistry(clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+        registry = new ConnectorTemplateRegistry(
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
+        );
     }
 
     @After

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -89,7 +89,8 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         registry.initialize();
         return List.of();

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -67,9 +68,10 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -235,7 +235,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
                 services.clusterService(),
                 services.threadPool(),
                 services.client(),
-                services.xContentRegistry()
+                services.xContentRegistry(),
+                services.featureService()
             );
             indexTemplateRegistry.initialize();
             return List.of(indexTemplateRegistry);

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/IdentityProviderPlugin.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/IdentityProviderPlugin.java
@@ -78,7 +78,8 @@ public class IdentityProviderPlugin extends Plugin implements ActionPlugin {
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         indexTemplateRegistry.initialize();
 

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTemplateRegistry.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTemplateRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.idp.saml.sp;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -31,9 +32,10 @@ public class SamlServiceProviderIndexTemplateRegistry extends IndexTemplateRegis
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -152,7 +152,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         ilmTemplateRegistry.initialize();
         ilmHistoryStore.set(

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -55,9 +56,10 @@ public class ILMHistoryTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.ilmHistoryEnabled = LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.get(nodeSettings);
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -84,7 +85,8 @@ public class ILMHistoryStoreTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         ClusterState state = clusterService.state();
         projectId = randomProjectIdOrDefault();

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigratePlugin.java
@@ -84,7 +84,8 @@ public class MigratePlugin extends Plugin implements ActionPlugin, PersistentTas
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         registry.initialize();
         return List.of(registry);

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigrateTemplateRegistry.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/MigrateTemplateRegistry.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.migrate;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -31,9 +32,10 @@ public class MigrateTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1067,7 +1067,8 @@ public class MachineLearning extends Plugin
             threadPool,
             client,
             canUseIlm,
-            xContentRegistry
+            xContentRegistry,
+            services.featureService()
         );
         registry.initialize();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -10,6 +10,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -126,9 +127,10 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
         ThreadPool threadPool,
         Client client,
         boolean useIlm,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.useIlm = useIlm;
         this.composableIndexTemplateConfigs = parseComposableTemplates(
             anomalyDetectionResultsTemplate(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -35,6 +36,8 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFiel
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -88,7 +91,8 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
             threadPool,
             client,
             true,
-            xContentRegistry
+            xContentRegistry,
+            new FeatureService(List.of())
         );
 
         registry.clusterChanged(createClusterChangedEvent(nodes));
@@ -119,7 +123,8 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
             threadPool,
             client,
             true,
-            xContentRegistry
+            xContentRegistry,
+            new FeatureService(List.of())
         );
 
         registry.clusterChanged(createClusterChangedEvent(nodes));
@@ -146,7 +151,8 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
             threadPool,
             client,
             false,
-            xContentRegistry
+            xContentRegistry,
+            new FeatureService(List.of())
         );
 
         registry.clusterChanged(createClusterChangedEvent(nodes));

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
@@ -157,7 +157,8 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
             clusterService,
             threadPool,
             client,
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         templateRegistry.initialize();
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -243,9 +244,10 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.clusterService = clusterService;
         this.monitoringTemplatesEnabled = MONITORING_TEMPLATES_ENABLED.get(nodeSettings);
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistryTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistryTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -84,7 +85,14 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
         threadPool = new TestThreadPool(this.getClass().getName());
         client = new VerifyingClient(threadPool);
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        registry = new MonitoringTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+        registry = new MonitoringTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
+        );
     }
 
     @After
@@ -117,7 +125,8 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         assertThat(disabledRegistry.getLegacyTemplateConfigs(), is(empty()));
         assertThat(disabledRegistry.getComposableTemplateConfigs(), anEmptyMap());
@@ -196,7 +205,8 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
                 clusterService,
                 threadPool,
                 client,
-                NamedXContentRegistry.EMPTY
+                NamedXContentRegistry.EMPTY,
+                new FeatureService(List.of())
             );
             testRegistry.clusterChanged(event);
         } else {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelIndexTemplateRegistry.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelIndexTemplateRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.oteldata;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -26,9 +27,10 @@ public class OTelIndexTemplateRegistry extends YamlTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
@@ -92,7 +92,14 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
         ClusterService clusterService = services.clusterService();
         indexingPressure.set(services.indexingPressure());
         registry.set(
-            new OTelIndexTemplateRegistry(settings, clusterService, services.threadPool(), services.client(), services.xContentRegistry())
+            new OTelIndexTemplateRegistry(
+                settings,
+                clusterService,
+                services.threadPool(),
+                services.client(),
+                services.xContentRegistry(),
+                services.featureService()
+            )
         );
         if (enabled) {
             OTelIndexTemplateRegistry registryInstance = registry.get();

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -91,7 +91,16 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         ThreadPool threadPool = services.threadPool();
 
         logger.info("Profiling is {}", enabled ? "enabled" : "disabled");
-        registry.set(new ProfilingIndexTemplateRegistry(settings, clusterService, threadPool, client, services.xContentRegistry()));
+        registry.set(
+            new ProfilingIndexTemplateRegistry(
+                settings,
+                clusterService,
+                threadPool,
+                client,
+                services.xContentRegistry(),
+                services.featureService()
+            )
+        );
         indexStateResolver.set(new IndexStateResolver(PROFILING_CHECK_OUTDATED_INDICES.get(settings)));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_CHECK_OUTDATED_INDICES, this::updateCheckOutdatedIndices);
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -75,9 +76,10 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     public void setTemplatesEnabled(boolean templatesEnabled) {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistryTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -76,7 +77,14 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
         threadPool = new TestThreadPool(this.getClass().getName());
         client = new VerifyingClient(threadPool);
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        registry = new ProfilingIndexTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+        registry = new ProfilingIndexTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
+        );
         registry.setTemplatesEnabled(true);
     }
 

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusIndexTemplateRegistry.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusIndexTemplateRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.prometheus;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -26,9 +27,10 @@ public class PrometheusIndexTemplateRegistry extends YamlTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusPlugin.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/PrometheusPlugin.java
@@ -70,7 +70,8 @@ public class PrometheusPlugin extends Plugin implements ActionPlugin {
                 clusterService,
                 services.threadPool(),
                 services.client(),
-                services.xContentRegistry()
+                services.xContentRegistry(),
+                services.featureService()
             )
         );
         if (enabled) {

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
@@ -120,7 +120,8 @@ public class SnapshotLifecycle extends Plugin implements ActionPlugin, HealthPlu
             clusterService,
             threadPool,
             client,
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         templateRegistry.initialize();
         snapshotHistoryStore.set(new SnapshotHistoryStore(new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN), clusterService));

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistry.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistry.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
@@ -63,9 +64,10 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         slmHistoryEnabled = SLM_HISTORY_INDEX_ENABLED_SETTING.get(nodeSettings);
     }
 

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistryTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistryTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -102,7 +103,14 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
             )
         );
         xContentRegistry = new NamedXContentRegistry(entries);
-        registry = new SnapshotLifecycleTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+        registry = new SnapshotLifecycleTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry,
+            new FeatureService(List.of())
+        );
     }
 
     @After
@@ -119,7 +127,8 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            xContentRegistry
+            xContentRegistry,
+            new FeatureService(List.of())
         );
         assertThat(disabledRegistry.getComposableTemplateConfigs(), anEmptyMap());
         assertThat(disabledRegistry.getLifecyclePolicies(), hasSize(0));

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -87,9 +88,10 @@ public class LegacyStackTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.clusterService = clusterService;
         this.stackTemplateEnabled = STACK_TEMPLATES_ENABLED.get(nodeSettings);
     }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -63,9 +64,10 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.queryLoggingRegistryEnabled = QUERY_LOGGING_REGISTRY_ENABLED.get(nodeSettings);
     }
 

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackPlugin.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackPlugin.java
@@ -33,7 +33,8 @@ public class StackPlugin extends Plugin implements ActionPlugin {
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         legacyStackTemplateRegistry.initialize();
         StackTemplateRegistry stackTemplateRegistry = new StackTemplateRegistry(
@@ -41,7 +42,8 @@ public class StackPlugin extends Plugin implements ActionPlugin {
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         stackTemplateRegistry.initialize();
         QueryLoggingTemplateRegistry queryLoggingTemplateRegistry = new QueryLoggingTemplateRegistry(
@@ -49,7 +51,8 @@ public class StackPlugin extends Plugin implements ActionPlugin {
             services.clusterService(),
             services.threadPool(),
             services.client(),
-            services.xContentRegistry()
+            services.xContentRegistry(),
+            services.featureService()
         );
         queryLoggingTemplateRegistry.initialize();
         return List.of(legacyStackTemplateRegistry, stackTemplateRegistry, queryLoggingTemplateRegistry);

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -118,9 +119,10 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         this.clusterService = clusterService;
         this.stackTemplateEnabled = STACK_TEMPLATES_ENABLED.get(nodeSettings);
         this.componentTemplateConfigs = parseComponentTemplates(getComponentTemplateConfigsAsConfigs());

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistryTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -24,6 +25,8 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.List;
+
 public class LegacyStackTemplateRegistryTests extends ESTestCase {
     private LegacyStackTemplateRegistry registry;
     private ThreadPool threadPool;
@@ -33,7 +36,14 @@ public class LegacyStackTemplateRegistryTests extends ESTestCase {
         threadPool = new TestThreadPool(this.getClass().getName());
         Client client = new NoOpClient(threadPool);
         ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        registry = new LegacyStackTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+        registry = new LegacyStackTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
+        );
     }
 
     @After

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistryTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -51,7 +52,8 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             new NoOpClient(threadPool),
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         assertThat(registry.getComposableTemplateConfigs(), anEmptyMap());
         assertThat(registry.getComponentTemplateConfigs(), anEmptyMap());
@@ -65,7 +67,8 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             new NoOpClient(threadPool),
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         assertThat(registry.getComposableTemplateConfigs(), not(anEmptyMap()));
         assertThat(registry.getComponentTemplateConfigs(), not(anEmptyMap()));
@@ -79,7 +82,8 @@ public class QueryLoggingTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             new NoOpClient(threadPool),
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         ComponentTemplate mappingsTemplate = registry.getComponentTemplateConfigs()
             .get(QueryLoggingTemplateRegistry.QUERY_LOGGING_MAPPINGS_NAME);

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackRegistryWithNonRequiredTemplates.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackRegistryWithNonRequiredTemplates.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
@@ -23,9 +24,10 @@ class StackRegistryWithNonRequiredTemplates extends StackTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
     }
 
     @Override

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -91,7 +92,14 @@ public class StackTemplateRegistryTests extends ESTestCase {
         threadPool = new TestThreadPool(this.getClass().getName());
         client = new VerifyingClient(threadPool);
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
-        registry = new StackTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+        registry = new StackTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
+        );
     }
 
     @After
@@ -108,7 +116,8 @@ public class StackTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         assertThat(disabledRegistry.getComposableTemplateConfigs(), anEmptyMap());
     }
@@ -120,7 +129,8 @@ public class StackTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
         assertThat(disabledRegistry.getComponentTemplateConfigs(), not(anEmptyMap()));
         assertThat(
@@ -364,7 +374,8 @@ public class StackTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            new FeatureService(List.of())
         );
 
         DiscoveryNode node = DiscoveryNodeUtils.create("node");

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/templates/StatelessTemplateSettingsDecoratorProviderIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/templates/StatelessTemplateSettingsDecoratorProviderIT.java
@@ -67,7 +67,8 @@ public class StatelessTemplateSettingsDecoratorProviderIT extends AbstractStatel
                 services.clusterService(),
                 services.threadPool(),
                 services.client(),
-                services.xContentRegistry()
+                services.xContentRegistry(),
+                services.featureService()
             );
         }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -337,7 +337,8 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
             clusterService,
             threadPool,
             client,
-            xContentRegistry
+            xContentRegistry,
+            services.featureService()
         );
         templateRegistry.initialize();
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.NotMultiProjectCapable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
@@ -54,9 +55,10 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
         ClusterService clusterService,
         ThreadPool threadPool,
         Client client,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
         ilmManagementEnabled = Watcher.USE_ILM_INDEX_MANAGEMENT.get(nodeSettings);
         composableTemplates = ilmManagementEnabled
             ? parseComposableTemplates(WATCH_HISTORY_CONFIG)

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.NotMultiProjectCapable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -107,7 +108,14 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
             )
         );
         xContentRegistry = new NamedXContentRegistry(entries);
-        registry = new WatcherIndexTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+        registry = new WatcherIndexTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry,
+            new FeatureService(List.of())
+        );
     }
 
     public void testThatNonExistingTemplatesAreAddedImmediately() {
@@ -142,7 +150,8 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            xContentRegistry
+            xContentRegistry,
+            new FeatureService(List.of())
         );
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
         registry.clusterChanged(event);
@@ -192,7 +201,8 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
             clusterService,
             threadPool,
             client,
-            xContentRegistry
+            xContentRegistry,
+            new FeatureService(List.of())
         );
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
         registry.clusterChanged(event);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Add conditional loading of templates based on node features (#154567)](https://github.com/elastic/elasticsearch/pull/154567)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)