### PR TITLE
failedShardsCache distinguishes failures from cancellations

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -676,6 +677,101 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
                 || Objects.equals(primaryShard.allocationId(), allocationId) == false;
         });
         awaitDirectCancellationMetric(node, 1L);
+    }
+
+    /// Verifies that an unrelated cluster state update arriving after a started-recovery cancellation (while the
+    /// master has not yet processed the resulting SHARD_FAILED) does not cause `failedAllocations` to be incorrectly
+    /// incremented. The data node resends the failure from `failedShardsCache` using a [RecoveryCancelledException].
+    public void testUnrelatedClusterStateUpdateAfterStartedCancellation() throws Exception {
+        final var masterNode = internalCluster().startMasterOnlyNode();
+        final var dataNode = internalCluster().startDataOnlyNode();
+
+        final var indexName = randomIndexName();
+        safeAcquire(TestRecoveryBlockerPlugin.beforeRecoveryGate);
+        prepareCreate(indexName).setSettings(indexSettings(1, 0).build()).execute();
+        safeAcquire(TestRecoveryBlockerPlugin.beforeRecoveryEntered);
+        TestRecoveryBlockerPlugin.beforeRecoveryEntered.release();
+
+        final var index = resolveIndex(indexName);
+        final var shardId = new ShardId(index, 0);
+        final var dataClusterService = internalCluster().getInstance(ClusterService.class, dataNode);
+        final var allocationId = dataClusterService.state().routingTable().shardRoutingTable(shardId).primaryShard().allocationId().getId();
+
+        // Block all RecoveryCancelledException SHARD_FAILED messages so the shard remains INITIALIZING in the cluster state.
+        final var blockedCancellationFailures = new CopyOnWriteArrayList<Runnable>();
+        final var firstCancellationFailureReceived = new CountDownLatch(1);
+        MockTransportService.getInstance(masterNode)
+            .addRequestHandlingBehavior(ShardStateAction.SHARD_FAILED_ACTION_NAME, (handler, request, channel, task) -> {
+                if (request instanceof FailedShardEntry failedShard
+                    && ExceptionsHelper.unwrap(failedShard.getFailure(), RecoveryCancelledException.class) != null) {
+                    assertThat("unexpected SHARD_FAILED cancellation", failedShard.getShardId(), equalTo(shardId));
+                    firstCancellationFailureReceived.countDown();
+                    blockedCancellationFailures.add(() -> {
+                        try {
+                            handler.messageReceived(request, channel, task);
+                        } catch (Exception e) {
+                            throw new AssertionError(e);
+                        }
+                    });
+                } else {
+                    handler.messageReceived(request, channel, task);
+                }
+            });
+
+        // Cancel the started recovery and release the gate so the cancellation takes effect.
+        final var cancellationRequest = new CancelRecoveriesAction.Request(
+            dataClusterService.state().term(),
+            dataClusterService.state().version(),
+            List.of(new ShardRecoveryCancellation(shardId, allocationId, true))
+        );
+        client(dataNode).execute(CancelRecoveriesAction.TYPE, cancellationRequest).get();
+        TestRecoveryBlockerPlugin.beforeRecoveryGate.release();
+
+        // Wait until the first SHARD_FAILED is blocked.
+        safeAwait(firstCancellationFailureReceived);
+
+        // Trigger an unrelated cluster state update. The data node sees shardId still INITIALIZING and resends
+        // the SHARD_FAILED from failedShardsCache using a RecoveryCancelledException.
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TimeValue.timeValueSeconds(10), TimeValue.timeValueSeconds(10))
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(
+                            EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(),
+                            EnableAllocationDecider.Allocation.NONE
+                        )
+                )
+        );
+        assertRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 0 && stats.currentFromStoreQueued() == 0));
+        waitNoPendingTasksOnAll();
+
+        // Another unrelated cluster state update. The data node applies it with shardId still INITIALIZING.
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TimeValue.timeValueSeconds(10), TimeValue.timeValueSeconds(10))
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(
+                            EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(),
+                            EnableAllocationDecider.Allocation.NONE
+                        )
+                )
+        );
+        assertRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 0 && stats.currentFromStoreQueued() == 0));
+        waitNoPendingTasksOnAll();
+
+        // Release all blocked SHARD_FAILED messages.
+        blockedCancellationFailures.forEach(Runnable::run);
+
+        awaitClusterState(state -> state.routingTable().shardRoutingTable(shardId).primaryShard().unassigned());
+
+        final var unassignedInfo = dataClusterService.state().routingTable().shardRoutingTable(shardId).primaryShard().unassignedInfo();
+        assertNotNull(unassignedInfo);
+        assertThat("directly cancelled recovery must not increment failedAllocations", unassignedInfo.failedAllocations(), equalTo(0));
+        assertThat(
+            "directly cancelled recovery must remain unassigned as RECOVERY_CANCELLED",
+            unassignedInfo.reason(),
+            equalTo(UnassignedInfo.Reason.RECOVERY_CANCELLED)
+        );
     }
 
     private void disableAllocation() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -774,6 +775,130 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
         assertThat("directly cancelled recovery must not increment failedAllocations", unassignedInfo.failedAllocations(), equalTo(0));
         assertThat(
             "directly cancelled recovery must remain unassigned as RECOVERY_CANCELLED",
+            unassignedInfo.reason(),
+            equalTo(UnassignedInfo.Reason.RECOVERY_CANCELLED)
+        );
+    }
+
+    /// Verifies that after a recovery is cancelled from the [ThrottlingRecoveryService] pending queue, subsequent
+    /// unrelated cluster state updates do not cause `failedAllocations` to be incorrectly incremented.
+    public void testUnrelatedClusterStateUpdateAfterQueuedCancellation() throws Exception {
+        final var masterNode = internalCluster().startMasterOnlyNode();
+        final var dataNode = internalCluster().startDataOnlyNode(
+            Settings.builder().put(ThrottlingRecoveryService.INDICES_RECOVERY_MAX_CONCURRENT_RECOVERIES_SETTING.getKey(), 1).build()
+        );
+        final var clusterService = internalCluster().getInstance(ClusterService.class, dataNode);
+
+        // Hold the one available slot.
+        final var index1Name = randomIndexName();
+        safeAcquire(TestRecoveryBlockerPlugin.beforeRecoveryGate);
+        prepareCreate(index1Name).setSettings(indexSettings(1, 0).build()).execute();
+        safeAcquire(TestRecoveryBlockerPlugin.beforeRecoveryEntered);
+        TestRecoveryBlockerPlugin.beforeRecoveryEntered.release();
+
+        // Second recovery is enqueued
+        final var index2Name = randomIndexName();
+        prepareCreate(index2Name).setSettings(indexSettings(1, 0).build()).execute();
+        awaitRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 1 && stats.currentFromStoreQueued() == 1));
+
+        final var index2 = resolveIndex(index2Name);
+        final var shardId2 = new ShardId(index2, 0);
+        final var allocationId2 = clusterService.state().routingTable().shardRoutingTable(shardId2).primaryShard().allocationId().getId();
+
+        // Block all RecoveryCancelledException `SHARD_FAILED` messages so shardId2 remains INITIALIZING.
+        final var blockedCancellationFailures = new CopyOnWriteArrayList<Runnable>();
+        final var firstCancellationFailureReceived = new CountDownLatch(1);
+        final var allCancellationFailuresReceived = new CountDownLatch(3);
+        MockTransportService.getInstance(masterNode)
+            .addRequestHandlingBehavior(ShardStateAction.SHARD_FAILED_ACTION_NAME, (handler, request, channel, task) -> {
+                if (request instanceof FailedShardEntry failedShard
+                    && ExceptionsHelper.unwrap(failedShard.getFailure(), RecoveryCancelledException.class) != null) {
+                    assertThat("unexpected SHARD_FAILED cancellation", failedShard.getShardId(), equalTo(shardId2));
+                    firstCancellationFailureReceived.countDown();
+                    allCancellationFailuresReceived.countDown();
+                    blockedCancellationFailures.add(() -> {
+                        try {
+                            handler.messageReceived(request, channel, task);
+                        } catch (Exception e) {
+                            throw new AssertionError(e);
+                        }
+                    });
+                } else {
+                    handler.messageReceived(request, channel, task);
+                }
+            });
+
+        // Cancel index2 from the pending queue. The response is returned to the test client, the master is kept unaware.
+        final var cancellationRequest = new CancelRecoveriesAction.Request(
+            clusterService.state().term(),
+            clusterService.state().version(),
+            List.of(new ShardRecoveryCancellation(shardId2, allocationId2, false))
+        );
+        final var cancellationResponse = client(dataNode).execute(CancelRecoveriesAction.TYPE, cancellationRequest).get();
+        assertThat(
+            "index2 recovery should be cancelled from the pending queue",
+            cancellationResponse.cancelledInQueue(),
+            equalTo(Set.of(new CancelRecoveriesAction.CancelledInQueue(shardId2, allocationId2)))
+        );
+
+        // Release index1's gate so it can complete recovery. The master publishes the resulting cluster state with
+        // shardId2 still INITIALIZING.
+        TestRecoveryBlockerPlugin.beforeRecoveryGate.release();
+        safeAwait(firstCancellationFailureReceived);
+        assertTrue(
+            "shard2 should still be initializing",
+            clusterService.state().routingTable().shardRoutingTable(shardId2).primaryShard().initializing()
+        );
+
+        // Trigger another unrelated cluster state update. The data node sees shardId2 still INITIALIZING.
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TimeValue.timeValueSeconds(10), TimeValue.timeValueSeconds(10))
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(
+                            EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(),
+                            EnableAllocationDecider.Allocation.NONE
+                        )
+                )
+        );
+        assertRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 0 && stats.currentFromStoreQueued() == 0));
+        waitNoPendingTasksOnAll();
+        assertTrue(
+            "shard2 should still be initializing",
+            clusterService.state().routingTable().shardRoutingTable(shardId2).primaryShard().initializing()
+        );
+
+        // Another unrelated cluster state update triggers SHARD_FAILED#3.
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TimeValue.timeValueSeconds(10), TimeValue.timeValueSeconds(10))
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(
+                            EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(),
+                            EnableAllocationDecider.Allocation.NONE
+                        )
+                )
+        );
+        assertRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 0 && stats.currentFromStoreQueued() == 0));
+        waitNoPendingTasksOnAll();
+        assertTrue(
+            "shard2 should still be initializing",
+            clusterService.state().routingTable().shardRoutingTable(shardId2).primaryShard().initializing()
+        );
+
+        // Wait for all 3 expected SHARD_FAILEDs: one from the enqueue rejection and two resends from failedShardsCache.
+        safeAwait(allCancellationFailuresReceived);
+
+        // Release all blocked SHARD_FAILED messages.
+        blockedCancellationFailures.forEach(Runnable::run);
+
+        awaitClusterState(state -> state.routingTable().shardRoutingTable(shardId2).primaryShard().unassigned());
+
+        final var unassignedInfo = clusterService.state().routingTable().shardRoutingTable(shardId2).primaryShard().unassignedInfo();
+        assertNotNull(unassignedInfo);
+        assertThat("queued-cancelled recovery must not increment failedAllocations", unassignedInfo.failedAllocations(), equalTo(0));
+        assertThat(
+            "queued-cancelled recovery must remain unassigned as RECOVERY_CANCELLED",
             unassignedInfo.reason(),
             equalTo(UnassignedInfo.Reason.RECOVERY_CANCELLED)
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
@@ -692,6 +692,7 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
         prepareCreate(indexName).setSettings(indexSettings(1, 0).build()).execute();
         safeAcquire(TestRecoveryBlockerPlugin.beforeRecoveryEntered);
         TestRecoveryBlockerPlugin.beforeRecoveryEntered.release();
+        waitNoPendingTasksOnAll();
 
         final var index = resolveIndex(indexName);
         final var shardId = new ShardId(index, 0);
@@ -800,6 +801,7 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
         final var index2Name = randomIndexName();
         prepareCreate(index2Name).setSettings(indexSettings(1, 0).build()).execute();
         awaitRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 1 && stats.currentFromStoreQueued() == 1));
+        waitNoPendingTasksOnAll();
 
         final var index2 = resolveIndex(index2Name);
         final var shardId2 = new ShardId(index2, 0);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
@@ -758,6 +759,8 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
         );
         assertRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 0 && stats.currentFromStoreQueued() == 0));
         waitNoPendingTasksOnAll();
+
+        assertThat("expected at least 3 SHARD_FAILED to have been sent", blockedCancellationFailures.size(), greaterThanOrEqualTo(3));
 
         // Release all blocked SHARD_FAILED messages.
         blockedCancellationFailures.forEach(Runnable::run);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DirectRecoveryCancellationIT.java
@@ -69,7 +69,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
@@ -701,12 +700,14 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
         // Block all RecoveryCancelledException SHARD_FAILED messages so the shard remains INITIALIZING in the cluster state.
         final var blockedCancellationFailures = new CopyOnWriteArrayList<Runnable>();
         final var firstCancellationFailureReceived = new CountDownLatch(1);
+        final var allCancellationFailuresReceived = new CountDownLatch(3);
         MockTransportService.getInstance(masterNode)
             .addRequestHandlingBehavior(ShardStateAction.SHARD_FAILED_ACTION_NAME, (handler, request, channel, task) -> {
                 if (request instanceof FailedShardEntry failedShard
                     && ExceptionsHelper.unwrap(failedShard.getFailure(), RecoveryCancelledException.class) != null) {
                     assertThat("unexpected SHARD_FAILED cancellation", failedShard.getShardId(), equalTo(shardId));
                     firstCancellationFailureReceived.countDown();
+                    allCancellationFailuresReceived.countDown();
                     blockedCancellationFailures.add(() -> {
                         try {
                             handler.messageReceived(request, channel, task);
@@ -760,7 +761,8 @@ public class DirectRecoveryCancellationIT extends AbstractIndexRecoveryIntegTest
         assertRecoveryCountStats(Map.of(dataNode, stats -> stats.currentFromStore() == 0 && stats.currentFromStoreQueued() == 0));
         waitNoPendingTasksOnAll();
 
-        assertThat("expected at least 3 SHARD_FAILED to have been sent", blockedCancellationFailures.size(), greaterThanOrEqualTo(3));
+        // Expect at least 3 SHARD_FAILED to have been sent
+        safeAwait(allCancellationFailuresReceived);
 
         // Release all blocked SHARD_FAILED messages.
         blockedCancellationFailures.forEach(Runnable::run);

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -76,6 +76,7 @@ import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
+import org.elasticsearch.indices.recovery.RecoveryCancelledException;
 import org.elasticsearch.indices.recovery.RecoveryClusterStateDelay;
 import org.elasticsearch.indices.recovery.RecoveryFailedException;
 import org.elasticsearch.indices.recovery.RecoveryListener;
@@ -143,7 +144,12 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
     private final Settings settings;
 
-    record FailedShardCacheEntry(ShardRouting routing, long primaryTerm) {}
+    private enum ShardFailureType {
+        FAILED,
+        RECOVERY_CANCELLED
+    }
+
+    record FailedShardCacheEntry(ShardRouting routing, long primaryTerm, ShardFailureType failureType) {}
 
     // A list of shards that failed during recovery.
     // We keep track of these shards in order to prevent repeated recovery of these shards on each cluster state update.
@@ -408,7 +414,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 } else if (masterNode != null) { // TODO: remove this? Is resending shard failures the responsibility of shardStateAction?
                     String message = "master " + masterNode + " has not removed previously failed shard. resending shard failure";
                     logger.trace("[{}] re-sending failed shard [{}], reason [{}]", matchedRouting.shardId(), matchedRouting, message);
-                    shardStateAction.localShardFailed(matchedRouting, message, null, ActionListener.noop(), state);
+                    final Exception resendFailure = cacheEntry.getValue().failureType() == ShardFailureType.RECOVERY_CANCELLED
+                        ? new RecoveryCancelledException(matchedRouting.shardId(), null, state.nodes().getLocalNode())
+                        : null;
+                    shardStateAction.localShardFailed(matchedRouting, message, resendFailure, ActionListener.noop(), state);
                 }
             }
         }
@@ -1313,7 +1322,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ShardId shardId = shardRouting.shardId();
         try {
             logger.warn(() -> format("%s marking and sending shard failed due to [%s]", shardId, message), failure);
-            failedShardsCache.put(shardRouting.shardId(), new FailedShardCacheEntry(shardRouting, primaryTerm));
+            final ShardFailureType failureType = ExceptionsHelper.unwrap(failure, RecoveryCancelledException.class) != null
+                ? ShardFailureType.RECOVERY_CANCELLED
+                : ShardFailureType.FAILED;
+            failedShardsCache.put(shardRouting.shardId(), new FailedShardCacheEntry(shardRouting, primaryTerm, failureType));
             shardStateAction.localShardFailed(shardRouting, message, failure, ActionListener.noop(), state);
         } catch (Exception inner) {
             if (failure != null) inner.addSuppressed(failure);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -107,11 +107,15 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
         Consumer<RecoveryListener> task
     ) {
         final Supplier<ThreadContext.StoredContext> context = restorableContextForProject(projectId);
+        final ShardId shardId = recoveryState.getShardId();
         final PendingRecovery pendingRecovery;
         final boolean serviceClosed;
         synchronized (this) {
             serviceClosed = isClosed();
-            if (serviceClosed || cancelledAllocationIds.get(allocationId) != null) {
+            if (serviceClosed || cancelledAllocationIds.containsKey(allocationId)) {
+                final ShardId cancelled = cancelledAllocationIds.get(allocationId);
+                assert serviceClosed || cancelled.equals(shardId)
+                    : "mismatch between cached cancellation [" + cancelled + "] and enqueue recovery: [" + recoveryState + "]";
                 pendingRecovery = null;
             } else {
                 pendingRecovery = new PendingRecovery(recoveryState, allocationId, stats, task, recoveryListener, context);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -111,7 +111,7 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
         final boolean serviceClosed;
         synchronized (this) {
             serviceClosed = isClosed();
-            if (serviceClosed || cancelledAllocationIds.remove(allocationId) != null) {
+            if (serviceClosed || cancelledAllocationIds.get(allocationId) != null) {
                 pendingRecovery = null;
             } else {
                 pendingRecovery = new PendingRecovery(recoveryState, allocationId, stats, task, recoveryListener, context);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
@@ -591,6 +591,41 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         ensureListenersWereNotified(listener);
     }
 
+    /// A recorded cancellation must persist across multiple [ThrottlingRecoveryService#enqueue] attempts for the same
+    /// allocation ID, until pruned by [#clusterChanged].
+    public void testRecordedCancellationPersistsForSubsequentEnqueueAttempts() {
+        final var taskQueue = new DeterministicTaskQueue();
+        final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(10));
+        final var shardId = new ShardId(randomIndexName(), UUIDs.randomBase64UUID(), 0);
+        final var allocationId = UUIDs.randomBase64UUID();
+
+        assertTrue(service.cancelRecoveries(Map.of(allocationId, shardId)).isEmpty());
+
+        final var listener1 = new TestCaptureResultListener(ExpectedRecoveryOutcome.CANCELLED_IN_QUEUE);
+        service.enqueue(
+            ProjectId.DEFAULT,
+            listener1,
+            newRecoveryState(shardId),
+            allocationId,
+            stats,
+            ignored -> fail("first enqueue attempt should have been rejected due to recorded cancellation")
+        );
+
+        final var listener2 = new TestCaptureResultListener(ExpectedRecoveryOutcome.CANCELLED_IN_QUEUE);
+        service.enqueue(
+            ProjectId.DEFAULT,
+            listener2,
+            newRecoveryState(shardId),
+            allocationId,
+            stats,
+            ignored -> fail("second enqueue attempt should also have been rejected")
+        );
+
+        taskQueue.runAllTasks();
+        assertThat(service.currentQueueSize(), equalTo(0));
+        ensureListenersWereNotified(listener1, listener2);
+    }
+
     public void testCancellationAppliedWhenTaskInPendingQueue() {
         final var taskQueue = new DeterministicTaskQueue();
         final var service = newStartedService(taskQueue.getThreadPool(), DefaultProjectResolver.INSTANCE, newClusterService(1));

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
@@ -94,6 +94,10 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         internalCluster().assertSameDocIdsOnShards();
     }
 
+    /// Asserts that the given per-node recovery-stats predicates are all satisfied.
+    ///
+    /// Unlike [#awaitRecoveryCountStats], this does not wait for recovery scheduling events. It reads
+    /// current stats and fails immediately if any predicate is not met.
     protected void assertRecoveryCountStats(Map<String, Predicate<RecoveryStats>> predicatePerNode) {
         for (final var nodePredicate : predicatePerNode.entrySet()) {
             final var indicesService = internalCluster().getInstance(IndicesService.class, nodePredicate.getKey());

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
@@ -94,6 +94,22 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         internalCluster().assertSameDocIdsOnShards();
     }
 
+    protected void assertRecoveryCountStats(Map<String, Predicate<RecoveryStats>> predicatePerNode) {
+        for (final var nodePredicate : predicatePerNode.entrySet()) {
+            final var indicesService = internalCluster().getInstance(IndicesService.class, nodePredicate.getKey());
+            final var stats = new RecoveryStats();
+            for (IndexService indexService : indicesService) {
+                for (IndexShard shard : indexService) {
+                    stats.add(shard.recoveryStats());
+                }
+            }
+            assertTrue(
+                "recovery stats predicate not met on node [" + nodePredicate.getKey() + "], current stats: " + stats,
+                nodePredicate.getValue().test(stats)
+            );
+        }
+    }
+
     /// Waits until the given recovery stats predicates are all satisfied, re-checking on every recovery scheduling
     /// event on all given nodes.
     protected void awaitRecoveryCountStats(Map<String, Predicate<RecoveryStats>> predicatePerNode) {


### PR DESCRIPTION
Follows discussion on: https://github.com/elastic/elasticsearch/pull/154374#issuecomment-5061470885

When a data node cancels an already-started shard recovery or catches a cancelled recovery at enqueue time, it calls `IndicesClusterStateService::sendFailShard`, which stores the routing in `failedShardsCache` and sends a `SHARD_FAILED` message carrying a `RecoveryCancelledException` to the master. 

If a subsequent unrelated cluster state update arrives before the master has processed that failure (i.e. the shard is still `INITIALIZING` in the new state), `updateFailedShardsCache` resends the failure. Previously it always resent with `null` as the exception, which caused the master to treat it as a regular failure and increment `failedAllocations`, preventing re-allocation without manual intervention.

This change tracks the kind of failure in `FailedShardCacheEntry` using a new `ShardFailureType` enum (`FAILED` / `RECOVERY_CANCELLED`). When resending from the cache, a `RecoveryCancelledException` is reconstructed for `RECOVERY_CANCELLED` entries, so that the master continues to set `UnassignedInfo.Reason.RECOVERY_CANCELLED` without incrementing `failedAllocations`.

Relates to: https://github.com/elastic/elasticsearch-team/issues/4559

Note: direct recovery cancellation is not yet enabled in production, so this bug has no actual impact at the moment

**Follow-up**

While this fix prevents the resends from incorrectly incrementing `failedAllocations`, it doesn't reduce the duplicate notifications issue. Both the queued path (when a new cluster state updates arrives before the master processes the cancellation) and the started path still produce duplicate `SHARD_FAILED` notifications. A better solution would guarantee that a single notification is sufficient (see https://github.com/elastic/elasticsearch/issues/82185)

Running `DirectRecoveryCancellationIT` in a loop on VM with load: [builds](https://gradle-enterprise.elastic.co/scans/tests?search.publicHostnames=inespot-ci-test&search.startTimeMax=1785297599999&search.startTimeMin=1785126600000&search.timeZoneId=America%2FNew_York&tests.container=org.elasticsearch.indices.recovery.DirectRecoveryCancellationIT)

