### PR TITLE
[9.4] Apply search timeout to the aggregation query rewrite step (#153968)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -9,7 +9,9 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.search.aggregations.support.TimeSeriesIndexSearcher;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.query.QueryPhaseExecutionException;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,8 +30,14 @@ public class AggregationPhase {
         }
         final Supplier<AggregatorCollector> collectorSupplier;
         if (context.aggregations().isInSortOrderExecutionRequired()) {
+
+            final List<Runnable> cancellationChecks = context.getCancellationChecks();
+            rewriteWithCancellation(context, cancellationChecks);
+            if (context.searcher().timeExceeded()) {
+                return;
+            }
             AggregatorCollector collector = newAggregatorCollector(context);
-            executeInSortOrder(context, collector.bucketCollector);
+            executeInSortOrder(context, collector.bucketCollector, cancellationChecks);
             collectorSupplier = () -> new AggregatorCollector(collector.aggregators, BucketCollector.NO_OP_BUCKET_COLLECTOR);
         } else {
             collectorSupplier = () -> newAggregatorCollector(context);
@@ -57,8 +65,20 @@ public class AggregationPhase {
         }
     }
 
-    private static void executeInSortOrder(SearchContext context, BucketCollector collector) {
-        TimeSeriesIndexSearcher searcher = new TimeSeriesIndexSearcher(context.searcher(), context.getCancellationChecks());
+    private static void rewriteWithCancellation(SearchContext context, List<Runnable> cancellationChecks) {
+        ContextIndexSearcher searcher = context.searcher();
+        cancellationChecks.forEach(searcher::addQueryCancellation);
+        try {
+            context.rewrittenQuery();
+        } catch (RuntimeException e) {
+            throw new QueryPhaseExecutionException(context.shardTarget(), "Failed to rewrite query", e);
+        } finally {
+            cancellationChecks.forEach(searcher::removeQueryCancellation);
+        }
+    }
+
+    private static void executeInSortOrder(SearchContext context, BucketCollector collector, List<Runnable> cancellationChecks) {
+        TimeSeriesIndexSearcher searcher = new TimeSeriesIndexSearcher(context.searcher(), cancellationChecks);
         searcher.setMinimumScore(context.minimumScore());
         searcher.setProfiler(context);
         try {

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -136,9 +136,7 @@ public class QueryPhase {
             LOGGER.trace("{}", new SearchContextSourcePrinter(searchContext));
         }
 
-        // Pre-process aggregations as late as possible. In the case of a DFS_Q_T_F
-        // request, preProcess is called on the DFS phase, this is why we pre-process them
-        // here to make sure it happens during the QUERY phase
+        // Pre-process aggregations as late as possible, i.e. during the QUERY phase, after the query has been rewritten.
         AggregationPhase.preProcess(searchContext);
 
         addCollectorsAndSearch(searchContext, searchContext.getSearchExecutionContext().getTimeRangeFilterFromMillis());
@@ -155,6 +153,11 @@ public class QueryPhase {
      * wire everything (mapperService, etc.)
      */
     static void addCollectorsAndSearch(SearchContext searchContext, Long timeRangeFilterFromMillis) throws QueryPhaseExecutionException {
+        addCollectorsAndSearch(searchContext, timeRangeFilterFromMillis, getTimeoutCheck(searchContext));
+    }
+
+    private static void addCollectorsAndSearch(SearchContext searchContext, Long timeRangeFilterFromMillis, Runnable timeoutRunnable)
+        throws QueryPhaseExecutionException {
         final ContextIndexSearcher searcher = searchContext.searcher();
         final IndexReader reader = searcher.getIndexReader();
         QuerySearchResult queryResult = searchContext.queryResult();
@@ -164,13 +167,17 @@ public class QueryPhase {
             queryResult.from(searchContext.from());
             queryResult.size(searchContext.size());
 
-            final Runnable timeoutRunnable = getTimeoutCheck(searchContext);
             if (timeoutRunnable != null) {
                 searcher.addQueryCancellation(timeoutRunnable);
             }
 
             Query query = searchContext.rewrittenQuery();
             assert query == searcher.rewrite(query); // already rewritten
+
+            if (searcher.timeExceeded()) {
+                finalizeAsTimedOutResult(searchContext);
+                return;
+            }
 
             final ScrollContext scrollContext = searchContext.scrollContext();
             if (scrollContext != null) {

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTimeoutTests.java
@@ -430,9 +430,83 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
         TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
         try (SearchContext context = createSearchContextWithTimeout(query, size, false)) {
             QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.executeQuery(context));
-            assertNotNull("expected a root cause", ex.getCause());
-            assertTrue("expected the cause to be a SearchTimeoutException", ex.getCause() instanceof SearchTimeoutException);
+            assertThat(ex.getCause(), Matchers.instanceOf(SearchTimeoutException.class));
         }
+    }
+
+    public void testRewriteTimeoutWithInSortOrderAggregation() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
+        try (TestSearchContext context = createSearchContextWithTimeout(query, size)) {
+            context.aggregations(inSortOrderAggregations());
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().searchTimedOut());
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value());
+            assertEquals(0, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        }
+    }
+
+    public void testRewriteTimeoutWithInSortOrderAggregationDisallowPartialResults() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
+        try (TestSearchContext context = createSearchContextWithTimeout(query, size, false)) {
+            context.aggregations(inSortOrderAggregations());
+            QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.executeQuery(context));
+            assertThat(ex.getCause(), Matchers.instanceOf(SearchTimeoutException.class));
+        }
+    }
+
+    private static SearchContextAggregations inSortOrderAggregations() {
+        return new SearchContextAggregations(
+            AggregatorFactories.EMPTY,
+            () -> { throw new AssertionError("reduce should not be called"); }
+        ) {
+            @Override
+            public boolean isInSortOrderExecutionRequired() {
+                return true;
+            }
+
+            @Override
+            public AggregatorFactories factories() {
+                throw new AssertionError("AggregationPhase.preProcess must not be called after a rewrite timeout");
+            }
+        };
+    }
+
+    public void testRewriteTimeoutWithAggregation() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
+        try (TestSearchContext context = createSearchContextWithTimeout(query, size)) {
+            context.aggregations(regularAggregations());
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().searchTimedOut());
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value());
+            assertEquals(0, context.queryResult().topDocs().topDocs.scoreDocs.length);
+            assertNotNull(context.queryResult().aggregations());
+            assertTrue(context.queryResult().aggregations().expand().asList().isEmpty());
+        }
+    }
+
+    public void testRewriteTimeoutWithAggregationDisallowPartialResults() throws IOException {
+        int size = randomBoolean() ? 0 : randomIntBetween(100, 500);
+        TimeoutQuery query = newMatchAllRewriteTimeoutQuery(true);
+        try (TestSearchContext context = createSearchContextWithTimeout(query, size, false)) {
+            context.aggregations(regularAggregations());
+            QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.executeQuery(context));
+            assertThat(ex.getCause(), Matchers.instanceOf(SearchTimeoutException.class));
+        }
+    }
+
+    private static SearchContextAggregations regularAggregations() {
+        return new SearchContextAggregations(
+            AggregatorFactories.EMPTY,
+            () -> { throw new AssertionError("reduce should not be called"); }
+        ) {
+            @Override
+            public AggregatorFactories factories() {
+                throw new AssertionError("AggregationPhase.preProcess must not be called after a rewrite timeout");
+            }
+        };
     }
 
     public void testPostFilterCreateWeightTimeout() throws IOException {
@@ -463,8 +537,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
         try (SearchContext context = createSearchContextWithTimeout(mainQuery, size, false)) {
             context.parsedPostFilter(new ParsedQuery(newThrowOnCreateWeightQuery()));
             QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.executeQuery(context));
-            assertNotNull("expected a root cause", ex.getCause());
-            assertTrue("expected the cause to be a SearchTimeoutException", ex.getCause() instanceof SearchTimeoutException);
+            assertThat(ex.getCause(), Matchers.instanceOf(SearchTimeoutException.class));
         }
     }
 
@@ -861,8 +934,7 @@ public class QueryPhaseTimeoutTests extends IndexShardTestCase {
 
             // expect QueryPhase to propagate a failure instead of marking timed_out=true
             QueryPhaseExecutionException ex = expectThrows(QueryPhaseExecutionException.class, () -> QueryPhase.execute(context));
-            assertNotNull("expected a root cause", ex.getCause());
-            assertTrue("expected the cause to be a SearchTimeoutException", ex.getCause() instanceof SearchTimeoutException);
+            assertThat(ex.getCause(), Matchers.instanceOf(SearchTimeoutException.class));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Apply search timeout to the aggregation query rewrite step (#153968)