### PR TITLE
[9.4] bbq_flat yaml refresh fixes

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
@@ -791,6 +791,10 @@ setup:
         max_num_segments: 1
 
   - do:
+      indices.refresh:
+        index: test_index
+
+  - do:
       search:
         index: test_index
         body:
@@ -936,6 +940,10 @@ setup:
       indices.forcemerge:
         index: test_index
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: test_index
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/210_knn_search_profile.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/210_knn_search_profile.yml
@@ -85,6 +85,10 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: bbq_hnsw
 ---
 "Profile rescored knn search":
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
@@ -74,6 +74,9 @@ setup:
       indices.forcemerge:
         index: bbq_flat
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:
@@ -460,6 +463,10 @@ setup:
       indices.forcemerge:
         index: bbq_flat_nested
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: bbq_flat_nested
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
@@ -78,6 +78,9 @@ setup:
       indices.forcemerge:
         index: bbq_flat
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:


### PR DESCRIPTION
Backport to `9.4` of #154996 

Backports two test-only visibility fixes:

- #154272 — add index refresh to bbq yaml tests to ensure changes are available
- #154688 — add index refresh after forced merge

