### PR TITLE
Add setting to disable knn filter eager cache

### DIFF
--- a/docs/changelog/155086.yaml
+++ b/docs/changelog/155086.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+ - 141582
+pr: 155086
+summary: Add setting to disable knn filter eager cache
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -164,6 +164,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.DYNAMIC_STRINGS_AUTO_TEXT,
                 DenseVectorFieldMapper.HNSW_FILTER_HEURISTIC,
                 DenseVectorFieldMapper.HNSW_EARLY_TERMINATION,
+                DenseVectorFieldMapper.KNN_FILTER_EAGER_CACHE,
                 DenseVectorFieldMapper.POST_FILTER_SELECTIVITY_THRESHOLD,
                 IndexFieldDataService.INDEX_FIELDDATA_CACHE_KEY,
                 IndexSettings.IGNORE_ABOVE_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1316,6 +1316,7 @@ public final class IndexSettings {
     private volatile int maxShingleDiff;
     private volatile DenseVectorFieldMapper.FilterHeuristic hnswFilterHeuristic;
     private volatile boolean earlyTermination;
+    private volatile boolean knnFilterEagerCache;
     private volatile float postFilterSelectivityThreshold;
     private volatile TimeValue searchIdleAfter;
     private volatile int maxAnalyzedOffset;
@@ -1553,6 +1554,7 @@ public final class IndexSettings {
         skipIgnoredSourceRead = scopedSettings.get(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_READ_SETTING);
         hnswFilterHeuristic = scopedSettings.get(DenseVectorFieldMapper.HNSW_FILTER_HEURISTIC);
         earlyTermination = scopedSettings.get(DenseVectorFieldMapper.HNSW_EARLY_TERMINATION);
+        knnFilterEagerCache = scopedSettings.get(DenseVectorFieldMapper.KNN_FILTER_EAGER_CACHE);
         postFilterSelectivityThreshold = scopedSettings.get(DenseVectorFieldMapper.POST_FILTER_SELECTIVITY_THRESHOLD);
         indexMappingSourceMode = scopedSettings.get(INDEX_MAPPER_SOURCE_MODE_SETTING);
         recoverySourceEnabled = RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.get(nodeSettings);
@@ -1701,6 +1703,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_READ_SETTING, this::setSkipIgnoredSourceRead);
         scopedSettings.addSettingsUpdateConsumer(DenseVectorFieldMapper.HNSW_FILTER_HEURISTIC, this::setHnswFilterHeuristic);
         scopedSettings.addSettingsUpdateConsumer(DenseVectorFieldMapper.HNSW_EARLY_TERMINATION, this::setHnswEarlyTermination);
+        scopedSettings.addSettingsUpdateConsumer(DenseVectorFieldMapper.KNN_FILTER_EAGER_CACHE, this::setKnnFilterEagerCache);
         scopedSettings.addSettingsUpdateConsumer(INTRA_MERGE_PARALLELISM_ENABLED_SETTING, this::setIntraMergeParallelismEnabled);
         scopedSettings.addSettingsUpdateConsumer(DYNAMIC_STRINGS_AUTO_TEXT, this::setDynamicStringsAutoText);
     }
@@ -2449,6 +2452,17 @@ public final class IndexSettings {
 
     private void setHnswEarlyTermination(boolean earlyTermination) {
         this.earlyTermination = earlyTermination;
+    }
+
+    /**
+     * Whether knn query filters are wrapped to force eager query-cache materialization.
+     */
+    public boolean getKnnFilterEagerCache() {
+        return this.knnFilterEagerCache;
+    }
+
+    private void setKnnFilterEagerCache(boolean knnFilterEagerCache) {
+        this.knnFilterEagerCache = knnFilterEagerCache;
     }
 
     public float getPostFilterSelectivityThreshold() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -215,6 +215,19 @@ public class DenseVectorFieldMapper extends FieldMapper {
     );
 
     /**
+     * Whether knn query filters are wrapped to force eager query-cache materialization.
+     * Disable on indices whose knn prefilters change frequently (for example geo filters based on user location)
+     * to avoid evicting reusable cache entries for other queries.
+     */
+    public static final Setting<Boolean> KNN_FILTER_EAGER_CACHE = Setting.boolSetting(
+        "index.dense_vector.knn_filter_eager_cache",
+        true,
+        Setting.Property.IndexScope,
+        Setting.Property.ServerlessPublic,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Selectivity threshold above which a filtered knn query is routed through the post-filter
      * pipeline (HNSW runs unfiltered, the filter is applied to the raw candidate set, retrying
      * with seeded entry points if {@code k} is not collected). Below this threshold the query
@@ -3442,7 +3455,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 heuristic,
                 hnswEarlyTermination,
                 sliceRouting != null,
-                sliceRouting
+                sliceRouting,
+                true
             );
         }
 
@@ -3459,6 +3473,38 @@ public class DenseVectorFieldMapper extends FieldMapper {
             boolean hnswEarlyTermination,
             boolean sliceEnabled,
             @Nullable String sliceRouting
+        ) {
+            return createKnnQuery(
+                queryVector,
+                k,
+                numCands,
+                visitPercentage,
+                oversample,
+                filter,
+                similarityThreshold,
+                parentFilter,
+                heuristic,
+                hnswEarlyTermination,
+                sliceEnabled,
+                sliceRouting,
+                true
+            );
+        }
+
+        public Query createKnnQuery(
+            VectorData queryVector,
+            int k,
+            int numCands,
+            Float visitPercentage,
+            Float oversample,
+            Query filter,
+            Float similarityThreshold,
+            BitSetProducer parentFilter,
+            FilterHeuristic heuristic,
+            boolean hnswEarlyTermination,
+            boolean sliceEnabled,
+            @Nullable String sliceRouting,
+            boolean knnFilterEagerCache
         ) {
             if (indexType.hasVectors() == false) {
                 throw new IllegalArgumentException(
@@ -3487,7 +3533,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     knnSearchStrategy,
                     hnswEarlyTermination,
                     sliceEnabled,
-                    sliceRouting
+                    sliceRouting,
+                    knnFilterEagerCache
                 );
                 case ResolvedVector.Bits(byte[] vector) -> createKnnBitQuery(
                     vector,
@@ -3497,7 +3544,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     similarityThreshold,
                     parentFilter,
                     knnSearchStrategy,
-                    hnswEarlyTermination
+                    hnswEarlyTermination,
+                    knnFilterEagerCache
                 );
                 case ResolvedVector.Bytes(byte[] vector) -> createKnnByteQuery(
                     vector,
@@ -3507,7 +3555,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     similarityThreshold,
                     parentFilter,
                     knnSearchStrategy,
-                    hnswEarlyTermination
+                    hnswEarlyTermination,
+                    knnFilterEagerCache
                 );
             };
         }
@@ -3535,9 +3584,10 @@ public class DenseVectorFieldMapper extends FieldMapper {
             Float similarityThreshold,
             BitSetProducer parentFilter,
             KnnSearchStrategy searchStrategy,
-            boolean hnswEarlyTermination
+            boolean hnswEarlyTermination,
+            boolean knnFilterEagerCache
         ) {
-            Query cachedFilter = filter == null ? null : new CachingEnableFilterQuery(filter);
+            Query cachedFilter = CachingEnableFilterQuery.wrapForKnnFilterCaching(filter, knnFilterEagerCache);
             Query knnQuery;
             if (indexOptions != null && indexOptions.isFlat()) {
                 // Bit vectors have no VectorSimilarityFunction; the codec scorer always computes Hamming distance.
@@ -3578,12 +3628,13 @@ public class DenseVectorFieldMapper extends FieldMapper {
             Float similarityThreshold,
             BitSetProducer parentFilter,
             KnnSearchStrategy searchStrategy,
-            boolean hnswEarlyTermination
+            boolean hnswEarlyTermination,
+            boolean knnFilterEagerCache
         ) {
             // Pre-filter consumers eagerly materialize the filter into a bitset, so we
-            // force the cache wrapper. PostFilterKnnQuery gets the raw filter because it evaluates the
+            // force the cache wrapper by default. PostFilterKnnQuery gets the raw filter because it evaluates the
             // filter against a small candidate set per query and would otherwise pay an unnecessary cache build.
-            Query cachedFilter = filter == null ? null : new CachingEnableFilterQuery(filter);
+            Query cachedFilter = CachingEnableFilterQuery.wrapForKnnFilterCaching(filter, knnFilterEagerCache);
             Query knnQuery;
             if (indexOptions != null && indexOptions.isFlat()) {
                 Query exactKnnQuery = DenseVectorQuery.Bytes.codecScored(queryVector, name()).filteredBy(filter);
@@ -3627,7 +3678,8 @@ public class DenseVectorFieldMapper extends FieldMapper {
             KnnSearchStrategy knnSearchStrategy,
             boolean hnswEarlyTermination,
             boolean sliceEnabled,
-            @Nullable String sliceRouting
+            @Nullable String sliceRouting,
+            boolean knnFilterEagerCache
         ) {
             int adjustedK = k;
             // By default utilize the quantized oversample is configured
@@ -3644,7 +3696,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 adjustedK = Math.min((int) Math.ceil(k * oversample), OVERSAMPLE_LIMIT);
                 numCands = Math.max(adjustedK, numCands);
             }
-            Query cachedFilter = filter == null ? null : new CachingEnableFilterQuery(filter);
+            Query cachedFilter = CachingEnableFilterQuery.wrapForKnnFilterCaching(filter, knnFilterEagerCache);
             Query knnQuery;
             if (indexOptions != null && indexOptions.isFlat()) {
                 Query exactKnnQuery = DenseVectorQuery.Floats.codecScored(queryVector, name()).filteredBy(filter);

--- a/server/src/main/java/org/elasticsearch/search/vectors/CachingEnableFilterQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/CachingEnableFilterQuery.java
@@ -19,6 +19,7 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.UsageTrackingQueryCachingPolicy;
 import org.apache.lucene.search.Weight;
+import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -53,6 +54,17 @@ import java.util.Objects;
  */
 public class CachingEnableFilterQuery extends Query {
     private final Query in;
+
+    /**
+     * Wraps {@code filter} for pre-filtered knn search when eager caching is enabled.
+     * When disabled, returns the filter unchanged so Lucene's default caching heuristics apply.
+     */
+    public static Query wrapForKnnFilterCaching(@Nullable Query filter, boolean eagerCache) {
+        if (filter == null) {
+            return null;
+        }
+        return eagerCache ? new CachingEnableFilterQuery(filter) : filter;
+    }
 
     public CachingEnableFilterQuery(Query in) {
         this.in = in;

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -565,6 +565,7 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
 
         DenseVectorFieldMapper.FilterHeuristic heuristic = context.getIndexSettings().getHnswFilterHeuristic();
         boolean hnswEarlyTermination = context.getIndexSettings().getHnswEarlyTermination();
+        boolean knnFilterEagerCache = context.getIndexSettings().getKnnFilterEagerCache();
         boolean sliceEnabled = context.getIndexSettings().isSliceEnabled();
         String sliceRouting = sliceEnabled ? context.getSliceRouting() : null;
         Float oversample = rescoreVectorBuilder() == null ? null : rescoreVectorBuilder.oversample();
@@ -582,7 +583,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             heuristic,
             hnswEarlyTermination,
             sliceEnabled,
-            sliceRouting
+            sliceRouting,
+            knnFilterEagerCache
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.ESTestCase;
@@ -246,6 +247,12 @@ public class IndexSettingsTests extends ESTestCase {
 
     public void testDenseVectorExperimentalFeaturesDefaultsFromBuildType() {
         assertEquals(Build.current().isSnapshot(), IndexSettings.DENSE_VECTOR_EXPERIMENTAL_FEATURES_SETTING.get(Settings.EMPTY));
+    }
+
+    public void testKnnFilterEagerCacheDefaultsToTrue() {
+        assertTrue(DenseVectorFieldMapper.KNN_FILTER_EAGER_CACHE.get(Settings.EMPTY));
+        IndexSettings indexSettings = newIndexSettings(newIndexMeta("index", Settings.EMPTY), Settings.EMPTY);
+        assertTrue(indexSettings.getKnnFilterEagerCache());
     }
 
     public void testSliceEnabledSettingRequiresFeatureFlag() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -9,8 +9,10 @@
 
 package org.elasticsearch.index.mapper.vectors;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
@@ -23,6 +25,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DenseVectorFieldType;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.VectorSimilarity;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.vectors.CachingEnableFilterQuery;
 import org.elasticsearch.search.vectors.DenseVectorQuery;
 import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatSlicedVectorQuery;
 import org.elasticsearch.search.vectors.DiversifyingChildrenIVFKnnFloatVectorQuery;
@@ -899,6 +902,56 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
         if (innerQuery instanceof ESKnnFloatVectorQuery esKnnFloatVectorQuery) {
             assertThat(esKnnFloatVectorQuery.kParam(), equalTo(20));
         }
+    }
+
+    public void testKnnFilterEagerCache() {
+        DenseVectorFieldType fieldType = new DenseVectorFieldType(
+            "f",
+            IndexVersion.current(),
+            FLOAT,
+            3,
+            true,
+            VectorSimilarity.COSINE,
+            new DenseVectorFieldMapper.HnswIndexOptions(16, 100, -1),
+            Collections.emptyMap(),
+            false
+        );
+        TermQuery filter = new TermQuery(new Term("category", "foo"));
+        Query withEagerCache = fieldType.createKnnQuery(
+            VectorData.fromFloats(new float[] { 1, 4, 10 }),
+            10,
+            100,
+            10f,
+            null,
+            filter,
+            null,
+            null,
+            DenseVectorFieldMapper.FilterHeuristic.FANOUT,
+            false,
+            false,
+            null,
+            true
+        );
+        assertThat(withEagerCache, instanceOf(ESKnnFloatVectorQuery.class));
+        assertThat(((KnnFloatVectorQuery) withEagerCache).getFilter(), instanceOf(CachingEnableFilterQuery.class));
+
+        Query withoutEagerCache = fieldType.createKnnQuery(
+            VectorData.fromFloats(new float[] { 1, 4, 10 }),
+            10,
+            100,
+            10f,
+            null,
+            filter,
+            null,
+            null,
+            DenseVectorFieldMapper.FilterHeuristic.FANOUT,
+            false,
+            false,
+            null,
+            false
+        );
+        assertThat(withoutEagerCache, instanceOf(ESKnnFloatVectorQuery.class));
+        assertThat(((KnnFloatVectorQuery) withoutEagerCache).getFilter(), equalTo(filter));
     }
 
     public void testFilterSearchThreshold() {

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -249,7 +249,10 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
         }
         BooleanQuery booleanQuery = builder.build();
         Query filterQuery = booleanQuery.clauses().isEmpty() ? null : booleanQuery;
-        Query approxFilterQuery = filterQuery != null ? new CachingEnableFilterQuery(filterQuery) : null;
+        Query approxFilterQuery = CachingEnableFilterQuery.wrapForKnnFilterCaching(
+            filterQuery,
+            context.getIndexSettings().getKnnFilterEagerCache()
+        );
         Integer numCands = queryBuilder.numCands();
         if (queryBuilder.rescoreVectorBuilder() != null && isQuantizedElementType()) {
             float oversample = queryBuilder.rescoreVectorBuilder().oversample();

--- a/server/src/test/java/org/elasticsearch/search/vectors/CachingEnableFilterQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/CachingEnableFilterQueryTests.java
@@ -31,6 +31,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class CachingEnableFilterQueryTests extends ESTestCase {
+    public void testWrapForKnnFilterCaching() {
+        TermQuery termQuery = new TermQuery(new Term("foo", "bar"));
+        assertThat(CachingEnableFilterQuery.wrapForKnnFilterCaching(null, true), equalTo(null));
+        assertThat(CachingEnableFilterQuery.wrapForKnnFilterCaching(null, false), equalTo(null));
+        assertThat(CachingEnableFilterQuery.wrapForKnnFilterCaching(termQuery, true), instanceOf(CachingEnableFilterQuery.class));
+        assertThat(CachingEnableFilterQuery.wrapForKnnFilterCaching(termQuery, false), equalTo(termQuery));
+    }
+
     public void testEquals() {
         Query c1 = new CachingEnableFilterQuery(new TermQuery(new Term("foo", "bar")));
         Query c2 = new CachingEnableFilterQuery(new TermQuery(new Term("foo", "bar")));

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -542,6 +542,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         MetadataIndexStateService.VERIFIED_READ_ONLY_SETTING,
         DenseVectorFieldMapper.HNSW_FILTER_HEURISTIC,
         DenseVectorFieldMapper.HNSW_EARLY_TERMINATION,
+        DenseVectorFieldMapper.KNN_FILTER_EAGER_CACHE,
         DenseVectorFieldMapper.POST_FILTER_SELECTIVITY_THRESHOLD,
         IndexSettings.INTRA_MERGE_PARALLELISM_ENABLED_SETTING
     );


### PR DESCRIPTION
Introduce the dynamic index setting `index.dense_vector.knn_filter_eager_cache` (default true) so
indices with frequently changing knn prefilters can opt out of eager query-cache materialization and 
avoid evicting reusable cache entries for other queries.

Fixes #141582