### PR TITLE
Remove duplicated number field mapper tests

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -93,23 +93,6 @@ public class ScaledFloatFieldMapperTests extends NumberFieldMapperTests {
         return true;
     }
 
-    public void testExistsQueryDocValuesDisabled() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("doc_values", false);
-        }));
-        assertExistsQuery(mapperService);
-        assertParseMinimalWarnings();
-    }
-
-    public void testAggregationsDocValuesDisabled() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("doc_values", false);
-        }));
-        assertAggregatableConsistency(mapperService.fieldType("field"));
-    }
-
     public void testDefaults() throws Exception {
         XContentBuilder mapping = fieldMapping(b -> b.field("type", "scaled_float").field("scaling_factor", 10.0));
         DocumentMapper mapper = createDocumentMapper(mapping);
@@ -333,14 +316,6 @@ public class ScaledFloatFieldMapperTests extends NumberFieldMapperTests {
                 containsString("Unknown value [unknown] for field [time_series_metric] - accepted values are [gauge, counter]")
             );
         }
-    }
-
-    public void testMetricAndDocvalues() {
-        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("time_series_metric", "counter").field("doc_values", false);
-        })));
-        assertThat(e.getCause().getMessage(), containsString("Field [time_series_metric] requires that [doc_values] is true"));
     }
 
     public void testTimeSeriesIndexDefault() throws Exception {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -223,15 +223,6 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
         }
     }
 
-    public void testExistsQueryDocValuesDisabled() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("doc_values", false);
-        }));
-        assertExistsQuery(mapperService);
-        assertParseMinimalWarnings();
-    }
-
     public void testDimension() throws IOException {
         // Test default setting
         MapperService mapperService = createMapperService(fieldMapping(b -> minimalMapping(b)));
@@ -242,23 +233,6 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
         assertDimension(false, UnsignedLongFieldMapper.UnsignedLongFieldType::isDimension);
 
         assertTimeSeriesIndexing();
-    }
-
-    public void testDimensionIndexedAndDocvalues() {
-        {
-            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
-                minimalMapping(b);
-                b.field("time_series_dimension", true).field("index", false).field("doc_values", false);
-            })));
-            assertThat(e.getCause().getMessage(), containsString("Field [time_series_dimension] requires that [doc_values] is true"));
-        }
-        {
-            Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
-                minimalMapping(b);
-                b.field("time_series_dimension", true).field("index", true).field("doc_values", false);
-            })));
-            assertThat(e.getCause().getMessage(), containsString("Field [time_series_dimension] requires that [doc_values] is true"));
-        }
     }
 
     public void testDimensionMultiValuedFieldTSDB() throws IOException {
@@ -318,25 +292,6 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
                 containsString("Unknown value [unknown] for field [time_series_metric] - accepted values are [gauge, counter]")
             );
         }
-    }
-
-    public void testMetricAndDocvalues() {
-        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("time_series_metric", "counter").field("doc_values", false);
-        })));
-        assertThat(e.getCause().getMessage(), containsString("Field [time_series_metric] requires that [doc_values] is true"));
-    }
-
-    public void testMetricAndDimension() {
-        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("time_series_metric", "counter").field("time_series_dimension", true);
-        })));
-        assertThat(
-            e.getCause().getMessage(),
-            containsString("Field [time_series_dimension] cannot be set in conjunction with field [time_series_metric]")
-        );
     }
 
     public void testTimeSeriesIndexDefault() throws Exception {


### PR DESCRIPTION
`ScaledFloatFieldMapperTests` and `UnsignedLongFieldMapperTests` override several test methods with byte-identical copies of the base class versions in `NumberFieldMapperTests` / `WholeNumberFieldMapperTests` (left over from when these classes got their own copies before the shared base was adopted). This removes them so the inherited tests run instead: same coverage, no risk of the copies drifting when base tests evolve.

- `ScaledFloatFieldMapperTests`: `testExistsQueryDocValuesDisabled`, `testAggregationsDocValuesDisabled`, `testMetricAndDocvalues`
- `UnsignedLongFieldMapperTests`: `testExistsQueryDocValuesDisabled`, `testDimensionIndexedAndDocvalues`, `testMetricAndDocvalues`, `testMetricAndDimension`

The remaining same-named overrides are intentionally kept: they either assert type-specific encoding (e.g. scaled_float's `LongField <field:1230>`) or cast to their own field type where the base version would `ClassCastException`.

Verified with `:modules:mapper-extras:test` and `:x-pack:plugin:mapper-unsigned-long:test` (91 and 93 tests, 0 failures) plus `spotlessJavaCheck`.

Relates to #92947