### PR TITLE
[ES|QL] Push MV_CONTAINS with foldable left

### DIFF
--- a/docs/changelog/155058.yaml
+++ b/docs/changelog/155058.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154459
+pr: 155058
+summary: Push MV_CONTAINS when the left argument is foldable
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvContains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvContains.java
@@ -27,7 +27,11 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
+import org.elasticsearch.xpack.esql.core.querydsl.query.BoolQuery;
+import org.elasticsearch.xpack.esql.core.querydsl.query.ExistsQuery;
+import org.elasticsearch.xpack.esql.core.querydsl.query.NotQuery;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
+import org.elasticsearch.xpack.esql.core.querydsl.query.TermsQuery;
 import org.elasticsearch.xpack.esql.core.querydsl.query.TermsSetQuery;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -334,7 +338,22 @@ public class MvContains extends BinaryScalarFunction implements EvaluatorMapper,
     @Override
     public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         // TODO: Add Lucene pushdown for spatial types too
-        DataType dataType = right().dataType();
+        Expression fieldExpression;
+        Expression foldableExpression;
+        boolean fieldIsLeft;
+        if (pushdownPredicates.isPushableFieldAttribute(left()) && right().foldable()) {
+            fieldExpression = left();
+            foldableExpression = right();
+            fieldIsLeft = true;
+        } else if (pushdownPredicates.isPushableFieldAttribute(right()) && left().foldable()) {
+            fieldExpression = right();
+            foldableExpression = left();
+            fieldIsLeft = false;
+        } else {
+            return Translatable.NO;
+        }
+
+        DataType dataType = fieldExpression.dataType();
         if (dataType.isNumeric() == false
             && DataType.isString(dataType) == false
             && dataType.isDate() == false
@@ -344,28 +363,45 @@ public class MvContains extends BinaryScalarFunction implements EvaluatorMapper,
             return Translatable.NO;
         }
 
-        if (pushdownPredicates.isPushableFieldAttribute(left()) && right().foldable()) {
-            Object literalValue = literalValueOf(right());
-            if (literalValue == null) {
-                return Translatable.NO;
-            }
-            if (literalValue instanceof List<?> list && list.isEmpty()) {
-                return Translatable.NO;
-            }
-
-            return Translatable.YES;
+        Object literalValue = literalValueOf(foldableExpression);
+        if (literalValue == null || (literalValue instanceof List<?> list && list.isEmpty())) {
+            return Translatable.NO;
         }
-        return Translatable.NO;
+
+        // The reverse form needs a row-level recheck: a terms query only proves that a field has at least one
+        // value from the constant set, not that all of its values are contained in that set. It also uses a
+        // missing-field clause below because MV_CONTAINS(constant, NULL) is true.
+        return fieldIsLeft ? Translatable.YES : Translatable.RECHECK_BUT_NO_NEGATED;
     }
 
     @Override
     public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
-        Object literalValue = literalValueOf(right());
+        Expression fieldExpression;
+        Expression foldableExpression;
+        boolean fieldIsLeft;
+        if (pushdownPredicates.isPushableFieldAttribute(left())) {
+            fieldExpression = left();
+            foldableExpression = right();
+            fieldIsLeft = true;
+        } else {
+            fieldExpression = right();
+            foldableExpression = left();
+            fieldIsLeft = false;
+        }
+
+        Object literalValue = literalValueOf(foldableExpression);
         List<?> values = literalValue instanceof List ? (List<?>) literalValue : List.of(literalValue);
 
         LinkedHashSet<Object> terms = new LinkedHashSet<>();
-        values.forEach(v -> terms.add(Foldables.literalValueAsLuceneQueryObject(v, left().dataType())));
+        values.forEach(v -> terms.add(Foldables.literalValueAsLuceneQueryObject(v, fieldExpression.dataType())));
 
-        return new TermsSetQuery(source(), handler.nameOf(left()), terms);
+        String fieldName = handler.nameOf(fieldExpression);
+        if (fieldIsLeft) {
+            return new TermsSetQuery(source(), fieldName, terms);
+        }
+
+        Query fieldContainsConstant = new TermsQuery(source(), fieldName, terms);
+        Query fieldIsMissing = new NotQuery(source(), new ExistsQuery(source(), fieldName));
+        return new BoolQuery(source(), false, fieldContainsConstant, fieldIsMissing);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvContainsStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvContainsStaticTests.java
@@ -7,6 +7,10 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.TermsSetQueryBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
@@ -99,6 +103,23 @@ public class MvContainsStaticTests extends ESTestCase {
         }
     }
 
+    public void testTranslatableWithFoldableLeftArgument() {
+        for (DataType dataType : pushableDataTypes) {
+            FieldAttribute fieldAttr = new FieldAttribute(
+                EMPTY,
+                "abc",
+                new EsField("abc", dataType, emptyMap(), true, EsField.TimeSeriesFieldType.NONE)
+            );
+            MvContains mvContains = new MvContains(Source.EMPTY, randomLiteral(dataType), fieldAttr);
+
+            assertThat(
+                mvContains.translatable(LucenePushdownPredicates.DEFAULT),
+                equalTo(TranslationAware.Translatable.RECHECK_BUT_NO_NEGATED)
+            );
+            assertThat(mvContains.translatable(LucenePushdownPredicates.DEFAULT).negate(), equalTo(TranslationAware.Translatable.NO));
+        }
+    }
+
     public void testAsQuery() {
         String fieldName = "my_field";
 
@@ -125,5 +146,38 @@ public class MvContainsStaticTests extends ESTestCase {
             assertThat(queryBuilder.getMinimumShouldMatch(), equalTo(Integer.toString(values.size())));
             assertThat(queryBuilder.getValues(), hasSize(values.size()));
         }
+    }
+
+    public void testAsQueryWithFoldableLeftArgument() {
+        String fieldName = "my_field";
+        List<BytesRef> values = List.of(new BytesRef("python"), new BytesRef("c++"));
+        FieldAttribute fieldAttr = new FieldAttribute(
+            EMPTY,
+            fieldName,
+            new EsField(fieldName, DataType.KEYWORD, emptyMap(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+        MvContains mvContains = new MvContains(EMPTY, new Literal(EMPTY, values, DataType.KEYWORD), fieldAttr);
+
+        assertThat(
+            mvContains.translatable(LucenePushdownPredicates.DEFAULT),
+            equalTo(TranslationAware.Translatable.RECHECK_BUT_NO_NEGATED)
+        );
+
+        Query query = mvContains.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER);
+        assertThat(query.toQueryBuilder(), instanceOf(BoolQueryBuilder.class));
+
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) query.toQueryBuilder();
+        assertThat(boolQuery.should(), hasSize(2));
+        assertThat(boolQuery.should().stream().anyMatch(TermsQueryBuilder.class::isInstance), equalTo(true));
+        assertThat(
+            boolQuery.should()
+                .stream()
+                .anyMatch(
+                    q -> q instanceof BoolQueryBuilder nested
+                        && nested.mustNot().size() == 1
+                        && nested.mustNot().getFirst() instanceof ExistsQueryBuilder
+                ),
+            equalTo(true)
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PushdownGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PushdownGoldenTests.java
@@ -256,6 +256,14 @@ public class PushdownGoldenTests extends UnmappedGoldenTestCase {
         runGoldenTest(query, STAGES);
     }
 
+    public void testMvContainsWithFoldableLeftArgument() {
+        String query = """
+                FROM employees
+                | WHERE mv_contains(["Alice", "Anna", "Peter"], first_name)
+            """;
+        runGoldenTest(query, STAGES);
+    }
+
     public void testMvIntersectsOnKeyword() {
         String query = """
                 FROM employees

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testMvContainsWithFoldableLeftArgument/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testMvContainsWithFoldableLeftArgument/local_physical_optimization.expected
@@ -1,0 +1,69 @@
+LimitExec[1000[INTEGER],null]
+\_ExchangeExec[[avg_worked_seconds{f}#0, birth_date{f}#1, emp_no{f}#2, first_name{f}#3, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22],false]
+  \_ProjectExec[[avg_worked_seconds{f}#0, birth_date{f}#1, emp_no{f}#2, first_name{f}#3, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22]]
+    \_FieldExtractExec[avg_worked_seconds{f}#0, birth_date{f}#1, emp_no{f}#2, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22]<[],[],[]>
+      \_LimitExec[1000[INTEGER],70]
+        \_FilterExec[MVCONTAINS([[41 6c 69 63 65], [41 6e 6e 61], [50 65 74 65 72]][KEYWORD],first_name{f}#3)]
+          \_FieldExtractExec[first_name{f}#3]<[],[],[]>
+            \_EsQueryExec[employees], indexMode[standard], [_doc{f}#23], limit[], sort[] estimatedRowSize[360] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "bool" : {
+    "filter" : [
+      {
+        "bool" : {
+          "should" : [
+            {
+              "terms" : {
+                "first_name" : [
+                  "Alice",
+                  "Anna",
+                  "Peter"
+                ],
+                "boost" : 0.0
+              }
+            },
+            {
+              "bool" : {
+                "must_not" : [
+                  {
+                    "exists" : {
+                      "field" : "first_name",
+                      "boost" : 0.0
+                    }
+                  }
+                ],
+                "boost" : 0.0
+              }
+            }
+          ],
+          "boost" : 1.0
+        }
+      }
+    ],
+    "should" : [
+      {
+        "terms" : {
+          "first_name" : [
+            "Alice",
+            "Anna",
+            "Peter"
+          ],
+          "boost" : 0.0
+        }
+      },
+      {
+        "bool" : {
+          "must_not" : [
+            {
+              "exists" : {
+                "field" : "first_name",
+                "boost" : 0.0
+              }
+            }
+          ],
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testMvContainsWithFoldableLeftArgument/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/golden_tests/PushdownGoldenTests/testMvContainsWithFoldableLeftArgument/query.esql
@@ -1,0 +1,2 @@
+    FROM employees
+    | WHERE mv_contains(["Alice", "Anna", "Peter"], first_name)


### PR DESCRIPTION
Fixes #154459

`MV_CONTAINS` currently pushes down only when the field is the first argument. This leaves the equivalent `MV_CONTAINS(["python", "c++"], programming_languages)` form as a full scan.

This change also preserves the function's null semantics:
- use a `terms` query as a candidate filter
- include documents where the field is missing because `MV_CONTAINS(constant, NULL)` is true
- retain `MV_CONTAINS` as a row-level recheck because a terms query cannot prove that every field value is contained in the constant set
- report `RECHECK_BUT_NO_NEGATED` so negated predicates are not unsafely pushed down

Tests:
- `./gradlew ':x-pack:plugin:esql:test' --tests org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvContainsStaticTests --tests org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvContainsTests --tests org.elasticsearch.xpack.esql.optimizer.PushdownGoldenTests.testMvContainsWithFoldableLeftArgument`
- `./gradlew ':x-pack:plugin:esql:spotlessJavaCheck'`
- `git diff --check`
