### PR TITLE
Use correct recovery priority for unassigned shards

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -155,8 +155,8 @@ public final class ShardRouting implements Writeable, ToXContentObject {
                 assert recoverySource != null : state + " shard must be created with a recovery source" + this;
                 assert primary ^ recoverySource == PeerRecoverySource.INSTANCE : "replica shards always recover from primary " + this;
                 assert recoveryPriority != null : state + " shard must be created with a recovery priority " + this;
-                assert !recoveryPriority.isRelocation()
-                    : state + " shard must be created with a recovery priority consistent with its relocation status " + this;
+                assert recoveryPriority == unassignedInfo.recoveryPriority()
+                    : state + " shard must be created with a recovery priority consistent with its unassigned info " + this;
             }
             case INITIALIZING -> {
                 assert currentNodeId != null : state + " shard must be assigned to a node " + this;
@@ -164,8 +164,13 @@ public final class ShardRouting implements Writeable, ToXContentObject {
                 assert recoverySource != null : state + "shard must be created with a recovery source " + this;
                 assert primary || recoverySource == PeerRecoverySource.INSTANCE : "replica shards always recover from primary " + this;
                 assert recoveryPriority != null : state + " shard must be created with a recovery priority " + this;
-                assert recoveryPriority.isRelocation() == (relocatingNodeId != null)
-                    : state + " shard must be created with a recovery priority consistent with its unassigned/relocation status " + this;
+                if (unassignedInfo != null) {
+                    assert recoveryPriority == unassignedInfo.recoveryPriority()
+                        : state + " shard must be created with a recovery priority consistent with its unassigned info " + this;
+                } else {
+                    assert recoveryPriority.isRelocation()
+                        : state + " shard must be created with a recovery priority consistent with its relocation status " + this;
+                }
             }
             case STARTED -> {
                 assert currentNodeId != null : state + " shard must be assigned to a node " + this;
@@ -229,9 +234,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
             primary,
             ShardRoutingState.UNASSIGNED,
             recoverySource,
-            // TODO: Populate this with the correct priority. For now, we use the higher of the two choices for a recovery from unassigned.
-            // As long as master-side recovery throttling is in effect, the priority is not that important.
-            RecoveryPriority.UNASSIGNED_EXISTING,
+            unassignedInfo.recoveryPriority(),
             unassignedInfo,
             RelocationFailureInfo.NO_FAILURES,
             null,
@@ -497,7 +500,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
             primary,
             state,
             recoverySource,
-            recoveryPriority,
+            unassignedInfo.recoveryPriority(),
             unassignedInfo,
             relocationFailureInfo,
             allocationId,
@@ -546,9 +549,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
             primary,
             ShardRoutingState.UNASSIGNED,
             recoverySource,
-            state == ShardRoutingState.INITIALIZING && unassignedInfo != null
-                ? recoveryPriority // Shard was previously initializing from unassigned, so keep the same recovery priority
-                : RecoveryPriority.UNASSIGNED_EXISTING, // Shard must previously have been started or relocating, so must be existing
+            unassignedInfo.recoveryPriority(),
             unassignedInfo,
             RelocationFailureInfo.NO_FAILURES,
             null,
@@ -647,6 +648,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
         assert assignedToNode() : this;
         assert relocatingNodeId != null : this;
         assert unassignedInfo == null : this;
+        UnassignedInfo newUnassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.REINITIALIZED, null);
         return new ShardRouting(
             shardId,
             currentNodeId,
@@ -654,8 +656,8 @@ public final class ShardRouting implements Writeable, ToXContentObject {
             primary,
             state,
             recoverySource,
-            RecoveryPriority.UNASSIGNED_EXISTING, // increase the recovery priority to reflect the fact that this is now unassigned
-            new UnassignedInfo(UnassignedInfo.Reason.REINITIALIZED, null),
+            newUnassignedInfo.recoveryPriority(), // increase the recovery priority to reflect the fact that this is now unassigned
+            newUnassignedInfo,
             relocationFailureInfo,
             AllocationId.finishRelocation(allocationId),
             expectedShardSize,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -103,61 +103,61 @@ public record UnassignedInfo(
         /**
          * Unassigned as a result of an API creation of an index.
          */
-        INDEX_CREATED(true),
+        INDEX_CREATED(true, false),
         /**
          * Unassigned as a result of a full cluster recovery.
          */
-        CLUSTER_RECOVERED(false),
+        CLUSTER_RECOVERED(false, true),
         /**
          * Unassigned as a result of opening a closed index.
          */
-        INDEX_REOPENED(true),
+        INDEX_REOPENED(true, true),
         /**
          * Unassigned as a result of importing a dangling index.
          */
-        DANGLING_INDEX_IMPORTED(true),
+        DANGLING_INDEX_IMPORTED(true, true),
         /**
          * Unassigned as a result of restoring into a new index.
          */
-        NEW_INDEX_RESTORED(true),
+        NEW_INDEX_RESTORED(true, false),
         /**
          * Unassigned as a result of restoring into a closed index.
          */
-        EXISTING_INDEX_RESTORED(true),
+        EXISTING_INDEX_RESTORED(true, true),
         /**
          * Unassigned as a result of explicit addition of a replica.
          */
-        REPLICA_ADDED(true),
+        REPLICA_ADDED(true, false),
         /**
          * Unassigned as a result of a failed allocation of the shard.
          */
-        ALLOCATION_FAILED(false),
+        ALLOCATION_FAILED(false, true),
         /**
          * Unassigned as a result of the node hosting it leaving the cluster.
          */
-        NODE_LEFT(false),
+        NODE_LEFT(false, true),
         /**
          * Unassigned as a result of explicit cancel reroute command.
          */
-        REROUTE_CANCELLED(true),
+        REROUTE_CANCELLED(true, true),
         /**
          * A replica shard which restarted initialization either because the primary changed or because it was previously a relocation
          * target whose relocation source has failed; the "source" of a replica relocation isn't the source of its data, that's the primary,
          * but we represent the movement of a STARTED replica shard as if it was.
          */
-        REINITIALIZED(false),
+        REINITIALIZED(false, true),
         /**
          * A better replica location is identified and causes the existing replica allocation to be cancelled.
          */
-        REALLOCATED_REPLICA(false),
+        REALLOCATED_REPLICA(false, true),
         /**
          * Unassigned as a result of a failed primary while the replica was initializing.
          */
-        PRIMARY_FAILED(false),
+        PRIMARY_FAILED(false, true),
         /**
          * Unassigned after forcing an empty primary
          */
-        FORCED_EMPTY_PRIMARY(true),
+        FORCED_EMPTY_PRIMARY(true, true),
         /**
          * Manual allocation via the cluster reroute API, to force allocation of a shard and/or to reset the
          * allocation failure counter.
@@ -166,33 +166,35 @@ public record UnassignedInfo(
          * cluster topology changes (e.g., new node joining).
          * See https://github.com/elastic/elasticsearch-team/issues/4064 for more details
          */
-        MANUAL_ALLOCATION(true),
+        MANUAL_ALLOCATION(true, true),
         /**
          * Unassigned as a result of closing an index.
          */
-        INDEX_CLOSED(true),
+        INDEX_CLOSED(true, true),
         /**
          * Similar to NODE_LEFT, but at the time the node left, it had been registered for a restart via the Node Shutdown API. Note that
          * there is no verification that it was ready to be restarted, so this may be an intentional restart or a node crash.
          */
-        NODE_RESTARTING(false),
+        NODE_RESTARTING(false, true),
         /**
          * Replica is unpromotable and the primary failed.
          */
-        UNPROMOTABLE_REPLICA(false),
+        UNPROMOTABLE_REPLICA(false, true),
         /**
          * New shard added as part of index re-sharding operation
          */
-        RESHARD_ADDED(true),
+        RESHARD_ADDED(true, false),
         /**
          * The master node deliberately direct cancelled an in-progress recovery (via `TransportCancelRecoveriesAction`).
          */
-        RECOVERY_CANCELLED(true);
+        RECOVERY_CANCELLED(true, true);
 
         private final boolean isExpectedTransient;
+        private final boolean isExistingShard;
 
-        Reason(boolean isExpectedTransient) {
+        Reason(boolean isExpectedTransient, boolean isExistingShard) {
             this.isExpectedTransient = isExpectedTransient;
+            this.isExistingShard = isExistingShard;
         }
 
         /// Returns `true` if this unassignment reason represents an expected transient event (e.g. index creation,
@@ -411,6 +413,13 @@ public record UnassignedInfo(
             .orElse(indexLevelDelay);
         assert nanoTimeNow - unassignedTimeNanos >= 0;
         return Math.max(0L, delayTimeoutNanos - (nanoTimeNow - unassignedTimeNanos));
+    }
+
+    /// Returns the priority to use when recovering the unassigned shard.
+    public ShardRouting.RecoveryPriority recoveryPriority() {
+        return this.reason().isExistingShard
+            ? ShardRouting.RecoveryPriority.UNASSIGNED_EXISTING
+            : ShardRouting.RecoveryPriority.UNASSIGNED_NEW;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -617,7 +617,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "another-index",
                                   "recovery_source": { "type": "EMPTY_STORE" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -634,7 +634,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "another-index",
                                   "recovery_source": { "type": "PEER" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -657,7 +657,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "common-index",
                                   "recovery_source": { "type": "EMPTY_STORE" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -674,7 +674,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "common-index",
                                   "recovery_source": { "type": "PEER" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -691,7 +691,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "common-index",
                                   "recovery_source": { "type": "PEER" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -723,7 +723,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "common-index",
                                   "recovery_source": { "type": "EMPTY_STORE" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -740,7 +740,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 0,
                                   "index": "common-index",
                                   "recovery_source": { "type": "PEER" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -759,7 +759,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 1,
                                   "index": "common-index",
                                   "recovery_source": { "type": "EMPTY_STORE" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -776,7 +776,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 1,
                                   "index": "common-index",
                                   "recovery_source": { "type": "PEER" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -795,7 +795,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 2,
                                   "index": "common-index",
                                   "recovery_source": { "type": "EMPTY_STORE" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",
@@ -812,7 +812,7 @@ public class ClusterStateTests extends ESTestCase {
                                   "shard": 2,
                                   "index": "common-index",
                                   "recovery_source": { "type": "PEER" },
-                                  "recovery_priority": "UNASSIGNED_EXISTING",
+                                  "recovery_priority": "UNASSIGNED_NEW",
                                   "unassigned_info": {
                                     "reason": "INDEX_CREATED",
                                     "at": "_DATE_",

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTableTests.java
@@ -165,6 +165,7 @@ public class IndexRoutingTableTests extends ESTestCase {
 
     private ShardRouting getShard(ShardId shardId, boolean isPrimary, ShardRoutingState state, ShardRouting.Role role) {
         final boolean hasRelocatingNodeId = TestShardRouting.randomHasRelocatingNodeId(state);
+        UnassignedInfo unassignedInfo = TestShardRouting.buildUnassignedInfo(state, hasRelocatingNodeId);
         return new ShardRouting(
             shardId,
             state == ShardRoutingState.UNASSIGNED ? null : randomIdentifier(),
@@ -172,8 +173,8 @@ public class IndexRoutingTableTests extends ESTestCase {
             isPrimary,
             state,
             TestShardRouting.buildRecoverySource(isPrimary, state),
-            TestShardRouting.buildRecoveryPriority(state, hasRelocatingNodeId),
-            TestShardRouting.buildUnassignedInfo(state, hasRelocatingNodeId),
+            TestShardRouting.buildRecoveryPriority(state, unassignedInfo),
+            unassignedInfo,
             TestShardRouting.buildRelocationFailureInfo(state),
             TestShardRouting.buildAllocationId(state),
             randomLongBetween(-1, 1024),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElseGet;
 import static org.elasticsearch.cluster.routing.TestShardRouting.randomHasRelocatingNodeId;
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
@@ -42,6 +43,7 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
         var state = randomFrom(ShardRoutingState.values());
         var primary = randomBoolean();
         var hasRelocatingNodeId = randomHasRelocatingNodeId(state);
+        UnassignedInfo unassignedInfo = TestShardRouting.buildUnassignedInfo(state, hasRelocatingNodeId);
         return new ShardRouting(
             new ShardId(randomIdentifier(), UUIDs.randomBase64UUID(), randomIntBetween(0, 99)),
             state == ShardRoutingState.UNASSIGNED ? null : randomIdentifier(),
@@ -49,8 +51,8 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
             primary,
             state,
             TestShardRouting.buildRecoverySource(primary, state),
-            TestShardRouting.buildRecoveryPriority(state, hasRelocatingNodeId),
-            TestShardRouting.buildUnassignedInfo(state, hasRelocatingNodeId),
+            TestShardRouting.buildRecoveryPriority(state, unassignedInfo),
+            unassignedInfo,
             TestShardRouting.buildRelocationFailureInfo(state),
             TestShardRouting.buildAllocationId(state),
             randomLongBetween(-1, 1024),
@@ -94,6 +96,14 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
     private static ShardRouting mutateState(ShardRouting instance) {
         var newState = randomValueOtherThan(instance.state(), () -> randomFrom(ShardRoutingState.values()));
         var newHasRelocatingNodeId = randomHasRelocatingNodeId(newState);
+        UnassignedInfo newUnassignedInfo = newState == ShardRoutingState.STARTED
+            || newState == ShardRoutingState.RELOCATING
+            || (newState == ShardRoutingState.INITIALIZING && newHasRelocatingNodeId)
+                ? null
+                : requireNonNullElseGet(
+                    instance.unassignedInfo(),
+                    () -> TestShardRouting.buildUnassignedInfo(newState, newHasRelocatingNodeId)
+                );
         return new ShardRouting(
             instance.shardId(),
             newState == ShardRoutingState.UNASSIGNED ? null : requireNonNullElseGet(instance.currentNodeId(), ESTestCase::randomIdentifier),
@@ -108,26 +118,18 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                 ),
             switch (newState) {
                 // Keep the existing recovery priority iff it is inconsistent with the newState and newHasRelocatingNodeId, else randomize:
-                case INITIALIZING -> (instance.recoveryPriority() != null
-                    && instance.recoveryPriority().isRelocation() == newHasRelocatingNodeId)
+                case INITIALIZING -> newUnassignedInfo != null
+                    ? newUnassignedInfo.recoveryPriority()
+                    : ((instance.recoveryPriority() != null && instance.recoveryPriority().isRelocation())
                         ? instance.recoveryPriority()
-                        : TestShardRouting.buildRecoveryPriority(newState, newHasRelocatingNodeId);
-                case UNASSIGNED -> (instance.recoveryPriority() != null && !instance.recoveryPriority().isRelocation())
+                        : TestShardRouting.buildRecoveryPriority(newState, null));
+                case UNASSIGNED -> requireNonNull(newUnassignedInfo).recoveryPriority();
+                case RELOCATING -> ((instance.recoveryPriority() != null && instance.recoveryPriority().isRelocation())
                     ? instance.recoveryPriority()
-                    : TestShardRouting.buildRecoveryPriority(newState, newHasRelocatingNodeId);
-                case RELOCATING -> (instance.recoveryPriority() != null && instance.recoveryPriority().isRelocation())
-                    ? instance.recoveryPriority()
-                    : TestShardRouting.buildRecoveryPriority(newState, newHasRelocatingNodeId);
+                    : TestShardRouting.buildRecoveryPriority(newState, null));
                 case STARTED -> null;
             },
-            newState == ShardRoutingState.STARTED
-                || newState == ShardRoutingState.RELOCATING
-                || (newState == ShardRoutingState.INITIALIZING && newHasRelocatingNodeId)
-                    ? null
-                    : requireNonNullElseGet(
-                        instance.unassignedInfo(),
-                        () -> TestShardRouting.buildUnassignedInfo(newState, newHasRelocatingNodeId)
-                    ),
+            newUnassignedInfo,
             instance.relocationFailureInfo(),
             switch (newState) {
                 case UNASSIGNED -> null;
@@ -388,8 +390,9 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                     }
                     break;
                 case 5:
-                    // change recovery priority (does not work when starting, when there is no recovery priority)
-                    if (otherRouting.started()) {
+                    // change recovery priority (does not work when starting, when there is no recovery priority, or when unassigned or
+                    // recovering from unassigned, when there is only one valid priority)
+                    if (otherRouting.started() || otherRouting.unassignedInfo() != null) {
                         unchanged = true;
                     } else {
                         otherRouting = new ShardRouting(
@@ -399,7 +402,7 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                             otherRouting.primary(),
                             otherRouting.state(),
                             otherRouting.recoverySource(),
-                            TestShardRouting.buildRecoveryPriority(otherRouting.state(), otherRouting.relocatingNodeId() != null),
+                            TestShardRouting.buildRecoveryPriority(otherRouting.state(), otherRouting.unassignedInfo()),
                             otherRouting.unassignedInfo(),
                             otherRouting.relocationFailureInfo(),
                             otherRouting.allocationId(),

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/ShardRoutingHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/ShardRoutingHelper.java
@@ -11,6 +11,8 @@ package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A helper class that allows access to package private APIs for testing.
  */
@@ -41,6 +43,9 @@ public class ShardRoutingHelper {
     }
 
     public static ShardRouting initWithSameId(ShardRouting copy, RecoverySource recoverySource) {
+        UnassignedInfo unassignedInfo = copy.relocatingNodeId() != null
+            ? null
+            : new UnassignedInfo(UnassignedInfo.Reason.REINITIALIZED, null);
         return new ShardRouting(
             copy.shardId(),
             copy.currentNodeId(),
@@ -48,10 +53,9 @@ public class ShardRoutingHelper {
             copy.primary(),
             ShardRoutingState.INITIALIZING,
             recoverySource,
-            copy.relocatingNodeId() != null
-                ? ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
-                : ShardRouting.RecoveryPriority.UNASSIGNED_EXISTING, // for testing, use arbitrary (highest) allowed priority
-            copy.relocatingNodeId() != null ? null : new UnassignedInfo(UnassignedInfo.Reason.REINITIALIZED, null),
+            // If unassigned, use the correct priority for the info given; if relocating, arbitrarily use the highest valid priority:
+            unassignedInfo != null ? unassignedInfo.recoveryPriority() : ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO,
+            unassignedInfo,
             RelocationFailureInfo.NO_FAILURES,
             copy.allocationId(),
             copy.getExpectedShardSize(),
@@ -72,11 +76,11 @@ public class ShardRoutingHelper {
             routing.state(),
             recoverySource,
             switch (routing.state()) {
-                // for testing, use arbitrary (highest) priority
-                case INITIALIZING -> routing.relocatingNodeId() != null
-                    ? ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
-                    : ShardRouting.RecoveryPriority.UNASSIGNED_EXISTING;
-                case UNASSIGNED -> ShardRouting.RecoveryPriority.UNASSIGNED_EXISTING;
+                // If unassigned, use the correct priority for the info given; if relocating, arbitrarily use the highest valid priority:
+                case INITIALIZING -> routing.unassignedInfo() != null
+                    ? routing.unassignedInfo().recoveryPriority()
+                    : ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO;
+                case UNASSIGNED -> requireNonNull(routing.unassignedInfo()).recoveryPriority();
                 case RELOCATING -> ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO;
                 case STARTED -> null;
             },

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -21,6 +21,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.cluster.routing.AllocationId.newInitializing;
 import static org.elasticsearch.cluster.routing.AllocationId.newRelocation;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
@@ -114,6 +115,9 @@ public class TestShardRouting {
         }
 
         public ShardRouting build() {
+            UnassignedInfo newUnassignedInfo = unassignedInfo != null
+                ? unassignedInfo
+                : buildUnassignedInfo(state, relocatingNodeId != null);
             return new ShardRouting(
                 shardId,
                 currentNodeId,
@@ -121,8 +125,8 @@ public class TestShardRouting {
                 primary,
                 state,
                 recoverySource != null ? recoverySource : buildRecoverySource(primary, state),
-                recoveryPriority != null ? recoveryPriority : buildRecoveryPriority(state, relocatingNodeId != null),
-                unassignedInfo != null ? unassignedInfo : buildUnassignedInfo(state, relocatingNodeId != null),
+                recoveryPriority != null ? recoveryPriority : buildRecoveryPriority(state, newUnassignedInfo),
+                newUnassignedInfo,
                 relocationFailureInfo != null ? relocationFailureInfo : buildRelocationFailureInfo(state),
                 allocationId != null ? allocationId : buildAllocationId(state),
                 expectedShardSize != null ? expectedShardSize : ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
@@ -157,6 +161,7 @@ public class TestShardRouting {
         ShardRouting.Role role
     ) {
         assertNotEquals(ShardRoutingState.RELOCATING, state);
+        UnassignedInfo unassignedInfo = buildUnassignedInfo(state, false);
         return new ShardRouting(
             shardId,
             currentNodeId,
@@ -164,8 +169,8 @@ public class TestShardRouting {
             primary,
             state,
             buildRecoverySource(primary, state),
-            buildRecoveryPriority(state, false),
-            buildUnassignedInfo(state, false),
+            buildRecoveryPriority(state, unassignedInfo),
+            unassignedInfo,
             buildRelocationFailureInfo(state),
             buildAllocationId(state),
             ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
@@ -182,6 +187,7 @@ public class TestShardRouting {
         ShardRouting.Role role
     ) {
         assertNotEquals(ShardRoutingState.RELOCATING, state);
+        UnassignedInfo unassignedInfo = buildUnassignedInfo(state, false);
         return new ShardRouting(
             shardId,
             currentNodeId,
@@ -189,8 +195,8 @@ public class TestShardRouting {
             primary,
             state,
             recoverySource,
-            buildRecoveryPriority(state, false),
-            buildUnassignedInfo(state, false),
+            buildRecoveryPriority(state, unassignedInfo),
+            unassignedInfo,
             buildRelocationFailureInfo(state),
             buildAllocationId(state),
             ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
@@ -222,6 +228,7 @@ public class TestShardRouting {
         boolean primary,
         ShardRoutingState state
     ) {
+        UnassignedInfo unassignedInfo = buildUnassignedInfo(state, relocatingNodeId != null);
         return new ShardRouting(
             shardId,
             currentNodeId,
@@ -229,8 +236,8 @@ public class TestShardRouting {
             primary,
             state,
             buildRecoverySource(primary, state),
-            buildRecoveryPriority(state, relocatingNodeId != null),
-            buildUnassignedInfo(state, relocatingNodeId != null),
+            buildRecoveryPriority(state, unassignedInfo),
+            unassignedInfo,
             buildRelocationFailureInfo(state),
             buildAllocationId(state),
             ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
@@ -255,17 +262,13 @@ public class TestShardRouting {
         };
     }
 
-    public static ShardRouting.RecoveryPriority buildRecoveryPriority(ShardRoutingState state, boolean hasRelocationNodeId) {
+    public static ShardRouting.RecoveryPriority buildRecoveryPriority(ShardRoutingState state, @Nullable UnassignedInfo unassignedInfo) {
         return switch (state) {
-            case INITIALIZING -> hasRelocationNodeId ? buildRecoveryPriorityForRelocation() : buildRecoveryPriorityForUnassigned();
-            case UNASSIGNED -> buildRecoveryPriorityForUnassigned();
+            case INITIALIZING -> unassignedInfo != null ? unassignedInfo.recoveryPriority() : buildRecoveryPriorityForRelocation();
+            case UNASSIGNED -> requireNonNull(unassignedInfo).recoveryPriority();
             case RELOCATING -> buildRecoveryPriorityForRelocation();
             case STARTED -> null;
         };
-    }
-
-    private static ShardRouting.RecoveryPriority buildRecoveryPriorityForUnassigned() {
-        return randomFrom(ShardRouting.RecoveryPriority.UNASSIGNED_EXISTING, ShardRouting.RecoveryPriority.UNASSIGNED_NEW);
     }
 
     private static ShardRouting.RecoveryPriority buildRecoveryPriorityForRelocation() {


### PR DESCRIPTION
This changes `ShardRouting.newUnassigned()` to use a `RecoveryPriority` derived from the `UnassignedInfo.Reason`, which should be the correct choice between `UNASSIGNED_EXISTING` and `UNASSIGNED_NEW`, rather than always using `UNASSIGNED_EXISTING`.

The validation on `ShardRouting` is strengthened to ensure that the `RecoveryPriority` is always consistent with the `UnassignedInfo`.

Relates elastic/elasticsearch-team#2918
