### PR TITLE
[ES|QL] Generalize block position cancellation

### DIFF
--- a/docs/changelog/155060.yaml
+++ b/docs/changelog/155060.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154095
+pr: 155060
+summary: Generalize block position cancellation
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -20,7 +20,6 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.compute.data.AbstractBlockBuilder;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -1504,7 +1503,7 @@ public class NdJsonPageDecoder implements Closeable {
          */
         private void cancelAndNullPositionEntry(boolean includeChildren) {
             if (blockBuilder != null && dataType != DataType.NULL) {
-                ((AbstractBlockBuilder) blockBuilder).cancelPositionEntry();
+                blockBuilder.cancelPositionEntry();
                 blockTracker.set(blockIdx);
                 blockBuilder.appendNull();
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
@@ -102,6 +102,11 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
     }
 
     @Override
+    void truncateValueStorageTo(int newValueCount) {
+        values.truncateTo(newValueCount);
+    }
+
+    @Override
     public BytesRefBlockBuilder copyFrom(Block block, int beginInclusive, int endExclusive) {
         if (block.areAllValuesNull()) {
             for (int p = beginInclusive; p < endExclusive; p++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlockBuilder.java
@@ -111,6 +111,29 @@ public abstract class AbstractBlockBuilder implements Block.Builder {
         return this;
     }
 
+    /**
+     * Removes the last scalar value appended to this builder. Composite builders use this to
+     * roll back the scalar values they delegated to their child builders.
+     */
+    void rollbackLastValue() {
+        assert positionEntryIsOpen == false : "cannot roll back a value inside an open position entry";
+        assert valueCount > 0 : "cannot roll back an empty builder";
+        assert firstValueIndexes == null || firstValueIndexes[positionCount - 1] == valueCount - 1
+            : "only scalar values can be rolled back";
+        valueCount--;
+        positionCount--;
+        truncateValueStorageTo(valueCount);
+        if (nullsMask != null) {
+            nullsMask.clear(positionCount);
+        }
+        hasNonNullValue = valueCount > (nullsMask == null ? 0 : nullsMask.cardinality());
+    }
+
+    /**
+     * Truncates storage maintained by a concrete builder after a value rollback.
+     */
+    void truncateValueStorageTo(int newValueCount) {}
+
     protected final boolean isDense() {
         return nullsMask == null;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractDelegatingCompoundBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractDelegatingCompoundBlock.java
@@ -407,6 +407,31 @@ public abstract class AbstractDelegatingCompoundBlock<T extends Block> extends A
         }
 
         @Override
+        public final Block.Builder cancelPositionEntry() {
+            assert closed == false;
+            assert built == false;
+            assert isPositionEntryOpen() : "must call beginPositionEntry() first";
+            int valuesToRemove = valueCount - openPositionEntryStartValue;
+            cancelSubBlockPositions(valuesToRemove);
+            valueCount = openPositionEntryStartValue;
+            openPositionEntryStartValue = -1;
+            return this;
+        }
+
+        /**
+         * Removes the scalar values that were appended to each sub-block for the current
+         * position entry.
+         */
+        protected abstract void cancelSubBlockPositions(int valuesToRemove);
+
+        protected static void rollbackLastValues(Block.Builder builder, int valuesToRemove) {
+            AbstractBlockBuilder abstractBuilder = (AbstractBlockBuilder) builder;
+            for (int i = 0; i < valuesToRemove; i++) {
+                abstractBuilder.rollbackLastValue();
+            }
+        }
+
+        @Override
         public final T build() {
             if (closed || built) {
                 throw new IllegalStateException("already closed");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -458,6 +458,17 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
         Builder beginPositionEntry();
 
         /**
+         * Cancels the current multivalued entry and discards every value appended since
+         * {@link #beginPositionEntry()} was called.
+         *
+         * <p>After cancellation, the builder is positioned as it was before the matching
+         * {@code beginPositionEntry()} call. Callers must append a replacement value, usually
+         * with {@link #appendNull()}, before starting the next position. Builders that do not
+         * support multivalued entries may throw {@link UnsupportedOperationException}.
+         */
+        Builder cancelPositionEntry();
+
+        /**
          * Ends the current multi-value entry.
          */
         Builder endPositionEntry();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -246,6 +246,11 @@ public final class ConstantNullBlock extends AbstractBlockRefCounted
         }
 
         @Override
+        public Builder cancelPositionEntry() {
+            throw new UnsupportedOperationException("cancelPositionEntry is not supported by null block builders");
+        }
+
+        @Override
         public Builder endPositionEntry() {
             throw new UnsupportedOperationException();
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -173,6 +173,11 @@ public class DocBlock extends AbstractVectorBlock implements Block, RefCounted {
         }
 
         @Override
+        public Builder cancelPositionEntry() {
+            throw new UnsupportedOperationException("cancelPositionEntry is not supported by doc blocks");
+        }
+
+        @Override
         public Builder endPositionEntry() {
             throw new UnsupportedOperationException("doc blocks only contain one value per position");
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DoubleRangeBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DoubleRangeBlockBuilder.java
@@ -107,8 +107,10 @@ public final class DoubleRangeBlockBuilder extends AbstractBlockBuilder implemen
     }
 
     @Override
-    public AbstractBlockBuilder cancelPositionEntry() {
-        throw new UnsupportedOperationException("cancelPositionEntry is not supported by DoubleRangeBlockBuilder");
+    public DoubleRangeBlockBuilder cancelPositionEntry() {
+        fromBuilder.cancelPositionEntry();
+        toBuilder.cancelPositionEntry();
+        return this;
     }
 
     public DoubleRangeBlockBuilder appendDoubleRange(double from, double to) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramBlockBuilder.java
@@ -93,6 +93,16 @@ public final class ExponentialHistogramBlockBuilder extends AbstractDelegatingCo
     }
 
     @Override
+    protected void cancelSubBlockPositions(int valuesToRemove) {
+        rollbackLastValues(minimaBuilder, valuesToRemove);
+        rollbackLastValues(maximaBuilder, valuesToRemove);
+        rollbackLastValues(sumsBuilder, valuesToRemove);
+        rollbackLastValues(valueCountsBuilder, valuesToRemove);
+        rollbackLastValues(zeroThresholdsBuilder, valuesToRemove);
+        rollbackLastValues(encodedHistogramsBuilder, valuesToRemove);
+    }
+
+    @Override
     public ExponentialHistogramBlockBuilder append(ExponentialHistogram histogram) {
         ExponentialHistogramArrayBlock.EncodedHistogramData data = ExponentialHistogramArrayBlock.encode(histogram);
         doAppend(data);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeBlockBuilder.java
@@ -109,10 +109,10 @@ public final class LongRangeBlockBuilder extends AbstractBlockBuilder implements
     }
 
     @Override
-    public AbstractBlockBuilder cancelPositionEntry() {
-        // LongRangeBlockBuilder delegates to inner builders; the inherited cancelPositionEntry rolls back
-        // only the outer valueCount and not the inner builders' state. Throw to make misuse obvious.
-        throw new UnsupportedOperationException("cancelPositionEntry is not supported by LongRangeBlockBuilder");
+    public LongRangeBlockBuilder cancelPositionEntry() {
+        fromBuilder.cancelPositionEntry();
+        toBuilder.cancelPositionEntry();
+        return this;
     }
 
     public LongRangeBlockBuilder appendLongRange(long from, long to) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestBlockBuilder.java
@@ -65,6 +65,15 @@ public final class TDigestBlockBuilder extends AbstractDelegatingCompoundBlock.A
     }
 
     @Override
+    protected void cancelSubBlockPositions(int valuesToRemove) {
+        rollbackLastValues(encodedDigestsBuilder, valuesToRemove);
+        rollbackLastValues(minimaBuilder, valuesToRemove);
+        rollbackLastValues(maximaBuilder, valuesToRemove);
+        rollbackLastValues(sumsBuilder, valuesToRemove);
+        rollbackLastValues(valueCountsBuilder, valuesToRemove);
+    }
+
+    @Override
     public TDigestBlock.Builder copyFrom(TDigestBlock block, int position) {
         copyFrom(block, position, position + 1);
         return this;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -129,6 +129,11 @@ $if(BytesRef)$
         super.cancelPositionEntry();
         return this;
     }
+
+    @Override
+    void truncateValueStorageTo(int newValueCount) {
+        values.truncateTo(newValueCount);
+    }
 $endif$
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/OrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/OrdinalsBuilder.java
@@ -73,6 +73,12 @@ final class OrdinalsBuilder implements BlockLoader.SortedSetOrdinalsBuilder, Rel
     }
 
     @Override
+    public OrdinalsBuilder cancelPositionEntry() {
+        ordsBuilder.cancelPositionEntry();
+        return this;
+    }
+
+    @Override
     public OrdinalsBuilder endPositionEntry() {
         ordsBuilder.endPositionEntry();
         return this;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonDoubleBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonDoubleBuilder.java
@@ -42,6 +42,11 @@ public final class SingletonDoubleBuilder implements BlockLoader.SingletonDouble
     }
 
     @Override
+    public Block.Builder cancelPositionEntry() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Block.Builder endPositionEntry() {
         throw new UnsupportedOperationException();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilder.java
@@ -41,6 +41,11 @@ public final class SingletonIntBuilder implements BlockLoader.SingletonIntBuilde
     }
 
     @Override
+    public Block.Builder cancelPositionEntry() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Block.Builder endPositionEntry() {
         throw new UnsupportedOperationException();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonLongBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonLongBuilder.java
@@ -41,6 +41,11 @@ public final class SingletonLongBuilder implements BlockLoader.SingletonLongBuil
     }
 
     @Override
+    public Block.Builder cancelPositionEntry() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Block.Builder endPositionEntry() {
         throw new UnsupportedOperationException();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
@@ -82,6 +82,11 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
     }
 
     @Override
+    public SingletonOrdinalsBuilder cancelPositionEntry() {
+        throw new UnsupportedOperationException("should only have one value per doc");
+    }
+
+    @Override
     public SingletonOrdinalsBuilder endPositionEntry() {
         throw new UnsupportedOperationException("should only have one value per doc");
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderTests.java
@@ -215,7 +215,7 @@ public class BlockBuilderTests extends ESTestCase {
             builder.beginPositionEntry();
             BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
             BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
-            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.cancelPositionEntry();
             builder.appendNull();                                                       // position 1 = null
             BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));   // position 2
             try (Block block = builder.build()) {
@@ -235,7 +235,7 @@ public class BlockBuilderTests extends ESTestCase {
         try (Block.Builder builder = elementType.newBlockBuilder(1, blockFactory)) {
             builder.beginPositionEntry();
             BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
-            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.cancelPositionEntry();
             builder.beginPositionEntry();
             BlockTestUtils.append(builder, good);
             builder.endPositionEntry();
@@ -260,7 +260,7 @@ public class BlockBuilderTests extends ESTestCase {
         try (Block.Builder builder = elementType.newBlockBuilder(1, blockFactory)) {
             builder.beginPositionEntry();
             BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
-            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.cancelPositionEntry();
             builder.appendNull();
             try (Block block = builder.build()) {
                 assertThat(block.getPositionCount(), equalTo(1));
@@ -287,7 +287,7 @@ public class BlockBuilderTests extends ESTestCase {
             builder.beginPositionEntry();
             builder.appendBytesRef(bad1);
             builder.appendBytesRef(bad2);
-            ((AbstractBlockBuilder) builder).cancelPositionEntry();
+            builder.cancelPositionEntry();
             builder.appendNull();                    // position 1 = null
             builder.appendBytesRef(gamma);           // position 2
             try (BytesRefBlock block = builder.build()) {
@@ -302,14 +302,27 @@ public class BlockBuilderTests extends ESTestCase {
         assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
     }
 
-    private void assumeMultiValued() {
+    public void testCancelPositionEntryCompositeBuilder() {
         assumeTrue(
-            "Type must support multi-values",
-            // TODO: DOUBLE_RANGE support
-            elementType != ElementType.AGGREGATE_METRIC_DOUBLE
-                && elementType != ElementType.LONG_RANGE
-                && elementType != ElementType.DOUBLE_RANGE
+            "Type must use a composite builder",
+            elementType == ElementType.EXPONENTIAL_HISTOGRAM || elementType == ElementType.TDIGEST
         );
+        try (Block.Builder builder = elementType.newBlockBuilder(2, blockFactory)) {
+            builder.beginPositionEntry();
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
+            BlockTestUtils.append(builder, BlockTestUtils.randomValue(elementType));
+            builder.cancelPositionEntry();
+            builder.appendNull();
+            try (Block block = builder.build()) {
+                assertThat(block.getPositionCount(), equalTo(1));
+                assertThat(block.isNull(0), is(true));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    private void assumeMultiValued() {
+        assumeTrue("Type must support multi-values", elementType != ElementType.AGGREGATE_METRIC_DOUBLE);
     }
 
     private void assumeAbstractBlockBuilder() {

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/TestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/TestBlockBuilder.java
@@ -39,6 +39,9 @@ public abstract class TestBlockBuilder implements Block.Builder {
     public abstract TestBlockBuilder beginPositionEntry();
 
     @Override
+    public abstract TestBlockBuilder cancelPositionEntry();
+
+    @Override
     public abstract TestBlockBuilder endPositionEntry();
 
     public static Block blockFromValues(List<List<Object>> blockValues, ElementType elementType) {
@@ -110,6 +113,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         }
 
         @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
+            return this;
+        }
+
+        @Override
         public TestBlockBuilder endPositionEntry() {
             builder.endPositionEntry();
             return this;
@@ -166,6 +175,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         @Override
         public TestBlockBuilder beginPositionEntry() {
             builder.beginPositionEntry();
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
             return this;
         }
 
@@ -230,6 +245,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         }
 
         @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
+            return this;
+        }
+
+        @Override
         public TestBlockBuilder endPositionEntry() {
             builder.endPositionEntry();
             return this;
@@ -290,6 +311,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         }
 
         @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
+            return this;
+        }
+
+        @Override
         public TestBlockBuilder endPositionEntry() {
             builder.endPositionEntry();
             return this;
@@ -346,6 +373,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         @Override
         public TestBlockBuilder beginPositionEntry() {
             builder.beginPositionEntry();
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
             return this;
         }
 
@@ -413,6 +446,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         }
 
         @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
+            return this;
+        }
+
+        @Override
         public TestBlockBuilder endPositionEntry() {
             builder.endPositionEntry();
             return this;
@@ -473,6 +512,12 @@ public abstract class TestBlockBuilder implements Block.Builder {
         @Override
         public TestBlockBuilder beginPositionEntry() {
             builder.beginPositionEntry();
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder cancelPositionEntry() {
+            builder.cancelPositionEntry();
             return this;
         }
 


### PR DESCRIPTION
Fixes #154095

The NDJSON decoder currently needs an implementation-specific cast to `AbstractBlockBuilder` to roll back a partially decoded multivalued position. This exposes an internal detail and cannot be used with other block builder implementations.

This change:
- adds `cancelPositionEntry()` to the public `Block.Builder` contract
- makes the NDJSON decoder use the interface directly
- preserves rollback semantics for primitive, BytesRef, long-range, and double-range builders
- rolls back delegated child values for TDigest and exponential histogram builders
- keeps builders that cannot represent multivalued positions explicitly unsupported

Tests:
- `./gradlew ':x-pack:plugin:esql:compute:test' --tests org.elasticsearch.compute.data.BlockBuilderTests`
- `./gradlew ':x-pack:plugin:esql-datasource-ndjson:test' --tests org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonPageDecoderTests`
- `./gradlew ':x-pack:plugin:esql:compute:spotlessJavaCheck' ':x-pack:plugin:esql-datasource-ndjson:spotlessJavaCheck'`
- `git diff --check`
