### PR TITLE
[9.5] Gate temporality templates on node support (#154931)

### DIFF
--- a/docs/changelog/154931.yaml
+++ b/docs/changelog/154931.yaml
@@ -1,0 +1,6 @@
+area: TSDB
+issues:
+ - 153331
+pr: 154931
+summary: Gate templates depending on temporality support on cluster feature
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -137,6 +137,11 @@ public class MapperFeatures implements FeatureSpecification {
     public static final NodeFeature TSDB_METRIC_TEMPORALITY_SUPPORT = new NodeFeature("mapper.tsdb.metric_temporality_support");
 
     @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(TSDB_METRIC_TEMPORALITY_SUPPORT);
+    }
+
+    @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
             RangeFieldMapper.DATE_RANGE_INDEXING_FIX,
@@ -224,8 +229,7 @@ public class MapperFeatures implements FeatureSpecification {
             DOC_VALUES_MULTI_VALUE_INDEX_SETTING,
             DOC_VALUES_MULTI_VALUE_FALSE_ALIAS,
             DOC_VALUES_EXTENDED_FORM_ONLY_IN_COLUMNAR,
-            DOC_VALUES_NULLABILITY,
-            TSDB_METRIC_TEMPORALITY_SUPPORT
+            DOC_VALUES_NULLABILITY
         );
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -43,6 +43,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperFeatures;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -121,7 +123,12 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
      * This map matches node features with predicates to detect when a template requires that feature.
      * This allows the registry to install the template only after the cluster fully supports a feature.
      */
-    protected static final Map<NodeFeature, Predicate<Template>> NODE_FEATURE_FILTERS = Map.of();
+    protected static final Map<NodeFeature, Predicate<Template>> NODE_FEATURE_FILTERS = Map.of(
+        MapperFeatures.TSDB_METRIC_TEMPORALITY_SUPPORT,
+        template -> template != null
+            && template.settings() != null
+            && template.settings().hasValue(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey())
+    );
     private final Map<NodeFeature, Predicate<Template>> nodeFeatureFilters;
     // This flag short-circuits the node feature check, if all node features are supported.
     private volatile boolean allFeaturesSupported = false;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
@@ -41,6 +41,8 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MapperFeatures;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.tasks.Task;
@@ -84,6 +86,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
@@ -1110,6 +1113,23 @@ public class IndexTemplateRegistryTests extends ESTestCase {
             containsInAnyOrder("test-index-one@template", "test-index-two@template")
         );
         assertThat(registry.allFeaturesSupported(), equalTo(true));
+    }
+
+    public void testTemporalitySettingRequiresClusterFeature() {
+        Predicate<Template> filter = IndexTemplateRegistry.NODE_FEATURE_FILTERS.get(MapperFeatures.TSDB_METRIC_TEMPORALITY_SUPPORT);
+        assertThat(filter, notNullValue());
+        assertThat(
+            filter.test(
+                new Template(
+                    Settings.builder().put(IndexSettings.TIME_SERIES_TEMPORALITY_FIELD.getKey(), "temporality").build(),
+                    null,
+                    null
+                )
+            ),
+            equalTo(true)
+        );
+        assertThat(filter.test(new Template(Settings.EMPTY, null, null)), equalTo(false));
+        assertThat(filter.test(null), equalTo(false));
     }
 
     public void testFeatureAbsentFiltersMatchingComponentTemplate() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Gate temporality templates on node support (#154931)](https://github.com/elastic/elasticsearch/pull/154931)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)