### PR TITLE
[8.19] [Transform] Retry transient failures during restarts (#153298)

### DIFF
--- a/docs/changelog/153298.yaml
+++ b/docs/changelog/153298.yaml
@@ -1,0 +1,5 @@
+area: Transform
+issues: []
+pr: 153298
+summary: Retry transient failures during restarts
+type: bug

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.AuthorizationState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformEffectiveSettings;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
@@ -64,11 +65,15 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.common.notifications.Level.ERROR;
 import static org.elasticsearch.xpack.core.common.notifications.Level.INFO;
+import static org.elasticsearch.xpack.core.common.notifications.Level.WARNING;
 import static org.elasticsearch.xpack.core.transform.TransformField.AWAITING_UPGRADE;
 import static org.elasticsearch.xpack.core.transform.TransformField.RESET_IN_PROGRESS;
 import static org.elasticsearch.xpack.transform.transforms.TransformNodes.nodeCanRunThisTransform;
@@ -79,6 +84,19 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
 
     // The amount of time we wait for the cluster state to respond when being marked as failed
     private static final int MARK_AS_FAILED_TIMEOUT_SEC = 90;
+
+    /**
+     * {@code isTransient} for the checkpoint loads in {@link #nodeOperation}: treat every failure as retryable. Unlike the
+     * stored-doc load -- which excludes {@link ResourceNotFoundException} because a missing doc is the "new transform" signal,
+     * not a failure -- a checkpoint load has no such not-a-failure case. We deliberately do NOT try to fail fast on a
+     * "permanent-looking" exception at this reassignment-time site: the transient errors this retry exists to absorb (a
+     * {@code .transform-internal} shard still recovering onto another node) can surface with the same status codes
+     * (e.g. 404/503) that {@code ExceptionRootCauseFinder#isExceptionIrrecoverable} would treat as permanent, so classifying
+     * here would risk failing the transform on exactly the transient condition we are trying to survive. Attended transforms
+     * are still bounded -- they fail once their {@code num_failure_retries} budget is exhausted; unattended transforms retry
+     * indefinitely by contract, now observably (see {@link #auditReassignmentLoadRetry}).
+     */
+    private static final Predicate<Exception> RETRY_ANY_CHECKPOINT_LOAD_FAILURE = e -> true;
     private final Client client;
     private final TransformServices transformServices;
     private final ThreadPool threadPool;
@@ -223,6 +241,11 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
             .setTransformServices(transformServices);
 
         final SetOnce<TransformState> stateHolder = new SetOnce<>();
+        // Set once the config has loaded (step <4> below); read by the checkpoint/state-load listeners further down so they can
+        // retry transient failures up to this transform's configured limit instead of failing outright (-1 == unattended,
+        // retry indefinitely). Unknowable any earlier in this pipeline (e.g. for the internal-index-creation step <1>), same
+        // constraint documented on getTransformConfig's retry, below.
+        final SetOnce<Integer> numFailureRetriesHolder = new SetOnce<>();
 
         // <8> log the start result
         ActionListener<StartTransformAction.Response> startTaskListener = ActionListener.wrap(
@@ -273,8 +296,14 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
 
             indexerBuilder.setLastCheckpoint(lastCheckpoint);
             logger.trace("[{}] Loaded last checkpoint [{}], looking for next checkpoint", transformId, lastCheckpoint.getCheckpoint());
-            transformServices.configManager()
-                .getTransformCheckpoint(transformId, lastCheckpoint.getCheckpoint() + 1, getTransformNextCheckpointListener);
+            retryTransientLoad(
+                buildTask,
+                params,
+                numFailureRetriesHolder.get(),
+                RETRY_ANY_CHECKPOINT_LOAD_FAILURE,
+                al -> transformServices.configManager().getTransformCheckpoint(transformId, lastCheckpoint.getCheckpoint() + 1, al),
+                getTransformNextCheckpointListener
+            );
         }, error -> {
             String msg = TransformMessages.getMessage(TransformMessages.FAILED_TO_LOAD_TRANSFORM_CHECKPOINT, transformId);
             logger.error(msg, error);
@@ -311,12 +340,24 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
 
                 if (lastCheckpoint == 0) {
                     logger.trace("[{}] No last checkpoint found, looking for next checkpoint", transformId);
-                    transformServices.configManager()
-                        .getTransformCheckpoint(transformId, lastCheckpoint + 1, getTransformNextCheckpointListener);
+                    retryTransientLoad(
+                        buildTask,
+                        params,
+                        numFailureRetriesHolder.get(),
+                        RETRY_ANY_CHECKPOINT_LOAD_FAILURE,
+                        al -> transformServices.configManager().getTransformCheckpoint(transformId, lastCheckpoint + 1, al),
+                        getTransformNextCheckpointListener
+                    );
                 } else {
                     logger.trace("[{}] Restore last checkpoint: [{}]", transformId, lastCheckpoint);
-                    transformServices.configManager()
-                        .getTransformCheckpoint(transformId, lastCheckpoint, getTransformLastCheckpointListener);
+                    retryTransientLoad(
+                        buildTask,
+                        params,
+                        numFailureRetriesHolder.get(),
+                        RETRY_ANY_CHECKPOINT_LOAD_FAILURE,
+                        al -> transformServices.configManager().getTransformCheckpoint(transformId, lastCheckpoint, al),
+                        getTransformLastCheckpointListener
+                    );
                 }
             },
             error -> {
@@ -351,7 +392,17 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
             ValidationException validationException = config.validate(null);
             if (validationException == null) {
                 indexerBuilder.setTransformConfig(config);
-                transformServices.configManager().getTransformStoredDoc(transformId, false, l);
+                numFailureRetriesHolder.set(TransformEffectiveSettings.getNumFailureRetries(config.getSettings(), numFailureRetries));
+                // ResourceNotFoundException means no stored doc exists yet (new transform) and must not be retried: `l`'s
+                // failure handler special-cases it to start the transform fresh, below.
+                retryTransientLoad(
+                    buildTask,
+                    params,
+                    numFailureRetriesHolder.get(),
+                    e -> (e instanceof ResourceNotFoundException) == false,
+                    al -> transformServices.configManager().getTransformStoredDoc(transformId, false, al),
+                    l
+                );
             } else {
                 auditor.error(transformId, validationException.getMessage());
                 markAsFailed(
@@ -423,6 +474,104 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         } catch (InterruptedException e) {
             logger.error("Timeout waiting for task [" + task.getTransformId() + "] to be marked as failed in cluster state", e);
         }
+    }
+
+    /**
+     * Retries a transient reassignment-time load — the transform's stored state/stats or a checkpoint doc — instead of letting
+     * a transient failure (e.g. a `.transform-internal` shard still recovering right after the node previously hosting this
+     * task left the cluster) reach {@code markAsFailed} on the first attempt. An unattended transform (
+     * {@code numFailureRetries == -1}) retries indefinitely, mirroring the unattended-never-fails contract
+     * {@link TransformFailureHandler} already enforces for indexer run-time failures. An attended transform retries up to its
+     * configured {@code settings.num_failure_retries} limit (see {@link TransformEffectiveSettings#getNumFailureRetries}, which
+     * already folds unattended into {@code -1}), then fails permanently — mirroring {@link TransformFailureHandler#retry}'s
+     * "tolerate N, fail on N+1" behavior for the indexer run-time path, applied here to the startup/reassignment pipeline.
+     * <p>
+     * Mirrors {@link #loadCloudCredentialWithRetry}'s shape on purpose: try {@code action} directly first, and only hand off
+     * to the transform scheduler on failure. This call runs nested inside another listener's own scheduler-triggered
+     * callback (config load, and possibly a caller of this method too) — registering with the scheduler unconditionally
+     * (i.e. even for the very first attempt, before knowing whether it's needed) would nest a second
+     * {@code TransformScheduler#registerTransform} call inside the first's still-active {@code processScheduledTasksInternal},
+     * which the scheduler's reentrancy guard silently no-ops; the newly-added task then only becomes eligible one full
+     * {@code frequency} interval later instead of immediately. Trying directly first avoids the scheduler entirely for the
+     * (common) case where the load just succeeds.
+     *
+     * @param numFailureRetries the transform's effective retry limit; {@code -1} means unattended/infinite (should always be
+     *                          resolved by the time this is called, see {@code numFailureRetriesHolder} in {@link #nodeOperation})
+     * @param isTransient tested against a failure to decide whether it's transient at all (retryable in principle) or should
+     *                    still reach {@code listener.onFailure} unmodified without consuming any retry budget — e.g.
+     *                    {@code ResourceNotFoundException} for a stored doc that genuinely doesn't exist yet, which is not a
+     *                    failure but the "new transform" signal
+     */
+    private <Response> void retryTransientLoad(
+        TransformTask task,
+        TransformTaskParams params,
+        int numFailureRetries,
+        Predicate<Exception> isTransient,
+        Consumer<ActionListener<Response>> action,
+        ActionListener<Response> listener
+    ) {
+        var transformId = params.getId();
+        var attempts = new AtomicInteger();
+        // Stateful by necessity: TransformRetryableStartUpListener bounds retries only via this predicate's return value, so
+        // the attempt count and audit have to live here. The same predicate instance is shared by the direct first attempt
+        // below and the scheduler-registered listener, so the retry budget is continuous across both.
+        Predicate<Exception> shouldRetry = e -> {
+            if (isTransient.test(e) == false) {
+                return false;
+            }
+            int count = attempts.incrementAndGet();
+            if (numFailureRetries == -1) {
+                // Unattended transforms retry indefinitely (they must never fail; mirrors TransformFailureHandler). We still
+                // surface the retry periodically -- throttled, because this path re-fires every scheduler frequency -- so a
+                // transform wedged on a persistently-failing load stays observable instead of looping silently forever.
+                if (count == 1 || count % TransformFailureHandler.LOG_FAILURE_EVERY == 0) {
+                    auditReassignmentLoadRetry(transformId, e, count, numFailureRetries);
+                }
+                return true;
+            }
+            boolean retry = count <= numFailureRetries;
+            if (retry) {
+                auditReassignmentLoadRetry(transformId, e, count, numFailureRetries);
+            }
+            return retry;
+        };
+        action.accept(listener.delegateResponse((l, e) -> {
+            if (shouldRetry.test(e) == false) {
+                l.onFailure(e);
+                return;
+            }
+            var scheduler = transformServices.scheduler();
+            scheduler.registerTransform(
+                params,
+                new TransformRetryableStartUpListener<>(
+                    transformId,
+                    action,
+                    ActionListener.runBefore(l, () -> scheduler.deregisterTransform(transformId)),
+                    retryListener(task),
+                    shouldRetry,
+                    task.getContext()
+                )
+            );
+        }));
+    }
+
+    /**
+     * Audits and logs a reassignment-load retry, mirroring {@code TransformFailureHandler.logRetry}'s convention and message
+     * shape for the indexer run-time retry path: WARNING for attended transforms (once per tolerated attempt), INFO for
+     * unattended transforms. Unattended transforms retry indefinitely, so {@link #retryTransientLoad} throttles how often it
+     * calls this. The {@code [count/limit]} suffix shows {@code -1} as the limit for unattended, exactly as
+     * {@code TransformFailureHandler.logRetry} does.
+     */
+    private void auditReassignmentLoadRetry(String transformId, Exception e, int count, int numFailureRetries) {
+        boolean unattended = numFailureRetries == -1;
+        String message = Strings.format(
+            "Transform encountered an exception while reloading state after reassignment: [%s]; Will automatically retry [%d/%d]",
+            e.getMessage(),
+            count,
+            numFailureRetries
+        );
+        logger.atLevel(unattended ? Level.INFO : Level.WARN).withThrowable(e).log("[{}] {}", transformId, message);
+        auditor.audit(unattended ? INFO : WARNING, transformId, message);
     }
 
     private ActionListener<Void> getTransformConfig(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -551,6 +551,15 @@ public class TransformTask extends AllocatedPersistentTask
                 listener.onResponse(null);
                 return;
             }
+            // If we are aborting, this means a cancellation request (e.g. the node the task is on is going away) is already
+            // tearing the indexer down towards a clean completion. A failure racing that teardown (e.g. an in-flight search
+            // failing because of the same disconnect that triggered the cancellation) must not override it with FAILED,
+            // since FAILED is sticky and blocks the reassigned task from auto-starting on the new node.
+            if (getIndexer() != null && getIndexer().getState() == IndexerState.ABORTING) {
+                logger.info("[{}] encountered a failure but indexer is ABORTING; reason [{}].", getTransformId(), reason);
+                listener.onResponse(null);
+                return;
+            }
 
             // We should not keep retrying. Either the task will be stopped, or started
             // If it is started again, it is registered again.

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
@@ -40,9 +41,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
 import org.elasticsearch.xpack.core.transform.transforms.AuthorizationState;
+import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
+import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
@@ -54,6 +57,7 @@ import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.InMemoryTransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformInternalIndexTests;
 import org.elasticsearch.xpack.transform.transforms.scheduling.TransformScheduler;
@@ -69,7 +73,10 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.xpack.core.common.notifications.Level.INFO;
+import static org.elasticsearch.xpack.core.common.notifications.Level.WARNING;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -407,6 +414,282 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             return true;
         }), any());
         verify(task).start(isNull(), any());
+    }
+
+    public void testNodeOperationStartupRetryWithStartFailure() throws Exception {
+        var failFirstCall = new AtomicBoolean(true);
+        var transformsConfigManager = new InMemoryTransformConfigManager();
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var transformServices = transformServices(transformsConfigManager, transformScheduler);
+        var taskExecutor = buildTaskExecutor(transformServices);
+
+        var transformId = "testNodeOperationStartupRetryWithStartFailure";
+        var params = taskParams(transformId);
+        putTransformConfiguration(transformsConfigManager, transformId);
+
+        var task = mockTransformTask();
+        // NotMasterException is a transient cluster-state/master failure -- the kind the startup retry loop is meant to
+        // recover from. See testNodeOperationDoesNotRetryPermanentStartFailure for the permanent-failure counterpart.
+        doAnswer(ans -> {
+            ActionListener<StartTransformAction.Response> listener = ans.getArgument(1);
+            if (failFirstCall.compareAndSet(true, false)) {
+                listener.onFailure(new NotMasterException("not master"));
+            } else {
+                listener.onResponse(new StartTransformAction.Response(true));
+            }
+            return Void.TYPE;
+        }).when(task).start(any(), any());
+        taskExecutor.nodeOperation(task, params, mock());
+
+        // skip waiting for the scheduler to run the task a second time and just rerun it now
+        transformScheduler.scheduleNow(transformId);
+
+        verify(task, times(2)).start(isNull(), any());
+        assertThat(transformScheduler.getStats().peekTransformName(), equalTo(transformId));
+        verify(transformServices.auditor()).warning(
+            eq(transformId),
+            assertArg(message -> assertThat(message, startsWith("Failed while starting Transform. Automatically retrying")))
+        );
+    }
+
+    /**
+     * Regression test for the transform startup retry loop bug: a permanent start failure (the
+     * task's own state, e.g. {@link CannotStartFailedTransformException}) must not be retried --
+     * previously every startup failure was retried forever regardless of type, so a transform that
+     * failed permanently (e.g. from memory pressure) would spam
+     * "Failed while starting Transform. Automatically retrying..." until force-stopped.
+     */
+    public void testNodeOperationDoesNotRetryPermanentStartFailure() throws Exception {
+        var transformsConfigManager = new InMemoryTransformConfigManager();
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var transformServices = transformServices(transformsConfigManager, transformScheduler);
+        var taskExecutor = buildTaskExecutor(transformServices);
+
+        var transformId = "testNodeOperationDoesNotRetryPermanentStartFailure";
+        var params = taskParams(transformId);
+        putTransformConfiguration(transformsConfigManager, transformId);
+
+        var task = mockTransformTask();
+        doAnswer(ans -> {
+            ActionListener<StartTransformAction.Response> listener = ans.getArgument(1);
+            listener.onFailure(new CannotStartFailedTransformException("failed state"));
+            return Void.TYPE;
+        }).when(task).start(any(), any());
+        taskExecutor.nodeOperation(task, params, mock());
+
+        // there is nothing to "skip waiting" for: no retry should have been scheduled at all
+        verify(task, times(1)).start(isNull(), any());
+        assertNull(transformScheduler.getStats().peekTransformName());
+        // the permanent failure still logs once via the pre-existing "please stop and attempt to start again" path...
+        verify(transformServices.auditor(), times(1)).audit(any(), eq(transformId), any());
+        // ...but the "Automatically retrying" loop-warning must never fire, since no retry is scheduled
+        verify(transformServices.auditor(), never()).warning(any(), any());
+    }
+
+    /**
+     * Regression test for https://github.com/elastic/ml-team/issues/1623: after a node hosting the transform's task leaves
+     * the cluster, the task is reassigned and {@code nodeOperation} reloads the transform's stored state from
+     * {@code .transform-internal-*}. If that read transiently fails (e.g. the shard hasn't recovered onto another node
+     * yet), an <b>unattended</b> transform must retry the load indefinitely instead of failing -- unattended transforms
+     * are contractually never supposed to require manual intervention, but {@code TransformTask#fail} has no
+     * unattended check, so previously any caller that reached it (like this reassignment path) could fail one anyway.
+     */
+    public void testNodeOperationRetriesTransientStateLoadForUnattendedTransform() throws Exception {
+        var transformId = "testUnattendedStateLoadRetry";
+        var failFirstCall = new AtomicBoolean(true);
+        var transformsConfigManager = new InMemoryTransformConfigManager() {
+            @Override
+            public void getTransformStoredDoc(
+                String tid,
+                boolean allowNoMatch,
+                ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> listener
+            ) {
+                if (failFirstCall.compareAndSet(true, false)) {
+                    listener.onFailure(new IllegalStateException("shard temporarily unavailable"));
+                } else {
+                    super.getTransformStoredDoc(tid, allowNoMatch, listener);
+                }
+            }
+        };
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var transformServices = transformServices(transformsConfigManager, transformScheduler);
+        var taskExecutor = buildTaskExecutor(transformServices);
+
+        var params = taskParams(transformId);
+        putUnattendedTransformConfiguration(transformsConfigManager, transformId);
+
+        // mockTransformTask()'s default stub fails this test outright if task.fail(...) is ever invoked, so reaching the
+        // assertions below already proves the transient failure did not fail the task.
+        var task = mockTransformTask();
+        taskExecutor.nodeOperation(task, params, mock());
+
+        // skip waiting for the scheduler to run the retry and just rerun it now -- this time the load succeeds
+        transformScheduler.scheduleNow(transformId);
+
+        verify(task).start(isNull(), any());
+        // unattended retries are still observable: one INFO-level audit for the single tolerated attempt
+        verify(transformServices.auditor(), times(1)).audit(eq(INFO), eq(transformId), any());
+        verify(transformServices.auditor(), never()).audit(eq(WARNING), any(), any());
+    }
+
+    /**
+     * Unattended transforms retry a transient reassignment-load failure indefinitely (see
+     * {@link #testNodeOperationRetriesTransientStateLoadForUnattendedTransform}), but that must not mean the retries are
+     * silent: an unattended transform stuck retrying this load forever needs an audit trail an operator can find. It also
+     * must not spam the audit log once per {@code frequency} tick forever, so the audit is throttled the same way
+     * {@code TransformFailureHandler.logRetry} throttles repeated indexer run-time failures
+     * ({@code TransformFailureHandler.LOG_FAILURE_EVERY}).
+     */
+    public void testNodeOperationThrottlesAuditForRepeatedUnattendedStateLoadRetry() throws Exception {
+        var transformId = "testUnattendedStateLoadRetryThrottled";
+        // Fail the first 11 attempts (counts 1..11), then let the 12th succeed.
+        var failuresRemaining = new AtomicInteger(11);
+        var transformsConfigManager = new InMemoryTransformConfigManager() {
+            @Override
+            public void getTransformStoredDoc(
+                String tid,
+                boolean allowNoMatch,
+                ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> listener
+            ) {
+                if (failuresRemaining.getAndUpdate(n -> Math.max(0, n - 1)) > 0) {
+                    listener.onFailure(new IllegalStateException("shard temporarily unavailable"));
+                } else {
+                    super.getTransformStoredDoc(tid, allowNoMatch, listener);
+                }
+            }
+        };
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var transformServices = transformServices(transformsConfigManager, transformScheduler);
+        var taskExecutor = buildTaskExecutor(transformServices);
+
+        var params = taskParams(transformId);
+        putUnattendedTransformConfiguration(transformsConfigManager, transformId);
+
+        var task = mockTransformTask();
+        taskExecutor.nodeOperation(task, params, mock()); // attempt 1 -- fails, audited (first attempt)
+        for (int attempt = 2; attempt <= 11; attempt++) {
+            // attempts 2-9, 11 are throttled; attempt 10 is audited (LOG_FAILURE_EVERY)
+            transformScheduler.scheduleNow(transformId);
+        }
+        transformScheduler.scheduleNow(transformId); // attempt 12 -- succeeds
+
+        verify(task).start(isNull(), any());
+        // audited only for attempts 1 and 10 -- the other 9 tolerated failures were throttled
+        verify(transformServices.auditor(), times(2)).audit(eq(INFO), eq(transformId), any());
+        verify(transformServices.auditor(), never()).audit(eq(WARNING), any(), any());
+    }
+
+    /**
+     * Regression test for the follow-up to https://github.com/elastic/ml-team/issues/1623: an attended transform's
+     * stored-state load must retry a transient failure up to its configured {@code num_failure_retries} limit -- like the
+     * indexer run-time failure path (TransformFailureHandler) already does -- rather than failing on the very first
+     * transient error at this reassignment-time site.
+     */
+    public void testNodeOperationRetriesTransientStateLoadForAttendedTransformThenFailsAtLimit() throws Exception {
+        var transformId = "testAttendedStateLoadFailsAtLimit";
+        var transformsConfigManager = new InMemoryTransformConfigManager() {
+            @Override
+            public void getTransformStoredDoc(
+                String tid,
+                boolean allowNoMatch,
+                ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> listener
+            ) {
+                listener.onFailure(new IllegalStateException("shard temporarily unavailable"));
+            }
+        };
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var transformServices = transformServices(transformsConfigManager, transformScheduler);
+        var taskExecutor = buildTaskExecutor(transformServices);
+
+        var params = taskParams(transformId);
+        // Forced attended with a small explicit limit (not putTransformConfiguration's random settings): randomTransformConfig
+        // can randomize unattended to true or the retry limit to something other than 2, which would make this test flaky.
+        putAttendedTransformConfiguration(transformsConfigManager, transformId, 2);
+
+        var task = mockTransformTask();
+        var failCalled = new AtomicBoolean(false);
+        doAnswer(ans -> {
+            failCalled.set(true);
+            ActionListener<Void> listener = ans.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(task).fail(any(), any(), any());
+
+        taskExecutor.nodeOperation(task, params, mock()); // attempt 1 (count=1, within limit of 2) -- retries
+        assertFalse(failCalled.get());
+
+        transformScheduler.scheduleNow(transformId); // attempt 2 (count=2, within limit of 2) -- retries
+        assertFalse(failCalled.get());
+
+        transformScheduler.scheduleNow(transformId); // attempt 3 (count=3, exceeds limit of 2) -- gives up
+        assertTrue(failCalled.get());
+        verify(task, never()).start(any(), any());
+        // no further retry was scheduled -- the failure is now terminal
+        assertNull(transformScheduler.getStats().peekTransformName());
+        // one retry-warning audit per tolerated attempt (attempts 1 and 2), none for the terminal 3rd
+        verify(transformServices.auditor(), times(2)).audit(eq(WARNING), eq(transformId), any());
+    }
+
+    /**
+     * Companion to {@link #testNodeOperationRetriesTransientStateLoadForAttendedTransformThenFailsAtLimit}: an attended
+     * transform whose transient failure count stays under its configured limit eventually succeeds and starts normally,
+     * without ever reaching {@code task.fail(...)}.
+     */
+    public void testNodeOperationRetriesTransientStateLoadForAttendedTransformThenSucceeds() throws Exception {
+        var transformId = "testAttendedStateLoadRetrySucceeds";
+        var failFirstCall = new AtomicBoolean(true);
+        var transformsConfigManager = new InMemoryTransformConfigManager() {
+            @Override
+            public void getTransformStoredDoc(
+                String tid,
+                boolean allowNoMatch,
+                ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> listener
+            ) {
+                if (failFirstCall.compareAndSet(true, false)) {
+                    listener.onFailure(new IllegalStateException("shard temporarily unavailable"));
+                } else {
+                    super.getTransformStoredDoc(tid, allowNoMatch, listener);
+                }
+            }
+        };
+
+        var transformScheduler = new TransformScheduler(Clock.systemUTC(), threadPool, fastRetry(), TimeValue.ZERO);
+        var taskExecutor = buildTaskExecutor(transformServices(transformsConfigManager, transformScheduler));
+
+        var params = taskParams(transformId);
+        putAttendedTransformConfiguration(transformsConfigManager, transformId, 2);
+
+        // mockTransformTask()'s default stub fails this test outright if task.fail(...) is ever invoked, so reaching the
+        // assertion below already proves the single transient failure (well within the limit of 2) did not fail the task.
+        var task = mockTransformTask();
+        taskExecutor.nodeOperation(task, params, mock());
+
+        // skip waiting for the scheduler to run the retry and just rerun it now -- this time the load succeeds
+        transformScheduler.scheduleNow(transformId);
+
+        verify(task).start(isNull(), any());
+    }
+
+    private void putAttendedTransformConfiguration(TransformConfigManager configManager, String transformId, int numFailureRetries) {
+        var base = TransformConfigTests.randomTransformConfig(transformId, TimeValue.timeValueMillis(1), TransformConfigVersion.CURRENT);
+        var attendedConfig = new TransformConfig.Builder(base).setSettings(
+            new SettingsConfig.Builder().setUnattended(false).setNumFailureRetries(numFailureRetries).build()
+        ).build();
+        configManager.putTransformConfiguration(attendedConfig, ActionListener.<Boolean>noop().delegateResponse((l, e) -> fail(e)));
+    }
+
+    private void putUnattendedTransformConfiguration(TransformConfigManager configManager, String transformId) {
+        var base = TransformConfigTests.randomTransformConfig(transformId, TimeValue.timeValueMillis(1), TransformConfigVersion.CURRENT);
+        // A fresh SettingsConfig.Builder (rather than one copied from base.getSettings()) so num_failure_retries stays unset:
+        // unattended forbids setting it explicitly (validation error), and randomTransformConfig may have randomized it.
+        var unattendedConfig = new TransformConfig.Builder(base).setSettings(new SettingsConfig.Builder().setUnattended(true).build())
+            .build();
+        configManager.putTransformConfiguration(unattendedConfig, ActionListener.<Boolean>noop().delegateResponse((l, e) -> fail(e)));
     }
 
     private Settings fastRetry() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -363,6 +363,70 @@ public class TransformTaskTests extends ESTestCase {
         );
     }
 
+    // see https://github.com/elastic/ml-team/issues/1623: an in-flight failure racing a cancellation-triggered abort
+    // (e.g. the node departure that triggered the cancellation also breaking the in-flight search/bulk request) must not
+    // override the abort with FAILED, which is sticky and would otherwise block the reassigned task from auto-starting.
+    public void testFailWhileIndexerIsAborting() {
+        Clock clock = Clock.systemUTC();
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(threadPool.executor("generic")).thenReturn(mock(ExecutorService.class));
+
+        TransformConfig transformConfig = TransformConfigTests.randomTransformConfigWithoutHeaders();
+        TransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+
+        TransformState transformState = new TransformState(
+            TransformTaskState.STARTED,
+            IndexerState.INDEXING,
+            null,
+            0L,
+            null,
+            null,
+            null,
+            false,
+            null
+        );
+
+        TransformTask transformTask = new TransformTask(
+            42,
+            "some_type",
+            "some_action",
+            TaskId.EMPTY_TASK_ID,
+            createTransformTaskParams(transformConfig.getId()),
+            transformState,
+            new TransformScheduler(clock, threadPool, Settings.EMPTY, TimeValue.ZERO),
+            auditor,
+            threadPool,
+            Collections.emptyMap(),
+            mockTransformNode()
+        );
+
+        TaskManager taskManager = mock(TaskManager.class);
+        PersistentTasksService persistentTasksService = mock(PersistentTasksService.class);
+        transformTask.init(persistentTasksService, taskManager, "task-id", 42);
+
+        // Simulate onCancelled() having already flipped the indexer to ABORTING.
+        transformTask.initializeIndexer(
+            indexerBuilder(transformConfig, transformServices(clock, auditor, threadPool)).setIndexerState(IndexerState.ABORTING)
+        );
+
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        transformTask.fail(
+            new RuntimeException("racing failure"),
+            "because",
+            ActionTestUtils.assertNoFailureListener(r -> listenerCalled.compareAndSet(false, true))
+        );
+
+        TransformState state = transformTask.getState();
+        assertEquals(TransformTaskState.STARTED, state.getTaskState());
+        assertThat(state.getReason(), nullValue());
+        assertTrue(listenerCalled.get());
+
+        // fail() returned early: no task completion/unregister and no cluster-state update should have been attempted.
+        verifyNoInteractions(taskManager);
+        verifyNoInteractions(persistentTasksService);
+    }
+
     public void testGetTransformTask() {
         {
             ClusterState clusterState = ClusterState.EMPTY_STATE;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Transform] Retry transient failures during restarts (#153298)](https://github.com/elastic/elasticsearch/pull/153298)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)