### PR TITLE
ESQL: Fix Contains exception on truncated UTF

### DIFF
--- a/docs/changelog/154947.yaml
+++ b/docs/changelog/154947.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154947
+summary: Fix Contains exception on truncated UTF
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -458,6 +458,42 @@ has_a:boolean | has_z:boolean
 true | false
 ;
 
+// Valid haystack, truncated needle (0xF0). 🐱 is F0 9F 90 B1 so the lead byte matches.
+containsTruncatedNeedleUtf8
+required_capability: fn_contains_fix_truncated_utf8
+ROW a = "🐱", b = FROM_BASE64("8A=="), c = "abc"
+| EVAL in_cat = CONTAINS(a, b), in_abc = CONTAINS(c, b)
+| KEEP in_cat, in_abc
+;
+
+in_cat:boolean | in_abc:boolean
+true           | false
+;
+
+// Both sides truncated UTF-8 (0xF0 alone as substr). Byte-level contains still matches.
+containsBothTruncatedUtf8
+required_capability: fn_contains_fix_truncated_utf8
+ROW a = FROM_BASE64("YfA="), b = FROM_BASE64("8A==")
+| EVAL both_broken = CONTAINS(a, b)
+| KEEP both_broken
+;
+
+both_broken:boolean
+true
+;
+
+// Both sides truncated and equal.
+containsBothTruncatedEqualUtf8
+required_capability: fn_contains_fix_truncated_utf8
+ROW a = FROM_BASE64("YfA=")
+| EVAL equal_broken = CONTAINS(a, a)
+| KEEP equal_broken
+;
+
+equal_broken:boolean
+true
+;
+
 containsLongerSubstr
 required_capability: fn_contains
 row a = "hello" | eval a_ll = contains(a, "farewell");

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -446,6 +446,18 @@ a:keyword | a_ll:boolean
 hello | false
 ;
 
+// Truncated UTF-8: 'a' + 0xF0. FROM_BASE64 needed; string literals cannot express invalid UTF-8.
+containsTruncatedUtf8
+required_capability: fn_contains_fix_truncated_utf8
+ROW a = FROM_BASE64("YfA=")
+| EVAL has_a = CONTAINS(a, "a"), has_z = CONTAINS(a, "z")
+| KEEP has_a, has_z
+;
+
+has_a:boolean | has_z:boolean
+true | false
+;
+
 containsLongerSubstr
 required_capability: fn_contains
 row a = "hello" | eval a_ll = contains(a, "farewell");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Contains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Contains.java
@@ -50,7 +50,11 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStr
  */
 public class Contains extends EsqlScalarFunction implements OptionalArgument, TranslationAware.SingleValueTranslationAware {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Contains", Contains::new);
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Contains.class).binary(Contains::new).name("contains");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Contains.class)
+        .binary(Contains::new)
+        // Avoid utf8ToString()/UTF8toUTF16 AIOOBE on truncated multi-byte UTF-8 sequences.
+        .capabilities("fix_truncated_utf8")
+        .name("contains");
 
     /**
      * Gate for rewriting {@code LIKE "*literal*"} into {@link Contains} (see {@code ReplaceRegexMatch}). Only safe when every node
@@ -139,7 +143,25 @@ public class Contains extends EsqlScalarFunction implements OptionalArgument, Tr
         if (str.length < substr.length) {
             return false;
         }
-        return str.utf8ToString().contains(substr.utf8ToString());
+        // Byte-level search: UTF-8 is self-synchronizing, so a valid UTF-8 substring matches
+        // iff its bytes appear contiguously. Avoid BytesRef#utf8ToString() — Lucene's UTF8toUTF16
+        // assumes well-formed UTF-8 and can throw ArrayIndexOutOfBoundsException on truncated
+        // multi-byte sequences (or when continuation bytes sit past BytesRef.length).
+        if (substr.length == 0) {
+            return true;
+        }
+        final byte[] strBytes = str.bytes;
+        final byte[] substrBytes = substr.bytes;
+        final int strFrom = str.offset;
+        final int strLimit = str.offset + str.length - substr.length;
+        final int substrFrom = substr.offset;
+        final int substrTo = substr.offset + substr.length;
+        for (int i = strFrom; i <= strLimit; i++) {
+            if (Arrays.equals(strBytes, i, i + substr.length, substrBytes, substrFrom, substrTo)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ContainsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ContainsTests.java
@@ -105,8 +105,18 @@ public class ContainsTests extends AbstractScalarFunctionTestCase {
         suppliers.add(supplier("🐱Meow!🐶Woof!", "eow!🐶Woof!", true));
 
         // Truncated UTF-8 lead byte 0xF0; must not throw via utf8ToString()
+        // Truncated haystack, valid needle
         suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, "a", true));
         suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, "z", false));
+        // Valid haystack, truncated needle (🐱 is F0 9F 90 B1; lone 0xF0 matches that lead byte)
+        suppliers.add(supplier("abc", new byte[] { (byte) 0xF0 }, false));
+        suppliers.add(supplier("🐱", new byte[] { (byte) 0xF0 }, true));
+        // Both sides truncated; byte-level contains still matches
+        suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, new byte[] { (byte) 0xF0 }, true));
+        suppliers.add(supplier(new byte[] { (byte) 'x', (byte) 'a', (byte) 0xF0 }, new byte[] { (byte) 'a', (byte) 0xF0 }, true));
+        suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, new byte[] { (byte) 0xF0, (byte) 0x9F }, false));
+        // Both truncated and equal
+        suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, new byte[] { (byte) 'a', (byte) 0xF0 }, true));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }
@@ -131,6 +141,22 @@ public class ContainsTests extends AbstractScalarFunctionTestCase {
             name,
             types(DataType.KEYWORD, DataType.KEYWORD),
             () -> testCase(DataType.KEYWORD, DataType.KEYWORD, new BytesRef(str), substr, expectedValue)
+        );
+    }
+
+    private static TestCaseSupplier supplier(String str, byte[] substr, @Nullable Boolean expectedValue) {
+        return new TestCaseSupplier(
+            "truncated utf8 in \"" + str + "\"",
+            types(DataType.KEYWORD, DataType.KEYWORD),
+            () -> testCase(DataType.KEYWORD, DataType.KEYWORD, new BytesRef(str), new BytesRef(substr), expectedValue)
+        );
+    }
+
+    private static TestCaseSupplier supplier(byte[] str, byte[] substr, @Nullable Boolean expectedValue) {
+        return new TestCaseSupplier(
+            "truncated utf8 in truncated utf8",
+            types(DataType.KEYWORD, DataType.KEYWORD),
+            () -> testCase(DataType.KEYWORD, DataType.KEYWORD, new BytesRef(str), new BytesRef(substr), expectedValue)
         );
     }
 
@@ -182,9 +208,19 @@ public class ContainsTests extends AbstractScalarFunctionTestCase {
         String substr,
         Boolean expectedValue
     ) {
+        return testCase(strType, substrType, str, substr == null ? null : new BytesRef(substr), expectedValue);
+    }
+
+    private static TestCaseSupplier.TestCase testCase(
+        DataType strType,
+        DataType substrType,
+        BytesRef str,
+        BytesRef substr,
+        Boolean expectedValue
+    ) {
         List<TestCaseSupplier.TypedData> values = new ArrayList<>();
         values.add(new TestCaseSupplier.TypedData(str, strType, "str"));
-        values.add(new TestCaseSupplier.TypedData(substr == null ? null : new BytesRef(substr), substrType, "substr"));
+        values.add(new TestCaseSupplier.TypedData(substr, substrType, "substr"));
         return new TestCaseSupplier.TestCase(values, expectedToString(), DataType.BOOLEAN, equalTo(expectedValue));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ContainsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ContainsTests.java
@@ -104,6 +104,10 @@ public class ContainsTests extends AbstractScalarFunctionTestCase {
         suppliers.add(supplier("🐱Meow!🐶Woof!", "Meow!🐶Woof!", true));
         suppliers.add(supplier("🐱Meow!🐶Woof!", "eow!🐶Woof!", true));
 
+        // Truncated UTF-8 lead byte 0xF0; must not throw via utf8ToString()
+        suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, "a", true));
+        suppliers.add(supplier(new byte[] { (byte) 'a', (byte) 0xF0 }, "z", false));
+
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }
 
@@ -118,6 +122,15 @@ public class ContainsTests extends AbstractScalarFunctionTestCase {
             name,
             types(DataType.KEYWORD, DataType.KEYWORD),
             () -> testCase(DataType.KEYWORD, DataType.KEYWORD, str, substr, expectedValue)
+        );
+    }
+
+    private static TestCaseSupplier supplier(byte[] str, String substr, @Nullable Boolean expectedValue) {
+        String name = String.format(Locale.ROOT, "\"%s\" in truncated utf8", substr);
+        return new TestCaseSupplier(
+            name,
+            types(DataType.KEYWORD, DataType.KEYWORD),
+            () -> testCase(DataType.KEYWORD, DataType.KEYWORD, new BytesRef(str), substr, expectedValue)
         );
     }
 
@@ -159,8 +172,18 @@ public class ContainsTests extends AbstractScalarFunctionTestCase {
         String substr,
         Boolean expectedValue
     ) {
+        return testCase(strType, substrType, str == null ? null : new BytesRef(str), substr, expectedValue);
+    }
+
+    private static TestCaseSupplier.TestCase testCase(
+        DataType strType,
+        DataType substrType,
+        BytesRef str,
+        String substr,
+        Boolean expectedValue
+    ) {
         List<TestCaseSupplier.TypedData> values = new ArrayList<>();
-        values.add(new TestCaseSupplier.TypedData(str == null ? null : new BytesRef(str), strType, "str"));
+        values.add(new TestCaseSupplier.TypedData(str, strType, "str"));
         values.add(new TestCaseSupplier.TypedData(substr == null ? null : new BytesRef(substr), substrType, "substr"));
         return new TestCaseSupplier.TestCase(values, expectedToString(), DataType.BOOLEAN, equalTo(expectedValue));
     }


### PR DESCRIPTION
Fixes an exception on `Contains` when UTF values are invalid:

```
java.lang.ArrayIndexOutOfBoundsException: Index 367 out of bounds for length 367
	at org.apache.lucene.util.UnicodeUtil.UTF8toUTF16(UnicodeUtil.java:647)
	at org.apache.lucene.util.BytesRef.utf8ToString(BytesRef.java:139)
	at org.elasticsearch.xpack.esql.expression.function.scalar.string.Contains.process(Contains.java:142)
	at org.elasticsearch.xpack.esql.expression.function.scalar.string.ContainsEvaluator.eval(ContainsEvaluator.java:117)
	at org.elasticsearch.xpack.esql.expression.function.scalar.string.ContainsEvaluator.eval(ContainsEvaluator.java:61)
```