### PR TITLE
[9.4] Fix flaky AsyncSearchErrorTraceIT shard lock failure (#154952)

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
@@ -281,12 +281,8 @@ public class AsyncSearchErrorTraceIT extends AsyncSearchIntegTestCase {
             return;
         }
 
-        // Make sure the .async-search system index is green before deleting it
-        try {
-            ensureGreen(".async-search");
-        } catch (Exception ignore) {
-            // the index may not exist
-        }
+        awaitIndexExists(".async-search");
+        ensureGreen(".async-search");
 
         Response response = getRestClient().performRequest(new Request("DELETE", "/_async_search/" + id));
         HttpEntity entity = response.getEntity();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix flaky AsyncSearchErrorTraceIT shard lock failure (#154952)](https://github.com/elastic/elasticsearch/pull/154952)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)