### PR TITLE
[Inference API] Skip Authorization request until upgrade completes to avoid sending unknown action

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -82,6 +82,9 @@ public class InferenceFeatures implements FeatureSpecification {
 
     public static final NodeFeature EMBEDDING_TASK_TYPE = new NodeFeature("inference.embedding_task_type");
     public static final NodeFeature ENDPOINT_METADATA_FIELD = new NodeFeature("inference.metadata_field");
+    public static final NodeFeature INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION = new NodeFeature(
+        "inference.internal_delete_endpoints_action"
+    );
     public static final NodeFeature INFERENCE_ELASTIC_REASONING_TASK_SETTINGS = new NodeFeature(
         "inference.elastic.reasoning_task_settings"
     );
@@ -99,6 +102,7 @@ public class InferenceFeatures implements FeatureSpecification {
             INFERENCE_CCM_ENABLEMENT_SERVICE,
             EMBEDDING_TASK_TYPE,
             ENDPOINT_METADATA_FIELD,
+            INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION,
             INFERENCE_ELASTIC_REASONING_TASK_SETTINGS,
             INFERENCE_INFERENCE_INDEX_DOC_TYPE,
             INFERENCE_CLEAR_PREFERENCES_CACHE

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsAction.java
@@ -90,7 +90,8 @@ public class TransportRefreshAuthorizedEndpointsAction extends HandledTransportA
             return;
         }
 
-        if (inferenceFeatureService.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD) == false) {
+        if (inferenceFeatureService.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD) == false
+            || inferenceFeatureService.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION) == false) {
             logger.info("Skipping sending authorization request, because the cluster is currently upgrading and missing required features");
             listener.onResponse(ActionResponse.Empty.INSTANCE);
             return;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportRefreshAuthorizedEndpointsActionTests.java
@@ -81,6 +81,7 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
     public void init() throws Exception {
         inferenceFeatureServiceMock = mock(InferenceFeatureService.class);
         when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD)).thenReturn(true);
+        when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION)).thenReturn(true);
         mockRegistry = mock(ModelRegistry.class);
         mockAuthHandler = mock(ElasticInferenceServiceAuthorizationRequestHandler.class);
         mockClient = mock(Client.class);
@@ -103,6 +104,18 @@ public class TransportRefreshAuthorizedEndpointsActionTests extends ESTestCase {
     public void testDoesNotSendAuthorizationRequest_WhenClusterDoesNotIncludeMetadata_MappingUpdate() {
         when(mockRegistry.isReady()).thenReturn(true);
         when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.ENDPOINT_METADATA_FIELD)).thenReturn(false);
+        var action = createAction();
+
+        var future = new TestPlainActionFuture<ActionResponse.Empty>();
+        action.doExecute(null, new RefreshAuthorizedEndpointsAction.Request(), future);
+
+        assertThat(future.actionGet(), is(ActionResponse.Empty.INSTANCE));
+        verify(mockAuthHandler, never()).getAuthorization(any(), any());
+    }
+
+    public void testDoesNotSendAuthorizationRequest_WhenClusterMissingInternalDeleteEndpointsFeature() {
+        when(mockRegistry.isReady()).thenReturn(true);
+        when(inferenceFeatureServiceMock.hasFeature(InferenceFeatures.INTERNAL_DELETE_INFERENCE_ENDPOINTS_ACTION)).thenReturn(false);
         var action = createAction();
 
         var future = new TestPlainActionFuture<ActionResponse.Empty>();


### PR DESCRIPTION
This PR is a follow on for https://github.com/elastic/elasticsearch/pull/154735

It fixes an issue to prevent sending the new master node action until the cluster has upgraded. Otherwise there's a chance the authorization task could be running on an upgraded node when the master node isn't upgraded yet and it'll cause a warning log about the action not being recognized.