### PR TITLE
Handle null-typed TOP output fields

### DIFF
--- a/docs/changelog/155042.yaml
+++ b/docs/changelog/155042.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154608
+pr: 155042
+summary: Handle null-typed TOP output fields during planning
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -13,6 +13,19 @@ null
 null
 ;
 
+topWithNullOutputField
+required_capability: agg_top_with_output_field
+required_capability: optional_fields_nullify_tech_preview
+
+SET unmapped_fields="nullify"\;
+FROM employees
+| STATS t = TOP(salary, 3, "asc", foo)
+;
+
+t:integer
+null
+;
+
 partialMappingUnmappedFromSource
 required_capability: optional_fields_nullify_tech_preview
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
@@ -326,7 +326,9 @@ public class Top extends AggregateFunction
 
     @Override
     public DataType dataType() {
-        return outputField() == null ? field().dataType().noText() : outputField().dataType().noText();
+        return outputField() == null || DataType.isNull(outputField().dataType())
+            ? field().dataType().noText()
+            : outputField().dataType().noText();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEval.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.FromPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Present;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.PresentOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.ToPartial;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Top;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -136,6 +137,11 @@ public class ReplaceStatsFilteredOrNullAggWithEval extends OptimizerRules.Optimi
 
     public static boolean shouldReplace(AggregateFunction aggFunction) {
         if (hasFalseFilter(aggFunction)) {
+            return true;
+        }
+        // TOP can return its optional output field rather than its primary field. A null-typed output field therefore makes the result null
+        // even when the primary field is mapped.
+        if (aggFunction instanceof Top top && top.parameters().size() == 3 && DataType.isNull(top.parameters().get(2).dataType())) {
             return true;
         }
         /*

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEvalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEvalTests.java
@@ -829,6 +829,27 @@ public class ReplaceStatsFilteredOrNullAggWithEvalTests extends AbstractLogicalP
     }
 
     /**
+     * TOP returns values from its optional output field. A null-typed output field must therefore be replaced with a typed null before
+     * planning tries to create a TOP aggregator for the incompatible {@code NULL} type.
+     */
+    public void testReplaceStatsTopWithNullOutputField() {
+        var plan = plan("""
+            row salary = 100, missing = null
+            | stats t = top(salary, 3, "asc", missing)
+            """);
+
+        var limit = as(plan, Limit.class);
+        var source = as(limit.child(), LocalRelation.class);
+        assertThat(Expressions.names(source.output()), contains("t"));
+        assertThat(source.output().getFirst().dataType(), is(INTEGER));
+
+        Page page = source.supplier().get();
+        assertThat(page.getBlockCount(), is(1));
+        assertThat(page.getPositionCount(), is(1));
+        assertTrue(page.getBlock(0).areAllValuesNull());
+    }
+
+    /**
      * {@snippet lang="text":
      * Project[[y{r}#6]]
      * \_Eval[[null[NULL] AS y#6]]


### PR DESCRIPTION
Closes #154608

## Problem

With unmapped_fields="nullify", TOP(salary, 3, "asc", foo) can have a mapped primary field and a NULL-typed output field. The null replacement rule only inspected the primary field, so the TOP aggregate reached planning and failed to find a (INTEGER, NULL) aggregator supplier.

## Solution

Treat a NULL-typed TOP output field as a null aggregate result before supplier selection. Preserve the primary field type for the folded null result, matching TOP's declared result type when the optional output field has no concrete type.

## Tests

- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStatsFilteredOrNullAggWithEvalTests.testReplaceStatsTopWithNullOutputField
- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStatsFilteredOrNullAggWithEvalTests
- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:internalClusterTest --tests 'org.elasticsearch.xpack.esql.CsvIT.*unmapped-nullify*topWithNullOutputField*'
- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck
- git diff --check