### PR TITLE
Unify signed zero group keys

### DIFF
--- a/docs/changelog/155049.yaml
+++ b/docs/changelog/155049.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154811
+pr: 155049
+summary: Treat signed zero values consistently in ES|QL grouping
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -53,6 +53,11 @@ final class DoubleBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
+    /** Canonicalizes signed zero before building an ES|QL double hash key. */
+    private static long hashDouble(double value) {
+        return Double.doubleToLongBits(value == 0.0d ? 0.0d : value);
+    }
+
     DoubleBlockHash(int channel, BlockFactory blockFactory) {
         super(blockFactory);
         this.channel = channel;
@@ -90,7 +95,7 @@ final class DoubleBlockHash extends BlockHash {
         int positions = vector.getPositionCount();
         try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
             for (int i = 0; i < positions; i++) {
-                long v = Double.doubleToLongBits(vector.getDouble(i));
+                long v = hashDouble(vector.getDouble(i));
                 builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(hash.add(v))));
             }
             return builder.build();
@@ -129,7 +134,7 @@ final class DoubleBlockHash extends BlockHash {
         int positions = vector.getPositionCount();
         try (var builder = blockFactory.newIntBlockBuilder(positions)) {
             for (int i = 0; i < positions; i++) {
-                long v = Double.doubleToLongBits(vector.getDouble(i));
+                long v = hashDouble(vector.getDouble(i));
                 long found = hash.find(v);
                 if (found < 0) {
                     builder.appendNull();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDouble.java
@@ -582,11 +582,11 @@ public class MultivalueDedupeDouble {
     }
 
     private void hashAdd(IntBlock.Builder builder, LongHashTable hash, double v) {
-        appendFound(builder, hash.add(Double.doubleToLongBits(v)));
+        appendFound(builder, hash.add(hashDouble(v)));
     }
 
     private long hashLookup(LongHashTable hash, double v) {
-        return hash.find(Double.doubleToLongBits(v));
+        return hash.find(hashDouble(v));
     }
 
     private void hashLookupSingle(IntBlock.Builder builder, LongHashTable hash, double v) {
@@ -600,6 +600,11 @@ public class MultivalueDedupeDouble {
 
     private void appendFound(IntBlock.Builder builder, long found) {
         builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(found)));
+    }
+
+    /** Canonicalizes signed zero before building an ES|QL double hash key. */
+    private static long hashDouble(double value) {
+        return Double.doubleToLongBits(value == 0.0d ? 0.0d : value);
     }
 
     private static boolean valuesEqual(double lhs, double rhs) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -556,6 +556,10 @@ final class PackedValuesBlockHash extends BlockHash {
     private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
     private static final VarHandle DOUBLE_HANDLE = MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.nativeOrder());
 
+    private static double canonicalizeDouble(double value) {
+        return value == 0.0d ? 0.0d : value;
+    }
+
     /**
      * Approximate shallow size of a {@link BytesRef} object: object header + {@code byte[]} reference + 2 ints.
      * Used only for breaker accounting; precision matches the rest of this class's manual byte counting.
@@ -695,7 +699,7 @@ final class PackedValuesBlockHash extends BlockHash {
                     case DOUBLE -> {
                         DoubleVector doubleVector = (DoubleVector) vector;
                         for (int i = 0; i < batchSize; i++) {
-                            DOUBLE_HANDLE.set(keys, i * keyLength + offset, doubleVector.getDouble(positionOffset + i));
+                            DOUBLE_HANDLE.set(keys, i * keyLength + offset, canonicalizeDouble(doubleVector.getDouble(positionOffset + i)));
                         }
                     }
                     case BOOLEAN -> {
@@ -1045,7 +1049,7 @@ final class PackedValuesBlockHash extends BlockHash {
                     case DOUBLE -> {
                         DoubleVector dv = (DoubleVector) vector;
                         for (int i = 0; i < rows; i++) {
-                            DOUBLE_HANDLE.set(keyBuf, cursors[i], dv.getDouble(positionOffset + i));
+                            DOUBLE_HANDLE.set(keyBuf, cursors[i], canonicalizeDouble(dv.getDouble(positionOffset + i)));
                             cursors[i] += Double.BYTES;
                         }
                     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -59,6 +59,14 @@ final class $Type$BlockHash extends BlockHash {
      */
     private boolean seenNull;
 
+$if(double)$
+    /** Canonicalizes signed zero before building an ES|QL double hash key. */
+    private static long hashDouble(double value) {
+        return Double.doubleToLongBits(value == 0.0d ? 0.0d : value);
+    }
+
+$endif$
+
 $if(BytesRef)$
     private static final int PREFETCH_BATCH = 128;
     private final PrefetchBarrier prefetchBarrier = new PrefetchBarrier();
@@ -135,7 +143,7 @@ $endif$
         try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
             for (int i = 0; i < positions; i++) {
 $if(double)$
-                long v = Double.doubleToLongBits(vector.getDouble(i));
+                long v = hashDouble(vector.getDouble(i));
 $elseif(BytesRef)$
                 BytesRef v = vector.getBytesRef(i, scratch);
 $else$
@@ -292,7 +300,7 @@ $endif$
         try (var builder = blockFactory.newIntBlockBuilder(positions)) {
             for (int i = 0; i < positions; i++) {
 $if(double)$
-                long v = Double.doubleToLongBits(vector.getDouble(i));
+                long v = hashDouble(vector.getDouble(i));
 $elseif(BytesRef)$
                 BytesRef v = vector.getBytesRef(i, scratch);
 $else$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/BatchEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/BatchEncoder.java
@@ -474,7 +474,7 @@ public abstract class BatchEncoder implements Releasable, Accountable {
          */
         protected final void encode(double v) {
             addingValue();
-            doubleHandle.set(bytes.bytes(), bytes.length(), v);
+            doubleHandle.set(bytes.bytes(), bytes.length(), canonicalizeDouble(v));
             bytes.setLength(bytes.length() + Double.BYTES);
         }
     }
@@ -490,10 +490,14 @@ public abstract class BatchEncoder implements Releasable, Accountable {
             int after = before + Double.BYTES;
             dst.grow(after);
             double v = ((DoubleBlock) block).getDouble(valueIndex);
-            doubleHandle.set(dst.bytes(), before, v);
+            doubleHandle.set(dst.bytes(), before, canonicalizeDouble(v));
             dst.setLength(after);
             return Double.BYTES;
         }
+    }
+
+    private static double canonicalizeDouble(double value) {
+        return value == 0.0d ? 0.0d : value;
     }
 
     private static class DoublesDecoder implements Decoder {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/X-MultivalueDedupe.java.st
@@ -697,7 +697,7 @@ $endif$
 
     private void hashAdd(IntBlock.Builder builder, $Hash$Table hash, $type$ v) {
 $if(double)$
-        appendFound(builder, hash.add(Double.doubleToLongBits(v)));
+        appendFound(builder, hash.add(hashDouble(v)));
 $else$
         appendFound(builder, hash.add(v));
 $endif$
@@ -705,7 +705,7 @@ $endif$
 
     private long hashLookup($Hash$Table hash, $type$ v) {
 $if(double)$
-        return hash.find(Double.doubleToLongBits(v));
+        return hash.find(hashDouble(v));
 $else$
         return hash.find(v);
 $endif$
@@ -723,6 +723,14 @@ $endif$
     private void appendFound(IntBlock.Builder builder, long found) {
         builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(found)));
     }
+
+$if(double)$
+    /** Canonicalizes signed zero before building an ES|QL double hash key. */
+    private static long hashDouble(double value) {
+        return Double.doubleToLongBits(value == 0.0d ? 0.0d : value);
+    }
+
+$endif$
 
     private static boolean valuesEqual($type$ lhs, $type$ rhs) {
 $if(BytesRef)$

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -297,6 +297,45 @@ public class BlockHashTests extends BlockHashTestCase {
         }, blockFactory.newDoubleArrayVector(values, values.length).asBlock());
     }
 
+    public void testDoubleHashTreatsSignedZeroAsOneGroup() {
+        double[] values = new double[] { 0.0, -0.0 };
+        hash(ordsAndKeys -> {
+            if (forcePackedHash) {
+                assertThat(ordsAndKeys.description(), startsWith("PackedValuesBlockHash{groups=[0:DOUBLE], entries=1, size="));
+                assertOrds(ordsAndKeys.ords(), 0, 0);
+                assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 1)));
+            } else {
+                assertThat(ordsAndKeys.description(), equalTo("DoubleBlockHash{channel=0, entries=1, seenNull=false}"));
+                assertOrds(ordsAndKeys.ords(), 1, 1);
+                assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 2)));
+            }
+            assertKeys(ordsAndKeys.keys(), 0.0);
+        }, blockFactory.newDoubleArrayVector(values, values.length).asBlock());
+    }
+
+    public void testMultiValuedDoubleHashTreatsSignedZeroAsOneGroup() {
+        try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(2)) {
+            builder.beginPositionEntry();
+            builder.appendDouble(0.0);
+            builder.appendDouble(-0.0);
+            builder.endPositionEntry();
+            builder.appendDouble(-0.0);
+
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    assertThat(ordsAndKeys.description(), startsWith("PackedValuesBlockHash{groups=[0:DOUBLE], entries=1, size="));
+                    assertOrds(ordsAndKeys.ords(), new int[] { 0 }, new int[] { 0 });
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 1)));
+                } else {
+                    assertThat(ordsAndKeys.description(), equalTo("DoubleBlockHash{channel=0, entries=1, seenNull=false}"));
+                    assertOrds(ordsAndKeys.ords(), new int[] { 1 }, new int[] { 1 });
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 2)));
+                }
+                assertKeys(ordsAndKeys.keys(), 0.0);
+            }, builder);
+        }
+    }
+
     public void testDoubleHashWithNulls() {
         try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(4)) {
             builder.appendDouble(0);


### PR DESCRIPTION
## Summary

- Treat signed zero as one ES|QL double grouping key.
- Canonicalize signed zero across generated scalar and multivalue hash paths, packed key encoding, and batch encoding.
- Add regression coverage for scalar and multivalued inputs across regular and packed hash implementations.

Closes #154811

## Testing

- `./gradlew --no-daemon --max-workers=1 :x-pack:plugin:esql:compute:test --tests 'org.elasticsearch.compute.aggregation.blockhash.BlockHashTests' --tests 'org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeTests'`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:compute:stringTemplates :x-pack:plugin:esql:compute:spotlessJavaApply :x-pack:plugin:esql:compute:spotlessJavaCheck`
