### PR TITLE
Modifying LocalPrimarySnapshotShardContext::assertFileContentsMatchHash to not throw AssertionErrors

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContext.java
@@ -141,20 +141,36 @@ public final class LocalPrimarySnapshotShardContext extends SnapshotShardContext
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * Note that verification failures are reported by throwing {@link IndexShardSnapshotFailedException} rather than
+     * {@link AssertionError}: an Error escapes the snapshot thread pool worker without ever completing the shard snapshot,
+     * which leaves the snapshot in progress forever, whereas an Exception fails the shard snapshot with the failure reason.
+     */
     @Override
     public boolean assertFileContentsMatchHash(BlobStoreIndexShardSnapshot.FileInfo fileInfo) {
         if (store.tryIncRef()) {
             try (IndexInput indexInput = store.openVerifyingInput(fileInfo.physicalName(), IOContext.READONCE, fileInfo.metadata())) {
                 final byte[] tmp = new byte[Math.toIntExact(fileInfo.metadata().length())];
                 indexInput.readBytes(tmp, 0, tmp.length);
-                assert fileInfo.metadata().hash().bytesEquals(new BytesRef(tmp));
+                if (fileInfo.metadata().hash().bytesEquals(new BytesRef(tmp)) == false) {
+                    throw new IndexShardSnapshotFailedException(
+                        shardId(),
+                        "contents of file [" + fileInfo.physicalName() + "] differ from the hash in its store metadata"
+                    );
+                }
             } catch (IOException e) {
                 if (Lucene.isCorruptionException(e)) {
-                    throw new AssertionError(e);
+                    failStoreIfCorrupted(e);
+                    throw new IndexShardSnapshotFailedException(
+                        shardId(),
+                        "detected corruption while verifying the hash of file [" + fileInfo.physicalName() + "]",
+                        e
+                    );
                 }
-                // A transient I/O failure while re-reading the file to verify its hash does not indicate a mismatch. Rethrowing it
-                // as an AssertionError would escape the snapshot thread pool worker without ever completing the shard snapshot,
-                // leaving the snapshot in progress forever, so skip the verification instead.
+                // A transient I/O failure while re-reading the file to verify its hash does not indicate a mismatch,
+                // so skip the verification
                 logger.warn(
                     () -> format(
                         "[%s] [%s] failed to read [%s] to verify its hash, skipping verification",

--- a/server/src/main/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContext.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 
+import static org.elasticsearch.common.Strings.format;
 import static org.elasticsearch.repositories.SnapshotShardContextHelper.withSnapshotIndexCommitRef;
 
 /**
@@ -148,7 +149,21 @@ public final class LocalPrimarySnapshotShardContext extends SnapshotShardContext
                 indexInput.readBytes(tmp, 0, tmp.length);
                 assert fileInfo.metadata().hash().bytesEquals(new BytesRef(tmp));
             } catch (IOException e) {
-                throw new AssertionError(e);
+                if (Lucene.isCorruptionException(e)) {
+                    throw new AssertionError(e);
+                }
+                // A transient I/O failure while re-reading the file to verify its hash does not indicate a mismatch. Rethrowing it
+                // as an AssertionError would escape the snapshot thread pool worker without ever completing the shard snapshot,
+                // leaving the snapshot in progress forever, so skip the verification instead.
+                logger.warn(
+                    () -> format(
+                        "[%s] [%s] failed to read [%s] to verify its hash, skipping verification",
+                        shardId(),
+                        snapshotId(),
+                        fileInfo.physicalName()
+                    ),
+                    e
+                );
             } finally {
                 store.decRef();
             }

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
@@ -103,6 +103,14 @@ public abstract class SnapshotShardContext extends DelegatingActionListener<Shar
 
     public abstract Collection<String> fileNames();
 
+    /**
+     * Verifies that the given file's contents match the hash stored in its snapshot metadata. Only invoked when assertions are
+     * enabled, as {@code assert context.assertFileContentsMatchHash(fileInfo)}, and always returns {@code true}: verification
+     * failures must be reported by throwing an {@link Exception} (failing the shard snapshot), never by returning {@code false}
+     * or throwing an {@link AssertionError} — an Error escapes the snapshot thread pool worker without completing the shard
+     * snapshot, leaving the snapshot in progress forever, and a {@code false} return fails the caller's assert statement with
+     * no message, which amounts to the same thing.
+     */
     public abstract boolean assertFileContentsMatchHash(BlobStoreIndexShardSnapshot.FileInfo fileInfo);
 
     public abstract void failStoreIfCorrupted(Exception e);

--- a/server/src/test/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContextTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/LocalPrimarySnapshotShardContextTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.snapshots.IndexShardSnapshotFailedException;
+import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.test.DummyShardLock;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class LocalPrimarySnapshotShardContextTests extends ESTestCase {
+
+    /**
+     * Verifies the failure contract of {@link LocalPrimarySnapshotShardContext#assertFileContentsMatchHash}: genuine
+     * verification failures (hash mismatch, corruption) are reported as {@link IndexShardSnapshotFailedException} so that they
+     * fail the shard snapshot, and never as an {@link AssertionError}, which would escape the snapshot thread pool worker
+     * without completing the shard snapshot and leave the snapshot in progress forever (see #154655). Transient I/O failures
+     * do not indicate a verification failure and are ignored.
+     */
+    public void testAssertFileContentsMatchHash() throws IOException {
+        final AtomicReference<Supplier<IOException>> openInputFailure = new AtomicReference<>();
+        try (Directory directory = new FilterDirectory(new NIOFSDirectory(createTempDir())) {
+            @Override
+            public IndexInput openInput(String name, IOContext context) throws IOException {
+                final var failure = openInputFailure.get();
+                if (failure != null) {
+                    throw failure.get();
+                }
+                return super.openInput(name, context);
+            }
+        }) {
+            try (IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig().setCodec(TestUtil.getDefaultCodec()))) {
+                for (int i = 0; i < randomIntBetween(1, 10); i++) {
+                    final var doc = new Document();
+                    doc.add(new StringField("id", "" + i, Field.Store.YES));
+                    writer.addDocument(doc);
+                }
+                writer.commit();
+            }
+
+            final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+                "index",
+                Settings.builder().put(IndexMetadata.SETTING_INDEX_UUID, "_uuid").build()
+            );
+            final var shardId = new ShardId(indexSettings.getIndex(), 0);
+            try (Store store = new Store(shardId, indexSettings, directory, new DummyShardLock(shardId))) {
+                final IndexCommit indexCommit = Lucene.getIndexCommit(Lucene.readSegmentInfos(store.directory()), store.directory());
+                final var context = new LocalPrimarySnapshotShardContext(
+                    store,
+                    null,
+                    new SnapshotId("snapshot", "_na_"),
+                    new IndexId(indexSettings.getIndex().getName(), indexSettings.getUUID()),
+                    new SnapshotIndexCommit(new Engine.IndexCommitRef(indexCommit, () -> {})),
+                    null,
+                    IndexShardSnapshotStatus.newInitializing(null, randomNonNegativeLong()),
+                    IndexVersion.current(),
+                    randomMillisUpToYear9999(),
+                    new PlainActionFuture<>()
+                );
+
+                // The segments file is one of the files whose full contents are stored as the metadata hash and verified
+                final StoreFileMetadata segmentsMetadata = store.getMetadata(indexCommit).get(indexCommit.getSegmentsFileName());
+                assertTrue(segmentsMetadata.hashEqualsContents());
+
+                // Matching contents verify successfully
+                assertTrue(context.assertFileContentsMatchHash(fileInfo(segmentsMetadata)));
+
+                // A transient I/O failure is not a verification failure and must not throw
+                openInputFailure.set(() -> new IOException("simulated transient failure"));
+                assertTrue(context.assertFileContentsMatchHash(fileInfo(segmentsMetadata)));
+                openInputFailure.set(null);
+
+                // A hash mismatch fails the shard snapshot
+                final BytesRef hash = segmentsMetadata.hash();
+                final byte[] tamperedHash = ArrayUtil.copyOfSubArray(hash.bytes, hash.offset, hash.offset + hash.length);
+                tamperedHash[randomIntBetween(0, tamperedHash.length - 1)]++;
+                final var tamperedMetadata = new StoreFileMetadata(
+                    segmentsMetadata.name(),
+                    segmentsMetadata.length(),
+                    segmentsMetadata.checksum(),
+                    segmentsMetadata.writtenBy(),
+                    new BytesRef(tamperedHash),
+                    segmentsMetadata.writerUuid()
+                );
+                final var mismatchException = expectThrows(
+                    IndexShardSnapshotFailedException.class,
+                    () -> context.assertFileContentsMatchHash(fileInfo(tamperedMetadata))
+                );
+                assertThat(mismatchException.getMessage(), containsString("differ from the hash"));
+
+                // A corruption exception fails the shard snapshot and marks the store corrupted
+                assertFalse(store.isMarkedCorrupted());
+                openInputFailure.set(() -> new CorruptIndexException("simulated corruption", "_test_resource"));
+                final var corruptionException = expectThrows(
+                    IndexShardSnapshotFailedException.class,
+                    () -> context.assertFileContentsMatchHash(fileInfo(segmentsMetadata))
+                );
+                assertThat(corruptionException.getMessage(), containsString("corruption"));
+                openInputFailure.set(null);
+                assertTrue(store.isMarkedCorrupted());
+            }
+        }
+    }
+
+    private static BlobStoreIndexShardSnapshot.FileInfo fileInfo(StoreFileMetadata metadata) {
+        return new BlobStoreIndexShardSnapshot.FileInfo("__" + metadata.name(), metadata, null);
+    }
+}

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotHashVerificationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotHashVerificationIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.snapshots;
+
+import org.apache.lucene.index.IndexCommit;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.common.lucene.FilterIndexCommit;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.plugins.IndexStorePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
+import org.elasticsearch.xpack.stateless.StatelessMockRepositoryPlugin;
+import org.elasticsearch.xpack.stateless.StatelessMockRepositoryStrategy;
+import org.elasticsearch.xpack.stateless.TestUtils;
+import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryTestUtils;
+import org.elasticsearch.xpack.stateless.lucene.IndexDirectory;
+import org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.oneOf;
+
+public class StatelessSnapshotHashVerificationIT extends AbstractStatelessPluginIntegTestCase {
+
+    @Override
+    protected boolean addMockFsRepository() {
+        // the object store is backed by StatelessMockRepositoryPlugin instead, which registers the same repository type
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        final var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(TestUtils.StatelessPluginWithTrialLicense.class);
+        plugins.add(SnapshotFileEnumerationInterceptPlugin.class);
+        plugins.add(StatelessMockRepositoryPlugin.class);
+        plugins.add(InternalSettingsPlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected Settings.Builder nodeSettings() {
+        return super.nodeSettings()
+            // use the mock object store so that the test can inject read failures
+            .put(ObjectStoreService.TYPE_SETTING.getKey(), ObjectStoreService.ObjectStoreType.MOCK)
+            // disable hollow shards so that the relocated shard keeps a regular IndexEngine and the snapshot code path stays simple
+            .put(STATELESS_HOLLOW_INDEX_SHARDS_ENABLED.getKey(), false);
+    }
+
+    /**
+     * Reproduces the snapshot hang behind https://github.com/elastic/elasticsearch/issues/154655: during shard snapshotting,
+     * {@code BlobStoreRepository#doSnapshotShard} re-reads "virtual" files (files whose contents are stored in the shard-level
+     * metadata, i.e. {@code segments_N} and {@code .si} files) via
+     * {@code LocalPrimarySnapshotShardContext#assertFileContentsMatchHash} to verify their hash. On a stateless index node that
+     * bootstrapped the shard from the object store, that read goes through the shared blob cache and, on a cache miss, to the
+     * object store. A transient read failure there used to be rethrown as an {@link AssertionError}, which escaped the snapshot
+     * thread pool worker without ever completing the shard snapshot, leaving the snapshot in progress forever.
+     *
+     * The test recreates the failure deterministically: it relocates the shard (so its commit files are not on local disk),
+     * then uses an intercepted {@link IndexCommit#getFileNames()} — invoked by {@code doSnapshotShard} after loading the store
+     * metadata and right before the file enumeration loop — to evict the blob cache and start injecting object store read
+     * failures. The next read is the hash-verification read, which is then guaranteed to hit the object store and fail. The
+     * injected failures may legitimately fail the shard snapshot, but the create-snapshot call must always complete.
+     */
+    public void testTransientReadFailureDuringSnapshotFileVerification() throws Exception {
+        startMasterOnlyNode();
+        final var nodeA = startIndexNode();
+        final var nodeB = startIndexNode();
+
+        final var repoName = "test-repo";
+        createRepository(repoName, "fs");
+
+        final var indexName = randomIdentifier();
+        createIndex(
+            indexName,
+            indexSettings(1, 0)
+                // a merge after the relocation could rewrite the shard's files locally on the new node, and the test needs the
+                // snapshotted commit files to be readable only through the blob cache / object store
+                .put(InternalSettingsPlugin.MERGE_ENABLED.getKey(), false)
+                .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeA)
+                .build()
+        );
+        ensureGreen(indexName);
+        indexDocs(indexName, randomIntBetween(32, 128));
+        flush(indexName);
+
+        // Relocate the shard so that its commit files on the new node can only be read through the blob cache / object store
+        updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getKey() + "_name", nodeB), indexName);
+        ensureGreen(indexName);
+
+        final var indexShard = findIndexShard(resolveIndex(indexName), 0);
+        assertThat(getNodeName(indexShard.routingEntry().currentNodeId()), equalTo(nodeB));
+        final var cacheService = BlobStoreCacheDirectoryTestUtils.getCacheService(
+            IndexDirectory.unwrapDirectory(indexShard.store().directory()).getBlobStoreCacheDirectory()
+        );
+
+        final var readFailuresInjected = new AtomicBoolean();
+        findPlugin(nodeB, SnapshotFileEnumerationInterceptPlugin.class).beforeSnapshotFileEnumeration.put(indexShard.shardId(), () -> {
+            if (readFailuresInjected.compareAndSet(false, true)) {
+                cacheService.forceEvict(cacheKey -> true);
+                setNodeRepositoryFailureStrategy(nodeB, true, false, Map.of(OperationPurpose.INDICES, ".*"));
+            }
+        });
+
+        try {
+            final var future = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, "test-snap")
+                .setIndices(indexName)
+                .setWaitForCompletion(true)
+                .execute();
+            final CreateSnapshotResponse response;
+            try {
+                response = future.get(60, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                throw new AssertionError(
+                    "create-snapshot did not complete, the shard snapshot likely failed without reporting its status",
+                    e
+                );
+            }
+            assertTrue("the test hook never ran, the snapshot never read the shard's file names", readFailuresInjected.get());
+            // The injected object store failures may legitimately fail the shard snapshot, but the snapshot must complete
+            assertThat(response.getSnapshotInfo().state(), oneOf(SnapshotState.SUCCESS, SnapshotState.PARTIAL));
+        } finally {
+            setNodeRepositoryStrategy(nodeB, StatelessMockRepositoryStrategy.DEFAULT);
+        }
+    }
+
+    private static String getNodeName(String id) {
+        return internalCluster().getInstance(ClusterService.class).state().nodes().get(id).getName();
+    }
+
+    /**
+     * Wraps the {@link IndexCommit} acquired for snapshotting so that a per-shard hook runs when the snapshot code calls
+     * {@link IndexCommit#getFileNames()}. In {@code BlobStoreRepository#doSnapshotShard} this happens after the store metadata
+     * has been loaded and immediately before the file enumeration loop that verifies virtual file hashes, which is the exact
+     * window this test needs to instrument.
+     */
+    public static class SnapshotFileEnumerationInterceptPlugin extends TestUtils.StatelessPluginWithTrialLicense {
+        final Map<ShardId, Runnable> beforeSnapshotFileEnumeration = new ConcurrentHashMap<>();
+
+        public SnapshotFileEnumerationInterceptPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
+            return super.getEngineFactory(indexSettings).map(factory -> engineConfig -> {
+                final var delegate = engineConfig.getSnapshotCommitSupplier();
+                final var shardId = engineConfig.getShardId();
+                final IndexStorePlugin.SnapshotCommitSupplier wrappedCommitSupplier = engine -> {
+                    final var commitRef = delegate.acquireIndexCommitForSnapshot(engine);
+                    final var wrappedCommit = new FilterIndexCommit(commitRef.getIndexCommit()) {
+                        @Override
+                        public Collection<String> getFileNames() throws IOException {
+                            final var hook = beforeSnapshotFileEnumeration.get(shardId);
+                            if (hook != null) {
+                                hook.run();
+                            }
+                            return super.getFileNames();
+                        }
+                    };
+                    return new Engine.IndexCommitRef(wrappedCommit, commitRef::close);
+                };
+                final var wrappedConfig = EngineConfig.builder(engineConfig).snapshotCommitSupplier(wrappedCommitSupplier).build();
+                return factory.newReadWriteEngine(wrappedConfig);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Two of the failures in https://github.com/elastic/elasticsearch/issues/154655 are due to the fact that `LocalPrimarySnapshotShardContext::assertFileContentsMatchHash` throws AssertionErrors.
Here is a sample stack trace from [a test failure](https://gradle-enterprise.elastic.co/s/km5w47o5jyhtg):
```
    2> java.lang.AssertionError: java.io.IOException: java.util.concurrent.ExecutionException: java.io.IOException: Random IOException
  2> 	at __randomizedtesting.SeedInfo.seed([D54BF72BCAAFB1D0]:0)
  2> 	at org.elasticsearch.repositories.LocalPrimarySnapshotShardContext.assertFileContentsMatchHash(LocalPrimarySnapshotShardContext.java:151)
  2> 	at org.elasticsearch.repositories.blobstore.BlobStoreRepository.doSnapshotShard(BlobStoreRepository.java:3578)
  2> 	at org.elasticsearch.repositories.blobstore.ShardSnapshotTaskRunner$ShardSnapshotTask.doRun(ShardSnapshotTaskRunner.java:97)
  2> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
  2> 	at org.elasticsearch.common.util.concurrent.PrioritizedThrottledTaskRunner$TaskWrapper.onResponse(PrioritizedThrottledTaskRunner.java:52)
  2> 	at org.elasticsearch.common.util.concurrent.PrioritizedThrottledTaskRunner$TaskWrapper.onResponse(PrioritizedThrottledTaskRunner.java:28)
  2> 	at org.elasticsearch.common.util.concurrent.AbstractThrottledTaskRunner$1.doRun(AbstractThrottledTaskRunner.java:141)
  2> 	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1114)
  2> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
  2> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
  2> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
  2> 	at java.base/java.lang.Thread.run(Thread.java:1516)
  2> Caused by: java.io.IOException: java.util.concurrent.ExecutionException: java.io.IOException: Random IOException
  2> 	at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.readInternal(BlobCacheIndexInput.java:212)
  2> 	at org.elasticsearch.blobcache.common.BlobCacheBufferedIndexInput.readBytes(BlobCacheBufferedIndexInput.java:133)
  2> 	at org.elasticsearch.blobcache.common.BlobCacheBufferedIndexInput.readBytes(BlobCacheBufferedIndexInput.java:92)
  2> 	at org.elasticsearch.index.store.StoreMetricsIndexInput.readBytes(StoreMetricsIndexInput.java:56)
  2> 	at org.elasticsearch.index.store.Store$VerifyingIndexInput.readBytes(Store.java:1289)
  2> 	at org.elasticsearch.repositories.LocalPrimarySnapshotShardContext.assertFileContentsMatchHash(LocalPrimarySnapshotShardContext.java:148)
  2> 	... 11 more
  2> Caused by: java.util.concurrent.ExecutionException: java.io.IOException: Random IOException
  2> 	at org.elasticsearch.action.support.PlainActionFuture$Sync.getValue(PlainActionFuture.java:279)
  2> 	at org.elasticsearch.action.support.PlainActionFuture$Sync.get(PlainActionFuture.java:266)
  2> 	at org.elasticsearch.action.support.PlainActionFuture.get(PlainActionFuture.java:96)
  2> 	at org.elasticsearch.blobcache.shared.SharedBlobCacheService$CacheFile.recordWait(SharedBlobCacheService.java:1969)
  2> 	at org.elasticsearch.xpack.stateless.cache.reader.CacheFileReader.doRead(CacheFileReader.java:523)
  2> 	at org.elasticsearch.xpack.stateless.cache.reader.CacheFileReader.read(CacheFileReader.java:442)
  2> 	at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.readInternalSlow(BlobCacheIndexInput.java:263)
  2> 	at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.doReadInternal(BlobCacheIndexInput.java:248)
  2> 	at org.elasticsearch.xpack.stateless.lucene.BlobCacheIndexInput.readInternal(BlobCacheIndexInput.java:201)
  2> 	... 16 more
  2> Caused by: java.io.IOException: Random IOException
  2> 	at org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase$1.failIfNeeded(AbstractStatelessPluginIntegTestCase.java:579)
  2> 	at org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase$1.blobContainerReadBlob(AbstractStatelessPluginIntegTestCase.java:606)
  2> 	at org.elasticsearch.xpack.stateless.StatelessMockRepository$StatelessMockBlobStore$StatelessMockBlobContainer.readBlob(StatelessMockRepository.java:129)
  2> 	at org.elasticsearch.xpack.stateless.cache.reader.ObjectStoreCacheBlobReader.getRangeInputStream(ObjectStoreCacheBlobReader.java:46)
  2> 	at org.elasticsearch.xpack.stateless.cache.reader.ObjectStoreCacheBlobReader.lambda$getRangeInputStream$0(ObjectStoreCacheBlobReader.java:55)
  2> 	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:58)
  2> 	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:55)
  2> 	at org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101)
  2> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
  2> 	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35)
  2> 	... 5 more
```
This IO exception is caught in assertFileContentsMatchHash(), and rethrown as an AssertionError. This kills the snapshot thread and permanently hangs the snapshot. AssertionError is an Error, so it escapes both AbstractRunnable.run and SnapshotTask.onFailure (which handle only Exception), the shard-snapshot listener is never completed, and the snapshot stays in SnapshotsInProgress forever. The stress test deliberately excluded the SNAPSHOT threadpool from failure injection to dodge exactly this assertion, but in stateless the verification read is a blob-cache miss whose object-store fetch runs on a different pool, and the failure is delivered back into the snapshot thread via a future. So I think the fix has to be in server code rather than in the test.
The fix is two parts:

- A transient IOException during the verification read is not a verification failure. It is logged and the verification is skipped. This is what StatelessHollowIndexShardsIT ran into.
- A genuine hash mismatch or a Lucene corruption exception now throw a `IndexShardSnapshotFailedException` instead of an AssertionError. The doSnapshotShard method's catch (Exception) routes this into a cleanly failed shard snapshot instead of a dead thread.

Note that this only impacts tests since it is only run in assertions. And this is just a partial fix for #154655 -- the other source of its failures will be handled in a separate PR.