### PR TITLE
Avoid invalid references after shadowing EVAL

### DIFF
--- a/docs/changelog/155048.yaml
+++ b/docs/changelog/155048.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154146
+pr: 155048
+summary: Prevent invalid references after shadowing EVAL in RLIKE filters
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferIsNotNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InferIsNotNull.java
@@ -15,10 +15,13 @@ import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -51,7 +54,13 @@ public class InferIsNotNull extends Rule<LogicalPlan, LogicalPlan> {
 
     private LogicalPlan inspectPlan(LogicalPlan plan, AttributeMap.Builder<Expression> aliasesBuilder) {
         plan.forEachExpression(Alias.class, a -> aliasesBuilder.put(a.toAttribute(), a.child()));
-        return plan.transformExpressionsOnlyUp(IsNotNull.class, inn -> inferNotNullable(inn, aliasesBuilder.build(), plan.inputSet()));
+        Set<IsNotNull> negatedIsNotNulls = Collections.newSetFromMap(new IdentityHashMap<>());
+        plan.forEachExpression(Not.class, not -> not.forEachDown(IsNotNull.class, negatedIsNotNulls::add));
+        AttributeMap<Expression> aliases = aliasesBuilder.build();
+        return plan.transformExpressionsOnlyUp(
+            IsNotNull.class,
+            inn -> negatedIsNotNulls.contains(inn) ? inn : inferNotNullable(inn, aliases, plan.inputSet())
+        );
     }
 
     private static Expression inferNotNullable(IsNotNull inn, AttributeMap<Expression> aliases, AttributeSet inputSet) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -850,6 +850,18 @@ public class LocalLogicalPlanOptimizerTests extends AbstractLocalLogicalPlanOpti
         as(eval.child(), EsRelation.class);
     }
 
+    public void testRLikeAfterShadowingEvalDoesNotReferenceShadowedField() {
+        var plan = localPlan("""
+            FROM test
+            | EVAL first_name = MV_CONCAT(first_name, ", ")
+            | WHERE NOT first_name RLIKE ".*"
+            """);
+
+        var filter = as(as(plan, Limit.class).child(), Filter.class);
+        assertThat(filter.condition().references(), hasSize(1));
+        assertThat(filter.condition().references().stream().noneMatch(FieldAttribute.class::isInstance), is(true));
+    }
+
     public void testVerifierOnMissingReferences() throws Exception {
         var plan = localPlan("""
             from test


### PR DESCRIPTION
## Summary

- Avoid inferring source-field nullability through a negated condition.
- Prevent `NOT RLIKE ".*"` from retaining a shadowed field reference after `EVAL`.
- Add a regression test that verifies the optimized filter only references the derived field.

Closes #154146

## Testing

- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test -x :x-pack:plugin:inference:compileTestJava --tests 'org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests.testRLikeAfterShadowingEvalDoesNotReferenceShadowedField'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:test -x :x-pack:plugin:inference:compileTestJava --tests 'org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:spotlessJavaApply :x-pack:plugin:esql:spotlessJavaCheck`