### PR TITLE
Refactor ElserInternalServiceSettings to use ObjectParser

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -7,24 +7,36 @@
 
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.elasticsearch.xpack.inference.common.parser.StatefulValue;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.core.inference.InferenceUtils.missingSettingErrorMsg;
+import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
+import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredPositiveInteger;
@@ -40,14 +52,76 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
     public static final String DEPLOYMENT_ID = "deployment_id";
     public static final String ADAPTIVE_ALLOCATIONS = "adaptive_allocations";
 
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createParser(false, Builder::new);
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createParser(true, Builder::new);
+
     private Integer numAllocations;
     private final int numThreads;
     private final String modelId;
     private AdaptiveAllocationsSettings adaptiveAllocationsSettings;
     private final String deploymentId;
 
+    /**
+     * Creates a parser declaring the settings common to all elasticsearch internal services. Subclasses with additional fields
+     * create their parsers through this method with their own builder supplier and declare the extra fields on the result.
+     *
+     * @param ignoreUnknownFields whether unknown fields are tolerated; {@code false} for user requests, {@code true} for persisted config
+     * @param builderSupplier constructs the builder instances the parser populates
+     */
+    static <B extends Builder> ObjectParser<B, ConfigurationParseContext> createParser(
+        boolean ignoreUnknownFields,
+        Supplier<B> builderSupplier
+    ) {
+        ObjectParser<B, ConfigurationParseContext> parser = new ObjectParser<>(
+            ModelConfigurations.SERVICE_SETTINGS,
+            ignoreUnknownFields,
+            builderSupplier
+        );
+        declareBaseFields(parser);
+        return parser;
+    }
+
+    private static <B extends Builder> void declareBaseFields(ObjectParser<B, ConfigurationParseContext> parser) {
+        parser.declareField(Builder::setNumAllocations, p -> {
+            int value = p.intValue();
+            validatePositiveInteger(value, NUM_ALLOCATIONS);
+            return value;
+        }, new ParseField(NUM_ALLOCATIONS), ObjectParser.ValueType.INT);
+        parser.declareField(Builder::setNumThreads, p -> {
+            int value = p.intValue();
+            validatePositiveInteger(value, NUM_THREADS);
+            return value;
+        }, new ParseField(NUM_THREADS), ObjectParser.ValueType.INT);
+        parser.declareField(Builder::setModelId, p -> {
+            String value = p.text();
+            validateStringIsNotNullOrEmpty(value, MODEL_ID);
+            return value;
+        }, new ParseField(MODEL_ID), ObjectParser.ValueType.STRING);
+        parser.declareField(Builder::setDeploymentId, p -> {
+            String value = p.text();
+            validateStringIsNotNullOrEmpty(value, DEPLOYMENT_ID);
+            return value;
+        }, new ParseField(DEPLOYMENT_ID), ObjectParser.ValueType.STRING);
+        parser.declareObject(
+            Builder::setAdaptiveAllocationsSettings,
+            (p, c) -> parseAdaptiveAllocationsSettings(p),
+            new ParseField(ADAPTIVE_ALLOCATIONS)
+        );
+    }
+
+    private static AdaptiveAllocationsSettings parseAdaptiveAllocationsSettings(XContentParser parser) throws IOException {
+        var settings = AdaptiveAllocationsSettings.PARSER.apply(parser, null).build();
+        var validationException = settings.validate();
+        if (validationException != null) {
+            throw validationException;
+        }
+        return settings;
+    }
+
     public static ElasticsearchInternalServiceSettings fromPersistedMap(Map<String, Object> map) {
-        return fromRequestMap(map).build();
+        var builder = parseFromMap(map, PERSISTENT_PARSER, ConfigurationParseContext.PERSISTENT);
+        validateRequiredFields(builder);
+        return builder.build();
     }
 
     /**
@@ -61,12 +135,59 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
      * @return A builder to allow the settings to be modified.
      */
     public static Builder fromRequestMap(Map<String, Object> map) {
-        var validationException = new ValidationException();
-        var builder = fromMap(map, validationException);
-        validationException.throwIfValidationErrorsExist();
+        var builder = parseFromMap(map, REQUEST_PARSER, ConfigurationParseContext.REQUEST);
+        validateRequiredFields(builder);
         return builder;
     }
 
+    private static Builder parseFromMap(
+        Map<String, Object> map,
+        ObjectParser<Builder, ConfigurationParseContext> parser,
+        ConfigurationParseContext context
+    ) {
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            var builder = parser.apply(xParser, context);
+            // TODO: remove once all elasticsearch internal service settings are parser-based and ElasticsearchInternalService no
+            // longer checks for unconsumed map entries. The object parser reads the map through an XContent view without consuming
+            // its entries, so the parsed fields must be removed explicitly to satisfy the caller's check that no unknown settings
+            // remain in the map.
+            map.remove(NUM_ALLOCATIONS);
+            map.remove(NUM_THREADS);
+            map.remove(MODEL_ID);
+            map.remove(DEPLOYMENT_ID);
+            map.remove(ADAPTIVE_ALLOCATIONS);
+            return builder;
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
+        }
+    }
+
+    /**
+     * Validates the presence rules that span multiple fields: {@code num_threads} is required and exactly one allocations style
+     * (fixed or adaptive) must be given. These checks run after parsing so that services can rely on them regardless of which
+     * parser variant populated the builder.
+     */
+    static void validateRequiredFields(Builder builder) {
+        var validationException = new ValidationException();
+
+        if (builder.getNumThreadsOrNull() == null) {
+            validationException.addValidationError(missingSettingErrorMsg(NUM_THREADS, ModelConfigurations.SERVICE_SETTINGS));
+        }
+
+        if (builder.getNumAllocations() == null && builder.getAdaptiveAllocationsSettings() == null) {
+            validationException.addValidationError(
+                ServiceUtils.missingOneOfSettingsErrorMsg(
+                    List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
+                    ModelConfigurations.SERVICE_SETTINGS
+                )
+            );
+        }
+
+        validationException.throwIfValidationErrorsExist();
+    }
+
+    // TODO: remove once the subclasses with additional fields (reranker, E5, text embedding) declare their fields on a parser
+    // created via createParser instead of extracting them from the map.
     protected static Builder fromMap(Map<String, Object> map, ValidationException validationException) {
         Integer numAllocations = extractOptionalPositiveInteger(
             map,
@@ -224,42 +345,76 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         return TransportVersion.minimumCompatible();
     }
 
+    /**
+     * Parses an update request. Only the allocations settings are mutable: {@code num_threads} is declared solely to reject it
+     * with a descriptive error, and any other field is rejected by the strict parser.
+     */
+    private static class Update {
+
+        private static final ObjectParser<Update, Void> PARSER = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, Update::new);
+
+        private StatefulValue<Integer> numAllocations = StatefulValue.undefined();
+        private StatefulValue<AdaptiveAllocationsSettings> adaptiveAllocationsSettings = StatefulValue.undefined();
+
+        static {
+            StatefulValue.declareNullable(PARSER, (update, value) -> update.numAllocations = value, p -> {
+                int value = p.intValue();
+                validatePositiveInteger(value, NUM_ALLOCATIONS);
+                return value;
+            }, new ParseField(NUM_ALLOCATIONS), ObjectParser.ValueType.INT_OR_NULL);
+            StatefulValue.declareNullable(
+                PARSER,
+                (update, value) -> update.adaptiveAllocationsSettings = value,
+                ElasticsearchInternalServiceSettings::parseAdaptiveAllocationsSettings,
+                new ParseField(ADAPTIVE_ALLOCATIONS),
+                ObjectParser.ValueType.OBJECT_OR_NULL
+            );
+            PARSER.declareField(
+                (update, value) -> {},
+                p -> { throw new ElasticsearchParseException("[{}] cannot be updated", NUM_THREADS); },
+                new ParseField(NUM_THREADS),
+                ObjectParser.ValueType.VALUE
+            );
+        }
+
+        Builder mergeInto(ElasticsearchInternalServiceSettings existing) {
+            var validationException = new ValidationException();
+
+            if (numAllocations.isPresent() == false && adaptiveAllocationsSettings.isPresent() == false) {
+                validationException.addValidationError(
+                    ServiceUtils.missingOneOfSettingsErrorMsg(
+                        List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
+                        ModelConfigurations.SERVICE_SETTINGS
+                    )
+                );
+            }
+            if (numAllocations.isPresent() && adaptiveAllocationsSettings.isPresent()) {
+                validationException.addValidationError(
+                    Strings.format("[%s] cannot be set if [%s] is set", NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS)
+                );
+            }
+            validationException.throwIfValidationErrorsExist();
+
+            return existing.toBuilder()
+                .setNumAllocations(numAllocations.orElse(null))
+                .setAdaptiveAllocationsSettings(adaptiveAllocationsSettings.orElse(null));
+        }
+    }
+
     @Override
     public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
-        var validationException = new ValidationException();
-
-        if (serviceSettings.containsKey(NUM_THREADS)) {
-            validationException.addValidationError(Strings.format("[%s] cannot be updated", NUM_THREADS));
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, serviceSettings)) {
+            var update = Update.PARSER.apply(xParser, null);
+            // TODO: remove once all elasticsearch internal service settings are parser-based and usesParserForServiceSettings can
+            // be enabled on ElasticsearchInternalService. The object parser reads the map through an XContent view without
+            // consuming its entries, so the parsed fields must be removed explicitly to satisfy the caller's check that no unknown
+            // settings remain in the map.
+            serviceSettings.remove(NUM_ALLOCATIONS);
+            serviceSettings.remove(ADAPTIVE_ALLOCATIONS);
+            return update.mergeInto(this).build();
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse Elasticsearch internal service settings update", e);
         }
-
-        var numAllocations = extractOptionalPositiveInteger(
-            serviceSettings,
-            NUM_ALLOCATIONS,
-            ModelConfigurations.SERVICE_SETTINGS,
-            validationException
-        );
-        var adaptiveAllocationsSettings = ServiceUtils.removeAsAdaptiveAllocationsSettings(
-            serviceSettings,
-            ADAPTIVE_ALLOCATIONS,
-            validationException
-        );
-
-        if (numAllocations == null && adaptiveAllocationsSettings == null) {
-            validationException.addValidationError(
-                ServiceUtils.missingOneOfSettingsErrorMsg(
-                    List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
-                    ModelConfigurations.SERVICE_SETTINGS
-                )
-            );
-        }
-        if (numAllocations != null && adaptiveAllocationsSettings != null) {
-            validationException.addValidationError(
-                Strings.format("[%s] cannot be set if [%s] is set", NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS)
-            );
-        }
-        validationException.throwIfValidationErrorsExist();
-
-        return toBuilder().setNumAllocations(numAllocations).setAdaptiveAllocationsSettings(adaptiveAllocationsSettings).build();
     }
 
     public Builder toBuilder() {
@@ -272,13 +427,21 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
 
     public static class Builder {
         private Integer numAllocations;
-        private int numThreads;
+        private Integer numThreads;
         private String modelId;
         private AdaptiveAllocationsSettings adaptiveAllocationsSettings;
         private String deploymentId;
 
         public ElasticsearchInternalServiceSettings build() {
-            return new ElasticsearchInternalServiceSettings(numAllocations, numThreads, modelId, adaptiveAllocationsSettings, deploymentId);
+            // the failed-parse sentinel keeps the legacy map-extraction path building without a null pointer when the accumulated
+            // validation errors are thrown after this call; the parser-based paths validate before building
+            return new ElasticsearchInternalServiceSettings(
+                numAllocations,
+                Objects.requireNonNullElse(numThreads, FAILED_INT_PARSE_VALUE),
+                modelId,
+                adaptiveAllocationsSettings,
+                deploymentId
+            );
         }
 
         public Builder setNumAllocations(Integer numAllocations) {
@@ -315,6 +478,10 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         }
 
         public int getNumThreads() {
+            return numThreads;
+        }
+
+        Integer getNumThreadsOrNull() {
             return numThreads;
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
@@ -133,14 +134,56 @@ public class ElasticsearchInternalServiceSettingsTests extends AbstractElasticse
         );
     }
 
-    public void testFromMapInvalidSettings() {
+    public void testFromMapInvalidNumAllocations() {
         var settingsMap = new HashMap<String, Object>(
-            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 0, ElasticsearchInternalServiceSettings.NUM_THREADS, -1)
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 0, ElasticsearchInternalServiceSettings.NUM_THREADS, 1)
         );
-        var e = expectThrows(ValidationException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
+        var e = expectThrows(XContentParseException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
 
-        assertThat(e.getMessage(), containsString("Invalid value [0]. [num_allocations] must be a positive integer"));
-        assertThat(e.getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [0]. [num_allocations] must be a positive integer"));
+    }
+
+    public void testFromMapInvalidNumThreads() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, -1)
+        );
+        var e = expectThrows(XContentParseException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
+
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
+    }
+
+    public void testFromMapUnknownFieldInRequestContext() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(
+                ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                ElasticsearchInternalServiceSettings.NUM_THREADS,
+                1,
+                "unknown_field",
+                "value"
+            )
+        );
+        var e = expectThrows(XContentParseException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
+
+        assertThat(e.getMessage(), containsString("unknown field [unknown_field]"));
+    }
+
+    public void testFromPersistedMapIgnoresUnknownFields() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(
+                ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                ElasticsearchInternalServiceSettings.NUM_THREADS,
+                4,
+                ElasticsearchInternalServiceSettings.MODEL_ID,
+                ".elser_model_1",
+                "unknown_field",
+                "value"
+            )
+        );
+        var serviceSettings = ElasticsearchInternalServiceSettings.fromPersistedMap(settingsMap);
+
+        assertEquals(new ElasticsearchInternalServiceSettings(1, 4, ".elser_model_1", null, null), serviceSettings);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -55,6 +54,7 @@ import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
@@ -314,7 +314,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
 
             ActionListener<Model> modelListener = ActionListener.<Model>wrap(
                 model -> fail("Model parsing should have failed"),
-                e -> assertThat(e, instanceOf(ElasticsearchStatusException.class))
+                e -> assertThat(e, instanceOf(XContentParseException.class))
             );
 
             service.parseRequestConfig(randomInferenceEntityId, TaskType.TEXT_EMBEDDING, settings, modelListener);
@@ -484,7 +484,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
 
             ActionListener<Model> modelListener = ActionListener.<Model>wrap(
                 model -> fail("Model parsing should have failed"),
-                e -> assertThat(e, instanceOf(ElasticsearchStatusException.class))
+                e -> assertThat(e, instanceOf(XContentParseException.class))
             );
 
             service.parseRequestConfig(randomInferenceEntityId, TaskType.SPARSE_EMBEDDING, config, modelListener);
@@ -2554,10 +2554,10 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
 
         var serviceSettingsWithNumThreads = new HashMap<String, Object>(Map.of(ElasticsearchInternalServiceSettings.NUM_THREADS, 8));
         var exception = expectThrows(
-            ValidationException.class,
+            XContentParseException.class,
             () -> existingSettings.updateServiceSettings(serviceSettingsWithNumThreads)
         );
-        assertThat(exception.getMessage(), containsString("[num_threads] cannot be updated"));
+        assertThat(exception.getCause().getMessage(), containsString("[num_threads] cannot be updated"));
     }
 
     private ElasticsearchInternalService createService(Client client) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.io.stream.Writeable;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModelsTests.randomElserModel;
+import static org.hamcrest.Matchers.is;
 
 public class ElserInternalServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<ElserInternalServiceSettings> {
 
@@ -65,6 +68,55 @@ public class ElserInternalServiceSettingsTests extends AbstractElasticsearchInte
             }
             default -> throw new IllegalStateException();
         };
+    }
+
+    /**
+     * Mirrors the persisted path taken by {@code ElserInternalModelCreator}: the base settings are parsed leniently from the
+     * stored config and wrapped in the ELSER-specific type.
+     */
+    public void testFromPersistedMap_CreatesElserSettings_IgnoringUnknownFields() {
+        var modelId = randomElserModel();
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                ElasticsearchInternalServiceSettings.NUM_THREADS,
+                4,
+                ElasticsearchInternalServiceSettings.MODEL_ID,
+                modelId,
+                "unknown_field_from_a_future_version",
+                "value"
+            )
+        );
+
+        var serviceSettings = new ElserInternalServiceSettings(ElasticsearchInternalServiceSettings.fromPersistedMap(map));
+
+        assertThat(
+            serviceSettings,
+            is(new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, modelId, null, null)))
+        );
+    }
+
+    /**
+     * Mirrors the request path taken by {@code elserCase} in {@code ElasticsearchInternalService}: the base settings builder is
+     * parsed strictly from the request and the ELSER default model id is applied before wrapping.
+     */
+    public void testFromRequestMap_BuilderWrapsIntoElserSettings_AfterModelDefaulting() {
+        var map = new HashMap<String, Object>(
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, 4)
+        );
+        var defaultModelId = randomElserModel();
+
+        var builder = ElasticsearchInternalServiceSettings.fromRequestMap(map);
+        assertNull(builder.getModelId());
+        builder.setModelId(defaultModelId);
+
+        var serviceSettings = new ElserInternalServiceSettings(builder.build());
+
+        assertThat(
+            serviceSettings,
+            is(new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, defaultModelId, null, null)))
+        );
     }
 
     @Override


### PR DESCRIPTION
Covers `ElserInternalServiceSettings` in the ObjectParser migration. ELSER has no parsing logic of its own — both its request path (`elserCase`) and persisted path (`ElserInternalModelCreator`) flow through the base class `ElasticsearchInternalServiceSettings`, whose conversion lands in https://github.com/elastic/elasticsearch/pull/154961. This PR adds ELSER-specific test coverage of those parser-based paths.

**Stacked on #154961 — review the last commit only.**

Based off the following PRs: https://github.com/elastic/elasticsearch/pull/149471, https://github.com/elastic/elasticsearch/pull/152922 and https://github.com/elastic/elasticsearch/pull/154441.

Closes https://github.com/elastic/search-team/issues/14781