### PR TITLE
Fix ESQL attribute qualifier updates

### DIFF
--- a/docs/changelog/155045.yaml
+++ b/docs/changelog/155045.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 152920
+pr: 155045
+summary: Preserve requested qualifiers on ES|QL attributes
+type: bug

--- a/docs/changelog/155045.yaml
+++ b/docs/changelog/155045.yaml
@@ -1,6 +1,0 @@
-area: ES|QL
-issues:
- - 152920
-pr: 155045
-summary: Preserve requested qualifiers on ES|QL attributes
-type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/Attribute.java
@@ -151,7 +151,9 @@ public abstract class Attribute extends NamedExpression {
     }
 
     public Attribute withQualifier(String qualifier) {
-        return Objects.equals(qualifier, qualifier) ? this : clone(source(), qualifier, name(), dataType(), nullable(), id(), synthetic());
+        return Objects.equals(qualifier(), qualifier)
+            ? this
+            : clone(source(), qualifier, name(), dataType(), nullable(), id(), synthetic());
     }
 
     public Attribute withName(String name) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/AttributeTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the License.
+ */
+package org.elasticsearch.xpack.esql.core.expression;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class AttributeTests extends ESTestCase {
+
+    public void testWithQualifierChangesQualifier() {
+        ReferenceAttribute attribute = new ReferenceAttribute(Source.EMPTY, "orders", "price", DataType.INTEGER);
+
+        Attribute qualified = attribute.withQualifier("inventory");
+
+        assertThat(qualified, not(sameInstance(attribute)));
+        assertThat(qualified.qualifier(), equalTo("inventory"));
+        assertThat(qualified.name(), equalTo(attribute.name()));
+        assertThat(qualified.dataType(), equalTo(attribute.dataType()));
+        assertThat(qualified.nullable(), equalTo(attribute.nullable()));
+    }
+
+    public void testWithQualifierReturnsSameAttributeWhenQualifierDoesNotChange() {
+        ReferenceAttribute attribute = new ReferenceAttribute(Source.EMPTY, "orders", "price", DataType.INTEGER);
+
+        assertThat(attribute.withQualifier("orders"), sameInstance(attribute));
+    }
+}


### PR DESCRIPTION
## Summary

Attribute.withQualifier compared the requested qualifier with itself, so changing a qualifier always returned the original attribute. Compare against the attribute's current qualifier so requested qualifier changes are preserved.

- Fix qualifier comparison in Attribute.withQualifier
- Add regression coverage for changed and unchanged qualifiers

Closes #152920

## Testing

- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck :x-pack:plugin:esql:test --tests 'org.elasticsearch.xpack.esql.core.expression.AttributeTests'