### PR TITLE
[ES|QL] Align project routing validation message

### DIFF
--- a/docs/changelog/155062.yaml
+++ b/docs/changelog/155062.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 152740
+pr: 155062
+summary: Align project routing validation with SQL and EQL
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -62,7 +62,9 @@ public final class QuerySettings {
     public static final QuerySettingDef<String> PROJECT_ROUTING = QuerySettingDef.string("project_routing")
         .withServerlessOnly()
         .withPreview()
-        .withValidator((value, ctx) -> ctx.crossProjectEnabled() ? null : "cross-project search not enabled")
+        .withValidator(
+            (value, ctx) -> ctx.crossProjectEnabled() ? null : "[project_routing] is only allowed when cross-project search is enabled"
+        )
         .withRequestBody()
         .withAliasAtRoot()
         .build();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
@@ -121,7 +121,7 @@ public class QuerySettingsTests extends ESTestCase {
             setting.name(),
             SNAPSHOT_CTX_WITH_CPS_DISABLED,
             of("my-project"),
-            "Error validating setting [project_routing]: cross-project search not enabled"
+            "[project_routing] is only allowed when cross-project search is enabled"
         );
     }
 
@@ -364,7 +364,7 @@ public class QuerySettingsTests extends ESTestCase {
             VerificationException.class,
             () -> QuerySettings.resolve(requestParams, null, SNAPSHOT_CTX_WITH_CPS_DISABLED)
         );
-        assertThat(ex.getMessage(), containsString("Error validating setting [project_routing]: cross-project search not enabled"));
+        assertThat(ex.getMessage(), containsString("[project_routing] is only allowed when cross-project search is enabled"));
     }
 
     public void testResolveRequestParameterAppliesWhenNoQuerySet() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -608,7 +608,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     // Expected: validation should fail because cross-project search is not enabled
                     assertThat(e, instanceOf(ParsingException.class));
-                    assertTrue(e.getMessage().contains("cross-project search not enabled"));
+                    assertTrue(e.getMessage().contains("[project_routing] is only allowed when cross-project search is enabled"));
                 }
             });
         }


### PR DESCRIPTION
Fixes #152740

ES|QL currently reports a different error when `project_routing` is used without cross-project search. SQL and EQL already use the clearer, established message, so the same condition is unnecessarily inconsistent across query APIs.

This change makes the ES|QL validator return the shared [project_routing] is only allowed when cross-project search is enabled wording and updates the validation and telemetry tests that lock down the contract.

Tests:
- ./gradlew ':x-pack:plugin:esql:test' --tests org.elasticsearch.xpack.esql.plan.QuerySettingsTests --tests org.elasticsearch.xpack.esql.telemetry.PlanExecutorMetricsTests
- ./gradlew ':x-pack:plugin:esql:spotlessJavaCheck'
- git diff --check