### PR TITLE
Refactor CustomElandInternalTextEmbeddingServiceSettings to use ObjectParser

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerModelCreator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerModelCreator.java
@@ -36,7 +36,7 @@ public class ElasticRerankerModelCreator extends ElasticsearchInternalModelCreat
             inferenceId,
             taskType,
             service,
-            ElasticRerankerServiceSettings.fromMap(serviceSettings),
+            ElasticRerankerServiceSettings.fromMap(serviceSettings, context),
             RerankTaskSettings.fromMap(taskSettings)
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
@@ -7,22 +7,28 @@
 
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalEnum;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
+import static org.elasticsearch.xpack.inference.common.parser.EnumParser.parseFromStringInObjectParserContext;
+import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.RERANKER_ID;
 
 public class ElasticRerankerServiceSettings extends ElasticsearchInternalServiceSettings {
@@ -32,9 +38,23 @@ public class ElasticRerankerServiceSettings extends ElasticsearchInternalService
     public static final String LONG_DOCUMENT_STRATEGY = "long_document_strategy";
     public static final String MAX_CHUNKS_PER_DOC = "max_chunks_per_doc";
 
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createRerankerParser(false);
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createRerankerParser(true);
+
     private static final TransportVersion ELASTIC_RERANKER_CHUNKING_CONFIGURATION = TransportVersion.fromName(
         "elastic_reranker_chunking_configuration"
     );
+
+    private static ObjectParser<Builder, ConfigurationParseContext> createRerankerParser(boolean ignoreUnknownFields) {
+        var parser = ElasticsearchInternalServiceSettings.createParser(ignoreUnknownFields, Builder::new);
+        parser.declareString(Builder::setLongDocumentStrategy, new ParseField(LONG_DOCUMENT_STRATEGY));
+        parser.declareField(Builder::setMaxChunksPerDoc, p -> {
+            int value = p.intValue();
+            validatePositiveInteger(value, MAX_CHUNKS_PER_DOC);
+            return value;
+        }, new ParseField(MAX_CHUNKS_PER_DOC), ObjectParser.ValueType.INT);
+        return parser;
+    }
 
     private final LongDocumentStrategy longDocumentStrategy;
     private final Integer maxChunksPerDoc;
@@ -96,37 +116,70 @@ public class ElasticRerankerServiceSettings extends ElasticsearchInternalService
      * {@link ValidationException} is thrown.
      *
      * @param map Source map containing the config
+     * @param context The parser context, whether it is from an HTTP request or from persistent storage
      * @return Parsed and validated service settings
      */
-    public static ElasticRerankerServiceSettings fromMap(Map<String, Object> map) {
-        ValidationException validationException = new ValidationException();
-        var baseSettings = ElasticsearchInternalServiceSettings.fromMap(map, validationException);
+    public static ElasticRerankerServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
+        var parser = context == ConfigurationParseContext.REQUEST ? REQUEST_PARSER : PERSISTENT_PARSER;
 
-        LongDocumentStrategy longDocumentStrategy = extractOptionalEnum(
-            map,
-            LONG_DOCUMENT_STRATEGY,
-            ModelConfigurations.SERVICE_SETTINGS,
-            LongDocumentStrategy::fromString,
-            EnumSet.allOf(LongDocumentStrategy.class),
-            validationException
-        );
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            var builder = parser.apply(xParser, context);
+            // TODO: remove once all elasticsearch internal service settings are parser-based and ElasticsearchInternalService no
+            // longer checks for unconsumed map entries. The object parser reads the map through an XContent view without consuming
+            // its entries, so the parsed fields must be removed explicitly to satisfy the caller's check that no unknown settings
+            // remain in the map.
+            map.remove(NUM_ALLOCATIONS);
+            map.remove(NUM_THREADS);
+            map.remove(MODEL_ID);
+            map.remove(DEPLOYMENT_ID);
+            map.remove(ADAPTIVE_ALLOCATIONS);
+            map.remove(LONG_DOCUMENT_STRATEGY);
+            map.remove(MAX_CHUNKS_PER_DOC);
 
-        Integer maxChunksPerDoc = extractOptionalPositiveInteger(
-            map,
-            MAX_CHUNKS_PER_DOC,
-            ModelConfigurations.SERVICE_SETTINGS,
-            validationException
-        );
+            ElasticsearchInternalServiceSettings.validateRequiredFields(builder);
+            validateChunkingRule(builder);
+            return builder.build();
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
+        }
+    }
 
-        if (maxChunksPerDoc != null && (longDocumentStrategy == null || longDocumentStrategy == LongDocumentStrategy.TRUNCATE)) {
+    private static void validateChunkingRule(Builder builder) {
+        if (builder.maxChunksPerDoc != null
+            && (builder.longDocumentStrategy == null || builder.longDocumentStrategy == LongDocumentStrategy.TRUNCATE)) {
+            ValidationException validationException = new ValidationException();
             validationException.addValidationError(
                 "The [" + MAX_CHUNKS_PER_DOC + "] setting requires [" + LONG_DOCUMENT_STRATEGY + "] to be set to [chunk]"
             );
+            throw validationException;
+        }
+    }
+
+    /**
+     * Builder for the reranker settings: extends the base builder with the chunking configuration fields declared by
+     * {@link #createRerankerParser}.
+     */
+    public static class Builder extends ElasticsearchInternalServiceSettings.Builder {
+        private LongDocumentStrategy longDocumentStrategy;
+        private Integer maxChunksPerDoc;
+
+        public void setLongDocumentStrategy(String longDocumentStrategy) {
+            this.longDocumentStrategy = parseFromStringInObjectParserContext(
+                longDocumentStrategy,
+                LongDocumentStrategy::fromString,
+                EnumSet.allOf(LongDocumentStrategy.class),
+                EnumSet.noneOf(LongDocumentStrategy.class)
+            );
         }
 
-        validationException.throwIfValidationErrorsExist();
+        public void setMaxChunksPerDoc(Integer maxChunksPerDoc) {
+            this.maxChunksPerDoc = maxChunksPerDoc;
+        }
 
-        return new ElasticRerankerServiceSettings(baseSettings.build(), longDocumentStrategy, maxChunksPerDoc);
+        @Override
+        public ElasticRerankerServiceSettings build() {
+            return new ElasticRerankerServiceSettings(super.build(), longDocumentStrategy, maxChunksPerDoc);
+        }
     }
 
     public LongDocumentStrategy getLongDocumentStrategy() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -408,7 +408,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         ActionListener<Model> modelListener
     ) {
 
-        var serviceSettings = ElasticRerankerServiceSettings.fromMap(serviceSettingsMap);
+        var serviceSettings = ElasticRerankerServiceSettings.fromMap(serviceSettingsMap, ConfigurationParseContext.REQUEST);
 
         throwIfNotEmptyMap(config, name());
         throwIfNotEmptyMap(serviceSettingsMap, name());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -7,24 +7,36 @@
 
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.elasticsearch.xpack.inference.common.parser.StatefulValue;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.core.inference.InferenceUtils.missingSettingErrorMsg;
+import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
+import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredPositiveInteger;
@@ -40,14 +52,76 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
     public static final String DEPLOYMENT_ID = "deployment_id";
     public static final String ADAPTIVE_ALLOCATIONS = "adaptive_allocations";
 
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createParser(false, Builder::new);
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createParser(true, Builder::new);
+
     private Integer numAllocations;
     private final int numThreads;
     private final String modelId;
     private AdaptiveAllocationsSettings adaptiveAllocationsSettings;
     private final String deploymentId;
 
+    /**
+     * Creates a parser declaring the settings common to all elasticsearch internal services. Subclasses with additional fields
+     * create their parsers through this method with their own builder supplier and declare the extra fields on the result.
+     *
+     * @param ignoreUnknownFields whether unknown fields are tolerated; {@code false} for user requests, {@code true} for persisted config
+     * @param builderSupplier constructs the builder instances the parser populates
+     */
+    static <B extends Builder> ObjectParser<B, ConfigurationParseContext> createParser(
+        boolean ignoreUnknownFields,
+        Supplier<B> builderSupplier
+    ) {
+        ObjectParser<B, ConfigurationParseContext> parser = new ObjectParser<>(
+            ModelConfigurations.SERVICE_SETTINGS,
+            ignoreUnknownFields,
+            builderSupplier
+        );
+        declareBaseFields(parser);
+        return parser;
+    }
+
+    private static <B extends Builder> void declareBaseFields(ObjectParser<B, ConfigurationParseContext> parser) {
+        parser.declareField(Builder::setNumAllocations, p -> {
+            int value = p.intValue();
+            validatePositiveInteger(value, NUM_ALLOCATIONS);
+            return value;
+        }, new ParseField(NUM_ALLOCATIONS), ObjectParser.ValueType.INT);
+        parser.declareField(Builder::setNumThreads, p -> {
+            int value = p.intValue();
+            validatePositiveInteger(value, NUM_THREADS);
+            return value;
+        }, new ParseField(NUM_THREADS), ObjectParser.ValueType.INT);
+        parser.declareField(Builder::setModelId, p -> {
+            String value = p.text();
+            validateStringIsNotNullOrEmpty(value, MODEL_ID);
+            return value;
+        }, new ParseField(MODEL_ID), ObjectParser.ValueType.STRING);
+        parser.declareField(Builder::setDeploymentId, p -> {
+            String value = p.text();
+            validateStringIsNotNullOrEmpty(value, DEPLOYMENT_ID);
+            return value;
+        }, new ParseField(DEPLOYMENT_ID), ObjectParser.ValueType.STRING);
+        parser.declareObject(
+            Builder::setAdaptiveAllocationsSettings,
+            (p, c) -> parseAdaptiveAllocationsSettings(p),
+            new ParseField(ADAPTIVE_ALLOCATIONS)
+        );
+    }
+
+    private static AdaptiveAllocationsSettings parseAdaptiveAllocationsSettings(XContentParser parser) throws IOException {
+        var settings = AdaptiveAllocationsSettings.PARSER.apply(parser, null).build();
+        var validationException = settings.validate();
+        if (validationException != null) {
+            throw validationException;
+        }
+        return settings;
+    }
+
     public static ElasticsearchInternalServiceSettings fromPersistedMap(Map<String, Object> map) {
-        return fromRequestMap(map).build();
+        var builder = parseFromMap(map, PERSISTENT_PARSER, ConfigurationParseContext.PERSISTENT);
+        validateRequiredFields(builder);
+        return builder.build();
     }
 
     /**
@@ -61,12 +135,59 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
      * @return A builder to allow the settings to be modified.
      */
     public static Builder fromRequestMap(Map<String, Object> map) {
-        var validationException = new ValidationException();
-        var builder = fromMap(map, validationException);
-        validationException.throwIfValidationErrorsExist();
+        var builder = parseFromMap(map, REQUEST_PARSER, ConfigurationParseContext.REQUEST);
+        validateRequiredFields(builder);
         return builder;
     }
 
+    private static Builder parseFromMap(
+        Map<String, Object> map,
+        ObjectParser<Builder, ConfigurationParseContext> parser,
+        ConfigurationParseContext context
+    ) {
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            var builder = parser.apply(xParser, context);
+            // TODO: remove once all elasticsearch internal service settings are parser-based and ElasticsearchInternalService no
+            // longer checks for unconsumed map entries. The object parser reads the map through an XContent view without consuming
+            // its entries, so the parsed fields must be removed explicitly to satisfy the caller's check that no unknown settings
+            // remain in the map.
+            map.remove(NUM_ALLOCATIONS);
+            map.remove(NUM_THREADS);
+            map.remove(MODEL_ID);
+            map.remove(DEPLOYMENT_ID);
+            map.remove(ADAPTIVE_ALLOCATIONS);
+            return builder;
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
+        }
+    }
+
+    /**
+     * Validates the presence rules that span multiple fields: {@code num_threads} is required and exactly one allocations style
+     * (fixed or adaptive) must be given. These checks run after parsing so that services can rely on them regardless of which
+     * parser variant populated the builder.
+     */
+    static void validateRequiredFields(Builder builder) {
+        var validationException = new ValidationException();
+
+        if (builder.getNumThreadsOrNull() == null) {
+            validationException.addValidationError(missingSettingErrorMsg(NUM_THREADS, ModelConfigurations.SERVICE_SETTINGS));
+        }
+
+        if (builder.getNumAllocations() == null && builder.getAdaptiveAllocationsSettings() == null) {
+            validationException.addValidationError(
+                ServiceUtils.missingOneOfSettingsErrorMsg(
+                    List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
+                    ModelConfigurations.SERVICE_SETTINGS
+                )
+            );
+        }
+
+        validationException.throwIfValidationErrorsExist();
+    }
+
+    // TODO: remove once the subclasses with additional fields (reranker, E5, text embedding) declare their fields on a parser
+    // created via createParser instead of extracting them from the map.
     protected static Builder fromMap(Map<String, Object> map, ValidationException validationException) {
         Integer numAllocations = extractOptionalPositiveInteger(
             map,
@@ -224,42 +345,76 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         return TransportVersion.minimumCompatible();
     }
 
+    /**
+     * Parses an update request. Only the allocations settings are mutable: {@code num_threads} is declared solely to reject it
+     * with a descriptive error, and any other field is rejected by the strict parser.
+     */
+    private static class Update {
+
+        private static final ObjectParser<Update, Void> PARSER = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, Update::new);
+
+        private StatefulValue<Integer> numAllocations = StatefulValue.undefined();
+        private StatefulValue<AdaptiveAllocationsSettings> adaptiveAllocationsSettings = StatefulValue.undefined();
+
+        static {
+            StatefulValue.declareNullable(PARSER, (update, value) -> update.numAllocations = value, p -> {
+                int value = p.intValue();
+                validatePositiveInteger(value, NUM_ALLOCATIONS);
+                return value;
+            }, new ParseField(NUM_ALLOCATIONS), ObjectParser.ValueType.INT_OR_NULL);
+            StatefulValue.declareNullable(
+                PARSER,
+                (update, value) -> update.adaptiveAllocationsSettings = value,
+                ElasticsearchInternalServiceSettings::parseAdaptiveAllocationsSettings,
+                new ParseField(ADAPTIVE_ALLOCATIONS),
+                ObjectParser.ValueType.OBJECT_OR_NULL
+            );
+            PARSER.declareField(
+                (update, value) -> {},
+                p -> { throw new ElasticsearchParseException("[{}] cannot be updated", NUM_THREADS); },
+                new ParseField(NUM_THREADS),
+                ObjectParser.ValueType.VALUE
+            );
+        }
+
+        Builder mergeInto(ElasticsearchInternalServiceSettings existing) {
+            var validationException = new ValidationException();
+
+            if (numAllocations.isPresent() == false && adaptiveAllocationsSettings.isPresent() == false) {
+                validationException.addValidationError(
+                    ServiceUtils.missingOneOfSettingsErrorMsg(
+                        List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
+                        ModelConfigurations.SERVICE_SETTINGS
+                    )
+                );
+            }
+            if (numAllocations.isPresent() && adaptiveAllocationsSettings.isPresent()) {
+                validationException.addValidationError(
+                    Strings.format("[%s] cannot be set if [%s] is set", NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS)
+                );
+            }
+            validationException.throwIfValidationErrorsExist();
+
+            return existing.toBuilder()
+                .setNumAllocations(numAllocations.orElse(null))
+                .setAdaptiveAllocationsSettings(adaptiveAllocationsSettings.orElse(null));
+        }
+    }
+
     @Override
     public ServiceSettings updateServiceSettings(Map<String, Object> serviceSettings) {
-        var validationException = new ValidationException();
-
-        if (serviceSettings.containsKey(NUM_THREADS)) {
-            validationException.addValidationError(Strings.format("[%s] cannot be updated", NUM_THREADS));
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, serviceSettings)) {
+            var update = Update.PARSER.apply(xParser, null);
+            // TODO: remove once all elasticsearch internal service settings are parser-based and usesParserForServiceSettings can
+            // be enabled on ElasticsearchInternalService. The object parser reads the map through an XContent view without
+            // consuming its entries, so the parsed fields must be removed explicitly to satisfy the caller's check that no unknown
+            // settings remain in the map.
+            serviceSettings.remove(NUM_ALLOCATIONS);
+            serviceSettings.remove(ADAPTIVE_ALLOCATIONS);
+            return update.mergeInto(this).build();
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse Elasticsearch internal service settings update", e);
         }
-
-        var numAllocations = extractOptionalPositiveInteger(
-            serviceSettings,
-            NUM_ALLOCATIONS,
-            ModelConfigurations.SERVICE_SETTINGS,
-            validationException
-        );
-        var adaptiveAllocationsSettings = ServiceUtils.removeAsAdaptiveAllocationsSettings(
-            serviceSettings,
-            ADAPTIVE_ALLOCATIONS,
-            validationException
-        );
-
-        if (numAllocations == null && adaptiveAllocationsSettings == null) {
-            validationException.addValidationError(
-                ServiceUtils.missingOneOfSettingsErrorMsg(
-                    List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
-                    ModelConfigurations.SERVICE_SETTINGS
-                )
-            );
-        }
-        if (numAllocations != null && adaptiveAllocationsSettings != null) {
-            validationException.addValidationError(
-                Strings.format("[%s] cannot be set if [%s] is set", NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS)
-            );
-        }
-        validationException.throwIfValidationErrorsExist();
-
-        return toBuilder().setNumAllocations(numAllocations).setAdaptiveAllocationsSettings(adaptiveAllocationsSettings).build();
     }
 
     public Builder toBuilder() {
@@ -272,13 +427,21 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
 
     public static class Builder {
         private Integer numAllocations;
-        private int numThreads;
+        private Integer numThreads;
         private String modelId;
         private AdaptiveAllocationsSettings adaptiveAllocationsSettings;
         private String deploymentId;
 
         public ElasticsearchInternalServiceSettings build() {
-            return new ElasticsearchInternalServiceSettings(numAllocations, numThreads, modelId, adaptiveAllocationsSettings, deploymentId);
+            // the failed-parse sentinel keeps the legacy map-extraction path building without a null pointer when the accumulated
+            // validation errors are thrown after this call; the parser-based paths validate before building
+            return new ElasticsearchInternalServiceSettings(
+                numAllocations,
+                Objects.requireNonNullElse(numThreads, FAILED_INT_PARSE_VALUE),
+                modelId,
+                adaptiveAllocationsSettings,
+                deploymentId
+            );
         }
 
         public Builder setNumAllocations(Integer numAllocations) {
@@ -315,6 +478,10 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         }
 
         public int getNumThreads() {
+            return numThreads;
+        }
+
+        Integer getNumThreadsOrNull() {
             return numThreads;
         }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -37,9 +37,6 @@ import java.util.function.Supplier;
 import static org.elasticsearch.xpack.core.inference.InferenceUtils.missingSettingErrorMsg;
 import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
 import static org.elasticsearch.xpack.inference.common.parser.StringParser.validateStringIsNotNullOrEmpty;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredPositiveInteger;
 
 public class ElasticsearchInternalServiceSettings implements ServiceSettings {
 
@@ -184,45 +181,6 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         }
 
         validationException.throwIfValidationErrorsExist();
-    }
-
-    // TODO: remove once the subclasses with additional fields (reranker, E5, text embedding) declare their fields on a parser
-    // created via createParser instead of extracting them from the map.
-    protected static Builder fromMap(Map<String, Object> map, ValidationException validationException) {
-        Integer numAllocations = extractOptionalPositiveInteger(
-            map,
-            NUM_ALLOCATIONS,
-            ModelConfigurations.SERVICE_SETTINGS,
-            validationException
-        );
-        Integer numThreads = extractRequiredPositiveInteger(map, NUM_THREADS, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        AdaptiveAllocationsSettings adaptiveAllocationsSettings = ServiceUtils.removeAsAdaptiveAllocationsSettings(
-            map,
-            ADAPTIVE_ALLOCATIONS,
-            validationException
-        );
-
-        // model id is optional as the ELSER service will default it. TODO make this a required field once the elser service is removed
-        String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-
-        if (numAllocations == null && adaptiveAllocationsSettings == null) {
-            validationException.addValidationError(
-                ServiceUtils.missingOneOfSettingsErrorMsg(
-                    List.of(NUM_ALLOCATIONS, ADAPTIVE_ALLOCATIONS),
-                    ModelConfigurations.SERVICE_SETTINGS
-                )
-            );
-        }
-
-        String deploymentId = extractOptionalString(map, DEPLOYMENT_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
-
-        // if an error occurred while parsing, we'll set these to an invalid value, so we don't accidentally get a
-        // null pointer when doing unboxing
-        return new Builder().setNumAllocations(numAllocations)
-            .setNumThreads(Objects.requireNonNullElse(numThreads, FAILED_INT_PARSE_VALUE))
-            .setModelId(modelId)
-            .setAdaptiveAllocationsSettings(adaptiveAllocationsSettings)
-            .setDeploymentId(deploymentId);
     }
 
     public ElasticsearchInternalServiceSettings(
@@ -433,8 +391,8 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         private String deploymentId;
 
         public ElasticsearchInternalServiceSettings build() {
-            // the failed-parse sentinel keeps the legacy map-extraction path building without a null pointer when the accumulated
-            // validation errors are thrown after this call; the parser-based paths validate before building
+            // the failed-parse sentinel avoids a null pointer when a builder is built without num_threads; the parser-based
+            // paths validate the field is present before building
             return new ElasticsearchInternalServiceSettings(
                 numAllocations,
                 Objects.requireNonNullElse(numThreads, FAILED_INT_PARSE_VALUE),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettings.java
@@ -7,17 +7,23 @@
 
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.elasticsearch.xpack.inference.common.parser.EnumParser;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
@@ -25,19 +31,63 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.inference.common.parser.EnumParser.parseFromStringInObjectParserContext;
+import static org.elasticsearch.xpack.inference.common.parser.NumberParser.validatePositiveInteger;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.ELEMENT_TYPE;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARITY;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalEnum;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
-import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSimilarity;
 
 public class ElasticsearchInternalTextEmbeddingServiceSettings extends ElasticsearchInternalServiceSettings {
 
     public static final String NAME = "custom_eland_model_internal_text_embedding_service_settings";
 
+    private static final ObjectParser<Builder, ConfigurationParseContext> REQUEST_PARSER = createTextEmbeddingParser(
+        false,
+        ConfigurationParseContext.REQUEST
+    );
+    private static final ObjectParser<Builder, ConfigurationParseContext> PERSISTENT_PARSER = createTextEmbeddingParser(
+        true,
+        ConfigurationParseContext.PERSISTENT
+    );
+    private static final ObjectParser<Builder, Void> SIMILARITY_AND_ELEMENT_TYPE_PARSER = createSimilarityAndElementTypeParser();
+
     /**
-     * Parse the CustomElandServiceSettings from map and validate the setting values.
+     * Creates a parser for the text embedding service settings. The {@code dimensions} field is declared only in the
+     * {@link ConfigurationParseContext#PERSISTENT} context: dimensions are not accepted from user requests because validation
+     * determines them after performing a request to the model, whereas persisted configurations store the determined value.
+     *
+     * @param ignoreUnknownFields whether unknown fields are tolerated; {@code false} for user requests, {@code true} for persisted config
+     * @param context the parse context the returned parser is intended for
+     */
+    private static ObjectParser<Builder, ConfigurationParseContext> createTextEmbeddingParser(
+        boolean ignoreUnknownFields,
+        ConfigurationParseContext context
+    ) {
+        var parser = ElasticsearchInternalServiceSettings.createParser(ignoreUnknownFields, Builder::new);
+        declareSimilarityAndElementType(parser);
+        if (context == ConfigurationParseContext.PERSISTENT) {
+            parser.declareField(Builder::setDimensions, p -> {
+                int value = p.intValue();
+                validatePositiveInteger(value, DIMENSIONS);
+                return value;
+            }, new ParseField(DIMENSIONS), ObjectParser.ValueType.INT);
+        }
+        return parser;
+    }
+
+    private static ObjectParser<Builder, Void> createSimilarityAndElementTypeParser() {
+        ObjectParser<Builder, Void> parser = new ObjectParser<>(ModelConfigurations.SERVICE_SETTINGS, true, Builder::new);
+        declareSimilarityAndElementType(parser);
+        return parser;
+    }
+
+    private static <C> void declareSimilarityAndElementType(ObjectParser<Builder, C> parser) {
+        parser.declareString(Builder::setSimilarity, new ParseField(SIMILARITY));
+        parser.declareString(Builder::setElementType, new ParseField(ELEMENT_TYPE));
+    }
+
+    /**
+     * Parse the text embedding service settings from map and validate the setting values.
      *
      * This method does not verify the model variant
      *
@@ -46,85 +96,102 @@ public class ElasticsearchInternalTextEmbeddingServiceSettings extends Elasticse
      *
      * @param map Source map containing the config
      * @param context The parser context, whether it is from an HTTP request or from persistent storage
-     * @return The {@code CustomElandServiceSettings} builder
+     * @return The parsed and validated service settings
      */
     public static ElasticsearchInternalTextEmbeddingServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
-        return switch (context) {
-            case REQUEST -> forRequest(map);
-            case PERSISTENT -> forPersisted(map);
-        };
-    }
+        var parser = context == ConfigurationParseContext.REQUEST ? REQUEST_PARSER : PERSISTENT_PARSER;
 
-    private static ElasticsearchInternalTextEmbeddingServiceSettings forRequest(Map<String, Object> map) {
-        ValidationException validationException = new ValidationException();
-        var commonFields = commonFieldsFromMap(map, validationException);
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            var builder = parser.apply(xParser, context);
+            // TODO: remove once all elasticsearch internal service settings are parser-based and ElasticsearchInternalService no
+            // longer checks for unconsumed map entries. The object parser reads the map through an XContent view without consuming
+            // its entries, so the parsed fields must be removed explicitly to satisfy the caller's check that no unknown settings
+            // remain in the map.
+            map.remove(NUM_ALLOCATIONS);
+            map.remove(NUM_THREADS);
+            map.remove(MODEL_ID);
+            map.remove(DEPLOYMENT_ID);
+            map.remove(ADAPTIVE_ALLOCATIONS);
+            map.remove(SIMILARITY);
+            map.remove(ELEMENT_TYPE);
+            map.remove(DIMENSIONS);
 
-        validationException.throwIfValidationErrorsExist();
-
-        return new ElasticsearchInternalTextEmbeddingServiceSettings(commonFields);
-    }
-
-    private static ElasticsearchInternalTextEmbeddingServiceSettings forPersisted(Map<String, Object> map) {
-        var commonFields = commonFieldsFromMap(map);
-        Integer dims = extractOptionalPositiveInteger(map, DIMENSIONS, ModelConfigurations.SERVICE_SETTINGS, new ValidationException());
-
-        return new ElasticsearchInternalTextEmbeddingServiceSettings(commonFields, dims);
+            ElasticsearchInternalServiceSettings.validateRequiredFields(builder);
+            return builder.build();
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
+        }
     }
 
     /**
      * Parse the similarity and element type from the request map, layering them onto a common settings
      * builder populated from another source (e.g. an existing ML deployment's assignment stats rather
      * than the map itself). Dimensions are left null; validation determines them after performing a
-     * request to the model.
+     * request to the model. Only the two parsed fields are consumed from the map so that any remaining
+     * entries still fail the caller's check for unknown settings.
      */
     public static ElasticsearchInternalTextEmbeddingServiceSettings fromMap(
         Map<String, Object> map,
         ElasticsearchInternalServiceSettings.Builder commonSettingsBuilder
     ) {
-        var validationException = new ValidationException();
-        var similarity = extractSimilarityOrDefault(map, validationException);
-        var elementType = extractElementTypeOrDefault(map, validationException);
-        validationException.throwIfValidationErrorsExist();
-
-        return new ElasticsearchInternalTextEmbeddingServiceSettings(commonSettingsBuilder.build(), null, similarity, elementType);
+        try (var xParser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, map)) {
+            var builder = SIMILARITY_AND_ELEMENT_TYPE_PARSER.apply(xParser, null);
+            map.remove(SIMILARITY);
+            map.remove(ELEMENT_TYPE);
+            return new ElasticsearchInternalTextEmbeddingServiceSettings(
+                commonSettingsBuilder.build(),
+                null,
+                builder.similarityOrDefault(),
+                builder.elementTypeOrDefault()
+            );
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse [{}]", e, ModelConfigurations.SERVICE_SETTINGS);
+        }
     }
 
-    private record CommonFields(
-        ElasticsearchInternalServiceSettings internalServiceSettings,
-        SimilarityMeasure similarityMeasure,
-        DenseVectorFieldMapper.ElementType elementType
-    ) {}
+    /**
+     * Builder for the text embedding settings: extends the base builder with the similarity, element type and dimensions fields
+     * declared by {@link #createTextEmbeddingParser}. Similarity and element type default to cosine and float when absent.
+     */
+    public static class Builder extends ElasticsearchInternalServiceSettings.Builder {
+        private SimilarityMeasure similarityMeasure;
+        private DenseVectorFieldMapper.ElementType elementType;
+        private Integer dimensions;
 
-    private static CommonFields commonFieldsFromMap(Map<String, Object> map) {
-        return commonFieldsFromMap(map, new ValidationException());
-    }
+        public void setSimilarity(String similarity) {
+            this.similarityMeasure = EnumParser.parseSimilarity(similarity);
+        }
 
-    private static CommonFields commonFieldsFromMap(Map<String, Object> map, ValidationException validationException) {
-        var internalSettings = ElasticsearchInternalServiceSettings.fromMap(map, validationException);
-        var similarity = extractSimilarityOrDefault(map, validationException);
-        var elementType = extractElementTypeOrDefault(map, validationException);
+        public void setElementType(String elementType) {
+            this.elementType = parseFromStringInObjectParserContext(
+                elementType,
+                DenseVectorFieldMapper.ElementType::fromString,
+                EnumSet.of(DenseVectorFieldMapper.ElementType.BYTE, DenseVectorFieldMapper.ElementType.FLOAT),
+                EnumSet.noneOf(DenseVectorFieldMapper.ElementType.class)
+            );
+        }
 
-        return new CommonFields(internalSettings.build(), similarity, elementType);
-    }
+        public void setDimensions(Integer dimensions) {
+            this.dimensions = dimensions;
+        }
 
-    private static SimilarityMeasure extractSimilarityOrDefault(Map<String, Object> map, ValidationException validationException) {
-        SimilarityMeasure similarity = extractSimilarity(map, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        return Objects.requireNonNullElse(similarity, SimilarityMeasure.COSINE);
-    }
+        SimilarityMeasure similarityOrDefault() {
+            return Objects.requireNonNullElse(similarityMeasure, SimilarityMeasure.COSINE);
+        }
 
-    private static DenseVectorFieldMapper.ElementType extractElementTypeOrDefault(
-        Map<String, Object> map,
-        ValidationException validationException
-    ) {
-        DenseVectorFieldMapper.ElementType elementType = extractOptionalEnum(
-            map,
-            ELEMENT_TYPE,
-            ModelConfigurations.SERVICE_SETTINGS,
-            DenseVectorFieldMapper.ElementType::fromString,
-            EnumSet.of(DenseVectorFieldMapper.ElementType.BYTE, DenseVectorFieldMapper.ElementType.FLOAT),
-            validationException
-        );
-        return Objects.requireNonNullElse(elementType, DenseVectorFieldMapper.ElementType.FLOAT);
+        DenseVectorFieldMapper.ElementType elementTypeOrDefault() {
+            return Objects.requireNonNullElse(elementType, DenseVectorFieldMapper.ElementType.FLOAT);
+        }
+
+        @Override
+        public ElasticsearchInternalTextEmbeddingServiceSettings build() {
+            return new ElasticsearchInternalTextEmbeddingServiceSettings(
+                super.build(),
+                dimensions,
+                similarityOrDefault(),
+                elementTypeOrDefault()
+            );
+        }
     }
 
     private final Integer dimensions;
@@ -164,23 +231,6 @@ public class ElasticsearchInternalTextEmbeddingServiceSettings extends Elasticse
         this.dimensions = dimensions;
         this.similarityMeasure = Objects.requireNonNull(similarityMeasure);
         this.elementType = Objects.requireNonNull(elementType);
-    }
-
-    private ElasticsearchInternalTextEmbeddingServiceSettings(CommonFields commonFields) {
-        this(commonFields, null);
-    }
-
-    private ElasticsearchInternalTextEmbeddingServiceSettings(CommonFields commonFields, Integer dimensions) {
-        super(
-            commonFields.internalServiceSettings.getNumAllocations(),
-            commonFields.internalServiceSettings.getNumThreads(),
-            commonFields.internalServiceSettings.modelId(),
-            commonFields.internalServiceSettings.getAdaptiveAllocationsSettings(),
-            commonFields.internalServiceSettings.getDeploymentId()
-        );
-        this.dimensions = dimensions;
-        similarityMeasure = commonFields.similarityMeasure;
-        elementType = commonFields.elementType;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.MinimalServiceSettings;
 import org.elasticsearch.inference.ServiceSettings;
@@ -74,24 +75,22 @@ public class MultilingualE5SmallInternalServiceSettings extends ElasticsearchInt
      * @return The builder
      */
     public static ElasticsearchInternalServiceSettings.Builder fromRequestMap(Map<String, Object> map) {
-        ValidationException validationException = new ValidationException();
-        var baseSettings = ElasticsearchInternalServiceSettings.fromMap(map, validationException);
-
-        String modelId = baseSettings.getModelId();
-        if (modelId != null) {
-            if (ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.contains(modelId) == false) {
-                validationException.addValidationError(
-                    "unknown Multilingual-E5-Small model ID ["
-                        + modelId
-                        + "]. Valid IDs are "
-                        + Arrays.toString(ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.toArray())
-                );
-            }
-        }
-
-        validationException.throwIfValidationErrorsExist();
-
+        var baseSettings = ElasticsearchInternalServiceSettings.fromRequestMap(map);
+        validateModelIdAllowlist(baseSettings.getModelId());
         return baseSettings;
+    }
+
+    private static void validateModelIdAllowlist(@Nullable String modelId) {
+        if (modelId != null && ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.contains(modelId) == false) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError(
+                "unknown Multilingual-E5-Small model ID ["
+                    + modelId
+                    + "]. Valid IDs are "
+                    + Arrays.toString(ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.toArray())
+            );
+            throw validationException;
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettingsTests.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -80,7 +82,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
             Optional.empty()
         );
 
-        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap);
+        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST);
         assertExpectedSettings(
             settings,
             Optional.of(numAllocations),
@@ -106,7 +108,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
             Optional.empty()
         );
 
-        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap);
+        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST);
         assertExpectedSettings(
             settings,
             Optional.empty(),
@@ -133,7 +135,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
 
         ValidationException exception = Assert.assertThrows(
             ValidationException.class,
-            () -> ElasticRerankerServiceSettings.fromMap(settingsMap)
+            () -> ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
         );
 
         assertTrue(
@@ -161,7 +163,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
             Optional.empty()
         );
 
-        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap);
+        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST);
         assertExpectedSettings(
             settings,
             Optional.ofNullable(numAllocations),
@@ -195,7 +197,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
 
         ValidationException exception = Assert.assertThrows(
             ValidationException.class,
-            () -> ElasticRerankerServiceSettings.fromMap(settingsMap)
+            () -> ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
         );
 
         assertTrue(
@@ -223,7 +225,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
             Optional.of(maxChunksPerDoc)
         );
 
-        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap);
+        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST);
         assertExpectedSettings(
             settings,
             Optional.ofNullable(numAllocations),
@@ -255,7 +257,7 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
             Optional.of(maxChunksPerDoc)
         );
 
-        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap);
+        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST);
         assertExpectedSettings(
             settings,
             Optional.ofNullable(numAllocations),
@@ -264,6 +266,88 @@ public class ElasticRerankerServiceSettingsTests extends AbstractElasticsearchIn
             Optional.ofNullable(adaptiveAllocationsSettings),
             Optional.of(longDocumentStrategy),
             Optional.of(maxChunksPerDoc)
+        );
+    }
+
+    public void testFromMap_InvalidLongDocumentStrategy_ThrowsException() {
+        var settingsMap = buildServiceSettingsMap(
+            Optional.of(1),
+            1,
+            randomAlphaOfLength(8),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()
+        );
+        settingsMap.put(LONG_DOCUMENT_STRATEGY, "invalid_strategy");
+
+        var exception = Assert.assertThrows(
+            XContentParseException.class,
+            () -> ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
+        );
+
+        assertTrue(exception.getCause().getMessage().contains("Invalid value [invalid_strategy]; expected one of [chunk, truncate]"));
+    }
+
+    public void testFromMap_InvalidMaxChunksPerDoc_ThrowsException() {
+        var settingsMap = buildServiceSettingsMap(
+            Optional.of(1),
+            1,
+            randomAlphaOfLength(8),
+            Optional.empty(),
+            Optional.of(ElasticRerankerServiceSettings.LongDocumentStrategy.CHUNK),
+            Optional.of(randomIntBetween(Integer.MIN_VALUE, 0))
+        );
+
+        var exception = Assert.assertThrows(
+            XContentParseException.class,
+            () -> ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
+        );
+
+        assertTrue(exception.getCause().getMessage().contains("[max_chunks_per_doc] must be a positive integer"));
+    }
+
+    public void testFromMap_UnknownField_ThrowsExceptionInRequestContext() {
+        var settingsMap = buildServiceSettingsMap(
+            Optional.of(1),
+            1,
+            randomAlphaOfLength(8),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()
+        );
+        settingsMap.put("unknown_field", "value");
+
+        var exception = Assert.assertThrows(
+            XContentParseException.class,
+            () -> ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.REQUEST)
+        );
+
+        assertTrue(exception.getMessage().contains("unknown field [unknown_field]"));
+    }
+
+    public void testFromMap_UnknownField_IgnoredInPersistentContext() {
+        var numAllocations = randomIntBetween(1, 10);
+        var numThreads = randomIntBetween(1, 10);
+        var modelId = randomAlphaOfLength(8);
+        var settingsMap = buildServiceSettingsMap(
+            Optional.of(numAllocations),
+            numThreads,
+            modelId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()
+        );
+        settingsMap.put("unknown_field_from_a_future_version", "value");
+
+        ElasticRerankerServiceSettings settings = ElasticRerankerServiceSettings.fromMap(settingsMap, ConfigurationParseContext.PERSISTENT);
+        assertExpectedSettings(
+            settings,
+            Optional.of(numAllocations),
+            numThreads,
+            modelId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 
 import java.io.IOException;
@@ -133,14 +134,56 @@ public class ElasticsearchInternalServiceSettingsTests extends AbstractElasticse
         );
     }
 
-    public void testFromMapInvalidSettings() {
+    public void testFromMapInvalidNumAllocations() {
         var settingsMap = new HashMap<String, Object>(
-            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 0, ElasticsearchInternalServiceSettings.NUM_THREADS, -1)
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 0, ElasticsearchInternalServiceSettings.NUM_THREADS, 1)
         );
-        var e = expectThrows(ValidationException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
+        var e = expectThrows(XContentParseException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
 
-        assertThat(e.getMessage(), containsString("Invalid value [0]. [num_allocations] must be a positive integer"));
-        assertThat(e.getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [0]. [num_allocations] must be a positive integer"));
+    }
+
+    public void testFromMapInvalidNumThreads() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, -1)
+        );
+        var e = expectThrows(XContentParseException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
+
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
+    }
+
+    public void testFromMapUnknownFieldInRequestContext() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(
+                ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                ElasticsearchInternalServiceSettings.NUM_THREADS,
+                1,
+                "unknown_field",
+                "value"
+            )
+        );
+        var e = expectThrows(XContentParseException.class, () -> ElasticsearchInternalServiceSettings.fromRequestMap(settingsMap));
+
+        assertThat(e.getMessage(), containsString("unknown field [unknown_field]"));
+    }
+
+    public void testFromPersistedMapIgnoresUnknownFields() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(
+                ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                ElasticsearchInternalServiceSettings.NUM_THREADS,
+                4,
+                ElasticsearchInternalServiceSettings.MODEL_ID,
+                ".elser_model_1",
+                "unknown_field",
+                "value"
+            )
+        );
+        var serviceSettings = ElasticsearchInternalServiceSettings.fromPersistedMap(settingsMap);
+
+        assertEquals(new ElasticsearchInternalServiceSettings(1, 4, ".elser_model_1", null, null), serviceSettings);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -55,6 +54,7 @@ import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
@@ -314,7 +314,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
 
             ActionListener<Model> modelListener = ActionListener.<Model>wrap(
                 model -> fail("Model parsing should have failed"),
-                e -> assertThat(e, instanceOf(ElasticsearchStatusException.class))
+                e -> assertThat(e, instanceOf(XContentParseException.class))
             );
 
             service.parseRequestConfig(randomInferenceEntityId, TaskType.TEXT_EMBEDDING, settings, modelListener);
@@ -484,7 +484,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
 
             ActionListener<Model> modelListener = ActionListener.<Model>wrap(
                 model -> fail("Model parsing should have failed"),
-                e -> assertThat(e, instanceOf(ElasticsearchStatusException.class))
+                e -> assertThat(e, instanceOf(XContentParseException.class))
             );
 
             service.parseRequestConfig(randomInferenceEntityId, TaskType.SPARSE_EMBEDDING, config, modelListener);
@@ -2554,10 +2554,10 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
 
         var serviceSettingsWithNumThreads = new HashMap<String, Object>(Map.of(ElasticsearchInternalServiceSettings.NUM_THREADS, 8));
         var exception = expectThrows(
-            ValidationException.class,
+            XContentParseException.class,
             () -> existingSettings.updateServiceSettings(serviceSettingsWithNumThreads)
         );
-        assertThat(exception.getMessage(), containsString("[num_threads] cannot be updated"));
+        assertThat(exception.getCause().getMessage(), containsString("[num_threads] cannot be updated"));
     }
 
     private ElasticsearchInternalService createService(Client client) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalTextEmbeddingServiceSettingsTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationSettingsTests;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
@@ -28,6 +29,7 @@ import java.util.Map;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.ELEMENT_TYPE;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_THREADS;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -125,46 +127,106 @@ public class ElasticsearchInternalTextEmbeddingServiceSettingsTests extends Abst
         );
     }
 
-    public void testFromMap_Request_IgnoresDimensions() {
-        var modelId = "model-foo";
-        var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
-        var numAllocations = 1;
-        var numThreads = 1;
+    public void testFromMap_Request_RejectsDimensions() {
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ServiceFields.MODEL_ID,
+                "model-foo",
+                NUM_ALLOCATIONS,
+                1,
+                NUM_THREADS,
+                1,
+                ServiceFields.SIMILARITY,
+                SimilarityMeasure.DOT_PRODUCT.toString(),
+                ELEMENT_TYPE,
+                DenseVectorFieldMapper.ElementType.FLOAT.toString(),
+                ServiceFields.DIMENSIONS,
+                1
+            )
+        );
+
+        var e = expectThrows(
+            XContentParseException.class,
+            () -> ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(e.getMessage(), containsString("unknown field [dimensions]"));
+    }
+
+    public void testFromMap_Request_InvalidElementType_ThrowsException() {
+        var map = new HashMap<String, Object>(
+            Map.of(ServiceFields.MODEL_ID, "model-foo", NUM_ALLOCATIONS, 1, NUM_THREADS, 1, ELEMENT_TYPE, "bit")
+        );
+
+        var e = expectThrows(
+            XContentParseException.class,
+            () -> ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [bit]; expected one of [byte, float]"));
+    }
+
+    public void testFromMap_Request_InvalidSimilarity_ThrowsException() {
+        var map = new HashMap<String, Object>(
+            Map.of(ServiceFields.MODEL_ID, "model-foo", NUM_ALLOCATIONS, 1, NUM_THREADS, 1, ServiceFields.SIMILARITY, "not_similar")
+        );
+
+        var e = expectThrows(
+            XContentParseException.class,
+            () -> ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [not_similar]; expected one of"));
+    }
+
+    public void testFromMap_Request_UnknownField_ThrowsException() {
+        var map = new HashMap<String, Object>(
+            Map.of(ServiceFields.MODEL_ID, "model-foo", NUM_ALLOCATIONS, 1, NUM_THREADS, 1, "unknown_field", "value")
+        );
+
+        var e = expectThrows(
+            XContentParseException.class,
+            () -> ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(map, ConfigurationParseContext.REQUEST)
+        );
+
+        assertThat(e.getMessage(), containsString("unknown field [unknown_field]"));
+    }
+
+    public void testFromMap_Persistent_IgnoresUnknownFields() {
         var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(
             new HashMap<>(
-                Map.of(
-                    ServiceFields.MODEL_ID,
-                    modelId,
-                    NUM_ALLOCATIONS,
-                    numAllocations,
-                    NUM_THREADS,
-                    numThreads,
-                    ServiceFields.SIMILARITY,
-                    similarity,
-                    ELEMENT_TYPE,
-                    DenseVectorFieldMapper.ElementType.FLOAT.toString(),
-                    ServiceFields.DIMENSIONS,
-                    1
-                )
+                Map.of(ServiceFields.MODEL_ID, "model-foo", NUM_ALLOCATIONS, 1, NUM_THREADS, 1, "unknown_field_from_the_future", "value")
             ),
-            ConfigurationParseContext.REQUEST
+            ConfigurationParseContext.PERSISTENT
         );
 
         assertThat(
             serviceSettings,
             is(
                 new ElasticsearchInternalTextEmbeddingServiceSettings(
-                    numAllocations,
-                    numThreads,
-                    modelId,
+                    1,
+                    1,
+                    "model-foo",
                     null,
                     null,
                     null,
-                    SimilarityMeasure.DOT_PRODUCT,
+                    SimilarityMeasure.COSINE,
                     DenseVectorFieldMapper.ElementType.FLOAT
                 )
             )
         );
+    }
+
+    public void testFromMapWithBuilder_LeavesUnparsedFieldsInMap() {
+        var builder = new ElasticsearchInternalServiceSettings.Builder().setNumAllocations(1).setNumThreads(1).setModelId("model-foo");
+        var map = new HashMap<String, Object>(
+            Map.of(ServiceFields.SIMILARITY, SimilarityMeasure.DOT_PRODUCT.toString(), NUM_ALLOCATIONS, 2)
+        );
+
+        var serviceSettings = ElasticsearchInternalTextEmbeddingServiceSettings.fromMap(map, builder);
+
+        assertThat(serviceSettings.similarity(), is(SimilarityMeasure.DOT_PRODUCT));
+        assertThat(map, is(Map.of(NUM_ALLOCATIONS, 2)));
     }
 
     public void testFromMap_Persistent_CreatesSettingsCorrectly() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalServiceSettingsTests.java
@@ -9,9 +9,12 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.io.stream.Writeable;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModelsTests.randomElserModel;
+import static org.hamcrest.Matchers.is;
 
 public class ElserInternalServiceSettingsTests extends AbstractElasticsearchInternalServiceSettingsTests<ElserInternalServiceSettings> {
 
@@ -65,6 +68,55 @@ public class ElserInternalServiceSettingsTests extends AbstractElasticsearchInte
             }
             default -> throw new IllegalStateException();
         };
+    }
+
+    /**
+     * Mirrors the persisted path taken by {@code ElserInternalModelCreator}: the base settings are parsed leniently from the
+     * stored config and wrapped in the ELSER-specific type.
+     */
+    public void testFromPersistedMap_CreatesElserSettings_IgnoringUnknownFields() {
+        var modelId = randomElserModel();
+        var map = new HashMap<String, Object>(
+            Map.of(
+                ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                ElasticsearchInternalServiceSettings.NUM_THREADS,
+                4,
+                ElasticsearchInternalServiceSettings.MODEL_ID,
+                modelId,
+                "unknown_field_from_a_future_version",
+                "value"
+            )
+        );
+
+        var serviceSettings = new ElserInternalServiceSettings(ElasticsearchInternalServiceSettings.fromPersistedMap(map));
+
+        assertThat(
+            serviceSettings,
+            is(new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, modelId, null, null)))
+        );
+    }
+
+    /**
+     * Mirrors the request path taken by {@code elserCase} in {@code ElasticsearchInternalService}: the base settings builder is
+     * parsed strictly from the request and the ELSER default model id is applied before wrapping.
+     */
+    public void testFromRequestMap_BuilderWrapsIntoElserSettings_AfterModelDefaulting() {
+        var map = new HashMap<String, Object>(
+            Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, 4)
+        );
+        var defaultModelId = randomElserModel();
+
+        var builder = ElasticsearchInternalServiceSettings.fromRequestMap(map);
+        assertNull(builder.getModelId());
+        builder.setModelId(defaultModelId);
+
+        var serviceSettings = new ElserInternalServiceSettings(builder.build());
+
+        assertThat(
+            serviceSettings,
+            is(new ElserInternalServiceSettings(new ElasticsearchInternalServiceSettings(1, 4, defaultModelId, null, null)))
+        );
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.XContentParseException;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,19 +71,43 @@ public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractEla
         );
     }
 
-    public void testFromMapInvalidSettings() {
+    public void testFromMapInvalidNumAllocations() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(MultilingualE5SmallInternalServiceSettings.NUM_ALLOCATIONS, 0, MultilingualE5SmallInternalServiceSettings.NUM_THREADS, 1)
+        );
+        var e = expectThrows(XContentParseException.class, () -> MultilingualE5SmallInternalServiceSettings.fromRequestMap(settingsMap));
+
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [0]. [num_allocations] must be a positive integer"));
+    }
+
+    public void testFromMapInvalidNumThreads() {
         var settingsMap = new HashMap<String, Object>(
             Map.of(
                 MultilingualE5SmallInternalServiceSettings.NUM_ALLOCATIONS,
-                0,
+                1,
                 MultilingualE5SmallInternalServiceSettings.NUM_THREADS,
                 -1
             )
         );
-        var e = expectThrows(ValidationException.class, () -> MultilingualE5SmallInternalServiceSettings.fromRequestMap(settingsMap));
+        var e = expectThrows(XContentParseException.class, () -> MultilingualE5SmallInternalServiceSettings.fromRequestMap(settingsMap));
 
-        assertThat(e.getMessage(), containsString("Invalid value [0]. [num_allocations] must be a positive integer"));
-        assertThat(e.getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
+        assertThat(e.getCause().getMessage(), containsString("Invalid value [-1]. [num_threads] must be a positive integer"));
+    }
+
+    public void testFromMapUnknownFieldInRequestContext() {
+        var settingsMap = new HashMap<String, Object>(
+            Map.of(
+                MultilingualE5SmallInternalServiceSettings.NUM_ALLOCATIONS,
+                1,
+                MultilingualE5SmallInternalServiceSettings.NUM_THREADS,
+                1,
+                "unknown_field",
+                "value"
+            )
+        );
+        var e = expectThrows(XContentParseException.class, () -> MultilingualE5SmallInternalServiceSettings.fromRequestMap(settingsMap));
+
+        assertThat(e.getMessage(), containsString("unknown field [unknown_field]"));
     }
 
     @Override


### PR DESCRIPTION
Refactoring parsing logic of `ElasticsearchInternalTextEmbeddingServiceSettings` (renamed from `CustomElandInternalTextEmbeddingServiceSettings` in #153688) to use the ObjectParser framework, reusing the base-class parser declarations from https://github.com/elastic/elasticsearch/pull/154961. Also removes the now-unused legacy map-extraction helper from `ElasticsearchInternalServiceSettings` — this was its last caller.

**Stacked on #154965 / #154964 / #154962 / #154961 — review the last commit only.**

Notable behavior notes:
- `dimensions` is declared only on the persistent parser: user requests supplying it now fail with `XContentParseException` ("unknown field [dimensions]") at parse time instead of the later unconsumed-map `ElasticsearchStatusException`; persisted values are now validated as positive integers (previously a corrupt persisted value was silently dropped).
- The two-arg `fromMap(map, builder)` used by the deployment-id path parses leniently and consumes only `similarity`/`element_type`, so leftover request fields still fail the service's unknown-settings check as before.
- Persisted configs are now validated for the required fields (`num_threads`, one of `num_allocations`/`adaptive_allocations`) like the other internal settings; previously this class discarded those errors on the persisted path.

Based off the following PRs: https://github.com/elastic/elasticsearch/pull/149471, https://github.com/elastic/elasticsearch/pull/152922 and https://github.com/elastic/elasticsearch/pull/154441.

Closes https://github.com/elastic/search-team/issues/14785