### PR TITLE
Over estimate memory usage of delayable writable

### DIFF
--- a/docs/changelog/155015.yaml
+++ b/docs/changelog/155015.yaml
@@ -1,0 +1,5 @@
+area: Aggregations
+issues: []
+pr: 155015
+summary: Over estimate memory usage of delayable writable
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -274,4 +274,8 @@ public final class CompositeBytesReference extends AbstractBytesReference {
         }
         return super.getDoubleLE(index);
     }
+
+    public BytesReference[] references() {
+        return references;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -94,6 +94,10 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
         return new ReleasableBytesReference(slice, refCounted);
     }
 
+    public BytesReference delegate() {
+        return delegate;
+    }
+
     @Override
     public void close() {
         refCounted.decRef();

--- a/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
@@ -11,12 +11,15 @@ package org.elasticsearch.common.io.stream;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -203,14 +206,29 @@ public abstract class DelayableWriteable<T extends Writeable> implements Writeab
 
         @Override
         public long getSerializedSize() {
-            // We're already serialized
-            return serialized.length();
+            return pageAlignedRamUsedByReferenceBytes(serialized);
         }
 
         @Override
         public void close() {
             serialized.close();
         }
+    }
+
+    /**
+     * Over-estimates retained RAM by rounding each component up to a
+     * {@link PageCacheRecycler#BYTE_PAGE_SIZE} page (composites sum per component).
+     * Matches how Netty retains page-sized buffers rather than exact payload lengths.
+     */
+    static long pageAlignedRamUsedByReferenceBytes(BytesReference bytes) {
+        if (bytes instanceof ReleasableBytesReference r) {
+            return pageAlignedRamUsedByReferenceBytes(r.delegate());
+        }
+        if (bytes instanceof CompositeBytesReference composited) {
+            return Arrays.stream(composited.references()).mapToLong(DelayableWriteable::pageAlignedRamUsedByReferenceBytes).sum();
+        }
+        final long numPages = (bytes.length() + PageCacheRecycler.BYTE_PAGE_SIZE - 1L) / PageCacheRecycler.BYTE_PAGE_SIZE;
+        return numPages * PageCacheRecycler.BYTE_PAGE_SIZE;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
@@ -10,6 +10,11 @@
 package org.elasticsearch.common.io.stream;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 
@@ -124,9 +129,12 @@ public class DelayableWriteableTests extends ESTestCase {
     }
 
     public void testRoundTripFromDelayed() throws IOException {
-        Example e = new Example(randomAlphaOfLength(5));
+        Example e = new Example(randomAlphaOfLengthBetween(100, 1000));
         DelayableWriteable<Example> original = DelayableWriteable.referencing(e).asSerialized(Example::new, writableRegistry());
         assertTrue(original.isSerialized());
+        long length = DelayableWriteable.getSerializedSize(e);
+        long page = PageCacheRecycler.BYTE_PAGE_SIZE;
+        assertThat(original.getSerializedSize(), equalTo(((length + page - 1) / page) * page));
         roundTripTestCase(original, Example::new);
     }
 
@@ -163,6 +171,26 @@ public class DelayableWriteableTests extends ESTestCase {
         DelayableWriteable<Example> d = DelayableWriteable.referencing(e).asSerialized(Example::new, writableRegistry());
         assertTrue(d.isSerialized());
         assertSame(d, d.asSerialized(Example::new, writableRegistry()));
+    }
+
+    public void testPageAlignedRamUsedByReferenceBytes() {
+        final int page = PageCacheRecycler.BYTE_PAGE_SIZE;
+        assertThat(DelayableWriteable.pageAlignedRamUsedByReferenceBytes(BytesArray.EMPTY), equalTo(0L));
+        assertThat(DelayableWriteable.pageAlignedRamUsedByReferenceBytes(new BytesArray(new byte[1])), equalTo((long) page));
+        assertThat(DelayableWriteable.pageAlignedRamUsedByReferenceBytes(new BytesArray(new byte[page])), equalTo((long) page));
+        assertThat(DelayableWriteable.pageAlignedRamUsedByReferenceBytes(new BytesArray(new byte[page + 1])), equalTo(2L * page));
+
+        assertThat(
+            DelayableWriteable.pageAlignedRamUsedByReferenceBytes(ReleasableBytesReference.wrap(new BytesArray(new byte[1]))),
+            equalTo((long) page)
+        );
+
+        BytesReference composite = CompositeBytesReference.of(
+            new BytesArray(new byte[1]),
+            new BytesArray(new byte[page / 2]),
+            new BytesArray(new byte[page + 1])
+        );
+        assertThat(DelayableWriteable.pageAlignedRamUsedByReferenceBytes(composite), equalTo(4L * page));
     }
 
     private <T extends Writeable> void roundTripTestCase(DelayableWriteable<T> original, Writeable.Reader<T> reader) throws IOException {


### PR DESCRIPTION
Search requests with many DelayableWriteable account for less memory in the circuit breaker than the memory actually retained by Netty. For example, we accounted for only 8.5GB while Netty actually retained 10–11GB.

The reason is that the Netty pool retains a whole page for smaller data, but currently we account for the exact byte length. This led to undercounting and OOM.

This change over-estimates the memory usage of DelayableWriteable by rounding each reference up to a 16KB page boundary. This is independent of the fix that uses uncompressed length for accounting.

I will make this change to newer branches.