### PR TITLE
Refactor ElasticInferenceServiceRerankServiceSettings to use ObjectParser

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettings.java
@@ -7,14 +7,18 @@
 
 package org.elasticsearch.xpack.inference.services.elastic.rerank;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceRateLimitServiceSettings;
@@ -25,8 +29,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 
 public class ElasticInferenceServiceRerankServiceSettings extends FilteredXContentObject
     implements
@@ -35,28 +39,78 @@ public class ElasticInferenceServiceRerankServiceSettings extends FilteredXConte
 
     public static final String NAME = "elastic_rerank_service_settings";
 
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createParser(
+        false,
+        ConfigurationParseContext.REQUEST
+    );
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createParser(
+        true,
+        ConfigurationParseContext.PERSISTENT
+    );
+
     private static final TransportVersion ML_INFERENCE_ELASTIC_RERANK = TransportVersion.fromName("ml_inference_elastic_rerank");
     private static final TransportVersion INFERENCE_API_DISABLE_EIS_RATE_LIMITING = TransportVersion.fromName(
         "inference_api_disable_eis_rate_limiting"
     );
 
-    public static ElasticInferenceServiceRerankServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
-        ValidationException validationException = new ValidationException();
+    /**
+     * Creates a parser for the rerank service settings. In the {@link ConfigurationParseContext#REQUEST} context the
+     * {@code rate_limit} field is declared solely to reject it with a validation error, since this service does not permit
+     * user-supplied rate limits; in the {@link ConfigurationParseContext#PERSISTENT} context it is ignored like any other
+     * unknown field, so that previously persisted configurations remain readable.
+     *
+     * @param ignoreUnknownFields whether unknown fields are tolerated; {@code false} for user requests, {@code true} for persisted config
+     * @param context the parse context the returned parser is intended for
+     */
+    public static ObjectParser<Builder, ConfigurationParseContext> createParser(
+        boolean ignoreUnknownFields,
+        ConfigurationParseContext context
+    ) {
+        ObjectParser<Builder, ConfigurationParseContext> parser = new ObjectParser<>(
+            ModelConfigurations.SERVICE_SETTINGS,
+            ignoreUnknownFields,
+            Builder::new
+        );
 
-        String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-
-        RateLimitSettings.rejectRateLimitFieldForRequestContext(
-            map,
+        parser.declareString(Builder::setModelId, new ParseField(MODEL_ID));
+        RateLimitSettings.declareUnsupportedRateLimitField(
+            parser,
             ModelConfigurations.SERVICE_SETTINGS,
             ElasticInferenceService.NAME,
             TaskType.RERANK,
-            context,
-            validationException
+            context
         );
 
-        validationException.throwIfValidationErrorsExist();
+        return parser;
+    }
 
-        return new ElasticInferenceServiceRerankServiceSettings(modelId);
+    public static ElasticInferenceServiceRerankServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
+        var parser = context == ConfigurationParseContext.REQUEST ? REQUEST_PARSER : PERSISTENT_PARSER;
+
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            var builder = parser.apply(xParser, context);
+            // TODO: remove once all elastic service settings are parser-based and usesParserForServiceSettings can be enabled on
+            // ElasticInferenceService. The object parser reads the map through an XContent view without consuming its entries, so
+            // the parsed fields must be removed explicitly to satisfy the caller's check that no unknown settings remain in the map.
+            map.remove(MODEL_ID);
+            map.remove(RateLimitSettings.FIELD_NAME);
+            return builder.build();
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
+        }
+    }
+
+    public static class Builder {
+        private String modelId;
+
+        public void setModelId(String modelId) {
+            this.modelId = Objects.requireNonNull(modelId);
+        }
+
+        public ElasticInferenceServiceRerankServiceSettings build() {
+            validateStringIsNotNullOrEmpty(modelId, MODEL_ID);
+            return new ElasticInferenceServiceRerankServiceSettings(modelId);
+        }
     }
 
     private final String modelId;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/rerank/ElasticInferenceServiceRerankServiceSettingsTests.java
@@ -7,15 +7,17 @@
 
 package org.elasticsearch.xpack.inference.services.elastic.rerank;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
@@ -26,11 +28,26 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
+public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractBWCSerializationTestCase<
     ElasticInferenceServiceRerankServiceSettings> {
+
+    private final boolean ignoreUnknownFields = randomBoolean();
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return ignoreUnknownFields;
+    }
+
+    @Override
+    protected ElasticInferenceServiceRerankServiceSettings doParseInstance(XContentParser parser) throws IOException {
+        return ElasticInferenceServiceRerankServiceSettings.createParser(true, ConfigurationParseContext.PERSISTENT)
+            .apply(parser, ConfigurationParseContext.PERSISTENT)
+            .build();
+    }
 
     @Override
     protected Writeable.Reader<ElasticInferenceServiceRerankServiceSettings> instanceReader() {
@@ -51,17 +68,25 @@ public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractB
 
     public void testFromMap() {
         var modelId = "my-model-id";
+        var map = new HashMap<String, Object>(Map.of(ServiceFields.MODEL_ID, modelId));
 
-        var serviceSettings = ElasticInferenceServiceRerankServiceSettings.fromMap(
-            new HashMap<>(Map.of(ServiceFields.MODEL_ID, modelId)),
-            ConfigurationParseContext.REQUEST
-        );
+        var serviceSettings = ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST);
 
         assertThat(serviceSettings, is(new ElasticInferenceServiceRerankServiceSettings(modelId)));
+        assertThat(map, is(anEmptyMap()));
         assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
     }
 
-    public void testFromMap_DoesNotRemoveRateLimitField_DoesNotThrowValidationException_PersistentContext() {
+    public void testFromMap_ThrowsIllegalArgumentException_WhenModelIdIsMissing() {
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ElasticInferenceServiceRerankServiceSettings.fromMap(new HashMap<>(), ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(e.getMessage(), containsString("[service_settings] does not contain the required setting [model_id]"));
+    }
+
+    public void testFromMap_IgnoresRateLimitField_PersistentContext() {
         var modelId = "my-model-id";
 
         var map = new HashMap<String, Object>(
@@ -76,7 +101,6 @@ public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractB
         var serviceSettings = ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.PERSISTENT);
 
         assertThat(serviceSettings, is(new ElasticInferenceServiceRerankServiceSettings(modelId)));
-        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
         assertThat(serviceSettings.rateLimitSettings(), sameInstance(RateLimitSettings.DISABLED_INSTANCE));
     }
 
@@ -105,15 +129,26 @@ public class ElasticInferenceServiceRerankServiceSettingsTests extends AbstractB
         );
 
         var exception = expectThrows(
-            ValidationException.class,
+            XContentParseException.class,
             () -> ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
         );
 
+        assertThat(exception.getCause(), instanceOf(ElasticsearchParseException.class));
         assertThat(
-            exception.getMessage(),
+            exception.getCause().getMessage(),
             containsString("[service_settings] rate limit settings are not permitted for service [elastic] and task type [rerank]")
         );
-        assertThat(map, is(Map.of(RateLimitSettings.FIELD_NAME, Map.of(RateLimitSettings.REQUESTS_PER_MINUTE_FIELD, 100))));
+    }
+
+    public void testFromMap_ThrowsException_WhenUnknownFieldExists_RequestContext() {
+        var map = new HashMap<String, Object>(Map.of(ServiceFields.MODEL_ID, "my-model-id", "unknown_field", "value"));
+
+        var exception = expectThrows(
+            XContentParseException.class,
+            () -> ElasticInferenceServiceRerankServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(exception.getMessage(), containsString("unknown field [unknown_field]"));
     }
 
     public void testToXContent_WritesAllFields() throws IOException {


### PR DESCRIPTION
Refactoring parsing logic of Elastic Inference Service rerank service settings to use the ObjectParser framework.

Based off the following PRs: https://github.com/elastic/elasticsearch/pull/149471, https://github.com/elastic/elasticsearch/pull/152922 and https://github.com/elastic/elasticsearch/pull/154441.

Closes https://github.com/elastic/search-team/issues/14779