### PR TITLE
[Search] Defer binary doc-values reader setup

### DIFF
--- a/docs/changelog/155054.yaml
+++ b/docs/changelog/155054.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 153927
+pr: 155054
+summary: Defer binary doc-values reader setup until scorer construction
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreScorerSupplier;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -22,6 +23,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
@@ -65,22 +67,26 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
                 if (fi == null || fi.getDocValuesType() != DocValuesType.BINARY) {
                     return null;
                 }
-                return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        final DocIdSetIterator iterator = getDocIdSetIterator(context, matchCost);
+                        if (iterator == null) {
+                            return ConstantScoreScorerSupplier.fromIterator(
+                                DocIdSetIterator.empty(),
+                                score(),
+                                scoreMode,
+                                context.reader().maxDoc()
+                            ).get(leadCost);
+                        }
+
+                        // Checkpoint now that a binary doc values reader has been opened for this surviving clause/segment pair.
+                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
+                        return new ConstantScoreScorer(score(), scoreMode, iterator);
+                    }
                     @Override
                     public long cost() {
                         return context.reader().maxDoc();
-                    }
-
-                    @Override
-                    public DocIdSetIterator iterator(long leadCost) throws IOException {
-                        // Checkpoint before opening: the probe is 0-byte heap sampling, so
-                        // checking before the allocation skips it entirely when under pressure.
-                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
-                        final DocIdSetIterator disi = getDocIdSetIterator(context, matchCost);
-                        if (disi == null) {
-                            return DocIdSetIterator.empty();
-                        }
-                        return disi;
                     }
                 };
             }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -84,6 +84,7 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
                         ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
                         return new ConstantScoreScorer(score(), scoreMode, iterator);
                     }
+
                     @Override
                     public long cost() {
                         return context.reader().maxDoc();

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
@@ -67,24 +68,24 @@ public final class BinaryDocValuesContainsTermQuery extends Query {
                 if (fi == null || fi.getDocValuesType() != DocValuesType.BINARY) {
                     return null;
                 }
-                return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
+                return new ScorerSupplier() {
                     @Override
-                    public long cost() {
-                        return context.reader().maxDoc();
-                    }
-
-                    @Override
-                    public DocIdSetIterator iterator(long leadCost) throws IOException {
-                        // Checkpoint before opening: the probe is 0-byte heap sampling, so
-                        // checking before the allocation skips it entirely when under pressure.
-                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
+                    public Scorer get(long leadCost) throws IOException {
                         final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
                         if (values == null) {
-                            return DocIdSetIterator.empty();
+                            return ConstantScoreScorerSupplier.fromIterator(
+                                DocIdSetIterator.empty(),
+                                score(),
+                                scoreMode,
+                                context.reader().maxDoc()
+                            ).get(leadCost);
                         }
 
+                        // Checkpoint now that a binary doc values reader has been opened for this surviving clause/segment pair.
+                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
+
                         // The optimized path returns a TwoPhaseIterator-backed iterator (see the contract
-                        // on tryContainsIterator). ConstantScoreScorerSupplier unwraps the TwoPhase so Lucene's
+                        // on tryContainsIterator). ConstantScoreScorer unwraps the TwoPhase so Lucene's
                         // BulkScorer drives approximation.advance(min) + matches() within [min, max), giving
                         // linear scaling under sub-segment slicing (DataPartitioning.DOC).
                         String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
@@ -97,14 +98,23 @@ public final class BinaryDocValuesContainsTermQuery extends Query {
                                 ? direct.tryContainsIterator(containsTerm)
                                 : null;
 
+                        final DocIdSetIterator iterator;
                         if (containsIter != null) {
-                            return containsIter;
+                            iterator = containsIter;
+                        } else {
+                            Predicate<BytesRef> predicate = bytes -> contains(bytes, containsTerm);
+                            final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
+                            iterator = arrayOrderInlineNull
+                                ? AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(values, counts, predicate, matchCost())
+                                : AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, predicate, matchCost());
                         }
-                        Predicate<BytesRef> predicate = bytes -> contains(bytes, containsTerm);
-                        final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
-                        return arrayOrderInlineNull
-                            ? AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(values, counts, predicate, matchCost())
-                            : AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, predicate, matchCost());
+                        return ConstantScoreScorerSupplier.fromIterator(iterator, score(), scoreMode, context.reader().maxDoc())
+                            .get(leadCost);
+                    }
+
+                    @Override
+                    public long cost() {
+                        return context.reader().maxDoc();
                     }
                 };
             }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
@@ -63,39 +64,54 @@ final class BinaryDocValuesLengthQuery extends Query {
                 if (fi == null || fi.getDocValuesType() != DocValuesType.BINARY) {
                     return null;
                 }
-                return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
+                return new ScorerSupplier() {
                     @Override
-                    public long cost() {
-                        return context.reader().maxDoc();
-                    }
-
-                    @Override
-                    public DocIdSetIterator iterator(long leadCost) throws IOException {
-                        // Checkpoint before opening: the probe is 0-byte heap sampling, so
-                        // checking before the allocation skips it entirely when under pressure.
-                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
+                    public Scorer get(long leadCost) throws IOException {
                         final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
                         if (values == null) {
-                            return DocIdSetIterator.empty();
+                            return ConstantScoreScorerSupplier.fromIterator(
+                                DocIdSetIterator.empty(),
+                                score(),
+                                scoreMode,
+                                context.reader().maxDoc()
+                            ).get(leadCost);
                         }
+
+                        // Checkpoint now that a binary doc values reader has been opened for this surviving clause/segment pair.
+                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
 
                         String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
                         final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
                         DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
+                        final DocIdSetIterator iterator;
                         if ((countsSkipper == null || countsSkipper.maxValue() == 1)
                             && values instanceof BlockLoader.OptionalLengthReader direct) {
                             // tryLengthIterator returns a TwoPhaseIterator-backed iterator (see the contract on
                             // BlockLoader.OptionalLengthReader), so sub-segment slicing scales with cores.
-                            return direct.tryLengthIterator(length);
-                        }
-                        Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
-                        if (arrayOrderInlineNull) {
-                            return AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(values, counts, lengthPredicate, matchCost);
-                        } else if (countsSkipper != null) {
-                            return AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, lengthPredicate, matchCost);
+                            iterator = direct.tryLengthIterator(length);
                         } else {
-                            return AbstractBinaryDocValuesQuery.singleValuedIterator(values, lengthPredicate, matchCost);
+                            Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
+                            if (arrayOrderInlineNull) {
+                                iterator = AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(
+                                    values,
+                                    counts,
+                                    lengthPredicate,
+                                    matchCost
+                                );
+                            } else if (countsSkipper != null) {
+                                iterator = AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, lengthPredicate, matchCost);
+                            } else {
+                                iterator = AbstractBinaryDocValuesQuery.singleValuedIterator(values, lengthPredicate, matchCost);
+                            }
                         }
+
+                        return ConstantScoreScorerSupplier.fromIterator(iterator, score(), scoreMode, context.reader().maxDoc())
+                            .get(leadCost);
+                    }
+
+                    @Override
+                    public long cost() {
+                        return context.reader().maxDoc();
                     }
                 };
             }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
@@ -252,7 +252,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
         }
     }
 
-    public void testChecksCircuitBreakerWhenReaderOpened() throws IOException {
+    public void testChecksCircuitBreakerWhenScorerBuilt() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
@@ -279,7 +279,11 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
                     searcher.setCircuitBreaker(breaker);
 
                     Query present = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("search"), false);
-                    expectThrows(CircuitBreakingException.class, () -> searcher.count(present));
+                    var weight = present.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                    var scorerSupplier = weight.scorerSupplier(reader.leaves().get(0));
+                    assertNotNull(scorerSupplier);
+                    assertEquals(-1L, checkpointedBytes.get());
+                    expectThrows(CircuitBreakingException.class, () -> scorerSupplier.get(Long.MAX_VALUE));
                     // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
                     assertEquals(0L, checkpointedBytes.get());
 

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
@@ -184,7 +184,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
         }
     }
 
-    public void testChecksCircuitBreakerWhenReaderOpened() throws IOException {
+    public void testChecksCircuitBreakerWhenScorerBuilt() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
@@ -218,7 +218,11 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                     searcher.setCircuitBreaker(breaker);
 
                     Query present = new BinaryDocValuesLengthQuery(fieldName, 1, false);
-                    expectThrows(CircuitBreakingException.class, () -> searcher.count(present));
+                    var weight = present.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                    var scorerSupplier = weight.scorerSupplier(reader.leaves().get(0));
+                    assertNotNull(scorerSupplier);
+                    assertEquals(-1L, checkpointedBytes.get());
+                    expectThrows(CircuitBreakingException.class, () -> scorerSupplier.get(Long.MAX_VALUE));
                     // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
                     assertEquals(0L, checkpointedBytes.get());
 

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQueryTests.java
@@ -343,7 +343,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
         }
     }
 
-    public void testChecksCircuitBreakerWhenReaderOpened() throws IOException {
+    public void testChecksCircuitBreakerWhenScorerBuilt() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
@@ -370,7 +370,11 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                     searcher.setCircuitBreaker(breaker);
 
                     Query present = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("hello"), false);
-                    expectThrows(CircuitBreakingException.class, () -> searcher.count(present));
+                    var weight = present.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+                    var scorerSupplier = weight.scorerSupplier(reader.leaves().get(0));
+                    assertNotNull(scorerSupplier);
+                    assertEquals(-1L, checkpointedBytes.get());
+                    expectThrows(CircuitBreakingException.class, () -> scorerSupplier.get(Long.MAX_VALUE));
                     // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
                     assertEquals(0L, checkpointedBytes.get());
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -196,6 +196,14 @@ abstract class BinaryDvConfirmedQuery extends Query {
                             ? SortingArrayOrderBinaryDocValues.from(context.reader(), field)
                             : MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), field);
                         final Scorer approxScorer = approxScorerSupplier.get(leadCost);
+
+                        // Checkpoint before opening the binary doc values reader for this surviving clause/segment pair.
+                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
+
+                        final SortedBinaryDocValues values = arrayOrder
+                            ? SortingArrayOrderBinaryDocValues.from(context.reader(), field)
+                            : MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), field);
+
                         final DocIdSetIterator approxDisi = approxScorer.iterator();
                         final TwoPhaseIterator twoPhase = new TwoPhaseIterator(approxDisi) {
                             @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -196,14 +196,6 @@ abstract class BinaryDvConfirmedQuery extends Query {
                             ? SortingArrayOrderBinaryDocValues.from(context.reader(), field)
                             : MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), field);
                         final Scorer approxScorer = approxScorerSupplier.get(leadCost);
-
-                        // Checkpoint before opening the binary doc values reader for this surviving clause/segment pair.
-                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
-
-                        final SortedBinaryDocValues values = arrayOrder
-                            ? SortingArrayOrderBinaryDocValues.from(context.reader(), field)
-                            : MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), field);
-
                         final DocIdSetIterator approxDisi = approxScorer.iterator();
                         final TwoPhaseIterator twoPhase = new TwoPhaseIterator(approxDisi) {
                             @Override

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -30,6 +30,8 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
@@ -201,7 +203,7 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         dir.close();
     }
 
-    public void testBinaryDvConfirmationChecksCircuitBreaker() throws IOException {
+    public void testBinaryDvConfirmationChecksCircuitBreakerWhenScorerBuilt() throws IOException {
         Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig(WildcardFieldMapper.WILDCARD_ANALYZER_7_10);
         iwc.setMergePolicy(newTieredMergePolicy(random()));
@@ -236,7 +238,11 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         searcher.setCircuitBreaker(breaker);
 
         Query wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery("*a*", null, null);
-        expectThrows(CircuitBreakingException.class, () -> searcher.count(wildcardFieldQuery));
+        var weight = wildcardFieldQuery.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(reader.leaves().get(0));
+        assertNotNull(scorerSupplier);
+        assertThat(checkpointedBytes.get(), equalTo(-1L));
+        expectThrows(CircuitBreakingException.class, () -> scorerSupplier.get(Long.MAX_VALUE));
         // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
         assertThat(checkpointedBytes.get(), equalTo(0L));
 


### PR DESCRIPTION
## Summary

Binary doc-values queries currently open their readers and build iterators from scorerSupplier(). Lucene may create suppliers for clauses that are only used for cost comparison, so this eagerly allocates per-segment reader state for clauses that never execute.

This change:

- defers binary doc-values reader, skipper, and iterator construction until ScorerSupplier#get()
- keeps the binary doc-values circuit-breaker checkpoint immediately before the deferred reader is opened
- preserves missing-field behavior and approximation cost reporting
- applies the same lifecycle to wildcard binary doc-values confirmation
- adds regression coverage proving supplier creation does not open the reader or trip the breaker

Fixes #153927

## Testing

- ./gradlew --no-daemon --max-workers=1 :server:test --tests org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQueryTests --tests org.elasticsearch.lucene.queries.BinaryDocValuesLengthQueryTests --tests org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQueryTests :x-pack:plugin:wildcard:test --tests org.elasticsearch.xpack.wildcard.mapper.WildcardFieldMapperTests.testBinaryDvConfirmationChecksCircuitBreakerWhenScorerBuilt
- ./gradlew --no-daemon --max-workers=1 :server:spotlessJavaCheck :x-pack:plugin:wildcard:spotlessJavaCheck