### PR TITLE
[8.19] [Inference API] Deploy text embedding models before validation call (#153886)

### DIFF
--- a/docs/changelog/153886.yaml
+++ b/docs/changelog/153886.yaml
@@ -1,0 +1,6 @@
+area: Inference
+issues:
+ - 144871
+pr: 153886
+summary: "[Inference API] Deploy text embedding models before validation call"
+type: bug

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.TextEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 
 import java.io.IOException;
@@ -313,7 +313,7 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
         assertNotNull(putModel.toString(), serviceSettings.get(ServiceFields.DIMENSIONS)); // set by validation
 
         var results = infer(inferenceId, List.of("hello"));
-        assertNotNull(results.get(DenseEmbeddingFloatResults.TEXT_EMBEDDING));
+        assertNotNull(results.get(TextEmbeddingFloatResults.TEXT_EMBEDDING));
 
         deleteModel(inferenceId);
         forceStopMlNodeDeployment(inferenceId); // endpoint's deployment id == inference id

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CreateFromDeploymentIT.java
@@ -15,6 +15,8 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.inference.services.ServiceFields;
 
 import java.io.IOException;
 import java.util.List;
@@ -286,6 +288,35 @@ public class CreateFromDeploymentIT extends InferenceBaseRestTest {
                 )
             )
         );
+
+        deleteModel(inferenceId);
+        forceStopMlNodeDeployment(deploymentId);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCreatesDeploymentForNotYetDeployedModel_TextEmbedding() throws IOException {
+        var modelId = "text_embedding_model_not_deployed";
+        var inferenceId = "inference_starts_deployment";
+        CustomElandModelIT.createMlNodeTextEmbeddingModel(modelId, client()); // model exists, NOT deployed
+
+        var putModel = putModel(inferenceId, Strings.format("""
+            {
+              "service": "elasticsearch",
+              "service_settings": {
+                "num_allocations": 1,
+                "num_threads": 1,
+                "model_id": "%s"
+              }
+            }
+            """, modelId), TaskType.TEXT_EMBEDDING);
+        var serviceSettings = (Map<String, Object>) putModel.get(ModelConfigurations.SERVICE_SETTINGS);
+        assertNotNull(putModel.toString(), serviceSettings.get(ServiceFields.DIMENSIONS)); // set by validation
+
+        var results = infer(inferenceId, List.of("hello"));
+        assertNotNull(results.get(DenseEmbeddingFloatResults.TEXT_EMBEDDING));
+
+        deleteModel(inferenceId);
+        forceStopMlNodeDeployment(inferenceId); // endpoint's deployment id == inference id
     }
 
     public void testStoppingDeploymentAttachedToInferenceEndpoint() throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CustomElandModelIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/CustomElandModelIT.java
@@ -17,15 +17,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 public class CustomElandModelIT extends InferenceBaseRestTest {
 
     // The model definition is taken from org.elasticsearch.xpack.ml.integration.TextExpansionQueryIT
 
-    static final String BASE_64_ENCODED_MODEL = "UEsDBAAACAgAAAAAAAAAAAAAAAAAA"
+    static final String SPARSE_EMBEDDING_BASE_64_ENCODED_MODEL = "UEsDBAAACAgAAAAAAAAAAAAAAAAAA"
         + "AAAAAAUAA4Ac2ltcGxlbW9kZWwvZGF0YS5wa2xGQgoAWlpaWlpaWlpaWoACY19fdG9yY2hfXwpUaW55VG"
         + "V4dEV4cGFuc2lvbgpxACmBfShYCAAAAHRyYWluaW5ncQGJWBYAAABfaXNfZnVsbF9iYWNrd2FyZF9ob29"
         + "rcQJOdWJxAy5QSwcIITmbsFgAAABYAAAAUEsDBBQACAgIAAAAAAAAAAAAAAAAAAAAAAAdAB0Ac2ltcGxl"
@@ -60,9 +63,48 @@ public class CustomElandModelIT extends InferenceBaseRestTest {
         + "AAIAAAATAAAAAAAAAAAAAAAAANQFAABzaW1wbGVtb2RlbC92ZXJzaW9uUEsGBiwAAAAAAAAAHgMtAAAAAAAA"
         + "AAAABQAAAAAAAAAFAAAAAAAAAGoBAAAAAAAAUgYAAAAAAABQSwYHAAAAALwHAAAAAAAAAQAAAFBLBQYAAAAABQAFAGoBAABSBgAAAAA=";
 
-    static final long RAW_MODEL_SIZE; // size of the model before base64 encoding
+    static final long SPARSE_EMBEDDING_RAW_MODEL_SIZE; // size of the model before base64 encoding
     static {
-        RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
+        SPARSE_EMBEDDING_RAW_MODEL_SIZE = Base64.getDecoder().decode(SPARSE_EMBEDDING_BASE_64_ENCODED_MODEL).length;
+    }
+
+    // The model definition is taken from org.elasticsearch.xpack.ml.integration.TextEmbeddingQueryIT
+    static final String TEXT_EMBEDDING_BASE_64_ENCODED_MODEL = "UEsDBAAACAgAAAAAAAAAAAAAAAAAAAAAAAAUAA4Ac2ltcGxlbW9kZWwvZGF0YS5wa2xGQgoAWl"
+        + "paWlpaWlpaWoACY19fdG9yY2hfXwpUaW55VGV4dEVtYmVkZGluZwpxACmBfShYCAAAAHRy"
+        + "YWluaW5ncQGJWBYAAABfaXNfZnVsbF9iYWNrd2FyZF9ob29rcQJOdWJxAy5QSwcIsFTQsF"
+        + "gAAABYAAAAUEsDBBQACAgIAAAAAAAAAAAAAAAAAAAAAAAdAB0Ac2ltcGxlbW9kZWwvY29k"
+        + "ZS9fX3RvcmNoX18ucHlGQhkAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWoWPMWvDMBCF9/"
+        + "yKGy1IQ7Ia0q1j2yWbMYdsnWphWWd0Em3+fS3bBEopXd99j/dd77UI3Fy43+grvUwdGePC"
+        + "R/XKJntS9QEAcdZRT5QoCiJcoWnXtMvW/ohS1C4sZaihY/YFcoI2e4+d7sdPHQ0OzONyf5"
+        + "+T46B9U8DSNWTBcixMJeRtvQwkjv2AePpld1wKAC7MOaEzUsONgnDc4sQjBUz3mbbbY2qD"
+        + "2usbB9rQmcWV47/gOiVIReAvUsHT8y5S7yKL/mnSIWuPQmSqLRm0DJWkWD0eUEqtjUgpx7"
+        + "AXow6mai5HuJzPrTp8A1BLBwiD/6yJ6gAAAKkBAABQSwMEFAAICAgAAAAAAAAAAAAAAAAA"
+        + "AAAAACcAQQBzaW1wbGVtb2RlbC9jb2RlL19fdG9yY2hfXy5weS5kZWJ1Z19wa2xGQj0AWl"
+        + "paWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpa"
+        + "WlpaWlpaWo2Qz0rDQBDGk/5RmjfwlmMCbWivBZ9gWL0IFkRCdLcmmOwmuxu0N08O3r2rCO"
+        + "rdx9CDgm/hWUUQMdugzUk6LCwzv++bGeak5YE1saoorNgCCwsbzFc9sm1PvivQo2zqToU8"
+        + "iiT1FEunfadXRcLzUocJVWN3i3ElZF3W4pDxUM9yVrPNXCeCR+lOLdp1190NwVktzoVKDF"
+        + "5COh+nQpbtsX+0/tjpOWYJuR8HMuJUZEEW8TJKQ8UY9eJIxZ7S0vvb3vf9yiCZLiV3Fz5v"
+        + "1HdHw6HvFK3JWnUElWR5ygbz8TThB4NMUJYG+axowyoWHbiHBwQbSWbHHXiEJ4QWkmOTPM"
+        + "MLQhvJaZOgSX49Z3a8uPq5Ia/whtBBctEkl4a8wwdCF8lVk1wb8glfCCtIbprkttntrkF0"
+        + "0Q1+AFBLBwi4BIswOAEAAP0BAABQSwMEAAAICAAAAAAAAAAAAAAAAAAAAAAAABkAQQBzaW"
+        + "1wbGVtb2RlbC9jb25zdGFudHMucGtsRkI9AFpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpa"
+        + "WlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlqAAikuUEsHCG0vCVcEAAAABA"
+        + "AAAFBLAwQAAAgIAAAAAAAAAAAAAAAAAAAAAAAAEwA7AHNpbXBsZW1vZGVsL3ZlcnNpb25G"
+        + "QjcAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWl"
+        + "paWlpaWjMKUEsHCNGeZ1UCAAAAAgAAAFBLAQIAAAAACAgAAAAAAACwVNCwWAAAAFgAAAAU"
+        + "AAAAAAAAAAAAAAAAAAAAAABzaW1wbGVtb2RlbC9kYXRhLnBrbFBLAQIAABQACAgIAAAAAA"
+        + "CD/6yJ6gAAAKkBAAAdAAAAAAAAAAAAAAAAAKgAAABzaW1wbGVtb2RlbC9jb2RlL19fdG9y"
+        + "Y2hfXy5weVBLAQIAABQACAgIAAAAAAC4BIswOAEAAP0BAAAnAAAAAAAAAAAAAAAAAPoBAA"
+        + "BzaW1wbGVtb2RlbC9jb2RlL19fdG9yY2hfXy5weS5kZWJ1Z19wa2xQSwECAAAAAAgIAAAA"
+        + "AAAAbS8JVwQAAAAEAAAAGQAAAAAAAAAAAAAAAADIAwAAc2ltcGxlbW9kZWwvY29uc3Rhbn"
+        + "RzLnBrbFBLAQIAAAAACAgAAAAAAADRnmdVAgAAAAIAAAATAAAAAAAAAAAAAAAAAFQEAABz"
+        + "aW1wbGVtb2RlbC92ZXJzaW9uUEsGBiwAAAAAAAAAHgMtAAAAAAAAAAAABQAAAAAAAAAFAA"
+        + "AAAAAAAGoBAAAAAAAA0gQAAAAAAABQSwYHAAAAADwGAAAAAAAAAQAAAFBLBQYAAAAABQAFAGoBAADSBAAAAAA=";
+
+    static final long TEXT_EMBEDDING_RAW_MODEL_SIZE; // size of the model before base64 encoding
+    static {
+        TEXT_EMBEDDING_RAW_MODEL_SIZE = Base64.getDecoder().decode(TEXT_EMBEDDING_BASE_64_ENCODED_MODEL).length;
     }
 
     // Test a sparse embedding model deployed with the ml trained models APIs
@@ -70,7 +112,7 @@ public class CustomElandModelIT extends InferenceBaseRestTest {
         String modelId = "custom-text-expansion-model";
 
         createTextExpansionModel(modelId, client());
-        putModelDefinition(modelId, BASE_64_ENCODED_MODEL, RAW_MODEL_SIZE, client());
+        putModelDefinition(modelId, SPARSE_EMBEDDING_BASE_64_ENCODED_MODEL, SPARSE_EMBEDDING_RAW_MODEL_SIZE, client());
         putVocabulary(
             List.of("these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"),
             modelId,
@@ -99,7 +141,7 @@ public class CustomElandModelIT extends InferenceBaseRestTest {
         String modelId = "custom-model-that-cannot-be-stopped";
 
         createTextExpansionModel(modelId, client());
-        putModelDefinition(modelId, BASE_64_ENCODED_MODEL, RAW_MODEL_SIZE, client());
+        putModelDefinition(modelId, SPARSE_EMBEDDING_BASE_64_ENCODED_MODEL, SPARSE_EMBEDDING_RAW_MODEL_SIZE, client());
         putVocabulary(
             List.of("these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"),
             modelId,
@@ -134,6 +176,83 @@ public class CustomElandModelIT extends InferenceBaseRestTest {
         // Force stop works
         String forceStopEndpoint = org.elasticsearch.common.Strings.format("_ml/trained_models/%s/deployment/_stop?force", inferenceId);
         assertStatusOkOrCreated(client().performRequest(new Request("POST", forceStopEndpoint)));
+    }
+
+    /**
+     * Verifies that when a text-embedding inference endpoint create fails after the model deployment has been started
+     * (the new {@code stopModelDeploymentIfStarted} behavior), the ML deployment is actually stopped and does not
+     * remain running as an orphan.
+     *
+     * <p>The failure is forced by the incompatible-semantic_text-mapping check in
+     * {@code checkForExistingUsesOfInferenceId}: a document is indexed with the semantic_text field
+     * (populating {@code model_settings} in the mapping), then the endpoint is force-deleted, and a recreation
+     * attempt with a different similarity setting triggers the incompatibility which fires after validation has
+     * already deployed the model.
+     */
+    @SuppressWarnings("unchecked")
+    public void testStopsDeployment_WhenCreateFailsAfterDeployment() throws Exception {
+        var modelId = "stop-deployment-on-failure-model";
+        var inferenceId = "stop-deployment-on-failure-inference";
+        var indexName = "stop-deployment-on-failure-index";
+
+        // Upload the text-embedding model (not yet deployed)
+        createMlNodeTextEmbeddingModel(modelId, client());
+
+        // Create the inference endpoint with the default similarity (cosine).
+        // Validation deploys the model and returns the embedding dimensions.
+        putModel(inferenceId, Strings.format("""
+            {
+              "service": "elasticsearch",
+              "service_settings": {
+                "model_id": "%s",
+                "num_allocations": 1,
+                "num_threads": 1
+              }
+            }
+            """, modelId), TaskType.TEXT_EMBEDDING);
+
+        // Create an index with a semantic_text field referencing the endpoint
+        putSemanticText(inferenceId, indexName);
+
+        // Index a document so that model_settings (task_type, similarity, dimensions, element_type) are
+        // written into the index mapping — required for the incompatibility check to fire later
+        var indexRequest = new Request("PUT", indexName + "/_create/1");
+        indexRequest.setJsonEntity("{\"inference_field\": \"hello world\"}");
+        assertStatusOkOrCreated(client().performRequest(indexRequest));
+        assertStatusOkOrCreated(client().performRequest(new Request("GET", "_refresh")));
+
+        // Force-delete the endpoint (stops the deployment while the index mapping still references it)
+        deleteModel(inferenceId, "force=true");
+
+        // Attempt to recreate the same inference endpoint with an incompatible similarity (dot_product).
+        // The validator redeploys the model, but checkForExistingUsesOfInferenceId then detects the
+        // conflict with the existing mapping and fails. stopModelDeploymentIfStarted must stop the
+        // newly-started deployment.
+        var e = expectThrows(ResponseException.class, () -> putModel(inferenceId, Strings.format("""
+            {
+              "service": "elasticsearch",
+              "service_settings": {
+                "model_id": "%s",
+                "num_allocations": 1,
+                "num_threads": 1,
+                "similarity": "dot_product"
+              }
+            }
+            """, modelId), TaskType.TEXT_EMBEDDING));
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), is(400));
+        assertThat(e.getMessage(), containsString("incompatible settings"));
+
+        // The deployment that validation started must have been stopped by stopModelDeploymentIfStarted.
+        // Use assertBusy because the ML stop is asynchronous relative to the HTTP response.
+        assertBusy(() -> {
+            var stats = (List<Map<String, Object>>) getTrainedModelStats(modelId).get("trained_model_stats");
+            assertNull(
+                "Deployment should have been stopped after the failed inference endpoint create, but deployment_stats is still present",
+                stats.get(0).get("deployment_stats")
+            );
+        }, 30, TimeUnit.SECONDS);
+
+        deleteIndex(indexName);
     }
 
     static void createTextExpansionModel(String modelId, RestClient client) throws IOException {
@@ -182,7 +301,37 @@ public class CustomElandModelIT extends InferenceBaseRestTest {
     // Create the model including definition and vocab
     static void createMlNodeTextExpansionModel(String modelId, RestClient client) throws IOException {
         createTextExpansionModel(modelId, client);
-        putModelDefinition(modelId, BASE_64_ENCODED_MODEL, RAW_MODEL_SIZE, client);
+        putModelDefinition(modelId, SPARSE_EMBEDDING_BASE_64_ENCODED_MODEL, SPARSE_EMBEDDING_RAW_MODEL_SIZE, client);
+        putVocabulary(
+            List.of("these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"),
+            modelId,
+            client
+        );
+    }
+
+    private static void createTextEmbeddingModel(String modelId, RestClient client) throws IOException {
+        Request request = new Request("PUT", "/_ml/trained_models/" + modelId);
+        request.setJsonEntity("""
+            {
+               "description": "a text embedding model",
+               "model_type": "pytorch",
+               "inference_config": {
+                 "text_embedding": {
+                   "tokenization": {
+                     "bert": {
+                       "with_special_tokens": false
+                     }
+                   }
+                 }
+               }
+             }""");
+        client.performRequest(request);
+    }
+
+    // Creates a text-embedding trained model with definition and vocabulary (model NOT deployed)
+    static void createMlNodeTextEmbeddingModel(String modelId, RestClient client) throws IOException {
+        createTextEmbeddingModel(modelId, client);
+        putModelDefinition(modelId, TEXT_EMBEDDING_BASE_64_ENCODED_MODEL, TEXT_EMBEDDING_RAW_MODEL_SIZE, client);
         putVocabulary(
             List.of("these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"),
             modelId,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -22,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.StrictDynamicMappingException;
@@ -49,6 +49,7 @@ import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
+import org.elasticsearch.xpack.inference.services.validation.ModelValidationResult;
 import org.elasticsearch.xpack.inference.services.validation.ModelValidatorBuilder;
 
 import java.io.IOException;
@@ -56,6 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.inference.InferencePlugin.INFERENCE_API_FEATURE;
@@ -73,7 +75,6 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
     private final XPackLicenseState licenseState;
     private final ModelRegistry modelRegistry;
     private final InferenceServiceRegistry serviceRegistry;
-    private final Client client;
     private volatile boolean skipValidationAndStart;
 
     @Inject
@@ -85,7 +86,6 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         XPackLicenseState licenseState,
         ModelRegistry modelRegistry,
         InferenceServiceRegistry serviceRegistry,
-        Client client,
         Settings settings
     ) {
         super(
@@ -101,7 +101,6 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         this.licenseState = licenseState;
         this.modelRegistry = modelRegistry;
         this.serviceRegistry = serviceRegistry;
-        this.client = client;
         this.skipValidationAndStart = InferencePlugin.SKIP_VALIDATE_AND_START.get(settings);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(InferencePlugin.SKIP_VALIDATE_AND_START, this::setSkipValidationAndStart);
@@ -209,42 +208,84 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         Metadata metadata,
         ActionListener<PutInferenceModelAction.Response> listener
     ) {
-        ActionListener<Model> storeModelListener = listener.delegateFailureAndWrap(
-            (delegate, verifiedModel) -> modelRegistry.storeModel(
-                verifiedModel,
-                ActionListener.wrap(r -> startInferenceEndpoint(service, timeout, verifiedModel, delegate), e -> {
-                    if (e.getCause() instanceof StrictDynamicMappingException && e.getCause().getMessage().contains("chunking_settings")) {
-                        delegate.onFailure(
-                            new ElasticsearchStatusException(
-                                "One or more nodes in your cluster does not support chunking_settings. "
-                                    + "Please update all nodes in your cluster to the latest version to use chunking_settings.",
-                                RestStatus.BAD_REQUEST
-                            )
-                        );
-                    } else {
-                        delegate.onFailure(e);
+        var validationResultRef = new AtomicReference<ModelValidationResult>();
+        // Before we return, let's ensure that the deployment is stopped if one was started
+        var stopOnFailure = listener.delegateResponse(
+            (l, e) -> stopModelDeploymentIfStarted(service, inferenceEntityId, validationResultRef.get(), l, e)
+        );
+
+        ActionListener<ModelValidationResult> storeModelListener = stopOnFailure.delegateFailureAndWrap(
+            (delegate, validationResult) -> modelRegistry.storeModel(
+                validationResult.model(),
+                ActionListener.wrap(
+                    r -> startInferenceEndpoint(service, timeout, validationResult.model(), validationResult.deploymentStarted(), delegate),
+                    e -> {
+                        if (e.getCause() instanceof StrictDynamicMappingException
+                            && e.getCause().getMessage().contains("chunking_settings")) {
+                            delegate.onFailure(
+                                new ElasticsearchStatusException(
+                                    "One or more nodes in your cluster does not support chunking_settings. "
+                                        + "Please update all nodes in your cluster to the latest version to use chunking_settings.",
+                                    RestStatus.BAD_REQUEST
+                                )
+                            );
+                        } else {
+                            delegate.onFailure(e);
+                        }
                     }
-                }),
+                ),
                 timeout
             )
         );
 
-        ActionListener<Model> modelValidatingListener = listener.delegateFailureAndWrap((delegate, model) -> {
+        ActionListener<ModelValidationResult> existingUsesListener = storeModelListener.delegateFailureAndWrap(
+            (delegate, validationResult) -> {
+                validationResultRef.set(validationResult);
+                var model = validationResult.model();
+                var modelDelegate = delegate.<Model>delegateFailureAndWrap(
+                    (validationResultActionListener, ignored) -> validationResultActionListener.onResponse(validationResult)
+                );
+                // Execute in another thread because checking for existing uses requires reading from indices
+                threadPool.executor(UTILITY_THREAD_POOL_NAME)
+                    .execute(() -> checkForExistingUsesOfInferenceId(metadata, model, modelDelegate));
+            }
+        );
+
+        ActionListener<Model> modelValidatingListener = existingUsesListener.delegateFailureAndWrap((delegate, model) -> {
             if (skipValidationAndStart) {
-                storeModelListener.onResponse(model);
+                delegate.onResponse(new ModelValidationResult(model, false));
             } else {
                 ModelValidatorBuilder.buildModelValidator(model.getTaskType(), service)
-                    .validate(service, model, timeout, storeModelListener);
+                    .validate(service, model, timeout, existingUsesListener);
             }
         });
 
-        ActionListener<Model> existingUsesListener = listener.delegateFailureAndWrap((delegate, model) -> {
-            // Execute in another thread because checking for existing uses requires reading from indices
-            threadPool.executor(UTILITY_THREAD_POOL_NAME)
-                .execute(() -> checkForExistingUsesOfInferenceId(metadata, model, modelValidatingListener));
-        });
+        service.parseRequestConfig(inferenceEntityId, taskType, config, modelValidatingListener);
+    }
 
-        service.parseRequestConfig(inferenceEntityId, taskType, config, existingUsesListener);
+    private void stopModelDeploymentIfStarted(
+        InferenceService service,
+        String inferenceEntityId,
+        @Nullable ModelValidationResult result,
+        ActionListener<PutInferenceModelAction.Response> listener,
+        Exception e
+    ) {
+        if (result == null || result.deploymentStarted() == false) {
+            listener.onFailure(e);
+            return;
+        }
+
+        service.stop(result.model(), ActionListener.wrap(stopped -> listener.onFailure(e), stopException -> {
+            stopException.addSuppressed(e);
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Failed to create the inference endpoint [{}] and the model deployment could not be stopped",
+                    RestStatus.INTERNAL_SERVER_ERROR,
+                    stopException,
+                    inferenceEntityId
+                )
+            );
+        }));
     }
 
     private void checkForExistingUsesOfInferenceId(Metadata metadata, Model model, ActionListener<Model> modelValidatingListener) {
@@ -289,9 +330,10 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         InferenceService service,
         TimeValue timeout,
         Model model,
+        boolean deploymentStarted,
         ActionListener<PutInferenceModelAction.Response> listener
     ) {
-        if (skipValidationAndStart) {
+        if (skipValidationAndStart || deploymentStarted) {
             listener.onResponse(new PutInferenceModelAction.Response(model.getConfigurations()));
         } else {
             service.start(model, timeout, listener.map(started -> new PutInferenceModelAction.Response(model.getConfigurations())));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ChatCompletionModelValidator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ChatCompletionModelValidator.java
@@ -22,13 +22,13 @@ public class ChatCompletionModelValidator implements ModelValidator {
     }
 
     @Override
-    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<Model> listener) {
+    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<ModelValidationResult> listener) {
         serviceIntegrationValidator.validate(service, model, timeout, listener.delegateFailureAndWrap((delegate, r) -> {
             delegate.onResponse(postValidate(service, model));
         }));
     }
 
-    private Model postValidate(InferenceService service, Model model) {
-        return service.updateModelWithChatCompletionDetails(model);
+    private ModelValidationResult postValidate(InferenceService service, Model model) {
+        return new ModelValidationResult(service.updateModelWithChatCompletionDetails(model), false);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidator.java
@@ -31,34 +31,45 @@ public class ElasticsearchInternalServiceModelValidator implements ModelValidato
     }
 
     @Override
-    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<Model> listener) {
-        if (model instanceof CustomElandEmbeddingModel elandModel && elandModel.getTaskType() == TaskType.TEXT_EMBEDDING) {
-            var temporaryModelWithModelId = new CustomElandEmbeddingModel(
-                elandModel.getServiceSettings().modelId(),
-                elandModel.getTaskType(),
-                elandModel.getConfigurations().getService(),
-                elandModel.getServiceSettings(),
-                elandModel.getConfigurations().getChunkingSettings()
-            );
-
-            serviceIntegrationValidator.validate(
-                service,
-                temporaryModelWithModelId,
-                timeout,
-                listener.delegateFailureAndWrap((delegate, r) -> {
-                    delegate.onResponse(postValidate(service, model, r));
-                })
-            );
-        } else if (model instanceof ElasticDeployedModel && model.getTaskType() == TaskType.TEXT_EMBEDDING) {
-            serviceIntegrationValidator.validate(
-                service,
-                model,
-                timeout,
-                listener.delegateFailureAndWrap((delegate, r) -> delegate.onResponse(postValidate(service, model, r)))
-            );
+    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<ModelValidationResult> listener) {
+        if (requiresDeploymentValidation(model)) {
+            // Deploy the model before running the validation inference request. Validation calls service.infer(),
+            // which fails with "Model [...] must be deployed to use" if the deployment has not been started.
+            // Fixes https://github.com/elastic/elasticsearch/issues/144871. For ElasticDeployedModel (an
+            // existing deployment) start()/stop() are no-ops, so it's ok to call start().
+            // Return deploymentStarted=true so the caller can skip starting the deployment a second time.
+            service.start(model, timeout, listener.delegateFailureAndWrap((startedListener, ignored) -> {
+                var stopOnFailure = startedListener.delegateResponse((l, e) -> stopModelDeployment(service, model, l, e));
+                serviceIntegrationValidator.validate(
+                    service,
+                    model,
+                    timeout,
+                    stopOnFailure.delegateFailureAndWrap(
+                        (l, results) -> l.onResponse(new ModelValidationResult(postValidate(service, model, results), true))
+                    )
+                );
+            }));
         } else {
-            listener.onResponse(model);
+            listener.onResponse(new ModelValidationResult(model, false));
         }
+    }
+
+    private static boolean requiresDeploymentValidation(Model model) {
+        return (model instanceof CustomElandEmbeddingModel || model instanceof ElasticDeployedModel)
+            && model.getTaskType() == TaskType.TEXT_EMBEDDING;
+    }
+
+    private void stopModelDeployment(InferenceService service, Model model, ActionListener<ModelValidationResult> listener, Exception e) {
+        service.stop(model, ActionListener.wrap(stopped -> listener.onFailure(e), stopException -> {
+            stopException.addSuppressed(e);
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Model validation failed and model deployment could not be stopped",
+                    RestStatus.INTERNAL_SERVER_ERROR,
+                    stopException
+                )
+            );
+        }));
     }
 
     private Model postValidate(InferenceService service, Model model, InferenceServiceResults results) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ModelValidationResult.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ModelValidationResult.java
@@ -7,11 +7,10 @@
 
 package org.elasticsearch.xpack.inference.services.validation;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.Model;
 
-public interface ModelValidator {
-    void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<ModelValidationResult> listener);
-}
+/**
+ * Holds the result of model validation, including the validated model and whether the validator started
+ * a model deployment as part of validation.
+ */
+public record ModelValidationResult(Model model, boolean deploymentStarted) {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/SimpleModelValidator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/SimpleModelValidator.java
@@ -22,9 +22,9 @@ public class SimpleModelValidator implements ModelValidator {
     }
 
     @Override
-    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<Model> listener) {
+    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<ModelValidationResult> listener) {
         serviceIntegrationValidator.validate(service, model, timeout, listener.delegateFailureAndWrap((delegate, r) -> {
-            delegate.onResponse(model);
+            delegate.onResponse(new ModelValidationResult(model, false));
         }));
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/TextEmbeddingModelValidator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/TextEmbeddingModelValidator.java
@@ -28,9 +28,9 @@ public class TextEmbeddingModelValidator implements ModelValidator {
     }
 
     @Override
-    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<Model> listener) {
+    public void validate(InferenceService service, Model model, TimeValue timeout, ActionListener<ModelValidationResult> listener) {
         serviceIntegrationValidator.validate(service, model, timeout, listener.delegateFailureAndWrap((delegate, r) -> {
-            delegate.onResponse(postValidate(service, model, r));
+            delegate.onResponse(new ModelValidationResult(postValidate(service, model, r), false));
         }));
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelActionTests.java
@@ -34,10 +34,9 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.PutInferenceModelAction;
-import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
-import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.TextEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.InferencePlugin;
+import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandEmbeddingModel;
@@ -271,13 +270,12 @@ public class TransportPutInferenceModelActionTests extends ESTestCase {
 
     private void stubServiceInferToReturnDenseEmbedding() {
         doAnswer(invocation -> {
-            ActionListener<InferenceServiceResults> listener = invocation.getArgument(6);
+            ActionListener<InferenceServiceResults> listener = invocation.getArgument(9);
             listener.onResponse(
-                new DenseEmbeddingFloatResults(List.of(new EmbeddingFloatResults.Embedding(new float[] { 1.0f, 2.0f, 3.0f })))
+                new TextEmbeddingFloatResults(List.of(new TextEmbeddingFloatResults.Embedding(new float[] { 1.0f, 2.0f, 3.0f })))
             );
             return null;
-        }).when(mockService)
-            .infer(any(), any(), anyBoolean(), any(), anyList(), anyBoolean(), anyMap(), any(InputType.class), any(), any());
+        }).when(mockService).infer(any(), any(), any(), any(), anyList(), anyBoolean(), anyMap(), any(InputType.class), any(), any());
     }
 
     private void stubStoreModelToFail(Exception e) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelActionTests.java
@@ -8,13 +8,120 @@
 package org.elasticsearch.xpack.inference.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.license.LicensedFeature;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.action.PutInferenceModelAction;
+import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
+import org.elasticsearch.xpack.inference.InferencePlugin;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
+import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandEmbeddingModel;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalTextEmbeddingServiceSettings;
+import org.junit.Before;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TransportPutInferenceModelActionTests extends ESTestCase {
+
+    private static final String INFERENCE_ID = "test-inference-id";
+    private static final String MODEL_ID = "test-model-id";
+    private static final String PUT_REQUEST_BODY = Strings.format("""
+        {
+          "service": "elasticsearch",
+          "service_settings": {
+            "model_id": "%s",
+            "num_allocations": 1,
+            "num_threads": 1
+          }
+        }
+        """, MODEL_ID);
+
+    private ModelRegistry mockModelRegistry;
+    private ElasticsearchInternalService mockService;
+    private TransportPutInferenceModelAction action;
+
+    @Before
+    public void createAction() throws Exception {
+        super.setUp();
+
+        var licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(any(LicensedFeature.class))).thenReturn(true);
+
+        mockModelRegistry = mock(ModelRegistry.class);
+
+        mockService = mock(ElasticsearchInternalService.class);
+        when(mockService.getMinimalSupportedVersion()).thenReturn(TransportVersion.minimumCompatible());
+
+        var mockServiceRegistry = mock(InferenceServiceRegistry.class);
+        when(mockServiceRegistry.getService(ElasticsearchInternalService.NAME)).thenReturn(Optional.of(mockService));
+
+        var mockThreadPool = mock(ThreadPool.class);
+        when(mockThreadPool.executor(UTILITY_THREAD_POOL_NAME)).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+
+        var clusterServiceMock = mock(ClusterService.class);
+        when(clusterServiceMock.getClusterSettings()).thenReturn(
+            new ClusterSettings(Settings.EMPTY, Set.of(InferencePlugin.SKIP_VALIDATE_AND_START))
+        );
+        when(clusterServiceMock.state()).thenReturn(ClusterState.EMPTY_STATE);
+
+        var featureServiceMock = mock(FeatureService.class);
+        when(featureServiceMock.clusterHasFeature(any(), any())).thenReturn(true);
+
+        action = new TransportPutInferenceModelAction(
+            mock(TransportService.class),
+            clusterServiceMock,
+            mockThreadPool,
+            mock(ActionFilters.class),
+            licenseState,
+            mockModelRegistry,
+            mockServiceRegistry,
+            Settings.EMPTY
+        );
+    }
 
     public void testResolveTaskType() {
 
@@ -37,5 +144,180 @@ public class TransportPutInferenceModelActionTests extends ESTestCase {
                 "Cannot resolve conflicting task_type parameter in the request URL [sparse_embedding] and the request body [text_embedding]"
             )
         );
+    }
+
+    /**
+     * When validation deploys the model and a subsequent failure occurs (e.g. storing the endpoint
+     * fails), the action must stop the deployment it started and propagate the original error.
+     */
+    public void testCreate_WhenDeploymentStarted_AndStoreModelFails_StopsDeployment_AndPropagatesOriginalError() throws Exception {
+        var model = createCustomElandEmbeddingModel();
+        stubParseRequestConfigToReturnModel(model);
+        stubServiceStartToSucceed(model);
+        stubServiceInferToReturnDenseEmbedding();
+        when(mockService.updateModelWithEmbeddingDetails(eq(model), anyInt())).thenReturn(model);
+
+        var storeException = new RuntimeException("store failed");
+        stubStoreModelToFail(storeException);
+        stubServiceStopToSucceed(model);
+
+        var listener = callMasterOperation();
+
+        var actualException = expectThrows(RuntimeException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException, sameInstance(storeException));
+        verify(mockService).stop(eq(model), any());
+    }
+
+    /**
+     * When both the post-validation failure and the subsequent stop call fail, the action must wrap
+     * them into a 500 error with the stop exception as the cause and the original failure suppressed.
+     */
+    public void testCreate_WhenDeploymentStarted_AndStopFails_ReturnsWrappedInternalServerError() throws Exception {
+        var model = createCustomElandEmbeddingModel();
+        stubParseRequestConfigToReturnModel(model);
+        stubServiceStartToSucceed(model);
+        stubServiceInferToReturnDenseEmbedding();
+        when(mockService.updateModelWithEmbeddingDetails(eq(model), anyInt())).thenReturn(model);
+
+        var storeException = new RuntimeException("store failed");
+        stubStoreModelToFail(storeException);
+
+        var stopException = new RuntimeException("stop failed");
+        stubServiceStopToFail(model, stopException);
+
+        var listener = callMasterOperation();
+
+        var actualException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException.status(), is(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(
+            actualException.getMessage(),
+            containsString("Failed to create the inference endpoint [" + INFERENCE_ID + "] and the model deployment could not be stopped")
+        );
+        // The stop exception is the cause; the original store failure is suppressed on it
+        assertThat(actualException.getCause(), sameInstance(stopException));
+        assertThat(stopException.getSuppressed()[0], sameInstance(storeException));
+        verify(mockService).stop(eq(model), any());
+    }
+
+    /**
+     * When no deployment is started during validation (e.g. a non-text-embedding elasticsearch model),
+     * a downstream failure must not trigger a stop call.
+     */
+    public void testCreate_WhenDeploymentNotStarted_DoesNotStopDeployment() throws Exception {
+        // Return a model that is not a CustomElandEmbeddingModel so requiresDeploymentValidation=false,
+        // meaning validation returns deploymentStarted=false without calling service.start().
+        var nonDeployedModel = mock(Model.class);
+        when(nonDeployedModel.getInferenceEntityId()).thenReturn(INFERENCE_ID);
+        stubParseRequestConfigToReturnModel(nonDeployedModel);
+
+        var storeException = new RuntimeException("store failed");
+        stubStoreModelToFail(storeException);
+
+        var listener = callMasterOperation();
+
+        var actualException = expectThrows(RuntimeException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException, sameInstance(storeException));
+        verify(mockService, never()).stop(any(), any());
+    }
+
+    /**
+     * When parsing the request config fails, the validation result reference is never populated,
+     * so stopModelDeploymentIfStarted sees a null result and must not call stop.
+     */
+    public void testCreate_WhenParseRequestConfigFails_DoesNotStopDeployment() throws Exception {
+        var parseException = new RuntimeException("parse failed");
+        doAnswer(invocation -> {
+            ActionListener<Model> listener = invocation.getArgument(3);
+            listener.onFailure(parseException);
+            return null;
+        }).when(mockService).parseRequestConfig(eq(INFERENCE_ID), any(TaskType.class), anyMap(), any());
+
+        var listener = callMasterOperation();
+
+        var actualException = expectThrows(RuntimeException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(actualException, sameInstance(parseException));
+        verify(mockService, never()).stop(any(), any());
+        verify(mockModelRegistry, never()).storeModel(any(), any(), any());
+    }
+
+    private CustomElandEmbeddingModel createCustomElandEmbeddingModel() {
+        var mockServiceSettings = mock(ElasticsearchInternalTextEmbeddingServiceSettings.class);
+        when(mockServiceSettings.modelId()).thenReturn(MODEL_ID);
+        when(mockServiceSettings.dimensionsSetByUser()).thenReturn(false);
+        return new CustomElandEmbeddingModel(
+            INFERENCE_ID,
+            TaskType.TEXT_EMBEDDING,
+            ElasticsearchInternalService.NAME,
+            mockServiceSettings,
+            ChunkingSettingsTests.createRandomChunkingSettings()
+        );
+    }
+
+    private void stubParseRequestConfigToReturnModel(Model model) {
+        doAnswer(invocation -> {
+            ActionListener<Model> listener = invocation.getArgument(3);
+            listener.onResponse(model);
+            return null;
+        }).when(mockService).parseRequestConfig(any(), any(TaskType.class), anyMap(), any());
+    }
+
+    private void stubServiceStartToSucceed(Model model) {
+        doAnswer(invocation -> {
+            ActionListener<Void> listener = invocation.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(mockService).start(eq(model), any(), any());
+    }
+
+    private void stubServiceInferToReturnDenseEmbedding() {
+        doAnswer(invocation -> {
+            ActionListener<InferenceServiceResults> listener = invocation.getArgument(6);
+            listener.onResponse(
+                new DenseEmbeddingFloatResults(List.of(new EmbeddingFloatResults.Embedding(new float[] { 1.0f, 2.0f, 3.0f })))
+            );
+            return null;
+        }).when(mockService)
+            .infer(any(), any(), anyBoolean(), any(), anyList(), anyBoolean(), anyMap(), any(InputType.class), any(), any());
+    }
+
+    private void stubStoreModelToFail(Exception e) {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(1);
+            listener.onFailure(e);
+            return null;
+        }).when(mockModelRegistry).storeModel(any(), any(), any());
+    }
+
+    private void stubServiceStopToSucceed(Model model) {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(1);
+            listener.onResponse(true);
+            return null;
+        }).when(mockService).stop(eq(model), any());
+    }
+
+    private void stubServiceStopToFail(Model model, Exception e) {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(1);
+            listener.onFailure(e);
+            return null;
+        }).when(mockService).stop(eq(model), any());
+    }
+
+    private TestPlainActionFuture<PutInferenceModelAction.Response> callMasterOperation() throws Exception {
+        var listener = new TestPlainActionFuture<PutInferenceModelAction.Response>();
+        action.masterOperation(
+            mock(Task.class),
+            new PutInferenceModelAction.Request(
+                TaskType.TEXT_EMBEDDING,
+                INFERENCE_ID,
+                new BytesArray(PUT_REQUEST_BODY),
+                XContentType.JSON,
+                null
+            ),
+            ClusterState.EMPTY_STATE,
+            listener
+        );
+        return listener;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ChatCompletionModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ChatCompletionModelValidatorTests.java
@@ -40,7 +40,7 @@ public class ChatCompletionModelValidatorTests extends ESTestCase {
     @Mock
     private Model mockModel;
     @Mock
-    private ActionListener<Model> mockActionListener;
+    private ActionListener<ModelValidationResult> mockActionListener;
 
     private ChatCompletionModelValidator underTest;
 
@@ -84,7 +84,7 @@ public class ChatCompletionModelValidatorTests extends ESTestCase {
 
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(mockModel), eq(TIMEOUT), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
-        verify(mockActionListener).onResponse(mockModel);
+        verify(mockActionListener).onResponse(new ModelValidationResult(mockModel, false));
         verify(mockInferenceService).updateModelWithChatCompletionDetails(mockModel);
         verifyNoMoreInteractions(
             mockServiceIntegrationValidator,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
@@ -332,7 +332,7 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
     public void testValidate_ElasticDeployedModel_TextEmbedding_RoutedThroughValidation() {
         var dimensions = randomIntBetween(1, 10);
-        var mockInferenceServiceResults = mock(DenseEmbeddingResults.class);
+        var mockInferenceServiceResults = mock(TextEmbeddingResults.class);
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
         var elasticDeployedModel = createElasticDeployedModel(false, null);
         stubServiceStartSuccess();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidatorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandEmbeddingModel;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticDeployedModel;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalTextEmbeddingServiceSettings;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -27,6 +28,7 @@ import org.mockito.Mock;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -39,7 +41,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase {
 
-    private static final TimeValue TIMEOUT = TimeValue.ONE_MINUTE;
+    private static final TimeValue TIMEOUT = ESTestCase.TEST_REQUEST_TIMEOUT;
     private static final String MODEL_VALIDATION_AND_STOP_FAILED_MESSAGE =
         "Model validation failed and model deployment could not be stopped";
 
@@ -50,7 +52,7 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
     @Mock
     private CustomElandEmbeddingModel mockCustomElandEmbeddingModel;
     @Mock
-    private ActionListener<Model> mockActionListener;
+    private ActionListener<ModelValidationResult> mockActionListener;
 
     private ElasticsearchInternalServiceModelValidator underTest;
 
@@ -68,7 +70,7 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         var mockModel = mock(Model.class);
         underTest.validate(mockInferenceService, mockModel, TIMEOUT, mockActionListener);
 
-        verify(mockActionListener).onResponse(mockModel);
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockModel && result.deploymentStarted() == false));
         verifyNoMoreInteractions(
             mockServiceIntegrationValidator,
             mockInferenceService,
@@ -83,25 +85,35 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, mockCustomElandEmbeddingModel, TIMEOUT, mockActionListener);
 
-        verify(mockActionListener).onResponse(mockCustomElandEmbeddingModel);
+        verify(mockActionListener).onResponse(
+            argThat(result -> result.model() == mockCustomElandEmbeddingModel && result.deploymentStarted() == false)
+        );
         verify(mockCustomElandEmbeddingModel).getTaskType();
         verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockCustomElandEmbeddingModel, mockActionListener);
     }
 
     public void testValidate_ElandTextEmbeddingModelValidationThrowsException() {
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        stubServiceStartSuccess();
 
         doThrow(new ElasticsearchStatusException("Model Validator Exception", RestStatus.INTERNAL_SERVER_ERROR)).when(
             mockServiceIntegrationValidator
         ).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
 
-        assertThrows(ElasticsearchStatusException.class, () -> {
-            underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
-        });
+        underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
+
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
+        verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
+        verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
+        verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockCustomElandEmbeddingModel, mockActionListener);
     }
 
     public void testValidate_ElandTextEmbeddingModelValidationFails() {
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        stubServiceStartSuccess();
+        stubServiceStopSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -111,9 +123,41 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockInferenceService).stop(eq(customElandEmbeddingModel), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
         verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
+        verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockCustomElandEmbeddingModel, mockActionListener);
+    }
+
+    public void testValidate_ValidationFails_StopAlsoFails_WrapsException() {
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        stubServiceStartSuccess();
+
+        doAnswer(ans -> {
+            ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
+            responseListener.onFailure(new ElasticsearchStatusException("Model validation failed", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+
+        doAnswer(ans -> {
+            ActionListener<Boolean> stopListener = ans.getArgument(1);
+            stopListener.onFailure(new ElasticsearchStatusException("stop failed", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(mockInferenceService).stop(any(), any());
+
+        underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
+
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
+        verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockInferenceService).stop(eq(customElandEmbeddingModel), any());
+        verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
+        verify(mockActionListener).onFailure(
+            argThat(e -> e instanceof ElasticsearchStatusException && e.getMessage().contains(MODEL_VALIDATION_AND_STOP_FAILED_MESSAGE))
+        );
         verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockCustomElandEmbeddingModel, mockActionListener);
     }
 
@@ -122,7 +166,8 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         var mockInferenceServiceResults = mock(TextEmbeddingResults.class);
         var mockUpdatedModel = mock(CustomElandEmbeddingModel.class);
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(true, dimensions);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(true, dimensions);
+        stubServiceStartSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -135,10 +180,12 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
         verify(mockInferenceService).updateModelWithEmbeddingDetails(eq(customElandEmbeddingModel), eq(dimensions));
         verify(mockActionListener).delegateFailureAndWrap(any());
-        verify(mockActionListener).onResponse(mockUpdatedModel);
+        verify(mockActionListener).delegateResponse(any());
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockUpdatedModel && result.deploymentStarted()));
         verify(mockInferenceServiceResults).getFirstEmbeddingSize();
         verifyNoMoreInteractions(
             mockServiceIntegrationValidator,
@@ -156,7 +203,9 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(
             randomValueOtherThan(dimensions, () -> randomIntBetween(1, 10))
         );
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(true, dimensions);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(true, dimensions);
+        stubServiceStartSuccess();
+        stubServiceStopSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -166,8 +215,11 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockInferenceService).stop(eq(customElandEmbeddingModel), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
         verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
         verify(mockInferenceServiceResults, times(2)).getFirstEmbeddingSize();
         verifyNoMoreInteractions(
@@ -183,7 +235,9 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         var dimensions = randomIntBetween(1, 10);
         var mockInferenceServiceResults = mock(InferenceServiceResults.class);
         when(mockInferenceServiceResults.getWriteableName()).thenReturn(randomAlphaOfLength(10));
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(true, dimensions);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(true, dimensions);
+        stubServiceStartSuccess();
+        stubServiceStopSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -193,8 +247,11 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockInferenceService).stop(eq(customElandEmbeddingModel), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
         verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
         verify(mockInferenceServiceResults).getWriteableName();
         verifyNoMoreInteractions(
@@ -210,7 +267,8 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         var dimensions = randomIntBetween(1, 10);
         var mockInferenceServiceResults = mock(TextEmbeddingResults.class);
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        stubServiceStartSuccess();
 
         var mockUpdatedModel = mock(CustomElandEmbeddingModel.class);
         when(mockInferenceService.updateModelWithEmbeddingDetails(eq(customElandEmbeddingModel), eq(dimensions))).thenReturn(
@@ -225,9 +283,11 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
-        verify(mockActionListener).onResponse(mockUpdatedModel);
+        verify(mockActionListener).delegateResponse(any());
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockUpdatedModel && result.deploymentStarted()));
         verify(mockInferenceService).updateModelWithEmbeddingDetails(eq(customElandEmbeddingModel), eq(dimensions));
         verify(mockInferenceServiceResults).getFirstEmbeddingSize();
         verifyNoMoreInteractions(
@@ -242,7 +302,9 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
     public void testValidate_ElandTextEmbeddingModelAndEmbeddingSizeRetrievalThrowsException() {
         var mockInferenceServiceResults = mock(TextEmbeddingResults.class);
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenThrow(ElasticsearchStatusException.class);
-        CustomElandEmbeddingModel customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        var customElandEmbeddingModel = createCustomElandEmbeddingModel(false, null);
+        stubServiceStartSuccess();
+        stubServiceStopSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -252,8 +314,11 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, customElandEmbeddingModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(customElandEmbeddingModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockInferenceService).stop(eq(customElandEmbeddingModel), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
         verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
         verify(mockInferenceServiceResults).getFirstEmbeddingSize();
         verifyNoMoreInteractions(
@@ -265,17 +330,56 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         );
     }
 
+    public void testValidate_ElasticDeployedModel_TextEmbedding_RoutedThroughValidation() {
+        var dimensions = randomIntBetween(1, 10);
+        var mockInferenceServiceResults = mock(DenseEmbeddingResults.class);
+        when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
+        var elasticDeployedModel = createElasticDeployedModel(false, null);
+        stubServiceStartSuccess();
+
+        var mockUpdatedModel = mock(ElasticDeployedModel.class);
+        when(mockInferenceService.updateModelWithEmbeddingDetails(eq(elasticDeployedModel), eq(dimensions))).thenReturn(mockUpdatedModel);
+
+        doAnswer(ans -> {
+            ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
+            responseListener.onResponse(mockInferenceServiceResults);
+            return null;
+        }).when(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+
+        underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
+
+        verify(mockInferenceService).start(eq(elasticDeployedModel), eq(TIMEOUT), any());
+        verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), any(), eq(TIMEOUT), any());
+        verify(mockInferenceService).updateModelWithEmbeddingDetails(eq(elasticDeployedModel), eq(dimensions));
+        verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockUpdatedModel && result.deploymentStarted()));
+        verify(mockInferenceServiceResults).getFirstEmbeddingSize();
+        verifyNoMoreInteractions(
+            mockServiceIntegrationValidator,
+            mockInferenceService,
+            mockCustomElandEmbeddingModel,
+            mockActionListener,
+            mockUpdatedModel,
+            mockInferenceServiceResults
+        );
+    }
+
     public void testValidate_ElasticDeployedModelWithNonTextEmbeddingTaskTypeSkipsValidation() {
         var elasticDeployedModel = createElasticDeployedModel(randomFrom(TaskType.RERANK, TaskType.SPARSE_EMBEDDING));
 
         underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
 
-        verify(mockActionListener).onResponse(elasticDeployedModel);
+        verify(mockActionListener).onResponse(
+            argThat(result -> result.model() == elasticDeployedModel && result.deploymentStarted() == false)
+        );
         verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockActionListener);
     }
 
     public void testValidate_ElasticDeployedTextEmbeddingModelValidationFails() {
         var elasticDeployedModel = createElasticDeployedModel(TaskType.TEXT_EMBEDDING);
+        stubServiceStartSuccess();
+        stubServiceStopSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -285,8 +389,11 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(elasticDeployedModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(elasticDeployedModel), eq(TIMEOUT), any());
+        verify(mockInferenceService).stop(eq(elasticDeployedModel), any());
         verify(mockActionListener).delegateFailureAndWrap(any());
+        verify(mockActionListener).delegateResponse(any());
         verify(mockActionListener).onFailure(any(ElasticsearchStatusException.class));
         verifyNoMoreInteractions(mockServiceIntegrationValidator, mockInferenceService, mockActionListener);
     }
@@ -297,6 +404,7 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         var mockUpdatedModel = mock(ElasticDeployedModel.class);
         when(mockInferenceServiceResults.getFirstEmbeddingSize()).thenReturn(dimensions);
         var elasticDeployedModel = createElasticDeployedModel(TaskType.TEXT_EMBEDDING);
+        stubServiceStartSuccess();
 
         doAnswer(ans -> {
             ActionListener<InferenceServiceResults> responseListener = ans.getArgument(3);
@@ -307,18 +415,37 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
 
         underTest.validate(mockInferenceService, elasticDeployedModel, TIMEOUT, mockActionListener);
 
+        verify(mockInferenceService).start(eq(elasticDeployedModel), eq(TIMEOUT), any());
         verify(mockServiceIntegrationValidator).validate(eq(mockInferenceService), eq(elasticDeployedModel), eq(TIMEOUT), any());
         verify(mockInferenceService).updateModelWithEmbeddingDetails(eq(elasticDeployedModel), eq(dimensions));
         verify(mockActionListener).delegateFailureAndWrap(any());
-        verify(mockActionListener).onResponse(mockUpdatedModel);
+        verify(mockActionListener).delegateResponse(any());
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockUpdatedModel && result.deploymentStarted()));
         verify(mockInferenceServiceResults).getFirstEmbeddingSize();
         verifyNoMoreInteractions(
             mockServiceIntegrationValidator,
             mockInferenceService,
+            mockCustomElandEmbeddingModel,
             mockActionListener,
             mockUpdatedModel,
             mockInferenceServiceResults
         );
+    }
+
+    private void stubServiceStartSuccess() {
+        doAnswer(ans -> {
+            ActionListener<Void> startListener = ans.getArgument(2);
+            startListener.onResponse(null);
+            return null;
+        }).when(mockInferenceService).start(any(), any(), any());
+    }
+
+    private void stubServiceStopSuccess() {
+        doAnswer(ans -> {
+            ActionListener<Boolean> stopListener = ans.getArgument(1);
+            stopListener.onResponse(Boolean.TRUE);
+            return null;
+        }).when(mockInferenceService).stop(any(), any());
     }
 
     private ElasticDeployedModel createElasticDeployedModel(TaskType taskType) {
@@ -343,6 +470,22 @@ public class ElasticsearchInternalServiceModelValidatorTests extends ESTestCase 
         }
 
         return new CustomElandEmbeddingModel(
+            randomAlphaOfLength(10),
+            TaskType.TEXT_EMBEDDING,
+            randomAlphaOfLength(10),
+            mockServiceSettings,
+            ChunkingSettingsTests.createRandomChunkingSettings()
+        );
+    }
+
+    private ElasticDeployedModel createElasticDeployedModel(boolean areDimensionsSetByUser, Integer dimensions) {
+        var mockServiceSettings = mock(ElasticsearchInternalServiceSettings.class);
+        when(mockServiceSettings.dimensionsSetByUser()).thenReturn(areDimensionsSetByUser);
+        if (dimensions != null) {
+            when(mockServiceSettings.dimensions()).thenReturn(dimensions);
+        }
+
+        return new ElasticDeployedModel(
             randomAlphaOfLength(10),
             TaskType.TEXT_EMBEDDING,
             randomAlphaOfLength(10),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ModelValidatorBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/ModelValidatorBuilderTests.java
@@ -87,9 +87,12 @@ public class ModelValidatorBuilderTests extends ESTestCase {
     }
 
     public void testBuildModelValidator_ValidTaskType() {
-        taskTypeToModelValidatorClassMap().forEach((taskType, modelValidatorClass) -> {
-            assertThat(ModelValidatorBuilder.buildModelValidator(taskType, null), isA(modelValidatorClass));
-        });
+        taskTypeToModelValidatorClassMap().forEach(
+            (taskType, modelValidatorClass) -> assertThat(
+                ModelValidatorBuilder.buildModelValidator(taskType, mock()),
+                isA(modelValidatorClass)
+            )
+        );
     }
 
     private Map<TaskType, Class<? extends ModelValidator>> taskTypeToModelValidatorClassMap() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/SimpleModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/SimpleModelValidatorTests.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.mockito.Mock;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -39,7 +40,7 @@ public class SimpleModelValidatorTests extends ESTestCase {
     @Mock
     private Model mockModel;
     @Mock
-    private ActionListener<Model> mockActionListener;
+    private ActionListener<ModelValidationResult> mockActionListener;
 
     private SimpleModelValidator underTest;
 
@@ -65,7 +66,7 @@ public class SimpleModelValidatorTests extends ESTestCase {
 
     public void testValidate_ServiceReturnsInferenceServiceResults() {
         mockCallToServiceIntegrationValidator(SparseEmbeddingResultsTests.createRandomResults());
-        verify(mockActionListener).onResponse(mockModel);
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockModel && result.deploymentStarted() == false));
         verifyInteractions();
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/TextEmbeddingModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/TextEmbeddingModelValidatorTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -49,7 +50,7 @@ public class TextEmbeddingModelValidatorTests extends ESTestCase {
     @Mock
     private Model mockModel;
     @Mock
-    private ActionListener<Model> mockActionListener;
+    private ActionListener<ModelValidationResult> mockActionListener;
     @Mock
     private ServiceSettings mockServiceSettings;
 
@@ -138,7 +139,7 @@ public class TextEmbeddingModelValidatorTests extends ESTestCase {
         when(mockServiceSettings.dimensions()).thenReturn(dimensionsSetByUser ? results.getFirstEmbeddingSize() : null);
 
         mockCallToServiceIntegrationValidator(results);
-        verify(mockActionListener).onResponse(mockModel);
+        verify(mockActionListener).onResponse(argThat(result -> result.model() == mockModel && result.deploymentStarted() == false));
         verify(mockModel).getServiceSettings();
         verify(mockServiceSettings).dimensionsSetByUser();
         verify(mockServiceSettings).dimensions();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Inference API] Deploy text embedding models before validation call (#153886)](https://github.com/elastic/elasticsearch/pull/153886)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)