### PR TITLE
[9.4] [build-tools] Make build tool tests more stable (#155079)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGitAwareGradleFuncTest.groovy
@@ -29,26 +29,9 @@ abstract class AbstractGitAwareGradleFuncTest extends AbstractGradleInternalPlug
     @Shared
     File preparedRemoteGitDir
 
-    @TempDir
-    File gradleUserHome
-
     File remoteGitRepo
 
-    @Override
-    protected File customGradleUserHome() {
-        return gradleUserHome
-    }
-
     def setup() {
-        // Pre-populate the TestKit Gradle user home with the locally cached Gradle wrapper
-        // distribution. TestKit sets GRADLE_USER_HOME=<gradleUserHome> in every forked process,
-        // including the ./gradlew subprocesses spawned by BWC build tasks. Without this copy
-        // those subprocesses would download the Gradle distribution on every test run.
-        File localWrapperDir = new File(System.getProperty("user.home"), ".gradle/wrapper")
-        if (localWrapperDir.exists()) {
-            FileUtils.copyDirectory(localWrapperDir, new File(gradleUserHome, "wrapper"))
-        }
-
         if (preparedRemoteGitDir == null) {
             preparedRemoteGitDir = setupGitRemote()
         }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.gradle.internal
 
-import spock.lang.Unroll
-
 import com.github.tomakehurst.wiremock.WireMockServer
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -76,7 +76,7 @@ abstract class AbstractGradleFuncTest extends Specification {
             minimumCompilerJava = 21
         """
         propertiesFile <<
-            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME\n"
+            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME\n"
         // Pin the JAXP TransformerFactory to the JDK built-in implementation.
         // The plugin-under-test classpath injected via GradleRunner#withPluginClasspath transitively
         // contains Saxon-HE (pulled in by the nmcp publishing plugin), which registers itself as a


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [build-tools] Make build tool tests more stable (#155079)