### PR TITLE
[8.19] [Inference API] Fix associating an inference endpoint to an ML node deployment (#153688)

### DIFF
--- a/docs/changelog/153688.yaml
+++ b/docs/changelog/153688.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+  - 144860
+pr: 153688
+summary: "[Inference API] Fix associating an inference endpoint to an ML node deployment"
+type: bug

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
@@ -11,12 +11,18 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.ELEMENT_TYPE;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARITY;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
@@ -75,6 +81,59 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
         var deploymentStats = stats.get(0).get("deployment_stats");
         assertNotNull(stats.toString(), deploymentStats);
 
+        forceStopMlNodeDeployment(deploymentId);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAttachToDeployment_TextEmbedding() throws IOException {
+        var deploymentId = ".multilingual-e5-small";
+
+        putE5TrainedModels(deploymentId);
+        deployE5TrainedModels(deploymentId);
+
+        var inferenceId = "inference_on_existing_e5_deployment";
+        var putModel = putModel(inferenceId, endpointConfig(deploymentId), TaskType.TEXT_EMBEDDING);
+        var serviceSettings = (Map<String, Object>) putModel.get("service_settings");
+        assertThat(putModel.toString(), serviceSettings.get("dimensions"), is(384));
+        assertNotNull(putModel.toString(), serviceSettings.get("similarity"));
+        assertNotNull(putModel.toString(), serviceSettings.get("element_type"));
+
+        // Note: on GET, the endpoint is reconstructed from the model_id (a built-in E5 model here), not the
+        // deployment_id, so it does not carry dimensions/similarity/element_type in its response. That is a
+        // pre-existing, unrelated behavior of the built-in E5 model settings.
+        var getModel = getModel(inferenceId);
+        assertThat(
+            getModel.get("service_settings"),
+            is(Map.of("num_allocations", 1, "num_threads", 1, "model_id", ".multilingual-e5-small", "deployment_id", deploymentId))
+        );
+
+        var results = infer(inferenceId, List.of("washing machine"));
+        assertNotNull(results.get("text_embedding"));
+
+        deleteModel(inferenceId);
+        forceStopMlNodeDeployment(deploymentId);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAttachToDeployment_TextEmbedding_ParsesSimilarityAndElementType() throws IOException {
+        var deploymentId = ".multilingual-e5-small";
+        var similarity = SimilarityMeasure.DOT_PRODUCT;
+        var elementType = DenseVectorFieldMapper.ElementType.BYTE;
+
+        putE5TrainedModels(deploymentId);
+        deployE5TrainedModels(deploymentId);
+
+        var inferenceId = "inference_on_e5_deployment_with_similarity_element_type";
+        var putModel = putModel(inferenceId, endpointConfig(deploymentId, similarity, elementType), TaskType.TEXT_EMBEDDING);
+        var serviceSettings = (Map<String, Object>) putModel.get(ModelConfigurations.SERVICE_SETTINGS);
+        assertThat(putModel.toString(), serviceSettings.get(DIMENSIONS), is(384));
+        assertThat(putModel.toString(), serviceSettings.get(SIMILARITY), is(similarity.toString()));
+        assertThat(putModel.toString(), serviceSettings.get(ELEMENT_TYPE), is(elementType.toString()));
+
+        var results = infer(inferenceId, List.of("washing machine"));
+        assertNotNull(results.get("text_embedding"));
+
+        deleteModel(inferenceId);
         forceStopMlNodeDeployment(deploymentId);
     }
 
@@ -283,6 +342,19 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
               }
             }
             """, numAllocations);
+    }
+
+    private String endpointConfig(String deploymentId, SimilarityMeasure similarity, DenseVectorFieldMapper.ElementType elementType) {
+        return Strings.format("""
+            {
+              "service": "elasticsearch",
+              "service_settings": {
+                "deployment_id": "%s",
+                "similarity": "%s",
+                "element_type": "%s"
+              }
+            }
+            """, deploymentId, similarity, elementType);
     }
 
     private Response startMlNodeDeploymemnt(String modelId, String deploymentId) throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -323,7 +323,11 @@ public class InferenceBaseRestTest extends ESRestTestCase {
     }
 
     protected Map<String, Object> putE5TrainedModels() throws IOException {
-        var request = new Request("PUT", "_ml/trained_models/.multilingual-e5-small?wait_for_completion=true");
+        return putE5TrainedModels(".multilingual-e5-small");
+    }
+
+    protected Map<String, Object> putE5TrainedModels(String deploymentId) throws IOException {
+        var request = new Request("PUT", Strings.format("_ml/trained_models/%s?wait_for_completion=true", deploymentId));
 
         String body = """
                 {
@@ -340,7 +344,11 @@ public class InferenceBaseRestTest extends ESRestTestCase {
     }
 
     protected Map<String, Object> deployE5TrainedModels() throws IOException {
-        var request = new Request("POST", "_ml/trained_models/.multilingual-e5-small/deployment/_start?wait_for=fully_allocated");
+        return deployE5TrainedModels(".multilingual-e5-small");
+    }
+
+    protected Map<String, Object> deployE5TrainedModels(String deploymentId) throws IOException {
+        var request = new Request("POST", Strings.format("_ml/trained_models/%s/deployment/_start?wait_for=fully_allocated", deploymentId));
 
         var response = client().performRequest(request);
         assertStatusOkOrCreated(response);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceNamedWriteablesProvider.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceNamedWriteablesProvider.java
@@ -75,9 +75,9 @@ import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServic
 import org.elasticsearch.xpack.inference.services.elastic.completion.ElasticInferenceServiceCompletionServiceSettings;
 import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenceServiceRerankServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandInternalServiceSettings;
-import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandInternalTextEmbeddingServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticRerankerServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalTextEmbeddingServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserInternalServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserMlNodeTaskSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.MultilingualE5SmallInternalServiceSettings;
@@ -610,8 +610,8 @@ public class InferenceNamedWriteablesProvider {
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(
                 ServiceSettings.class,
-                CustomElandInternalTextEmbeddingServiceSettings.NAME,
-                CustomElandInternalTextEmbeddingServiceSettings::new
+                ElasticsearchInternalTextEmbeddingServiceSettings.NAME,
+                ElasticsearchInternalTextEmbeddingServiceSettings::new
             )
         );
         namedWriteables.add(new NamedWriteableRegistry.Entry(TaskSettings.class, RerankTaskSettings.NAME, RerankTaskSettings::new));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandEmbeddingModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandEmbeddingModel.java
@@ -16,14 +16,14 @@ public class CustomElandEmbeddingModel extends CustomElandModel {
         String inferenceEntityId,
         TaskType taskType,
         String service,
-        CustomElandInternalTextEmbeddingServiceSettings serviceSettings,
+        ElasticsearchInternalTextEmbeddingServiceSettings serviceSettings,
         ChunkingSettings chunkingSettings
     ) {
         super(inferenceEntityId, taskType, service, serviceSettings, chunkingSettings);
     }
 
     @Override
-    public CustomElandInternalTextEmbeddingServiceSettings getServiceSettings() {
-        return (CustomElandInternalTextEmbeddingServiceSettings) super.getServiceSettings();
+    public ElasticsearchInternalTextEmbeddingServiceSettings getServiceSettings() {
+        return (ElasticsearchInternalTextEmbeddingServiceSettings) super.getServiceSettings();
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticDeployedModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticDeployedModel.java
@@ -15,7 +15,28 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.core.ml.action.CreateTrainedModelAssignmentAction;
 import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
 
+import java.util.Map;
+
 public class ElasticDeployedModel extends ElasticsearchInternalModel {
+
+    /**
+     * Creates an {@link ElasticDeployedModel} with the appropriate {@link ElasticsearchInternalServiceSettings} based on the task type.
+     */
+    public static ElasticDeployedModel of(
+        String inferenceEntityId,
+        TaskType taskType,
+        String service,
+        ElasticsearchInternalServiceSettings.Builder settingsBuilder,
+        Map<String, Object> serviceSettingsMap,
+        ChunkingSettings chunkingSettings
+    ) {
+        var deployedServiceSettings = taskType == TaskType.TEXT_EMBEDDING
+            ? ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(serviceSettingsMap, settingsBuilder)
+            : settingsBuilder.build();
+
+        return new ElasticDeployedModel(inferenceEntityId, taskType, service, deployedServiceSettings, chunkingSettings);
+    }
+
     public ElasticDeployedModel(
         String inferenceEntityId,
         TaskType taskType,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
@@ -72,6 +73,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.inference.results.ResultUtils.createInvalidChunkedResultException;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
@@ -170,9 +172,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             String modelId = (String) serviceSettingsMap.get(MODEL_ID);
             String deploymentId = (String) serviceSettingsMap.get(ElasticsearchInternalServiceSettings.DEPLOYMENT_ID);
             if (deploymentId != null) {
-                validateAgainstDeployment(modelId, deploymentId, taskType, modelListener.delegateFailureAndWrap((l, settings) -> {
-                    l.onResponse(new ElasticDeployedModel(inferenceEntityId, taskType, NAME, settings.build(), chunkingSettings));
-                }));
+                deploymentIdCase(inferenceEntityId, taskType, serviceSettingsMap, taskSettingsMap, chunkingSettings, modelListener);
             } else if (modelId == null) {
                 if (OLD_ELSER_SERVICE_NAME.equals(serviceName)) {
                     // TODO complete deprecation of null model ID
@@ -244,6 +244,34 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         return Configuration.get();
     }
 
+    private void deploymentIdCase(
+        String inferenceEntityId,
+        TaskType taskType,
+        Map<String, Object> serviceSettingsMap,
+        Map<String, Object> taskSettingsMap,
+        ChunkingSettings chunkingSettings,
+        ActionListener<Model> modelListener
+    ) {
+        var validationException = new ValidationException();
+        String modelId = extractOptionalString(serviceSettingsMap, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
+        String deploymentId = extractOptionalString(
+            serviceSettingsMap,
+            ElasticsearchInternalServiceSettings.DEPLOYMENT_ID,
+            ModelConfigurations.SERVICE_SETTINGS,
+            validationException
+        );
+        validationException.throwIfValidationErrorsExist();
+
+        validateAgainstDeployment(modelId, deploymentId, taskType, modelListener.delegateFailureAndWrap((l, settings) -> {
+            var model = ElasticDeployedModel.of(inferenceEntityId, taskType, NAME, settings, serviceSettingsMap, chunkingSettings);
+
+            throwIfNotEmptyMap(serviceSettingsMap, name());
+            throwIfNotEmptyMap(taskSettingsMap, name());
+
+            l.onResponse(model);
+        }));
+    }
+
     private void customElandCase(
         String inferenceEntityId,
         TaskType taskType,
@@ -298,7 +326,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 inferenceEntityId,
                 taskType,
                 NAME,
-                CustomElandInternalTextEmbeddingServiceSettings.fromMap(serviceSettings, context),
+                ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(serviceSettings, context),
                 chunkingSettings
             );
             case SPARSE_EMBEDDING -> new CustomElandModel(
@@ -540,7 +568,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
     @Override
     public Model updateModelWithEmbeddingDetails(Model model, int embeddingSize) {
         if (model instanceof CustomElandEmbeddingModel customElandEmbeddingModel && model.getTaskType() == TaskType.TEXT_EMBEDDING) {
-            CustomElandInternalTextEmbeddingServiceSettings serviceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+            ElasticsearchInternalTextEmbeddingServiceSettings serviceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
                 customElandEmbeddingModel.getServiceSettings().getNumAllocations(),
                 customElandEmbeddingModel.getServiceSettings().getNumThreads(),
                 customElandEmbeddingModel.getServiceSettings().modelId(),
@@ -557,6 +585,21 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 customElandEmbeddingModel.getConfigurations().getService(),
                 serviceSettings,
                 customElandEmbeddingModel.getConfigurations().getChunkingSettings()
+            );
+        } else if (model instanceof ElasticDeployedModel elasticDeployedModel && model.getTaskType() == TaskType.TEXT_EMBEDDING) {
+            var serviceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
+                elasticDeployedModel.getServiceSettings(),
+                embeddingSize,
+                elasticDeployedModel.getServiceSettings().similarity(),
+                elasticDeployedModel.getServiceSettings().elementType()
+            );
+
+            return new ElasticDeployedModel(
+                elasticDeployedModel.getInferenceEntityId(),
+                elasticDeployedModel.getTaskType(),
+                elasticDeployedModel.getConfigurations().getService(),
+                serviceSettings,
+                elasticDeployedModel.getConfigurations().getChunkingSettings()
             );
         } else if (model instanceof ElasticsearchInternalModel) {
             return model;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettings.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSimilarity;
 
-public class CustomElandInternalTextEmbeddingServiceSettings extends ElasticsearchInternalServiceSettings {
+public class ElasticsearchInternalTextEmbeddingServiceSettings extends ElasticsearchInternalServiceSettings {
 
     public static final String NAME = "custom_eland_model_internal_text_embedding_service_settings";
 
@@ -48,14 +48,14 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
      * @param context The parser context, whether it is from an HTTP request or from persistent storage
      * @return The {@code CustomElandServiceSettings} builder
      */
-    public static CustomElandInternalTextEmbeddingServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
+    public static ElasticsearchInternalTextEmbeddingServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         return switch (context) {
             case REQUEST -> forRequest(map);
             case PERSISTENT -> forPersisted(map);
         };
     }
 
-    private static CustomElandInternalTextEmbeddingServiceSettings forRequest(Map<String, Object> map) {
+    private static ElasticsearchInternalTextEmbeddingServiceSettings forRequest(Map<String, Object> map) {
         ValidationException validationException = new ValidationException();
         var commonFields = commonFieldsFromMap(map, validationException);
 
@@ -63,14 +63,32 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
             throw validationException;
         }
 
-        return new CustomElandInternalTextEmbeddingServiceSettings(commonFields);
+        return new ElasticsearchInternalTextEmbeddingServiceSettings(commonFields);
     }
 
-    private static CustomElandInternalTextEmbeddingServiceSettings forPersisted(Map<String, Object> map) {
+    private static ElasticsearchInternalTextEmbeddingServiceSettings forPersisted(Map<String, Object> map) {
         var commonFields = commonFieldsFromMap(map);
         Integer dims = extractOptionalPositiveInteger(map, DIMENSIONS, ModelConfigurations.SERVICE_SETTINGS, new ValidationException());
 
-        return new CustomElandInternalTextEmbeddingServiceSettings(commonFields, dims);
+        return new ElasticsearchInternalTextEmbeddingServiceSettings(commonFields, dims);
+    }
+
+    /**
+     * Parse the similarity and element type from the request map, layering them onto a common settings
+     * builder populated from another source (e.g. an existing ML deployment's assignment stats rather
+     * than the map itself). Dimensions are left null; validation determines them after performing a
+     * request to the model.
+     */
+    public static ElasticsearchInternalTextEmbeddingServiceSettings fromMap(
+        Map<String, Object> map,
+        ElasticsearchInternalServiceSettings.Builder commonSettingsBuilder
+    ) {
+        var validationException = new ValidationException();
+        var similarity = extractSimilarityOrDefault(map, validationException);
+        var elementType = extractElementTypeOrDefault(map, validationException);
+        validationException.throwIfValidationErrorsExist();
+
+        return new ElasticsearchInternalTextEmbeddingServiceSettings(commonSettingsBuilder.build(), null, similarity, elementType);
     }
 
     private record CommonFields(
@@ -85,7 +103,21 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
 
     private static CommonFields commonFieldsFromMap(Map<String, Object> map, ValidationException validationException) {
         var internalSettings = ElasticsearchInternalServiceSettings.fromMap(map, validationException);
+        var similarity = extractSimilarityOrDefault(map, validationException);
+        var elementType = extractElementTypeOrDefault(map, validationException);
+
+        return new CommonFields(internalSettings.build(), similarity, elementType);
+    }
+
+    private static SimilarityMeasure extractSimilarityOrDefault(Map<String, Object> map, ValidationException validationException) {
         SimilarityMeasure similarity = extractSimilarity(map, ModelConfigurations.SERVICE_SETTINGS, validationException);
+        return Objects.requireNonNullElse(similarity, SimilarityMeasure.COSINE);
+    }
+
+    private static DenseVectorFieldMapper.ElementType extractElementTypeOrDefault(
+        Map<String, Object> map,
+        ValidationException validationException
+    ) {
         DenseVectorFieldMapper.ElementType elementType = extractOptionalEnum(
             map,
             ELEMENT_TYPE,
@@ -94,20 +126,15 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
             EnumSet.of(DenseVectorFieldMapper.ElementType.BYTE, DenseVectorFieldMapper.ElementType.FLOAT),
             validationException
         );
-
-        return new CommonFields(
-            internalSettings.build(),
-            Objects.requireNonNullElse(similarity, SimilarityMeasure.COSINE),
-            Objects.requireNonNullElse(elementType, DenseVectorFieldMapper.ElementType.FLOAT)
-        );
+        return Objects.requireNonNullElse(elementType, DenseVectorFieldMapper.ElementType.FLOAT);
     }
 
     private final Integer dimensions;
     private final SimilarityMeasure similarityMeasure;
     private final DenseVectorFieldMapper.ElementType elementType;
 
-    CustomElandInternalTextEmbeddingServiceSettings(
-        Integer numAllocations,
+    ElasticsearchInternalTextEmbeddingServiceSettings(
+        @Nullable Integer numAllocations,
         int numThreads,
         String modelId,
         AdaptiveAllocationsSettings adaptiveAllocationsSettings,
@@ -122,7 +149,7 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
         this.elementType = Objects.requireNonNull(elementType);
     }
 
-    public CustomElandInternalTextEmbeddingServiceSettings(StreamInput in) throws IOException {
+    public ElasticsearchInternalTextEmbeddingServiceSettings(StreamInput in) throws IOException {
         super(in);
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0)) {
             dimensions = in.readOptionalVInt();
@@ -135,11 +162,23 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
         }
     }
 
-    private CustomElandInternalTextEmbeddingServiceSettings(CommonFields commonFields) {
+    ElasticsearchInternalTextEmbeddingServiceSettings(
+        ElasticsearchInternalServiceSettings internalServiceSettings,
+        @Nullable Integer dimensions,
+        SimilarityMeasure similarityMeasure,
+        DenseVectorFieldMapper.ElementType elementType
+    ) {
+        super(internalServiceSettings);
+        this.dimensions = dimensions;
+        this.similarityMeasure = Objects.requireNonNull(similarityMeasure);
+        this.elementType = Objects.requireNonNull(elementType);
+    }
+
+    private ElasticsearchInternalTextEmbeddingServiceSettings(CommonFields commonFields) {
         this(commonFields, null);
     }
 
-    private CustomElandInternalTextEmbeddingServiceSettings(CommonFields commonFields, Integer dimensions) {
+    private ElasticsearchInternalTextEmbeddingServiceSettings(CommonFields commonFields, Integer dimensions) {
         super(
             commonFields.internalServiceSettings.getNumAllocations(),
             commonFields.internalServiceSettings.getNumThreads(),
@@ -176,7 +215,7 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
 
     @Override
     public String getWriteableName() {
-        return CustomElandInternalTextEmbeddingServiceSettings.NAME;
+        return ElasticsearchInternalTextEmbeddingServiceSettings.NAME;
     }
 
     @Override
@@ -214,7 +253,7 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        CustomElandInternalTextEmbeddingServiceSettings that = (CustomElandInternalTextEmbeddingServiceSettings) o;
+        ElasticsearchInternalTextEmbeddingServiceSettings that = (ElasticsearchInternalTextEmbeddingServiceSettings) o;
         return super.equals(that)
             && Objects.equals(dimensions, that.dimensions)
             && Objects.equals(similarityMeasure, that.similarityMeasure)
@@ -225,5 +264,4 @@ public class CustomElandInternalTextEmbeddingServiceSettings extends Elasticsear
     public int hashCode() {
         return Objects.hash(super.hashCode(), dimensions, similarityMeasure, elementType);
     }
-
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidator.java
@@ -20,6 +20,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandEmbeddingModel;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticDeployedModel;
 
 public class ElasticsearchInternalServiceModelValidator implements ModelValidator {
 
@@ -47,6 +48,13 @@ public class ElasticsearchInternalServiceModelValidator implements ModelValidato
                 listener.delegateFailureAndWrap((delegate, r) -> {
                     delegate.onResponse(postValidate(service, model, r));
                 })
+            );
+        } else if (model instanceof ElasticDeployedModel && model.getTaskType() == TaskType.TEXT_EMBEDDING) {
+            serviceIntegrationValidator.validate(
+                service,
+                model,
+                timeout,
+                listener.delegateFailureAndWrap((delegate, r) -> delegate.onResponse(postValidate(service, model, r)))
             );
         } else {
             listener.onResponse(model);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -108,6 +109,7 @@ import static org.elasticsearch.xpack.inference.services.elasticsearch.Elasticse
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.NAME;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -768,7 +770,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 TaskType.TEXT_EMBEDDING,
                 settings
             );
-            var elandServiceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+            var elandServiceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
                 1,
                 4,
                 "invalid",
@@ -878,7 +880,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
 
     public void testUpdateModelWithEmbeddingDetails_TextEmbeddingCustomElandEmbeddingsModelUpdatesDimensions() {
         var service = createService(mock(Client.class));
-        var elandServiceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+        var elandServiceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
             1,
             4,
             "invalid",
@@ -904,7 +906,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
 
     public void testUpdateModelWithEmbeddingDetails_NonTextEmbeddingCustomElandEmbeddingsModelNotModified() {
         var service = createService(mock(Client.class));
-        var elandServiceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+        var elandServiceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
             1,
             4,
             "invalid",
@@ -936,6 +938,45 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
 
         assertEquals(model, updatedModel);
         verifyNoMoreInteractions(model);
+    }
+
+    public void testUpdateModelWithEmbeddingDetails_ElasticDeployedModel() {
+        var service = createService(mock(Client.class));
+        var deploymentId = randomAlphaOfLength(10);
+        var modelId = randomAlphaOfLength(10);
+        var numAllocations = randomIntBetween(1, 4);
+        var numThreads = randomIntBetween(1, 4);
+
+        var serviceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
+            numAllocations,
+            numThreads,
+            modelId,
+            null,
+            deploymentId,
+            null,
+            SimilarityMeasure.COSINE,
+            DenseVectorFieldMapper.ElementType.FLOAT
+        );
+        var model = new ElasticDeployedModel(
+            randomAlphaOfLength(10),
+            TaskType.TEXT_EMBEDDING,
+            ElasticsearchInternalService.NAME,
+            serviceSettings,
+            null
+        );
+
+        var embeddingSize = randomNonNegativeInt();
+        var updatedModel = service.updateModelWithEmbeddingDetails(model, embeddingSize);
+
+        assertThat(updatedModel, instanceOf(ElasticDeployedModel.class));
+        var updatedServiceSettings = (ElasticsearchInternalServiceSettings) updatedModel.getServiceSettings();
+        assertEquals(embeddingSize, updatedServiceSettings.dimensions().intValue());
+        assertEquals(SimilarityMeasure.COSINE, updatedServiceSettings.similarity());
+        assertEquals(DenseVectorFieldMapper.ElementType.FLOAT, updatedServiceSettings.elementType());
+        assertEquals(deploymentId, updatedServiceSettings.getDeploymentId());
+        assertEquals(modelId, updatedServiceSettings.modelId());
+        assertEquals(numAllocations, updatedServiceSettings.getNumAllocations().intValue());
+        assertEquals(numThreads, updatedServiceSettings.getNumThreads());
     }
 
     public void testChunkInfer_E5WithNullChunkingSettings() throws InterruptedException {
@@ -1463,7 +1504,7 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
                 RerankTaskSettings.DEFAULT_SETTINGS
             );
         } else if (taskType == TaskType.TEXT_EMBEDDING) {
-            var serviceSettings = new CustomElandInternalTextEmbeddingServiceSettings(
+            var serviceSettings = new ElasticsearchInternalTextEmbeddingServiceSettings(
                 1,
                 4,
                 "custom-model",
@@ -1491,6 +1532,164 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
             );
         }
         return expectedModel;
+    }
+
+    public void testParseRequestConfig_TextEmbeddingDeploymentId() {
+        var deploymentId = randomAlphaOfLength(10);
+        var modelId = randomAlphaOfLength(10);
+        var numAllocations = randomIntBetween(1, 4);
+        var numThreads = randomIntBetween(1, 4);
+
+        var assignmentStats = mock(AssignmentStats.class);
+        when(assignmentStats.getDeploymentId()).thenReturn(deploymentId);
+        when(assignmentStats.getModelId()).thenReturn(modelId);
+        when(assignmentStats.getNumberOfAllocations()).thenReturn(numAllocations);
+        when(assignmentStats.getThreadsPerAllocation()).thenReturn(numThreads);
+
+        var modelConfig = mock(TrainedModelConfig.class);
+        when(modelConfig.getInferenceConfig()).thenReturn(mock(TextEmbeddingConfig.class));
+
+        var client = mock(Client.class);
+        doAnswer(invocation -> {
+            ActionListener<GetDeploymentStatsAction.Response> listener = invocation.getArgument(2);
+            var response = mock(GetDeploymentStatsAction.Response.class);
+            when(response.getStats()).thenReturn(new QueryPage<>(List.of(assignmentStats), 1, RESULTS_FIELD));
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetDeploymentStatsAction.INSTANCE), any(), any());
+        doAnswer(invocation -> {
+            ActionListener<GetTrainedModelsAction.Response> listener = invocation.getArgument(2);
+            listener.onResponse(new GetTrainedModelsAction.Response(new QueryPage<>(List.of(modelConfig), 1, mock(ParseField.class))));
+            return null;
+        }).when(client).execute(eq(GetTrainedModelsAction.INSTANCE), any(), any());
+        when(client.threadPool()).thenReturn(threadPool);
+
+        var service = createService(client);
+        var settings = new HashMap<String, Object>();
+        settings.put(
+            ModelConfigurations.SERVICE_SETTINGS,
+            new HashMap<>(Map.of(ElasticsearchInternalServiceSettings.DEPLOYMENT_ID, deploymentId))
+        );
+
+        var listener = new TestPlainActionFuture<Model>();
+        service.parseRequestConfig(randomInferenceEntityId, TaskType.TEXT_EMBEDDING, settings, listener);
+        var model = listener.actionGet(TimeValue.THIRTY_SECONDS);
+
+        assertThat(model, instanceOf(ElasticDeployedModel.class));
+        var serviceSettings = model.getServiceSettings();
+        assertThat(serviceSettings, instanceOf(ElasticsearchInternalTextEmbeddingServiceSettings.class));
+        assertNull(serviceSettings.dimensions());
+        assertEquals(SimilarityMeasure.COSINE, serviceSettings.similarity());
+        assertEquals(DenseVectorFieldMapper.ElementType.FLOAT, serviceSettings.elementType());
+        assertEquals(deploymentId, ((ElasticsearchInternalServiceSettings) serviceSettings).getDeploymentId());
+        assertEquals(modelId, serviceSettings.modelId());
+        assertEquals(numAllocations, ((ElasticsearchInternalServiceSettings) serviceSettings).getNumAllocations().intValue());
+        assertEquals(numThreads, ((ElasticsearchInternalServiceSettings) serviceSettings).getNumThreads());
+    }
+
+    public void testParseRequestConfig_TextEmbeddingDeploymentId_WithSimilarityAndElementType() {
+        var deploymentId = randomAlphaOfLength(10);
+        var modelId = randomAlphaOfLength(10);
+
+        var assignmentStats = mock(AssignmentStats.class);
+        when(assignmentStats.getDeploymentId()).thenReturn(deploymentId);
+        when(assignmentStats.getModelId()).thenReturn(modelId);
+        when(assignmentStats.getNumberOfAllocations()).thenReturn(1);
+        when(assignmentStats.getThreadsPerAllocation()).thenReturn(1);
+
+        var modelConfig = mock(TrainedModelConfig.class);
+        when(modelConfig.getInferenceConfig()).thenReturn(mock(TextEmbeddingConfig.class));
+
+        var client = mock(Client.class);
+        doAnswer(invocation -> {
+            ActionListener<GetDeploymentStatsAction.Response> listener = invocation.getArgument(2);
+            var response = mock(GetDeploymentStatsAction.Response.class);
+            when(response.getStats()).thenReturn(new QueryPage<>(List.of(assignmentStats), 1, RESULTS_FIELD));
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetDeploymentStatsAction.INSTANCE), any(), any());
+        doAnswer(invocation -> {
+            ActionListener<GetTrainedModelsAction.Response> listener = invocation.getArgument(2);
+            listener.onResponse(new GetTrainedModelsAction.Response(new QueryPage<>(List.of(modelConfig), 1, mock(ParseField.class))));
+            return null;
+        }).when(client).execute(eq(GetTrainedModelsAction.INSTANCE), any(), any());
+        when(client.threadPool()).thenReturn(threadPool);
+
+        var service = createService(client);
+        var settings = new HashMap<String, Object>();
+        settings.put(
+            ModelConfigurations.SERVICE_SETTINGS,
+            new HashMap<>(
+                Map.of(
+                    ElasticsearchInternalServiceSettings.DEPLOYMENT_ID,
+                    deploymentId,
+                    ServiceFields.SIMILARITY,
+                    SimilarityMeasure.DOT_PRODUCT.toString(),
+                    ServiceFields.ELEMENT_TYPE,
+                    DenseVectorFieldMapper.ElementType.BYTE.toString()
+                )
+            )
+        );
+
+        var listener = new TestPlainActionFuture<Model>();
+        service.parseRequestConfig(randomInferenceEntityId, TaskType.TEXT_EMBEDDING, settings, listener);
+        var model = listener.actionGet(TimeValue.THIRTY_SECONDS);
+
+        assertThat(model, instanceOf(ElasticDeployedModel.class));
+        var serviceSettings = model.getServiceSettings();
+        assertThat(serviceSettings, instanceOf(ElasticsearchInternalTextEmbeddingServiceSettings.class));
+        assertNull(serviceSettings.dimensions());
+        assertEquals(SimilarityMeasure.DOT_PRODUCT, serviceSettings.similarity());
+        assertEquals(DenseVectorFieldMapper.ElementType.BYTE, serviceSettings.elementType());
+    }
+
+    public void testParseRequestConfig_TextEmbeddingDeploymentId_ThrowsOnUnknownSettings() {
+        var deploymentId = randomAlphaOfLength(10);
+        var modelId = randomAlphaOfLength(10);
+
+        var assignmentStats = mock(AssignmentStats.class);
+        when(assignmentStats.getDeploymentId()).thenReturn(deploymentId);
+        when(assignmentStats.getModelId()).thenReturn(modelId);
+        when(assignmentStats.getNumberOfAllocations()).thenReturn(1);
+        when(assignmentStats.getThreadsPerAllocation()).thenReturn(1);
+
+        var modelConfig = mock(TrainedModelConfig.class);
+        when(modelConfig.getInferenceConfig()).thenReturn(mock(TextEmbeddingConfig.class));
+
+        var client = mock(Client.class);
+        doAnswer(invocation -> {
+            ActionListener<GetDeploymentStatsAction.Response> listener = invocation.getArgument(2);
+            var response = mock(GetDeploymentStatsAction.Response.class);
+            when(response.getStats()).thenReturn(new QueryPage<>(List.of(assignmentStats), 1, RESULTS_FIELD));
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(GetDeploymentStatsAction.INSTANCE), any(), any());
+        doAnswer(invocation -> {
+            ActionListener<GetTrainedModelsAction.Response> listener = invocation.getArgument(2);
+            listener.onResponse(new GetTrainedModelsAction.Response(new QueryPage<>(List.of(modelConfig), 1, mock(ParseField.class))));
+            return null;
+        }).when(client).execute(eq(GetTrainedModelsAction.INSTANCE), any(), any());
+        when(client.threadPool()).thenReturn(threadPool);
+
+        var service = createService(client);
+        var settings = new HashMap<String, Object>();
+        settings.put(
+            ModelConfigurations.SERVICE_SETTINGS,
+            new HashMap<>(
+                Map.of(
+                    ElasticsearchInternalServiceSettings.DEPLOYMENT_ID,
+                    deploymentId,
+                    ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                    1
+                )
+            )
+        );
+
+        var listener = new TestPlainActionFuture<Model>();
+        service.parseRequestConfig(randomInferenceEntityId, TaskType.TEXT_EMBEDDING, settings, listener);
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TimeValue.THIRTY_SECONDS));
+        assertThat(exception.getMessage(), containsString(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS));
     }
 
     public void testBuildInferenceRequest() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettingsTests.java
@@ -12,10 +12,13 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationSettingsTests;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.elasticsearch.xpack.inference.Utils;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 
@@ -28,10 +31,10 @@ import static org.elasticsearch.xpack.inference.services.elasticsearch.Elasticse
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_THREADS;
 import static org.hamcrest.Matchers.is;
 
-public class CustomElandInternalTextEmbeddingServiceSettingsTests extends AbstractWireSerializingTestCase<
-    CustomElandInternalTextEmbeddingServiceSettings> {
+public class ElasticsearchInternalTextEmbeddingServiceSettingsTests extends AbstractWireSerializingTestCase<
+    ElasticsearchInternalTextEmbeddingServiceSettings> {
 
-    public static CustomElandInternalTextEmbeddingServiceSettings createRandom() {
+    public static ElasticsearchInternalTextEmbeddingServiceSettings createRandom() {
         var withAdaptiveAllocations = randomBoolean();
         var numAllocations = withAdaptiveAllocations ? null : randomIntBetween(1, 10);
         var adaptiveAllocationsSettings = withAdaptiveAllocations
@@ -44,7 +47,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         var dims = setDimensions ? 123 : null;
         var elementType = randomFrom(DenseVectorFieldMapper.ElementType.values());
 
-        return new CustomElandInternalTextEmbeddingServiceSettings(
+        return new ElasticsearchInternalTextEmbeddingServiceSettings(
             numAllocations,
             numThreads,
             modelId,
@@ -61,7 +64,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
         var numAllocations = 1;
         var numThreads = 1;
-        var serviceSettings = CustomElandInternalTextEmbeddingServiceSettings.fromMap(
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(
             new HashMap<>(
                 Map.of(
                     ServiceFields.MODEL_ID,
@@ -82,7 +85,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         assertThat(
             serviceSettings,
             is(
-                new CustomElandInternalTextEmbeddingServiceSettings(
+                new ElasticsearchInternalTextEmbeddingServiceSettings(
                     numAllocations,
                     numThreads,
                     modelId,
@@ -100,7 +103,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         var modelId = "model-foo";
         var numAllocations = 1;
         var numThreads = 1;
-        var serviceSettings = CustomElandInternalTextEmbeddingServiceSettings.fromMap(
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(
             new HashMap<>(Map.of(ServiceFields.MODEL_ID, modelId, NUM_ALLOCATIONS, numAllocations, NUM_THREADS, numThreads)),
             ConfigurationParseContext.REQUEST
         );
@@ -108,7 +111,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         assertThat(
             serviceSettings,
             is(
-                new CustomElandInternalTextEmbeddingServiceSettings(
+                new ElasticsearchInternalTextEmbeddingServiceSettings(
                     numAllocations,
                     numThreads,
                     modelId,
@@ -127,7 +130,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
         var numAllocations = 1;
         var numThreads = 1;
-        var serviceSettings = CustomElandInternalTextEmbeddingServiceSettings.fromMap(
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(
             new HashMap<>(
                 Map.of(
                     ServiceFields.MODEL_ID,
@@ -150,7 +153,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         assertThat(
             serviceSettings,
             is(
-                new CustomElandInternalTextEmbeddingServiceSettings(
+                new ElasticsearchInternalTextEmbeddingServiceSettings(
                     numAllocations,
                     numThreads,
                     modelId,
@@ -169,7 +172,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
         var numAllocations = 1;
         var numThreads = 1;
-        var serviceSettings = CustomElandInternalTextEmbeddingServiceSettings.fromMap(
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(
             new HashMap<>(
                 Map.of(
                     ServiceFields.MODEL_ID,
@@ -192,7 +195,7 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         assertThat(
             serviceSettings,
             is(
-                new CustomElandInternalTextEmbeddingServiceSettings(
+                new ElasticsearchInternalTextEmbeddingServiceSettings(
                     numAllocations,
                     numThreads,
                     modelId,
@@ -206,8 +209,75 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
         );
     }
 
+    public void testFromMapWithBuilder_ParsesSimilarityAndElementType() {
+        var modelId = "model-foo";
+        var deploymentId = "deployment-foo";
+        var numAllocations = 1;
+        var numThreads = 1;
+        var builder = new ElasticsearchInternalServiceSettings.Builder().setNumAllocations(numAllocations)
+            .setNumThreads(numThreads)
+            .setModelId(modelId)
+            .setDeploymentId(deploymentId);
+
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.SIMILARITY,
+                SimilarityMeasure.DOT_PRODUCT.toString(),
+                ELEMENT_TYPE,
+                DenseVectorFieldMapper.ElementType.BYTE.toString()
+            )
+        );
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(map, builder);
+
+        assertThat(
+            serviceSettings,
+            is(
+                new ElasticsearchInternalTextEmbeddingServiceSettings(
+                    numAllocations,
+                    numThreads,
+                    modelId,
+                    null,
+                    deploymentId,
+                    null,
+                    SimilarityMeasure.DOT_PRODUCT,
+                    DenseVectorFieldMapper.ElementType.BYTE
+                )
+            )
+        );
+        assertTrue(map.isEmpty());
+    }
+
+    public void testFromMapWithBuilder_DefaultsSimilarityAndElementTypeWhenAbsent() {
+        var modelId = "model-foo";
+        var deploymentId = "deployment-foo";
+        var numAllocations = 1;
+        var numThreads = 1;
+        var builder = new ElasticsearchInternalServiceSettings.Builder().setNumAllocations(numAllocations)
+            .setNumThreads(numThreads)
+            .setModelId(modelId)
+            .setDeploymentId(deploymentId);
+
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(new HashMap<>(), builder);
+
+        assertThat(
+            serviceSettings,
+            is(
+                new ElasticsearchInternalTextEmbeddingServiceSettings(
+                    numAllocations,
+                    numThreads,
+                    modelId,
+                    null,
+                    deploymentId,
+                    null,
+                    SimilarityMeasure.COSINE,
+                    DenseVectorFieldMapper.ElementType.FLOAT
+                )
+            )
+        );
+    }
+
     public void testToXContent_WritesAllValues() throws IOException {
-        var entity = new CustomElandInternalTextEmbeddingServiceSettings(
+        var entity = new ElasticsearchInternalTextEmbeddingServiceSettings(
             1,
             1,
             "model_id",
@@ -227,18 +297,50 @@ public class CustomElandInternalTextEmbeddingServiceSettingsTests extends Abstra
     }
 
     @Override
-    protected Writeable.Reader<CustomElandInternalTextEmbeddingServiceSettings> instanceReader() {
-        return CustomElandInternalTextEmbeddingServiceSettings::new;
+    protected Writeable.Reader<ElasticsearchInternalTextEmbeddingServiceSettings> instanceReader() {
+        return ElasticsearchInternalTextEmbeddingServiceSettings::new;
     }
 
     @Override
-    protected CustomElandInternalTextEmbeddingServiceSettings createTestInstance() {
+    protected ElasticsearchInternalTextEmbeddingServiceSettings createTestInstance() {
         return createRandom();
     }
 
     @Override
-    protected CustomElandInternalTextEmbeddingServiceSettings mutateInstance(CustomElandInternalTextEmbeddingServiceSettings instance)
+    protected ElasticsearchInternalTextEmbeddingServiceSettings mutateInstance(ElasticsearchInternalTextEmbeddingServiceSettings instance)
         throws IOException {
-        return randomValueOtherThan(instance, CustomElandInternalTextEmbeddingServiceSettingsTests::createRandom);
+        var numAllocations = instance.getNumAllocations();
+        var numThreads = instance.getNumThreads();
+        var modelId = instance.modelId();
+        var adaptiveAllocationsSettings = instance.getAdaptiveAllocationsSettings();
+        var deploymentId = instance.getDeploymentId();
+        var dimensions = instance.dimensions();
+        var similarity = instance.similarity();
+        var elementType = instance.elementType();
+        switch (randomInt(7)) {
+            case 0 -> numAllocations = randomValueOtherThan(numAllocations, () -> randomFrom(randomIntBetween(1, 10), null));
+            case 1 -> numThreads = randomValueOtherThan(numThreads, () -> randomIntBetween(1, 10));
+            case 2 -> modelId = randomValueOtherThan(modelId, () -> randomAlphaOfLength(8));
+            case 3 -> adaptiveAllocationsSettings = randomValueOtherThan(
+                adaptiveAllocationsSettings,
+                () -> randomFrom(AdaptiveAllocationSettingsTests.testInstance(), null)
+            );
+            case 4 -> deploymentId = randomValueOtherThan(deploymentId, () -> randomAlphaOfLengthOrNull(8));
+            case 5 -> dimensions = randomValueOtherThan(dimensions, ESTestCase::randomNonNegativeIntOrNull);
+            case 6 -> similarity = randomValueOtherThan(similarity, Utils::randomSimilarityMeasure);
+            case 7 -> elementType = randomValueOtherThan(elementType, () -> randomFrom(DenseVectorFieldMapper.ElementType.values()));
+            default -> throw new AssertionError("Illegal randomisation branch");
+        }
+
+        return new ElasticsearchInternalTextEmbeddingServiceSettings(
+            numAllocations,
+            numThreads,
+            modelId,
+            adaptiveAllocationsSettings,
+            deploymentId,
+            dimensions,
+            similarity,
+            elementType
+        );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
@@ -19,7 +19,8 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandEmbeddingModel;
-import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandInternalTextEmbeddingServiceSettings;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticDeployedModel;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalTextEmbeddingServiceSettings;
 import org.junit.Before;
 import org.mockito.Mock;
 
@@ -264,8 +265,77 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         );
     }
 
+    public void testValidate_ElasticDeployedModelWithNonTextEmbeddingTaskTypeSkipsValidation() {
+        var elasticDeployedModel = createElasticDeployedModel(randomFrom(TaskType.RERANK, TaskType.SPARSE_EMBEDDING));
+
+        underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
+
+        verify(mockActionListener).onResponse(elasticDeployedModel);
+        verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockActionListener);
+    }
+
+    public void testValidate_ElasticDeployedTextEmbeddingModelValidationFails() {
+        var elasticDeployedModel = createElasticDeployedModel(TaskType.TEXT_EMBEDDING);
+
+        doAnswer(ans -> {
+            ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
+            responseListener.onFailure(new ElasticsearchStatusException("Model validation failed", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(elasticDeployedModel), eq(TIMEOUT), any());
+
+        underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
+
+        verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(elasticDeployedModel), eq(TIMEOUT), any());
+        verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
+        verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockActionListener);
+    }
+
+    public void testValidate_ElasticDeployedTextEmbeddingModelValidationSucceeds() {
+        var dimensions = randomIntBetween(1, 10);
+        var mockInferenceServiceResults = mock(DenseEmbeddingResults.class);
+        var mockUpdatedModel = mock(ElasticDeployedModel.class);
+        when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
+        var elasticDeployedModel = createElasticDeployedModel(TaskType.TEXT_EMBEDDING);
+
+        doAnswer(ans -> {
+            ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
+            responseListener.onResponse(mockInferenceServiceResults);
+            return null;
+        }).when(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(elasticDeployedModel), eq(TIMEOUT), any());
+        when(mockInferenceService.updateModelWithEmbeddingDetails(eq(elasticDeployedModel), eq(dimensions))).thenReturn(mockUpdatedModel);
+
+        underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
+
+        verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(elasticDeployedModel), eq(TIMEOUT), any());
+        verify(mockInferenceService).updateModelWithEmbeddingDetails(eq(elasticDeployedModel), eq(dimensions));
+        verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).onResponse(mockUpdatedModel);
+        verify(mockInferenceServiceResults).getFirstEmbeddingSize();
+        verifyNoMoreInteractions(
+            mockServiceIntegrationValidator,
+            mockInferenceService,
+            mockActionListener,
+            mockUpdatedModel,
+            mockInferenceServiceResults
+        );
+    }
+
+    private ElasticDeployedModel createElasticDeployedModel(TaskType taskType) {
+        var mockServiceSettings = mock(ElasticsearchInternalTextEmbeddingServiceSettings.class);
+        when(mockServiceSettings.modelId()).thenReturn(randomAlphaOfLength(10));
+
+        return new ElasticDeployedModel(
+            randomAlphaOfLength(10),
+            taskType,
+            randomAlphaOfLength(10),
+            mockServiceSettings,
+            ChunkingSettingsTests.createRandomChunkingSettings()
+        );
+    }
+
     private CustomElandEmbeddingModel createCustomElandEmbeddingModel(boolean areDimensionsSetByUser, Integer dimensions) {
-        var mockServiceSettings = mock(CustomElandInternalTextEmbeddingServiceSettings.class);
+        var mockServiceSettings = mock(ElasticsearchInternalTextEmbeddingServiceSettings.class);
         when(mockServiceSettings.modelId()).thenReturn(randomAlphaOfLength(10));
         when(mockServiceSettings.dimensionsSetByUser()).thenReturn(areDimensionsSetByUser);
         if (dimensions != null) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
@@ -293,7 +293,7 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
     public void testValidate_ElasticDeployedTextEmbeddingModelValidationSucceeds() {
         var dimensions = randomIntBetween(1, 10);
-        var mockInferenceServiceResults = mock(DenseEmbeddingResults.class);
+        var mockInferenceServiceResults = mock(TextEmbeddingResults.class);
         var mockUpdatedModel = mock(ElasticDeployedModel.class);
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
         var elasticDeployedModel = createElasticDeployedModel(TaskType.TEXT_EMBEDDING);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Inference API] Fix associating an inference endpoint to an ML node deployment (#153688)](https://github.com/elastic/elasticsearch/pull/153688)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)