### PR TITLE
[9.5] Validate inference processor target_field at pipeline parse time (#154795)

### DIFF
--- a/docs/changelog/154795.yaml
+++ b/docs/changelog/154795.yaml
@@ -1,0 +1,6 @@
+pr: 154795
+summary: Validate the inference ingest processor `target_field`
+area: Machine Learning
+type: bug
+issues:
+ - 88059

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -498,6 +498,7 @@ public class InferenceProcessor extends AbstractProcessor {
                 // If multiple inference processors are in the same pipeline, it is wise to tag them
                 // The tag will keep default value entries from stepping on each other
                 String targetField = ConfigurationUtils.readStringProperty(TYPE, tag, config, TARGET_FIELD, defaultTargetField);
+                validateTargetField(tag, targetField);
                 Map<String, String> fieldMap = ConfigurationUtils.readOptionalMap(TYPE, tag, config, FIELD_MAP);
                 if (fieldMap == null) {
                     fieldMap = ConfigurationUtils.readOptionalMap(TYPE, tag, config, FIELD_MAPPINGS);
@@ -684,6 +685,30 @@ public class InferenceProcessor extends AbstractProcessor {
 
         private ElasticsearchException duplicatedFieldNameError(String property, String fieldName, String tag) {
             return newConfigurationException(TYPE, tag, property, "names must be unique but [" + fieldName + "] is repeated");
+        }
+
+        private static void validateTargetField(String tag, String targetField) {
+            if (targetField.isEmpty()) {
+                throw invalidTargetFieldException(tag);
+            }
+            for (String segment : targetField.split("\\.", -1)) {
+                if (segment.isEmpty()) {
+                    throw invalidTargetFieldException(tag);
+                }
+            }
+        }
+
+        private static ElasticsearchException invalidTargetFieldException(String tag) {
+            return newConfigurationException(
+                TYPE,
+                tag,
+                TARGET_FIELD,
+                "must be a non-empty, dot-delimited field path; to write results to the document root use the ["
+                    + INPUT_OUTPUT
+                    + "] configuration with an ["
+                    + OUTPUT_FIELD
+                    + "]"
+            );
         }
 
         /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -551,6 +551,66 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         );
     }
 
+    public void testCreateProcessorEmptyTargetFieldThrows() {
+        assertInvalidTargetFieldThrows("");
+    }
+
+    public void testCreateProcessorDotTargetFieldThrows() {
+        assertInvalidTargetFieldThrows(".");
+    }
+
+    public void testCreateProcessorMalformedTargetFieldThrows() {
+        assertInvalidTargetFieldThrows("a..b");
+    }
+
+    public void testCreateProcessorValidTargetFieldParses() {
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(
+            client,
+            clusterService,
+            Settings.EMPTY,
+            new SetOnce<>(mock(InferenceAuditor.class))
+        );
+
+        Map<String, Object> config = new HashMap<>() {
+            {
+                put(InferenceProcessor.MODEL_ID, "my_model");
+                put(InferenceProcessor.TARGET_FIELD, "result");
+            }
+        };
+
+        var processor = processorFactory.create(Collections.emptyMap(), "my_inference_processor", null, config, null);
+        assertFalse(processor.isConfiguredWithInputsFields());
+        assertEquals("result", processor.getTargetField());
+    }
+
+    private void assertInvalidTargetFieldThrows(String targetField) {
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(
+            client,
+            clusterService,
+            Settings.EMPTY,
+            new SetOnce<>(mock(InferenceAuditor.class))
+        );
+
+        Map<String, Object> config = new HashMap<>() {
+            {
+                put(InferenceProcessor.MODEL_ID, "my_model");
+                put(InferenceProcessor.TARGET_FIELD, targetField);
+            }
+        };
+
+        ElasticsearchParseException ex = expectThrows(
+            ElasticsearchParseException.class,
+            () -> processorFactory.create(Collections.emptyMap(), "my_inference_processor", null, config, null)
+        );
+        assertThat(
+            ex.getMessage(),
+            equalTo(
+                "[target_field] must be a non-empty, dot-delimited field path; to write results to the document root use the "
+                    + "[input_output] configuration with an [output_field]"
+            )
+        );
+    }
+
     public void testCreateProcessorWithIncompatibleResultFieldSetting() {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(
             client,


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Validate inference processor target_field at pipeline parse time (#154795)