### PR TITLE
ESQL: parquet read-options allocator back to heap — direct buffers there were never freed

### DIFF
--- a/docs/changelog/155038.yaml
+++ b/docs/changelog/155038.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 155038
+summary: Fix off-heap memory growth when reading external Parquet datasets
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.ParquetReadOptions;
-import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
@@ -505,14 +505,21 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
      * {@link ParquetReadOptions.Builder}'s unconditional loading of {@code ParquetInputFormat}
      * (which extends Hadoop's {@code FileInputFormat}) and {@code HadoopCodecs}.
      */
-    private PlainParquetReadOptions.Builder readOptionsBuilder() {
+    // Package-private so ParquetFormatReaderTests can pin the allocator wiring: a heap-backed
+    // delegate is a correctness property here, not a preference (see the comment below).
+    PlainParquetReadOptions.Builder readOptionsBuilder() {
         // parquet-mr defaults useColumnIndexFilter=true (since 1.12.0), so when a FilterPredicate
         // is set via withRecordFilter, page-index filtering (ColumnIndex/OffsetIndex) is automatically
         // active in addition to row-group level statistics, dictionary, and bloom filter checks.
         // Note: all read operations happen synchronously with the ESQL engine. If some operations
         // change to be async, we'll have to unwrap the breaker if it's a LocalBreaker.
+        //
+        // Keep the delegate heap-backed. parquet-mr's DirectByteBufferAllocator.release() is empty, so a
+        // direct delegate returns the breaker charge but leaves the memory to a Cleaner -- reclamation
+        // becomes a function of GC frequency, which a large heap starves. Nothing reads these buffers
+        // natively either: they are footers and dictionary-page copies, both copied to the heap next step.
         var breaker = blockFactory.breaker();
-        var allocator = new CircuitBreakerByteBufferAllocator(new DirectByteBufferAllocator(), breaker);
+        var allocator = new CircuitBreakerByteBufferAllocator(new HeapByteBufferAllocator(), breaker);
         return PlainParquetReadOptions.builder(codecFactory).withAllocator(allocator);
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -60,10 +60,11 @@ import java.util.zip.GZIPOutputStream;
  *       never reaches the {@code ByteBuffer} overload, regardless of the allocator or the
  *       {@code useOffHeapDecryptBuffer} flag (which is a decryption-only flag). The decompressed
  *       page bytes on that path are therefore still allocated as a heap {@code byte[]} by the
- *       codec. Wiring {@code DirectByteBufferAllocator} into the read options still benefits
- *       this path: parquet-mr's other allocations that go through the read-options allocator
- *       (e.g. the page reader's {@code ByteBufferReleaser}) become direct, and our
- *       {@link CircuitBreakerByteBufferAllocator} wrapper accounts those allocations.
+ *       codec. The read-options allocator is therefore deliberately heap-backed (see
+ *       {@code ParquetFormatReader.readOptionsBuilder}): nothing on that path hands its buffers
+ *       to a native codec in place, so direct memory would buy no zero-copy while making release
+ *       depend on garbage collection. Our {@link CircuitBreakerByteBufferAllocator} wrapper still
+ *       accounts those allocations.
  *       Routing the non-prefetched decompression output through the {@code ByteBuffer} overload
  *       would require a parquet-mr change and is left as future work.</li>
  * </ul>
@@ -207,9 +208,10 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
         @Override
         public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
             byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            // Both production call sites (PrefetchedPageReader and ColumnChunkPageReadStore with
-            // DirectByteBufferAllocator) use the ByteBuffer overload, so this overload is not on
-            // the hot path. It is retained as a safety net for external callers or future use.
+            // PrefetchedPageReader (the optimized path) uses the ByteBuffer overload with Arrow
+            // buffers on both sides. This BytesInput overload is what everything else reaches:
+            // parquet-mr's ColumnChunkPageReadStore.readPage() on the baseline path, and
+            // ParquetFileReader.readDictionary during dictionary filtering on the optimized path.
             // Fast path: avoid BytesInput.toByteArray() for heap-buffer-backed inputs — the default
             // toByteArray() funnels through a sized ByteArrayOutputStream, adding one allocation
             // and one System.arraycopy that the JNI Snappy binding does not need.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainParquetReadOptions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainParquetReadOptions.java
@@ -74,6 +74,12 @@ public final class PlainParquetReadOptions {
     }
 
     public static final class Builder {
+        // TODO decide whether any of the nine booleans below should be configurable; a separate issue
+        // tracks this. They are dead configuration today: they look settable, but have no setter and are
+        // never assigned, existing only to fill the positional signature of the constructor in build().
+        // Note that usePageChecksumVerification and useOffHeapDecryptBuffer gate the parquet-mr paths
+        // that consume this allocator's buffers natively, so wiring either up means revisiting the heap
+        // allocator choice in ParquetFormatReader#readOptionsBuilder.
         private boolean useSignedStringMinMax = false;
         private boolean useStatsFilter = true;
         private boolean useDictionaryFilter = true;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -6940,4 +6940,30 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertTrue("numeric extrema compare naturally", ParquetFormatReader.compareStatExtremum(5L, 10L) < 0);
     }
 
+    /**
+     * A direct delegate leaks native memory until GC, so a revert must fail here rather than in a heap dump.
+     * Rationale in {@code ParquetFormatReader#readOptionsBuilder}. Asserted on both the type and the observable
+     * behaviour: {@code isDirect()} and {@code hasArray()} each flip on their own when the delegate changes.
+     */
+    public void testReadOptionsAllocatorIsHeapBackedAndBreakerAccounted() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        var factory = new BlockFactory(breaker, blockFactory.bigArrays());
+        ParquetReadOptions options = new ParquetFormatReader(factory).readOptionsBuilder().build();
+
+        var allocator = options.getAllocator();
+        assertThat(allocator, instanceOf(CircuitBreakerByteBufferAllocator.class));
+        assertFalse("parquet's allocator must not be direct — its release() cannot free direct memory", allocator.isDirect());
+
+        long before = breaker.getUsed();
+        ByteBuffer buffer = allocator.allocate(128);
+        try {
+            assertTrue("a heap-backed delegate yields array-backed buffers", buffer.hasArray());
+            assertFalse(buffer.isDirect());
+            assertEquals("allocation must be charged to the request breaker", before + 128, breaker.getUsed());
+        } finally {
+            allocator.release(buffer);
+        }
+        assertEquals("release must return the full charge", before, breaker.getUsed());
+    }
+
 }


### PR DESCRIPTION
## What this is about

We hand parquet-mr an allocator so its internal reads are charged to our circuit breaker. Since #149239 that allocator has been direct, to keep those buffers off-heap and let native codecs read them without a copy.

Neither payoff applies any more. #147691 had already moved row-group reading and decompression onto Arrow, so what still comes from this allocator is footers and dictionary-page copies — both copied onto the heap by the next step anyway.

What the direct delegate did bring is a `release` that does nothing:

```java
public void release(ByteBuffer b) {
    // The ByteBuffer.allocateDirect
    return;
}
```

Not a parquet-mr bug — Java offers no way to free an `allocateDirect` block. But our wrapper uncharges the breaker on release and delegates the free to that empty method, so we return the accounting and keep the memory. Freeing falls to a `Cleaner`, which means it tracks GC frequency, and a large heap starves it.

Same query and dataset, heap the only variable: at 1 GiB direct memory sits flat at 98 MB over 60 queries. At 24 GiB the young-GC counter moves 8 times in 200 queries while direct memory climbs to 203 MB, and a forced collection drops the live buffer count from 553 to 50. Heap and breaker read healthy throughout, which is why nothing caught it.

## The fix

```java
-new CircuitBreakerByteBufferAllocator(new DirectByteBufferAllocator(), breaker)
+new CircuitBreakerByteBufferAllocator(new HeapByteBufferAllocator(), breaker)
```

The wrapper is unchanged — still charged on allocate, still uncharged on release. Only the delegate differs, and it now matches what `PlainParquetReadOptions.Builder` already defaults to.

## Does it work

At 24 GiB over 152 iterations, direct memory settles at `132,120,601 bytes / 50 buffers` after warm-up and never moves again — same starved-GC regime that produced the climb before. Breaker steady, no trips.

Worth noting that flat direct memory alone isn't proof, since heap buffers never show up in `BufferPoolMXBean`; stable RSS and a breaker returning to baseline are the real signals. The residual 126 MB is the Arrow and storage prefetch pools, which this doesn't touch.

A new test pins the wiring — reverting the delegate fails on both `isDirect()` and `hasArray()`.

## Why heap rather than Arrow

Arrow gives real explicit release, but nothing closes this allocator today, and an unreachable `ArrowBuf` never frees and never uncharges — so a missed path would trade a GC-reclaimed leak for a permanent one. It would also double-count, since `CircuitBreakerAllocationListener` already charges Arrow allocations. The buffers that genuinely need to be off-heap, the ones zstd and Snappy read in place, come from Arrow via `PrefetchedPageReader` and are untouched.

## What's in the diff

- **`ParquetFormatReader`** — the allocator swap, and why heap is correct at the decision point.
- **`PlainCompressionCodecFactory`** — two comments corrected; the class doc justified the direct allocator by a benefit it doesn't deliver.
- **`PlainParquetReadOptions`** — a note on the nine read-option booleans, none of which has a setter.
- **`ParquetFormatReaderTests`** — the pinning test. `readOptionsBuilder` becomes package-private.

A dataset setting `optimized_reader: false` routes through parquet-mr's `ConsecutivePartList`, whose 8 MiB slabs become heap arrays — heavier on G1, breaker-bounded, correct.

## Scope

This is one instance of a wider pattern: native memory in this module whose release depends on garbage collection. A full sweep of the external read path turned up more of the same shape, along with the reason none of it gets caught — there's no per-query Arrow allocator, so nothing ever checks for outstanding buffers. Those are tracked separately and aren't in scope here.
