### PR TITLE
[9.4] [Inference API] Delete default endpoints using master node action only (#154735)

### DIFF
--- a/docs/changelog/154735.yaml
+++ b/docs/changelog/154735.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 154710
+pr: 154735
+summary: "[Inference API] Delete default endpoints using master node action only"
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsAction.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.action;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Internal action to delete inference endpoints. This should only be used internally and not exposed via a REST API.
+ * For the exposed REST API action see {@link DeleteInferenceEndpointAction}.
+ */
+public class InternalDeleteInferenceEndpointsAction extends ActionType<AcknowledgedResponse> {
+
+    public static final InternalDeleteInferenceEndpointsAction INSTANCE = new InternalDeleteInferenceEndpointsAction();
+    public static final String NAME = "cluster:internal/xpack/inference/delete_endpoints";
+
+    public InternalDeleteInferenceEndpointsAction() {
+        super(NAME);
+    }
+
+    public static class Request extends AcknowledgedRequest<Request> {
+        private final Set<String> inferenceEntityIds;
+
+        public Request(Set<String> inferenceEntityIds, TimeValue timeout) {
+            super(timeout, DEFAULT_ACK_TIMEOUT);
+            this.inferenceEntityIds = Objects.requireNonNull(inferenceEntityIds);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            inferenceEntityIds = in.readCollectionAsImmutableSet(StreamInput::readString);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeStringCollection(inferenceEntityIds);
+        }
+
+        public Set<String> getInferenceEntityIds() {
+            return inferenceEntityIds;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            var request = (Request) o;
+            return Objects.equals(inferenceEntityIds, request.inferenceEntityIds);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(inferenceEntityIds);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InternalDeleteInferenceEndpointsActionRequestTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+
+public class InternalDeleteInferenceEndpointsActionRequestTests extends AbstractBWCWireSerializationTestCase<
+    InternalDeleteInferenceEndpointsAction.Request> {
+
+    @Override
+    protected InternalDeleteInferenceEndpointsAction.Request mutateInstanceForVersion(
+        InternalDeleteInferenceEndpointsAction.Request instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+
+    @Override
+    protected Writeable.Reader<InternalDeleteInferenceEndpointsAction.Request> instanceReader() {
+        return InternalDeleteInferenceEndpointsAction.Request::new;
+    }
+
+    @Override
+    protected InternalDeleteInferenceEndpointsAction.Request createTestInstance() {
+        var ids = new HashSet<String>();
+        int count = randomIntBetween(1, 5);
+        for (int i = 0; i < count; i++) {
+            ids.add(randomAlphaOfLength(10));
+        }
+        return new InternalDeleteInferenceEndpointsAction.Request(ids, randomTimeValue());
+    }
+
+    @Override
+    protected InternalDeleteInferenceEndpointsAction.Request mutateInstance(InternalDeleteInferenceEndpointsAction.Request instance)
+        throws IOException {
+        var newIds = new HashSet<>(instance.getInferenceEntityIds());
+        newIds.add(randomAlphaOfLength(10));
+        return new InternalDeleteInferenceEndpointsAction.Request(newIds, instance.masterNodeTimeout());
+    }
+
+    public void testRequestHoldsExpectedIds() {
+        var ids = Set.of("id-1", "id-2", "id-3");
+        var request = new InternalDeleteInferenceEndpointsAction.Request(ids, TEST_REQUEST_TIMEOUT);
+        assertThat(request.getInferenceEntityIds(), is(ids));
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -80,6 +80,9 @@ public class InferenceFeatures implements FeatureSpecification {
     public static final NodeFeature EMBEDDING_TASK_TYPE = new NodeFeature("inference.embedding_task_type");
 
     public static final NodeFeature ENDPOINT_METADATA_FIELD = new NodeFeature("inference.metadata_field");
+    public static final NodeFeature INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION = new NodeFeature(
+        "inference.internal_delete_endpoints_action"
+    );
 
     @Override
     public Set<NodeFeature> getFeatures() {
@@ -89,7 +92,8 @@ public class InferenceFeatures implements FeatureSpecification {
             INFERENCE_AUTH_POLLER_PERSISTENT_TASK,
             INFERENCE_CCM_ENABLEMENT_SERVICE,
             EMBEDDING_TASK_TYPE,
-            ENDPOINT_METADATA_FIELD
+            ENDPOINT_METADATA_FIELD,
+            INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -70,6 +70,7 @@ import org.elasticsearch.xpack.core.inference.action.GetInferenceServicesAction;
 import org.elasticsearch.xpack.core.inference.action.GetRerankerWindowSizeAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceActionProxy;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.PutCCMConfigurationAction;
 import org.elasticsearch.xpack.core.inference.action.PutInferenceModelAction;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
@@ -88,6 +89,7 @@ import org.elasticsearch.xpack.inference.action.TransportGetRerankerWindowSizeAc
 import org.elasticsearch.xpack.inference.action.TransportInferenceAction;
 import org.elasticsearch.xpack.inference.action.TransportInferenceActionProxy;
 import org.elasticsearch.xpack.inference.action.TransportInferenceUsageAction;
+import org.elasticsearch.xpack.inference.action.TransportInternalDeleteEndpointsAction;
 import org.elasticsearch.xpack.inference.action.TransportPutCCMConfigurationAction;
 import org.elasticsearch.xpack.inference.action.TransportPutInferenceModelAction;
 import org.elasticsearch.xpack.inference.action.TransportStoreEndpointsAction;
@@ -293,6 +295,7 @@ public class InferencePlugin extends Plugin
             new ActionHandler(GetRerankerWindowSizeAction.INSTANCE, TransportGetRerankerWindowSizeAction.class),
             new ActionHandler(ClearInferenceEndpointCacheAction.INSTANCE, ClearInferenceEndpointCacheAction.class),
             new ActionHandler(StoreInferenceEndpointsAction.INSTANCE, TransportStoreEndpointsAction.class),
+            new ActionHandler(InternalDeleteInferenceEndpointsAction.INSTANCE, TransportInternalDeleteEndpointsAction.class),
             new ActionHandler(GetCCMConfigurationAction.INSTANCE, TransportGetCCMConfigurationAction.class),
             new ActionHandler(PutCCMConfigurationAction.INSTANCE, TransportPutCCMConfigurationAction.class),
             new ActionHandler(DeleteCCMConfigurationAction.INSTANCE, TransportDeleteCCMConfigurationAction.class),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsAction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+
+import java.util.Objects;
+
+/**
+ * Handles the internal action for deleting multiple inference endpoints. This should not be used by external REST APIs.
+ * This implementation differs from {@link TransportDeleteInferenceEndpointAction} in that this one can handle deleting multiple endpoints
+ * at a time, but it does not perform the safeguard checks. This implementation will not check to see if the default endpoint is
+ * referenced by pipelines or indices.
+ */
+public class TransportInternalDeleteEndpointsAction extends TransportMasterNodeAction<
+    InternalDeleteInferenceEndpointsAction.Request,
+    AcknowledgedResponse> {
+
+    private final ModelRegistry modelRegistry;
+
+    @Inject
+    public TransportInternalDeleteEndpointsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        ModelRegistry modelRegistry
+    ) {
+        super(
+            InternalDeleteInferenceEndpointsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            InternalDeleteInferenceEndpointsAction.Request::new,
+            AcknowledgedResponse::readFrom,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        this.modelRegistry = Objects.requireNonNull(modelRegistry);
+    }
+
+    @Override
+    protected void masterOperation(
+        Task task,
+        InternalDeleteInferenceEndpointsAction.Request request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> masterListener
+    ) {
+        modelRegistry.deleteModels(
+            request.getInferenceEntityIds(),
+            masterListener.delegateFailureAndWrap((l, r) -> l.onResponse(AcknowledgedResponse.TRUE))
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(InternalDeleteInferenceEndpointsAction.Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPoller.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPoller.java
@@ -308,7 +308,8 @@ public class AuthorizationPoller extends AllocatedPersistentTask {
             listener.onResponse(SkipAndLogAction.REGISTRY_NOT_READY_ACTION);
             return;
         }
-        if (inferenceFeatureService.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD) == false) {
+        if (inferenceFeatureService.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD) == false
+            || inferenceFeatureService.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION) == false) {
             listener.onResponse(SkipAndLogAction.MISSING_REQUIRED_FEATURES);
             return;
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPoller.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPoller.java
@@ -26,6 +26,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
 import org.elasticsearch.xpack.inference.InferenceFeatures;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
@@ -350,10 +351,15 @@ public class AuthorizationPoller extends AllocatedPersistentTask {
         }
 
         logger.info("Deleting removed EIS inference endpoints: {}", toDelete);
-        modelRegistry.deleteModels(toDelete, ActionListener.wrap(success -> listener.onResponse(authModel), e -> {
-            logger.atWarn().withThrowable(e).log("Failed to delete removed EIS inference endpoints: {}", toDelete);
-            listener.onResponse(authModel);
-        }));
+        var deleteRequest = new InternalDeleteInferenceEndpointsAction.Request(toDelete, TimeValue.THIRTY_SECONDS);
+        client.execute(
+            InternalDeleteInferenceEndpointsAction.INSTANCE,
+            deleteRequest,
+            ActionListener.wrap(response -> listener.onResponse(authModel), e -> {
+                logger.atWarn().withThrowable(e).log("Failed to delete removed EIS inference endpoints: {}", toDelete);
+                listener.onResponse(authModel);
+            })
+        );
     }
 
     private List<Model> selectEndpointsToPersist(ElasticInferenceServiceAuthorizationModel authModel) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportInternalDeleteEndpointsActionTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Set;
+
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TransportInternalDeleteEndpointsActionTests extends ESTestCase {
+
+    private TransportInternalDeleteEndpointsAction action;
+    private ThreadPool threadPool;
+    private ModelRegistry mockModelRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = createThreadPool(inferenceUtilityExecutors());
+        mockModelRegistry = mock(ModelRegistry.class);
+        action = new TransportInternalDeleteEndpointsAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            threadPool,
+            mock(ActionFilters.class),
+            mockModelRegistry
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(threadPool);
+    }
+
+    public void testMasterOperation_DelegatesDeleteToModelRegistry() {
+        var ids = Set.of("id-1", "id-2");
+        doAnswer(invocation -> {
+            invocation.<org.elasticsearch.action.ActionListener<Boolean>>getArgument(1).onResponse(true);
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModels(eq(ids), any());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        action.masterOperation(
+            mock(Task.class),
+            new InternalDeleteInferenceEndpointsAction.Request(ids, TimeValue.THIRTY_SECONDS),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+        assertTrue(response.isAcknowledged());
+        verify(mockModelRegistry).deleteModels(eq(ids), any());
+    }
+
+    public void testMasterOperation_AcknowledgedTrue_Even_WhenRegistryReturnsFalse() {
+        var ids = Set.of("id-1");
+        doAnswer(invocation -> {
+            invocation.<org.elasticsearch.action.ActionListener<Boolean>>getArgument(1).onResponse(false);
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModels(eq(ids), any());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        action.masterOperation(
+            mock(Task.class),
+            new InternalDeleteInferenceEndpointsAction.Request(ids, TimeValue.THIRTY_SECONDS),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+        assertTrue(response.isAcknowledged());
+    }
+
+    public void testMasterOperation_PropagatesFailure() {
+        var ids = Set.of("id-1");
+        doAnswer(invocation -> {
+            invocation.<ActionListener<Boolean>>getArgument(1).onFailure(new RuntimeException("delete failed"));
+            return Void.TYPE;
+        }).when(mockModelRegistry).deleteModels(eq(ids), any());
+
+        var future = new TestPlainActionFuture<AcknowledgedResponse>();
+        action.masterOperation(
+            mock(Task.class),
+            new InternalDeleteInferenceEndpointsAction.Request(ids, TimeValue.THIRTY_SECONDS),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+
+        var exception = expectThrows(RuntimeException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.getMessage(), is("delete failed"));
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPollerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPollerTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.inference.services.elastic.authorization;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.Nullable;
@@ -21,6 +22,7 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.inference.action.InternalDeleteInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.action.StoreInferenceEndpointsAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.InferenceFeatures;
@@ -501,11 +503,15 @@ public class AuthorizationPollerTests extends ESTestCase {
         ccmService = createMockCCMService(true);
 
         givenAuthHandlerRespondsForUrl(randomAlphaOfLength(10), List.of(), endpointsToDelete);
+        givenDeleteActionRespondsWith(AcknowledgedResponse.TRUE);
 
         var poller = createPoller();
         poller.sendAuthorizationRequest();
 
-        verify(mockRegistry).deleteModels(eq(endpointsToDelete), any());
+        var requestArgCaptor = ArgumentCaptor.forClass(InternalDeleteInferenceEndpointsAction.Request.class);
+        verify(mockClient).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), requestArgCaptor.capture(), any());
+        assertThat(requestArgCaptor.getValue().getInferenceEntityIds(), is(endpointsToDelete));
+        verify(mockRegistry, never()).deleteModel(any(), any());
     }
 
     public void testSendsAuthorizationRequest_ShouldIgnoreRemovedEndpointsNotInRegistry() {
@@ -517,11 +523,15 @@ public class AuthorizationPollerTests extends ESTestCase {
         ccmService = createMockCCMService(true);
 
         givenAuthHandlerRespondsForUrl(randomAlphaOfLength(10), List.of(), Set.of("id-1", "id-2", "id-3", "id-4"));
+        givenDeleteActionRespondsWith(AcknowledgedResponse.TRUE);
 
         var poller = createPoller();
         poller.sendAuthorizationRequest();
 
-        verify(mockRegistry).deleteModels(eq(endpointsToDelete), any());
+        var requestArgCaptor = ArgumentCaptor.forClass(InternalDeleteInferenceEndpointsAction.Request.class);
+        verify(mockClient).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), requestArgCaptor.capture(), any());
+        assertThat(requestArgCaptor.getValue().getInferenceEntityIds(), is(endpointsToDelete));
+        verify(mockRegistry, never()).deleteModel(any(), any());
     }
 
     public void testSendsAuthorizationRequest_ShouldNotDeleteAnyWhenNoRemovedEndpointIsPresentInRegistry() {
@@ -535,7 +545,7 @@ public class AuthorizationPollerTests extends ESTestCase {
         var poller = createPoller();
         poller.sendAuthorizationRequest();
 
-        verify(mockRegistry, never()).deleteModels(any(), any());
+        verify(mockClient, never()).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), any(), any());
     }
 
     private AuthorizationPoller createPoller() {
@@ -580,6 +590,14 @@ public class AuthorizationPollerTests extends ESTestCase {
         // Throwing an exception should cause the poller to shutdown and mark itself as completed
         eisSettings = mock(ElasticInferenceServiceSettings.class);
         when(eisSettings.isPeriodicAuthorizationEnabled()).thenThrow(exception);
+    }
+
+    private void givenDeleteActionRespondsWith(AcknowledgedResponse response) {
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(2);
+            listener.onResponse(response);
+            return null;
+        }).when(mockClient).execute(eq(InternalDeleteInferenceEndpointsAction.INSTANCE), any(), any());
     }
 
     private void sendAuthRequestAndVerifyStoreActionCalledForSparseEndpoints(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPollerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationPollerTests.java
@@ -91,6 +91,7 @@ public class AuthorizationPollerTests extends ESTestCase {
         taskQueue = new DeterministicTaskQueue();
         inferenceFeatureServiceMock = mock(InferenceFeatureService.class);
         when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD)).thenReturn(true);
+        when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION)).thenReturn(true);
         mockRegistry = mock(ModelRegistry.class);
         mockAuthHandler = mock(ElasticInferenceServiceAuthorizationRequestHandler.class);
         mockClient = mock(Client.class);
@@ -146,6 +147,32 @@ public class AuthorizationPollerTests extends ESTestCase {
         ccmFeature = createMockCCMFeature(true);
         ccmService = createMockCCMService(true);
         when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD)).thenReturn(false);
+        var poller = createPoller();
+
+        var persistentTaskId = "id";
+        var allocationId = 0L;
+
+        var mockPersistentTasksService = mock(PersistentTasksService.class);
+        poller.init(mockPersistentTasksService, mock(TaskManager.class), persistentTaskId, allocationId);
+
+        poller.sendAuthorizationRequest();
+
+        verify(mockAuthHandler, never()).getAuthorization(any(), any());
+        verify(mockPersistentTasksService, never()).sendCompletionRequest(
+            eq(persistentTaskId),
+            eq(allocationId),
+            isNull(),
+            isNull(),
+            any(),
+            any()
+        );
+    }
+
+    public void testDoesNotSendAuthorizationRequest_WhenClusterMissingInternalDeleteEndpointsFeature() {
+        when(mockRegistry.isReady()).thenReturn(true);
+        ccmFeature = createMockCCMFeature(true);
+        ccmService = createMockCCMService(true);
+        when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION)).thenReturn(false);
         var poller = createPoller();
 
         var persistentTaskId = "id";

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -333,6 +333,7 @@ public class Constants {
         "cluster:internal/xpack/inference/clear_inference_ccm_cache",
         "cluster:internal/xpack/inference/clear_inference_endpoint_cache",
         "cluster:internal/xpack/inference/create_endpoints",
+        "cluster:internal/xpack/inference/delete_endpoints",
         "cluster:internal/xpack/inference/embedding",
         "cluster:internal/xpack/inference/rerankwindowsize/get",
         "cluster:internal/xpack/inference/unified",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Inference API] Delete default endpoints using master node action only (#154735)](https://github.com/elastic/elasticsearch/pull/154735)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)