### PR TITLE
[Test] Fix race in BlockRefreshUponIndexCreationIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -541,9 +541,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=indices.sort/30_multi_value/Index Sort with doc_values multi_value false - integer}
   issue: https://github.com/elastic/elasticsearch/issues/154602
-- class: org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT
-  method: testIndexWithZeroReplicasAndAutoExpandReplicasHasClusterBlocks
-  issue: https://github.com/elastic/elasticsearch/issues/154605
 - class: org.elasticsearch.xpack.stateless.commits.StatelessCommitServiceTests
   method: testFullyUploadedListenerDoesNotFireBeforeItsCopyCompletes
   issue: https://github.com/elastic/elasticsearch/issues/154606

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/BlockRefreshUponIndexCreationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/BlockRefreshUponIndexCreationIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.stateless.recovery;
 
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.readonly.AddIndexBlockRequest;
 import org.elasticsearch.action.admin.indices.readonly.RemoveIndexBlockRequest;
@@ -22,6 +23,7 @@ import org.elasticsearch.action.search.OpenPointInTimeResponse;
 import org.elasticsearch.action.search.TransportClosePointInTimeAction;
 import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
@@ -42,6 +44,7 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
 import org.elasticsearch.xpack.stateless.StatelessPlugin;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -486,15 +489,23 @@ public class BlockRefreshUponIndexCreationIT extends AbstractStatelessPluginInte
         );
         String searchNodeName = startSearchNode();
 
-        // Intercept TransportRegisterCommitForRecoveryAction on the search node. This action is sent
-        // by the search node to register its shard copy during recovery; until it completes the shard
-        // stays in RECOVERING (not STARTED)
-        Queue<CheckedRunnable<Exception>> blockedRegistrations = new ConcurrentLinkedQueue<>();
+        // Intercept TransportRegisterCommitForRecoveryAction on the search node. This action is sent by the search
+        // node to register its shard copy during recovery; until it completes the shard stays in RECOVERING (not
+        // STARTED). Hold every such send until the test releases them: once released, the held send(s) and any
+        // later retry / re-allocation send are forwarded immediately (a completed SubscribableListener runs late
+        // subscribers inline), so recovery can never get stuck on a send the test forgot to forward.
         CountDownLatch recoveryBlockedLatch = new CountDownLatch(1);
+        SubscribableListener<Void> releaseRegistrations = new SubscribableListener<>();
         MockTransportService.getInstance(searchNodeName).addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(TransportRegisterCommitForRecoveryAction.NAME)) {
-                blockedRegistrations.add(() -> connection.sendRequest(requestId, action, request, options));
                 recoveryBlockedLatch.countDown();
+                releaseRegistrations.addListener(ActionListener.running(() -> {
+                    try {
+                        connection.sendRequest(requestId, action, request, options);
+                    } catch (IOException e) {
+                        throw new AssertionError(e);
+                    }
+                }));
             } else {
                 connection.sendRequest(requestId, action, request, options);
             }
@@ -526,9 +537,8 @@ public class BlockRefreshUponIndexCreationIT extends AbstractStatelessPluginInte
             assertNoSearchHits(prepareSearch(indexName).setQuery(new MatchAllQueryBuilder()));
         }
 
-        var registration = blockedRegistrations.poll();
-        assertNotNull(registration);
-        registration.run();
+        // Release the held registration(s); any subsequent retry / re-allocation send is forwarded inline.
+        releaseRegistrations.onResponse(null);
 
         assertAcked(createIndexFuture.actionGet());
         ensureGreen(indexName);


### PR DESCRIPTION
## Problem

`testIndexWithZeroReplicasAndAutoExpandReplicasHasClusterBlocks` fails intermittently in CI with:

    java.lang.AssertionError: CreateIndexResponse failed - index creation acked but not all shards were started
    Expected: is <true> but: was <false>

The test holds the search shard in recovery by intercepting the search node's
`TransportRegisterCommitForRecoveryAction` sends, releasing exactly one, then asserting the
index becomes green.

The search node can legitimately send that registration more than once during recovery: the
first attempt can fail transiently and be retried (indexing primary not yet active ->
`ShardNotFoundException`; or the indexing shard has not uploaded a commit yet ->
`NoShardAvailableActionException`, which restarts recovery). The old test released only the
first send and left any retry blocked forever, so the search replica never started,
create-index never became shards-acknowledged, and `assertAcked` failed.

## Fix

Replace the "release exactly one" queue with a `SubscribableListener` gate: every intercepted
registration subscribes to it, and releasing it forwards all held sends. Because a completed
`SubscribableListener` runs later subscribers inline, any subsequent retry / re-allocation send
is forwarded immediately too. The harness is now correct regardless of how many registration
sends recovery performs. Also unmutes the test.

Backport because test exists on 9.5, but hasn't raced, at least yet.

## Why I believe it is fixed

- Reproduced the test by running continuously on VM (repro'd in 8 hours)
- Ran the test fix continuously on a VM for ~1 day, didn't repro
- Reproduced deterministically by injecting a retryable failure on the first registration send
  (forcing the retry the old harness dropped): failed exactly as in CI, and passed with the fix.
- The change is a strict correctness improvement to the harness, independent of the specific
  retry trigger.

Closes #154605