### PR TITLE
Unmute topNLongRangeWildcardSort: capability gate already in place

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -253,9 +253,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.core.anonymizer.AnonymizationContextTests
   method: testNullClusterUuidDoesNotNpe
   issue: https://github.com/elastic/elasticsearch/issues/150887
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecTopNIT
-  method: test {csv-spec:topN.topNLongRangeWildcardSort}
-  issue: https://github.com/elastic/elasticsearch/issues/150874
 - class: org.elasticsearch.xpack.esql.inference.rerank.RerankOperatorTests
   method: testInferenceFailure
   issue: https://github.com/elastic/elasticsearch/issues/150976


### PR DESCRIPTION
FIX_TOPN_LONG_RANGE_ENCODING was added to EsqlCapabilities and required_capability: fix_topn_long_range_encoding was added to the test by the follow-up fix. The mute entry was never removed.

Fixes #150874
