### PR TITLE
Fix ShardRoutingTests#testEqualsIgnoringVersion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -588,9 +588,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/154877
-- class: org.elasticsearch.cluster.routing.ShardRoutingTests
-  method: testEqualsIgnoringVersion
-  issue: https://github.com/elastic/elasticsearch/issues/154886
 - class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
   method: testIsUserInitiatedProjectRoutingChangeWhenRoutingNarrowsShouldReturnTrue
   issue: https://github.com/elastic/elasticsearch/issues/154908

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -454,6 +454,7 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                     otherRouting.primary(),
                     otherRouting.state()
                 ).withRelocatingNodeId(otherRouting.relocatingNodeId())
+                    .withRecoveryPriority(otherRouting.recoveryPriority())
                     .withUnassignedInfo(
                         otherRouting.unassignedInfo() == null
                             ? new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -392,6 +392,8 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                     if (otherRouting.started()) {
                         unchanged = true;
                     } else {
+                        final var originalState = otherRouting.state();
+                        final var originalRelocatingNodeId = otherRouting.relocatingNodeId();
                         otherRouting = new ShardRouting(
                             otherRouting.shardId(),
                             otherRouting.currentNodeId(),
@@ -399,7 +401,10 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                             otherRouting.primary(),
                             otherRouting.state(),
                             otherRouting.recoverySource(),
-                            TestShardRouting.buildRecoveryPriority(otherRouting.state(), otherRouting.relocatingNodeId() != null),
+                            randomValueOtherThan(
+                                otherRouting.recoveryPriority(),
+                                () -> TestShardRouting.buildRecoveryPriority(originalState, originalRelocatingNodeId != null)
+                            ),
                             otherRouting.unassignedInfo(),
                             otherRouting.relocationFailureInfo(),
                             otherRouting.allocationId(),


### PR DESCRIPTION
Just 
- a missing `randomValueOtherThan` which sometimes left recovery priority unchanged when mutating the object
- a missing builder method invocation which sometimes reset the recovery priority

Fixes #154886