### PR TITLE
Fix approximation setting conflict checks

### DIFF
--- a/docs/changelog/155047.yaml
+++ b/docs/changelog/155047.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 152739
+pr: 155047
+summary: Detect conflicting ES|QL approximation settings
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/approximation/ApproximationSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/approximation/ApproximationSettings.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Settings for query approximation.
@@ -131,6 +132,29 @@ public record ApproximationSettings(Integer rows, Double confidenceLevel) implem
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalInt(rows());
         out.writeOptionalDouble(confidenceLevel());
+    }
+
+    /**
+     * Keeps the explicit-null sentinel distinct from an enabled setting whose fields are both null.
+     * The record components alone cannot represent that distinction.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ApproximationSettings other = (ApproximationSettings) obj;
+        return (this == EXPLICIT_NULL) == (other == EXPLICIT_NULL)
+            && Objects.equals(rows, other.rows)
+            && Objects.equals(confidenceLevel, other.confidenceLevel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rows, confidenceLevel, this == EXPLICIT_NULL);
     }
 
     public static class Builder {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
@@ -845,6 +845,24 @@ public class EsqlQueryRequestTests extends ESTestCase {
         );
     }
 
+    public void testSettingsBlockRejectsExplicitApproximationDisableConflict() {
+        Exception e = expectThrows(IllegalArgumentException.class, () -> parseEsqlQueryRequestSync("""
+            {
+                "query": "FROM idx",
+                "approximation": false,
+                "settings": {
+                    "approximation": {
+                        "rows": null,
+                        "confidence_level": null
+                    }
+                }
+            }"""));
+        assertThat(
+            e.getMessage(),
+            containsString("Setting [approximation] has conflicting values at the top level of the request body and under [settings]")
+        );
+    }
+
     public void testSettingsBlockRejectsConflictingValuesRegardlessOfOrder() {
         // Same conflict, JSON order swapped — the check runs after the whole body is parsed, so order is irrelevant.
         Exception e = expectThrows(IllegalArgumentException.class, () -> parseEsqlQueryRequestSync("""

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSettingsTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ApproximationSettingsTests extends ESTestCase {
@@ -142,6 +143,12 @@ public class ApproximationSettingsTests extends ESTestCase {
         assertNotNull(result);
         assertThat(result.rows(), nullValue());
         assertThat(result.confidenceLevel(), equalTo(0.90));
+    }
+
+    public void testExplicitNullIsDistinctFromNullFieldSettings() {
+        ApproximationSettings nullFieldSettings = new ApproximationSettings.Builder(true).rows(null).confidenceLevel(null).build();
+        assertNotNull(nullFieldSettings);
+        assertThat(nullFieldSettings, not(equalTo(ApproximationSettings.EXPLICIT_NULL)));
     }
 
     public void testMergeDefaultPreservesNullRows() {


### PR DESCRIPTION
## Summary

- Distinguish the explicit-null approximation sentinel from enabled settings with null fields.
- Reject conflicting `approximation` values supplied at the top level and under `settings`.
- Add unit and request-level regression coverage.

Closes #152739

## Testing

- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test --tests 'org.elasticsearch.xpack.esql.approximation.ApproximationSettingsTests' --tests 'org.elasticsearch.xpack.esql.action.EsqlQueryRequestTests'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck`