### PR TITLE
[9.5] [Inference API] Delete default endpoints using master node action only (#154735)

### DIFF
--- a/docs/changelog/154735.yaml
+++ b/docs/changelog/154735.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 154710
+pr: 154735
+summary: "[Inference API] Delete default endpoints using master node action only"
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsAction.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.action;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Internal action to delete inference endpoints. This should only be used internally and not exposed via a REST API.
+ * For the exposed REST API action see {@link DeleteInferenceEndpointAction}.
+ */
+public class InternalDeleteInferenceEndpointsAction extends ActionType<AcknowledgedResponse> {
+
+    public static final InternalDeleteInferenceEndpointsAction INSTANCE = new InternalDeleteInferenceEndpointsAction();
+    public static final String NAME = "cluster:internal/xpack/inference/delete_endpoints";
+
+    public InternalDeleteInferenceEndpointsAction() {
+        super(NAME);
+    }
+
+    public static class Request extends AcknowledgedRequest<Request> {
+        private final Set<String> inferenceEntityIds;
+
+        public Request(Set<String> inferenceEntityIds, TimeValue timeout) {
+            super(timeout, DEFAULT_ACK_TIMEOUT);
+            this.inferenceEntityIds = Objects.requireNonNull(inferenceEntityIds);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            inferenceEntityIds = in.readCollectionAsImmutableSet(StreamInput::readString);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeStringCollection(inferenceEntityIds);
+        }
+
+        public Set<String> getInferenceEntityIds() {
+            return inferenceEntityIds;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            var request = (Request) o;
+            return Objects.equals(inferenceEntityIds, request.inferenceEntityIds);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(inferenceEntityIds);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsActionRequestTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+
+public class InternalDeleteInferenceEndpointsActionRequestTests extends AbstractBWCWireSerializationTestCase<
+    InternalDeleteInferenceEndpointsAction.Request> {
+
+    @Override
+    protected InternalDeleteInferenceEndpointsAction.Request mutateInstanceForVersion(
+        InternalDeleteInferenceEndpointsAction.Request instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+
+    @Override
+    protected Writeable.Reader<InternalDeleteInferenceEndpointsAction.Request> instanceReader() {
+        return InternalDeleteInferenceEndpointsAction.Request::new;
+    }
+
+    @Override
+    protected InternalDeleteInferenceEndpointsAction.Request createTestInstance() {
+        var ids = new HashSet<String>();
+        int count = randomIntBetween(1, 5);
+        for (int i = 0; i < count; i++) {
+            ids.add(randomAlphaOfLength(10));
+        }
+        return new InternalDeleteInferenceEndpointsAction.Request(ids, randomTimeValue());
+    }
+
+    @Override
+    protected InternalDeleteInferenceEndpointsAction.Request mutateInstance(InternalDeleteInferenceEndpointsAction.Request instance)
+        throws IOException {
+        var newIds = new HashSet<>(instance.getInferenceEntityIds());
+        newIds.add(randomAlphaOfLength(10));
+        return new InternalDeleteInferenceEndpointsAction.Request(newIds, instance.masterNodeTimeout());
+    }
+
+    public void testRequestHoldsExpectedIds() {
+        var ids = Set.of("id-1", "id-2", "id-3");
+        var request = new InternalDeleteInferenceEndpointsAction.Request(ids, TEST_REQUEST_TIMEOUT);
+        assertThat(request.getInferenceEntityIds(), is(ids));
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -82,6 +82,9 @@ public class InferenceFeatures implements FeatureSpecification {
 
     public static final NodeFeature EMBEDDING_TASK_TYPE = new NodeFeature("inference.embedding_task_type");
     public static final NodeFeature ENDPOINT_METADATA_FIELD = new NodeFeature("inference.metadata_field");
+    public static final NodeFeature INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION = new NodeFeature(
+        "inference.internal_delete_endpoints_action"
+    );
     public static final NodeFeature INFERENCE_ELASTIC_REASONING_TASK_SETTINGS = new NodeFeature(
         "inference.elastic.reasoning_task_settings"
     );
@@ -99,6 +102,7 @@ public class InferenceFeatures implements FeatureSpecification {
             INFERENCE_CCM_ENABLEMENT_SERVICE,
             EMBEDDING_TASK_TYPE,
             ENDPOINT_METADATA_FIELD,
+            INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION,
             INFERENCE_ELASTIC_REASONING_TASK_SETTINGS,
             INFERENCE_INFERENCE_INDEX_DOC_TYPE,
             INFERENCE_CLEAR_PREFERENCES_CACHE

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -75,6 +75,7 @@ import org.elasticsearch.xpack.core.inference.action.GetRegionPolicyAction;
 import org.elasticsearch.xpack.core.inference.action.GetRerankerWindowSizeAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceActionProxy;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.PutCCMConfigurationAction;
 import org.elasticsearch.xpack.core.inference.action.PutInferenceModelAction;
 import org.elasticsearch.xpack.core.inference.action.PutRegionPolicyAction;
@@ -98,6 +99,7 @@ import org.elasticsearch.xpack.inference.action.TransportGetRerankerWindowSizeAc
 import org.elasticsearch.xpack.inference.action.TransportInferenceAction;
 import org.elasticsearch.xpack.inference.action.TransportInferenceActionProxy;
 import org.elasticsearch.xpack.inference.action.TransportInferenceUsageAction;
+import org.elasticsearch.xpack.inference.action.TransportInternalDeleteEndpointsAction;
 import org.elasticsearch.xpack.inference.action.TransportPutCCMConfigurationAction;
 import org.elasticsearch.xpack.inference.action.TransportPutInferenceModelAction;
 import org.elasticsearch.xpack.inference.action.TransportPutRegionPolicyAction;
@@ -320,6 +322,7 @@ public class InferencePlugin extends Plugin
             new ActionHandler(GetRerankerWindowSizeAction.INSTANCE, TransportGetRerankerWindowSizeAction.class),
             new ActionHandler(ClearInferenceEndpointCacheAction.INSTANCE, ClearInferenceEndpointCacheAction.class),
             new ActionHandler(StoreInferenceEndpointsAction.INSTANCE, TransportStoreEndpointsAction.class),
+            new ActionHandler(InternalDeleteInferenceEndpointsAction.INSTANCE, TransportInternalDeleteEndpointsAction.class),
             new ActionHandler(GetCCMConfigurationAction.INSTANCE, TransportGetCCMConfigurationAction.class),
             new ActionHandler(PutCCMConfigurationAction.INSTANCE, TransportPutCCMConfigurationAction.class),
             new ActionHandler(DeleteCCMConfigurationAction.INSTANCE, TransportDeleteCCMConfigurationAction.class),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsAction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+
+import java.util.Objects;
+
+/**
+ * Handles the internal action for deleting multiple inference endpoints. This should not be used by external REST APIs.
+ * This implementation differs from {@link TransportDeleteInferenceEndpointAction} in that this one can handle deleting multiple endpoints
+ * at a time, but it does not perform the safeguard checks. This implementation will not check to see if the default endpoint is
+ * referenced by pipelines or indices.
+ */
+public class TransportInternalDeleteEndpointsAction extends TransportMasterNodeAction<
+    InternalDeleteInferenceEndpointsAction.Request,
+    AcknowledgedResponse> {
+
+    private final ModelRegistry modelRegistry;
+
+    @Inject
+    public TransportInternalDeleteEndpointsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        ModelRegistry modelRegistry
+    ) {
+        super(
+            InternalDeleteInferenceEndpointsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            InternalDeleteInferenceEndpointsAction.Request::new,
+            AcknowledgedResponse::readFrom,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        this.modelRegistry = Objects.requireNonNull(modelRegistry);
+    }
+
+    @Override
+    protected void masterOperation(
+        Task task,
+        InternalDeleteInferenceEndpointsAction.Request request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> masterListener
+    ) {
+        modelRegistry.deleteModels(
+            request.getInferenceEntityIds(),
+            masterListener.delegateFailureAndWrap((l, r) -> l.onResponse(AcknowledgedResponse.TRUE))
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(InternalDeleteInferenceEndpointsAction.Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
 import org.elasticsearch.xpack.inference.InferenceFeatures;
@@ -124,10 +125,15 @@ public class TransportRefreshAuthorizedEndpointsAction extends HandledTransportA
         }
 
         logger.info("Deleting removed EIS inference endpoints: {}", toDelete);
-        modelRegistry.deleteModels(toDelete, ActionListener.wrap(success -> listener.onResponse(authModel), e -> {
-            logger.atWarn().withThrowable(e).log("Failed to delete removed EIS inference endpoints: {}", toDelete);
-            listener.onResponse(authModel);
-        }));
+        var deleteRequest = new InternalDeleteInferenceEndpointsAction.Request(toDelete, TimeValue.THIRTY_SECONDS);
+        client.execute(
+            InternalDeleteInferenceEndpointsAction.INSTANCE,
+            deleteRequest,
+            ActionListener.wrap(response -> listener.onResponse(authModel), e -> {
+                logger.atWarn().withThrowable(e).log("Failed to delete removed EIS inference endpoints: {}", toDelete);
+                listener.onResponse(authModel);
+            })
+        );
     }
 
     private List<Model> selectEndpointsToPersist(ElasticInferenceServiceAuthorizationModel authModel) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
@@ -90,7 +90,8 @@ public class TransportRefreshAuthorizedEndpointsAction extends HandledTransportA
             return;
         }
 
-        if (inferenceFeatureService.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD) == false) {
+        if (inferenceFeatureService.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD) == false
+            || inferenceFeatureService.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION) == false) {
             logger.info("Skipping sending authorization request, because the cluster is currently upgrading and missing required features");
             listener.onResponse(ActionResponse.Empty.INSTANCE);
             return;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsActionTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Set;
+
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TransportInternalDeleteEndpointsActionTests extends ESTestCase {
+
+    private TransportInternalDeleteEndpointsAction action;
+    private ThreadPool threadPool;
+    private ModelRegistry mockModelRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = createThreadPool(inferenceUtilityExecutors());
+        mockModelRegistry = mock(ModelRegistry.class);
+        action = new TransportInternalDeleteEndpointsAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            threadPool,
+            mock(ActionFilters.class),
+            mockModelRegistry
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(threadPool);
+    }
+
+    public void testMasterOperation_DelegatesDeleteToModelRegistry() {
+        var ids = Set.of("id-1", "id-2");
+        doAnswer(invocation -> {
+            invocation.<org.elasticsearch.action.ActionListener<Boolean>>getArgument(1).onResponse(true);
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModels(eq(ids), any());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        action.masterOperation(
+            mock(Task.class),
+            new InternalDeleteInferenceEndpointsAction.Request(ids, TimeValue.THIRTY_SECONDS),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+        assertTrue(response.isAcknowledged());
+        verify(mockModelRegistry).deleteModels(eq(ids), any());
+    }
+
+    public void testMasterOperation_AcknowledgedTrue_Even_WhenRegistryReturnsFalse() {
+        var ids = Set.of("id-1");
+        doAnswer(invocation -> {
+            invocation.<org.elasticsearch.action.ActionListener<Boolean>>getArgument(1).onResponse(false);
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModels(eq(ids), any());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        action.masterOperation(
+            mock(Task.class),
+            new InternalDeleteInferenceEndpointsAction.Request(ids, TimeValue.THIRTY_SECONDS),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+        assertTrue(response.isAcknowledged());
+    }
+
+    public void testMasterOperation_PropagatesFailure() {
+        var ids = Set.of("id-1");
+        doAnswer(invocation -> {
+            invocation.<ActionListener<Boolean>>getArgument(1).onFailure(new RuntimeException("delete failed"));
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModels(eq(ids), any());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        action.masterOperation(
+            mock(Task.class),
+            new InternalDeleteInferenceEndpointsAction.Request(ids, TimeValue.THIRTY_SECONDS),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+
+        var exception = expectThrows(RuntimeException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.getMessage(), is("delete failed"));
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
@@ -81,6 +81,7 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
     public void init() throws Exception {
         inferenceFeatureServiceMock = mock(InferenceFeatureService.class);
         when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD)).thenReturn(true);
+        when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION)).thenReturn(true);
         mockRegistry = mock(ModelRegistry.class);
         mockAuthHandler = mock(ElasticInferenceServiceAuthorizationRequestHandler.class);
         mockClient = mock(Client.class);
@@ -103,6 +104,18 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
     public void testDoesNotSendAuthorizationRequest_WhenClusterDoesNotIncludeMetadata_MappingUpdate() {
         when(mockRegistry.isReady()).thenReturn(true);
         when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD)).thenReturn(false);
+        var action = createAction();
+
+        var future = new TestPlainActionFuture<ActionResponse.Empty>();
+        action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), future);
+
+        assertThat(future.actionGet(), is(ActionResponse.Empty.INSTANCE));
+        verify(mockAuthHandler, never()).getAuthorization(any(), any());
+    }
+
+    public void testDoesNotSendAuthorizationRequest_WhenClusterMissingInternalDeleteEndpointsFeature() {
+        when(mockRegistry.isReady()).thenReturn(true);
+        when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION)).thenReturn(false);
         var action = createAction();
 
         var future = new TestPlainActionFuture<ActionResponse.Empty>();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -26,6 +27,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.RefreshAuthorizedEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
@@ -284,11 +286,15 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         when(mockRegistry.getInferenceIds()).thenReturn(Set.of("id-1", "id-2", "id-3"));
 
         givenAuthHandlerRespondsForUrl(randomAlphaOfLength(10), List.of(), endpointsToDelete);
+        givenDeleteActionRespondsWith(AcknowledgedResponse.TRUE);
 
         var action = createAction();
         action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), new TestPlainActionFuture<>());
 
-        verify(mockRegistry).deleteModels(eq(endpointsToDelete), any());
+        var requestArgCaptor = ArgumentCaptor.forClass(InternalDeleteInferenceEndpointsAction.Request.class);
+        verify(mockClient).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), requestArgCaptor.capture(), any());
+        assertThat(requestArgCaptor.getValue().getInferenceEntityIds(), is(endpointsToDelete));
+        verify(mockRegistry, never()).deleteModel(any(), any());
     }
 
     public void testSendsAuthorizationRequest_ShouldIgnoreRemovedEndpointsNotInRegistry() {
@@ -298,11 +304,15 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         when(mockRegistry.getInferenceIds()).thenReturn(endpointsToDelete);
 
         givenAuthHandlerRespondsForUrl(randomAlphaOfLength(10), List.of(), Set.of("id-1", "id-2", "id-3", "id-4"));
+        givenDeleteActionRespondsWith(AcknowledgedResponse.TRUE);
 
         var action = createAction();
         action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), new TestPlainActionFuture<>());
 
-        verify(mockRegistry).deleteModels(eq(endpointsToDelete), any());
+        var requestArgCaptor = ArgumentCaptor.forClass(InternalDeleteInferenceEndpointsAction.Request.class);
+        verify(mockClient).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), requestArgCaptor.capture(), any());
+        assertThat(requestArgCaptor.getValue().getInferenceEntityIds(), is(endpointsToDelete));
+        verify(mockRegistry, never()).deleteModel(any(), any());
     }
 
     public void testSendsAuthorizationRequest_ShouldNotDeleteAnyWhenNoRemovedEndpointIsPresentInRegistry() {
@@ -314,7 +324,7 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
         var action = createAction();
         action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), new TestPlainActionFuture<>());
 
-        verify(mockRegistry, never()).deleteModels(any(), any());
+        verify(mockClient, never()).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), any(), any());
     }
 
     private TransportRefreshAuthorizedEndpointsAction createAction() {
@@ -369,6 +379,14 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
             listener.onResponse(new StoreInferenceEndpointsAction.Response(List.of(results)));
             return null;
         }).when(mockClient).execute(eq(StoreInferenceEndpointsAction.INSTANCE), any(), any());
+    }
+
+    private void givenDeleteActionRespondsWith(AcknowledgedResponse response) {
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), any(), any());
     }
 
     private void sendAuthRequestAndVerifyStoreActionCalledForSparseEndpoints(

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -341,6 +341,7 @@ public class Constants {
         "cluster:internal/xpack/inference/clear_inference_preferences_cache",
         "cluster:internal/xpack/inference/clear_oauth2_token_cache",
         "cluster:internal/xpack/inference/create_endpoints",
+        "cluster:internal/xpack/inference/delete_endpoints",
         "cluster:internal/xpack/inference/embedding",
         "cluster:internal/xpack/inference/refresh_authorized_endpoints",
         "cluster:internal/xpack/inference/rerank",


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Inference API] Delete default endpoints using master node action only (#154735)