### PR TITLE
Fall back to scroll for slice-enabled reindex

### DIFF
--- a/docs/changelog/155044.yaml
+++ b/docs/changelog/155044.yaml
@@ -1,0 +1,6 @@
+area: Reindex
+issues:
+ - 154592
+pr: 155044
+summary: Fall back to scroll when reindex PIT pagination is incompatible with index slicing
+type: bug

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSliceEnabledIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSliceEnabledIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0, the GNU Affero General Public License v3.0 only, and the Server Side
+ * Public License v 1; you may not use this file except in compliance with, at
+ * your election, the Elastic License 2.0, the GNU Affero General Public
+ * License v3.0 only, or the Server Side Public License v 1.
+ */
+
+package org.elasticsearch.index.reindex;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.SliceIndexing;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.reindex.TransportReindexAction;
+import org.elasticsearch.rest.root.MainRestPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
+public class ReindexSliceEnabledIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(ReindexPlugin.class, MainRestPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(TransportReindexAction.REMOTE_CLUSTER_WHITELIST.getKey(), "*:*")
+            .build();
+    }
+
+    public void testReindexFallsBackToScrollForSliceEnabledSource() throws Exception {
+        assumeTrue("slice indexing feature flag must be enabled", SliceIndexing.SLICE_FEATURE_FLAG.isEnabled());
+
+        String source = "slice-source";
+        String destination = "regular-destination";
+        assertAcked(
+            prepareCreate(source).setSettings(Settings.builder().put("index.slice.enabled", true).put("number_of_replicas", 0)).get()
+        );
+        assertAcked(prepareCreate(destination).setSettings(Settings.builder().put("number_of_replicas", 0)).get());
+
+        client().index(new IndexRequest(source).id("1").routing("tenant-a").setRoutingFromSlice(true).source("value", "test")).get();
+        indicesAdmin().prepareRefresh(source).get();
+
+        BulkByPaginatedSearchResponse response = client().execute(
+            ReindexAction.INSTANCE,
+            new ReindexRequest().setSourceIndices(source).setDestIndex(destination)
+        ).actionGet();
+
+        assertThat(response.getSearchFailures(), empty());
+        assertThat(response.getBulkFailures(), empty());
+        assertThat(response.getCreated(), equalTo(1L));
+        assertBusy(() -> assertHitCount(prepareSearch(destination).setSize(0), 1L));
+    }
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -19,6 +19,7 @@ import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.apache.http.message.BasicHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
@@ -124,6 +125,7 @@ import static org.elasticsearch.reindex.remote.RemoteReindexingUtils.openPit;
 public class Reindexer {
 
     private static final Logger logger = LogManager.getLogger(Reindexer.class);
+    private static final String PIT_SLICE_ENABLED_ERROR = "[point in time] is not supported when [index.slice.enabled] is true";
 
     private final ClusterService clusterService;
     private final ReindexSettings reindexSettings;
@@ -275,7 +277,7 @@ public class Reindexer {
                 executePaginatedSearch(task, request, listenerWithClosePit, workerActionWithClosePit, null);
             } else {
                 normalizeRequestOnOpeningPit(request);
-                openPitAndExecute(task, request, bulkClient, responseListener);
+                openPitAndExecute(task, request, bulkClient, responseListener, workerAction);
             }
         }
     }
@@ -356,16 +358,21 @@ public class Reindexer {
     }
 
     /**
-     * Opens a PIT on the local cluster, runs the sliced action, and closes the PIT when done.
+     * Opens a PIT on the local cluster, runs the sliced action, and closes the PIT when done. If the source contains a
+     * slice-enabled index, PIT is not supported and the request falls back to scroll pagination.
      */
     private void openPitAndExecute(
         BulkByPaginatedSearchTask task,
         ReindexRequest request,
         Client bulkClient,
-        ActionListener<BulkByPaginatedSearchResponse> listener
+        ActionListener<BulkByPaginatedSearchResponse> listener,
+        Consumer<Version> workerAction
     ) {
         SearchRequest searchRequest = request.getSearchRequest();
-        String[] indices = searchRequest.indices();
+        String[] indices = searchRequest.indices().clone();
+        TimeValue scroll = searchRequest.scroll();
+        String projectRouting = searchRequest.getProjectRouting();
+        String[] sourceIndicesForDescription = request.getSourceIndicesForDescription();
 
         // The routing and preference parameters can be set for a PIT request. However, scroll currently does not use these,
         // so for parity we assert here in case that changes
@@ -389,19 +396,68 @@ public class Reindexer {
         }
 
         // NB this is a local request, so we call the TransportAction rather than issuing a REST call
-        client.execute(TransportOpenPointInTimeAction.TYPE, pitRequest, listener.delegateFailureAndWrap((l, pitResponse) -> {
+        client.execute(TransportOpenPointInTimeAction.TYPE, pitRequest, ActionListener.wrap(pitResponse -> {
             BytesReference pitId = pitResponse.getPointInTimeId();
             request.convertSearchRequestToUsePit(pitId, reindexSettings.pitKeepAlive());
+            ActionListener<BulkByPaginatedSearchResponse> pitListener = new ActionListener<>() {
+                @Override
+                public void onResponse(BulkByPaginatedSearchResponse response) {
+                    listener.onResponse(response);
+                }
+
+                @Override
+                public void onFailure(Exception failure) {
+                    if (isSliceEnabledPitFailure(failure)) {
+                        restoreRequestAfterPitFailure(request, indices, scroll, projectRouting, sourceIndicesForDescription);
+                        executePaginatedSearch(task, request, listener, workerAction, null);
+                    } else {
+                        listener.onFailure(failure);
+                    }
+                }
+            };
             ActionListener<BulkByPaginatedSearchResponse> listenerWithClosePit = wrapListenerWithClosePit(
                 pitId,
-                l,
+                pitListener,
                 this::closeLocalPit,
                 task,
                 shouldNotClosePitOnResponse(task)
             );
             Consumer<Version> workerActionWithClosePit = createWorkerAction(task, request, bulkClient, listenerWithClosePit);
             executePaginatedSearch(task, request, listenerWithClosePit, workerActionWithClosePit, null);
+        }, failure -> {
+            if (isSliceEnabledPitFailure(failure)) {
+                executePaginatedSearch(task, request, listener, workerAction, null);
+            } else {
+                listener.onFailure(failure);
+            }
         }));
+    }
+
+    static boolean isSliceEnabledPitFailure(Exception failure) {
+        return ExceptionsHelper.unwrapCausesAndSuppressed(
+            failure,
+            cause -> cause instanceof IllegalArgumentException
+                && cause.getMessage() != null
+                && cause.getMessage().startsWith(PIT_SLICE_ENABLED_ERROR)
+        ).isPresent();
+    }
+
+    private static void restoreRequestAfterPitFailure(
+        ReindexRequest request,
+        String[] indices,
+        @Nullable TimeValue scroll,
+        @Nullable String projectRouting,
+        @Nullable String[] sourceIndicesForDescription
+    ) {
+        SearchRequest searchRequest = request.getSearchRequest();
+        searchRequest.source().pointInTimeBuilder(null);
+        searchRequest.indices(indices);
+        searchRequest.scroll(scroll);
+        searchRequest.clearProjectRouting();
+        if (projectRouting != null) {
+            searchRequest.setProjectRouting(projectRouting);
+        }
+        request.setSourceIndicesForDescription(sourceIndicesForDescription);
     }
 
     /**

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -143,6 +143,19 @@ import static org.mockito.Mockito.when;
 @SuppressForbidden(reason = "use a http server")
 public class ReindexerTests extends ESTestCase {
 
+    public void testIsSliceEnabledPitFailure() {
+        assertTrue(
+            Reindexer.isSliceEnabledPitFailure(
+                new RuntimeException(
+                    new IllegalArgumentException(
+                        "[point in time] is not supported when [index.slice.enabled] is true for search request targeting [slice-source]"
+                    )
+                )
+            )
+        );
+        assertFalse(Reindexer.isSliceEnabledPitFailure(new IllegalArgumentException("a different search failure")));
+    }
+
     // --- wrapWithMetrics tests ---
 
     public void testWrapWithMetricsSuccess() {


### PR DESCRIPTION
Closes #154592

Local reindex currently opens a point-in-time before paginating source documents. For `index.slice.enabled=true`, opening the PIT succeeds but the first PIT search is rejected, so reindex fails even when the destination is a regular index.

This change detects only the explicit PIT/slice incompatibility, closes the opened PIT, restores the original search request state, and retries the same operation through scroll pagination. Other PIT failures keep their existing failure behavior.

Tests:
- `./gradlew --no-daemon --max-workers=2 :modules:reindex:internalClusterTest --tests 'org.elasticsearch.index.reindex.ReindexSliceEnabledIT.testReindexFallsBackToScrollForSliceEnabledSource'`
- `./gradlew --no-daemon --max-workers=2 :modules:reindex:test --tests 'org.elasticsearch.reindex.ReindexerTests'`
- `./gradlew --no-daemon --max-workers=2 :modules:reindex:spotlessJavaApply :modules:reindex:spotlessJavaCheck`