### PR TITLE
Support stored geo point context paths

### DIFF
--- a/docs/changelog/155034.yaml
+++ b/docs/changelog/155034.yaml
@@ -1,0 +1,6 @@
+area: Suggesters
+issues:
+ - 28669
+pr: 155034
+summary: Support stored-only geo points in completion context paths
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.suggest.completion.context;
 
 import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.LatLonPoint;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
@@ -182,6 +183,9 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
             GeoPoint spare = new GeoPoint();
             for (IndexableField field : fields) {
                 if (field instanceof StringField) {
+                    spare.resetFromString(field.stringValue());
+                    geohashes.add(spare.geohash());
+                } else if (field instanceof StoredField) {
                     spare.resetFromString(field.stringValue());
                     geohashes.add(spare.geohash());
                 } else if (field instanceof LatLonDocValuesField || field instanceof GeoPointFieldMapper.LatLonPointWithDocValues) {

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
@@ -9,15 +9,19 @@
 
 package org.elasticsearch.search.suggest.completion;
 
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
@@ -35,8 +39,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.geometry.utils.Geohash.addNeighborsAtLevel;
+import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.elasticsearch.search.suggest.completion.CategoryContextMappingTests.assertContextSuggestFields;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -240,6 +246,72 @@ public class GeoContextMappingTests extends MapperServiceTestCase {
             .parse(new SourceToParse("1", BytesReference.bytes(builder), XContentType.JSON));
         List<IndexableField> fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
         assertContextSuggestFields(fields, 3);
+    }
+
+    public void testIndexingWithStoredOnlyGeoPointPath() throws Exception {
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "location")
+            .field("type", "geo")
+            .field("path", "loc")
+            .endObject()
+            .endArray()
+            .endObject()
+            .startObject("loc")
+            .field("type", "geo_point")
+            .field("index", false)
+            .field("doc_values", false)
+            .field("store", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        MapperService mapperService = createMapperService(mapping);
+        MappedFieldType completionFieldType = mapperService.fieldType("completion");
+        ParsedDocument parsedDocument = mapperService.documentMapper()
+            .parse(
+                new SourceToParse(
+                    "1",
+                    BytesReference.bytes(
+                        jsonBuilder().startObject()
+                            .startObject("completion")
+                            .field("input", "suggestion")
+                            .endObject()
+                            .startObject("loc")
+                            .field("lat", 43.6624803)
+                            .field("lon", -79.3863353)
+                            .endObject()
+                            .endObject()
+                    ),
+                    XContentType.JSON
+                )
+            );
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
+        assertContextSuggestFields(fields, 1);
+
+        try (TokenStream tokenStream = fields.get(0).tokenStream(Lucene.WHITESPACE_ANALYZER, null)) {
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+            }
+            tokenStream.end();
+        }
+    }
+
+    public void testParsingStoredGeoPointField() {
+        GeoContextMapping mapping = ContextBuilder.geo("location").field("loc").build();
+        LuceneDocument document = new LuceneDocument();
+        document.add(new StoredField("loc", "43.6624803, -79.3863353"));
+
+        assertThat(
+            mapping.parseContext(document),
+            equalTo(Set.of(stringEncode(-79.3863353, 43.6624803, GeoContextMapping.DEFAULT_PRECISION)))
+        );
     }
 
     public void testMalformedGeoField() throws Exception {


### PR DESCRIPTION
Closes #28669

A geo_point configured with `index: false`, `doc_values: false`, and `store: true` is represented in the Lucene document by a `StoredField` containing the canonical coordinate string. Geo context extraction previously ignored that field, so a completion context whose `path` referenced the stored-only geo_point lost its context and failed when the completion token stream was built.

This change parses stored geo_point values with the existing `GeoPoint.resetFromString` path. Indexed and doc-values representations remain unchanged.

Tests:
- ./gradlew --offline --no-daemon --max-workers=2 :server:test --tests org.elasticsearch.search.suggest.completion.GeoContextMappingTests
- ./gradlew --offline --no-daemon --max-workers=2 :server:spotlessJavaCheck
- git diff --check

Full `./gradlew --offline --no-daemon --max-workers=2 check` and `:server:check` were attempted but could not be configured because the local offline cache lacks unrelated JMH and APM/OpenTelemetry dependencies.