### PR TITLE
[Search] Correct annotated_text family type

### DIFF
--- a/docs/changelog/155057.yaml
+++ b/docs/changelog/155057.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 153418
+pr: 155057
+summary: Expose annotated_text as the text field family
+type: bug

--- a/plugins/mapper-annotated-text/build.gradle
+++ b/plugins/mapper-annotated-text/build.gradle
@@ -16,6 +16,6 @@ esplugin {
 
 restResources {
   restApi {
-    include '_common', 'indices', 'index', 'search'
+    include '_common', 'indices', 'index', 'search', 'field_caps'
   }
 }

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -524,6 +524,11 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         public String typeName() {
             return CONTENT_TYPE;
         }
+
+        @Override
+        public String familyTypeName() {
+            return TextFieldMapper.CONTENT_TYPE;
+        }
     }
 
     private final IndexVersion indexCreatedVersion;

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -17,12 +17,20 @@ import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.TextFamilyFieldType;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
+
+    public void testFamilyTypeName() {
+        TextFamilyFieldType fieldType = new AnnotatedTextFieldMapper.AnnotatedTextFieldType("field", Collections.emptyMap());
+
+        assertEquals(AnnotatedTextFieldMapper.CONTENT_TYPE, fieldType.typeName());
+        assertEquals(TextFieldMapper.CONTENT_TYPE, fieldType.familyTypeName());
+    }
 
     public void testIntervals() throws IOException {
         TextFamilyFieldType ft = new AnnotatedTextFieldMapper.AnnotatedTextFieldType("field", Collections.emptyMap());

--- a/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/30_combined_fields_and_more_like_this.yml
+++ b/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/30_combined_fields_and_more_like_this.yml
@@ -47,6 +47,36 @@
   - match: { hits.total.value: 1 }
 
 ---
+"field_caps reports annotated_text as text family":
+  - do:
+      indices.create:
+        index: annotated
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+          mappings:
+            properties:
+              title:
+                type: annotated_text
+
+  - do:
+      index:
+        index: annotated
+        id: "1"
+        body:
+          "title": "A searchable title"
+        refresh: true
+
+  - do:
+      field_caps:
+        index: annotated
+        fields: [ title ]
+  - match: { fields.title.text.type: text }
+  - match: { fields.title.text.searchable: true }
+  - match: { fields.title.text.aggregatable: false }
+
+---
 "more_like_this query on an annotated_text field":
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
@@ -299,8 +299,7 @@ public final class CombinedFieldsQueryBuilder extends LeafQueryBuilder<CombinedF
                 continue;
             }
 
-            if (fieldType.familyTypeName().equals(TextFieldMapper.CONTENT_TYPE) == false
-                && fieldType instanceof TextFieldMapper.TextFieldType == false) {
+            if (fieldType.familyTypeName().equals(TextFieldMapper.CONTENT_TYPE) == false) {
                 throw new IllegalArgumentException(
                     "Field [" + fieldType.name() + "] of type [" + fieldType.typeName() + "] does not support [" + NAME + "] queries"
                 );


### PR DESCRIPTION
Fixes #153418

AnnotatedTextFieldType inherits MappedFieldType.familyTypeName(), so it reports annotated_text instead of the text family. This makes _field_caps?types=text omit the field and causes ES|QL to resolve it as unsupported.

Return text from familyTypeName() while preserving typeName() as annotated_text. Remove the now-redundant instanceof workaround in combined_fields, and add unit and YAML REST coverage for the public behavior.

Tests:
- ./gradlew --no-daemon --max-workers=1 :plugins:mapper-annotated-text:test :server:test --tests 'org.elasticsearch.index.query.CombinedFieldsQueryBuilderTests' :plugins:mapper-annotated-text:spotlessJavaCheck :server:spotlessJavaCheck
- ./gradlew --no-daemon --max-workers=1 :plugins:mapper-annotated-text:yamlRestTest