### PR TITLE
Wait for secrets index after restart in testRestart

### DIFF
--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -35,6 +35,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.xpack.inference.InferenceIndex;
+import org.elasticsearch.xpack.inference.InferenceSecretsIndex;
 import org.elasticsearch.xpack.inference.LocalStateInferencePlugin;
 import org.elasticsearch.xpack.inference.mock.TestDenseInferenceServiceExtension;
 import org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension;
@@ -223,7 +224,7 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
         storeModel(modelRegistry, model2);
 
         internalCluster().fullRestart(new InternalTestCluster.RestartCallback());
-        ensureGreen(InferenceIndex.INDEX_NAME, "index_restart");
+        ensureGreen(InferenceIndex.INDEX_NAME, "index_restart", InferenceSecretsIndex.INDEX_NAME);
 
         assertRandomBulkOperations("index_restart", isIndexRequest -> {
             Map<String, Object> map = new HashMap<>();
@@ -233,7 +234,7 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
         });
 
         internalCluster().fullRestart(new InternalTestCluster.RestartCallback());
-        ensureGreen(InferenceIndex.INDEX_NAME, "index_restart");
+        ensureGreen(InferenceIndex.INDEX_NAME, "index_restart", InferenceSecretsIndex.INDEX_NAME);
 
         assertRandomBulkOperations("index_restart", isIndexRequest -> {
             Map<String, Object> map = new HashMap<>();


### PR DESCRIPTION
Ensuring that .secrets-inference index is available after full restart.


Backports #145317

closes #154867