### PR TITLE
[9.5] unmute KeyRotationITs (#154128)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -520,9 +520,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testCloseWhileShardsAreHollowed
   issue: https://github.com/elastic/elasticsearch/issues/151861
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testConsecutiveRotations
-  issue: https://github.com/elastic/elasticsearch/issues/152472
 - class: org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.DivTests
   method: testCrankyEvaluateBlockWithoutNulls {TestCase=<double>, <dense_vector>}
   issue: https://github.com/elastic/elasticsearch/issues/152794
@@ -535,9 +532,6 @@ tests:
 - class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
   method: testConjunctionOfRangeFiltersMatchesBruteForce
   issue: https://github.com/elastic/elasticsearch/issues/152887
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationCycleWithNoHandlers
-  issue: https://github.com/elastic/elasticsearch/issues/152913
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/152914
@@ -550,9 +544,6 @@ tests:
 - class: org.elasticsearch.compute.operator.fuse.LinearScoreEvalOperatorTests
   method: testMultivaluedGroupColumnProducesWarning
   issue: https://github.com/elastic/elasticsearch/issues/152929
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testEachInstallOrRotationAddsExactlyOneNewKey
-  issue: https://github.com/elastic/elasticsearch/issues/153024
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/153046
@@ -700,9 +691,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.FromDatasetIT
   method: testWildcardSpanningIndexAndDatasetSucceeds
   issue: https://github.com/elastic/elasticsearch/issues/154200
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationCompletesWithMultipleHandlers
-  issue: https://github.com/elastic/elasticsearch/issues/153747
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterWhere}
   issue: https://github.com/elastic/elasticsearch/issues/152591

--- a/x-pack/plugin/encryption/spi/src/main/java/org/elasticsearch/xpack/encryption/spi/EncryptedDataHandler.java
+++ b/x-pack/plugin/encryption/spi/src/main/java/org/elasticsearch/xpack/encryption/spi/EncryptedDataHandler.java
@@ -30,7 +30,8 @@ public interface EncryptedDataHandler<T extends Metadata.ProjectCustom> {
      * @param current          the current value of the custom in cluster state, or {@code null} if absent
      * @param encryptionService used to decrypt with the previous key and encrypt under the active key
      * @param activeKeyId      the key ID every encrypted value in the returned custom must be under
-     * @return the re-encrypted custom
+     * @return the re-encrypted custom. This may be the same instance if no change is needed. This must not be null when {@code current}
+     *         is not null.
      */
     T reEncrypt(T current, EncryptionService encryptionService, String activeKeyId);
 

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -258,6 +258,16 @@ public class KeyRotationIT extends SecurityIntegTestCase {
             assertThat("beta blob re-encrypted off initial", betaBlob.blob.keyId(), not(equalTo(initialKeyId)));
             assertThat("alpha blob's key still present", m.getKeys().keySet(), hasItem(alphaBlob.blob.keyId()));
             assertThat("beta blob's key still present", m.getKeys().keySet(), hasItem(betaBlob.blob.keyId()));
+            assertThat(
+                "handlerKeyIds not in sync with actual keys",
+                m.getHandlerKeyIds().get(AlphaBlob.TYPE),
+                equalTo(alphaBlob.blob.keyId())
+            );
+            assertThat(
+                "handlerKeyIds not in sync with actual keys",
+                m.getHandlerKeyIds().get(BetaBlob.TYPE),
+                equalTo(betaBlob.blob.keyId())
+            );
         }, 30, TimeUnit.SECONDS);
 
         AlphaBlob alphaBlob = customOnMaster(AlphaBlob.TYPE);

--- a/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
+++ b/x-pack/plugin/encryption/src/main/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinator.java
@@ -133,7 +133,7 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
 
     private volatile Scheduler.Cancellable scheduledTask;
     private volatile boolean closed = false;
-    private final AtomicBoolean rotating = new AtomicBoolean(false);
+    private final AtomicBoolean reEncrypting = new AtomicBoolean(false);
     private final AtomicBoolean installInFlight = new AtomicBoolean(false);
     private final AtomicBoolean beginRotationInFlight = new AtomicBoolean(false);
     private final AtomicBoolean passwordIdRotateInFlight = new AtomicBoolean(false);
@@ -221,12 +221,15 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         if (closed) {
             return;
         }
-        rotating.set(false);
+        reEncrypting.set(false);
         stopSchedule();
     }
 
     // package-private for testing
     void onClusterStateChanged(ClusterChangedEvent event) {
+        if (closed) {
+            return;
+        }
         ClusterState state = event.state();
         if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
             return;
@@ -251,17 +254,12 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         }
     }
 
-    private void advanceKeyLifecycle(ProjectEncryptionKeyMetadata metadata, long now, boolean wasRotating) {
+    private void advanceKeyLifecycle(ProjectEncryptionKeyMetadata metadata, long now) {
         if (metadata.isUnwrapFailed()) {
             logger.debug("project encryption key: skipping lifecycle advancement in degraded state");
             return;
         }
         if (rotationDisabled()) {
-            return;
-        }
-        if (wasRotating) {
-            // In-flight ReEncryptApplyTasks would lose their CAS check if the active key rotated now.
-            logger.debug("project encryption key: deferring lifecycle advancement; re-encryption from previous tick still in progress");
             return;
         }
         long activeKeyAge = now - metadata.getGeneratedAt(metadata.getActiveKeyId());
@@ -271,7 +269,7 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         }
         long retireCutoff = now - GRACE_TICKS * checkInterval.millis();
         if (metadata.findRetireableKeyIds(retireCutoff).isEmpty() == false) {
-            submitRetireKeys(retireCutoff);
+            submitTaskIfOpen("retire-project-encryption-keys", new RetireKeysTask(retireCutoff));
         }
     }
 
@@ -310,27 +308,31 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
             return;
         }
         long now = threadPool.absoluteTimeInMillis();
-        // Snapshot before rotate() — reflects the previous tick's in-flight state, not this tick's.
-        boolean wasRotating = rotating.get();
-        rotate(metadata);
-        advanceKeyLifecycle(metadata, now, wasRotating);
+        var reEncryptionInProgress = reEncrypt(metadata);
+        // In-flight ReEncryptApplyTasks would lose their CAS check if the active key rotated now.
+        if (reEncryptionInProgress) {
+            logger.debug("project encryption key: deferring lifecycle advancement; re-encryption still in progress");
+            return;
+        }
+
+        advanceKeyLifecycle(metadata, now);
     }
 
-    private void rotate(ProjectEncryptionKeyMetadata metadata) {
+    private boolean reEncrypt(ProjectEncryptionKeyMetadata metadata) {
         String activeKeyId = metadata.getActiveKeyId();
         List<EncryptedDataHandler<?>> pending = handlers.stream().filter(h -> metadata.isHandlerOnActive(h.customName()) == false).toList();
         if (pending.isEmpty()) {
-            return;
+            return false;
         }
-        if (rotating.compareAndSet(false, true) == false) {
+        if (reEncrypting.compareAndSet(false, true) == false) {
             logger.warn("re-encryption already in progress, skipping this tick");
-            return;
+            return true;
         }
         try (
             var listeners = new RefCountingListener(
                 ActionListener.runAfter(
                     ActionListener.wrap(unused -> {}, e -> logger.warn("re-encryption failed; will retry on next tick", e)),
-                    () -> rotating.set(false)
+                    () -> reEncrypting.set(false)
                 )
             )
         ) {
@@ -339,6 +341,7 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
                 threadPool.generic().execute(() -> dispatchOne(handler, activeKeyId, l));
             }
         }
+        return true;
     }
 
     private <T extends Metadata.ProjectCustom> void dispatchOne(
@@ -352,22 +355,23 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
 
             T oldCustom = projectState.metadata().custom(handler.customName());
             T newCustom = handler.reEncrypt(oldCustom, encryptionService, expectedActiveKeyId);
-            if (newCustom == null || newCustom == oldCustom) {
-                listener.onResponse(null);
+            if (oldCustom != null && newCustom == null) {
+                listener.onFailure(new IllegalStateException("Re-encrypting non-null state returned null state"));
                 return;
             }
-            assert handler.customName().equals(newCustom.getWriteableName())
+
+            assert newCustom == null || handler.customName().equals(newCustom.getWriteableName())
                 : "handler ["
                     + handler.getClass().getSimpleName()
                     + "] customName="
                     + handler.customName()
                     + " does not match returned custom getWriteableName="
                     + newCustom.getWriteableName();
-            taskQueue.submitTask(
-                "re-encrypt-" + handler.customName(),
-                new ReEncryptApplyTask(handler.customName(), oldCustom, newCustom, expectedActiveKeyId, listener),
-                null
-            );
+            var task = new ReEncryptApplyTask(handler.customName(), oldCustom, newCustom, expectedActiveKeyId, listener);
+            if (submitTaskIfOpen("re-encrypt-" + handler.customName(), task) == false) {
+                // we still need to complete the callback when the cluster is shutting down, otherwise we'll end up with a dangling listener
+                listener.onResponse(null);
+            }
         } catch (Exception e) {
             listener.onFailure(e);
         }
@@ -378,6 +382,15 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         closed = true;
         clusterService.removeListener(clusterStateListener);
         stopSchedule();
+    }
+
+    private synchronized boolean submitTaskIfOpen(String source, KeyRotationTask task) {
+        if (closed) {
+            // do not submit new tasks when cluster is shutting down
+            return false;
+        }
+        taskQueue.submitTask(source, task, null);
+        return true;
     }
 
     // Visible for testing
@@ -433,10 +446,9 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         byte[] plaintextPek = randomKey();
         String keyId = ProjectEncryptionKeyMetadata.generateKeyId();
         logger.debug("submitting install-project-encryption-key task: keyId={}, passwordId={}", keyId, passwordId);
-        taskQueue.submitTask(
+        submitTaskIfOpen(
             "install-project-encryption-key",
-            new InstallKeyTask(keyId, plaintextPek, passwordId, threadPool.absoluteTimeInMillis()),
-            null
+            new InstallKeyTask(keyId, plaintextPek, passwordId, threadPool.absoluteTimeInMillis())
         );
     }
 
@@ -454,11 +466,10 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
         }
         byte[] plaintextPek = randomKey();
         String newKeyId = ProjectEncryptionKeyMetadata.generateKeyId();
-        taskQueue.submitTask(
-            "begin-project-encryption-key-rotation",
-            new BeginRotationTask(newKeyId, plaintextPek, threadPool.absoluteTimeInMillis(), beginRotationInFlight),
-            null
-        );
+        var task = new BeginRotationTask(newKeyId, plaintextPek, threadPool.absoluteTimeInMillis(), beginRotationInFlight);
+        if (submitTaskIfOpen("begin-project-encryption-key-rotation", task) == false) {
+            beginRotationInFlight.set(false);
+        }
     }
 
     private void schedulePasswordIdChange(ProjectEncryptionKeyMetadata metadata, String newPasswordId) {
@@ -503,11 +514,7 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
             return;
         }
         logger.info("submitting password id change: [{}] -> [{}]", oldPasswordId, newPasswordId);
-        taskQueue.submitTask("update-project-encryption-key-password-id", new UpdatePasswordIdTask(newPasswordId, oldPasswordId), null);
-    }
-
-    void submitRetireKeys(long cutoffDeactivationMillis) {
-        taskQueue.submitTask("retire-project-encryption-keys", new RetireKeysTask(cutoffDeactivationMillis), null);
+        submitTaskIfOpen("update-project-encryption-key-password-id", new UpdatePasswordIdTask(newPasswordId, oldPasswordId));
     }
 
     private static byte[] randomKey() {
@@ -574,7 +581,7 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
     record ReEncryptApplyTask(
         String customName,
         Metadata.ProjectCustom expectedOld,
-        Metadata.ProjectCustom newCustom,
+        @Nullable Metadata.ProjectCustom newCustom,
         String expectedActiveKeyId,
         ActionListener<Void> completionListener
     ) implements KeyRotationTask {
@@ -750,10 +757,12 @@ class KeyRotationCoordinator implements LocalNodeMasterListener, Closeable {
                 return Tuple.tuple(clusterState, null);
             }
             ProjectEncryptionKeyMetadata updatedPek = existing.withHandlerKeyId(task.customName(), task.expectedActiveKeyId());
-            ClusterState newState = clusterState.copyAndUpdateProject(
-                projectState.projectId(),
-                b -> b.putCustom(task.customName(), task.newCustom()).putCustom(ProjectEncryptionKeyMetadata.TYPE, updatedPek)
-            );
+            ClusterState newState = clusterState.copyAndUpdateProject(projectState.projectId(), b -> {
+                if (task.newCustom() != null) {
+                    b = b.putCustom(task.customName(), task.newCustom());
+                }
+                b.putCustom(ProjectEncryptionKeyMetadata.TYPE, updatedPek);
+            });
             return Tuple.tuple(newState, null);
         }
 

--- a/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinatorTests.java
+++ b/x-pack/plugin/encryption/src/test/java/org/elasticsearch/xpack/encryption/KeyRotationCoordinatorTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.encryption.ProjectEncryptionKeyMetadata.KeyEntry;
 import org.elasticsearch.xpack.encryption.spi.EncryptedDataHandler;
 import org.elasticsearch.xpack.encryption.spi.EncryptionService;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -417,6 +418,26 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         );
     }
 
+    public void testTickDefersKeyLifecycleWhenHandlerApplyTaskSubmitted() {
+        long generatedAt = 1_000_000_000L;
+        long now = generatedAt + TimeValue.timeValueDays(30).millis() + 1;
+        ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(
+            Map.of("k1", entry(generatedAt)),
+            "k1",
+            PASSWORD_ID,
+            Map.of(),
+            NO_OP_ENCRYPTION
+        );
+        TestCustom seeded = TestCustom.encryptedUnder("old-key");
+        AtomicInteger calls = new AtomicInteger();
+        setup(clusterStateWith(metadata, seeded, true), now, TimeValue.timeValueDays(30), List.of(captureHandler(calls, "k1")));
+
+        coordinator.tick();
+
+        assertEquals(1, calls.get());
+        verify(taskQueue).submitTask(eq("re-encrypt-test_kc_custom"), isA(KeyRotationCoordinator.ReEncryptApplyTask.class), any());
+    }
+
     public void testTickDoesNotBeginRotationWhenOneIsAlreadyInFlight() {
         long generatedAt = 1_000_000_000L;
         long now = generatedAt + TimeValue.timeValueDays(30).millis() + 1;
@@ -494,7 +515,7 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
         verify(taskQueue).submitTask(eq("re-encrypt-" + TestCustom.TYPE), isA(KeyRotationCoordinator.ReEncryptApplyTask.class), any());
     }
 
-    public void testHandlerReturningInputSkipsTaskSubmission() {
+    public void testTickSubmitsApplyTaskWhenHandlerReturnsSameCustom() {
         long now = 100L;
         ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(
             Map.of("k1", entry(50L)),
@@ -518,6 +539,46 @@ public class KeyRotationCoordinatorTests extends ESTestCase {
             }
         };
         setup(clusterStateWith(metadata, seeded, true), now, TimeValue.timeValueDays(30), List.of(identityHandler));
+
+        coordinator.tick();
+
+        ArgumentCaptor<KeyRotationCoordinator.ReEncryptApplyTask> taskCaptor = ArgumentCaptor.forClass(
+            KeyRotationCoordinator.ReEncryptApplyTask.class
+        );
+
+        assertEquals(1, calls.get());
+        verify(taskQueue).submitTask(eq("re-encrypt-" + TestCustom.TYPE), taskCaptor.capture(), any());
+
+        KeyRotationCoordinator.ReEncryptApplyTask task = taskCaptor.getValue();
+        assertSame(seeded, task.expectedOld());
+        assertSame(seeded, task.newCustom());
+        assertEquals("k1", task.expectedActiveKeyId());
+    }
+
+    public void testHandlerReturningNullForExistingCustomDoesNotSubmitApplyTask() {
+        long now = 100L;
+        ProjectEncryptionKeyMetadata metadata = new ProjectEncryptionKeyMetadata(
+            Map.of("k1", entry(50L)),
+            "k1",
+            PASSWORD_ID,
+            Map.of(),
+            NO_OP_ENCRYPTION
+        );
+        TestCustom seeded = TestCustom.encryptedUnder("k1");
+        AtomicInteger calls = new AtomicInteger();
+        EncryptedDataHandler<TestCustom> nullReturningHandler = new EncryptedDataHandler<>() {
+            @Override
+            public String customName() {
+                return TestCustom.TYPE;
+            }
+
+            @Override
+            public TestCustom reEncrypt(TestCustom current, EncryptionService svc, String activeKeyId) {
+                calls.incrementAndGet();
+                return null;
+            }
+        };
+        setup(clusterStateWith(metadata, seeded, true), now, TimeValue.timeValueDays(30), List.of(nullReturningHandler));
 
         coordinator.tick();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [unmute KeyRotationITs (#154128)](https://github.com/elastic/elasticsearch/pull/154128)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)