### PR TITLE
[8.19] Fix #153353 - Don't assert on null centroids (#154963) (#155097)

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroidTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroidTests.java
@@ -74,9 +74,11 @@ public class InternalCartesianCentroidTests extends InternalAggregationTestCase<
 
     @Override
     protected void assertSampled(InternalCartesianCentroid sampled, InternalCartesianCentroid reduced, SamplingContext samplingContext) {
-        assertThat(sampled.centroid().getY(), closeTo(reduced.centroid().getY(), Math.abs(reduced.centroid().getY() / 1e10)));
-        assertThat(sampled.centroid().getX(), closeTo(reduced.centroid().getX(), Math.abs(reduced.centroid().getX() / 1e10)));
         assertEquals(sampled.count(), samplingContext.scaleUp(reduced.count()), 0);
+        if (sampled.count() > 0) {
+            assertThat(sampled.centroid().getY(), closeTo(reduced.centroid().getY(), Math.abs(reduced.centroid().getY() / 1e10)));
+            assertThat(sampled.centroid().getX(), closeTo(reduced.centroid().getX(), Math.abs(reduced.centroid().getX() / 1e10)));
+        }
     }
 
     public void testReduceMaxCount() {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix #153353 - Don't assert on null centroids (#154963) (#155097)