### PR TITLE
[ES|QL] Guard quantile aggregations against non-finite values

### DIFF
--- a/docs/changelog/155063.yaml
+++ b/docs/changelog/155063.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 154815
+pr: 155063
+summary: Return null when quantile aggregations receive non-finite values
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -22,6 +24,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.arrow.DoubleArrowBufVector;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
@@ -29,7 +32,10 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
+
+  private final Warnings warnings;
 
   private final DriverContext driverContext;
 
@@ -37,8 +43,9 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
 
   private final List<Integer> channels;
 
-  MedianAbsoluteDeviationDoubleAggregatorFunction(DriverContext driverContext,
+  MedianAbsoluteDeviationDoubleAggregatorFunction(Warnings warnings, DriverContext driverContext,
       List<Integer> channels) {
+    this.warnings = warnings;
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = MedianAbsoluteDeviationDoubleAggregator.initSingle(driverContext);
@@ -113,7 +120,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
       DoubleArrayVector specialized = (DoubleArrayVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         double vValue = specialized.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -121,7 +134,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
       DoubleArrowBufVector specialized = (DoubleArrowBufVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         double vValue = specialized.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -129,13 +148,25 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
       ConstantDoubleVector specialized = (ConstantDoubleVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         double vValue = specialized.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
     for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
       double vValue = vVector.getDouble(valuesPosition);
-      MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+      try {
+        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -147,7 +178,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
           continue;
         }
         double vValue = specialized.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -158,7 +195,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
           continue;
         }
         double vValue = specialized.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -169,7 +212,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
           continue;
         }
         double vValue = specialized.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -178,7 +227,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
         continue;
       }
       double vValue = vVector.getDouble(valuesPosition);
-      MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+      try {
+        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -192,7 +247,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -210,7 +271,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -234,8 +301,23 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert failed.getPositionCount() == 1;
     BytesRef quartScratch = new BytesRef();
-    MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch));
+    MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch), failed.getBoolean(0));
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier.java
@@ -9,13 +9,19 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  public MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier() {
+  WarningSourceLocation warningsSource;
+
+  public MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(
+      WarningSourceLocation warningsSource) {
+    this.warningsSource = warningsSource;
   }
 
   @Override
@@ -31,13 +37,15 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier imple
   @Override
   public MedianAbsoluteDeviationDoubleAggregatorFunction aggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new MedianAbsoluteDeviationDoubleAggregatorFunction(driverContext, channels);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new MedianAbsoluteDeviationDoubleAggregatorFunction(warnings, driverContext, channels);
   }
 
   @Override
   public MedianAbsoluteDeviationDoubleGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext, List<Integer> channels) {
-    return new MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(channels, driverContext);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(warnings, channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,8 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -21,6 +24,7 @@ import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
@@ -28,16 +32,20 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
 
   private final QuantileStates.GroupingState state;
+
+  private final Warnings warnings;
 
   private final List<Integer> channels;
 
   private final DriverContext driverContext;
 
-  MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(List<Integer> channels,
+  MedianAbsoluteDeviationDoubleGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
       DriverContext driverContext) {
+    this.warnings = warnings;
     this.channels = channels;
     this.state = MedianAbsoluteDeviationDoubleAggregator.initGrouping(driverContext);
     this.driverContext = driverContext;
@@ -124,11 +132,19 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+          try {
+            MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -144,8 +160,16 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         double vValue = vVector.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -168,6 +192,21 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -178,7 +217,7 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -196,11 +235,19 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+          try {
+            MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -216,8 +263,16 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         double vValue = vVector.getDouble(valuesPosition);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -240,6 +295,21 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -250,7 +320,7 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -262,11 +332,19 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
         continue;
       }
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       int vStart = vBlock.getFirstValueIndex(valuesPosition);
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+        try {
+          MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -275,8 +353,16 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       double vValue = vVector.getDouble(valuesPosition);
-      MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+      try {
+        MedianAbsoluteDeviationDoubleAggregator.combine(state, groupId, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.setFailed(groupId);
+      }
     }
   }
 
@@ -298,11 +384,26 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
-      MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+      MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -22,6 +24,7 @@ import org.elasticsearch.compute.data.FloatVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.arrow.FloatArrowBufVector;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunction} implementation for {@link MedianAbsoluteDeviationFloatAggregator}.
@@ -29,7 +32,10 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class MedianAbsoluteDeviationFloatAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
+
+  private final Warnings warnings;
 
   private final DriverContext driverContext;
 
@@ -37,8 +43,9 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
 
   private final List<Integer> channels;
 
-  MedianAbsoluteDeviationFloatAggregatorFunction(DriverContext driverContext,
+  MedianAbsoluteDeviationFloatAggregatorFunction(Warnings warnings, DriverContext driverContext,
       List<Integer> channels) {
+    this.warnings = warnings;
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = MedianAbsoluteDeviationFloatAggregator.initSingle(driverContext);
@@ -113,7 +120,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
       FloatArrayVector specialized = (FloatArrayVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         float vValue = specialized.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -121,7 +134,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
       FloatArrowBufVector specialized = (FloatArrowBufVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         float vValue = specialized.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -129,13 +148,25 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
       ConstantFloatVector specialized = (ConstantFloatVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         float vValue = specialized.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
     for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
       float vValue = vVector.getFloat(valuesPosition);
-      MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+      try {
+        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -147,7 +178,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
           continue;
         }
         float vValue = specialized.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -158,7 +195,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
           continue;
         }
         float vValue = specialized.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -169,7 +212,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
           continue;
         }
         float vValue = specialized.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -178,7 +227,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
         continue;
       }
       float vValue = vVector.getFloat(valuesPosition);
-      MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+      try {
+        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -192,7 +247,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -210,7 +271,13 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -234,8 +301,23 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert failed.getPositionCount() == 1;
     BytesRef quartScratch = new BytesRef();
-    MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch));
+    MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch), failed.getBoolean(0));
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunctionSupplier.java
@@ -9,13 +9,19 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationFloatAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class MedianAbsoluteDeviationFloatAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
-  public MedianAbsoluteDeviationFloatAggregatorFunctionSupplier() {
+  WarningSourceLocation warningsSource;
+
+  public MedianAbsoluteDeviationFloatAggregatorFunctionSupplier(
+      WarningSourceLocation warningsSource) {
+    this.warningsSource = warningsSource;
   }
 
   @Override
@@ -31,13 +37,15 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunctionSupplier implem
   @Override
   public MedianAbsoluteDeviationFloatAggregatorFunction aggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new MedianAbsoluteDeviationFloatAggregatorFunction(driverContext, channels);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new MedianAbsoluteDeviationFloatAggregatorFunction(warnings, driverContext, channels);
   }
 
   @Override
   public MedianAbsoluteDeviationFloatGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext, List<Integer> channels) {
-    return new MedianAbsoluteDeviationFloatGroupingAggregatorFunction(channels, driverContext);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new MedianAbsoluteDeviationFloatGroupingAggregatorFunction(warnings, channels, driverContext);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,8 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -21,6 +24,7 @@ import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link MedianAbsoluteDeviationFloatAggregator}.
@@ -28,16 +32,20 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
 
   private final QuantileStates.GroupingState state;
+
+  private final Warnings warnings;
 
   private final List<Integer> channels;
 
   private final DriverContext driverContext;
 
-  MedianAbsoluteDeviationFloatGroupingAggregatorFunction(List<Integer> channels,
+  MedianAbsoluteDeviationFloatGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
       DriverContext driverContext) {
+    this.warnings = warnings;
     this.channels = channels;
     this.state = MedianAbsoluteDeviationFloatAggregator.initGrouping(driverContext, driverContext.bigArrays());
     this.driverContext = driverContext;
@@ -124,11 +132,19 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+          try {
+            MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -144,8 +160,16 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         float vValue = vVector.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -168,6 +192,21 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -178,7 +217,7 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -196,11 +235,19 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+          try {
+            MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -216,8 +263,16 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         float vValue = vVector.getFloat(valuesPosition);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -240,6 +295,21 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -250,7 +320,7 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -262,11 +332,19 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
         continue;
       }
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       int vStart = vBlock.getFirstValueIndex(valuesPosition);
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+        try {
+          MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -275,8 +353,16 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       float vValue = vVector.getFloat(valuesPosition);
-      MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+      try {
+        MedianAbsoluteDeviationFloatAggregator.combine(state, groupId, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.setFailed(groupId);
+      }
     }
   }
 
@@ -298,11 +384,26 @@ public final class MedianAbsoluteDeviationFloatGroupingAggregatorFunction implem
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
-      MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+      MedianAbsoluteDeviationFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -22,6 +24,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.arrow.DoubleArrowBufVector;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunction} implementation for {@link PercentileDoubleAggregator}.
@@ -29,7 +32,10 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class PercentileDoubleAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
+
+  private final Warnings warnings;
 
   private final DriverContext driverContext;
 
@@ -41,10 +47,11 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
 
   private final double tDigestStateCompression;
 
-  PercentileDoubleAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-      double percentile, double tDigestStateCompression) {
+  PercentileDoubleAggregatorFunction(Warnings warnings, DriverContext driverContext,
+      List<Integer> channels, double percentile, double tDigestStateCompression) {
     this.percentile = percentile;
     this.tDigestStateCompression = tDigestStateCompression;
+    this.warnings = warnings;
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = PercentileDoubleAggregator.initSingle(driverContext, percentile, tDigestStateCompression);
@@ -119,7 +126,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
       DoubleArrayVector specialized = (DoubleArrayVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         double vValue = specialized.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -127,7 +140,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
       DoubleArrowBufVector specialized = (DoubleArrowBufVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         double vValue = specialized.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -135,13 +154,25 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
       ConstantDoubleVector specialized = (ConstantDoubleVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         double vValue = specialized.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
     for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
       double vValue = vVector.getDouble(valuesPosition);
-      PercentileDoubleAggregator.combine(state, vValue);
+      try {
+        PercentileDoubleAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -153,7 +184,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
           continue;
         }
         double vValue = specialized.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -164,7 +201,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
           continue;
         }
         double vValue = specialized.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -175,7 +218,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
           continue;
         }
         double vValue = specialized.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -184,7 +233,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
         continue;
       }
       double vValue = vVector.getDouble(valuesPosition);
-      PercentileDoubleAggregator.combine(state, vValue);
+      try {
+        PercentileDoubleAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -198,7 +253,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -216,7 +277,13 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        PercentileDoubleAggregator.combine(state, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -240,8 +307,23 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert failed.getPositionCount() == 1;
     BytesRef quartScratch = new BytesRef();
-    PercentileDoubleAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch));
+    PercentileDoubleAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch), failed.getBoolean(0));
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionSupplier.java
@@ -9,18 +9,23 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileDoubleAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class PercentileDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  WarningSourceLocation warningsSource;
+
   private final double percentile;
 
   private final double tDigestStateCompression;
 
-  public PercentileDoubleAggregatorFunctionSupplier(double percentile,
-      double tDigestStateCompression) {
+  public PercentileDoubleAggregatorFunctionSupplier(WarningSourceLocation warningsSource,
+      double percentile, double tDigestStateCompression) {
+    this.warningsSource = warningsSource;
     this.percentile = percentile;
     this.tDigestStateCompression = tDigestStateCompression;
   }
@@ -38,13 +43,15 @@ public final class PercentileDoubleAggregatorFunctionSupplier implements Aggrega
   @Override
   public PercentileDoubleAggregatorFunction aggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new PercentileDoubleAggregatorFunction(driverContext, channels, percentile, tDigestStateCompression);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new PercentileDoubleAggregatorFunction(warnings, driverContext, channels, percentile, tDigestStateCompression);
   }
 
   @Override
   public PercentileDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new PercentileDoubleGroupingAggregatorFunction(channels, driverContext, percentile, tDigestStateCompression);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new PercentileDoubleGroupingAggregatorFunction(warnings, channels, driverContext, percentile, tDigestStateCompression);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,8 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -21,6 +24,7 @@ import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link PercentileDoubleAggregator}.
@@ -28,9 +32,12 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class PercentileDoubleGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
 
   private final QuantileStates.GroupingState state;
+
+  private final Warnings warnings;
 
   private final List<Integer> channels;
 
@@ -40,10 +47,11 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
 
   private final double tDigestStateCompression;
 
-  PercentileDoubleGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
-      double percentile, double tDigestStateCompression) {
+  PercentileDoubleGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
+      DriverContext driverContext, double percentile, double tDigestStateCompression) {
     this.percentile = percentile;
     this.tDigestStateCompression = tDigestStateCompression;
+    this.warnings = warnings;
     this.channels = channels;
     this.state = PercentileDoubleAggregator.initGrouping(driverContext, percentile, tDigestStateCompression);
     this.driverContext = driverContext;
@@ -130,11 +138,19 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          PercentileDoubleAggregator.combine(state, groupId, vValue);
+          try {
+            PercentileDoubleAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -150,8 +166,16 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         double vValue = vVector.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, groupId, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -174,6 +198,21 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -184,7 +223,7 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -202,11 +241,19 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           double vValue = vBlock.getDouble(vOffset);
-          PercentileDoubleAggregator.combine(state, groupId, vValue);
+          try {
+            PercentileDoubleAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -222,8 +269,16 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         double vValue = vVector.getDouble(valuesPosition);
-        PercentileDoubleAggregator.combine(state, groupId, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -246,6 +301,21 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -256,7 +326,7 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -268,11 +338,19 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
         continue;
       }
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       int vStart = vBlock.getFirstValueIndex(valuesPosition);
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         double vValue = vBlock.getDouble(vOffset);
-        PercentileDoubleAggregator.combine(state, groupId, vValue);
+        try {
+          PercentileDoubleAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -281,8 +359,16 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       double vValue = vVector.getDouble(valuesPosition);
-      PercentileDoubleAggregator.combine(state, groupId, vValue);
+      try {
+        PercentileDoubleAggregator.combine(state, groupId, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.setFailed(groupId);
+      }
     }
   }
 
@@ -304,11 +390,26 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
-      PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+      PercentileDoubleAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -22,6 +24,7 @@ import org.elasticsearch.compute.data.FloatVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.arrow.FloatArrowBufVector;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunction} implementation for {@link PercentileFloatAggregator}.
@@ -29,7 +32,10 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class PercentileFloatAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
+
+  private final Warnings warnings;
 
   private final DriverContext driverContext;
 
@@ -39,9 +45,10 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
 
   private final double percentile;
 
-  PercentileFloatAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-      double percentile) {
+  PercentileFloatAggregatorFunction(Warnings warnings, DriverContext driverContext,
+      List<Integer> channels, double percentile) {
     this.percentile = percentile;
+    this.warnings = warnings;
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = PercentileFloatAggregator.initSingle(driverContext, percentile);
@@ -116,7 +123,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
       FloatArrayVector specialized = (FloatArrayVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         float vValue = specialized.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -124,7 +137,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
       FloatArrowBufVector specialized = (FloatArrowBufVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         float vValue = specialized.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -132,13 +151,25 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
       ConstantFloatVector specialized = (ConstantFloatVector) vVector;
       for (int valuesPosition = 0; valuesPosition < specialized.getPositionCount(); valuesPosition++) {
         float vValue = specialized.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
     for (int valuesPosition = 0; valuesPosition < vVector.getPositionCount(); valuesPosition++) {
       float vValue = vVector.getFloat(valuesPosition);
-      PercentileFloatAggregator.combine(state, vValue);
+      try {
+        PercentileFloatAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -150,7 +181,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
           continue;
         }
         float vValue = specialized.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -161,7 +198,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
           continue;
         }
         float vValue = specialized.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -172,7 +215,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
           continue;
         }
         float vValue = specialized.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
       return;
     }
@@ -181,7 +230,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
         continue;
       }
       float vValue = vVector.getFloat(valuesPosition);
-      PercentileFloatAggregator.combine(state, vValue);
+      try {
+        PercentileFloatAggregator.combine(state, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.failed(true);
+        return;
+      }
     }
   }
 
@@ -195,7 +250,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -213,7 +274,13 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
       int vEnd = vStart + vValueCount;
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        PercentileFloatAggregator.combine(state, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.failed(true);
+          return;
+        }
       }
     }
   }
@@ -237,8 +304,23 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert failed.getPositionCount() == 1;
     BytesRef quartScratch = new BytesRef();
-    PercentileFloatAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch));
+    PercentileFloatAggregator.combineIntermediate(state, quart.getBytesRef(0, quartScratch), failed.getBoolean(0));
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunctionSupplier.java
@@ -9,15 +9,21 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileFloatAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class PercentileFloatAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  WarningSourceLocation warningsSource;
+
   private final double percentile;
 
-  public PercentileFloatAggregatorFunctionSupplier(double percentile) {
+  public PercentileFloatAggregatorFunctionSupplier(WarningSourceLocation warningsSource,
+      double percentile) {
+    this.warningsSource = warningsSource;
     this.percentile = percentile;
   }
 
@@ -34,13 +40,15 @@ public final class PercentileFloatAggregatorFunctionSupplier implements Aggregat
   @Override
   public PercentileFloatAggregatorFunction aggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new PercentileFloatAggregatorFunction(driverContext, channels, percentile);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new PercentileFloatAggregatorFunction(warnings, driverContext, channels, percentile);
   }
 
   @Override
   public PercentileFloatGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new PercentileFloatGroupingAggregatorFunction(channels, driverContext, percentile);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new PercentileFloatGroupingAggregatorFunction(warnings, channels, driverContext, percentile);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.lang.IllegalArgumentException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -11,6 +12,8 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -21,6 +24,7 @@ import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link PercentileFloatAggregator}.
@@ -28,9 +32,12 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class PercentileFloatGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("quart", ElementType.BYTES_REF)  );
+      new IntermediateStateDesc("quart", ElementType.BYTES_REF),
+      new IntermediateStateDesc("failed", ElementType.BOOLEAN)  );
 
   private final QuantileStates.GroupingState state;
+
+  private final Warnings warnings;
 
   private final List<Integer> channels;
 
@@ -38,9 +45,10 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
 
   private final double percentile;
 
-  PercentileFloatGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
-      double percentile) {
+  PercentileFloatGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
+      DriverContext driverContext, double percentile) {
     this.percentile = percentile;
+    this.warnings = warnings;
     this.channels = channels;
     this.state = PercentileFloatAggregator.initGrouping(driverContext, percentile);
     this.driverContext = driverContext;
@@ -127,11 +135,19 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          PercentileFloatAggregator.combine(state, groupId, vValue);
+          try {
+            PercentileFloatAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -147,8 +163,16 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         float vValue = vVector.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, groupId, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -171,6 +195,21 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -181,7 +220,7 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        PercentileFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        PercentileFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -199,11 +238,19 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         int vStart = vBlock.getFirstValueIndex(valuesPosition);
         int vEnd = vStart + vBlock.getValueCount(valuesPosition);
         for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
           float vValue = vBlock.getFloat(vOffset);
-          PercentileFloatAggregator.combine(state, groupId, vValue);
+          try {
+            PercentileFloatAggregator.combine(state, groupId, vValue);
+          } catch (IllegalArgumentException e) {
+            warnings.registerException(e);
+            state.setFailed(groupId);
+          }
         }
       }
     }
@@ -219,8 +266,16 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        if (state.hasFailed(groupId)) {
+          continue;
+        }
         float vValue = vVector.getFloat(valuesPosition);
-        PercentileFloatAggregator.combine(state, groupId, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -243,6 +298,21 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       if (groups.isNull(groupPosition)) {
@@ -253,7 +323,7 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
         int valuesPosition = groupPosition + positionOffset;
-        PercentileFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+        PercentileFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
       }
     }
   }
@@ -265,11 +335,19 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
         continue;
       }
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       int vStart = vBlock.getFirstValueIndex(valuesPosition);
       int vEnd = vStart + vBlock.getValueCount(valuesPosition);
       for (int vOffset = vStart; vOffset < vEnd; vOffset++) {
         float vValue = vBlock.getFloat(vOffset);
-        PercentileFloatAggregator.combine(state, groupId, vValue);
+        try {
+          PercentileFloatAggregator.combine(state, groupId, vValue);
+        } catch (IllegalArgumentException e) {
+          warnings.registerException(e);
+          state.setFailed(groupId);
+        }
       }
     }
   }
@@ -278,8 +356,16 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      if (state.hasFailed(groupId)) {
+        continue;
+      }
       float vValue = vVector.getFloat(valuesPosition);
-      PercentileFloatAggregator.combine(state, groupId, vValue);
+      try {
+        PercentileFloatAggregator.combine(state, groupId, vValue);
+      } catch (IllegalArgumentException e) {
+        warnings.registerException(e);
+        state.setFailed(groupId);
+      }
     }
   }
 
@@ -301,11 +387,26 @@ public final class PercentileFloatGroupingAggregatorFunction implements Grouping
       return;
     }
     BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
+    Block failedUncast = page.getBlock(channels.get(1));
+    if (failedUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    BooleanVector failed = ((BooleanBlock) failedUncast).asVector();
+    assert quart.getPositionCount() == failed.getPositionCount();
     BytesRef quartScratch = new BytesRef();
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = groups.getInt(groupPosition);
       int valuesPosition = groupPosition + positionOffset;
-      PercentileFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch));
+      PercentileFloatAggregator.combineIntermediate(state, groupId, quart.getBytesRef(valuesPosition, quartScratch), failed.getBoolean(valuesPosition));
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
@@ -15,7 +15,10 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
-@Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
+@Aggregator(
+    value = { @IntermediateState(name = "quart", type = "BYTES_REF"), @IntermediateState(name = "failed", type = "BOOLEAN") },
+    warnExceptions = IllegalArgumentException.class
+)
 @GroupingAggregator
 class MedianAbsoluteDeviationDoubleAggregator {
 
@@ -27,8 +30,12 @@ class MedianAbsoluteDeviationDoubleAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
-        state.add(inValue);
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.failed(true);
+        } else {
+            state.add(inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.SingleState state, DriverContext driverContext) {
@@ -43,8 +50,12 @@ class MedianAbsoluteDeviationDoubleAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
-        state.add(groupId, inValue);
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.setFailed(groupId);
+        } else {
+            state.add(groupId, inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregator.java
@@ -16,7 +16,10 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
-@Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
+@Aggregator(
+    value = { @IntermediateState(name = "quart", type = "BYTES_REF"), @IntermediateState(name = "failed", type = "BOOLEAN") },
+    warnExceptions = IllegalArgumentException.class
+)
 @GroupingAggregator
 class MedianAbsoluteDeviationFloatAggregator {
 
@@ -28,8 +31,12 @@ class MedianAbsoluteDeviationFloatAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
-        state.add(inValue);
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.failed(true);
+        } else {
+            state.add(inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.SingleState state, DriverContext driverContext) {
@@ -44,8 +51,12 @@ class MedianAbsoluteDeviationFloatAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
-        state.add(groupId, inValue);
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.setFailed(groupId);
+        } else {
+            state.add(groupId, inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
@@ -15,7 +15,10 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
-@Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
+@Aggregator(
+    value = { @IntermediateState(name = "quart", type = "BYTES_REF"), @IntermediateState(name = "failed", type = "BOOLEAN") },
+    warnExceptions = IllegalArgumentException.class
+)
 @GroupingAggregator
 class PercentileDoubleAggregator {
 
@@ -27,8 +30,12 @@ class PercentileDoubleAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
-        state.add(inValue);
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.failed(true);
+        } else {
+            state.add(inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.SingleState state, DriverContext driverContext) {
@@ -47,8 +54,12 @@ class PercentileDoubleAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
-        state.add(groupId, inValue);
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.setFailed(groupId);
+        } else {
+            state.add(groupId, inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileFloatAggregator.java
@@ -15,7 +15,10 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
-@Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
+@Aggregator(
+    value = { @IntermediateState(name = "quart", type = "BYTES_REF"), @IntermediateState(name = "failed", type = "BOOLEAN") },
+    warnExceptions = IllegalArgumentException.class
+)
 @GroupingAggregator
 class PercentileFloatAggregator {
 
@@ -27,8 +30,12 @@ class PercentileFloatAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
-        state.add(inValue);
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.failed(true);
+        } else {
+            state.add(inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.SingleState state, DriverContext driverContext) {
@@ -43,8 +50,12 @@ class PercentileFloatAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
-        state.add(groupId, inValue);
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue, boolean failed) {
+        if (failed) {
+            state.setFailed(groupId);
+        } else {
+            state.add(groupId, inValue);
+        }
     }
 
     public static Block evaluateFinal(QuantileStates.GroupingState state, IntVector selected, GroupingAggregatorEvaluationContext ctx) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
@@ -63,6 +63,7 @@ public final class QuantileStates {
         private final CircuitBreaker breaker;
         private final TDigestState digest;
         private final Double percentile;
+        private boolean failed;
 
         SingleState(CircuitBreaker breaker, double percentile) {
             this(breaker, percentile, DEFAULT_COMPRESSION);
@@ -80,13 +81,23 @@ public final class QuantileStates {
         }
 
         void add(double v) {
+            if (failed) {
+                return;
+            }
             digest.add(v);
         }
 
         void add(BytesRef other) {
+            if (failed) {
+                return;
+            }
             try (var otherDigest = deserializeDigest(breaker, other)) {
                 digest.add(otherDigest);
             }
+        }
+
+        void failed(boolean failed) {
+            this.failed |= failed;
         }
 
         /** Extracts an intermediate view of the contents of this state.  */
@@ -94,12 +105,15 @@ public final class QuantileStates {
         public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
             assert blocks.length >= offset + 1;
             blocks[offset] = driverContext.blockFactory().newConstantBytesRefBlockWith(serializeDigest(this.digest), 1);
+            if (blocks.length > offset + 1) {
+                blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(failed, 1);
+            }
         }
 
         Block evaluateMedianAbsoluteDeviation(DriverContext driverContext) {
             BlockFactory blockFactory = driverContext.blockFactory();
             assert percentile == MEDIAN : "Median must be 50th percentile [percentile = " + percentile + "]";
-            if (digest.size() == 0) {
+            if (failed || digest.size() == 0) {
                 return blockFactory.newConstantNullBlock(1);
             }
             double result = InternalMedianAbsoluteDeviation.computeMedianAbsoluteDeviation(digest);
@@ -108,7 +122,7 @@ public final class QuantileStates {
 
         Block evaluatePercentile(DriverContext driverContext) {
             BlockFactory blockFactory = driverContext.blockFactory();
-            if (percentile == null || digest.size() == 0) {
+            if (failed || percentile == null || digest.size() == 0) {
                 return blockFactory.newConstantNullBlock(1);
             }
             double result = digest.quantile(percentile / 100);
@@ -116,7 +130,7 @@ public final class QuantileStates {
         }
     }
 
-    static class GroupingState implements GroupingAggregatorState {
+    static class GroupingState extends AbstractFallibleArrayState {
         private long largestGroupId = -1;
         private ObjectArray<TDigestState> digests;
         private final BigArrays bigArrays;
@@ -129,6 +143,7 @@ public final class QuantileStates {
         }
 
         GroupingState(CircuitBreaker breaker, BigArrays bigArrays, double percentile, double tDigestStateCompression) {
+            super(bigArrays);
             this.breaker = breaker;
             this.bigArrays = bigArrays;
             this.digests = bigArrays.newObjectArray(1);
@@ -147,21 +162,25 @@ public final class QuantileStates {
         }
 
         void add(int groupId, double v) {
+            if (hasFailed(groupId)) {
+                return;
+            }
             getOrAddGroup(groupId).add(v);
         }
 
         void add(int groupId, TDigestState other) {
+            if (hasFailed(groupId)) {
+                return;
+            }
             if (other != null) {
                 getOrAddGroup(groupId).add(other);
             }
         }
 
-        @Override
-        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {
-            // We always enable.
-        }
-
         void add(int groupId, BytesRef other) {
+            if (hasFailed(groupId)) {
+                return;
+            }
             try (var digestToAdd = deserializeDigest(breaker, other)) {
                 getOrAddGroup(groupId).add(digestToAdd);
             }
@@ -178,7 +197,10 @@ public final class QuantileStates {
         /** Extracts an intermediate view of the contents of this state.  */
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
             assert blocks.length >= offset + 1;
-            try (var builder = driverContext.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
+            try (
+                var builder = driverContext.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount());
+                var failedBuilder = driverContext.blockFactory().newBooleanBlockBuilder(selected.getPositionCount())
+            ) {
                 for (int i = 0; i < selected.getPositionCount(); i++) {
                     int group = selected.getInt(i);
                     TDigestState state;
@@ -194,12 +216,16 @@ public final class QuantileStates {
                         closeState = true;
                     }
                     builder.appendBytesRef(serializeDigest(state));
+                    failedBuilder.appendBoolean(hasFailed(group));
 
                     if (closeState) {
                         state.close();
                     }
                 }
                 blocks[offset] = builder.build();
+                if (blocks.length > offset + 1) {
+                    blocks[offset + 1] = failedBuilder.build();
+                }
             }
         }
 
@@ -208,7 +234,7 @@ public final class QuantileStates {
             try (DoubleBlock.Builder builder = driverContext.blockFactory().newDoubleBlockBuilder(selected.getPositionCount())) {
                 for (int i = 0; i < selected.getPositionCount(); i++) {
                     int si = selected.getInt(i);
-                    if (si >= digests.size()) {
+                    if (si >= digests.size() || hasFailed(si)) {
                         builder.appendNull();
                         continue;
                     }
@@ -227,7 +253,7 @@ public final class QuantileStates {
             try (DoubleBlock.Builder builder = driverContext.blockFactory().newDoubleBlockBuilder(selected.getPositionCount())) {
                 for (int i = 0; i < selected.getPositionCount(); i++) {
                     int si = selected.getInt(i);
-                    if (si >= digests.size()) {
+                    if (si >= digests.size() || hasFailed(si)) {
                         builder.appendNull();
                         continue;
                     }
@@ -244,7 +270,11 @@ public final class QuantileStates {
 
         @Override
         public void close() {
-            Releasables.close(Releasables.wrap(LongStream.range(0, digests.size()).mapToObj(i -> digests.get(i)).toList()), digests);
+            Releasables.close(
+                Releasables.wrap(LongStream.range(0, digests.size()).mapToObj(i -> digests.get(i)).toList()),
+                digests,
+                () -> super.close()
+            );
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionTests.java
@@ -13,10 +13,13 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.SequenceDoubleBlockSourceOperator;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.DoubleStream;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -31,7 +34,7 @@ public class MedianAbsoluteDeviationDoubleAggregatorFunctionTests extends Aggreg
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier();
+        return new MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(TestWarningsSource.INSTANCE);
     }
 
     @Override
@@ -42,5 +45,15 @@ public class MedianAbsoluteDeviationDoubleAggregatorFunctionTests extends Aggreg
     @Override
     protected void assertSimpleOutput(List<Page> input, Block result) {
         assertThat(((DoubleBlock) result).getDouble(0), equalTo(0.8));
+    }
+
+    public void testNonFiniteInputReturnsNull() {
+        var runner = new TestDriverRunner().builder(driverContext());
+        runner.input(new SequenceDoubleBlockSourceOperator(runner.blockFactory(), DoubleStream.of(Double.NaN)));
+
+        List<Page> results = runner.run(simple());
+
+        assertThat(results.size(), equalTo(1));
+        assertThat(results.get(0).getBlock(0).isNull(0), equalTo(true));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.LongDoubleTupleBlockSourceOperator;
 import org.elasticsearch.core.Tuple;
 
@@ -47,7 +48,7 @@ public class MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests extend
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier();
+        return new MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(TestWarningsSource.INSTANCE);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunctionTests.java
@@ -13,12 +13,15 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.SequenceFloatBlockSourceOperator;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
 
 public class MedianAbsoluteDeviationFloatAggregatorFunctionTests extends AggregatorFunctionTestCase {
 
@@ -31,7 +34,7 @@ public class MedianAbsoluteDeviationFloatAggregatorFunctionTests extends Aggrega
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new MedianAbsoluteDeviationFloatAggregatorFunctionSupplier();
+        return new MedianAbsoluteDeviationFloatAggregatorFunctionSupplier(TestWarningsSource.INSTANCE);
     }
 
     @Override
@@ -42,5 +45,15 @@ public class MedianAbsoluteDeviationFloatAggregatorFunctionTests extends Aggrega
     @Override
     protected void assertSimpleOutput(List<Page> input, Block result) {
         assertThat(((DoubleBlock) result).getDouble(0), closeTo(0.8, 0.001d));
+    }
+
+    public void testNonFiniteInputReturnsNull() {
+        var runner = new TestDriverRunner().builder(driverContext());
+        runner.input(new SequenceFloatBlockSourceOperator(runner.blockFactory(), List.of(Float.NaN).stream()));
+
+        List<Page> results = runner.run(simple());
+
+        assertThat(results.size(), equalTo(1));
+        assertThat(results.get(0).getBlock(0).isNull(0), equalTo(true));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatGroupingAggregatorFunctionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.LongFloatTupleBlockSourceOperator;
 import org.elasticsearch.core.Tuple;
 
@@ -47,7 +48,7 @@ public class MedianAbsoluteDeviationFloatGroupingAggregatorFunctionTests extends
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new MedianAbsoluteDeviationFloatAggregatorFunctionSupplier();
+        return new MedianAbsoluteDeviationFloatAggregatorFunctionSupplier(TestWarningsSource.INSTANCE);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionTests.java
@@ -13,15 +13,20 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.SequenceDoubleBlockSourceOperator;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.util.List;
+import java.util.stream.DoubleStream;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class PercentileDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase {
 
@@ -34,7 +39,7 @@ public class PercentileDoubleAggregatorFunctionTests extends AggregatorFunctionT
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new PercentileDoubleAggregatorFunctionSupplier(percentile, QuantileStates.DEFAULT_COMPRESSION);
+        return new PercentileDoubleAggregatorFunctionSupplier(TestWarningsSource.INSTANCE, percentile, QuantileStates.DEFAULT_COMPRESSION);
     }
 
     @Override
@@ -56,4 +61,31 @@ public class PercentileDoubleAggregatorFunctionTests extends AggregatorFunctionT
             assertThat(value, closeTo(expected, expected * 0.1));
         }
     }
+
+    public void testNonFiniteInputReturnsNull() {
+        for (double nonFinite : new double[] { Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY }) {
+            var runner = new TestDriverRunner().builder(driverContext());
+            runner.input(new SequenceDoubleBlockSourceOperator(runner.blockFactory(), DoubleStream.of(nonFinite)));
+
+            List<Page> results = runner.run(simple());
+
+            assertThat(results, hasSize(1));
+            assertThat(results.get(0).getBlock(0).isNull(0), equalTo(true));
+        }
+    }
+
+    public void testNonFiniteInputReturnsNullAfterPartialAggregation() {
+        var runner = new TestDriverRunner().builder(driverContext());
+        runner.input(new SequenceDoubleBlockSourceOperator(runner.blockFactory(), DoubleStream.of(1.0, Double.POSITIVE_INFINITY)));
+
+        List<Page> results = runner.run(
+            simpleWithMode(AggregatorMode.INITIAL),
+            simpleWithMode(AggregatorMode.INTERMEDIATE),
+            simpleWithMode(AggregatorMode.FINAL)
+        );
+
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getBlock(0).isNull(0), equalTo(true));
+    }
+
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunctionTests.java
@@ -13,6 +13,8 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.LongDoubleTupleBlockSourceOperator;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
@@ -22,6 +24,8 @@ import java.util.List;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class PercentileDoubleGroupingAggregatorFunctionTests extends GroupingAggregatorFunctionTestCase {
 
@@ -34,7 +38,7 @@ public class PercentileDoubleGroupingAggregatorFunctionTests extends GroupingAgg
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new PercentileDoubleAggregatorFunctionSupplier(percentile, QuantileStates.DEFAULT_COMPRESSION);
+        return new PercentileDoubleAggregatorFunctionSupplier(TestWarningsSource.INSTANCE, percentile, QuantileStates.DEFAULT_COMPRESSION);
     }
 
     @Override
@@ -62,5 +66,45 @@ public class PercentileDoubleGroupingAggregatorFunctionTests extends GroupingAgg
                 assertTrue(result.isNull(position));
             }
         }
+    }
+
+    public void testNonFiniteInputReturnsNullForGroup() {
+        var runner = new TestDriverRunner().builder(driverContext());
+        BlockFactory blockFactory = runner.blockFactory();
+        runner.input(
+            List.of(
+                new Page(
+                    blockFactory.newConstantLongBlockWith(0L, 2),
+                    blockFactory.newDoubleArrayVector(new double[] { 1.0, Double.POSITIVE_INFINITY }, 2).asBlock()
+                )
+            )
+        );
+
+        List<Page> results = runner.run(simple());
+
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getBlock(1).isNull(0), equalTo(true));
+    }
+
+    public void testNonFiniteInputReturnsNullAfterPartialAggregationForGroup() {
+        var runner = new TestDriverRunner().builder(driverContext());
+        BlockFactory blockFactory = runner.blockFactory();
+        runner.input(
+            List.of(
+                new Page(
+                    blockFactory.newConstantLongBlockWith(0L, 2),
+                    blockFactory.newDoubleArrayVector(new double[] { 1.0, Double.POSITIVE_INFINITY }, 2).asBlock()
+                )
+            )
+        );
+
+        List<Page> results = runner.run(
+            simpleWithMode(AggregatorMode.INITIAL),
+            simpleWithMode(AggregatorMode.INTERMEDIATE),
+            simpleWithMode(AggregatorMode.FINAL)
+        );
+
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getBlock(1).isNull(0), equalTo(true));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunctionTests.java
@@ -13,6 +13,8 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.SequenceFloatBlockSourceOperator;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.test.ESTestCase;
@@ -22,6 +24,7 @@ import java.util.List;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
 
 public class PercentileFloatAggregatorFunctionTests extends AggregatorFunctionTestCase {
 
@@ -34,7 +37,7 @@ public class PercentileFloatAggregatorFunctionTests extends AggregatorFunctionTe
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new PercentileFloatAggregatorFunctionSupplier(percentile);
+        return new PercentileFloatAggregatorFunctionSupplier(TestWarningsSource.INSTANCE, percentile);
     }
 
     @Override
@@ -55,5 +58,15 @@ public class PercentileFloatAggregatorFunctionTests extends AggregatorFunctionTe
             double value = ((DoubleBlock) result).getDouble(0);
             assertThat(value, closeTo(expected, expected * 0.1));
         }
+    }
+
+    public void testNonFiniteInputReturnsNull() {
+        var runner = new TestDriverRunner().builder(driverContext());
+        runner.input(new SequenceFloatBlockSourceOperator(runner.blockFactory(), List.of(Float.NaN).stream()));
+
+        List<Page> results = runner.run(simple());
+
+        assertThat(results.size(), equalTo(1));
+        assertThat(results.get(0).getBlock(0).isNull(0), equalTo(true));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileFloatGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileFloatGroupingAggregatorFunctionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestWarningsSource;
 import org.elasticsearch.compute.test.operator.blocksource.LongFloatTupleBlockSourceOperator;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
@@ -34,7 +35,7 @@ public class PercentileFloatGroupingAggregatorFunctionTests extends GroupingAggr
 
     @Override
     protected AggregatorFunctionSupplier aggregatorFunction() {
-        return new PercentileFloatAggregatorFunctionSupplier(percentile);
+        return new PercentileFloatAggregatorFunctionSupplier(TestWarningsSource.INSTANCE, percentile);
     }
 
     @Override


### PR DESCRIPTION
## What

PERCENTILE, MEDIAN, and MEDIAN_ABSOLUTE_DEVIATION use TDigest, which rejects non-finite doubles with an uncaught IllegalArgumentException. This turns a valid ES|QL request into a 400 response.

This change:

- records the failure and returns null for the affected aggregation or group;
- propagates the failure through partial aggregation intermediate state;
- uses the standard aggregation warning path; and
- covers both double and float quantile implementations.

Closes #154815

## Testing

- ./gradlew ':x-pack:plugin:esql:compute:test' --tests 'org.elasticsearch.compute.aggregation.PercentileDoubleAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.PercentileDoubleGroupingAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.PercentileFloatAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.PercentileFloatGroupingAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.MedianAbsoluteDeviationDoubleAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.MedianAbsoluteDeviationFloatAggregatorFunctionTests' --tests 'org.elasticsearch.compute.aggregation.MedianAbsoluteDeviationFloatGroupingAggregatorFunctionTests'
- ./gradlew ':x-pack:plugin:esql:compute:spotlessJavaCheck'
- git diff --check