### PR TITLE
Allow unbounded ILM snapshot shards

### DIFF
--- a/docs/changelog/155051.yaml
+++ b/docs/changelog/155051.yaml
@@ -1,0 +1,6 @@
+pr: 155051
+summary: Allow searchable snapshot ILM actions to use -1 for unbounded shard allocation
+area: ILM
+type: enhancement
+issues:
+ - 153993

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -55,8 +55,8 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
         super(key, nextStepKey, client);
         this.restoredIndexPrefix = restoredIndexPrefix;
         this.storageType = Objects.requireNonNull(storageType, "a storage type must be specified");
-        if (totalShardsPerNode != null && totalShardsPerNode < 1) {
-            throw new IllegalArgumentException("[" + SearchableSnapshotAction.TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= 1");
+        if (totalShardsPerNode != null && totalShardsPerNode < -1) {
+            throw new IllegalArgumentException("[" + SearchableSnapshotAction.TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= -1");
         }
         this.totalShardsPerNode = totalShardsPerNode;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -136,8 +136,8 @@ public class SearchableSnapshotAction implements LifecycleAction {
         this.snapshotRepository = snapshotRepository;
         this.forceMergeIndex = forceMergeIndex;
 
-        if (totalShardsPerNode != null && totalShardsPerNode < 1) {
-            throw new IllegalArgumentException("[" + TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= 1");
+        if (totalShardsPerNode != null && totalShardsPerNode < -1) {
+            throw new IllegalArgumentException("[" + TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= -1");
         }
         this.totalShardsPerNode = totalShardsPerNode;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -116,7 +116,7 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
     }
 
     public void testCreateWithInvalidTotalShardsPerNode() throws Exception {
-        int invalidTotalShardsPerNode = randomIntBetween(-100, 0);
+        int invalidTotalShardsPerNode = randomIntBetween(-100, -2);
 
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -130,7 +130,21 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 0
             )
         );
-        assertEquals("[total_shards_per_node] must be >= 1", exception.getMessage());
+        assertEquals("[total_shards_per_node] must be >= -1", exception.getMessage());
+    }
+
+    public void testCreateWithUnboundedTotalShardsPerNode() {
+        MountSnapshotStep step = new MountSnapshotStep(
+            randomStepKey(),
+            randomStepKey(),
+            client,
+            RESTORED_INDEX_PREFIX,
+            randomStorageType(),
+            -1,
+            0
+        );
+
+        assertThat(step.getTotalShardsPerNode(), is(-1));
     }
 
     public void testPerformActionFailure() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -115,13 +115,32 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
     }
 
     public void testCreateWithInvalidTotalShardsPerNode() {
-        int invalidTotalShardsPerNode = randomIntBetween(-100, 0);
+        int invalidTotalShardsPerNode = randomIntBetween(-100, -2);
 
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
             () -> new SearchableSnapshotAction("test", true, invalidTotalShardsPerNode, null, null)
         );
-        assertEquals("[" + TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= 1", exception.getMessage());
+        assertEquals("[" + TOTAL_SHARDS_PER_NODE.getPreferredName() + "] must be >= -1", exception.getMessage());
+    }
+
+    public void testCreateWithUnboundedTotalShardsPerNode() {
+        SearchableSnapshotAction action = new SearchableSnapshotAction("test", true, -1, null, null);
+
+        assertThat(action.getTotalShardsPerNode(), is(-1));
+    }
+
+    public void testUnboundedTotalShardsPerNodeIsPassedToMountStep() {
+        SearchableSnapshotAction action = new SearchableSnapshotAction("test", true, -1, null, null);
+
+        MountSnapshotStep mountStep = (MountSnapshotStep) action.toSteps(
+            null,
+            TimeseriesLifecycleType.COLD_PHASE,
+            new StepKey(TimeseriesLifecycleType.COLD_PHASE, "next", "step"),
+            null
+        ).stream().filter(step -> step instanceof MountSnapshotStep).findFirst().orElseThrow();
+
+        assertThat(mountStep.getTotalShardsPerNode(), is(-1));
     }
 
     private List<StepKey> expectedStepKeys(String phase, boolean forceMergeIndex, boolean hasReplicateFor, Boolean forceMergeOnClone) {


### PR DESCRIPTION
## Summary

- Allow the searchable snapshot ILM action to use `total_shards_per_node: -1` as the unbounded value.
- Keep values below `-1` invalid, matching the existing AllocateAction contract.
- Preserve the unbounded value through SearchableSnapshotAction into MountSnapshotStep.

Closes #153993

## Testing

- `./gradlew --no-daemon --max-workers=1 :x-pack:plugin:core:test --tests 'org.elasticsearch.xpack.core.ilm.SearchableSnapshotActionTests.testCreateWithUnboundedTotalShardsPerNode' --tests 'org.elasticsearch.xpack.core.ilm.MountSnapshotStepTests.testCreateWithUnboundedTotalShardsPerNode'`
- `./gradlew --no-daemon --max-workers=1 :x-pack:plugin:core:test --tests 'org.elasticsearch.xpack.core.ilm.SearchableSnapshotActionTests' --tests 'org.elasticsearch.xpack.core.ilm.MountSnapshotStepTests'`
- `./gradlew --no-daemon --max-workers=1 :x-pack:plugin:core:spotlessJavaApply :x-pack:plugin:core:spotlessJavaCheck`
- `./gradlew --no-daemon --max-workers=2 :x-pack:plugin:core:test`
