### PR TITLE
ESQL: Fix Sum Long test warnings

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -214,9 +214,6 @@ tests:
 - class: org.elasticsearch.upgrades.TransformSurvivesUpgradeIT
   method: testTransformRollingUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/150442
-- class: org.elasticsearch.compute.aggregation.SumLongAggregatorFunctionTests
-  method: testOverflowFails
-  issue: https://github.com/elastic/elasticsearch/issues/150455
 - class: org.elasticsearch.xpack.stateless.recovery.BlockRefreshUponIndexCreationIT
   method: testRefreshesAreBlockedUntilBlockIsRemoved
   issue: https://github.com/elastic/elasticsearch/issues/150492
@@ -636,9 +633,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=downsample/100_downsample_histograms/Downsample tdigest with last value}
   issue: https://github.com/elastic/elasticsearch/issues/155028
-- class: org.elasticsearch.compute.aggregation.SumLongGroupingAggregatorFunctionTests
-  method: testOverflowInGroupingProducesNullAndWarning
-  issue: https://github.com/elastic/elasticsearch/issues/150769
 - class: org.elasticsearch.indices.ShardLimitValidatorTests
   method: testValidateShardLimitOpenIndices
   issue: https://github.com/elastic/elasticsearch/issues/154859

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
@@ -77,7 +77,7 @@ public class SumLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
                 }
             )
         ) {
-            new TestDriverRunner().run(driver);
+            new TestDriverRunner().numThreads(1).run(driver);
         }
 
         assertDriverContext(driverContext);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunctionTests.java
@@ -98,7 +98,7 @@ public class SumLongGroupingAggregatorFunctionTests extends GroupingAggregatorFu
                 () -> warnings.addAll(threadContext.getResponseHeaders().getOrDefault("Warning", List.of()))
             )
         ) {
-            new TestDriverRunner().run(driver);
+            new TestDriverRunner().numThreads(1).run(driver);
         }
 
         assertDriverContext(driverContext);


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/150455
Fixes https://github.com/elastic/elasticsearch/issues/150769

With multiple threads, the warnings are sometimes lost in the `ThreadLocal`s.
This PR forces a single thread in the custom tests