### PR TITLE
Support COALESCE for aggregate_metric_double

### DIFF
--- a/docs/changelog/155046.yaml
+++ b/docs/changelog/155046.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154744
+pr: 155046
+summary: Support COALESCE for aggregate metric double values
+type: bug

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/types/coalesce.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/types/coalesce.md
@@ -4,6 +4,7 @@
 
 | first | rest | result |
 | --- | --- | --- |
+| aggregate_metric_double | aggregate_metric_double | aggregate_metric_double |
 | boolean | boolean | boolean |
 | boolean | | boolean |
 | cartesian_point | cartesian_point | cartesian_point |

--- a/docs/reference/query-languages/esql/kibana/generated/x-pack-esql/definition/functions/coalesce.json
+++ b/docs/reference/query-languages/esql/kibana/generated/x-pack-esql/definition/functions/coalesce.json
@@ -8,6 +8,24 @@
       "params" : [
         {
           "name" : "first",
+          "type" : "aggregate_metric_double",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "aggregate_metric_double",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "aggregate_metric_double"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
           "type" : "boolean",
           "optional" : false,
           "description" : "Expression to evaluate."

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -453,6 +453,7 @@ def prop(Name, Type, type, TYPE, BYTES, Array) {
     "float"      : type == "float" ? "true" : "",
     "BytesRef"   : type == "BytesRef" ? "true" : "",
     "boolean"    : type == "boolean" ? "true" : "",
+    "AggregateMetricDouble": Name == "AggregateMetricDouble" ? "true" : "",
     "nanosMillis": Name == "NanosMillis" ? "true" : "",
     "millisNanos": Name == "MillisNanos" ? "true" : "",
     "LongRange"  : Name == "LongRange" ? "true" : "",
@@ -468,6 +469,14 @@ tasks.named('stringTemplates').configure {
   var floatProperties = prop("Float", "Float", "float", "FLOAT", "Float.BYTES", "FloatArray")
   var bytesRefProperties = prop("BytesRef", "BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF", "")
   var booleanProperties = prop("Boolean", "Boolean", "boolean", "BOOLEAN", "Byte.BYTES", "BitArray")
+  var aggregateMetricDoubleProperties = prop(
+    "AggregateMetricDouble",
+    "AggregateMetricDouble",
+    "AggregateMetricDouble",
+    "AGGREGATE_METRIC_DOUBLE",
+    "",
+    ""
+  )
   var expHistoProperties = prop("ExponentialHistogram", "ExponentialHistogram", "ExponentialHistogram", "EXPONENTIAL_HISTOGRAM", "", "")
   var tdigestProperties = prop("TDigest", "TDigest", "tdigest", "TDIGEST", "", "")
   var longRangeProperties = prop("LongRange", "LongRange", "LongRange", "LONG_RANGE", "", "")
@@ -549,6 +558,12 @@ tasks.named('stringTemplates').configure {
     it.properties = expHistoProperties
     it.inputFile = coalesceInputFile
     it.outputFile = "org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceExponentialHistogramEvaluator.java"
+  }
+
+  template {
+    it.properties = aggregateMetricDoubleProperties
+    it.inputFile = coalesceInputFile
+    it.outputFile = "org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceAggregateMetricDoubleEvaluator.java"
   }
 
   template {

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceAggregateMetricDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceAggregateMetricDoubleEvaluator.java
@@ -8,15 +8,10 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.nulls;
 
 // begin generated imports
-$if(BytesRef)$
-import org.apache.lucene.util.BytesRef;
-$endif$
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.$Type$Block;
-$if(AggregateMetricDouble)$
+import org.elasticsearch.compute.data.AggregateMetricDoubleBlock;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
-$endif$
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -33,11 +28,11 @@ import java.util.stream.IntStream;
  * {@link ExpressionEvaluator} implementation for {@link Coalesce}.
  * This class is generated. Edit {@code X-CoalesceEvaluator.java.st} instead.
  */
-abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator permits // checkstyle hack
-    Coalesce$Type$Evaluator.Coalesce$Type$EagerEvaluator, // checkstyle hack
-    Coalesce$Type$Evaluator.Coalesce$Type$LazyEvaluator {
+abstract sealed class CoalesceAggregateMetricDoubleEvaluator implements ExpressionEvaluator permits // checkstyle hack
+    CoalesceAggregateMetricDoubleEvaluator.CoalesceAggregateMetricDoubleEagerEvaluator, // checkstyle hack
+    CoalesceAggregateMetricDoubleEvaluator.CoalesceAggregateMetricDoubleLazyEvaluator {
 
-    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Coalesce$Type$Evaluator.class);
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(CoalesceAggregateMetricDoubleEvaluator.class);
 
     static ExpressionEvaluator.Factory toEvaluator(EvaluatorMapper.ToEvaluator toEvaluator, List<Expression> children) {
         List<ExpressionEvaluator.Factory> childEvaluators = children.stream().map(toEvaluator::apply).toList();
@@ -45,7 +40,7 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
             return new ExpressionEvaluator.Factory() {
                 @Override
                 public ExpressionEvaluator get(DriverContext context) {
-                    return new Coalesce$Type$EagerEvaluator(
+                    return new CoalesceAggregateMetricDoubleEagerEvaluator(
                         // comment to make spotless happy about line breaks
                         context,
                         childEvaluators.stream().map(x -> x.get(context)).toList()
@@ -54,14 +49,14 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
 
                 @Override
                 public String toString() {
-                    return "Coalesce$Type$EagerEvaluator[values=" + childEvaluators + ']';
+                    return "CoalesceAggregateMetricDoubleEagerEvaluator[values=" + childEvaluators + ']';
                 }
             };
         }
         return new ExpressionEvaluator.Factory() {
             @Override
             public ExpressionEvaluator get(DriverContext context) {
-                return new Coalesce$Type$LazyEvaluator(
+                return new CoalesceAggregateMetricDoubleLazyEvaluator(
                     // comment to make spotless happy about line breaks
                     context,
                     childEvaluators.stream().map(x -> x.get(context)).toList()
@@ -70,7 +65,7 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
 
             @Override
             public String toString() {
-                return "Coalesce$Type$LazyEvaluator[values=" + childEvaluators + ']';
+                return "CoalesceAggregateMetricDoubleLazyEvaluator[values=" + childEvaluators + ']';
             }
         };
     }
@@ -78,13 +73,13 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
     protected final DriverContext driverContext;
     protected final List<ExpressionEvaluator> evaluators;
 
-    protected Coalesce$Type$Evaluator(DriverContext driverContext, List<ExpressionEvaluator> evaluators) {
+    protected CoalesceAggregateMetricDoubleEvaluator(DriverContext driverContext, List<ExpressionEvaluator> evaluators) {
         this.driverContext = driverContext;
         this.evaluators = evaluators;
     }
 
     @Override
-    public final $Type$Block eval(Page page) {
+    public final AggregateMetricDoubleBlock eval(Page page) {
         return entireBlock(page);
     }
 
@@ -106,10 +101,10 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
      *     </li>
      * </ul>
      */
-    private $Type$Block entireBlock(Page page) {
+    private AggregateMetricDoubleBlock entireBlock(Page page) {
         int lastFullBlockIdx = 0;
         while (true) {
-            $Type$Block lastFullBlock = ($Type$Block) evaluators.get(lastFullBlockIdx++).eval(page);
+            AggregateMetricDoubleBlock lastFullBlock = (AggregateMetricDoubleBlock) evaluators.get(lastFullBlockIdx++).eval(page);
             if (lastFullBlockIdx == evaluators.size() || lastFullBlock.asVector() != null) {
                 return lastFullBlock;
             }
@@ -139,7 +134,7 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
      * any way it likes.
      * </p>
      */
-    protected abstract $Type$Block perPosition(Page page, $Type$Block lastFullBlock, int firstToEvaluate);
+    protected abstract AggregateMetricDoubleBlock perPosition(Page page, AggregateMetricDoubleBlock lastFullBlock, int firstToEvaluate);
 
     @Override
     public final String toString() {
@@ -164,41 +159,33 @@ abstract sealed class Coalesce$Type$Evaluator implements ExpressionEvaluator per
      * Evaluates {@code COALESCE} eagerly per position if entire-block evaluation fails.
      * First we evaluate all remaining evaluators, and then we pluck the first non-null
      * value from each one. This is <strong>much</strong> faster than
-     * {@link Coalesce$Type$LazyEvaluator} but will include spurious warnings if any of the
+     * {@link CoalesceAggregateMetricDoubleLazyEvaluator} but will include spurious warnings if any of the
      * evaluators make them so we only use it for evaluators that are
      * {@link Factory#eagerEvalSafeInLazy safe} to evaluate eagerly
      * in a lazy environment.
      */
-    static final class Coalesce$Type$EagerEvaluator extends Coalesce$Type$Evaluator {
-        Coalesce$Type$EagerEvaluator(DriverContext driverContext, List<ExpressionEvaluator> evaluators) {
+    static final class CoalesceAggregateMetricDoubleEagerEvaluator extends CoalesceAggregateMetricDoubleEvaluator {
+        CoalesceAggregateMetricDoubleEagerEvaluator(DriverContext driverContext, List<ExpressionEvaluator> evaluators) {
             super(driverContext, evaluators);
         }
 
         @Override
-        protected $Type$Block perPosition(Page page, $Type$Block lastFullBlock, int firstToEvaluate) {
-$if(BytesRef)$
-            BytesRef scratch = new BytesRef();
-$endif$
+        protected AggregateMetricDoubleBlock perPosition(Page page, AggregateMetricDoubleBlock lastFullBlock, int firstToEvaluate) {
             int positionCount = page.getPositionCount();
-            $Type$Block[] flatten = new $Type$Block[evaluators.size() - firstToEvaluate + 1];
+            AggregateMetricDoubleBlock[] flatten = new AggregateMetricDoubleBlock[evaluators.size() - firstToEvaluate + 1];
             try {
                 flatten[0] = lastFullBlock;
                 for (int f = 1; f < flatten.length; f++) {
-                    flatten[f] = ($Type$Block) evaluators.get(firstToEvaluate + f - 1).eval(page);
+                    flatten[f] = (AggregateMetricDoubleBlock) evaluators.get(firstToEvaluate + f - 1).eval(page);
                 }
                 try (
-$if(AggregateMetricDouble)$
                     AggregateMetricDoubleBlockBuilder result = driverContext.blockFactory() //
                         .newAggregateMetricDoubleBlockBuilder(positionCount)
-$else$
-                    $Type$Block.Builder result = driverContext.blockFactory() //
-                        .new$Type$BlockBuilder(positionCount)
-$endif$
                 ) {
                     position: for (int p = 0; p < positionCount; p++) {
-                        for ($Type$Block f : flatten) {
+                        for (AggregateMetricDoubleBlock f : flatten) {
                             if (false == f.isNull(p)) {
-                                result.copyFrom(f, p$if(BytesRef)$, scratch$endif$);
+                                result.copyFrom(f, p);
                                 continue position;
                             }
                         }
@@ -223,25 +210,17 @@ $endif$
      *     </li>
      * </ul>
      */
-    static final class Coalesce$Type$LazyEvaluator extends Coalesce$Type$Evaluator {
-        Coalesce$Type$LazyEvaluator(DriverContext driverContext, List<ExpressionEvaluator> evaluators) {
+    static final class CoalesceAggregateMetricDoubleLazyEvaluator extends CoalesceAggregateMetricDoubleEvaluator {
+        CoalesceAggregateMetricDoubleLazyEvaluator(DriverContext driverContext, List<ExpressionEvaluator> evaluators) {
             super(driverContext, evaluators);
         }
 
         @Override
-        protected $Type$Block perPosition(Page page, $Type$Block lastFullBlock, int firstToEvaluate) {
-$if(BytesRef)$
-            BytesRef scratch = new BytesRef();
-$endif$
+        protected AggregateMetricDoubleBlock perPosition(Page page, AggregateMetricDoubleBlock lastFullBlock, int firstToEvaluate) {
             int positionCount = page.getPositionCount();
             try (
-$if(AggregateMetricDouble)$
                 AggregateMetricDoubleBlockBuilder result = driverContext.blockFactory() //
                     .newAggregateMetricDoubleBlockBuilder(positionCount)
-$else$
-                $Type$Block.Builder result = driverContext.blockFactory() //
-                    .new$Type$BlockBuilder(positionCount)
-$endif$
             ) {
                 position: for (int p = 0; p < positionCount; p++) {
                     if (lastFullBlock.isNull(p) == false) {
@@ -257,9 +236,9 @@ $endif$
                     );
                     try (Releasable ignored = limited::releaseBlocks) {
                         for (int e = firstToEvaluate; e < evaluators.size(); e++) {
-                            try ($Type$Block block = ($Type$Block) evaluators.get(e).eval(limited)) {
+                            try (AggregateMetricDoubleBlock block = (AggregateMetricDoubleBlock) evaluators.get(e).eval(limited)) {
                                 if (false == block.isNull(0)) {
-                                    result.copyFrom(block, 0$if(BytesRef)$, scratch$endif$);
+                                    result.copyFrom(block, 0);
                                     continue position;
                                 }
                             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
@@ -52,6 +52,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
     @FunctionInfo(
         appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.GA) },
         returnType = {
+            "aggregate_metric_double",
             "boolean",
             "cartesian_point",
             "cartesian_shape",
@@ -82,6 +83,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
         @Param(
             name = "first",
             type = {
+                "aggregate_metric_double",
                 "boolean",
                 "cartesian_point",
                 "cartesian_shape",
@@ -109,6 +111,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
         @Param(
             name = "rest",
             type = {
+                "aggregate_metric_double",
                 "boolean",
                 "cartesian_point",
                 "cartesian_shape",
@@ -234,15 +237,14 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
             );
             case KEYWORD, TEXT, CARTESIAN_POINT, CARTESIAN_SHAPE, FLATTENED, HISTOGRAM, GEO_POINT, GEO_SHAPE, IP, VERSION ->
                 CoalesceBytesRefEvaluator.toEvaluator(toEvaluator, children());
+            case AGGREGATE_METRIC_DOUBLE -> CoalesceAggregateMetricDoubleEvaluator.toEvaluator(toEvaluator, children());
             case EXPONENTIAL_HISTOGRAM -> CoalesceExponentialHistogramEvaluator.toEvaluator(toEvaluator, children());
             case TDIGEST -> CoalesceTDigestEvaluator.toEvaluator(toEvaluator, children());
             case DENSE_VECTOR -> CoalesceFloatEvaluator.toEvaluator(toEvaluator, children());
             case DATE_RANGE -> CoalesceLongRangeEvaluator.toEvaluator(toEvaluator, children());
             case NULL -> ConstantEvaluators.CONSTANT_NULL_FACTORY;
             case UNSUPPORTED, SHORT, BYTE, DATE_PERIOD, OBJECT, DOC_DATA_TYPE, SOURCE, TIME_DURATION, FLOAT, HALF_FLOAT, TSID_DATA_TYPE,
-                SCALED_FLOAT, PARTIAL_AGG, AGGREGATE_METRIC_DOUBLE, DOUBLE_RANGE -> throw new UnsupportedOperationException(
-                    dataType() + " can't be coalesced"
-                );
+                SCALED_FLOAT, PARTIAL_AGG, DOUBLE_RANGE -> throw new UnsupportedOperationException(dataType() + " can't be coalesced");
         };
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -157,6 +157,19 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
                 equalTo(firstHisto == null ? secondHisto : firstHisto)
             );
         }));
+        noNullsSuppliers.add(new TestCaseSupplier(List.of(DataType.AGGREGATE_METRIC_DOUBLE, DataType.AGGREGATE_METRIC_DOUBLE), () -> {
+            Object first = randomBoolean() ? null : randomLiteral(DataType.AGGREGATE_METRIC_DOUBLE).value();
+            Object second = randomLiteral(DataType.AGGREGATE_METRIC_DOUBLE).value();
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(first, DataType.AGGREGATE_METRIC_DOUBLE, "first"),
+                    new TestCaseSupplier.TypedData(second, DataType.AGGREGATE_METRIC_DOUBLE, "second")
+                ),
+                "CoalesceAggregateMetricDoubleEagerEvaluator[values=[Attribute[channel=0], Attribute[channel=1]]]",
+                DataType.AGGREGATE_METRIC_DOUBLE,
+                equalTo(first == null ? second : first)
+            );
+        }));
         noNullsSuppliers.add(new TestCaseSupplier(List.of(DataType.DATE_RANGE, DataType.DATE_RANGE), () -> {
             assumeTrue("Requires COALESCE_DATE_RANGE capability", EsqlCapabilities.Cap.COALESCE_DATE_RANGE.isEnabled());
             long from1 = randomMillisUpToYear9999();


### PR DESCRIPTION
## Summary

- Add `aggregate_metric_double` support to ESQL `COALESCE`.
- Generate a dedicated evaluator using `AggregateMetricDoubleBlockBuilder`.
- Add regression coverage and generated documentation.

Closes #154744

## Testing

- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests 'org.elasticsearch.xpack.esql.expression.function.scalar.nulls.CoalesceTests'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:stringTemplates :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck`