### PR TITLE
Omit completion suggestion options for failed shard fetches

### DIFF
--- a/docs/changelog/155033.yaml
+++ b/docs/changelog/155033.yaml
@@ -1,0 +1,6 @@
+area: Suggesters
+issues:
+ - 32467
+pr: 155033
+summary: Omit completion suggestion options missing fetch results
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -230,8 +230,10 @@ public final class SearchPhaseController {
         var fetchResults = fetchResultsArray.asList();
         SearchHits hits = getHits(reducedQueryPhase, ignoreFrom, fetchResultsArray);
         try {
-            if (reducedQueryPhase.suggest != null && fetchResults.isEmpty() == false) {
-                mergeSuggest(reducedQueryPhase, fetchResultsArray, hits.getHits().length, reducedQueryPhase.sortedTopDocs.scoreDocs);
+            if (reducedQueryPhase.suggest != null) {
+                int suggestionsOffset = reducedQueryPhase.sortedTopDocs.scoreDocs.length
+                    - reducedQueryPhase.sortedTopDocs.numberOfCompletionsSuggestions;
+                mergeSuggest(reducedQueryPhase, fetchResultsArray, suggestionsOffset, reducedQueryPhase.sortedTopDocs.scoreDocs);
             }
             // Own refs for suggestion option hits so they survive fetch result release (caller exits try-with-resources).
             // Refs are incremented inside Suggest#collectCompletionOptionHits when passed true, not in mergeSuggest above.
@@ -256,7 +258,12 @@ public final class SearchPhaseController {
     ) {
         for (CompletionSuggestion suggestion : reducedQueryPhase.suggest.filter(CompletionSuggestion.class)) {
             final List<CompletionSuggestion.Entry.Option> suggestionOptions = suggestion.getOptions();
-            for (int scoreDocIndex = currentOffset; scoreDocIndex < currentOffset + suggestionOptions.size(); scoreDocIndex++) {
+            if (suggestionOptions.isEmpty()) {
+                continue;
+            }
+            final int suggestionEnd = currentOffset + suggestionOptions.size();
+            final List<CompletionSuggestion.Entry.Option> fetchedOptions = new ArrayList<>(suggestionOptions.size());
+            for (int scoreDocIndex = currentOffset; scoreDocIndex < suggestionEnd; scoreDocIndex++) {
                 ScoreDoc shardDoc = sortedDocs[scoreDocIndex];
                 SearchPhaseResult searchResultProvider = fetchResultsArray.get(shardDoc.shardIndex);
                 if (searchResultProvider == null) {
@@ -277,8 +284,11 @@ public final class SearchPhaseController {
                 hit.score(shardDoc.score);
                 hit.shard(fetchResult.getSearchShardTarget());
                 suggestOption.setHit(hit);
+                fetchedOptions.add(suggestOption);
             }
-            currentOffset += suggestionOptions.size();
+            suggestionOptions.clear();
+            suggestionOptions.addAll(fetchedOptions);
+            currentOffset = suggestionEnd;
         }
         assert currentOffset == sortedDocs.length : "expected no more score doc slices";
     }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -103,6 +103,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class SearchPhaseControllerTests extends ESTestCase {
     private ThreadPool threadPool;
@@ -1501,6 +1502,121 @@ public class SearchPhaseControllerTests extends ESTestCase {
                 }
             } finally {
                 fetchResults.asList().forEach(RefCounted::decRef);
+            }
+        } finally {
+            queryResults.asList().forEach(RefCounted::decRef);
+        }
+    }
+
+    public void testMergeOmitsCompletionOptionsWithoutFetchResults() {
+        AtomicArray<SearchPhaseResult> queryResults = new AtomicArray<>(2);
+        for (int shardIndex = 0; shardIndex < 2; shardIndex++) {
+            SearchShardTarget target = new SearchShardTarget("", new ShardId("", "", shardIndex), null);
+            QuerySearchResult queryResult = new QuerySearchResult(new ShardSearchContextId("", shardIndex), target, null);
+            queryResult.topDocs(new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN), null);
+            queryResult.size(0);
+            CompletionSuggestion suggestion = new CompletionSuggestion("suggestion", 2, false);
+            CompletionSuggestion.Entry entry = new CompletionSuggestion.Entry(new Text("term"), 0, 4);
+            entry.addOption(
+                new CompletionSuggestion.Entry.Option(shardIndex, new Text("suggestion-" + shardIndex), 1.0f, Collections.emptyMap())
+            );
+            suggestion.addTerm(entry);
+            queryResult.suggest(new Suggest(new ArrayList<>(List.of(suggestion))));
+            queryResult.setShardIndex(shardIndex);
+            queryResults.set(shardIndex, queryResult);
+        }
+
+        try {
+            SearchPhaseController.ReducedQueryPhase reducedQueryPhase = SearchPhaseController.reducedQueryPhase(
+                queryResults.asList(),
+                InternalAggregations.EMPTY,
+                new ArrayList<>(),
+                new TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE),
+                0,
+                false,
+                null,
+                null
+            );
+
+            AtomicArray<SearchPhaseResult> fetchResults = new AtomicArray<>(2);
+            SearchShardTarget target = queryResults.get(0).getSearchShardTarget();
+            FetchSearchResult fetchResult = new FetchSearchResult(new ShardSearchContextId("", 0), target);
+            fetchResult.shardResult(
+                new SearchHits(new SearchHit[] { new SearchHit(0, "") }, new TotalHits(1, Relation.EQUAL_TO), 1.0f),
+                null
+            );
+            fetchResults.set(0, fetchResult);
+
+            try (SearchResponseSections response = SearchPhaseController.merge(false, reducedQueryPhase, fetchResults)) {
+                CompletionSuggestion suggestion = (CompletionSuggestion) response.suggest().getSuggestion("suggestion");
+                assertThat(suggestion.getOptions(), hasSize(1));
+                assertThat(suggestion.getOptions().get(0).getHit(), notNullValue());
+            } finally {
+                fetchResult.decRef();
+            }
+        } finally {
+            queryResults.asList().forEach(RefCounted::decRef);
+        }
+    }
+
+    public void testMergeUsesScoreDocOffsetForCompletionOptions() {
+        AtomicArray<SearchPhaseResult> queryResults = new AtomicArray<>(2);
+        for (int shardIndex = 0; shardIndex < 2; shardIndex++) {
+            SearchShardTarget target = new SearchShardTarget("", new ShardId("", "", shardIndex), null);
+            QuerySearchResult queryResult = new QuerySearchResult(new ShardSearchContextId("", shardIndex), target, null);
+            TopDocs topDocs = shardIndex == 0
+                ? new TopDocs(new TotalHits(1, Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(0, 1.0f) })
+                : Lucene.EMPTY_TOP_DOCS;
+            queryResult.topDocs(new TopDocsAndMaxScore(topDocs, 1.0f), null);
+            queryResult.size(shardIndex == 0 ? 1 : 0);
+
+            CompletionSuggestion suggestion = new CompletionSuggestion("suggestion", 1, false);
+            CompletionSuggestion.Entry entry = new CompletionSuggestion.Entry(new Text("term"), 0, 4);
+            if (shardIndex == 1) {
+                entry.addOption(new CompletionSuggestion.Entry.Option(0, new Text("suggestion"), 1.0f, Collections.emptyMap()));
+            }
+            suggestion.addTerm(entry);
+            queryResult.suggest(new Suggest(new ArrayList<>(List.of(suggestion))));
+            queryResult.setShardIndex(shardIndex);
+            queryResults.set(shardIndex, queryResult);
+        }
+
+        List<TopDocs> bufferedTopDocs = new ArrayList<>();
+        TopDocsStats topDocsStats = new TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
+        for (SearchPhaseResult result : queryResults.asList()) {
+            TopDocsAndMaxScore topDocs = result.queryResult().consumeTopDocs();
+            SearchPhaseController.setShardIndex(topDocs.topDocs, result.getShardIndex());
+            bufferedTopDocs.add(topDocs.topDocs);
+            topDocsStats.add(topDocs, false, false);
+        }
+
+        try {
+            SearchPhaseController.ReducedQueryPhase reducedQueryPhase = SearchPhaseController.reducedQueryPhase(
+                queryResults.asList(),
+                InternalAggregations.EMPTY,
+                bufferedTopDocs,
+                topDocsStats,
+                0,
+                false,
+                null,
+                null
+            );
+
+            AtomicArray<SearchPhaseResult> fetchResults = new AtomicArray<>(2);
+            SearchShardTarget target = queryResults.get(1).getSearchShardTarget();
+            FetchSearchResult fetchResult = new FetchSearchResult(new ShardSearchContextId("", 1), target);
+            fetchResult.shardResult(
+                new SearchHits(new SearchHit[] { new SearchHit(0, "") }, new TotalHits(1, Relation.EQUAL_TO), 1.0f),
+                null
+            );
+            fetchResults.set(1, fetchResult);
+
+            try (SearchResponseSections response = SearchPhaseController.merge(false, reducedQueryPhase, fetchResults)) {
+                CompletionSuggestion suggestion = (CompletionSuggestion) response.suggest().getSuggestion("suggestion");
+                assertThat(suggestion.getOptions(), hasSize(1));
+                assertThat(suggestion.getOptions().get(0).getHit(), notNullValue());
+            } finally {
+                fetchResult.decRef();
             }
         } finally {
             queryResults.asList().forEach(RefCounted::decRef);


### PR DESCRIPTION
When a shard completes the query phase but its fetch phase fails, for
example because its node leaves during a rolling restart, a partial search
response can retain completion suggestion options from that shard without
their enriched `SearchHit` metadata.

This change omits completion options whose fetch result is unavailable,
consistent with how ordinary search hits from failed shard fetches are
handled.

The merged `scoreDocs` array retains its original query-phase layout when
ordinary hits are omitted after a shard fetch failure. Therefore, the
completion-option offset is derived from the number of completion score
docs rather than from the number of successfully fetched ordinary hits.
This prevents missing ordinary hits from shifting suggestion enrichment.


Closes #32467