### PR TITLE
[9.4] Adding check against self referencing filters in MultiplexerTokenFilterFactory and ScriptedConditionTokenFilterFactory (#154793)

### DIFF
--- a/docs/changelog/154793.yaml
+++ b/docs/changelog/154793.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 154793
+summary: Adding check against self referencing filters
+type: bug

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
@@ -59,6 +59,9 @@ public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
         List<TokenFilterFactory> previousTokenFilters,
         Function<String, TokenFilterFactory> allFilters
     ) {
+        // Guard against a filter referring to itself (directly or via a cycle), which would otherwise
+        // recurse until the stack overflows and takes the node down.
+        allFilters = ReferringFilterResolver.enter(name(), allFilters);
         List<TokenFilterFactory> filters = new ArrayList<>();
         if (preserveOriginal) {
             filters.add(IDENTITY_FILTER);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ReferringFilterResolver.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ReferringFilterResolver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.analysis.common;
+
+import org.elasticsearch.index.analysis.TokenFilterFactory;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A wrapper around the {@code allFilters} lookup passed to
+ * {@link TokenFilterFactory#getChainAwareTokenFilterFactory} that detects reference cycles between
+ * token filters which recursively rewrite other filters they refer to by name (for example
+ * {@code multiplexer} and {@code condition}).
+ *
+ * <p>Such a filter resolves its referenced filters and calls
+ * {@link TokenFilterFactory#getChainAwareTokenFilterFactory} on each of them. If a filter refers to
+ * itself, directly or through a chain of other referring filters, this rewriting recurses forever
+ * and blows the stack.
+ */
+final class ReferringFilterResolver implements Function<String, TokenFilterFactory> {
+    private final Function<String, TokenFilterFactory> delegate;
+    private final Set<String> expansionPath;
+
+    private ReferringFilterResolver(Function<String, TokenFilterFactory> delegate, Set<String> expansionPath) {
+        this.delegate = delegate;
+        this.expansionPath = expansionPath;
+    }
+
+    @Override
+    public TokenFilterFactory apply(String name) {
+        return delegate.apply(name);
+    }
+
+    /**
+     * Records that the referring filter {@code filterName} is about to expand the filters it refers
+     * to, returning a resolver to use for that expansion. Throws {@link IllegalArgumentException} if
+     * {@code filterName} is already being expanded higher up the chain, which indicates a reference
+     * cycle.
+     *
+     * @param filterName the name of the referring token filter (e.g. a {@code multiplexer} or
+     *                   {@code condition} filter) that is about to rewrite its referenced filters
+     * @param allFilters the {@code allFilters} lookup received by the referring filter, which may
+     *                   itself be a {@link ReferringFilterResolver} created by an ancestor
+     */
+    static ReferringFilterResolver enter(String filterName, Function<String, TokenFilterFactory> allFilters) {
+        if (allFilters instanceof ReferringFilterResolver resolver) {
+            if (resolver.expansionPath.contains(filterName)) {
+                throw new IllegalArgumentException(
+                    "Token filter ["
+                        + filterName
+                        + "] refers to itself, either directly or via a cycle of filters "
+                        + resolver.expansionPath
+                );
+            }
+            Set<String> nextPath = new LinkedHashSet<>(resolver.expansionPath);
+            nextPath.add(filterName);
+            return new ReferringFilterResolver(resolver.delegate, nextPath);
+        }
+        Set<String> path = new LinkedHashSet<>();
+        path.add(filterName);
+        return new ReferringFilterResolver(allFilters, path);
+    }
+}

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterFactory.java
@@ -65,6 +65,9 @@ public class ScriptedConditionTokenFilterFactory extends AbstractTokenFilterFact
         List<TokenFilterFactory> previousTokenFilters,
         Function<String, TokenFilterFactory> allFilters
     ) {
+        // Guard against a filter referring to itself (directly or via a cycle), which would otherwise
+        // recurse until the stack overflows and takes the node down.
+        allFilters = ReferringFilterResolver.enter(name(), allFilters);
         List<TokenFilterFactory> filters = new ArrayList<>();
         List<TokenFilterFactory> existingChain = new ArrayList<>(previousTokenFilters);
         for (String filter : filterNames) {

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterTests.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 
 import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.assertAnalyzesTo;
+import static org.hamcrest.Matchers.containsString;
 
 public class MultiplexerTokenFilterTests extends ESTokenStreamTestCase {
 
@@ -89,7 +90,45 @@ public class MultiplexerTokenFilterTests extends ESTokenStreamTestCase {
             assertNotNull(analyzer);
             assertAnalyzesTo(analyzer, "ONe tHree", new String[] { "on", "ONE", "th", "THREE" }, new int[] { 1, 0, 1, 0, });
         }
-
     }
 
+    public void testSelfReferentialFilterIsRejected() {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+            .put("index.analysis.filter.mux.type", "multiplexer")
+            .putList("index.analysis.filter.mux.filters", "mux")
+            .put("index.analysis.analyzer.myAnalyzer.type", "custom")
+            .put("index.analysis.analyzer.myAnalyzer.tokenizer", "standard")
+            .putList("index.analysis.analyzer.myAnalyzer.filter", "mux")
+            .build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> buildAnalyzers(settings, idxSettings));
+        assertThat(e.getMessage(), containsString("Token filter [mux] refers to itself"));
+    }
+
+    public void testFilterReferenceCycleIsRejected() {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+            .put("index.analysis.filter.mux1.type", "multiplexer")
+            .putList("index.analysis.filter.mux1.filters", "mux2")
+            .put("index.analysis.filter.mux2.type", "multiplexer")
+            .putList("index.analysis.filter.mux2.filters", "mux1")
+            .put("index.analysis.analyzer.myAnalyzer.type", "custom")
+            .put("index.analysis.analyzer.myAnalyzer.tokenizer", "standard")
+            .putList("index.analysis.analyzer.myAnalyzer.filter", "mux1")
+            .build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> buildAnalyzers(settings, idxSettings));
+        assertThat(e.getMessage(), containsString("refers to itself, either directly or via a cycle of filters"));
+    }
+
+    private static IndexAnalyzers buildAnalyzers(Settings settings, IndexSettings idxSettings) throws IOException {
+        return new AnalysisModule(
+            TestEnvironment.newEnvironment(settings),
+            Collections.singletonList(new CommonAnalysisPlugin()),
+            new StablePluginsRegistry()
+        ).getAnalysisRegistry().build(IndexCreationContext.CREATE_INDEX, idxSettings);
+    }
 }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import java.util.Collections;
 
 import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.assertAnalyzesTo;
+import static org.hamcrest.Matchers.containsString;
 
 public class ScriptedConditionTokenFilterTests extends ESTokenStreamTestCase {
     private TestThreadPool threadPool;
@@ -96,5 +97,49 @@ public class ScriptedConditionTokenFilterTests extends ESTokenStreamTestCase {
             assertNotNull(analyzer);
             assertAnalyzesTo(analyzer, "Vorsprung Durch Technik", new String[] { "Vorsprung", "Durch", "TECHNIK" });
         }
+    }
+
+    public void testSelfReferentialConditionIsRejected() throws Exception {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+            .put("index.analysis.filter.cond.type", "condition")
+            .put("index.analysis.filter.cond.script.source", "token.getPosition() > 1")
+            .putList("index.analysis.filter.cond.filter", "cond")
+            .put("index.analysis.analyzer.myAnalyzer.type", "custom")
+            .put("index.analysis.analyzer.myAnalyzer.tokenizer", "standard")
+            .putList("index.analysis.analyzer.myAnalyzer.filter", "cond")
+            .build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+        AnalysisPredicateScript.Factory factory = () -> new AnalysisPredicateScript() {
+            @Override
+            public boolean execute(Token token) {
+                return token.getPosition() > 1;
+            }
+        };
+        @SuppressWarnings("unchecked")
+        ScriptService scriptService = new ScriptService(
+            indexSettings,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            () -> 1L,
+            TestProjectResolvers.singleProject(randomProjectIdOrDefault())
+        ) {
+            @Override
+            public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+                return (FactoryType) factory;
+            }
+        };
+        CommonAnalysisPlugin plugin = new TestCommonAnalysisPluginBuilder(threadPool).scriptService(scriptService).build();
+        AnalysisModule module = new AnalysisModule(
+            TestEnvironment.newEnvironment(settings),
+            Collections.singletonList(plugin),
+            new StablePluginsRegistry()
+        );
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> module.getAnalysisRegistry().build(IndexCreationContext.CREATE_INDEX, idxSettings)
+        );
+        assertThat(e.getMessage(), containsString("Token filter [cond] refers to itself"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Adding check against self referencing filters in MultiplexerTokenFilterFactory and ScriptedConditionTokenFilterFactory (#154793)