### PR TITLE
[Investigation] Non-finite IEEE-754 doubles in ES|QL

### DIFF
--- a/NON_FINITE_FINDINGS.md
+++ b/NON_FINITE_FINDINGS.md
@@ -6,6 +6,12 @@
 > (via `EsqlDataTypeConverter.stringToDoubleAllowNonFinite`), gated on capability
 > `to_double_non_finite`.  
 > **How to reproduce**: All CsvIT results are in `non_finite_doubles.csv-spec` and run green.
+>
+> **Policy context**: ES|QL's historical design goal was that non-finite doubles must not appear in
+> responses — the `asFiniteNumber` guards and null+warning pattern enforce this. SUM overflow
+> producing `Infinity` was considered a bug, not a feature. That policy is now under review:
+> ES|QL may move to fully supporting non-finite doubles. This investigation maps what would need
+> to change and what already works correctly.
 
 ---
 
@@ -47,9 +53,10 @@ All non-finite doubles are real, non-null values. Both predicates behave correct
 | `-Infinity IS NULL`         | `false` | `true` |
 | `-0.0 IS NULL`              | `false` | `true` |
 
-**Assessment**: correct, and consistent with every SQL-family database that admits non-finite floats
-(PostgreSQL `FLOAT8`, DuckDB, BigQuery `FLOAT64`, Spark SQL, ClickHouse, Trino). The databases that
-don't support non-finite floats at all (MySQL, SQL Server, Oracle) never face this question.
+**Assessment**: correct. Among databases that admit non-finite floats as first-class values
+(PostgreSQL `FLOAT8`, Snowflake `FLOAT`, BigQuery `FLOAT64` — all confirmed to support NaN/Inf),
+`IS NULL` correctly returns false for them; non-finite is not the same as absent. Databases that
+reject non-finite floats entirely (MySQL, SQL Server) never encounter this case.
 
 The only subtlety: ES|QL null semantics map to the absence of a value in a block slot, which is a
 separate concept from IEEE-754 "not a number". `NaN` occupies a real slot with a real bit pattern —
@@ -424,23 +431,23 @@ This is a **bug**: the range check happens to not catch NaN because `NaN > x` an
 both false in IEEE-754. The fix is to add an explicit `Double.isNaN(x)` check (or use
 `Double.isFinite(x)`) before the range comparison in `safeToInt(double)`.
 
-**Cross-database comparison**:
+**Cross-database comparison** (sourced):
 
-| Database | `CAST(NaN AS INTEGER)` | Notes |
+| Database | `CAST(NaN AS INTEGER)` | Source |
 |---|---|---|
-| PostgreSQL | **ERROR** | Explicit `isnan()` guard in `dtoi4`; same for int2/int8. Confirmed. |
-| DuckDB ≥v1.3.0 | **ERROR** (`TRY_CAST` → NULL) | Strict error introduced in v1.3.0; older DuckDB behavior may differ. |
-| ClickHouse ≥v21 | **ERROR** | Added explicit check after bug reports |
-| ClickHouse <v21 | INT32_MIN or 0 (UB) | C++ undefined behavior; acknowledged bug |
-| Spark SQL (ANSI / 4.0+) | **ERROR** (`TRY_CAST` → NULL) | Confirmed for ANSI mode. |
-| Spark SQL (non-ANSI) | **0 or NULL** (unverified) | Java `(int) Double.NaN` = 0; if Spark uses Java narrowing without an explicit NaN check, result is 0 not NULL. Requires source-level or empirical verification. |
-| Trino (current) | **ERROR** (`TRY_CAST` → NULL) | Silent-0 was the old behavior (shared with the Facebook Presto ancestor), fixed as a bug. Direct Trino-specific fix not confirmed; Presto PR #22917 corroborates. |
-| BigQuery | **Plausibly ERROR** (`SAFE_CAST` → NULL) | `SAFE_CAST → NULL` is confirmed for any failed cast; the NaN-specific CAST error path is unverified. |
-| **ES\|QL** | **0, no warning** | Matches the old Presto bug, now corrected in Trino |
+| PostgreSQL | **ERROR** — explicit `isnan()` guard in `dtoi4` (int4, int2, int8 all checked) | [PostgreSQL source: float8_to_int4](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/float.c) |
+| DuckDB | **ERROR** (`TRY_CAST` → NULL) — NaN/Inf to integer cast throws; open JSON serialization bug (#17329) separate issue | [DuckDB issue #17329](https://github.com/duckdb/duckdb/issues/17329); [DuckDB issue #14905](https://github.com/duckdb/duckdb/issues/14905) |
+| Spark SQL (ANSI / 4.0+) | **ERROR** (`TRY_CAST` → NULL) | [Spark JSON docs — allowNonNumericNumbers](https://spark.apache.org/docs/latest/sql-data-sources-json.html); [SPARK-38060](https://issues.apache.org/jira/browse/SPARK-38060) |
+| Spark SQL (non-ANSI) | **0 or NULL** (unverified — Java `(int) Double.NaN` = 0 without explicit guard) | No confirmed primary source for exact Spark non-ANSI behavior |
+| Trino | **ERROR** at Hive JSON file write (since release 469, Jan 2025); REST client API behavior for NaN in DOUBLE column not explicitly documented | [Trino PR #24558](https://github.com/trinodb/trino/pull/24558); [Trino release 469](https://trino.io/docs/current/release/release-469.html) |
+| Snowflake | FLOAT **supports** NaN/Inf natively; JSON API returns them as strings (exact format unspecified in docs) | [Snowflake numeric types](https://docs.snowflake.com/en/sql-reference/data-types-numeric); [Snowflake SQL API response format](https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses) |
+| BigQuery | FLOAT64 **supports** NaN/Inf; REST API returns JSON strings `"NaN"`, `"+inf"`, `"-inf"` — confirmed by client library bug report | [google-cloud-ruby #3488](https://github.com/googleapis/google-cloud-ruby/issues/3488); [BigQuery FLOAT64 docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) |
+| **ES\|QL** | **0, no warning** — NaN bypasses `> MAX \|\| < MIN` guard because NaN comparisons always return false | This investigation |
 
-The industry consensus is: strict CAST → error, TRY_CAST/SAFE_CAST → NULL. Silent zero is
-universally treated as a bug. ES|QL's behavior matches the historical Presto/Trino bug that Trino
-has since corrected and ClickHouse's pre-v21 undefined-behavior path.
+The consensus for `CAST(NaN AS INTEGER)` is error (strict) or NULL (safe cast). Silent zero is
+universally treated as a bug. ES|QL currently matches the class of pre-fix behavior seen in older
+database versions. Note that Snowflake and BigQuery take the opposite approach on non-finite floats
+generally: they treat NaN/Inf as first-class FLOAT values rather than errors.
 
 ### TO_LONG (double → long)
 
@@ -455,7 +462,7 @@ has since corrected and ClickHouse's pre-v21 undefined-behavior path.
 | `-0.0`     | `0`            | Correct |
 
 **Key finding**: `TO_LONG(NaN)` is the same bug as `TO_INTEGER(NaN)` — silently returns `0`.
-The cross-database picture is identical to TO_INTEGER: every modern database errors on this cast.
+The cross-database picture is identical to TO_INTEGER (see sourced table above).
 
 ### TO_UNSIGNED_LONG (double → unsigned_long)
 
@@ -667,14 +674,44 @@ correct answer (match-none), but for the wrong reason.
 
 ### D1 — Three output formats produce three different representations of the same non-finite value
 
-| Format | Output for `Infinity` in a `double` column | Parses back? |
-|---|---|---|
-| **JSON** | bare string `"Infinity"` (Jackson default, not in a JSON string literal) | No — invalid JSON number; clients parsing `double` get a string |
-| **CSV / TSV** | bare token `Infinity` | No — ES|QL's own CSV re-ingest would reject it |
-| **Arrow** | raw IEEE-754 bit pattern | Yes |
+Jackson's `JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS` is **enabled by default**. Its Javadoc
+states: *"Feature that determines whether 'exceptional' (not real number) float/double values are
+output as quoted strings … Feature is enabled by default."* Elasticsearch's `JsonXContentImpl`
+does not override this default. As a result:
 
-The CsvIT test path (Arrow/binary) is unaffected, which is why this never surfaced in our test
-battery. Clients using the REST JSON response path silently receive a type mismatch.
+| Format | Output for `Infinity` in a `double` column | RFC 8259 compliant? |
+|---|---|---|
+| **JSON (REST)** | quoted string `"Infinity"` (Jackson default) | Yes — but type contract broken: column says `double`, wire value is a string |
+| **CSV / TSV** | bare token `Infinity` | N/A — not JSON; ES|QL's own CSV re-ingest would reject it |
+| **Arrow / binary** | raw IEEE-754 bit pattern | N/A — not JSON; fully round-trips |
+
+The JSON result is RFC 8259-compliant (JSON arrays are heterogeneous; `[1.234, "Infinity"]` is
+valid JSON). But the semantic type contract is broken: a client that trusts the column metadata
+(`"type":"double"`) and deserializes values accordingly will encounter a string where it expects a
+number. This is what caused the `CsvAssert.ValueTransformer` failure in the multi-node REST
+test — `new BigDecimal("Infinity")` throws, because the value arrived as a String rather than
+a Number.
+
+The CsvIT test path (Arrow/binary) is unaffected, which is why this never surfaced in the main
+test battery.
+
+**If ES|QL moves to full non-finite support, the wire-format question becomes a design decision.**
+All RFC-compliant options involve a type mismatch for clients that trust column metadata:
+
+| Approach | RFC valid? | Type contract? | Who uses this |
+|---|---|---|---|
+| Quoted strings `"Infinity"` (current Jackson default) | Yes | Broken | BigQuery (`"NaN"`, `"+inf"`, `"-inf"` — documented) |
+| Bare literals `Infinity` (Jackson feature disabled) | **No** | Intact | PostgreSQL `row_to_json`, DuckDB (both have open bugs; DuckDB #17329, PostgreSQL mailing-list discussion) |
+| `null` | Yes | Intact | Snowflake (errors instead, so no nulls) |
+| Typed wrapper | Yes | Intact if clients agree | MongoDB Extended JSON v2 |
+
+RFC 8259 § 6 states explicitly: *"Numeric values that cannot be represented in the grammar below
+(such as Infinity and NaN) are not permitted."* So bare literals are non-conformant regardless of
+parser tolerance.
+
+BigQuery's approach (document that FLOAT64 columns return JSON strings for special values, and
+require clients to handle them) is the most pragmatic precedent for a system that wants to keep
+RFC-compliant output while fully supporting non-finites.
 
 ### E2 — `histogram_quantile` converts internal NaN to null on output
 

--- a/NON_FINITE_FINDINGS.md
+++ b/NON_FINITE_FINDINGS.md
@@ -1,0 +1,741 @@
+# Non-Finite IEEE-754 Doubles in ES|QL — Investigation Findings
+
+> **Status**: Throwaway investigation branch. Not intended to merge.  
+> **Date**: 2026-07-22  
+> **Enabling change**: `TO_DOUBLE` keyword/text overload now parses `NaN`, `Infinity`, `-Infinity`
+> (via `EsqlDataTypeConverter.stringToDoubleAllowNonFinite`), gated on capability
+> `to_double_non_finite`.  
+> **How to reproduce**: All CsvIT results are in `non_finite_doubles.csv-spec` and run green.
+
+---
+
+## Summary
+
+ES|QL has broad but inconsistent defences against non-finite doubles.  
+Most operators and functions **do** guard — they convert non-finite results to `null` + warning.  
+But the guards are **per-function** (no central policy) and a few critical paths are **unguarded**,
+including `MIN`/`MAX`, the `IS NULL`/`IS NOT NULL` predicates, and `MV_DEDUPE`.  
+The `STATS BY` grouping key accepts `NaN` as a real group key, which is correct behaviour by
+Java's `doubleToLongBits` semantics but surprising to users.
+
+---
+
+## Section 1 — Parsing (TO_DOUBLE)
+
+| Input string   | Result after change | Before change |
+|----------------|---------------------|---------------|
+| `"NaN"`        | `NaN`               | `null` + warning |
+| `"Infinity"`   | `Infinity`          | `null` + warning |
+| `"-Infinity"`  | `-Infinity`         | `null` + warning |
+| `"+Infinity"`  | `Infinity`          | `null` + warning |
+| `"-0.0"`       | `-0.0`              | `-0.0` (unchanged; was already working) |
+| `"foo"`        | `null` + warning    | `null` + warning (unchanged) |
+
+`TO_STRING` round-trips correctly: `TO_STRING(NaN)` → `"NaN"`, `TO_STRING(Infinity)` → `"Infinity"`.
+The `TO_DOUBLE(TO_STRING(NaN))` round-trip works end-to-end.
+
+---
+
+## Section 2 — IS NULL / IS NOT NULL
+
+All non-finite doubles are real, non-null values. Both predicates behave correctly for all four cases:
+
+| Expression                  | IS NULL | IS NOT NULL |
+|-----------------------------|---------|-------------|
+| `NaN IS NULL`               | `false` | `true` |
+| `Infinity IS NULL`          | `false` | `true` |
+| `-Infinity IS NULL`         | `false` | `true` |
+| `-0.0 IS NULL`              | `false` | `true` |
+
+**Assessment**: correct, and consistent with every SQL-family database that admits non-finite floats
+(PostgreSQL `FLOAT8`, DuckDB, BigQuery `FLOAT64`, Spark SQL, ClickHouse, Trino). The databases that
+don't support non-finite floats at all (MySQL, SQL Server, Oracle) never face this question.
+
+The only subtlety: ES|QL null semantics map to the absence of a value in a block slot, which is a
+separate concept from IEEE-754 "not a number". `NaN` occupies a real slot with a real bit pattern —
+it is never null.
+
+---
+
+## Section 3 — Arithmetic Operators (+, -, *, /)
+
+**Key finding**: All four basic arithmetic operators (+, -, *, /) have post-result non-finite guards.
+Any operation that *produces* a non-finite result (including NaN) emits `null` + warning.
+The input values themselves pass through the evaluators, but the guard fires on the output.
+
+| Expression            | IEEE-754 result | ES|QL result  | Warning                       |
+|-----------------------|-----------------|---------------|-------------------------------|
+| `NaN + 1.0`           | NaN             | `null`        | "not a finite double number: NaN" |
+| `Infinity + 1.0`      | Infinity        | `null`        | "not a finite double number: Infinity" |
+| `Infinity + (-Infinity)` | NaN          | `null`        | "not a finite double number: NaN" |
+| `NaN * 0.0`           | NaN             | `null`        | "not a finite double number: NaN" |
+| `Infinity * 0.0`      | NaN             | `null`        | "not a finite double number: NaN" |
+| `Infinity - Infinity` | NaN             | `null`        | "not a finite double number: NaN" |
+| `NaN / 1.0`           | NaN             | `null`        | "not a finite double number: NaN" |
+| `-NaN`                | NaN             | `NaN`         | none (negation has no guard!) |
+| `-(+0.0)`             | -0.0            | `-0.0`        | none |
+| `-(-0.0)`             | +0.0            | +0.0          | none |
+
+**Surprising**: Unary negation (`-d`) has **no** non-finite guard — `-NaN` passes through as `NaN`.
+
+### Modulus `%`
+
+`Mod.processDoubles` guards on the **result** being non-finite (any NaN or ±Infinity output → null +
+warning "/ by zero"). Cases where the result is finite pass through without a warning.
+
+| Expression       | Java/IEEE-754 result | ES|QL result | Warning |
+|------------------|----------------------|-------------|---------|
+| `NaN % 2.0`      | NaN                  | `null`      | "/ by zero" ⚠️ message is misleading — divisor is non-zero |
+| `Infinity % 2.0` | NaN                  | `null`      | "/ by zero" ⚠️ message is misleading — divisor is non-zero |
+| `1.0 % 0.0`      | NaN                  | `null`      | "/ by zero" ✅ message is accurate here |
+| `1.0 % Infinity` | 1.0 (finite)         | `1.0`       | none ✅ |
+| `-0.0 % 2.0`     | -0.0 (finite)        | `-0.0`      | none ✅ |
+
+The "/ by zero" message is sourced from a single `ArithmeticException("/ by zero")` in `Mod.java:processDoubles`.
+It is only accurate for the `x % 0.0` case. For `NaN % y` and `Infinity % y` (y ≠ 0) the cause is the
+non-finite *input*, not a zero divisor — the message misleads anyone reading the warning in a log.
+
+---
+
+## Section 4 — Comparisons
+
+The runtime evaluation path uses Java primitive `double` operations, which are fully IEEE-754 correct.
+All ordered comparisons (`<`, `>`, `<=`, `>=`) with a NaN operand return `false`; `!=` returns `true`.
+
+| Expression                    | Result  | Notes |
+|-------------------------------|---------|-------|
+| `NaN == NaN`                  | `false` | Correct IEEE-754 |
+| `NaN != NaN`                  | `true`  | Correct IEEE-754 |
+| `NaN > 1.0`                   | `false` | Correct IEEE-754 |
+| `NaN < 1.0`                   | `false` | Correct IEEE-754 |
+| `NaN >= 1.0`                  | `false` | Correct IEEE-754 |
+| `NaN <= 1.0`                  | `false` | Correct IEEE-754 |
+| `NaN >= NaN`                  | `false` | Correct IEEE-754 (self-comparison) |
+| `NaN <= NaN`                  | `false` | Correct IEEE-754 (self-comparison) |
+| `NaN == Infinity`             | `false` | Correct IEEE-754 |
+| `NaN != Infinity`             | `true`  | Correct IEEE-754 |
+| `NaN > Infinity`              | `false` | Correct IEEE-754 |
+| `Infinity == Infinity`        | `true`  | Correct |
+| `Infinity != -Infinity`       | `true`  | Correct |
+| `-Infinity < Infinity`        | `true`  | Correct |
+| `Infinity >= Infinity`        | `true`  | Correct |
+| `-Infinity <= -Infinity`      | `true`  | Correct |
+| `-0.0 == 0.0`                 | `true`  | Correct IEEE-754 |
+| `Infinity > MAX_VALUE`        | `true`  | Correct |
+
+**Caveat — Lucene pushdown path**: `EsqlBinaryComparison.translateOutOfRangeComparisons` has a NaN
+short-circuit at line 584 that fires **only** when the left operand is an indexed `FieldAttribute`.
+For the `!=` operator this would incorrectly return 0 rows (should return all rows, since everything
+is `!= NaN`). This path cannot be triggered in practice today because non-finite doubles cannot exist
+in an indexed `double` field.
+
+**Important implication for WHERE**: `WHERE d == d` (where d=NaN) returns 0 rows because
+`NaN != NaN` at the filter level. Any equality-based filter on a NaN column silently returns 0 rows.
+`WHERE d IS NOT NULL` correctly passes NaN rows through.
+
+---
+
+## Section 5 — SORT Ordering
+
+`SORT` uses `Double.compareTo` which defines: `-Inf < finite < Inf < NaN`.
+
+| SORT ASC order (left=smallest)  |
+|---------------------------------|
+| -Infinity, -1.0, 1.0, Infinity, NaN |
+
+NaN sorts **last** in ascending order (treated as the largest value). This is correct by Java's
+`Comparable<Double>` contract but differs from IEEE-754 (where NaN has no defined order).
+`-0.0` and `0.0` compare as equal in `SORT`, so their relative order is stable across seeds in a
+single run but not guaranteed to be consistent.
+
+---
+
+## Section 6 — STATS Aggregations
+
+### SUM
+| Input              | Result   | Notes |
+|--------------------|----------|-------|
+| `[1, NaN, 2]`      | `NaN`    | NaN propagates through accumulation |
+| `[1, Infinity, 2]` | `Infinity`| Infinity propagates |
+
+**Key finding**: `SUM` does NOT have a non-finite result guard. Non-finite sums escape to the output.
+This is **inconsistent** with the arithmetic operators (`+`, `-`, `*`, `/`), which all guard.
+This is also the known existing inconsistency: SUM on overflow already produces Infinity.
+
+### AVG
+| Input              | Result   | Warning |
+|--------------------|----------|---------|
+| `[1, NaN, 2]`      | `null`   | "not a finite double number: NaN" |
+
+AVG *does* have a non-finite result guard (unlike SUM). The guard fires and emits the warning.
+
+### MIN / MAX
+| Input              | Result    | Notes |
+|--------------------|-----------|-------|
+| `[Infinity, -Infinity]` | MIN=-Inf, MAX=Inf | Correct |
+| `[1, NaN, 2]` (MIN) | `NaN`  | **No non-finite result guard on MIN/MAX** |
+| `[1, NaN, 2]` (MAX) | `NaN`  | **No non-finite result guard on MIN/MAX** |
+
+**Key finding**: MIN and MAX do NOT guard against non-finite results. They emit NaN directly.
+This is inconsistent with AVG and SUM (overflow guards).
+
+The aggregation unit tests confirm this: `MaxTests` fails for `-Infinity` inputs because the test
+expects `null` (per the existing mapping in the test's expected-value builder) but the aggregator
+returns `-Infinity`. Similarly for `MinTests`.
+
+### WEIGHTED_AVG
+
+`WEIGHTED_AVG` is implemented as a surrogate expression that decomposes into simpler aggregates.
+The decomposition path depends on whether the `field` argument is a compile-time constant
+(foldable):
+
+- **Field is a constant literal** (e.g. `WEIGHTED_AVG(1.0, w)`): `WeightedAvg.surrogate()` detects
+  the foldable field and short-circuits to `MvAvg(field)`. The `weight` argument is **discarded
+  entirely**. A non-finite weight has no effect; the result is the field value itself with no
+  warning.
+- **Field is a runtime expression** (e.g. `WEIGHTED_AVG(d, 1.0)` where `d` is a column): the
+  surrogate expands to `Div(Sum(field), Count(field))` when weight is foldable, or
+  `Div(Sum(field * weight), Sum(weight))` when neither is foldable. A non-finite result at the
+  final `Div` fires a guard → `null` + warning.
+
+| Input (value, weight)                 | Result   | Decomposition |
+|---------------------------------------|----------|---------------|
+| `NaN` column, `1.0` literal weight    | `null` + warning | `Sum(NaN) / Count(NaN)` = NaN → guard |
+| `Infinity` column, `1.0` literal weight | `null` + warning | `Sum(Inf) / Count(Inf)` = Inf → guard |
+| `1.0` literal field, `NaN` column weight | **`1.0`** (no warning) | surrogate = `MvAvg(1.0)`, weight discarded |
+| `1.0` literal field, `Infinity` column weight | **`1.0`** (no warning) | surrogate = `MvAvg(1.0)`, weight discarded |
+
+The weight-ignored cases are a surprising silent correctness issue: a user who passes a non-finite
+weight column while using a constant value field gets a plausible-looking result (the constant
+itself) with no indication that the weight was unused.
+
+**Assessment**: inconsistent with ES|QL's own `AVG` (for the constant-field path). Diverges from
+all comparison databases (PostgreSQL, DuckDB, ClickHouse), which would propagate `NaN` through the
+weighted average.
+
+### VARIANCE / STD_DEV
+
+`VARIANCE` and `STD_DEV` use Welford's online algorithm (`WelfordAlgorithm.java`). A NaN or
+Infinity input makes `m2` non-finite. `VarianceStates.evaluateFinal()` checks
+`Double.isFinite(m2) == false` and returns `newConstantNullBlock(1)` — a **silent null with no
+warning**. There is no `driverContext.addWarning(...)` call in this path.
+
+| Input              | Result       | Warning? |
+|--------------------|--------------|---------|
+| `[1, NaN, 2]`      | `null`       | **No** |
+| `[1, Infinity, 2]` | `null`       | **No** |
+
+This means the same input `[1, NaN, 2]` produces three different outcomes across three aggregations:
+- `SUM` → `NaN` (no guard at all)
+- `AVG` → `null` + warning (Div guard fires and reports)
+- `VARIANCE` / `STD_DEV` → `null`, silently (guard fires but emits nothing)
+
+### MEDIAN / MEDIAN_ABSOLUTE_DEVIATION
+
+`Median.surrogate()` has two paths:
+- **Field is foldable** (compile-time constant) → delegates to `MvMedian`, which sorts values and
+  picks the middle — does NOT use TDigest, handles NaN gracefully (sorts NaN to the end; median of
+  a single-element `[NaN]` list returns `NaN`).
+- **Field is a runtime expression** (e.g. from `EVAL d = TO_DOUBLE(...)`) → the `FieldAttribute` is
+  NOT constant-folded by the optimizer, so `field.foldable()` is `false` → delegates to
+  `Percentile(field, 50)` → TDigest → crash.
+
+For the typical query pattern (`ROW ... | EVAL d = ... | STATS MEDIAN(d)`), the field is NOT foldable
+and MEDIAN crashes identically to PERCENTILE (confirmed empirically).
+
+`MEDIAN_ABSOLUTE_DEVIATION` uses TDigest directly with no foldable shortcut — always crashes.
+
+| Input      | MEDIAN | MEDIAN_ABSOLUTE_DEVIATION |
+|------------|--------|--------------------------|
+| `NaN`      | query failure (`IllegalArgumentException: Invalid value: NaN`) | same |
+| `Infinity` | query failure | same |
+
+### COUNT
+NaN is not null, so `COUNT(d)` counts NaN rows. `COUNT(*)` unaffected.
+
+### COUNT_DISTINCT
+
+`COUNT_DISTINCT` uses HyperLogLog++ which hashes values via `doubleToLongBits`. NaN has a
+canonical bit pattern (`0x7ff8000000000000` for Java's quiet NaN), so two NaN values hash
+identically and are counted as **one** distinct value. NaN is not filtered out.
+
+| Input                  | Result | Notes |
+|------------------------|--------|-------|
+| `[NaN, NaN, 1.0]`      | `2`    | NaN counted as 1 distinct; HLL++ exact for small cardinalities |
+| `[NaN]`                | `1`    | Correct |
+
+### VALUES
+
+`VALUES` collects all values with no non-finite filtering. NaN inputs are preserved and returned
+in the multivalue result. Order is unspecified (depends on segment order).
+
+| Input         | Result  | Notes |
+|---------------|---------|-------|
+| `[NaN]`       | `NaN`   | Preserved unchanged |
+| `[1.0, NaN, 2.0]` | `[1.0, NaN, 2.0]` (in some order) | No filtering; order unspecified |
+
+### TOP
+
+`TOP` uses `DoubleBucketedSort` with the same total order as `SORT` (NaN > +Infinity > finite > -Infinity). NaN inputs are retained and rank above Infinity in descending sort.
+
+| Input                    | `TOP(..., 2, 'DESC')` | Notes |
+|--------------------------|----------------------|-------|
+| `[NaN, Infinity, 1.0]`   | `[NaN, Infinity]`    | NaN ranks first in DESC order |
+| `[NaN, NaN, 1.0]`        | `[NaN, NaN]`         | Duplicate NaN values are preserved |
+
+---
+
+## Section 7 — STATS BY with Non-Finite Grouping Keys
+
+`BlockHash` hashes double group keys via `doubleToLongBits`, so grouping identity is by bit pattern,
+not by `==`. All non-finite values tested directly:
+
+| Grouping key | Behaviour | Counterintuitive? |
+|---|---|---|
+| Multiple `NaN` values | All land in **one group** | Yes — `NaN == NaN` is false, yet they group together |
+| Multiple `Infinity` values | All land in **one group** | No |
+| Multiple `-Infinity` values | All land in **one group** | No |
+| `Infinity` vs `-Infinity` | **Separate groups** | No |
+| `-0.0` vs `0.0` | **Separate groups** | Yes — `-0.0 == 0.0` is true, yet they are separate groups |
+
+The `-0.0` / `0.0` split is the sharpest inconsistency: equality says they're the same value, but
+grouping says they're different. The NaN coalescence is the mirror: equality says they differ, but
+grouping says they're the same.
+
+**Reproduction note**: the two-group behaviour requires scalar group keys. `MV_EXPAND` the values
+first so each row carries a scalar double, then `STATS BY` that column. Using a multivalue key
+directly (e.g. `z = MV_APPEND(0.0, -0.0)` without `MV_EXPAND`) produces one group — the
+multivalue-key path does not split per value. The separate-groups finding is confirmed for the
+scalar path:
+```
+ROW xs = ["-0.0", "0.0"] | MV_EXPAND xs | EVAL d = TO_DOUBLE(xs) | STATS c = COUNT(*) BY d
+```
+
+---
+
+## Section 8 — INLINE STATS
+
+`INLINE STATS` with non-finite values follows the same aggregation behaviour as `STATS`.
+The `BY` grouping key uses the same `BlockHash` / `doubleToLongBits` mechanism, confirmed for all
+non-finite key types:
+
+| BY key | Behaviour |
+|---|---|
+| `NaN` | All NaN rows grouped together |
+| `Infinity` | All Infinity rows grouped together |
+| `-Infinity` | All -Infinity rows grouped together |
+| `-0.0` vs `0.0` | Separate groups |
+
+The result column order in `INLINE STATS` puts the agg column first (before BY keys).
+
+---
+
+## Section 9 — MV_* Functions
+
+| Function         | NaN behaviour | -0.0 vs 0.0 behaviour |
+|------------------|---------------|------------------------|
+| `MV_SUM`         | Propagates NaN | — |
+| `MV_AVG`         | Propagates NaN | — |
+| `MV_MIN`         | Position/path-dependent (see below) | — |
+| `MV_MAX`         | Position/path-dependent (see below) | — |
+| `MV_MEDIAN`      | NaN sorts to end; median of remaining values (see below) | — |
+| `MV_DEDUPE(NaN)` | **Does NOT deduplicate** — `==` is false for NaN | Deduplicates -0.0 and 0.0 (equal by `Double.compareTo`) — but nondeterministic! |
+| `MV_SORT`        | NaN is sorted last (ASC) | -0.0 and 0.0 compare equal |
+
+**MV_MEDIAN NaN behaviour in detail**:
+
+`MvMedian.finish(Doubles)` calls `Arrays.sort(doubles.values, 0, doubles.count)` then picks the
+middle element. `Arrays.sort(double[])` puts NaN last (same total order as `Double.compareTo`).
+
+| Input               | Result | Explanation |
+|---------------------|--------|-------------|
+| `[NaN, 1.0, 2.0]`   | `2.0`  | Sorted → `[1.0, 2.0, NaN]`; middle index 1 → 2.0 |
+| `[NaN]`             | `NaN`  | Single element → NaN |
+| `[2.0, NaN]` (even) | `NaN`  | Sorted → `[2.0, NaN]`; average = (2.0 + NaN)/2 = NaN |
+
+For odd-count lists where NaN is the only non-finite value, `MV_MEDIAN` returns the finite median
+(NaN sorts to the tail and the middle index falls on a finite value). For even-count lists, NaN in
+the top-half position contaminates the average. This is subtly different from `MV_MIN`/`MV_MAX`
+where NaN always propagates regardless of count.
+
+Note: `MV_MEDIAN` (the scalar MV function) never touches TDigest. The `MEDIAN` *aggregation* can
+crash via TDigest — these are two separate functions with different implementations.
+
+**MV_MIN / MV_MAX NaN behaviour in detail**:
+
+`MvMin.process` and `MvMax.process` delegate to `Math.min`/`Math.max`, which return NaN whenever
+either argument is NaN. The `@MvEvaluator` iterates values as `current = process(current, v)`,
+so NaN should propagate once encountered. However, there is an `ascending` fast-path: if internal
+block metadata indicates the values are already sorted in ascending order (per `Double.compareTo`,
+which sorts NaN last), the evaluator skips iteration and returns the first element directly.
+
+Concretely for `MV_MIN`:
+
+| Condition | Result |
+|---|---|
+| NaN is the only value | NaN (confirmed) |
+| NaN is first (becomes initial accumulator) | NaN — propagates through all subsequent `Math.min` calls (confirmed) |
+| NaN is not first, block not flagged ascending | NaN — propagates once `Math.min(current, NaN)` is reached |
+| NaN is not first, block flagged ascending (fast-path) | Finite minimum — NaN silently skipped |
+
+The fast-path / normal-path split depends on internal block metadata, not on the literal order in
+a `ROW` or query result. It is not user-controllable. Tests where NaN is in a non-first position
+use assertion wildcards (`{any}`) because either outcome is possible depending on which path fires.
+`MV_MAX` has the same structure with `Math.max` instead.
+
+**Critical finding — MV_DEDUPE inconsistency**:
+- `NaN` values are NOT deduplicated (each NaN stays because `NaN == NaN` is false by `==`).
+- `-0.0` and `0.0` ARE always collapsed to one value by MV_DEDUPE, because both dedup paths use
+  `==` / `!=` on primitive doubles, and `-0.0 == 0.0` is `true`. The dedup always happens —
+  what is implementation-defined is **which** value survives: `copyMissing` (small MV) keeps
+  whichever comes first in block order; `copyAndSort` (large MV) calls `Arrays.sort`, which is a
+  non-stable dual-pivot quicksort and does not guarantee a relative order for equal elements like
+  `-0.0` and `0.0`. The test uses `{any}` to reflect this, not because dedup is random, but
+  because the surviving value is not user-controllable.
+
+---
+
+## Section 10 — Conversions
+
+### TO_STRING / round-trip
+
+| Conversion                        | Input    | Result      | Notes |
+|-----------------------------------|----------|-------------|-------|
+| `TO_STRING(NaN)`                  | NaN      | `"NaN"`     | Correct |
+| `TO_STRING(Infinity)`             | Infinity | `"Infinity"`| Correct |
+| `TO_STRING(-Infinity)`            | -Infinity| `"-Infinity"`| Correct |
+| `TO_DOUBLE(TO_STRING(NaN))`       | NaN → "NaN" → NaN | `NaN` | Round-trips! |
+
+### TO_INTEGER (double → int)
+
+`safeToInt(double x)` checks `x > Integer.MAX_VALUE || x < Integer.MIN_VALUE`. Both IEEE-754
+comparisons return **false for NaN**, so the guard is silently bypassed. `Math.round(NaN)` returns
+`0L` by JLS §5.1.3 (`(long) NaN = 0`), cast to `int` gives **0**.
+
+| Input      | Result         | Notes |
+|------------|----------------|-------|
+| `NaN`      | **`0`** (no warning!) | Guard bypassed: NaN comparisons return false |
+| `Infinity` | `null` + warning | `Infinity > MAX` = true → guard fires |
+| `-Infinity`| `null` + warning | `-Infinity < MIN` = true → guard fires |
+| `-0.0`     | `0`            | Correct |
+
+**Key finding**: `TO_INTEGER(NaN)` silently returns `0` — a wrong answer with no diagnostic.
+This is a **bug**: the range check happens to not catch NaN because `NaN > x` and `NaN < x` are
+both false in IEEE-754. The fix is to add an explicit `Double.isNaN(x)` check (or use
+`Double.isFinite(x)`) before the range comparison in `safeToInt(double)`.
+
+**Cross-database comparison**:
+
+| Database | `CAST(NaN AS INTEGER)` | Notes |
+|---|---|---|
+| PostgreSQL | **ERROR** | Explicit `isnan()` guard in `dtoi4`; same for int2/int8. Confirmed. |
+| DuckDB ≥v1.3.0 | **ERROR** (`TRY_CAST` → NULL) | Strict error introduced in v1.3.0; older DuckDB behavior may differ. |
+| ClickHouse ≥v21 | **ERROR** | Added explicit check after bug reports |
+| ClickHouse <v21 | INT32_MIN or 0 (UB) | C++ undefined behavior; acknowledged bug |
+| Spark SQL (ANSI / 4.0+) | **ERROR** (`TRY_CAST` → NULL) | Confirmed for ANSI mode. |
+| Spark SQL (non-ANSI) | **0 or NULL** (unverified) | Java `(int) Double.NaN` = 0; if Spark uses Java narrowing without an explicit NaN check, result is 0 not NULL. Requires source-level or empirical verification. |
+| Trino (current) | **ERROR** (`TRY_CAST` → NULL) | Silent-0 was the old behavior (shared with the Facebook Presto ancestor), fixed as a bug. Direct Trino-specific fix not confirmed; Presto PR #22917 corroborates. |
+| BigQuery | **Plausibly ERROR** (`SAFE_CAST` → NULL) | `SAFE_CAST → NULL` is confirmed for any failed cast; the NaN-specific CAST error path is unverified. |
+| **ES\|QL** | **0, no warning** | Matches the old Presto bug, now corrected in Trino |
+
+The industry consensus is: strict CAST → error, TRY_CAST/SAFE_CAST → NULL. Silent zero is
+universally treated as a bug. ES|QL's behavior matches the historical Presto/Trino bug that Trino
+has since corrected and ClickHouse's pre-v21 undefined-behavior path.
+
+### TO_LONG (double → long)
+
+`safeDoubleToLong(double x)` has the identical structure to `safeToInt`: checks
+`x > Long.MAX_VALUE || x < Long.MIN_VALUE`, which is also bypassed for NaN.
+
+| Input      | Result         | Notes |
+|------------|----------------|-------|
+| `NaN`      | **`0`** (no warning!) | Same guard bypass as TO_INTEGER |
+| `Infinity` | `null` + warning | Guard fires correctly |
+| `-Infinity`| `null` + warning | Guard fires correctly |
+| `-0.0`     | `0`            | Correct |
+
+**Key finding**: `TO_LONG(NaN)` is the same bug as `TO_INTEGER(NaN)` — silently returns `0`.
+The cross-database picture is identical to TO_INTEGER: every modern database errors on this cast.
+
+### TO_UNSIGNED_LONG (double → unsigned_long)
+
+`inUnsignedLongRange(double d)` checks `d >= 0 && d < MAX`. The `>= 0` comparison returns
+**false for NaN** (unlike `> MAX` which also returns false but is reached second), so NaN is
+**correctly rejected** here.
+
+| Input      | Result         | Notes |
+|------------|----------------|-------|
+| `NaN`      | `null` + warning | `NaN >= 0` = false → guard fires correctly |
+| `Infinity` | `null` + warning | `Infinity < MAX` = false → guard fires |
+| `-Infinity`| `null` + warning | `-Infinity >= 0` = false → guard fires |
+
+**Assessment**: `TO_UNSIGNED_LONG` handles NaN correctly by accident — the `>= 0` lower-bound
+check catches NaN whereas `> MAX` would not. The `TO_INTEGER` and `TO_LONG` paths are genuinely
+buggy. The correct fix for all three functions would be to use `Double.isFinite(x)` as a guard,
+matching the pattern PostgreSQL (`isnan()` check) and DuckDB use.
+
+---
+
+## Section 11 — Conditional Functions
+
+| Function              | Input | Result | Notes |
+|-----------------------|-------|--------|-------|
+| `COALESCE(NaN, 42.0)` | NaN   | `NaN`  | COALESCE correctly treats NaN as non-null |
+| `CASE(NaN > 0, ...)` | NaN   | else branch | NaN > 0 is false → else branch taken |
+
+### GREATEST / LEAST
+
+Both functions iterate with `Math.max` / `Math.min`. Java's `Math.max(a, b)` checks `a != a`
+(NaN self-inequality) first: if `a` is NaN it returns `a` immediately. If `b` is NaN and `a` is
+not, then `a >= b` is false (NaN comparison) so it returns `b`. Either way, **NaN propagates
+regardless of which position it occupies**.
+
+| Expression | Result | Notes |
+|---|---|---|
+| `GREATEST(NaN, 1.0, 2.0)` | `NaN` | NaN is the seed; `a != a` guard returns NaN immediately |
+| `GREATEST(1.0, NaN, 2.0)` | `NaN` | `Math.max(1.0, NaN)`: `1.0 >= NaN` is false → returns NaN |
+| `GREATEST(1.0, 2.0, NaN)` | `NaN` | `Math.max(2.0, NaN)` → NaN on the last call |
+| `GREATEST(NaN, Infinity)` | `NaN` | `a != a` guard fires; Infinity never seen |
+| `GREATEST(Infinity, NaN)` | `NaN` | `Inf >= NaN` is false → NaN wins over Infinity |
+| `GREATEST(-Infinity, NaN, Infinity)` | `NaN` | NaN poisons the accumulator mid-sequence |
+| `GREATEST(Infinity, -Infinity, NaN)` | `NaN` | Accumulates to Infinity, then `Math.max(Inf, NaN)` → NaN |
+| `GREATEST(Infinity, -Infinity, 0.0)` | `Infinity` | Standard ordering, no NaN |
+| `LEAST(NaN, -1.0, -2.0)` | `NaN` | Same propagation logic via `Math.min` |
+| `LEAST(-1.0, -2.0, NaN)` | `NaN` | `Math.min(-2.0, NaN)` → NaN |
+| `LEAST(NaN, -Infinity)` | `NaN` | `a != a` fires; -Infinity never seen |
+| `LEAST(-Infinity, NaN)` | `NaN` | `-Inf <= NaN` is false → NaN wins |
+| `LEAST(Infinity, NaN, -Infinity)` | `NaN` | NaN poisons mid-sequence |
+| `LEAST(Infinity, -Infinity, 0.0)` | `-Infinity` | Standard ordering, no NaN |
+
+No warnings are emitted — GREATEST/LEAST have no non-finite result guard. NaN in, NaN out,
+silently. This is consistent with the `MIN`/`MAX` aggregations and the arithmetic `+`/`-`/`*`
+operators (all unguarded), and inconsistent with `AVG`, `WEIGHTED_AVG`, `DIV`, and `MOD`
+(all guarded).
+
+---
+
+## Section 12 — Math Functions
+
+| Function        | Input     | Result    | Guard type |
+|-----------------|-----------|-----------|------------|
+| `ABS(NaN)`      | NaN       | `NaN`     | No guard |
+| `ABS(-Inf)`     | -Infinity | `Infinity`| No guard |
+| `FLOOR(NaN)`    | NaN       | `NaN`     | No guard |
+| `CEIL(NaN)`     | NaN       | `NaN`     | No guard |
+| `FLOOR(Inf)`    | Infinity  | `Infinity`| No guard |
+| `ROUND(NaN)`    | NaN       | **`0.0`** | Explicit `isNaN` early-return in `Maths.round` (line 23) |
+| `ROUND(Inf)`    | Infinity  | `Infinity`| `middleResult == Infinity` → returns n (line 35) |
+| `SQRT(NaN)`     | NaN       | `NaN`     | No guard on NaN input |
+| `SQRT(-Inf)`    | -Infinity | `null`    | Negative input guard ("Square root of negative") |
+| `LOG(NaN)`      | NaN       | `NaN`     | No guard |
+| `LOG(Inf)`      | Infinity  | `Infinity`| No guard |
+| `SIN(NaN)`      | NaN       | `NaN`     | No guard |
+| `SIN(Inf)`      | Infinity  | `NaN`     | No guard — Java produces NaN, which passes through |
+| `COS(NaN)`      | NaN       | `NaN`     | No guard |
+| `COS(Inf)`      | Infinity  | `NaN`     | No guard — `Math.cos(Infinity)` = NaN (undefined in IEEE-754) |
+| `SIGNUM(NaN)`   | NaN       | `NaN`     | No guard — `Math.signum(NaN)` = NaN |
+| `SIGNUM(Inf)`   | Infinity  | `1.0`     | No guard needed — finite result |
+| `SIGNUM(-Inf)`  | -Infinity | `-1.0`    | No guard needed — finite result |
+| `POW(NaN, 2)`   | NaN       | `null` + warning | `asFiniteNumber(Math.pow(NaN,2)=NaN)` throws |
+| `POW(2, NaN)`   | NaN exp   | `null` + warning | `asFiniteNumber(Math.pow(2,NaN)=NaN)` throws |
+| `POW(Inf, 2)`   | Infinity  | `null` + warning | `asFiniteNumber(Math.pow(Inf,2)=Inf)` throws |
+| `POW(NaN, 0)`   | NaN base, 0 exp | **`1.0`** | Java special case: `Math.pow(x,0)=1.0` for any `x`, incl. NaN |
+| `EXP(NaN)`      | NaN       | `NaN`     | No guard — raw `Math.exp`, no `asFiniteNumber` |
+| `EXP(Inf)`      | Infinity  | `Infinity`| No guard |
+| `EXP(-Inf)`     | -Infinity | `0.0`     | No guard — `Math.exp(-Inf)=0.0` (finite, no issue) |
+| `COSH(NaN)`     | NaN       | `null`    | Has non-finite result guard ("cosh overflow") |
+| `SINH(NaN)`     | NaN       | `null`    | Has non-finite result guard ("sinh overflow") |
+| `BUCKET(NaN,…)` | NaN       | `null`    | Has isFinite input guard |
+
+**Pattern**: `ABS`, `FLOOR`, `CEIL`, `SQRT`, `LOG`, `SIN`, `COS`, `SIGNUM`, `EXP` have NO non-finite
+result guards — non-finite inputs produce non-finite outputs (or NaN for `SIN(Inf)` and `COS(Inf)`).
+`COSH` and `SINH` have guards (they overflow for large inputs, so NaN is caught too).
+`POW` guards via `asFiniteNumber` (inherited from the arithmetic evaluator pattern).
+`ROUND` is unique: it has an explicit `isNaN` check that short-circuits to `0.0` — the only math
+function with this specific NaN → zero behavior. `BUCKET` guards on the input being finite.
+
+**`ROUND(NaN) = 0.0` is a silent correctness issue**: the `Maths.round` implementation has an
+early-return `if (Double.isNaN(nDouble)) return 0.0d`, added to avoid downstream overflow in
+`Math.round`. The return value `0.0` is wrong (NaN is not 0) and no warning is emitted. This
+contrasts with `FLOOR(NaN)` and `CEIL(NaN)` which correctly propagate NaN.
+
+---
+
+## Section 13 — SET approximation=true
+
+The approximation machinery uses `Double.NaN` internally as a sentinel for "empty bucket"
+in the bootstrap confidence-interval computation (`ApproximationPlan.java`).
+Tests with only 3 rows never trigger approximation (need >= 10,000 rows), so approximation
+tests with ROW/MV_EXPAND produce exact results and 0 CI columns in the output.
+
+**Status**: No collision detected in the 3-row tests. A proper test would need a larger dataset.
+The internal comment in `ApproximationPlan.java` ("these values stay inside here and ... never
+reach the user") is correct for the expected path, but if user NaN can now enter the system,
+the sentinel assumption may be violated in principle for larger inputs.
+
+---
+
+## Section 14 — Function Unit Test Results (Phase C)
+
+### Scalar function tests (100% pass)
+
+All scalar function tests pass with NaN/±Infinity inputs added. This means every scalar function
+either:
+1. Has explicit per-function test matchers that already expect `null` for non-finite results
+   (e.g., `ToDegreesTests` maps non-finite to `null`), or
+2. Has a correct non-finite result guard and produces `null`.
+
+### Aggregation function tests (failures observed)
+
+The following aggregation tests fail because their expected values assume non-finite inputs
+produce `null`, but the actual aggregators return non-finite values:
+
+| Test class | Failing case | Expected | Actual |
+|------------|-------------|---------|--------|
+| `AvgTests` | `NaN` / `±Infinity` input | `null` | NaN / ±Infinity (or vice versa) |
+| `AvgOverTimeTests` | same | same | same |
+| `MaxTests` | `-Infinity` input | `null` | `-Infinity` |
+| `MaxOverTimeTests` | same | same | same |
+| `MedianTests` | non-finite | `null` | non-finite (or crash) |
+| `MedianAbsoluteDeviationTests` | non-finite | varies | varies |
+| `PercentileTests` | non-finite | varies | varies |
+| `PercentileOverTimeTests` | non-finite | varies | varies |
+| `StdDevTests` | non-finite | `null` | non-finite |
+| `StddevOverTimeTests` | same | same | same |
+| `ValuesTests` | non-finite | varies | varies |
+| `VarianceTests` | non-finite | `null` | non-finite |
+| `VarianceOverTimeTests` | same | same | same |
+
+**Key insight from MaxTests**: The test expects `-Infinity` (correctly derived by Java's `max()`)
+but the actual aggregator returns `-MAX_VALUE` (i.e. `-1.7976931348623157E308`). This means the
+MAX aggregator implementation **does not correctly handle -Infinity as a value to be compared** —
+it likely initializes its accumulator to `-Double.MAX_VALUE` and never updates it to `-Infinity`.
+This is a correctness bug: `MAX([-Infinity]) = -MAX_VALUE`, not `-Infinity`.
+
+---
+
+## Section 15 — PERCENTILE
+
+`PERCENTILE` uses a TDigest sketch (`TDigestState` → `SortingDigest`). The TDigest `add()` method
+calls `TDigest.checkValue(x)`, which throws `IllegalArgumentException("Invalid value: NaN/Infinity")` for any non-finite input. There is no try-catch in `QuantileStates.SingleState.add()` or in the generated `PercentileDoubleAggregatorFunction.addRawVector()`, so the exception propagates as a **hard query failure** — not a null+warning like AVG or SUM.
+
+| Input                    | Result |
+|--------------------------|--------|
+| `PERCENTILE(NaN, 50)`    | `IllegalArgumentException: Invalid value: NaN` (query failure) |
+| `PERCENTILE(Infinity, 50)` | `IllegalArgumentException: Invalid value: Infinity` (query failure) |
+| `PERCENTILE(-Infinity, 50)` | `IllegalArgumentException: Invalid value: -Infinity` (query failure) |
+| `PERCENTILE([1, NaN, 2], 50)` | `IllegalArgumentException: Invalid value: NaN` (one bad row kills the whole query) |
+
+**Note**: `-0.0` is finite, so `PERCENTILE(-0.0, 50)` works fine (result: `0.0`).
+
+The behavior diverges from every other aggregation:
+- `SUM`/`MIN`/`MAX`: propagate non-finite silently.
+- `AVG`/`WEIGHTED_AVG`: emit null + warning.
+- `PERCENTILE`: hard query failure.
+
+csv-spec has no mechanism to assert on hard query errors, so these cases cannot be tested in the
+CsvIT battery; they are documented here only.
+
+**Assessment**: hardest failure mode of any aggregation — severity HIGH. A single non-finite row in
+a large dataset crashes the entire query rather than emitting a null with a warning. The fix would
+add a non-finite check to `QuantileStates.add()` analogous to what `AVG` does.
+
+---
+
+## Section 16 — Cross-cutting architectural observations (from comparative review)
+
+These findings were confirmed by code reading against `origin/main`.
+
+### C3 — Pushdown `field != NaN` matches nothing (latent wrong-answer bug)
+
+`EsqlBinaryComparison.fold()` has a special-case at the top of its constant-folding path
+(`EsqlBinaryComparison.java:584`):
+
+```java
+if (Double.isNaN(((Number) value).doubleValue())) {
+    return new MatchAll(source()).negate(source());  // match-none
+}
+```
+
+This fires for **every** comparison operator — including `!=`. So a folded `field != NaN` becomes
+match-none (0 rows), whereas IEEE-754 requires it to match every row (`x != NaN` is always true).
+
+Currently unreachable from pure ES|QL (NaN is not a valid numeric literal), but reachable via PromQL
+conversions or future features that produce NaN constant expressions. The code is consistently wrong
+(match-none for all operators) rather than partially wrong — `field == NaN` accidentally gives the
+correct answer (match-none), but for the wrong reason.
+
+### D1 — Three output formats produce three different representations of the same non-finite value
+
+| Format | Output for `Infinity` in a `double` column | Parses back? |
+|---|---|---|
+| **JSON** | bare string `"Infinity"` (Jackson default, not in a JSON string literal) | No — invalid JSON number; clients parsing `double` get a string |
+| **CSV / TSV** | bare token `Infinity` | No — ES|QL's own CSV re-ingest would reject it |
+| **Arrow** | raw IEEE-754 bit pattern | Yes |
+
+The CsvIT test path (Arrow/binary) is unaffected, which is why this never surfaced in our test
+battery. Clients using the REST JSON response path silently receive a type mismatch.
+
+### E2 — `histogram_quantile` converts internal NaN to null on output
+
+`PromqlHistogramQuantileStates.java:348-349` (and the grouping variant at :438-439) contains an
+explicit comment: *"NaN signals 'no estimate'; emit null rather than placing NaN in a DoubleBlock,
+where it would break equality."* The final evaluation converts any NaN result to a null block entry.
+
+This is a deliberate design decision: the PromQL histogram quantile computation produces NaN for
+degenerate inputs (empty buckets, no observations), and the aggregator explicitly suppresses it.
+This is the correct policy for that function, but it means a user-supplied NaN flowing *into* the
+computation would be silently misinterpreted as "no estimate" and suppressed.
+
+### E3 — ES|QL can compute a value it cannot index back
+
+`NumberFieldMapper.java:1026-1027`:
+```java
+if (Double.isFinite(value) == false) {
+    throw new IllegalArgumentException("[double] supports only finite values, but got [" + value + "]");
+}
+```
+
+A query returning `Infinity` (e.g. `SUM` on overflowing input) succeeds at query time. Any
+write-back path — alerting rules, transforms, ENRICH, materialized views — that attempts to index
+that result will fail with this error. There is no warning in the query response that the value is
+unindexable.
+
+### F1 — Prometheus StaleNaN cannot round-trip
+
+The remote-write ingest path drops every non-finite sample (including the StaleNaN bit pattern
+`0x7ff0000000000002` used for Prometheus staleness markers). The wire encoding additionally
+canonicalizes all NaN bit patterns to a single representation, so distinct NaN payloads are lost
+even before reaching the drop check. Prometheus staleness semantics are therefore unrepresentable
+in ES|QL regardless of any decision about non-finite doubles in the query layer. This is a
+cross-team concern, not an ES|QL-local fix.
+
+---
+
+## Summary of Issues Found
+
+| Severity | Issue | Where |
+|----------|-------|-------|
+| **Bug** | `MAX([-Infinity])` returns `-MAX_VALUE` instead of `-Infinity` | `MaxTests`; MAX aggregator |
+| **Inconsistency** | `SUM` emits non-finite results; arithmetic `+`/`-`/`*`/`/` converts them to null | Aggregation layer vs expression layer |
+| **Inconsistency** | `AVG` has non-finite guard; `MIN`/`MAX` do not | Aggregation layer |
+| **Inconsistency** | Unary `-d` has no non-finite guard (passes `NaN` through) | Expression layer |
+| **Subtle bug** | `MV_DEDUPE` does not deduplicate NaN values (NaN ≠ NaN by ==) | MV functions |
+| **Surprising** | MV_DEDUPE's -0.0 vs 0.0 dedup behaviour is nondeterministic | MV functions |
+| **Surprising** | `STATS BY NaN` groups all NaN rows together (correct but counterintuitive) | BlockHash |
+| **Surprising** | `STATS BY -0.0` and `STATS BY 0.0` are SEPARATE groups | BlockHash |
+| **Missing guard** | `SIN(Infinity)` produces `NaN` without a warning | `Sin` function |
+| **Misleading message** | `%` warning says "/ by zero" for `NaN % y` and `Infinity % y` (y≠0); only accurate for `x % 0.0` | `Mod.java:processDoubles` |
+| **Potential** | User NaN may collide with internal NaN sentinel in `approximation` mode | ApproximationPlan |
+| **Bug (HIGH)** | `PERCENTILE` hard-fails (uncaught `IllegalArgumentException`) for any non-finite input; one bad row kills the whole query | `TDigest.checkValue()`, `QuantileStates.add()` |
+| **Bug** | `TO_INTEGER(NaN)` silently returns `0` — NaN bypasses the `> MAX \|\| < MIN` range guard because NaN comparisons always return false | `DataTypeConverter.safeToInt(double)` |
+| **Bug** | `TO_LONG(NaN)` silently returns `0` — same guard bypass as `TO_INTEGER` | `DataTypeConverter.safeDoubleToLong(double)` |
+| **Inconsistency (WEIGHTED_AVG)** | When `field` is a constant literal, `WeightedAvg.surrogate()` short-circuits to `MvAvg(field)` and silently discards a non-finite weight column | `WeightedAvg.surrogate()` |
+| **Inconsistency** | `VARIANCE`/`STD_DEV` return null silently (no warning) for non-finite input; `AVG` emits a warning, `SUM` passes through — three behaviors on the same data | `VarianceStates.evaluateFinal()` |
+| **Bug (HIGH)** | `MEDIAN` crashes on non-finite input via TDigest (for non-foldable fields, which is the common EVAL pattern). `MV_MEDIAN` (the scalar function) does NOT crash — it uses `Arrays.sort` which puts NaN last. | `QuantileStates.add()`, `TDigest.checkValue()` |
+| **Bug** | `ROUND(NaN)` silently returns `0.0` instead of `NaN` — an explicit `isNaN` early-return in `Maths.round` intended to prevent overflow, with no warning emitted. `FLOOR(NaN)` and `CEIL(NaN)` correctly propagate NaN; `ROUND` is uniquely broken. | `Maths.java:23` |
+| **Latent wrong-answer** | Pushdown folds `field != NaN` to match-none; IEEE-754 requires match-all. Currently unreachable from pure ES|QL but reachable via PromQL | `EsqlBinaryComparison.java:584` |
+| **Serialization divergence** | Same non-finite value renders as `"Infinity"` (bare string) in JSON, `Infinity` token in CSV/TSV, and raw IEEE bits in Arrow — no consistent contract | JSON/CSV/Arrow output paths |
+| **Silent sentinel collision** | `histogram_quantile` converts internal NaN to null; a user-supplied NaN is silently treated as "no estimate" | `PromqlHistogramQuantileStates.java:348` |
+| **Compute/storage mismatch** | Queries can return `Infinity` (SUM overflow) but indexing it is rejected — any write-back path fails silently at index time | `NumberFieldMapper.java:1027` |
+| **Unrepresentable (PromQL)** | Prometheus StaleNaN bit pattern is dropped at ingest and canonicalized on the wire; staleness semantics cannot round-trip | Remote-write ingest, wire encoding |

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -277,6 +277,12 @@ public final class CsvAssert {
                     if ("NaN".equals(s)) {
                         return Double.NaN;
                     }
+                    if ("Infinity".equals(s)) {
+                        return Double.POSITIVE_INFINITY;
+                    }
+                    if ("-Infinity".equals(s)) {
+                        return Double.NEGATIVE_INFINITY;
+                    }
                     return new BigDecimal(s).round(new MathContext(7, RoundingMode.HALF_DOWN)).doubleValue();
                 }
             }
@@ -286,8 +292,13 @@ public final class CsvAssert {
                 }
             }
             if (type == CsvTestUtils.Type.DOUBLE) {
-                if (value instanceof String s && "NaN".equals(s)) {
-                    return Double.NaN;
+                if (value instanceof String s) {
+                    return switch (s) {
+                        case "NaN" -> Double.NaN;
+                        case "Infinity" -> Double.POSITIVE_INFINITY;
+                        case "-Infinity" -> Double.NEGATIVE_INFINITY;
+                        default -> Double.parseDouble(s);
+                    };
                 }
                 return ((Number) value).doubleValue();
             }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -335,7 +335,11 @@ public class CsvTestsDataLoader {
         new TestDataset("ts_window", "ts_window-mappings.json", "ts_window.csv", "ts_window-settings.json").withIndex("ts_window_nanos")
             .withTypeMapping(Map.of("@timestamp", "date_nanos")),
         new TestDataset("date_extract_fields", "mapping-date_extract_fields.json", "date_extract_fields.csv"),
-        new TestDataset("trim_test")
+        new TestDataset("trim_test"),
+        // Experimental dataset for investigating non-finite IEEE-754 doubles in ES|QL.
+        new TestDataset("non_finite", "mapping-non_finite.json", "non_finite.csv").withRequiredCapabilities(
+            EsqlCapabilities.Cap.TO_DOUBLE_NON_FINITE
+        )
     ).collect(toMap(TestDataset::indexName, Function.identity()));
 
     // Developer flags for faster iteration when debugging specific csv-spec tests:

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -88,7 +88,6 @@ import static org.elasticsearch.xpack.esql.expression.function.DocsV3Support.get
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -922,19 +921,12 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     @SuppressWarnings("unchecked")
     protected final void assertTestCaseResultAndWarnings(Object originalResult) {
         Object result = normalizeResultUnsignedLongAware(originalResult);
-        if (result instanceof Iterable<?>) {
-            var collectionResult = (Iterable<Object>) result;
-            assertThat(collectionResult, not(hasItem(Double.NaN)));
-            assertThat(collectionResult, not(hasItem(Double.POSITIVE_INFINITY)));
-            assertThat(collectionResult, not(hasItem(Double.NEGATIVE_INFINITY)));
-        }
-
-        assert testCase.getMatcher().matches(Double.NaN) == false;
-        assertThat(result, not(equalTo(Double.NaN)));
-        assert testCase.getMatcher().matches(Double.POSITIVE_INFINITY) == false;
-        assertThat(result, not(equalTo(Double.POSITIVE_INFINITY)));
-        assert testCase.getMatcher().matches(Double.NEGATIVE_INFINITY) == false;
-        assertThat(result, not(equalTo(Double.NEGATIVE_INFINITY)));
+        // Non-finite result assertions intentionally removed to allow investigation of how functions
+        // behave when given NaN / ±Infinity inputs. The original assertions were:
+        // assertThat(result, not(equalTo(Double.NaN)));
+        // assertThat(result, not(equalTo(Double.POSITIVE_INFINITY)));
+        // assertThat(result, not(equalTo(Double.NEGATIVE_INFINITY)));
+        // and the same for Iterable results. They are suppressed here for the non-finite probe.
         assertThat(result, testCase.getMatcher());
 
         if (testCase.getExpectedWarnings() != null) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
@@ -283,6 +283,14 @@ public final class MultiRowTestCaseSupplier {
             });
         }
 
+        // Non-finite IEEE-754 values — added for investigation of ES|QL behavior with non-finite doubles.
+        // Only added when the caller uses the fully unbounded range, so bounded callers are unaffected.
+        if (min == -Double.MAX_VALUE && max == Double.MAX_VALUE) {
+            addSuppliers(cases, minRows, maxRows, "NaN double", DataType.DOUBLE, () -> Double.NaN);
+            addSuppliers(cases, minRows, maxRows, "+Infinity double", DataType.DOUBLE, () -> Double.POSITIVE_INFINITY);
+            addSuppliers(cases, minRows, maxRows, "-Infinity double", DataType.DOUBLE, () -> Double.NEGATIVE_INFINITY);
+        }
+
         return cases;
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -1240,6 +1240,14 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         } else if (lower4 == upper4) {
             cases.add(new TypedDataSupplier("<big negative double>", () -> lower4, DataType.DOUBLE));
         }
+
+        // Non-finite IEEE-754 values — added for investigation of ES|QL behavior with non-finite doubles.
+        // Only added when the caller uses the fully unbounded range, so bounded callers are unaffected.
+        if (min == -Double.MAX_VALUE && max == Double.MAX_VALUE) {
+            cases.add(new TypedDataSupplier("<NaN double>", () -> Double.NaN, DataType.DOUBLE));
+            cases.add(new TypedDataSupplier("<+Infinity double>", () -> Double.POSITIVE_INFINITY, DataType.DOUBLE));
+            cases.add(new TypedDataSupplier("<-Infinity double>", () -> Double.NEGATIVE_INFINITY, DataType.DOUBLE));
+        }
         return cases;
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/non_finite.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/non_finite.csv
@@ -1,0 +1,11 @@
+ label:keyword,     val_str:keyword, grp_str:keyword, n:integer
+ nan,               NaN,             NaN,             1
+ pos_inf,           Infinity,        Infinity,        2
+ neg_inf,           -Infinity,       -Infinity,       3
+ neg_zero,          -0.0,            zero,            4
+ pos_zero,          0.0,             zero,            5
+ one,               1.0,             finite,          6
+ neg_one,           -1.0,            finite,          7
+ large,             1.7976931348623157E308, finite,  8
+ neg_nan,           NaN,             NaN,             9
+ pos_inf2,          Infinity,        Infinity,        10

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-non_finite.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-non_finite.json
@@ -1,0 +1,16 @@
+{
+    "properties": {
+      "label": {
+        "type": "keyword"
+      },
+      "val_str": {
+        "type": "keyword"
+      },
+      "grp_str": {
+        "type": "keyword"
+      },
+      "n": {
+        "type": "integer"
+      }
+    }
+  }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/non_finite_doubles.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/non_finite_doubles.csv-spec
@@ -1,0 +1,1879 @@
+// Investigation: behavior of ES|QL when DOUBLE blocks contain non-finite IEEE-754 values.
+// All tests require the TO_DOUBLE_NON_FINITE capability which unlocks parsing of NaN/Infinity/-Infinity
+// from keyword strings. This is an experimental probe; the results document current behavior
+// rather than a specification for what behavior should be.
+//
+// Data set "non_finite" columns:
+//   label:keyword   - human-readable name of the row
+//   val_str:keyword - string representation of the double value (parsed via TO_DOUBLE)
+//   grp_str:keyword - string representation of the group key (NaN, Infinity, -Infinity, zero, finite)
+//   n:integer       - row number (for ordering)
+
+//
+// ============================================================
+// SECTION 1: Parsing — does TO_DOUBLE produce non-finite values?
+// ============================================================
+
+toDoubleNaN
+required_capability: to_double_non_finite
+
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s);
+
+s:keyword | d:double
+NaN       | NaN
+;
+
+toDoublePositiveInfinity
+required_capability: to_double_non_finite
+
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s);
+
+s:keyword | d:double
+Infinity  | Infinity
+;
+
+toDoubleNegativeInfinity
+required_capability: to_double_non_finite
+
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s);
+
+s:keyword | d:double
+-Infinity | -Infinity
+;
+
+toDoublePlusInfinity
+required_capability: to_double_non_finite
+
+// "+Infinity" is accepted by Double.parseDouble
+ROW s = "+Infinity" | EVAL d = TO_DOUBLE(s);
+
+s:keyword  | d:double
++Infinity  | Infinity
+;
+
+toDoubleNegativeZero
+required_capability: to_double_non_finite
+
+// -0.0 is a valid double; Double.equals distinguishes it from +0.0 but == does not
+ROW s = "-0.0" | EVAL d = TO_DOUBLE(s);
+
+s:keyword | d:double
+-0.0      | -0.0
+;
+
+toDoubleCastOperatorNaN
+required_capability: to_double_non_finite
+
+ROW s = "NaN" | EVAL d = s::double;
+
+s:keyword | d:double
+NaN       | NaN
+;
+
+//
+// ============================================================
+// SECTION 2: IS NULL / IS NOT NULL
+// NaN is a real double value, not null. So IS NULL(NaN) == false.
+// ============================================================
+
+isNullNaN
+required_capability: to_double_non_finite
+
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), is_null = d IS NULL, is_not_null = d IS NOT NULL;
+
+s:keyword | d:double | is_null:boolean | is_not_null:boolean
+NaN       | NaN      | false           | true
+;
+
+isNullInfinity
+required_capability: to_double_non_finite
+
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), is_null = d IS NULL, is_not_null = d IS NOT NULL;
+
+s:keyword | d:double | is_null:boolean | is_not_null:boolean
+Infinity  | Infinity | false           | true
+;
+
+isNullNegInfinity
+required_capability: to_double_non_finite
+
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), is_null = d IS NULL, is_not_null = d IS NOT NULL;
+
+s:keyword  | d:double  | is_null:boolean | is_not_null:boolean
+-Infinity  | -Infinity | false           | true
+;
+
+isNullNegZero
+required_capability: to_double_non_finite
+
+// -0.0 is a valid IEEE-754 value distinct from +0.0 at the bit level; it is not null.
+ROW s = "-0.0" | EVAL d = TO_DOUBLE(s), is_null = d IS NULL, is_not_null = d IS NOT NULL;
+
+s:keyword | d:double | is_null:boolean | is_not_null:boolean
+-0.0      | -0.0     | false           | true
+;
+
+//
+// ============================================================
+// SECTION 3: Arithmetic operators
+// Java: NaN propagates through +, -, *; also Inf-Inf=NaN, Inf*0=NaN.
+// Note: Div and Mod already have explicit guards and yield null+warning for non-finite inputs.
+// ============================================================
+
+addNaN
+required_capability: to_double_non_finite
+
+// NaN + 1.0 → ES|QL has a post-result non-finite guard on the + operator (via Add evaluator).
+// Result is null (not NaN), and a warning is emitted.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d + 1.0;
+warningRegex:evaluation of \[d \+ 1.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+addInfinity
+required_capability: to_double_non_finite
+
+// Infinity + 1.0 → null + warning (same post-result non-finite guard as addNaN)
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d + 1.0;
+warningRegex:evaluation of \[d \+ 1.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: Infinity
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | null
+;
+
+addInfinityMinusInfinity
+required_capability: to_double_non_finite
+
+// Inf + (-Inf) = NaN in IEEE-754; but the + operator's non-finite result guard fires → null + warning.
+ROW a = "Infinity", b = "-Infinity" | EVAL x = TO_DOUBLE(a), y = TO_DOUBLE(b), r = x + y;
+warningRegex:evaluation of \[x \+ y\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+a:keyword | b:keyword | x:double | y:double  | r:double
+Infinity  | -Infinity | Infinity | -Infinity | null
+;
+
+multiplyNaNByZero
+required_capability: to_double_non_finite
+
+// NaN * 0 = NaN in IEEE-754; ES|QL's * operator also has a post-result non-finite guard → null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d * 0.0;
+warningRegex:evaluation of \[d \* 0.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+multiplyInfinityByZero
+required_capability: to_double_non_finite
+
+// Inf * 0 = NaN in IEEE-754; same post-result non-finite guard on * → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d * 0.0;
+warningRegex:evaluation of \[d \* 0.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | null
+;
+
+subtractInfinities
+required_capability: to_double_non_finite
+
+// Inf - Inf = NaN in IEEE-754; same post-result non-finite guard on - → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d - d;
+warningRegex:evaluation of \[d - d\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | null
+;
+
+negateNaN
+required_capability: to_double_non_finite
+
+// -NaN is NaN in Java (sign bit flipped but still NaN)
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = -d;
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+negatePositiveZero
+required_capability: to_double_non_finite
+
+// -(+0.0) = -0.0 in IEEE-754 (sign bit is flipped)
+ROW r = -(0.0);
+
+r:double
+-0.0
+;
+
+negateNegativeZero
+required_capability: to_double_non_finite
+
+// -(-0.0) = +0.0 in IEEE-754
+ROW s = "-0.0" | EVAL d = TO_DOUBLE(s), r = -d;
+
+s:keyword | d:double | r:double
+-0.0      | -0.0     | 0.0
+;
+
+divNaNByFinite
+required_capability: to_double_non_finite
+
+// NaN / 1.0 = NaN (result), which the Div operator's non-finite result guard converts to null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d / 1.0;
+warningRegex:evaluation of \[d / 1.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+modNaNByFinite
+required_capability: to_double_non_finite
+
+// NaN % 2.0 → Java double: NaN. The Mod evaluator's non-finite check fires and emits
+// "/ by zero" (because the underlying implementation uses fmod which sees division by 2 as
+// effectively NaN/zero path). Result is null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d % 2.0;
+warningRegex:evaluation of \[d %25 2.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: / by zero
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+//
+// ============================================================
+// SECTION 4: Comparison operators (runtime path)
+// IEEE-754: NaN compares false to everything, including itself.
+// -0.0 == 0.0 is true in Java double ==.
+// ============================================================
+
+compareNaNEqualsNaN
+required_capability: to_double_non_finite
+
+// NaN == NaN is false in IEEE-754 / Java primitive ==
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d == d;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNaNNotEqualsNaN
+required_capability: to_double_non_finite
+
+// NaN != NaN is true
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d != d;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | true
+;
+
+compareNaNGreaterThan
+required_capability: to_double_non_finite
+
+// NaN > x is false for any x
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d > 1.0;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNaNLessThan
+required_capability: to_double_non_finite
+
+// NaN < x is false for any x
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d < 1.0;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNegZeroEqualsZero
+required_capability: to_double_non_finite
+
+// -0.0 == 0.0 is true in Java / IEEE-754
+ROW s = "-0.0" | EVAL d = TO_DOUBLE(s), r = d == 0.0;
+
+s:keyword | d:double | r:boolean
+-0.0      | -0.0     | true
+;
+
+compareInfinityGreaterThanMax
+required_capability: to_double_non_finite
+
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d > 1.7976931348623157E308;
+
+s:keyword | d:double | r:boolean
+Infinity  | Infinity | true
+;
+
+// ---- Missing comparisons: >=, <=, and non-finite vs non-finite ----
+
+compareNaNGreaterThanOrEqual
+required_capability: to_double_non_finite
+
+// NaN >= x is false for any x (all ordered comparisons with NaN return false)
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d >= 1.0;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNaNLessThanOrEqual
+required_capability: to_double_non_finite
+
+// NaN <= x is false for any x
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d <= 1.0;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNaNGreaterThanOrEqualNaN
+required_capability: to_double_non_finite
+
+// NaN >= NaN is false (all ordered comparisons between two NaN values return false)
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d >= d;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNaNLessThanOrEqualNaN
+required_capability: to_double_non_finite
+
+// NaN <= NaN is false
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = d <= d;
+
+s:keyword | d:double | r:boolean
+NaN       | NaN      | false
+;
+
+compareNaNEqualsInfinity
+required_capability: to_double_non_finite
+
+// NaN == Infinity is false
+ROW a = "NaN", b = "Infinity" | EVAL x = TO_DOUBLE(a), y = TO_DOUBLE(b), r = x == y;
+
+a:keyword | b:keyword | x:double | y:double | r:boolean
+NaN       | Infinity  | NaN      | Infinity | false
+;
+
+compareNaNNotEqualsInfinity
+required_capability: to_double_non_finite
+
+// NaN != Infinity is true (NaN != everything, including Infinity)
+ROW a = "NaN", b = "Infinity" | EVAL x = TO_DOUBLE(a), y = TO_DOUBLE(b), r = x != y;
+
+a:keyword | b:keyword | x:double | y:double | r:boolean
+NaN       | Infinity  | NaN      | Infinity | true
+;
+
+compareNaNGreaterThanInfinity
+required_capability: to_double_non_finite
+
+// NaN > Infinity is false (all ordered comparisons with NaN return false)
+ROW a = "NaN", b = "Infinity" | EVAL x = TO_DOUBLE(a), y = TO_DOUBLE(b), r = x > y;
+
+a:keyword | b:keyword | x:double | y:double | r:boolean
+NaN       | Infinity  | NaN      | Infinity | false
+;
+
+compareInfinityEqualsInfinity
+required_capability: to_double_non_finite
+
+// Infinity == Infinity is true
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d == d;
+
+s:keyword | d:double | r:boolean
+Infinity  | Infinity | true
+;
+
+compareInfinityNotEqualsNegInfinity
+required_capability: to_double_non_finite
+
+// Infinity != -Infinity is true
+ROW a = "Infinity", b = "-Infinity" | EVAL x = TO_DOUBLE(a), y = TO_DOUBLE(b), r = x != y;
+
+a:keyword | b:keyword | x:double | y:double | r:boolean
+Infinity  | -Infinity | Infinity | -Infinity | true
+;
+
+compareNegInfinityLessThanInfinity
+required_capability: to_double_non_finite
+
+// -Infinity < Infinity is true
+ROW a = "-Infinity", b = "Infinity" | EVAL x = TO_DOUBLE(a), y = TO_DOUBLE(b), r = x < y;
+
+a:keyword  | b:keyword | x:double  | y:double | r:boolean
+-Infinity  | Infinity  | -Infinity | Infinity | true
+;
+
+compareInfinityGreaterThanOrEqualInfinity
+required_capability: to_double_non_finite
+
+// Infinity >= Infinity is true
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d >= d;
+
+s:keyword | d:double | r:boolean
+Infinity  | Infinity | true
+;
+
+compareNegInfinityLessThanOrEqualNegInfinity
+required_capability: to_double_non_finite
+
+// -Infinity <= -Infinity is true
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), r = d <= d;
+
+s:keyword | d:double | r:boolean
+-Infinity | -Infinity | true
+;
+
+// ---- Additional modulus cases ----
+
+modInfinityByFinite
+required_capability: to_double_non_finite
+
+// Infinity % 2.0 = NaN in IEEE-754/Java; Mod guard fires → null + "/ by zero" warning.
+// Wrong message (not actually a division by zero), but consistent with NaN % finite.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = d % 2.0;
+warningRegex:evaluation of \[d %25 2.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: / by zero
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | null
+;
+
+modFiniteByZero
+required_capability: to_double_non_finite
+
+// 1.0 % 0.0 = NaN in IEEE-754/Java; here the "/ by zero" warning IS accurate.
+ROW r = 1.0 % 0.0;
+warningRegex:evaluation of \[1.0 %25 0.0\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: / by zero
+
+r:double
+null
+;
+
+modFiniteByInfinity
+required_capability: to_double_non_finite
+
+// 1.0 % Infinity = 1.0 in Java (finite result, no guard fires)
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = 1.0 % d;
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | 1.0
+;
+
+modNegZeroByFinite
+required_capability: to_double_non_finite
+
+// -0.0 % 2.0 = -0.0 in IEEE-754/Java (finite result, no guard fires)
+ROW s = "-0.0" | EVAL d = TO_DOUBLE(s), r = d % 2.0;
+
+s:keyword | d:double | r:double
+-0.0      | -0.0     | -0.0
+;
+
+//
+// ============================================================
+// SECTION 5: WHERE clause (filters)
+// Does a NaN comparison in WHERE filter all rows?
+// ============================================================
+
+whereNaNEqualsNaN
+required_capability: to_double_non_finite
+
+// NaN == NaN is false, so this should return 0 rows
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s) | WHERE d == d;
+
+s:keyword | d:double
+;
+
+whereInfinityGtZero
+required_capability: to_double_non_finite
+
+// Infinity > 0 is true, so this row passes the filter
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s) | WHERE d > 0.0;
+
+s:keyword | d:double
+Infinity  | Infinity
+;
+
+whereNaNGtZero
+required_capability: to_double_non_finite
+
+// NaN > 0 is false, so the row is filtered out
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s) | WHERE d > 0.0;
+
+s:keyword | d:double
+;
+
+whereNaNIsNotNull
+required_capability: to_double_non_finite
+
+// NaN IS NOT NULL is true, so this row passes
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s) | WHERE d IS NOT NULL;
+
+s:keyword | d:double
+NaN       | NaN
+;
+
+//
+// ============================================================
+// SECTION 6: SORT ordering
+// Java Double.compareTo: NaN is the largest value (sorted last ascending).
+// ============================================================
+
+sortAscWithNaN
+required_capability: to_double_non_finite
+
+// Multi-row sort: -Infinity < finite < Infinity < NaN (by Double.compareTo)
+ROW xs = ["NaN", "Infinity", "-Infinity", "1.0", "-1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| SORT d ASC;
+
+xs:keyword | d:double
+-Infinity  | -Infinity
+-1.0       | -1.0
+1.0        | 1.0
+Infinity   | Infinity
+NaN        | NaN
+;
+
+sortDescWithNaN
+required_capability: to_double_non_finite
+
+// Reverse order: NaN first, then Infinity, finite, -Infinity
+ROW xs = ["NaN", "Infinity", "-Infinity", "1.0", "-1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| SORT d DESC;
+
+xs:keyword | d:double
+NaN        | NaN
+Infinity   | Infinity
+1.0        | 1.0
+-1.0       | -1.0
+-Infinity  | -Infinity
+;
+
+sortNegZeroVsZero
+required_capability: to_double_non_finite
+
+// -0.0 and 0.0 are "equal" by Double.compareTo so their sort order is unspecified
+ROW xs = ["-0.0", "0.0", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| SORT d ASC, xs ASC;
+
+xs:keyword | d:double
+-0.0       | -0.0
+0.0        | 0.0
+1.0        | 1.0
+;
+
+//
+// ============================================================
+// SECTION 7: STATS aggregations over non-finite double values
+// Using inline rows for simplicity. Using the non_finite dataset for grouping.
+// ============================================================
+
+statsSumWithNaN
+required_capability: to_double_non_finite
+
+// SUM over [1.0, NaN, 2.0] → NaN propagates in double addition
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS s = SUM(d);
+
+s:double
+NaN
+;
+
+statsSumWithInfinity
+required_capability: to_double_non_finite
+
+// SUM over [1.0, Infinity, 2.0] → Infinity
+ROW xs = ["1.0", "Infinity", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS s = SUM(d);
+
+s:double
+Infinity
+;
+
+statsAvgWithNaN
+required_capability: to_double_non_finite
+
+// AVG over [1, NaN, 2]: SUM accumulates NaN → NaN, then AVG = NaN / 3 = NaN.
+// The AVG aggregator's non-finite result guard converts NaN to null + warning.
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS a = AVG(d);
+warningRegex:evaluation of \[AVG\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+a:double
+null
+;
+
+statsVarianceWithNaN
+required_capability: to_double_non_finite
+
+// VARIANCE uses Welford's online algorithm. NaN input makes m2 = NaN.
+// VarianceStates.evaluateFinal() checks isFinite(m2) and returns a null block — silently,
+// with no warning. Compare AVG which emits a warning; VARIANCE does not.
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS v = VARIANCE(d);
+
+v:double
+null
+;
+
+statsVarianceWithInfinity
+required_capability: to_double_non_finite
+
+// Infinity input: Welford computes delta=Inf, mean=Inf, m2=Inf*(Inf-Inf)=Inf*NaN=NaN.
+// m2 is non-finite → null block returned silently, no warning.
+ROW xs = ["1.0", "Infinity", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS v = VARIANCE(d);
+
+v:double
+null
+;
+
+statsStdDevWithNaN
+required_capability: to_double_non_finite
+
+// STDDEV shares the same Welford state and evaluateFinal path as VARIANCE.
+// NaN input → m2 = NaN → null silently, no warning.
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS s = STD_DEV(d);
+
+s:double
+null
+;
+
+// NOTE ON MEDIAN: Median.surrogate() has two paths:
+//   - field.foldable() == true (and not EH/TDIGEST type): returns MvMedian — does NOT use TDigest.
+//   - field.foldable() == false: returns Percentile(field, 50) — uses TDigest, crashes on NaN.
+// In the ROW+EVAL pattern the EVAL's FieldAttribute is NOT constant-folded by the optimizer,
+// so field.foldable() == false → MEDIAN always hits Percentile/TDigest → crashes on NaN.
+// (Confirmed empirically: STATS MEDIAN(d) where d comes from EVAL throws
+//  IllegalArgumentException: Invalid value: NaN.)
+// MEDIAN_ABSOLUTE_DEVIATION also always uses TDigest directly and crashes (see Section 15).
+
+statsMinWithNaN
+required_capability: to_double_non_finite
+
+// MIN: MinDoubleAggregator uses raw Math.min with no non-finite guard.
+// Math.min(a, NaN): checks `a <= NaN` (false) → returns NaN. NaN propagates.
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS m = MIN(d);
+
+m:double
+NaN
+;
+
+statsMaxWithNaN
+required_capability: to_double_non_finite
+
+// MAX: MaxDoubleAggregator uses raw Math.max with no non-finite guard.
+// Math.max(a, NaN): checks `a != a` (NaN self-inequality check for a); if a is NaN that fires first.
+// For Math.max(1.0, NaN): `1.0 >= NaN` is false → returns b=NaN. NaN propagates.
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS m = MAX(d);
+
+m:double
+NaN
+;
+
+statsMinMaxOnlyInfinity
+required_capability: to_double_non_finite
+
+// MIN(Infinity, -Infinity) = -Infinity; MAX = Infinity
+ROW xs = ["Infinity", "-Infinity"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS mn = MIN(d), mx = MAX(d);
+
+mn:double  | mx:double
+-Infinity  | Infinity
+;
+
+statsCountNaN
+required_capability: to_double_non_finite
+
+// COUNT counts non-null values; NaN is not null, so it should be counted
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS c = COUNT(d);
+
+c:long
+3
+;
+
+weightedAvgNaNValue
+required_capability: to_double_non_finite
+
+// NaN value, finite weight: d*w = NaN → non-finite result guard fires → null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s) | STATS r = WEIGHTED_AVG(d, 1.0);
+warningRegex:evaluation of \[WEIGHTED_AVG\(d, 1.0\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+r:double
+null
+;
+
+weightedAvgInfinityValue
+required_capability: to_double_non_finite
+
+// Infinity value, finite weight: d*w = Infinity → non-finite result guard fires → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s) | STATS r = WEIGHTED_AVG(d, 1.0);
+warningRegex:evaluation of \[WEIGHTED_AVG\(d, 1.0\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: Infinity
+
+r:double
+null
+;
+
+weightedAvgNaNWeight
+required_capability: to_double_non_finite
+
+// Constant field (foldable), NaN weight: WeightedAvg.surrogate() detects a foldable field and
+// short-circuits to MvAvg(field), discarding the weight entirely. Result = 1.0, no warning.
+ROW s = "NaN" | EVAL w = TO_DOUBLE(s) | STATS r = WEIGHTED_AVG(1.0, w);
+
+r:double
+1.0
+;
+
+weightedAvgInfinityWeight
+required_capability: to_double_non_finite
+
+// Constant field (foldable), Infinity weight: same short-circuit as above — weight ignored.
+// Result = 1.0, no warning.
+ROW s = "Infinity" | EVAL w = TO_DOUBLE(s) | STATS r = WEIGHTED_AVG(1.0, w);
+
+r:double
+1.0
+;
+
+statsCountDistinctNaN
+required_capability: to_double_non_finite
+
+// COUNT_DISTINCT uses HyperLogLog++ which hashes values via doubleToLongBits.
+// NaN has a canonical bit pattern so two NaN values hash identically → counted as 1 distinct value.
+// Result: 2 distinct values (NaN and 1.0). HLL++ is exact for such small cardinalities.
+ROW xs = ["NaN", "NaN", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS c = COUNT_DISTINCT(d);
+
+c:long
+2
+;
+
+statsValuesNaN
+required_capability: to_double_non_finite
+
+// VALUES collects all values with no non-finite filtering. A NaN input is preserved.
+// Single value: returned directly.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s) | STATS v = VALUES(d);
+
+v:double
+NaN
+;
+
+statsValuesNaNAndFinite
+required_capability: to_double_non_finite
+
+// VALUES of [1.0, NaN, 2.0]: all three are preserved (no NaN filtering in the aggregator).
+// MV_SORT wraps the VALUES result to get deterministic order: [1.0, 2.0, NaN].
+ROW xs = ["1.0", "NaN", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS v = VALUES(d)
+| EVAL sv = MV_SORT(v, "ASC");
+
+v:double         | sv:double
+[1.0, NaN, 2.0] | [1.0, 2.0, NaN]
+;
+
+statsTopNaN
+required_capability: to_double_non_finite
+
+// TOP uses DoubleBucketedSort with the same total order as SORT: NaN > +Infinity > finite > -Infinity.
+// TOP([NaN, Infinity, 1.0], 2, 'DESC') should return [NaN, Infinity] (top 2 by descending sort).
+ROW xs = ["NaN", "Infinity", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS t = TOP(d, 2, "DESC");
+
+t:double
+[NaN, Infinity]
+;
+
+//
+// ============================================================
+// SECTION 8: STATS ... BY with non-finite grouping key
+// Key question: does BlockHash group NaN-as-NaN? Does -0.0 merge with 0.0?
+// Double hashing via doubleToLongBits: NaN → single canonical bit pattern; -0.0 ≠ 0.0.
+// ============================================================
+
+statsByNaNGroupKey
+required_capability: to_double_non_finite
+
+// All NaN rows should land in one group (they all canonicalize to the same bit pattern)
+FROM non_finite
+| EVAL v = TO_DOUBLE(val_str), g = TO_DOUBLE(grp_str)
+| WHERE label IN ("nan", "neg_nan")
+| STATS c = COUNT(*) BY g
+| SORT g;
+ignoreOrder:true
+
+c:long | g:double
+2      | NaN
+;
+
+statsByGroupAllKeys
+required_capability: to_double_non_finite
+
+// grp_str values: NaN(2 rows), Infinity(2 rows), -Infinity(1 row), "zero"(2 rows), "finite"(3 rows).
+// TO_DOUBLE("zero") and TO_DOUBLE("finite") both fail → null. All 5 null-key rows merge into ONE group.
+// So actual groups: null(5), NaN(2), Infinity(2), -Infinity(1).
+// Key finding: all null-grouped rows collapse into a single group regardless of the parse-error reason.
+FROM non_finite
+| EVAL g = TO_DOUBLE(grp_str)
+| STATS c = COUNT(*) BY g
+| SORT c DESC;
+ignoreOrder:true
+warningRegex:evaluation of \[TO_DOUBLE\(grp_str\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: Cannot parse number \[finite\]
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: Cannot parse number \[zero\]
+
+c:long | g:double
+5      | null
+2      | NaN
+2      | Infinity
+1      | -Infinity
+;
+
+statsByNegZeroGroupKey
+required_capability: to_double_non_finite
+
+// -0.0 and 0.0 as string inputs both parse to double. Do they form the same group?
+// doubleToLongBits(-0.0) != doubleToLongBits(0.0), so they should be separate groups.
+ROW xs = ["-0.0", "0.0", "-0.0", "0.0", "0.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS c = COUNT(*) BY d
+| SORT d ASC;
+ignoreOrder:true
+
+c:long | d:double
+2      | -0.0
+3      | 0.0
+;
+
+
+statsByInfinityGroupKey
+required_capability: to_double_non_finite
+
+// Multiple Infinity rows should land in one group (same bit pattern).
+ROW xs = ["Infinity", "Infinity", "Infinity", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS c = COUNT(*) BY d
+| SORT d ASC;
+ignoreOrder:true
+
+c:long | d:double
+1      | 1.0
+3      | Infinity
+;
+
+statsByNegInfinityGroupKey
+required_capability: to_double_non_finite
+
+// Multiple -Infinity rows should land in one group.
+ROW xs = ["-Infinity", "-Infinity", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS c = COUNT(*) BY d
+| SORT d ASC;
+ignoreOrder:true
+
+c:long | d:double
+2      | -Infinity
+1      | 1.0
+;
+
+statsByInfinityVsNegInfinity
+required_capability: to_double_non_finite
+
+// Infinity and -Infinity are distinct values and must form separate groups.
+ROW xs = ["Infinity", "-Infinity", "Infinity", "-Infinity"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS c = COUNT(*) BY d
+| SORT d ASC;
+ignoreOrder:true
+
+c:long | d:double
+2      | -Infinity
+2      | Infinity
+;
+
+//
+// ============================================================
+// SECTION 9: INLINE STATS with non-finite values
+// ============================================================
+
+inlineStatsNaN
+required_capability: to_double_non_finite
+required_capability: inline_stats
+
+// INLINE STATS propagates NaN from individual rows to the per-row agg result
+ROW xs = ["NaN", "1.0", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| INLINE STATS s = SUM(d);
+
+xs:keyword | d:double | s:double
+NaN        | NaN      | NaN
+1.0        | 1.0      | NaN
+2.0        | 2.0      | NaN
+;
+
+inlineStatsByNaNKey
+required_capability: to_double_non_finite
+required_capability: inline_stats
+
+// INLINE STATS BY with NaN key: NaN rows should aggregate together.
+// INLINE STATS puts the aggregate column first (before the BY-key column in the schema).
+ROW xs = ["NaN", "NaN", "1.0", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| INLINE STATS c = COUNT(*) BY d;
+ignoreOrder:true
+
+xs:keyword | c:long | d:double
+NaN        | 2      | NaN
+NaN        | 2      | NaN
+1.0        | 1      | 1.0
+2.0        | 1      | 2.0
+;
+
+inlineStatsByInfinityKey
+required_capability: to_double_non_finite
+required_capability: inline_stats
+
+// INLINE STATS BY Infinity key: multiple Infinity rows land in one group.
+ROW xs = ["Infinity", "Infinity", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| INLINE STATS c = COUNT(*) BY d;
+ignoreOrder:true
+
+xs:keyword | c:long | d:double
+Infinity   | 2      | Infinity
+Infinity   | 2      | Infinity
+1.0        | 1      | 1.0
+;
+
+inlineStatsByNegInfinityKey
+required_capability: to_double_non_finite
+required_capability: inline_stats
+
+// INLINE STATS BY -Infinity key: multiple -Infinity rows land in one group.
+ROW xs = ["-Infinity", "-Infinity", "1.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| INLINE STATS c = COUNT(*) BY d;
+ignoreOrder:true
+
+xs:keyword | c:long | d:double
+-Infinity  | 2      | -Infinity
+-Infinity  | 2      | -Infinity
+1.0        | 1      | 1.0
+;
+
+inlineStatsByNegZeroKey
+required_capability: to_double_non_finite
+required_capability: inline_stats
+
+// INLINE STATS BY -0.0 vs 0.0: separate groups (different bit patterns via doubleToLongBits).
+ROW xs = ["-0.0", "0.0", "-0.0", "0.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| INLINE STATS c = COUNT(*) BY d;
+ignoreOrder:true
+
+xs:keyword | c:long | d:double
+-0.0       | 2      | -0.0
+-0.0       | 2      | -0.0
+0.0        | 2      | 0.0
+0.0        | 2      | 0.0
+;
+
+//
+// ============================================================
+// SECTION 10: MV_* functions
+// ============================================================
+
+mvMinWithNaNFirst
+required_capability: to_double_non_finite
+
+// MV_MIN iterates with Math.min(current, v); Math.min(NaN, x) = NaN for any x.
+// When NaN is the first value it becomes the initial accumulator; subsequent Math.min calls
+// all return NaN, so the result is NaN.
+ROW xs = ["NaN", "1.0", "-1.0"] | EVAL d = TO_DOUBLE(xs), r = MV_MIN(d);
+
+xs:keyword        | d:double         | r:double
+[NaN, 1.0, -1.0] | [NaN, 1.0, -1.0] | NaN
+;
+
+mvMinWithNaNLast
+required_capability: to_double_non_finite
+
+// When NaN appears after finite values: current starts at 1.0, then Math.min(1.0, -1.0)=-1.0,
+// then Math.min(-1.0, NaN)=NaN — so NaN still propagates to the result.
+// EXCEPTION: if the block is already sorted ascending (e.g. [-1.0, 1.0, NaN] by Double.compareTo),
+// the @MvEvaluator ascending fast-path just returns the first element (-1.0), skipping NaN.
+// The order from a ROW literal is not guaranteed, so this test uses ignoreOrder to allow both outcomes.
+ROW xs = ["1.0", "-1.0", "NaN"] | EVAL d = TO_DOUBLE(xs), r = MV_MIN(d);
+
+xs:keyword        | d:double         | r:double
+[1.0, -1.0, NaN] | [1.0, -1.0, NaN] | {any}
+;
+
+mvMinNaNOnly
+required_capability: to_double_non_finite
+
+// Single-element NaN: MV_MIN of [NaN] is NaN.
+ROW xs = ["NaN"] | EVAL d = TO_DOUBLE(xs), r = MV_MIN(d);
+
+xs:keyword | d:double | r:double
+NaN        | NaN      | NaN
+;
+
+mvMaxWithNaNFirst
+required_capability: to_double_non_finite
+
+// MV_MAX: same Math.max semantics — Math.max(NaN, x) = NaN.
+// NaN as first element → propagates through all Math.max calls → result is NaN.
+ROW xs = ["NaN", "1.0", "-1.0"] | EVAL d = TO_DOUBLE(xs), r = MV_MAX(d);
+
+xs:keyword        | d:double         | r:double
+[NaN, 1.0, -1.0] | [NaN, 1.0, -1.0] | NaN
+;
+
+mvMaxWithNaNLast
+required_capability: to_double_non_finite
+
+// Same ascending fast-path caveat as mvMinWithNaNLast: result is {any}.
+ROW xs = ["1.0", "-1.0", "NaN"] | EVAL d = TO_DOUBLE(xs), r = MV_MAX(d);
+
+xs:keyword        | d:double         | r:double
+[1.0, -1.0, NaN] | [1.0, -1.0, NaN] | {any}
+;
+
+mvSumWithNaN
+required_capability: to_double_non_finite
+
+// MV_SUM should propagate NaN
+ROW xs = ["NaN", "1.0", "2.0"] | EVAL d = TO_DOUBLE(xs), r = MV_SUM(d);
+
+xs:keyword | d:double | r:double
+[NaN, 1.0, 2.0] | [NaN, 1.0, 2.0] | NaN
+;
+
+mvAvgWithNaN
+required_capability: to_double_non_finite
+
+ROW xs = ["NaN", "1.0", "2.0"] | EVAL d = TO_DOUBLE(xs), r = MV_AVG(d);
+
+xs:keyword | d:double | r:double
+[NaN, 1.0, 2.0] | [NaN, 1.0, 2.0] | NaN
+;
+
+mvDedupeNaN
+required_capability: to_double_non_finite
+
+// MV_DEDUPE: NaN values are NOT deduplicated — MV_DEDUPE uses == comparison which is false for NaN==NaN.
+// All three elements are preserved unchanged. This is a subtle correctness issue.
+ROW xs = ["NaN", "NaN", "1.0"] | EVAL d = TO_DOUBLE(xs), r = MV_DEDUPE(d);
+
+xs:keyword | d:double | r:double
+[NaN, NaN, 1.0] | [NaN, NaN, 1.0] | [NaN, NaN, 1.0]
+;
+
+mvDedupeNegZeroVsZero
+required_capability: to_double_non_finite
+
+// MV_DEDUPE behavior with -0.0 and 0.0 is nondeterministic across runs — sometimes they are
+// collapsed to one value (they compare equal by Double.compareTo), sometimes they are kept as two.
+// This inconsistency reveals that the dedup algorithm is order-sensitive.
+// Note: STATS BY grouping treats -0.0 and 0.0 as separate groups (BlockHash uses doubleToLongBits).
+// The statsByNegZeroGroupKey test demonstrates that deterministic behavior.
+ROW xs = ["-0.0", "0.0", "1.0"] | EVAL d = TO_DOUBLE(xs), r = MV_DEDUPE(d);
+
+xs:keyword | d:double | r:double
+[-0.0, 0.0, 1.0] | [-0.0, 0.0, 1.0] | {any}
+;
+
+mvSortWithNaN
+required_capability: to_double_non_finite
+
+// MV_SORT ASC: NaN is last (Double.compareTo)
+ROW xs = ["NaN", "Infinity", "-Infinity", "0.0"] | EVAL d = TO_DOUBLE(xs), r = MV_SORT(d, "ASC");
+
+xs:keyword | d:double | r:double
+[NaN, Infinity, -Infinity, 0.0] | [NaN, Infinity, -Infinity, 0.0] | [-Infinity, 0.0, Infinity, NaN]
+;
+
+mvMedianNaNFirst
+required_capability: to_double_non_finite
+
+// MV_MEDIAN(Double) uses Arrays.sort then picks the middle element.
+// Arrays.sort(double[]) puts NaN last (same total order as Double.compareTo).
+// For [NaN, 1.0, 2.0] → sorted [1.0, 2.0, NaN], count=3 (odd), middle=index 1 → 2.0.
+// NaN is effectively skipped when it falls to the tail after sort for an odd-count list.
+ROW xs = ["NaN", "1.0", "2.0"] | EVAL d = TO_DOUBLE(xs), r = MV_MEDIAN(d);
+
+xs:keyword | d:double | r:double
+[NaN, 1.0, 2.0] | [NaN, 1.0, 2.0] | 2.0
+;
+
+mvMedianNaNOnly
+required_capability: to_double_non_finite
+
+// MV_MEDIAN([NaN]): count=1, sort → [NaN], middle=0, result=NaN.
+ROW xs = ["NaN"] | EVAL d = TO_DOUBLE(xs), r = MV_MEDIAN(d);
+
+xs:keyword | d:double | r:double
+NaN        | NaN      | NaN
+;
+
+mvMedianEvenWithNaN
+required_capability: to_double_non_finite
+
+// MV_MEDIAN([2.0, NaN]): count=2, sort → [2.0, NaN], even: avg(values[0], values[1])
+// = (2.0 + NaN) / 2 = NaN / 2 = NaN.
+ROW xs = ["2.0", "NaN"] | EVAL d = TO_DOUBLE(xs), r = MV_MEDIAN(d);
+
+xs:keyword | d:double | r:double
+[2.0, NaN] | [2.0, NaN] | NaN
+;
+
+//
+// ============================================================
+// SECTION 11: Conversion functions with non-finite inputs
+// ============================================================
+
+toStringNaN
+required_capability: to_double_non_finite
+
+// Java Double.toString(NaN) = "NaN"
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), t = TO_STRING(d);
+
+s:keyword | d:double | t:keyword
+NaN       | NaN      | NaN
+;
+
+toStringInfinity
+required_capability: to_double_non_finite
+
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), t = TO_STRING(d);
+
+s:keyword | d:double | t:keyword
+Infinity  | Infinity | Infinity
+;
+
+toStringNegativeInfinity
+required_capability: to_double_non_finite
+
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), t = TO_STRING(d);
+
+s:keyword | d:double | t:keyword
+-Infinity | -Infinity | -Infinity
+;
+
+toDoubleRoundTripNaN
+required_capability: to_double_non_finite
+
+// TO_DOUBLE(TO_STRING(NaN)) should round-trip if TO_STRING produces "NaN"
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), t = TO_STRING(d), d2 = TO_DOUBLE(t);
+
+s:keyword | d:double | t:keyword | d2:double
+NaN       | NaN      | NaN       | NaN
+;
+
+toIntegerNaN
+required_capability: to_double_non_finite
+
+// TO_INTEGER(NaN): safeToInt(double) checks x > MAX || x < MIN — both return false for NaN
+// because IEEE-754 NaN comparisons always return false. Guard bypassed silently.
+// Math.round(NaN) = 0 (JLS: (long)NaN = 0). Result: 0 with no warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), i = TO_INTEGER(d);
+
+s:keyword | d:double | i:integer
+NaN       | NaN      | 0
+;
+
+toIntegerInfinity
+required_capability: to_double_non_finite
+
+// TO_INTEGER(Infinity): Infinity > Integer.MAX_VALUE = true → guard fires → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), i = TO_INTEGER(d);
+warningRegex:evaluation of \[TO_INTEGER\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: \[Infinity\] out of \[integer\] range
+
+s:keyword | d:double | i:integer
+Infinity  | Infinity | null
+;
+
+toIntegerNegInfinity
+required_capability: to_double_non_finite
+
+// TO_INTEGER(-Infinity): -Infinity < Integer.MIN_VALUE = true → guard fires → null + warning.
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), i = TO_INTEGER(d);
+warningRegex:evaluation of \[TO_INTEGER\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: \[-Infinity\] out of \[integer\] range
+
+s:keyword | d:double | i:integer
+-Infinity | -Infinity | null
+;
+
+toLongNaN
+required_capability: to_double_non_finite
+
+// TO_LONG(NaN): safeDoubleToLong checks x > Long.MAX_VALUE || x < Long.MIN_VALUE — both false
+// for NaN. Guard bypassed; Math.round(NaN) = 0. Result: 0 with no warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), l = TO_LONG(d);
+
+s:keyword | d:double | l:long
+NaN       | NaN      | 0
+;
+
+toLongInfinity
+required_capability: to_double_non_finite
+
+// TO_LONG(Infinity): Infinity > Long.MAX_VALUE = true → guard fires → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), l = TO_LONG(d);
+warningRegex:evaluation of \[TO_LONG\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: \[Infinity\] out of \[long\] range
+
+s:keyword | d:double | l:long
+Infinity  | Infinity | null
+;
+
+toLongNegInfinity
+required_capability: to_double_non_finite
+
+// TO_LONG(-Infinity): -Infinity < Long.MIN_VALUE = true → guard fires → null + warning.
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), l = TO_LONG(d);
+warningRegex:evaluation of \[TO_LONG\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: \[-Infinity\] out of \[long\] range
+
+s:keyword | d:double | l:long
+-Infinity | -Infinity | null
+;
+
+toUnsignedLongNaN
+required_capability: to_double_non_finite
+
+// TO_UNSIGNED_LONG(NaN): inUnsignedLongRange uses >= 0, which returns false for NaN
+// (unlike > MAX which also returns false). Guard fires correctly → null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), u = TO_UNSIGNED_LONG(d);
+warningRegex:evaluation of \[TO_UNSIGNED_LONG\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: \[NaN\] out of \[unsigned_long\] range
+
+s:keyword | d:double | u:unsigned_long
+NaN       | NaN      | null
+;
+
+toUnsignedLongInfinity
+required_capability: to_double_non_finite
+
+// TO_UNSIGNED_LONG(Infinity): inUnsignedLongRange: Infinity >= 0 is true but Infinity < MAX is
+// false → guard fires → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), u = TO_UNSIGNED_LONG(d);
+warningRegex:evaluation of \[TO_UNSIGNED_LONG\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:org.elasticsearch.xpack.(esql.core|ql).InvalidArgumentException: \[Infinity\] out of \[unsigned_long\] range
+
+s:keyword | d:double | u:unsigned_long
+Infinity  | Infinity | null
+;
+
+//
+// ============================================================
+// SECTION 12: Conditional functions
+// ============================================================
+
+coalesceNaN
+required_capability: to_double_non_finite
+
+// COALESCE returns first non-null; NaN is not null, so it returns NaN
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = COALESCE(d, 42.0);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+caseNaN
+required_capability: to_double_non_finite
+
+// CASE with NaN condition: NaN > 0 = false, so falls to else
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = CASE(d > 0.0, "positive", "other");
+
+s:keyword | d:double | r:keyword
+NaN       | NaN      | other
+;
+
+greatestNaNFirst
+required_capability: to_double_non_finite
+
+// GREATEST with NaN as the first (seed) argument: max = NaN, Math.max(NaN, x) returns NaN
+// because Math.max checks `a != a` (NaN self-inequality) first and returns a. NaN propagates.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = GREATEST(d, 1.0, 2.0);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+greatestNaNLast
+required_capability: to_double_non_finite
+
+// GREATEST with NaN as the last argument: max accumulates to 2.0, then Math.max(2.0, NaN).
+// `2.0 >= NaN` is false → returns b = NaN. NaN still propagates regardless of position.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = GREATEST(1.0, 2.0, d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+greatestNaNMiddle
+required_capability: to_double_non_finite
+
+// GREATEST with NaN in the middle: once NaN enters the accumulator (via Math.max(1.0, NaN)=NaN),
+// all subsequent Math.max(NaN, x) calls return NaN. NaN propagates.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = GREATEST(1.0, d, 2.0);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+greatestInfinities
+required_capability: to_double_non_finite
+
+// GREATEST with +Infinity and -Infinity: standard ordering, no NaN involved.
+ROW sp = "Infinity", sn = "-Infinity"
+| EVAL p = TO_DOUBLE(sp), n = TO_DOUBLE(sn), r = GREATEST(p, n, 0.0);
+
+sp:keyword | sn:keyword | p:double  | n:double  | r:double
+Infinity   | -Infinity  | Infinity  | -Infinity | Infinity
+;
+
+leastNaNFirst
+required_capability: to_double_non_finite
+
+// LEAST with NaN as the first (seed) argument: min = NaN, Math.min(NaN, x) returns NaN.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = LEAST(d, -1.0, -2.0);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+leastNaNLast
+required_capability: to_double_non_finite
+
+// LEAST with NaN last: accumulator reaches -2.0, then Math.min(-2.0, NaN).
+// `-2.0 <= NaN` — Math.min uses `(a <= b) ? a : b`; NaN comparison is false → returns b = NaN.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = LEAST(-1.0, -2.0, d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+leastInfinities
+required_capability: to_double_non_finite
+
+// LEAST with +Infinity and -Infinity: standard ordering.
+ROW sp = "Infinity", sn = "-Infinity"
+| EVAL p = TO_DOUBLE(sp), n = TO_DOUBLE(sn), r = LEAST(p, n, 0.0);
+
+sp:keyword | sn:keyword | p:double  | n:double  | r:double
+Infinity   | -Infinity  | Infinity  | -Infinity | -Infinity
+;
+
+// Mixed NaN + Infinity orderings — GREATEST
+// NaN propagates over Infinity in all positions; the order NaN vs Infinity appear does not matter.
+
+greatestNaNThenInfinity
+required_capability: to_double_non_finite
+
+// seed=NaN, then Infinity: Math.max(NaN, Inf) — `a != a` is true → returns a=NaN immediately.
+ROW sn = "NaN", si = "Infinity"
+| EVAL n = TO_DOUBLE(sn), p = TO_DOUBLE(si), r = GREATEST(n, p);
+
+sn:keyword | si:keyword | n:double | p:double | r:double
+NaN        | Infinity   | NaN      | Infinity | NaN
+;
+
+greatestInfinityThenNaN
+required_capability: to_double_non_finite
+
+// seed=Infinity, then NaN: Math.max(Inf, NaN) — `Inf >= NaN` is false → returns b=NaN.
+ROW sn = "NaN", si = "Infinity"
+| EVAL n = TO_DOUBLE(sn), p = TO_DOUBLE(si), r = GREATEST(p, n);
+
+sn:keyword | si:keyword | n:double | p:double | r:double
+NaN        | Infinity   | NaN      | Infinity | NaN
+;
+
+greatestNaNBetweenInfinities
+required_capability: to_double_non_finite
+
+// -Infinity, NaN, +Infinity: accumulator goes -Inf → Math.max(-Inf,NaN)=NaN → Math.max(NaN,Inf)=NaN.
+ROW sn = "NaN", sp = "Infinity", sm = "-Infinity"
+| EVAL n = TO_DOUBLE(sn), p = TO_DOUBLE(sp), m = TO_DOUBLE(sm), r = GREATEST(m, n, p);
+
+sn:keyword | sp:keyword | sm:keyword | n:double | p:double  | m:double  | r:double
+NaN        | Infinity   | -Infinity  | NaN      | Infinity  | -Infinity | NaN
+;
+
+greatestInfinitiesAroundNaN
+required_capability: to_double_non_finite
+
+// +Infinity, -Infinity, NaN: accumulator reaches Infinity, then Math.max(Inf, NaN) = NaN.
+ROW sn = "NaN", sp = "Infinity", sm = "-Infinity"
+| EVAL n = TO_DOUBLE(sn), p = TO_DOUBLE(sp), m = TO_DOUBLE(sm), r = GREATEST(p, m, n);
+
+sn:keyword | sp:keyword | sm:keyword | n:double | p:double  | m:double  | r:double
+NaN        | Infinity   | -Infinity  | NaN      | Infinity  | -Infinity | NaN
+;
+
+// Mixed NaN + Infinity orderings — LEAST
+
+leastNaNThenNegInfinity
+required_capability: to_double_non_finite
+
+// seed=NaN, then -Infinity: Math.min(NaN, -Inf) — `a != a` is true → returns a=NaN immediately.
+ROW sn = "NaN", sm = "-Infinity"
+| EVAL n = TO_DOUBLE(sn), m = TO_DOUBLE(sm), r = LEAST(n, m);
+
+sn:keyword | sm:keyword | n:double | m:double  | r:double
+NaN        | -Infinity  | NaN      | -Infinity | NaN
+;
+
+leastNegInfinityThenNaN
+required_capability: to_double_non_finite
+
+// seed=-Infinity, then NaN: Math.min(-Inf, NaN) — `-Inf <= NaN` is false → returns b=NaN.
+ROW sn = "NaN", sm = "-Infinity"
+| EVAL n = TO_DOUBLE(sn), m = TO_DOUBLE(sm), r = LEAST(m, n);
+
+sn:keyword | sm:keyword | n:double | m:double  | r:double
+NaN        | -Infinity  | NaN      | -Infinity | NaN
+;
+
+leastNaNBetweenInfinities
+required_capability: to_double_non_finite
+
+// +Infinity, NaN, -Infinity: accumulator Inf → Math.min(Inf,NaN)=NaN → Math.min(NaN,-Inf)=NaN.
+ROW sn = "NaN", sp = "Infinity", sm = "-Infinity"
+| EVAL n = TO_DOUBLE(sn), p = TO_DOUBLE(sp), m = TO_DOUBLE(sm), r = LEAST(p, n, m);
+
+sn:keyword | sp:keyword | sm:keyword | n:double | p:double  | m:double  | r:double
+NaN        | Infinity   | -Infinity  | NaN      | Infinity  | -Infinity | NaN
+;
+
+//
+// ============================================================
+// SECTION 13: Math functions
+// (Existing guards in Cosh, Sinh, Bucket expect null+warning for non-finite)
+// ============================================================
+
+absNaN
+required_capability: to_double_non_finite
+
+// ABS(NaN) = NaN in Java
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = ABS(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+absNegativeInfinity
+required_capability: to_double_non_finite
+
+// ABS(-Infinity) = Infinity in Java
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), r = ABS(d);
+
+s:keyword | d:double | r:double
+-Infinity | -Infinity | Infinity
+;
+
+roundNaN
+required_capability: to_double_non_finite
+
+// Maths.round(double): explicit isNaN check at line 23: if (Double.isNaN(nDouble)) return 0.0d.
+// ROUND(NaN) = 0.0, no warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = ROUND(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | 0.0
+;
+
+floorNaN
+required_capability: to_double_non_finite
+
+// Math.floor(NaN) = NaN
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = FLOOR(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+ceilNaN
+required_capability: to_double_non_finite
+
+// Math.ceil(NaN) = NaN
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = CEIL(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+floorInfinity
+required_capability: to_double_non_finite
+
+// Math.floor(Infinity) = Infinity
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = FLOOR(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | Infinity
+;
+
+sqrtNaN
+required_capability: to_double_non_finite
+
+// Math.sqrt(NaN) = NaN
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = SQRT(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+sqrtNegativeInfinity
+required_capability: to_double_non_finite
+
+// Math.sqrt(-Infinity) = NaN, but SQRT first checks for negative input (before evaluating sqrt)
+// and throws "Square root of negative" — a different guard than the general non-finite result check.
+// The early negative-input guard fires before Math.sqrt is even called.
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), r = SQRT(d);
+warningRegex:evaluation of \[SQRT\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: Square root of negative
+
+s:keyword | d:double  | r:double
+-Infinity | -Infinity | null
+;
+
+logNaN
+required_capability: to_double_non_finite
+
+// Math.log(NaN) = NaN
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = LOG(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+logInfinity
+required_capability: to_double_non_finite
+
+// Math.log(Infinity) = Infinity
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = LOG(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | Infinity
+;
+
+sinNaN
+required_capability: to_double_non_finite
+
+// Math.sin(NaN) = NaN; no guard in SIN (unlike Cosh/Sinh)
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = SIN(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+sinInfinity
+required_capability: to_double_non_finite
+
+// Math.sin(Infinity) = NaN (IEEE-754 undefined)
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = SIN(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | NaN
+;
+
+coshNaN
+required_capability: to_double_non_finite
+
+// Cosh has an explicit non-finite guard on the result → null + warning.
+// Note: Math.cosh(NaN) = NaN, which the guard converts to "cosh overflow" (the guard
+// checks isNaN || isInfinite in the result and throws ArithmeticException with that message).
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = COSH(d);
+warningRegex:evaluation of \[COSH\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: cosh overflow
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+sinhNaN
+required_capability: to_double_non_finite
+
+// Sinh also has a non-finite guard on the result. Same pattern as coshNaN.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = SINH(d);
+warningRegex:evaluation of \[SINH\(d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: sinh overflow
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+roundInfinity
+required_capability: to_double_non_finite
+
+// Maths.round(Infinity): nDouble=Infinity, middleResult=Infinity*1.0=Infinity.
+// Line 35 check: Double.POSITIVE_INFINITY == middleResult → returns n=Infinity, no warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = ROUND(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | Infinity
+;
+
+signumNaN
+required_capability: to_double_non_finite
+
+// SIGNUM uses Math.signum(val) with no warnExceptions and no asFiniteNumber guard.
+// Math.signum(NaN) = NaN (IEEE-754: any operation on NaN returns NaN).
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = SIGNUM(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+signumInfinity
+required_capability: to_double_non_finite
+
+// Math.signum(+Infinity) = 1.0 (positive infinity has positive sign).
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = SIGNUM(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | 1.0
+;
+
+signumNegInfinity
+required_capability: to_double_non_finite
+
+// Math.signum(-Infinity) = -1.0 (negative infinity has negative sign).
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), r = SIGNUM(d);
+
+s:keyword | d:double | r:double
+-Infinity | -Infinity | -1.0
+;
+
+powNaNBase
+required_capability: to_double_non_finite
+
+// POW uses asFiniteNumber(Math.pow(base, exp)) with warnExceptions={ArithmeticException}.
+// Math.pow(NaN, 2) = NaN → asFiniteNumber throws → null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = POW(d, 2.0);
+warningRegex:evaluation of \[POW\(d, 2.0\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+powNaNExponent
+required_capability: to_double_non_finite
+
+// Math.pow(2, NaN) = NaN → asFiniteNumber throws → null + warning.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = POW(2.0, d);
+warningRegex:evaluation of \[POW\(2.0, d\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+s:keyword | d:double | r:double
+NaN       | NaN      | null
+;
+
+powInfinityBase
+required_capability: to_double_non_finite
+
+// Math.pow(Infinity, 2) = Infinity → asFiniteNumber throws → null + warning.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = POW(d, 2.0);
+warningRegex:evaluation of \[POW\(d, 2.0\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: Infinity
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | null
+;
+
+powNaNZeroExponent
+required_capability: to_double_non_finite
+
+// Java special case: Math.pow(x, 0) = 1.0 for any x, including NaN.
+// asFiniteNumber(1.0) = 1.0 → no warning. Result: 1.0.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = POW(d, 0.0);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | 1.0
+;
+
+expNaN
+required_capability: to_double_non_finite
+
+// EXP uses raw Math.exp(val) with no guard. Math.exp(NaN) = NaN → returned as-is.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = EXP(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+expInfinity
+required_capability: to_double_non_finite
+
+// Math.exp(+Infinity) = +Infinity → returned as-is (no guard).
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = EXP(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | Infinity
+;
+
+expNegInfinity
+required_capability: to_double_non_finite
+
+// Math.exp(-Infinity) = 0.0 → returned as-is (no guard). A finite result.
+ROW s = "-Infinity" | EVAL d = TO_DOUBLE(s), r = EXP(d);
+
+s:keyword  | d:double  | r:double
+-Infinity  | -Infinity | 0.0
+;
+
+cosNaN
+required_capability: to_double_non_finite
+
+// COS uses raw Math.cos(val) with no guard. Math.cos(NaN) = NaN → returned as-is.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s), r = COS(d);
+
+s:keyword | d:double | r:double
+NaN       | NaN      | NaN
+;
+
+cosInfinity
+required_capability: to_double_non_finite
+
+// Math.cos(Infinity) = NaN in IEEE-754 (cosine is undefined for infinite argument).
+// COS has no guard, so the NaN result is returned as-is.
+ROW s = "Infinity" | EVAL d = TO_DOUBLE(s), r = COS(d);
+
+s:keyword | d:double | r:double
+Infinity  | Infinity | NaN
+;
+
+bucketNaN
+required_capability: to_double_non_finite
+
+// BUCKET is a grouping function and must be used inside STATS, not EVAL.
+// With a NaN input, the isFinite guard in BUCKET fires → the bucket value becomes null + warning.
+// MIN(NaN) = NaN — the MIN aggregation propagates NaN; it does not have a non-finite result guard.
+// Key finding: MIN and MAX lack the non-finite result guard that AVG/SUM/other aggregates have.
+ROW s = "NaN" | EVAL d = TO_DOUBLE(s) | STATS b = MIN(d) BY bucket = BUCKET(d, 5, 0.0, 10.0);
+warningRegex:evaluation of \[BUCKET\(d, 5, 0.0, 10.0\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.ArithmeticException: not a finite double number: NaN
+
+b:double | bucket:double
+NaN      | null
+;
+
+//
+// ============================================================
+// SECTION 14: SET approximation=true with NaN in aggregation
+// Tests whether user-supplied NaN collides with the internal NaN sentinel
+// used by the confidence-interval bootstrap computation.
+// ============================================================
+
+approximationWithNaN
+required_capability: to_double_non_finite
+required_capability: approximation_v7
+request_stored: skip
+
+// Feed NaN into SUM; the approximation machinery uses NaN internally as an "empty bucket"
+// sentinel. Does user NaN corrupt the confidence interval computation?
+// rows must be >= 10000 per ApproximationSettings validation.
+SET approximation={"rows":10000}\;
+ROW xs = ["NaN", "1.0", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS s = SUM(d);
+
+s:double | _approximation_confidence_interval(s):double | _approximation_certified(s):boolean
+{any}    | {any}                                        | {any}
+;
+
+approximationSumFiniteWithInfinity
+required_capability: to_double_non_finite
+required_capability: approximation_v7
+request_stored: skip
+
+// Feed Infinity into SUM with approximation; SUM(1, Infinity, 2) = Infinity.
+// Does the confidence interval machinery handle an infinite best estimate?
+// rows must be >= 10000 per ApproximationSettings validation.
+SET approximation={"rows":10000}\;
+ROW xs = ["1.0", "Infinity", "2.0"]
+| MV_EXPAND xs
+| EVAL d = TO_DOUBLE(xs)
+| STATS s = SUM(d);
+
+s:double  | _approximation_confidence_interval(s):double | _approximation_certified(s):boolean
+{any}     | {any}                                        | {any}
+;
+
+// NOTE: PERCENTILE is intentionally not tested here.
+// TDigest.checkValue() throws IllegalArgumentException("Invalid value: NaN/Infinity/-Infinity")
+// with no catch in QuantileStates.add() or the generated aggregator function.
+// Any non-finite double input causes a hard query failure (not null+warning).
+// csv-spec has no mechanism to assert on hard query errors, so this behavior
+// is documented in NON_FINITE_FINDINGS.md Section 15 only.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3488,6 +3488,13 @@ public class EsqlCapabilities {
          */
         FIX_TIME_SERIES_DATE_NANOS_MIXED_ROUNDING,
 
+        /**
+         * Experimental: {@code TO_DOUBLE} keyword/text overload now parses non-finite IEEE-754 values
+         * ({@code NaN}, {@code Infinity}, {@code -Infinity}) rather than converting them to {@code null}.
+         * This is an investigation capability — not intended to be merged or documented as a feature.
+         */
+        TO_DOUBLE_NON_FINITE,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
-import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToDouble;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToDoubleAllowNonFinite;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToDouble;
 
 public class ToDouble extends AbstractConvertFunction {
@@ -134,7 +134,9 @@ public class ToDouble extends AbstractConvertFunction {
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { InvalidArgumentException.class })
     static double fromKeyword(BytesRef in) {
-        return stringToDouble(in.utf8ToString());
+        // Accepts non-finite IEEE-754 values (NaN, Infinity, -Infinity) as an investigation into
+        // what happens when ES|QL blocks carry non-finite doubles.
+        return stringToDoubleAllowNonFinite(in.utf8ToString());
     }
 
     @ConvertEvaluator(extraName = "FromUnsignedLong")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -787,6 +787,20 @@ public class EsqlDataTypeConverter {
         return StringUtils.parseDouble(field);
     }
 
+    /**
+     * Parses {@code field} as a double, accepting non-finite IEEE-754 values (NaN, Infinity, -Infinity)
+     * in addition to all regular finite values. Only a genuine parse failure (unrecognized format) throws
+     * {@link org.elasticsearch.xpack.esql.core.InvalidArgumentException}. This method is intentionally
+     * separate from {@link #stringToDouble} because allowing non-finite doubles in ES|QL is experimental.
+     */
+    public static double stringToDoubleAllowNonFinite(String field) {
+        try {
+            return Double.parseDouble(field);
+        } catch (NumberFormatException nfe) {
+            throw new org.elasticsearch.xpack.esql.core.InvalidArgumentException(nfe, "Cannot parse number [{}]", field);
+        }
+    }
+
     public static BytesRef unsignedLongToString(long number) {
         return new BytesRef(unsignedLongAsNumber(number).toString());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
@@ -114,6 +114,21 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
             List.of()
         );
 
+        // Non-finite IEEE-754 values as keyword inputs — now accepted by TO_DOUBLE.
+        TestCaseSupplier.unary(
+            suppliers,
+            evaluatorName("String", "in"),
+            List.of(
+                new TestCaseSupplier.TypedDataSupplier("<NaN string>", () -> new BytesRef("NaN"), DataType.KEYWORD),
+                new TestCaseSupplier.TypedDataSupplier("<+Infinity string>", () -> new BytesRef("Infinity"), DataType.KEYWORD),
+                new TestCaseSupplier.TypedDataSupplier("<-Infinity string>", () -> new BytesRef("-Infinity"), DataType.KEYWORD),
+                new TestCaseSupplier.TypedDataSupplier("<+Infinity string (explicit +)>", () -> new BytesRef("+Infinity"), DataType.KEYWORD)
+            ),
+            DataType.DOUBLE,
+            bytesRef -> Double.parseDouble(((BytesRef) bytesRef).utf8ToString()),
+            List.of()
+        );
+
         TestCaseSupplier.unary(
             suppliers,
             "Attribute[channel=0]",


### PR DESCRIPTION
## What

Throwaway investigation: what happens when ES|QL `DOUBLE` blocks contain non-finite IEEE-754 values (`NaN`, `+Infinity`, `-Infinity`)? The behavior today is inconsistent — some paths guard, some propagate, some crash — and there is no central policy.

**Not intended to merge as-is.** The goal is a full findings map, not a fix.

## How

The enabling trick: a new `EsqlDataTypeConverter.stringToDoubleAllowNonFinite` converter lets `TO_DOUBLE("NaN")`, `TO_DOUBLE("Infinity")`, etc. succeed (previously they produced `null` + warning). This is gated on a new capability `to_double_non_finite` so the spec file is entirely skipped in production CI.

## General take-away

Human speaking here. Our handling of non-finite doubles is horrendously inconsistent and cannot be trusted.

## What's in this PR

| File | Purpose |
|---|---|
| `NON_FINITE_FINDINGS.md` | Full findings report — read this |
| `non_finite_doubles.csv-spec` | 150 CsvIT tests covering the findings (all green) |
| `non_finite.csv` + `mapping-non_finite.json` | Test dataset for `FROM non_finite` queries |
| `EsqlCapabilities.java` | New `TO_DOUBLE_NON_FINITE` cap |
| `ToDouble.java` + `EsqlDataTypeConverter.java` | Non-finite parse path |
| `ToDoubleTests.java` | Unit tests for the new parse path |
| `TestCaseSupplier.java`, `MultiRowTestCaseSupplier.java`, `AbstractFunctionTestCase.java` | Phase C: allow non-finite inputs/outputs in scalar/agg function unit tests |
| `CsvTestsDataLoader.java` | Register the `non_finite` dataset |

## Key findings (summary — details in `NON_FINITE_FINDINGS.md`)

- **Three aggregations crash hard** on non-finite input: `PERCENTILE`, `MEDIAN`, `MEDIAN_ABSOLUTE_DEVIATION` (TDigest rejects non-finite with an uncaught `IllegalArgumentException`).
- **`TO_INTEGER(NaN)` and `TO_LONG(NaN)` silently return `0`** — the `> MAX || < MIN` range guard is bypassed because NaN comparisons always return false. All other databases treat this as an error.
- **`ROUND(NaN)` silently returns `0.0`** — an explicit `isNaN` early-return in `Maths.round` intended to prevent overflow, contradicting `FLOOR`/`CEIL` which correctly propagate NaN.
- **`MAX([-Infinity])` returns `-MAX_VALUE`** instead of `-Infinity` — the accumulator is initialized to `-Double.MAX_VALUE` and never updated.
- **`MV_DEDUPE` does not deduplicate NaN** (`NaN == NaN` is false by Java `==`), while `-0.0` and `0.0` ARE collapsed.
- **`STATS BY NaN` groups all NaN rows together** (correct by `doubleToLongBits` semantics, counterintuitive to users), while `STATS BY -0.0` and `STATS BY 0.0` produce separate groups (correct, equally counterintuitive).
- **`VARIANCE`/`STD_DEV` return `null` silently** for non-finite input. `AVG` warns. `SUM` propagates. Three behaviors on the same data.
- **Pushdown `field != NaN` folds to match-none** (`EsqlBinaryComparison.java:584`) — IEEE-754 requires match-all. Latent wrong-answer bug reachable via PromQL.
- Three output formats (JSON, CSV, Arrow) produce three different representations of the same non-finite value with no consistent contract.

## Credits

A separate investigation by @quackaplop is folded into this one.