### PR TITLE
Deduplicate repeated ESQL exception warnings

### DIFF
--- a/docs/changelog/155050.yaml
+++ b/docs/changelog/155050.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 151382
+pr: 155050
+summary: Deduplicate repeated ES|QL exception warnings
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Warnings.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Warnings.java
@@ -102,6 +102,7 @@ public class Warnings {
     private final String location;
     private final String firstExceptionWarning;
     private final String nonExceptionWarningPrefix;
+    private final Set<String> emittedExceptionWarnings = new HashSet<>();
     private final Set<String> emittedNonExceptionWarnings = new HashSet<>();
 
     private int addedWarnings;
@@ -131,18 +132,23 @@ public class Warnings {
     /**
      * Register an exception to be included in the warnings.
      * <p>
+     *     Repeated exceptions with the same class and message are emitted only once so that a
+     *     recurring failure does not consume the warning limit.
+     * </p>
+     * <p>
      *     This overload avoids the need to instantiate the exception, which can be expensive.
      *     Instead, it asks only the required pieces to build the warning.
      * </p>
      */
     public void registerException(Class<? extends Exception> exceptionClass, String message) {
-        if (addedWarnings < MAX_ADDED_WARNINGS) {
+        String exceptionWarning = exceptionClass.getName() + ": " + message;
+        if (addedWarnings < MAX_ADDED_WARNINGS && emittedExceptionWarnings.add(exceptionWarning)) {
             if (exceptionWarningEmitted == false) {
                 exceptionWarningEmitted = true;
                 addWarning(firstExceptionWarning);
             }
             // location needs to be added to the exception too, since the headers are deduplicated
-            addWarning(location + exceptionClass.getName() + ": " + message);
+            addWarning(location + exceptionWarning);
             addedWarnings++;
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/WarningsTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/WarningsTests.java
@@ -35,6 +35,22 @@ public class WarningsTests extends ESTestCase {
         assertWarnings(expected);
     }
 
+    public void testRegisterExceptionDeduplication() {
+        Warnings warnings = Warnings.createWarnings(DriverContext.WarningsMode.COLLECT, new TestWarningsSource("foo"));
+        for (int i = 0; i < Warnings.MAX_ADDED_WARNINGS + 1000; i++) {
+            warnings.registerException(new IllegalArgumentException("duplicate"));
+        }
+        warnings.registerException(new IllegalArgumentException("distinct message"));
+        warnings.registerException(new IllegalStateException("distinct exception"));
+
+        assertWarnings(
+            "Line 1:1: evaluation of [foo] failed, treating result as null. Only first 20 failures recorded.",
+            "Line 1:1: java.lang.IllegalArgumentException: duplicate",
+            "Line 1:1: java.lang.IllegalArgumentException: distinct message",
+            "Line 1:1: java.lang.IllegalStateException: distinct exception"
+        );
+    }
+
     public void testRegisterCollectViews() {
         Warnings warnings = Warnings.createWarnings(DriverContext.WarningsMode.COLLECT, new TestWarningsSource("foo", "view1"));
         for (int i = 0; i < Warnings.MAX_ADDED_WARNINGS + 1000; i++) {


### PR DESCRIPTION
## Summary

- Deduplicate repeated ESQL exception warnings by exception class and message.
- Preserve the shared warning limit for distinct failures so recurring failures do not hide actionable failures.
- Add regression coverage for repeated and distinct exceptions.

Closes #151382

## Testing

- ./gradlew --no-daemon --max-workers=1 :x-pack:plugin:esql:compute:test --tests 'org.elasticsearch.compute.operator.WarningsTests'
- ./gradlew --no-daemon --max-workers=2 :x-pack:plugin:esql:compute:test
- ./gradlew --no-daemon --max-workers=1 :x-pack:plugin:esql:compute:spotlessJavaApply :x-pack:plugin:esql:compute:spotlessJavaCheck