### PR TITLE
Warn when lists are read as strings

### DIFF
--- a/docs/changelog/155036.yaml
+++ b/docs/changelog/155036.yaml
@@ -1,0 +1,14 @@
+area: Infra/Settings
+deprecation:
+  area: Cluster and node setting
+  details: |-
+    Calling `Settings#get` for a setting whose raw value is a list now emits a deprecation warning.
+    The current string representation is preserved during the deprecation period.
+  impact: |-
+    Callers that expect multiple values should use `Settings#getAsList` instead of reading the setting as a scalar string.
+  title: Reading list-valued settings as strings is deprecated.
+issues:
+ - 33135
+pr: 155036
+summary: Deprecate reading list-valued settings as strings
+type: deprecation

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.VersionId;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -82,6 +83,8 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
     public static final Diff<Settings> EMPTY_DIFF = new SettingsDiff(DiffableUtils.emptyDiff());
 
     public static final String FLAT_SETTINGS_PARAM = "flat_settings";
+
+    private static final String LIST_AS_STRING_DEPRECATION_KEY_SUFFIX = ".list_as_string";
 
     public static final MapParams FLAT_SETTINGS_TRUE = new MapParams(Map.of(FLAT_SETTINGS_PARAM, "true"));
 
@@ -279,7 +282,17 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
      * @return The setting value, {@code null} if it does not exists.
      */
     public String get(String setting) {
-        return toString(settings.get(setting));
+        Object value = settings.get(setting);
+        if (value instanceof List<?>) {
+            DeprecationLoggerHolder.deprecationLogger.warn(
+                DeprecationCategory.SETTINGS,
+                setting + LIST_AS_STRING_DEPRECATION_KEY_SUFFIX,
+                "[{}] setting is configured as a list but is being read as a string. "
+                    + "This behavior is deprecated and will be removed in a future release. Configure a single value instead.",
+                setting
+            );
+        }
+        return toString(value);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -135,6 +135,23 @@ public class SettingsTests extends ESTestCase {
         assertTrue(names.contains("baz"));
     }
 
+    public void testGetWarnsWhenReadingListAsString() {
+        Settings settings = Settings.builder().putList("value", "one", "two").build();
+
+        assertThat(settings.get("value"), equalTo("[one, two]"));
+        assertWarnings(
+            "[value] setting is configured as a list but is being read as a string. This behavior is deprecated and will be removed in a future release. "
+                + "Configure a single value instead."
+        );
+    }
+
+    public void testGetAsListDoesNotWarnWhenReadingList() {
+        Settings settings = Settings.builder().putList("value", "one", "two").build();
+
+        assertThat(settings.getAsList("value"), contains("one", "two"));
+        assertWarnings();
+    }
+
     public void testThatArraysAreOverriddenCorrectly() throws IOException {
         // overriding a single value with an array
         Settings settings = Settings.builder()
@@ -236,6 +253,10 @@ public class SettingsTests extends ESTestCase {
             .build();
         assertThat(settings.get("value.data"), is("1"));
         assertThat(settings.get("value"), is("[4, 5]"));
+        assertWarnings(
+            "[value] setting is configured as a list but is being read as a string. This behavior is deprecated and will be removed in a future release. "
+                + "Configure a single value instead."
+        );
     }
 
     public void testPrefixNormalization() {


### PR DESCRIPTION
Closes #33135

### Summary

`Settings#get` currently converts a raw list to its Java string representation when a scalar setting is read. This can silently preserve an invalid configuration during a future transition to stricter parsing.

This change emits a settings deprecation warning when a raw list is read as a string while preserving the current return value. The warning is deduplicated per setting key, and `getAsList` remains warning-free. This gives operators an actionable migration signal before the behavior changes.

### Tests

- `./gradlew --offline --no-daemon --max-workers=2 :server:test --tests org.elasticsearch.common.settings.SettingsTests`
- `./gradlew --offline --no-daemon --max-workers=2 :server:test --tests org.elasticsearch.common.settings.SettingTests`
- `./gradlew --offline --no-daemon --max-workers=2 :server:spotlessJavaCheck`
- `git diff --check`

The repository-wide `check` and `:server:check` could not resolve uncached offline dependencies (`jmh-generator-annprocess:1.37` and APM/OpenTelemetry artifacts respectively).