### PR TITLE
[9.4] Fix copy-paste errors in esql/40_tsdb.yml & a bug that was hiding (#154691)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -182,6 +182,7 @@ tasks.named("yamlRestCompatTestTransform").configure(
     task.skipTest("esql/192_lookup_join_on_aliases/alias-pattern-single", "New SORT warning not in original test")
     task.skipTest("ml/data_frame_analytics_crud/Test put config with remote source index", "Error message changed")
     task.skipTest("esql/40_tsdb/PromQL irate on counter field", "We filter out null values now")
+    task.skipTest("esql/40_tsdb/to_aggregate_metric_double with multi_values", "We convert correctly the unsigned long")
     // Expected deprecation warning to compat yaml tests:
     task.addAllowedWarningRegex("Parameter \\[default_metric\\] is deprecated and will be removed in a future version")
     task.skipTest("aggregate-metrics/10_basic/Sort", "Average is used now instead of the default metric")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2659,6 +2659,11 @@ public class EsqlCapabilities {
          */
         FIX_ROUND_TO_QUERY_AND_TAGS_OVER_FUNCTION,
 
+        /**
+         * Fix multi value unsigned long conversion to aggregate metric double
+         */
+        FIX_UNSIGNED_LONG_TO_AGGREGATE_METRIC_DOUBLE,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDouble.java
@@ -500,7 +500,7 @@ public class ToAggregateMetricDouble extends AbstractConvertFunction {
                         continue;
                     }
                     if (valueCount == 1) {
-                        double current = EsqlDataTypeConverter.unsignedLongToDouble(longBlock.getLong(p));
+                        double current = EsqlDataTypeConverter.unsignedLongToDouble(longBlock.getLong(start));
                         builder.min().appendDouble(current);
                         builder.max().appendDouble(current);
                         builder.sum().appendDouble(current);
@@ -510,7 +510,7 @@ public class ToAggregateMetricDouble extends AbstractConvertFunction {
                     double min = Double.POSITIVE_INFINITY;
                     double max = Double.NEGATIVE_INFINITY;
                     for (int i = start; i < end; i++) {
-                        double current = EsqlDataTypeConverter.unsignedLongToDouble(longBlock.getLong(p));
+                        double current = EsqlDataTypeConverter.unsignedLongToDouble(longBlock.getLong(i));
                         min = Math.min(min, current);
                         max = Math.max(max, current);
                         sum.add(current);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -654,14 +654,6 @@ _source:
       reason: "_source is available in 8.13+"
 
   - do:
-      bulk:
-        index: test
-        refresh: true
-        body:
-          - { "index" : { "_index" : "test", "_id" : "id-1" } }
-          - { "wow": 1, "such": "_source", "you'd": "never", "expect": ["amazing", "source"] }
-
-  - do:
       esql.query:
         body:
           query: 'FROM test METADATA _source | WHERE @timestamp == "2021-04-28T18:50:23.142Z" | KEEP _source | LIMIT 1'
@@ -689,7 +681,7 @@ to_aggregate_metric_double with multi_values:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_v0 ]
+          capabilities: [ aggregate_metric_double_v0, fix_unsigned_long_to_aggregate_metric_double ]
       reason: "Support for to_aggregate_metric_double function"
 
   - do:
@@ -709,14 +701,14 @@ to_aggregate_metric_double with multi_values:
   - do:
       bulk:
         refresh: true
-        index: new_test
+        index: convert_test
         body:
           - {"index": {}}
           - {"some_long_field": [20385, 182941, -10958], "some_double_field": [195.1, 102.444], "some_int_field": [64, 121, 498, 1456], "some_unsigned_long_field": [13985, 19418924, 123]}
   - do:
       esql.query:
         body:
-          query: 'FROM new_test | EVAL from_long=TO_AGGREGATE_METRIC_DOUBLE(some_long_field), from_double=TO_AGGREGATE_METRIC_DOUBLE(some_double_field), from_int=TO_AGGREGATE_METRIC_DOUBLE(some_int_field), from_ulong=TO_AGGREGATE_METRIC_DOUBLE(some_unsigned_long_field) | KEEP from_long, from_double, from_int, from_ulong | LIMIT 1'
+          query: 'FROM convert_test | EVAL from_long=TO_AGGREGATE_METRIC_DOUBLE(some_long_field), from_double=TO_AGGREGATE_METRIC_DOUBLE(some_double_field), from_int=TO_AGGREGATE_METRIC_DOUBLE(some_int_field), from_ulong=TO_AGGREGATE_METRIC_DOUBLE(some_unsigned_long_field) | KEEP from_long, from_double, from_int, from_ulong | LIMIT 1'
 
   - match: {columns.0.name: "from_long"}
   - match: {columns.0.type: "aggregate_metric_double"}
@@ -727,7 +719,7 @@ to_aggregate_metric_double with multi_values:
   - match: {columns.3.name: "from_ulong"}
   - match: {columns.3.type: "aggregate_metric_double"}
   - match: {values.0.0: '{"min":-10958.0,"max":182941.0,"sum":192368.0,"value_count":3}'}
-  - match: {values.0.1: '{"min":102.44400024414062,"max":195.10000610351562,"sum":297.54400634765625,"value_count":2}'}
+  - match: {values.0.1: '{"min":102.444,"max":195.1,"sum":297.544,"value_count":2}'}
   - match: {values.0.2: '{"min":64.0,"max":1456.0,"sum":2139.0,"value_count":4}'}
   - match: {values.0.3: '{"min":123.0,"max":1.9418924E7,"sum":1.9433032E7,"value_count":3}'}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix copy-paste errors in esql/40_tsdb.yml &amp; a bug that was hiding (#154691)](https://github.com/elastic/elasticsearch/pull/154691)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)