### PR TITLE
Honor drop_null_columns for Arrow responses

### DIFF
--- a/docs/changelog/155043.yaml
+++ b/docs/changelog/155043.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154522
+pr: 155043
+summary: Honor drop_null_columns for Arrow responses
+type: bug

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/ArrowFormatIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/ArrowFormatIT.java
@@ -69,6 +69,9 @@ public class ArrowFormatIT extends ESRestTestCase {
                   "description": {
                     "type": "keyword"
                   },
+                  "always_null": {
+                    "type": "keyword"
+                  },
                   "ip": {
                     "type": "ip"
                   },
@@ -97,12 +100,30 @@ public class ArrowFormatIT extends ESRestTestCase {
     }
 
     private VectorSchemaRoot esql(String query) throws IOException {
-        Request request = new Request("POST", "/_query?format=arrow");
+        return esql(query, "");
+    }
+
+    private VectorSchemaRoot esql(String query, String additionalParams) throws IOException {
+        String path = "/_query?format=arrow" + (additionalParams.isEmpty() ? "" : "&" + additionalParams);
+        Request request = new Request("POST", path);
         request.setJsonEntity(query);
         Response response = client().performRequest(request);
 
         assertEquals("application/vnd.apache.arrow.stream", response.getEntity().getContentType().getValue());
         return readArrow(response.getEntity().getContent());
+    }
+
+    public void testDropNullColumns() throws Exception {
+        try (VectorSchemaRoot root = esql("""
+            {
+                "query": "FROM arrow-test | SORT value | LIMIT 100 | KEEP value, always_null, description"
+            }""", "drop_null_columns=true")) {
+            List<Field> fields = root.getSchema().getFields();
+            assertEquals(List.of("value", "description"), fields.stream().map(Field::getName).toList());
+
+            assertValues(root);
+            assertDescription(root);
+        }
     }
 
     public void testInteger() throws Exception {
@@ -159,7 +180,7 @@ public class ArrowFormatIT extends ESRestTestCase {
                 "query": "FROM arrow-test | SORT value | LIMIT 100"
             }""")) {
             List<Field> fields = root.getSchema().getFields();
-            assertEquals(4, fields.size());
+            assertEquals(5, fields.size());
 
             assertDescription(root);
             assertValues(root);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.xpack.esql.formatter.TextFormat.CSV;
 import static org.elasticsearch.xpack.esql.formatter.TextFormat.URL_PARAM_DELIMITER;
@@ -140,10 +141,7 @@ public final class EsqlResponseListener extends RestRefCountedChunkedToXContentL
                     releasable
                 );
             } else if (mediaType == ArrowFormat.INSTANCE) {
-                ArrowResponse arrowResponse = new ArrowResponse(
-                    esqlResponse.columns().stream().map(c -> new ArrowResponse.Column(c.type(), c.name())).toList(),
-                    esqlResponse.pages()
-                );
+                ArrowResponse arrowResponse = buildArrowResponse(esqlResponse);
                 restResponse = RestResponse.chunked(RestStatus.OK, arrowResponse, Releasables.wrap(arrowResponse, releasable));
             } else {
                 restResponse = RestResponse.chunked(
@@ -160,6 +158,21 @@ public final class EsqlResponseListener extends RestRefCountedChunkedToXContentL
                 releasable.close();
             }
         }
+    }
+
+    private ArrowResponse buildArrowResponse(EsqlQueryResponse esqlResponse) {
+        boolean[] nullColumns = restRequest.paramAsBoolean(EsqlQueryResponse.DROP_NULL_COLUMNS_OPTION, false)
+            ? esqlResponse.nullColumns()
+            : new boolean[esqlResponse.columns().size()];
+        int[] blockMapping = IntStream.range(0, nullColumns.length).filter(column -> nullColumns[column] == false).toArray();
+        return new ArrowResponse(
+            IntStream.of(blockMapping)
+                .mapToObj(column -> esqlResponse.columns().get(column))
+                .map(c -> new ArrowResponse.Column(c.type(), c.name()))
+                .toList(),
+            esqlResponse.pages(),
+            blockMapping
+        );
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/arrow/ArrowResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/arrow/ArrowResponse.java
@@ -42,6 +42,7 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 public class ArrowResponse implements ChunkedRestResponseBodyPart, Releasable {
 
@@ -60,17 +61,33 @@ public class ArrowResponse implements ChunkedRestResponseBodyPart, Releasable {
     }
 
     private final List<Column> columns;
+    private final int[] blockMapping;
     private Iterator<ResponseSegment> segments;
     private ResponseSegment currentSegment;
 
     public ArrowResponse(List<Column> columns, List<Page> pages) {
+        this(columns, pages, IntStream.range(0, columns.size()).toArray());
+    }
+
+    /**
+     * Creates an Arrow response whose columns can expose a projected view of each page.
+     *
+     * @param columns the columns to expose in the Arrow schema
+     * @param pages the pages containing the response data
+     * @param blockMapping the source block index for each exposed column
+     */
+    public ArrowResponse(List<Column> columns, List<Page> pages, int[] blockMapping) {
+        if (columns.size() != blockMapping.length) {
+            throw new IllegalArgumentException("columns and block mapping must have the same size");
+        }
         this.columns = columns;
+        this.blockMapping = blockMapping.clone();
 
         // Find multivalued columns
         int colSize = columns.size();
         for (int col = 0; col < colSize; col++) {
             for (Page page : pages) {
-                if (page.getBlock(col).mayHaveMultivaluedFields()) {
+                if (page.getBlock(this.blockMapping[col]).mayHaveMultivaluedFields()) {
                     columns.get(col).multivalued = true;
                     break;
                 }
@@ -267,15 +284,15 @@ public class ArrowResponse implements ChunkedRestResponseBodyPart, Releasable {
             // See https://arrow.apache.org/docs/format/Columnar.html#recordbatch-message
 
             // Field metadata
-            List<ArrowFieldNode> nodes = new ArrayList<>(page.getBlockCount());
+            List<ArrowFieldNode> nodes = new ArrayList<>(response.columns.size());
 
             // Buffers added to the record batch. They're used to track data size so that Arrow can compute offsets
             // but contain no data. Actual writing will be done by the bufWriters. This avoids having to deal with
             // Arrow's memory management, and in the future will allow direct write from ESQL block vectors.
-            List<ArrowBuf> bufs = new ArrayList<>(page.getBlockCount() * 2);
+            List<ArrowBuf> bufs = new ArrayList<>(response.columns.size() * 2);
 
             // Closures that will actually write a Block's data. Maps 1:1 to `bufs`.
-            List<BlockArrowFormatter.BufWriter> bufWriters = new ArrayList<>(page.getBlockCount() * 2);
+            List<BlockArrowFormatter.BufWriter> bufWriters = new ArrayList<>(response.columns.size() * 2);
 
             // Give Arrow a WriteChannel that will iterate on `bufWriters` when requested to write a buffer.
             WriteChannel arrowOut = new WriteChannel(arrowOut(out)) {
@@ -310,11 +327,11 @@ public class ArrowResponse implements ChunkedRestResponseBodyPart, Releasable {
             };
 
             // Create Arrow buffers for each of the blocks in this page
-            for (int b = 0; b < page.getBlockCount(); b++) {
+            for (int b = 0; b < response.columns.size(); b++) {
                 var column = response.columns.get(b);
                 var converter = column.converter;
 
-                Block block = page.getBlock(b);
+                Block block = page.getBlock(response.blockMapping[b]);
                 converter.addFieldNodes(block, column.multivalued, nodes);
                 converter.convert(block, column.multivalued, bufs, bufWriters);
             }


### PR DESCRIPTION
Closes #154522

When `drop_null_columns=true` was requested, Arrow responses still included all-null fields in both the schema and record batches. JSON, CSV, and other text formats already applied this option.

This change applies the existing response-level null-column detection to Arrow responses. It keeps a source-block mapping for projected columns so removing a middle column cannot shift the data of later columns. The default Arrow response remains unchanged.

Tests:
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:qa:server:single-node:javaRestTest --tests 'org.elasticsearch.xpack.esql.qa.single_node.ArrowFormatIT.testDropNullColumns'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:qa:server:single-node:javaRestTest --tests 'org.elasticsearch.xpack.esql.qa.single_node.ArrowFormatIT.testEverything'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests 'org.elasticsearch.xpack.esql.formatter.arrow.ArrowResponseTests'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:qa:server:single-node:spotlessJavaApply :x-pack:plugin:esql:qa:server:single-node:spotlessJavaCheck`