### PR TITLE
ES|QL: Fix logical operator folding on MV constants

### DIFF
--- a/docs/changelog/154950.yaml
+++ b/docs/changelog/154950.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154079
+pr: 154950
+summary: Fix logical operator folding on MV constants
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
@@ -161,6 +161,41 @@ v:boolean
 null
 ;
 
+mvConstantFoldingBinaryLogic
+required_capability: fix_logical_operators_folding_on_multivalue_constants
+row aa = [true, false] AND true, oo = [true, false] OR false;
+
+aa:boolean | oo:boolean
+null       | null
+;
+
+mvConstantFoldingBinaryLogicShortCircuit
+required_capability: fix_logical_operators_folding_on_multivalue_constants
+row aa = false AND [true, false], oo = true OR [true, false];
+
+aa:boolean | oo:boolean
+null       | null
+;
+
+mvConstantFoldingNot
+required_capability: fix_logical_operators_folding_on_multivalue_constants
+row v = NOT [true, false];
+warningRegex:evaluation of \[NOT \[true, false\]\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+v:boolean
+null
+;
+
+// https://github.com/elastic/elasticsearch/issues/154079
+mvConstantFoldingBinaryLogicInCaseCondition
+required_capability: fix_logical_operators_folding_on_multivalue_constants
+row x = [true, false] | eval y = case(x AND mv_last(x), 1, 2) | keep y;
+
+y:integer
+2
+;
+
 convertFromBoolean
 row tf = [true, false] | eval tt = to_boolean(true), ff = to_boolean(false), ttff = to_boolean(tf);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3510,6 +3510,12 @@ public class EsqlCapabilities {
          */
         FIX_UNSIGNED_LONG_TO_AGGREGATE_METRIC_DOUBLE,
 
+        /**
+         * Constant folding of logical operators ({@code AND}, {@code OR}, {@code NOT}) applied to multivalue
+         * constants returns {@code null}, matching runtime semantics, instead of throwing a {@code ClassCastException}.
+         */
+        FIX_LOGICAL_OPERATORS_FOLDING_ON_MULTIVALUE_CONSTANTS,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.ScoreOperator;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal;
 import org.elasticsearch.xpack.esql.core.expression.predicate.BinaryOperator;
@@ -72,6 +73,11 @@ public abstract class BinaryLogic extends BinaryOperator<Boolean, Boolean, Boole
     public Nullability nullable() {
         // Cannot fold null due to 3vl, constant folding will do any possible folding.
         return Nullability.UNKNOWN;
+    }
+
+    @Override
+    public Boolean fold(FoldContext ctx) {
+        return (Boolean) EvaluatorMapper.super.fold(source(), ctx);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/Not.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/Not.java
@@ -12,7 +12,6 @@ import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.UnaryScalarFunction;
@@ -66,19 +65,7 @@ public class Not extends UnaryScalarFunction implements EvaluatorMapper, Negatab
 
     @Override
     public Object fold(FoldContext ctx) {
-        return apply(field().fold(ctx));
-    }
-
-    private static Boolean apply(Object input) {
-        if (input == null) {
-            return null;
-        }
-
-        if ((input instanceof Boolean) == false) {
-            throw new QlIllegalArgumentException("A boolean is required; received {}", input);
-        }
-
-        return ((Boolean) input).booleanValue() ? Boolean.FALSE : Boolean.TRUE;
+        return EvaluatorMapper.super.fold(source(), ctx);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ConstantFoldingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ConstantFoldingTests.java
@@ -32,6 +32,8 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
+import java.util.List;
+
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.FIVE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.THREE;
@@ -97,6 +99,25 @@ public class ConstantFoldingTests extends ESTestCase {
         assertEquals(Nullability.TRUE, constantFolding(new Or(EMPTY, NULL, FALSE)).canonical().nullable());
         assertEquals(Nullability.TRUE, constantFolding(new Or(EMPTY, FALSE, NULL)).canonical().nullable());
         assertEquals(Nullability.TRUE, constantFolding(new Or(EMPTY, NULL, NULL)).canonical().nullable());
+    }
+
+    // https://github.com/elastic/elasticsearch/issues/154079
+    public void testConstantFoldingBinaryLogic_WithMultivalues() {
+        Literal mv = new Literal(EMPTY, List.of(true, false), DataType.BOOLEAN);
+        Literal expected = new Literal(EMPTY, null, DataType.BOOLEAN);
+        assertEquals(expected, constantFolding(new And(EMPTY, mv, TRUE)));
+        assertEquals(expected, constantFolding(new And(EMPTY, FALSE, mv)));
+        assertEquals(expected, constantFolding(new Or(EMPTY, mv, FALSE)));
+        assertEquals(expected, constantFolding(new Or(EMPTY, TRUE, mv)));
+    }
+
+    public void testConstantNot_WithMultivalues() {
+        Literal mv = new Literal(EMPTY, List.of(true, false), DataType.BOOLEAN);
+        assertEquals(new Literal(EMPTY, null, DataType.BOOLEAN), constantFolding(new Not(EMPTY, mv)));
+        assertWarnings(
+            "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+            "Line -1:-1: java.lang.IllegalArgumentException: single-value function encountered multi-value"
+        );
     }
 
     public void testConstantFoldingRange() {


### PR DESCRIPTION
Using `EvaluatorMapper.fold()`

Fixes: https://github.com/elastic/elasticsearch/issues/154079