### PR TITLE
Fix null filtering for AVG on long fields

### DIFF
--- a/docs/changelog/155040.yaml
+++ b/docs/changelog/155040.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154804
+pr: 155040
+summary: Infer non-null constraints for `AVG` over long fields
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferNonNullAggConstraint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferNonNullAggConstraint.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical.local;
 
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
@@ -53,9 +54,11 @@ public class InferNonNullAggConstraint extends OptimizerRules.ParameterizedOptim
         LogicalPlan plan = aggregate;
         var aggs = aggregate.aggregates();
         Set<Expression> nonNullAggFields = Sets.newLinkedHashSetWithExpectedSize(aggs.size());
+        AttributeMap.Builder<Expression> aliasesBuilder = AttributeMap.builder();
+        aggregate.child().forEachExpression(Alias.class, alias -> aliasesBuilder.put(alias.toAttribute(), alias.child()));
+        AttributeMap<Expression> aliases = aliasesBuilder.build();
         for (var agg : aggs) {
             if (Alias.unwrap(agg) instanceof AggregateFunction af) {
-                Expression field = af.field();
                 // ignore literals (e.g. COUNT(1))
                 // make sure the field exists at the source and is indexed (not runtime)
 
@@ -64,12 +67,12 @@ public class InferNonNullAggConstraint extends OptimizerRules.ParameterizedOptim
                     return plan;
                 }
 
-                if (field.foldable() == false && field instanceof FieldAttribute fa && stats.isIndexed(fa.fieldName())) {
-                    nonNullAggFields.add(field);
-                } else {
+                Set<Expression> fields = resolveNonNullAggFields(af.field(), aliases, stats);
+                if (fields.isEmpty()) {
                     // otherwise bail out since unless disjunction needs to cover _all_ fields, things get filtered out
                     return plan;
                 }
+                nonNullAggFields.addAll(fields);
             }
         }
 
@@ -80,5 +83,33 @@ public class InferNonNullAggConstraint extends OptimizerRules.ParameterizedOptim
             plan = aggregate.replaceChild(new Filter(aggregate.source(), aggregate.child(), condition));
         }
         return plan;
+    }
+
+    private static Set<Expression> resolveNonNullAggFields(Expression field, AttributeMap<Expression> aliases, SearchStats stats) {
+        if (field.foldable()) {
+            return Set.of();
+        }
+
+        if (field instanceof FieldAttribute fa && stats.isIndexed(fa.fieldName())) {
+            return Set.of(field);
+        }
+
+        // Surrogate aggregations can introduce an alias around the original field, for example AVG(long)
+        // becomes SUM(TO_DOUBLE(long)). Resolve that alias to keep the filter pushable to the source.
+        Set<Expression> resolvedFields = new InferIsNotNull().resolveExpressionAsRootAttributes(field, aliases);
+        if (resolvedFields.isEmpty()) {
+            return Set.of();
+        }
+
+        for (Expression resolvedField : resolvedFields) {
+            if (resolvedField instanceof FieldAttribute == false) {
+                return Set.of();
+            }
+            FieldAttribute fa = (FieldAttribute) resolvedField;
+            if (stats.isIndexed(fa.fieldName()) == false) {
+                return Set.of();
+            }
+        }
+        return resolvedFields;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -1066,6 +1066,25 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
     }
 
     /**
+     * AVG is represented as an expression over SUM and COUNT before local optimization. The non-null constraint must still be inferred from
+     * those nested aggregate functions so the query filters null values before executing the aggregation.
+     */
+    public void testAvgOnLongInfersNonNullAggConstraint() {
+        LogicalPlan coordinatorOptimized = allTypes().coordinatorPlan("FROM test_all | STATS avg = AVG(long)");
+        var plan = localPlan(coordinatorOptimized, TEST_SEARCH_STATS);
+
+        var project = as(plan, Project.class);
+        var eval = as(project.child(), Eval.class);
+        var limit = as(eval.child(), Limit.class);
+        var aggregate = as(limit.child(), Aggregate.class);
+        var aggregateEval = as(aggregate.child(), Eval.class);
+        var filter = as(aggregateEval.child(), Filter.class);
+        var condition = as(filter.condition(), IsNotNull.class);
+        var field = as(condition.field(), FieldAttribute.class);
+        assertThat(field.fieldName().string(), equalTo("long"));
+    }
+
+    /**
      * {@snippet lang="text":
      * \_Aggregate[[first_name{r}#7, $$first_name$temp_name$17{r}#18],[SUM(salary{f}#11,true[BOOLEAN]) AS SUM(salary)#5, first_nam
      * e{r}#7, first_name{r}#7 AS last_name#10]]


### PR DESCRIPTION
Closes #154804

## Problem

The local optimizer did not infer a pushable non-null constraint for AVG(long_field). AVG is rewritten into SUM and COUNT, and the SUM surrogate uses an EVAL alias for TO_DOUBLE(long_field). The existing rule only recognized direct source fields, so the alias was treated as an unindexed field and no filter was added.

## Solution

Resolve aggregation input aliases to their root source fields before checking indexability. This preserves the conservative behavior for literals, runtime or unindexed fields, and FIRST/LAST while allowing the AVG long-field surrogate to produce a pushable field IS NOT NULL filter.

## Tests

- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests.testAvgOnLongInfersNonNullAggConstraint
- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck
- git diff --check