### PR TITLE
Back out row-major batch-path from field mappers

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchIndexerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchIndexerTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.escf.EscfBatch;
 import org.elasticsearch.escf.EscfEncoder;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ShardId;
@@ -37,8 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class ShardBatchIndexerTests extends IndexShardTestCase {
 
@@ -109,143 +106,17 @@ public class ShardBatchIndexerTests extends IndexShardTestCase {
         return EscfEncoder.encode(sources, XContentType.JSON);
     }
 
-    public void testBatchIndexOnPrimarySingleDoc() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(1)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-        }
-
-        assertFalse(context.hasMoreOperationsToExecute());
-        BulkItemResponse response = items[0].getPrimaryResponse();
-        assertThat(response, notNullValue());
-        assertFalse(response.isFailed());
-        assertThat(response.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        assertThat(response.getResponse().getSeqNo(), greaterThanOrEqualTo(0L));
-
-        closeShards(shard);
-    }
-
-    public void testBatchIndexOnPrimaryMultipleDocs() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        int numDocs = randomIntBetween(2, 20);
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest(Integer.toString(i)));
-        }
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(numDocs)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-        }
-
-        assertFalse(context.hasMoreOperationsToExecute());
-        for (int i = 0; i < numDocs; i++) {
-            BulkItemResponse response = items[i].getPrimaryResponse();
-            assertThat(response, notNullValue());
-            assertFalse(response.isFailed());
-            assertThat(response.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        }
-
-        shard.refresh("test");
-        try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
-            assertThat(searcher.getIndexReader().numDocs(), equalTo(numDocs));
-        }
-
-        closeShards(shard);
-    }
-
-    public void testBatchIndexOnPrimaryChunking() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        int numDocs = ShardBatchIndexer.BATCH_CHUNK_SIZE + randomIntBetween(1, 32);
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest(Integer.toString(i)));
-        }
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(numDocs)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-        }
-
-        assertFalse(context.hasMoreOperationsToExecute());
-        for (int i = 0; i < numDocs; i++) {
-            BulkItemResponse response = items[i].getPrimaryResponse();
-            assertThat("doc " + i + " should have a response", response, notNullValue());
-            assertFalse("doc " + i + " should not have failed", response.isFailed());
-        }
-
-        shard.refresh("test");
-        try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
-            assertThat(searcher.getIndexReader().numDocs(), equalTo(numDocs));
-        }
-
-        closeShards(shard);
-    }
-
-    public void testBatchIndexOnPrimaryDuplicateUids() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        BulkItemRequest[] items = new BulkItemRequest[] {
-            new BulkItemRequest(0, indexRequest("same-id")),
-            new BulkItemRequest(1, indexRequest("same-id")) };
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(2)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-        }
-
-        // Both operations complete: duplicate UIDs are split across sub-batches, so the second
-        // overwrites the first rather than triggering a fallback to the sequential path.
-        assertFalse(context.hasMoreOperationsToExecute());
-        assertFalse(items[0].getPrimaryResponse().isFailed());
-        assertFalse(items[1].getPrimaryResponse().isFailed());
-
-        shard.refresh("test");
-        try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
-            assertThat(searcher.getIndexReader().numDocs(), equalTo(1));
-        }
-
-        closeShards(shard);
-    }
-
+    // TODO(columnar): add tests for the following scenarios once FieldMapper#supportsColumnarParse()
+    // is implemented for real field mappers so that ShardBatchMapper.mapColumnBatch does not fall back:
+    // - testBatchIndexOnPrimarySingleDoc
+    // - testBatchIndexOnPrimaryMultipleDocs
+    // - testBatchIndexOnPrimaryChunking (batch exceeds BATCH_CHUNK_SIZE)
+    // - testBatchIndexOnPrimaryDuplicateUids (duplicate UIDs split across sub-batches)
+    // - testBatchIndexOnPrimaryStoredSource
+    // - testBatchIndexOnReplicaSingleDoc
+    // - testBatchIndexOnReplicaMultipleDocs
+    // - testBatchIndexOnReplicaFailedPrimaryResponse
+    // - testBatchIndexWithNestedFields
     public void testBatchIndexOnPrimaryAbortedItem() throws Exception {
         IndexShard shard = newMappedPrimaryShard();
 
@@ -276,146 +147,6 @@ public class ShardBatchIndexerTests extends IndexShardTestCase {
         assertFalse(context.hasMoreOperationsToExecute());
 
         closeShards(shard);
-    }
-
-    public void testBatchIndexOnPrimaryStoredSource() throws Exception {
-        IndexShard shard = newMappedPrimaryShard(STORED_SOURCE_SETTINGS);
-
-        int numDocs = randomIntBetween(2, 10);
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest(Integer.toString(i)));
-        }
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(numDocs)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-        }
-
-        assertFalse(context.hasMoreOperationsToExecute());
-        for (int i = 0; i < numDocs; i++) {
-            BulkItemResponse response = items[i].getPrimaryResponse();
-            assertThat(response, notNullValue());
-            assertFalse(response.isFailed());
-            assertThat(response.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        }
-
-        shard.refresh("test");
-        try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
-            assertThat(searcher.getIndexReader().numDocs(), equalTo(numDocs));
-        }
-
-        closeShards(shard);
-    }
-
-    public void testBatchIndexOnReplicaSingleDoc() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(1)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-            assertFalse(context.hasMoreOperationsToExecute());
-
-            IndexShard replica = newMappedReplicaShard();
-
-            ShardBatchIndexer.ReplicaBatchResult result = ShardBatchIndexer.performBatchIndexOnReplica(items, batch, replica);
-            assertThat(result.processedItems(), equalTo(1));
-            assertThat(result.location(), notNullValue());
-
-            closeShards(shard, replica);
-        }
-    }
-
-    public void testBatchIndexOnReplicaMultipleDocs() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        int numDocs = randomIntBetween(2, 20);
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest(Integer.toString(i)));
-        }
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(numDocs)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-            assertFalse(context.hasMoreOperationsToExecute());
-
-            IndexShard replica = newMappedReplicaShard();
-
-            ShardBatchIndexer.ReplicaBatchResult result = ShardBatchIndexer.performBatchIndexOnReplica(items, batch, replica);
-            assertThat(result.processedItems(), equalTo(numDocs));
-            assertThat(result.location(), notNullValue());
-
-            replica.refresh("test");
-            try (Engine.Searcher searcher = replica.acquireSearcher("test")) {
-                assertThat(searcher.getIndexReader().numDocs(), equalTo(numDocs));
-            }
-
-            closeShards(shard, replica);
-        }
-    }
-
-    public void testBatchIndexOnReplicaFailedPrimaryResponse() throws Exception {
-        IndexShard shard = newMappedPrimaryShard();
-
-        BulkItemRequest[] items = new BulkItemRequest[] {
-            new BulkItemRequest(0, indexRequest("1")),
-            new BulkItemRequest(1, indexRequest("2")) };
-        BulkShardRequest bulkShardRequest = new BulkShardRequest(
-            shard.shardId(),
-            SplitShardCountSummary.IRRELEVANT,
-            RefreshPolicy.NONE,
-            items
-        );
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-        try (SourceBatch batch = buildBatch(2)) {
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-
-            // Override the second item's response with a failure
-            items[1].setPrimaryResponse(
-                BulkItemResponse.failure(
-                    1,
-                    DocWriteRequest.OpType.INDEX,
-                    new BulkItemResponse.Failure("index", "2", new RuntimeException())
-                )
-            );
-
-            IndexShard replica = newMappedReplicaShard();
-
-            ShardBatchIndexer.ReplicaBatchResult result = ShardBatchIndexer.performBatchIndexOnReplica(items, batch, replica);
-            assertThat(result.processedItems(), equalTo(1));
-
-            closeShards(shard, replica);
-        }
     }
 
     private static final String NESTED_MAPPING = """
@@ -466,56 +197,6 @@ public class ShardBatchIndexerTests extends IndexShardTestCase {
         trackedShards.add(shard);
         recoverShardFromStore(shard);
         return shard;
-    }
-
-    public void testBatchIndexWithNestedFields() throws Exception {
-        IndexShard shard = newPrimaryShardWithMapping(NESTED_MAPPING);
-
-        int numDocs = randomIntBetween(2, 10);
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        List<BytesReference> sources = new ArrayList<>();
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest(Integer.toString(i)));
-            try (XContentBuilder b = XContentBuilder.builder(XContentType.JSON.xContent())) {
-                b.startObject();
-                b.startObject("host");
-                b.field("name", "host-" + i);
-                b.field("ip", "10.0.0." + i);
-                b.endObject();
-                b.field("message", "hello from " + i);
-                b.endObject();
-                sources.add(BytesReference.bytes(b));
-            }
-        }
-
-        try (EscfBatch batch = EscfEncoder.encode(sources, XContentType.JSON)) {
-            BulkShardRequest bulkShardRequest = new BulkShardRequest(
-                shard.shardId(),
-                SplitShardCountSummary.IRRELEVANT,
-                RefreshPolicy.NONE,
-                items
-            );
-            BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
-
-            PlainActionFuture<Void> future = new PlainActionFuture<>();
-            ShardBatchIndexer.performBatchIndexOnPrimary(items, batch, context, future);
-            future.actionGet();
-
-            assertFalse(context.hasMoreOperationsToExecute());
-            for (int i = 0; i < numDocs; i++) {
-                BulkItemResponse response = items[i].getPrimaryResponse();
-                assertThat(response, notNullValue());
-                assertFalse("doc " + i + " should not have failed", response.isFailed());
-                assertThat(response.getResponse().getResult(), equalTo(DocWriteResponse.Result.CREATED));
-            }
-
-            shard.refresh("test");
-            try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
-                assertThat(searcher.getIndexReader().numDocs(), equalTo(numDocs));
-            }
-        }
-
-        closeShards(shard);
     }
 
     public void testBatchIndexWithArrayFieldsFallsBack() throws Exception {

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperParseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperParseTests.java
@@ -9,42 +9,20 @@
 
 package org.elasticsearch.action.bulk;
 
-import org.apache.lucene.document.InetAddressPoint;
-import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.escf.EscfEncoder;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
-import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.RoutingFieldMapper;
-import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.ShardBatchMapper;
-import org.elasticsearch.index.mapper.ShardBatchMapper.BatchMapperResolution;
-import org.elasticsearch.index.mapper.SourceFieldMapper;
-import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.sourcebatch.SourceBatch;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 /**
  * Parse-time tests for the batch-mapping fast path: drives {@link ShardBatchMapper} directly and
@@ -76,19 +54,6 @@ public class ShardBatchMapperParseTests extends IndexShardTestCase {
         return new IndexRequest("index").id(id);
     }
 
-    private List<Engine.Index> parseBatch(IndexShard shard, SourceBatch batch, BulkItemRequest[] items) throws IOException {
-        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), shard.mapperService().mappingLookup());
-        assertNotNull("expected batch path to support this mapping", resolution);
-        List<Engine.Index> ops = ShardBatchMapper.parseMappings(items, batch, shard, items.length, 0, resolution);
-        assertNotNull("parseMappings returned null (fallback signal)", ops);
-        assertThat(ops, hasSize(items.length));
-        return ops;
-    }
-
-    private static LuceneDocument rootDoc(Engine.Index op) {
-        return op.parsedDoc().rootDoc();
-    }
-
     /** Builds a single-document JSON {@link BytesReference} from alternating name/value pairs. */
     private static BytesReference doc(Object... kvPairs) throws IOException {
         try (XContentBuilder b = XContentFactory.jsonBuilder()) {
@@ -101,367 +66,20 @@ public class ShardBatchMapperParseTests extends IndexShardTestCase {
         }
     }
 
-    public void testSupportedMapperTypes() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "ts":    { "type": "date" },
-                "host":  { "type": "keyword" },
-                "value": { "type": "long" },
-                "score": { "type": "double" }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
+    // TODO(columnar): the tests below drove the row-major ShardBatchMapper.parseMappings, which was
+    // replaced by the columnar batch-mapping path (mapColumnBatch). Re-enable (adapted to the
+    // columnar API) once field (non-metadata) mappers support columnar parsing:
+    // - testSupportedMapperTypes (date, keyword, long, double)
+    // - testResolveFallsBackForUnsupportedMapper (text+index_prefixes triggers sequential fallback)
+    // - testIgnoredLeafUnderDynamicFalseParentIsDropped
+    // - testNumberMapperReceivesStringValue
+    // - testIgnoreAboveOnKeywordDoesNotFail
+    // - testParseMappingsAddsMetadataFields (id, routing, version, seq_no, source via preParse/postParse)
+    // - testParseMappingsSyntheticSourceAndIgnored
+    // - testNullValuesAreSkipped
+    // - testBooleanMapper
+    // - testIpMapper
+    // - testIpMapperIgnoreMalformed
+    // - testTextMapper
 
-        int numDocs = 5;
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest("id-" + i));
-        }
-
-        List<BytesReference> sources = new ArrayList<>(numDocs);
-        for (int i = 0; i < numDocs; i++) {
-            sources.add(doc("ts", 1_700_000_000_000L + i, "host", "host-" + i, "value", 100L + i, "score", 1.5 + i));
-        }
-        try (SourceBatch batch = EscfEncoder.encode(sources, XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            for (int i = 0; i < numDocs; i++) {
-                LuceneDocument doc = rootDoc(ops.get(i));
-                assertThat(doc.getField("ts").numericValue().longValue(), equalTo(1_700_000_000_000L + i));
-                assertThat(doc.getBinaryValue("host"), equalTo(new BytesRef("host-" + i)));
-                assertThat(doc.getField("value").numericValue().longValue(), equalTo(100L + i));
-                // Double doc-values field stores Double.doubleToLongBits(value); decode for assertion.
-                long scoreBits = doc.getField("score").numericValue().longValue();
-                assertThat(Double.longBitsToDouble(scoreBits), equalTo(1.5 + i));
-            }
-        }
-
-        closeShards(shard);
-    }
-
-    public void testResolveFallsBackForUnsupportedMapper() throws Exception {
-        // A text field with index_prefixes is not in the v1 support list — resolveMappers should
-        // return null so the caller falls back to the sequential path.
-        String mapping = """
-            {
-              "properties": {
-                "host": { "type": "keyword" },
-                "body": { "type": "text", "index_prefixes": {} }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
-
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("host", "a", "body", "hello world")), XContentType.JSON)) {
-            BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), shard.mapperService().mappingLookup());
-            assertNull("batch path should refuse text+index_prefixes leaves and trigger sequential fallback", resolution);
-        }
-
-        closeShards(shard);
-    }
-
-    public void testIgnoredLeafUnderDynamicFalseParentIsDropped() throws Exception {
-        String mapping = """
-            {
-              "dynamic": "false",
-              "properties": {
-                "host":  { "type": "keyword" }
-              }
-            }""";
-        // Stored source: with synthetic source the non-batch path would route the unmapped `extra`
-        // through _ignored_source, which the batch path does not implement yet.
-        IndexShard shard = newShardWithMapping(mapping, STORED_SOURCE_SETTINGS);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("host", "alpha", "extra", "silent")), XContentType.JSON)) {
-            BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), shard.mapperService().mappingLookup());
-            assertNotNull(resolution);
-            int hostLeaf = batch.schema().findLeaf("host", 0);
-            int extraLeaf = batch.schema().findLeaf("extra", 0);
-            assertNotNull(resolution.columnMappers()[hostLeaf]);
-            assertNull(resolution.columnMappers()[extraLeaf]);
-
-            List<Engine.Index> ops = ShardBatchMapper.parseMappings(items, batch, shard, items.length, 0, resolution);
-            assertNotNull(ops);
-            assertThat(ops, hasSize(1));
-            LuceneDocument doc = rootDoc(ops.get(0));
-            assertThat(doc.getBinaryValue("host"), equalTo(new BytesRef("alpha")));
-            assertThat(doc.getFields("extra"), empty());
-        }
-
-        closeShards(shard);
-    }
-
-    public void testNumberMapperReceivesStringValue() throws Exception {
-        // The contract is: NumberFieldMapper should parse string batch values via its usual
-        // parseCreateField path; resolveMappers does not pre-match column types.
-        String mapping = """
-            {
-              "properties": {
-                "v": { "type": "long" }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("v", "42")), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            LuceneDocument doc = rootDoc(ops.get(0));
-            assertThat(doc.getField("v").numericValue().longValue(), equalTo(42L));
-        }
-
-        closeShards(shard);
-    }
-
-    public void testIgnoreAboveOnKeywordDoesNotFail() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "host": { "type": "keyword", "ignore_above": 4 }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("host", "way-too-long-value")), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            LuceneDocument doc = rootDoc(ops.get(0));
-            assertThat(doc.getFields("host"), empty());
-            assertTrue(
-                "ignore_above should record the field name in _ignored",
-                doc.getFields("_ignored").stream().anyMatch(f -> "host".equals(f.stringValue()))
-            );
-        }
-
-        closeShards(shard);
-    }
-
-    /**
-     * Drives {@link ShardBatchMapper#parseMappings} directly (no fallback safety net) and inspects
-     * the {@link ParsedDocument} produced by {@code parseRow}. Each metadata-mapper hook that the
-     * batch path relies on contributes a Lucene field by a known name, so checking for those names
-     * tells us preParse/postParse actually ran. If the metadata phases are skipped, parseRow either
-     * NPEs (no _id) or emits a doc missing _routing/_source/_version/_seq_no — both make this test fail.
-     */
-    public void testParseMappingsAddsMetadataFields() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "host":  { "type": "keyword" },
-                "value": { "type": "long" }
-              }
-            }""";
-        // Use stored source so SourceFieldMapper.preParse adds a _source StoredField we can inspect.
-        IndexShard shard = newShardWithMapping(mapping, STORED_SOURCE_SETTINGS);
-
-        IndexRequest indexRequest = indexRequest("doc-1").routing("route-1");
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest) };
-
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("host", "alpha", "value", 7)), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            ParsedDocument parsed = ops.getFirst().parsedDoc();
-            LuceneDocument doc = parsed.rootDoc();
-
-            // ProvidedIdFieldMapper.preParse — sets context.id and adds an indexed _id field.
-            assertThat("ParsedDocument id should be populated by IdFieldMapper.preParse", parsed.id(), equalTo("doc-1"));
-            assertNotNull("_id Lucene field must be present", doc.getField(IdFieldMapper.NAME));
-
-            // RoutingFieldMapper.preParse — adds a stored _routing field whose string value is the routing key.
-            IndexableField routingField = doc.getField(RoutingFieldMapper.NAME);
-            assertNotNull("_routing must be added by RoutingFieldMapper.preParse", routingField);
-            assertThat(routingField.stringValue(), equalTo("route-1"));
-
-            // VersionFieldMapper.preParse — adds a placeholder _version doc-values field.
-            assertNotNull("_version must be added by VersionFieldMapper.preParse", doc.getField(VersionFieldMapper.NAME));
-
-            // SeqNoFieldMapper.postParse — adds the _seq_no placeholder doc-values field.
-            assertNotNull("_seq_no must be added by SeqNoFieldMapper.postParse", doc.getField(SeqNoFieldMapper.NAME));
-
-            // SourceFieldMapper.preParse — adds the _source stored field with the row-synthesized JSON.
-            IndexableField sourceField = doc.getField(SourceFieldMapper.NAME);
-            assertNotNull("_source must be added by SourceFieldMapper.preParse", sourceField);
-            assertNotNull(sourceField.binaryValue());
-        }
-
-        closeShards(shard);
-    }
-
-    /**
-     * Synthetic-source variant of the metadata-field audit. Combines coverage for:
-     * <ul>
-     *   <li>{@link SourceFieldMapper#preParse} (synthetic branch — adds {@code _recovery_source}
-     *       or {@code _recovery_source_size} and does <em>not</em> add a stored {@code _source})</li>
-     *   <li>{@link IgnoredFieldMapper#postParse} (records {@code _ignored} for fields that hit
-     *       {@code ignore_above})</li>
-     * </ul>
-     *
-     * <p>Note that {@code IgnoredSourceFieldMapper.postParse} is not exercised by an
-     * {@code ignore_above} trigger: {@code KeywordFieldMapper} stores the ignored bytes directly
-     * into a synthetic-source fallback field rather than via
-     * {@code DocumentParserContext#addIgnoredFieldValue}, so {@code getIgnoredFieldValues()}
-     * stays empty and the postParse hook is a no-op for this case. Exercising it would require
-     * an {@code ignore_malformed} trigger on a numeric column.
-     */
-    public void testParseMappingsSyntheticSourceAndIgnored() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "host": { "type": "keyword", "ignore_above": 4 }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping, SYNTHETIC_SOURCE_SETTINGS);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("doc-1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("host", "way-too-long")), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            LuceneDocument doc = rootDoc(ops.getFirst());
-
-            // Synthetic source: stored _source is absent, but a _recovery_source flavor must be present.
-            assertNull("stored _source must not be present in synthetic mode", doc.getField(SourceFieldMapper.NAME));
-            boolean hasRecovery = doc.getField(SourceFieldMapper.RECOVERY_SOURCE_NAME) != null
-                || doc.getField(SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME) != null;
-            assertTrue(
-                "SourceFieldMapper.preParse must add either _recovery_source or _recovery_source_size in synthetic mode",
-                hasRecovery
-            );
-
-            // ignore_above triggered → IgnoredFieldMapper.postParse records the field name.
-            assertNotNull("_ignored must be added when a column exceeds ignore_above", doc.getField(IgnoredFieldMapper.NAME));
-        }
-
-        closeShards(shard);
-    }
-
-    public void testNullValuesAreSkipped() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "host": { "type": "keyword" },
-                "v":    { "type": "long" }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("host", null, "v", null)), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            LuceneDocument doc = rootDoc(ops.get(0));
-            assertThat(doc.getFields("host"), empty());
-            assertThat(doc.getFields("v"), empty());
-        }
-
-        closeShards(shard);
-    }
-
-    public void testBooleanMapper() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "active": { "type": "boolean" }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
-
-        int numDocs = 3;
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest("id-" + i));
-        }
-        try (
-            SourceBatch batch = EscfEncoder.encode(
-                List.of(doc("active", true), doc("active", false), doc("active", null)),
-                XContentType.JSON
-            )
-        ) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-
-            LuceneDocument trueDoc = rootDoc(ops.get(0));
-            List<IndexableField> trueFields = trueDoc.getFields("active");
-            assertFalse("expected indexable fields for true", trueFields.isEmpty());
-            assertTrue(
-                "boolean true should encode as numeric 1",
-                trueFields.stream().anyMatch(f -> f.numericValue() != null && f.numericValue().longValue() == 1L)
-            );
-
-            LuceneDocument falseDoc = rootDoc(ops.get(1));
-            List<IndexableField> falseFields = falseDoc.getFields("active");
-            assertFalse("expected indexable fields for false", falseFields.isEmpty());
-            assertTrue(
-                "boolean false should encode as numeric 0",
-                falseFields.stream().anyMatch(f -> f.numericValue() != null && f.numericValue().longValue() == 0L)
-            );
-
-            LuceneDocument nullDoc = rootDoc(ops.get(2));
-            assertThat(nullDoc.getFields("active"), empty());
-        }
-
-        closeShards(shard);
-    }
-
-    public void testIpMapper() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "addr": { "type": "ip" }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping);
-
-        int numDocs = 2;
-        BulkItemRequest[] items = new BulkItemRequest[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            items[i] = new BulkItemRequest(i, indexRequest("id-" + i));
-        }
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("addr", "192.168.1.1"), doc("addr", "::1")), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-
-            BytesRef expectedV4 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("192.168.1.1")));
-            BytesRef expectedV6 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1")));
-            assertThat(rootDoc(ops.get(0)).getField("addr").binaryValue(), equalTo(expectedV4));
-            assertThat(rootDoc(ops.get(1)).getField("addr").binaryValue(), equalTo(expectedV6));
-        }
-
-        closeShards(shard);
-    }
-
-    public void testIpMapperIgnoreMalformed() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "addr": { "type": "ip", "ignore_malformed": true }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping, STORED_SOURCE_SETTINGS);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("addr", "not-an-ip")), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            LuceneDocument doc = rootDoc(ops.get(0));
-            assertThat(doc.getFields("addr"), empty());
-            assertTrue(
-                "ignore_malformed should record the field name in _ignored",
-                doc.getFields("_ignored").stream().anyMatch(f -> "addr".equals(f.stringValue()))
-            );
-        }
-
-        closeShards(shard);
-    }
-
-    public void testTextMapper() throws Exception {
-        String mapping = """
-            {
-              "properties": {
-                "body": { "type": "text" }
-              }
-            }""";
-        IndexShard shard = newShardWithMapping(mapping, STORED_SOURCE_SETTINGS);
-
-        BulkItemRequest[] items = new BulkItemRequest[] { new BulkItemRequest(0, indexRequest("1")) };
-        try (SourceBatch batch = EscfEncoder.encode(List.of(doc("body", "the quick brown fox")), XContentType.JSON)) {
-            List<Engine.Index> ops = parseBatch(shard, batch, items);
-            LuceneDocument doc = rootDoc(ops.get(0));
-            assertThat(doc.getField("body").stringValue(), equalTo("the quick brown fox"));
-        }
-
-        closeShards(shard);
-    }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -363,16 +363,6 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    public boolean supportsBatchIndexing() {
-        // Constant keyword can be driven through parseCreateField by the bulk batch path only
-        // once the value is pinned. While the value is unset, parseCreateField triggers a
-        // dynamic mapping update, which the v1 batch path does not support. copy_to and
-        // multi-fields pull in behavior that the v1 batch path does not support either; scripts
-        // are not configurable on this mapper.
-        return fieldType().value() != null && copyTo().copyToFields().isEmpty() && multiFields().iterator().hasNext() == false;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         final String value = parser.textOrNull();

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -8,25 +8,18 @@
 package org.elasticsearch.xpack.constantkeyword.mapper;
 
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.action.bulk.BulkItemRequest;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.eirf.EirfBatch;
-import org.elasticsearch.eirf.EirfRowBuilder;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.DummyBlockLoaderContext;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -34,10 +27,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.ShardBatchMapper;
-import org.elasticsearch.index.mapper.ShardBatchMapper.BatchMapperResolution;
 import org.elasticsearch.index.mapper.TestBlock;
-import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.constantkeyword.ConstantKeywordMapperPlugin;
@@ -49,13 +39,9 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ConstantKeywordFieldMapperTests extends MapperTestCase {
 
@@ -328,80 +314,4 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
         return false;
     }
 
-    public void testSupportsBatchIndexingWhenValueIsSet() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
-        FieldMapper mapper = (FieldMapper) mapperService.mappingLookup().getMapper("field");
-        assertTrue(mapper.supportsBatchIndexing());
-    }
-
-    public void testSupportsBatchIndexingFalseWhenValueIsUnset() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword")));
-        FieldMapper mapper = (FieldMapper) mapperService.mappingLookup().getMapper("field");
-        assertFalse(mapper.supportsBatchIndexing());
-    }
-
-    public void testBatchResolveHappyPath() throws IOException {
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
-        try (EirfBatch batch = singleStringRowBatch("field", "foo")) {
-            BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), ms.mappingLookup());
-            assertNotNull(resolution);
-            assertEquals(1, resolution.columnMappers().length);
-            assertThat(resolution.columnMappers()[0], instanceOf(ConstantKeywordFieldMapper.class));
-        }
-    }
-
-    public void testBatchResolveFallsBackWhenValueUnset() throws IOException {
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword")));
-        try (EirfBatch batch = singleStringRowBatch("field", "foo")) {
-            assertNull(ShardBatchMapper.resolveMappers(batch.schema(), ms.mappingLookup()));
-        }
-    }
-
-    public void testBatchParseAddsSyntheticSourceMarker() throws IOException {
-        MapperService ms = createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
-        BulkItemRequest[] items = { new BulkItemRequest(0, new IndexRequest("idx").id("1")) };
-        try (EirfBatch batch = singleStringRowBatch("field", "foo")) {
-            List<Engine.Index> ops = parseBatch(ms, batch, items);
-            LuceneDocument doc = ops.get(0).parsedDoc().rootDoc();
-            // Synthetic-source mode records a single-valued doc-values marker so reconstruction
-            // knows the field was present.
-            List<IndexableField> fields = doc.getFields("field");
-            assertThat(fields, hasSize(1));
-            assertThat(fields.get(0).numericValue().longValue(), equalTo(1L));
-        }
-    }
-
-    public void testBatchParseStoredSourceProducesNoField() throws IOException {
-        // In non-synthetic mode the constant_keyword mapper validates the value matches the
-        // pinned value but does not add any indexed/doc-value field.
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
-        BulkItemRequest[] items = { new BulkItemRequest(0, new IndexRequest("idx").id("1")) };
-        try (EirfBatch batch = singleStringRowBatch("field", "foo")) {
-            List<Engine.Index> ops = parseBatch(ms, batch, items);
-            LuceneDocument doc = ops.get(0).parsedDoc().rootDoc();
-            assertThat(doc.getFields("field"), empty());
-        }
-    }
-
-    private static EirfBatch singleStringRowBatch(String field, String value) {
-        try (EirfRowBuilder builder = new EirfRowBuilder()) {
-            builder.startDocument();
-            builder.setString(field, value);
-            builder.endDocument();
-            return builder.build();
-        }
-    }
-
-    private static List<Engine.Index> parseBatch(MapperService ms, EirfBatch batch, BulkItemRequest[] items) throws IOException {
-        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), ms.mappingLookup());
-        assertNotNull("expected batch path to support this mapping", resolution);
-        IndexShard primary = mock(IndexShard.class);
-        when(primary.mapperService()).thenReturn(ms);
-        when(primary.getOperationPrimaryTerm()).thenReturn(1L);
-        when(primary.getRelativeTimeInNanos()).thenReturn(0L);
-        List<Engine.Index> ops = ShardBatchMapper.parseMappings(items, batch, primary, items.length, 0, resolution);
-        assertNotNull("parseMappings returned null (fallback signal)", ops);
-        assertThat(ops, hasSize(items.length));
-        return ops;
-    }
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -804,19 +804,6 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     }
 
     @Override
-    public boolean supportsBatchIndexing() {
-        // Plain unsigned_long mappers can be driven through parseCreateField by the bulk batch
-        // path. ignore_malformed and null_value are allowed. Dimensions, time-series metrics,
-        // copy_to, multi-fields, and scripts pull in behavior that the v1 batch path does not
-        // support.
-        return hasScript() == false
-            && copyTo().copyToFields().isEmpty()
-            && multiFields().iterator().hasNext() == false
-            && dimension == false
-            && metricType == null;
-    }
-
-    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         Long numericValue;

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -8,32 +8,23 @@
 package org.elasticsearch.xpack.unsignedlong;
 
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.action.bulk.BulkItemRequest;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.eirf.EirfBatch;
-import org.elasticsearch.eirf.EirfRowBuilder;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberTypeOutOfRangeSpec;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.ShardBatchMapper;
-import org.elasticsearch.index.mapper.ShardBatchMapper.BatchMapperResolution;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
 import org.elasticsearch.index.mapper.WholeNumberFieldMapperTests;
-import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
@@ -54,9 +45,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
 
@@ -550,102 +538,5 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
     @Override
     protected List<SortShortcutSupport> getSortShortcutSupport() {
         return List.of(new SortShortcutSupport(this::minimalMapping, this::writeField, true));
-    }
-
-    public void testSupportsBatchIndexingHappyPath() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "unsigned_long")));
-        FieldMapper mapper = (FieldMapper) mapperService.mappingLookup().getMapper("field");
-        assertTrue(mapper.supportsBatchIndexing());
-    }
-
-    public void testSupportsBatchIndexingWithIgnoreMalformed() throws IOException {
-        MapperService mapperService = createMapperService(
-            fieldMapping(b -> b.field("type", "unsigned_long").field("ignore_malformed", true))
-        );
-        FieldMapper mapper = (FieldMapper) mapperService.mappingLookup().getMapper("field");
-        assertTrue(mapper.supportsBatchIndexing());
-    }
-
-    public void testSupportsBatchIndexingFalseWithMetric() throws IOException {
-        MapperService mapperService = createMapperService(
-            fieldMapping(b -> b.field("type", "unsigned_long").field("time_series_metric", "gauge"))
-        );
-        FieldMapper mapper = (FieldMapper) mapperService.mappingLookup().getMapper("field");
-        assertFalse(mapper.supportsBatchIndexing());
-    }
-
-    public void testBatchResolveHappyPath() throws IOException {
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "unsigned_long")));
-        try (EirfBatch batch = singleStringRowBatch("field", "1")) {
-            BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), ms.mappingLookup());
-            assertNotNull(resolution);
-            assertEquals(1, resolution.columnMappers().length);
-            assertThat(resolution.columnMappers()[0], instanceOf(UnsignedLongFieldMapper.class));
-        }
-    }
-
-    public void testBatchResolveFallsBackWithMetric() throws IOException {
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "unsigned_long").field("time_series_metric", "gauge")));
-        try (EirfBatch batch = singleStringRowBatch("field", "1")) {
-            assertNull(ShardBatchMapper.resolveMappers(batch.schema(), ms.mappingLookup()));
-        }
-    }
-
-    public void testBatchParseEncodesValue() throws IOException {
-        // Max unsigned long string → encoded as Long.MAX_VALUE in the sortable signed-long form
-        // used by doc values; max signed long → encoded as -1.
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "unsigned_long")));
-        BulkItemRequest[] items = {
-            new BulkItemRequest(0, new IndexRequest("idx").id("1")),
-            new BulkItemRequest(1, new IndexRequest("idx").id("2")) };
-        try (EirfRowBuilder builder = new EirfRowBuilder()) {
-            builder.startDocument();
-            builder.setString("field", "18446744073709551615"); // 2^64 - 1
-            builder.endDocument();
-            builder.startDocument();
-            builder.setString("field", "9223372036854775807"); // 2^63 - 1
-            builder.endDocument();
-            try (EirfBatch batch = builder.build()) {
-                List<Engine.Index> ops = parseBatch(ms, batch, items);
-                assertThat(ops.get(0).parsedDoc().rootDoc().getField("field").numericValue().longValue(), equalTo(Long.MAX_VALUE));
-                assertThat(ops.get(1).parsedDoc().rootDoc().getField("field").numericValue().longValue(), equalTo(-1L));
-            }
-        }
-    }
-
-    public void testBatchParseIgnoreMalformed() throws IOException {
-        MapperService ms = createMapperService(fieldMapping(b -> b.field("type", "unsigned_long").field("ignore_malformed", true)));
-        BulkItemRequest[] items = { new BulkItemRequest(0, new IndexRequest("idx").id("1")) };
-        try (EirfBatch batch = singleStringRowBatch("field", "not-a-number")) {
-            List<Engine.Index> ops = parseBatch(ms, batch, items);
-            LuceneDocument doc = ops.get(0).parsedDoc().rootDoc();
-            assertThat(doc.getFields("field"), empty());
-            assertTrue(
-                "ignore_malformed should record the field name in _ignored",
-                doc.getFields("_ignored").stream().anyMatch(f -> "field".equals(f.stringValue()))
-            );
-        }
-    }
-
-    private static EirfBatch singleStringRowBatch(String field, String value) {
-        try (EirfRowBuilder builder = new EirfRowBuilder()) {
-            builder.startDocument();
-            builder.setString(field, value);
-            builder.endDocument();
-            return builder.build();
-        }
-    }
-
-    private static List<Engine.Index> parseBatch(MapperService ms, EirfBatch batch, BulkItemRequest[] items) throws IOException {
-        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(batch.schema(), ms.mappingLookup());
-        assertNotNull("expected batch path to support this mapping", resolution);
-        IndexShard primary = mock(IndexShard.class);
-        when(primary.mapperService()).thenReturn(ms);
-        when(primary.getOperationPrimaryTerm()).thenReturn(1L);
-        when(primary.getRelativeTimeInNanos()).thenReturn(0L);
-        List<Engine.Index> ops = ShardBatchMapper.parseMappings(items, batch, primary, items.length, 0, resolution);
-        assertNotNull("parseMappings returned null (fallback signal)", ops);
-        assertThat(ops, hasSize(items.length));
-        return ops;
     }
 }


### PR DESCRIPTION
Remove the supportsBatchIndexing() implementations from
ConstantKeywordFieldMapper and UnsignedLongFieldMapper, along with
all tests that exercised the row-major ShardBatchMapper.parseMappings
contract. These mappers will need to be rebuilt against the columnar
mapColumnBatch API once FieldMapper#supportsColumnarParse() is
available. TODOs in ShardBatchIndexerTests and
ShardBatchMapperParseTests enumerate the test scenarios to restore.