### PR TITLE
Set bulk-timeout to 260s in serverless

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.AutoCreateAction;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.termvectors.EnsureDocsSearchableAction;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
@@ -731,6 +732,12 @@ public class StatelessPlugin extends Plugin
 
         // always override counting reads, stateless does not expose this number so the overhead for tracking it is wasted in any case
         settings.put(SharedBlobCacheService.SHARED_CACHE_COUNT_READS.getKey(), false);
+
+        // Should stay below any upstream HTTP timeout (proxy, load balancer) and the client-side request
+        // timeout — if either drops the connection first, cooperative cancellation has no effect. Cooperative:
+        // an in-flight shard write completes before the next chunk sees TaskCancelledException, so the value
+        // includes head start for that. Too high → connection cut externally; too low → healthy requests fail.
+        settings.put(IncrementalBulkService.REQUEST_TIMEOUT.getKey(), TimeValue.timeValueSeconds(260));
 
         String nodeMemoryAttrName = "node.attr." + MEMORY_NODE_ATTR;
         if (settings.get(nodeMemoryAttrName) == null) {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/StatelessPluginSettingsTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/StatelessPluginSettingsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.stateless;
 
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.allocation.IndexBalanceMetricsTaskExecutor;
@@ -84,5 +85,18 @@ public class StatelessPluginSettingsTests extends ESTestCase {
             statelessNode.additionalSettings().get(IndexBalanceMetricsTaskExecutor.INDEX_BALANCE_METRICS_ENABLED_SETTING.getKey()),
             equalTo("true")
         );
+    }
+
+    public void testIncrementalBulkRequestTimeoutDefaultForStateless() {
+        var statelessNode = new TestUtils.StatelessPluginWithTrialLicense(
+            Settings.builder()
+                .put(StatelessPlugin.STATELESS_ENABLED.getKey(), true)
+                .put(
+                    NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+                    randomFrom(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.INDEX_ROLE, DiscoveryNodeRole.SEARCH_ROLE).roleName()
+                )
+                .build()
+        );
+        assertThat(statelessNode.additionalSettings().get(IncrementalBulkService.REQUEST_TIMEOUT.getKey()), equalTo("260s"));
     }
 }


### PR DESCRIPTION
Enable bulk timeout in serverless with 260 seconds by default.