### PR TITLE
[8.19] Update Slack references: #es-delivery-alerts -> #es-core-infra-alerts and user group (#154730)

### DIFF
--- a/.buildkite/pipelines/ecs-dynamic-template-tests.yml
+++ b/.buildkite/pipelines/ecs-dynamic-template-tests.yml
@@ -8,7 +8,7 @@ steps:
       diskSizeGb: 350
       machineType: custom-32-98304
 notify:
-  - slack: "#es-delivery"
+  - slack: "#es-core-infra"
     if: build.state == "failed"
   - slack: "#es-data-management"
     if: build.state == "failed"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update Slack references: #es-delivery-alerts -> #es-core-infra-alerts and user group (#154730)](https://github.com/elastic/elasticsearch/pull/154730)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)