### PR TITLE
[9.5] ES|QL: gate field_extract pushdown, use RECHECK (#154135)

### DIFF
--- a/docs/changelog/154135.yaml
+++ b/docs/changelog/154135.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154135
+summary: "Gate `field_extract` pushdown, use RECHECK"
+type: enhancement

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FieldExtractPushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FieldExtractPushQueriesIT.java
@@ -47,16 +47,21 @@ import static org.hamcrest.Matchers.startsWith;
  * End-to-end tests that {@code field_extract(<flattened root>, "<key>") <op> <literal>} does not
  * just compile to a {@code TermQuery}/{@code TermsQuery} object in the unit tests, but actually
  * shows up as a query against the {@code <root>._keyed} sub-field in the
- * {@code LuceneSourceOperator} {@code processed_queries} profile field on the data node. The tests
- * also assert that the data-node compute pipeline drops the {@code FilterOperator}, which is the
- * signal that the predicate is being filtered by Lucene rather than re-checked per row.
+ * {@code LuceneSourceOperator} {@code processed_queries} profile field on the data node.
+ * <p>
+ *     Pushdown uses the RECHECK contract: the candidate query is pushed to Lucene <em>and</em> the
+ *     predicate is retained in a {@code FilterOperator} that re-applies it per row to restore ES|QL
+ *     single-value semantics. So the tests assert both signals: the keyed candidate query appears in
+ *     {@code processed_queries}, and the data-node compute pipeline keeps the {@code FilterOperator}
+ *     (see {@link ComputeSignature#FILTER_IN_COMPUTE}).
+ * </p>
  * <p>
  *     Parameterized over {@link Mode} so every assertion runs against {@code standard},
- *     {@code time_series} and {@code logsdb} indices. The Lucene query shape and the data-driver
- *     operator chain are mode-independent (the keyed sub-field {@code TermQuery} doesn't care
- *     about the underlying doc-values format), so the existing assertions transfer verbatim and
- *     the parameterization mainly guards against silent regressions in the per-mode index
- *     wiring (TSDB dimensions, logsdb {@code @timestamp} requirement, etc.).
+ *     {@code time_series} and {@code logsdb} indices. The candidate query is a bare
+ *     {@code TermQuery}/{@code TermsQuery}/{@code RangeQuery} with no {@code SingleValueQuery}
+ *     wrapper, so its printed shape no longer depends on the doc-values format and is identical
+ *     across modes. The parameterization mainly guards against silent regressions in the per-mode
+ *     index wiring (TSDB dimensions, logsdb {@code @timestamp} requirement, etc.).
  * </p>
  */
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
@@ -121,8 +126,8 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
     public ProfileLogger profileLogger = new ProfileLogger();
 
     /**
-     * {@code field_extract(...) == "v"} must push to a {@code TermQuery} against the keyed
-     * sub-field, so the data driver has no {@code FilterOperator}.
+     * {@code field_extract(...) == "v"} must push a candidate {@code TermQuery} against the keyed
+     * sub-field, and the data driver keeps the {@code FilterOperator} that rechecks the predicate.
      */
     public void testEqualityPushed() throws IOException {
         assumeTrue("fn_field_extract must be enabled", FieldExtract.isFnFieldExtractCapabilityMet());
@@ -134,13 +139,13 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE field_extract(%s, "%s") == "%s"
             | KEEP id
-            """, FLATTENED_ROOT, SUBKEY, value), equalTo(expectedEqualityQuery(value)), ComputeSignature.FILTER_IN_QUERY, 1);
+            """, FLATTENED_ROOT, SUBKEY, value), equalTo(expectedEqualityQuery(value)), ComputeSignature.FILTER_IN_COMPUTE, 1);
     }
 
     /**
-     * {@code field_extract(...) != "v"} must push to a negated {@code TermQuery} against the keyed
-     * sub-field. Lucene renders the negation as {@code -<inner> #<filter>} (must-not + filter); see
-     * {@link #expectedInequalityQuery} for why the filter clause depends on the index mode.
+     * {@code field_extract(...) != "v"} must push a candidate negated {@code TermQuery} against the
+     * keyed sub-field, with the {@code FilterOperator} retained for the recheck. Lucene renders the
+     * pure-negative bool as {@code #*:* -<inner>} (match-all filter + must-not).
      */
     public void testInequalityPushed() throws IOException {
         assumeTrue("fn_field_extract must be enabled", FieldExtract.isFnFieldExtractCapabilityMet());
@@ -152,7 +157,7 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE field_extract(%s, "%s") != "%s"
             | KEEP id
-            """, FLATTENED_ROOT, SUBKEY, value), equalTo(expectedInequalityQuery(value)), ComputeSignature.FILTER_IN_QUERY, 1);
+            """, FLATTENED_ROOT, SUBKEY, value), equalTo(expectedInequalityQuery(value)), ComputeSignature.FILTER_IN_COMPUTE, 1);
     }
 
     /**
@@ -171,69 +176,44 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE field_extract(%s, "%s") IN ("%s", "%s")
             | KEEP id
-            """, FLATTENED_ROOT, SUBKEY, first, second), startsWith(expectedInQueryPrefix()), ComputeSignature.FILTER_IN_QUERY, 2);
+            """, FLATTENED_ROOT, SUBKEY, first, second), startsWith(expectedInQueryPrefix()), ComputeSignature.FILTER_IN_COMPUTE, 2);
     }
 
     /**
-     * {@code SingleValueQuery} wraps the inner per-key term query at planning time but rewrites
-     * itself away to the inner query at execution time when the field can prove its doc-value set
-     * is singleton (so the per-row "single value" check would always succeed). For a flattened
-     * keyed sub-field this depends on the underlying doc-values format:
-     * <ul>
-     *   <li>{@link Mode#STANDARD} stores keyed values in {@code SortedSetDocValues}, where
-     *       singleton-ness is observable per leaf. The wrapper rewrites away and the printed
-     *       Lucene query is the bare {@code TermQuery}.</li>
-     *   <li>{@link Mode#TIME_SERIES} and {@link Mode#LOGSDB} store keyed values in
-     *       {@code BinaryDocValues} (driven by {@code IndexSettings.useTimeSeriesDocValuesFormat()},
-     *       which is on for any columnar index mode). The wrapper can't cheaply prove
-     *       singleton-ness here, so it stays and the printed query is
-     *       {@code #<inner> #single_value_match(<keyed>)}.</li>
-     * </ul>
-     * Either form is correct: pushdown still happens, the data driver still drops the
-     * {@code FilterOperator}, and per-row results are identical. The shape of the printed query
-     * just differs because of where Lucene gets to short-circuit.
+     * RECHECK pushdown emits a bare candidate {@code TermQuery} against the keyed sub-field. There is
+     * no {@code SingleValueQuery} wrapper (single-value semantics are restored by the retained
+     * {@code FilterOperator}), so the printed query no longer has a {@code single_value_match} clause
+     * and is identical across index modes.
      */
     private String expectedEqualityQuery(String value) {
-        String inner = KEYED_INTERNAL_FIELD + ":" + SUBKEY + KEYED_TERM_SEPARATOR + value;
-        return switch (mode) {
-            case STANDARD -> inner;
-            case TIME_SERIES, LOGSDB -> "#" + inner + " #single_value_match(" + KEYED_INTERNAL_FIELD + ")";
-        };
+        return KEYED_INTERNAL_FIELD + ":" + SUBKEY + KEYED_TERM_SEPARATOR + value;
     }
 
     /**
-     * Inequality already produces a {@code NotQuery} (see {@code EsqlBinaryComparison.NotEquals}),
-     * which Lucene renders as {@code -<term> #<filter>}. In {@link Mode#STANDARD} the filter slot
-     * is the {@code SingleValueQuery}'s rewritten {@code MatchAllDocsQuery} ({@code *:*}); in TSDB
-     * and logsdb the filter slot keeps the {@code single_value_match(<keyed>)} clause. Same
-     * reasoning as {@link #expectedEqualityQuery}.
+     * {@code NotEquals} produces a bare {@code NotQuery} wrapping the keyed {@code TermQuery} (see
+     * {@code NotEquals#asQuery}). A pure-negative boolean needs a positive clause to match against,
+     * so Lucene prepends a {@code MatchAllDocsQuery} filter and renders it as {@code #*:* -<term>}.
+     * There is no {@code single_value_match} clause under RECHECK, so the shape is identical across
+     * index modes.
      */
     private String expectedInequalityQuery(String value) {
-        String negated = "-" + KEYED_INTERNAL_FIELD + ":" + SUBKEY + KEYED_TERM_SEPARATOR + value;
-        return switch (mode) {
-            case STANDARD -> negated + " #*:*";
-            case TIME_SERIES, LOGSDB -> negated + " #single_value_match(" + KEYED_INTERNAL_FIELD + ")";
-        };
+        return "#*:* -" + KEYED_INTERNAL_FIELD + ":" + SUBKEY + KEYED_TERM_SEPARATOR + value;
     }
 
     /**
-     * Same {@link #expectedEqualityQuery} reasoning, applied to the {@code TermsQuery} the
+     * Same {@link #expectedEqualityQuery} reasoning, applied to the bare {@code TermsQuery} the
      * {@code IN} predicate compiles to. We only assert the leading prefix because the printed
-     * order of the byte-prefixed terms isn't stable.
+     * order of the byte-prefixed terms isn't stable. Mode-independent under RECHECK.
      */
     private String expectedInQueryPrefix() {
-        String prefix = KEYED_INTERNAL_FIELD + ":(" + SUBKEY + KEYED_TERM_SEPARATOR;
-        return switch (mode) {
-            case STANDARD -> prefix;
-            case TIME_SERIES, LOGSDB -> "#" + prefix;
-        };
+        return KEYED_INTERNAL_FIELD + ":(" + SUBKEY + KEYED_TERM_SEPARATOR;
     }
 
     /**
      * {@code field_extract(...) > "m"} pushes to a single-sided {@code RangeQuery} against the
      * keyed sub-field. The keyed flattened mapper substitutes a {@code <key>\1} sentinel for the
      * open upper bound on the data node so the Lucene term range stays inside this key's slice
-     * of the term namespace, and the data driver drops the {@code FilterOperator}.
+     * of the term namespace, and the data driver keeps the {@code FilterOperator} for the recheck.
      */
     public void testGreaterThanPushed() throws IOException {
         assumeTrue("fn_field_extract must be enabled", FieldExtract.isFnFieldExtractCapabilityMet());
@@ -245,7 +225,7 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE %s
             | KEEP id
-            """, randomizedComparison(">", "m")), equalTo(expectedLowerOnlyRangeQuery("m", false)), ComputeSignature.FILTER_IN_QUERY, 1);
+            """, randomizedComparison(">", "m")), equalTo(expectedLowerOnlyRangeQuery("m", false)), ComputeSignature.FILTER_IN_COMPUTE, 1);
     }
 
     /**
@@ -262,14 +242,14 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE %s
             | KEEP id
-            """, randomizedComparison(">=", "m")), equalTo(expectedLowerOnlyRangeQuery("m", true)), ComputeSignature.FILTER_IN_QUERY, 1);
+            """, randomizedComparison(">=", "m")), equalTo(expectedLowerOnlyRangeQuery("m", true)), ComputeSignature.FILTER_IN_COMPUTE, 1);
     }
 
     /**
      * {@code field_extract(...) < "m"} pushes to a single-sided {@code RangeQuery} against the
      * keyed sub-field. The keyed flattened mapper substitutes a {@code <key>\0} sentinel for the
      * open lower bound on the data node so the Lucene term range starts at the smallest term
-     * for this key, and the data driver drops the {@code FilterOperator}.
+     * for this key, and the data driver keeps the {@code FilterOperator} for the recheck.
      */
     public void testLessThanPushed() throws IOException {
         assumeTrue("fn_field_extract must be enabled", FieldExtract.isFnFieldExtractCapabilityMet());
@@ -281,7 +261,7 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE %s
             | KEEP id
-            """, randomizedComparison("<", "m")), equalTo(expectedUpperOnlyRangeQuery("m", false)), ComputeSignature.FILTER_IN_QUERY, 1);
+            """, randomizedComparison("<", "m")), equalTo(expectedUpperOnlyRangeQuery("m", false)), ComputeSignature.FILTER_IN_COMPUTE, 1);
     }
 
     /**
@@ -298,15 +278,16 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             FROM test
             | WHERE %s
             | KEEP id
-            """, randomizedComparison("<=", "m")), equalTo(expectedUpperOnlyRangeQuery("m", true)), ComputeSignature.FILTER_IN_QUERY, 1);
+            """, randomizedComparison("<=", "m")), equalTo(expectedUpperOnlyRangeQuery("m", true)), ComputeSignature.FILTER_IN_COMPUTE, 1);
     }
 
     /**
      * A closed range over {@code field_extract(root, "key")} (the conjunction of one {@code >=}
-     * and one {@code <=}, equivalent to {@code BETWEEN}) must push to a {@code RangeQuery}
-     * against the keyed sub-field {@code <root>._keyed} and drop the {@code FilterOperator} on
-     * the data node. The Lucene profile should show a single per-key range query with both
-     * bounds prefixed by the key's {@code <key>\0} separator.
+     * and one {@code <=}, equivalent to {@code BETWEEN}) is merged into one {@code RangeQuery} by the
+     * logical {@code CombineBinaryComparisons} rule and pushed against the keyed sub-field
+     * {@code <root>._keyed}. The data driver keeps the {@code FilterOperator} for the recheck. The
+     * Lucene profile should show a single per-key range query with both bounds prefixed by the key's
+     * {@code <key>\0} separator.
      */
     public void testBetweenPushed() throws IOException {
         assumeTrue("fn_field_extract must be enabled", FieldExtract.isFnFieldExtractCapabilityMet());
@@ -322,24 +303,24 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
                 | KEEP id
                 """, randomizedComparison(">=", "b"), randomizedComparison("<=", "y")),
             equalTo(expectedRangeQuery("b", true, "y", true)),
-            ComputeSignature.FILTER_IN_QUERY,
+            ComputeSignature.FILTER_IN_COMPUTE,
             1
         );
     }
 
     /**
-     * Expected printed form of a closed {@code field_extract} range pushed to the keyed
-     * sub-field. Mirrors {@link #expectedEqualityQuery}'s mode split: STANDARD rewrites the
-     * SVQ wrapper away (SortedSetDocValues lets the per-row singleton check trivialize at
-     * rewrite time), TIME_SERIES and LOGSDB keep the wrapper because BinaryDocValues can't
-     * prove singleton-ness up front. Lucene's {@code TermRangeQuery.toString} renders as
-     * {@code field:[lower TO upper]} for inclusive bounds (and {@code {…}} for exclusive),
-     * with each bound being the raw UTF-8 of the keyed term ({@code <key>\0<value>}).
+     * Expected printed form of a closed {@code field_extract} range pushed to the keyed sub-field.
+     * The two single-sided comparators are merged into one {@code RangeQuery} by the logical
+     * {@code CombineBinaryComparisons} rule before pushdown. Under RECHECK the range is bare (no
+     * {@code SingleValueQuery} wrapper), so the shape is identical across modes. Lucene's
+     * {@code TermRangeQuery.toString} renders as {@code field:[lower TO upper]} for inclusive bounds
+     * (and {@code {…}} for exclusive), with each bound being the raw UTF-8 of the keyed term
+     * ({@code <key>\0<value>}).
      */
     private String expectedRangeQuery(String lower, boolean includeLower, String upper, boolean includeUpper) {
         String openBracket = includeLower ? "[" : "{";
         String closeBracket = includeUpper ? "]" : "}";
-        String inner = KEYED_INTERNAL_FIELD
+        return KEYED_INTERNAL_FIELD
             + ":"
             + openBracket
             + SUBKEY
@@ -350,10 +331,6 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             + KEYED_TERM_SEPARATOR
             + upper
             + closeBracket;
-        return switch (mode) {
-            case STANDARD -> inner;
-            case TIME_SERIES, LOGSDB -> "#" + inner + " #single_value_match(" + KEYED_INTERNAL_FIELD + ")";
-        };
     }
 
     /**
@@ -361,12 +338,12 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
      * bound set, pushed to the keyed sub-field. The keyed flattened mapper substitutes
      * {@code <key>\1} (the {@link #KEYED_TERM_OPEN_UPPER_SENTINEL}) exclusive for the open upper
      * bound. The bracket choice reflects only the caller-supplied {@code includeLower}: the
-     * upper side is always exclusive because the sentinel itself is exclusive. Same SVQ
-     * rewrite rules as {@link #expectedRangeQuery}.
+     * upper side is always exclusive because the sentinel itself is exclusive. Bare range under
+     * RECHECK, so the shape is identical across modes.
      */
     private String expectedLowerOnlyRangeQuery(String lower, boolean includeLower) {
         String openBracket = includeLower ? "[" : "{";
-        String inner = KEYED_INTERNAL_FIELD
+        return KEYED_INTERNAL_FIELD
             + ":"
             + openBracket
             + SUBKEY
@@ -376,10 +353,6 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
             + SUBKEY
             + KEYED_TERM_OPEN_UPPER_SENTINEL
             + "}";
-        return switch (mode) {
-            case STANDARD -> inner;
-            case TIME_SERIES, LOGSDB -> "#" + inner + " #single_value_match(" + KEYED_INTERNAL_FIELD + ")";
-        };
     }
 
     /**
@@ -388,40 +361,22 @@ public class FieldExtractPushQueriesIT extends ESRestTestCase {
      * {@code <key>\0} (the {@link #KEYED_TERM_SEPARATOR}) inclusive for the open lower bound,
      * which is the encoding of value {@code ""} and the smallest term in this key's slice. The
      * bracket choice reflects only the caller-supplied {@code includeUpper}: the lower side is
-     * always inclusive because the sentinel is inclusive. Same SVQ rewrite rules as
-     * {@link #expectedRangeQuery}.
+     * always inclusive because the sentinel is inclusive. Bare range under RECHECK, so the shape is
+     * identical across modes.
      */
     private String expectedUpperOnlyRangeQuery(String upper, boolean includeUpper) {
         String closeBracket = includeUpper ? "]" : "}";
-        String inner = KEYED_INTERNAL_FIELD
-            + ":["
-            + SUBKEY
-            + KEYED_TERM_SEPARATOR
-            + " TO "
-            + SUBKEY
-            + KEYED_TERM_SEPARATOR
-            + upper
-            + closeBracket;
-        return switch (mode) {
-            case STANDARD -> inner;
-            case TIME_SERIES, LOGSDB -> "#" + inner + " #single_value_match(" + KEYED_INTERNAL_FIELD + ")";
-        };
+        return KEYED_INTERNAL_FIELD + ":[" + SUBKEY + KEYED_TERM_SEPARATOR + " TO " + SUBKEY + KEYED_TERM_SEPARATOR + upper + closeBracket;
     }
 
     /**
-     * Compute signatures expected on the data driver. {@link #FILTER_IN_QUERY} mirrors
-     * {@code PushQueriesIT.ComputeSignature.FILTER_IN_QUERY} (no FilterOperator). The
-     * {@link #FILTER_IN_COMPUTE} case has an extra {@code ValuesSourceReaderOperator} after
-     * {@code LimitOperator} because the WHERE clause reads the flattened sub-field and the
-     * KEEP clause reads {@code id}; with two distinct fields we end up with two reader stages.
+     * Compute signature expected on the data driver. Under RECHECK the candidate query is pushed to
+     * Lucene <em>and</em> the predicate is retained, so every {@code field_extract} pushdown keeps a
+     * {@code FilterOperator}. {@link #FILTER_IN_COMPUTE} has two {@code ValuesSourceReaderOperator}
+     * stages because the WHERE clause reads the flattened sub-field and the KEEP clause reads
+     * {@code id}; with two distinct fields we end up with two reader stages.
      */
     private enum ComputeSignature {
-        FILTER_IN_QUERY(
-            matchesList().item("LuceneSourceOperator")
-                .item("ValuesSourceReaderOperator")
-                .item("ProjectOperator")
-                .item("ExchangeSinkOperator")
-        ),
         FILTER_IN_COMPUTE(
             matchesList().item("LuceneSourceOperator")
                 .item("ValuesSourceReaderOperator")

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/field_extract.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/field_extract.csv-spec
@@ -522,10 +522,11 @@ FROM flattened_otel_logs
 2020-01-01T11:38:54.751Z
 ;
 
-// != on a literal flat key pushes to a NotQuery wrapping a TermQuery against the keyed
-// sub-field, wrapped in SingleValueQuery so the result matches the per-row evaluator's
-// "multi-value compares to null" semantics. A doc only contributes to the count if its
-// host.name key is present, single-valued, and not equal to the literal.
+// != on a literal flat key pushes a candidate NotQuery wrapping a TermQuery against the keyed
+// sub-field. The comparison reports RECHECK, so the FilterOperator re-applies the predicate on the
+// extracted keyword column to match the per-row evaluator's "multi-value compares to null" semantics.
+// A doc only contributes to the count if its host.name key is present, single-valued, and not equal
+// to the literal.
 notEqualsPushedToKeyedSubfield
 required_capability: fn_field_extract
 required_capability: flattened_datatype
@@ -539,8 +540,8 @@ c:long
 9
 ;
 
-// IN on a literal flat key pushes to a TermsQuery against the keyed sub-field, again
-// wrapped in SingleValueQuery for ES|QL-consistent multi-value semantics.
+// IN on a literal flat key pushes a candidate TermsQuery against the keyed sub-field, again with a
+// RECHECK filter re-applying the predicate for ES|QL-consistent multi-value semantics.
 inListPushedToKeyedSubfield
 required_capability: fn_field_extract
 required_capability: flattened_datatype
@@ -559,9 +560,9 @@ FROM flattened_otel_logs
 
 // Scalar == against a multi-value extract emits the standard "single-value function
 // encountered multi-value" warning and treats the result as null, so the count is zero.
-// Both paths arrive at the same warning text: the pushdown path through the
-// SingleValueQuery wrapping the keyed sub-field, and the parse path through the per-row
-// Equals operator on the multi-value keyword block.
+// The pushdown path matches the doc as a candidate, then the RECHECK filter re-evaluates the
+// per-row Equals operator on the multi-value keyword block, arriving at the same warning text and
+// null result as the parse path.
 multiValuedSubkeyDoesNotMatchScalarEquality
 required_capability: fn_field_extract
 required_capability: flattened_datatype
@@ -577,6 +578,25 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
 
 c:long
 0
+;
+
+// The paranoid NOT + RECHECK case: != against a multi-value extract must null out (not count) the
+// multi-valued documents, exactly like ==
+multiValuedSubkeyDoesNotMatchScalarInequality
+required_capability: fn_field_extract
+required_capability: flattened_datatype
+required_capability: field_extract_returns_multi_value
+
+FROM flattened_otel_logs
+| WHERE field_extract(resource.attributes, "host.ip") != "10.224.0.170"
+| STATS c = count(*)
+;
+
+warning:Line 2:9: evaluation of [field_extract(resource.attributes, \"host.ip\") != \"10.224.0.170\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+c:long
+2
 ;
 
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtract.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -392,8 +393,22 @@ public class FieldExtract extends EsqlScalarFunction implements BlockLoaderExpre
      * returns the synthetic data-node field name (e.g. {@code "resource.attributes.host.name"}).
      * The data node's {@code FieldTypeLookup} resolves this name to a
      * {@code KeyedFlattenedFieldType} which handles the key-prefix encoding in
-     * {@code indexedValueForSearch}. The caller is responsible for wrapping the produced query
-     * in a {@code SingleValueQuery} to preserve ES|QL's single-value comparison semantics.
+     * {@code indexedValueForSearch}.
+     * <p>
+     *     The produced query is a <em>candidate</em> query: it matches every document whose keyed
+     *     sub-field holds the value under that key, including multi-valued documents. Exact ES|QL
+     *     single-value semantics are restored by rechecking the predicate in the compute engine, so
+     *     the comparison operators report {@link TranslationAware.Translatable#RECHECK} rather than
+     *     wrapping the query in a {@code SingleValueQuery}. A {@code SingleValueQuery} would have to
+     *     decompress the flattened field's binary doc values to count the values per document; the
+     *     recheck instead reuses the keyword column the evaluator already extracts, which is far cheaper.
+     * </p>
+     * <p>
+     *     Pushdown requires the flattened root to be <strong>indexed</strong>. The candidate query is
+     *     only worthwhile against a real postings list; on a doc-values-only field the keyed term query
+     *     degrades to a full doc-values scan, which is no better than running the predicate as a plain
+     *     filter. In that case this returns empty so the comparison stays in the {@code FilterExec}.
+     * </p>
      * <p>
      *     Explicitly mapped sub-fields are <strong>not</strong> pushed: for them the synthetic name
      *     resolves to the real typed field (e.g. an {@code ip} or {@code long}), so a pushed query
@@ -412,6 +427,7 @@ public class FieldExtract extends EsqlScalarFunction implements BlockLoaderExpre
             return Optional.empty();
         }
         return foldedKeyForFlattenedRoot().filter(k -> pushdownPredicates.isIndexedAndHasDocValues(k.root()))
+            .filter(k -> pushdownPredicates.isIndexed(k.root()))
             .filter(
                 k -> pushdownPredicates.supportsLoaderConfig(
                     k.root(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/Range.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
-import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 import org.elasticsearch.xpack.versionfield.Version;
 
 import java.io.IOException;
@@ -233,7 +232,9 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
             return Translatable.YES;
         }
         if (value instanceof FieldExtract fe && fe.tryAsKeyedSubfieldName(pushdownPredicates).isPresent()) {
-            return Translatable.YES;
+            // Candidate range against the keyed sub-field; RECHECK keeps the predicate in the
+            // FilterOperator to null out multi-valued documents the range let through.
+            return Translatable.RECHECK;
         }
         return Translatable.NO;
     }
@@ -250,17 +251,16 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
     }
 
     /**
-     * Translates a closed range over {@code field_extract(root, "key")} to a {@link RangeQuery}
+     * Translates a closed range over {@code field_extract(root, "key")} to a candidate {@link RangeQuery}
      * on the synthetic data-node field name {@code root.key}. The data node's
      * {@code FieldTypeLookup} resolves that name to a {@code KeyedFlattenedFieldType} which
      * prefixes both bounds with {@code key + "\0"} at search time, keeping the range inside the
      * key's slice of the {@code _keyed} term space.
      * <p>
-     * The result is wrapped in {@link SingleValueQuery} so that the multi-valued-sub-key
-     * semantics match the per-row evaluator's "multi-value compares to null" rule (consistent
-     * with how {@code Equals}/{@code NotEquals}/{@code In} on {@code field_extract} wrap their
-     * {@code TermQuery}/{@code TermsQuery}). {@code useSyntheticSourceDelegate} is {@code false}
-     * because the keyed sub-field is not addressed via a synthetic-source delegate.
+     * The range is not wrapped in a {@code SingleValueQuery}: {@link #translatable} reports
+     * {@code RECHECK} (consistent with how {@code Equals}/{@code NotEquals}/{@code In} on
+     * {@code field_extract} push a bare candidate query), so the FilterOperator re-applies the range on
+     * the extracted keyword column and nulls out multi-valued documents the candidate range let through.
      */
     private Query translateFieldExtractRange(String keyedName) {
         Object lo = literalValueOf(lower);
@@ -271,17 +271,7 @@ public class Range extends ScalarFunction implements TranslationAware.SingleValu
         if (hi instanceof BytesRef br) {
             hi = br.utf8ToString();
         }
-        RangeQuery rangeQuery = new RangeQuery(
-            source(),
-            keyedName,
-            lo,
-            includeLower,
-            hi,
-            includeUpper,
-            /* format */ null,
-            /* zoneId */ null
-        );
-        return new SingleValueQuery(rangeQuery, keyedName, false);
+        return new RangeQuery(source(), keyedName, lo, includeLower, hi, includeUpper, /* format */ null, /* zoneId */ null);
     }
 
     private RangeQuery translate(TranslatorHandler handler) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
@@ -190,8 +190,7 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
                         if (value instanceof BytesRef br) {
                             value = br.utf8ToString();
                         }
-                        TermQuery termQuery = new TermQuery(source(), kn, value);
-                        return new SingleValueQuery(termQuery, kn, false);
+                        return new TermQuery(source(), kn, value);
                     }).orElseThrow();
                 }
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
@@ -382,7 +382,7 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
                 return this instanceof Equals || this instanceof NotEquals ? Translatable.YES : Translatable.NO;
             }
             if (left() instanceof FieldExtract fe && fe.tryAsKeyedSubfieldName(pushdownPredicates).isPresent()) {
-                return Translatable.YES;
+                return Translatable.RECHECK;
             }
         }
         return Translatable.NO;
@@ -425,11 +425,14 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
     }
 
     /**
-     * Build a {@link SingleValueQuery}-wrapped {@link RangeQuery} against the synthetic
-     * {@code <root>.<key>} sub-field for a {@code field_extract(...)} LHS. The keyed flattened
-     * mapper substitutes the missing side with a key-prefix sentinel so the resulting Lucene
-     * range stays inside this key's portion of the term namespace, which lets us push the
-     * one-sided shape that the original mapper rejected.
+     * Build a candidate {@link RangeQuery} against the synthetic {@code <root>.<key>} sub-field for a
+     * {@code field_extract(...)} LHS. The keyed flattened mapper substitutes the missing side with a
+     * key-prefix sentinel so the resulting Lucene range stays inside this key's portion of the term
+     * namespace, which lets us push the one-sided shape that the original mapper rejected.
+     * <p>
+     * The range is not wrapped in a {@link SingleValueQuery}: the comparison reports
+     * {@link Translatable#RECHECK}, so the FilterOperator re-evaluates the predicate on the extracted
+     * keyword column and nulls out multi-valued documents that the candidate range let through.
      * <p>
      * Only the range comparators ({@code >}, {@code >=}, {@code <}, {@code <=}) reach this
      * helper. {@link Equals} and {@link NotEquals} override {@link #asQuery} so they never
@@ -441,22 +444,16 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
         if (value instanceof BytesRef br) {
             value = br.utf8ToString();
         }
-        RangeQuery inner;
-        if (this instanceof GreaterThan) {
-            inner = new RangeQuery(source(), keyedName, value, false, null, false, null, null);
-        } else if (this instanceof GreaterThanOrEqual) {
-            inner = new RangeQuery(source(), keyedName, value, true, null, false, null, null);
-        } else if (this instanceof LessThan) {
-            inner = new RangeQuery(source(), keyedName, null, false, value, false, null, null);
-        } else if (this instanceof LessThanOrEqual) {
-            inner = new RangeQuery(source(), keyedName, null, false, value, true, null, null);
-        } else {
-            throw new QlIllegalArgumentException(
+        return switch (this) {
+            case GreaterThan ignored -> new RangeQuery(source(), keyedName, value, false, null, false, null, null);
+            case GreaterThanOrEqual ignored -> new RangeQuery(source(), keyedName, value, true, null, false, null, null);
+            case LessThan ignored -> new RangeQuery(source(), keyedName, null, false, value, false, null, null);
+            case LessThanOrEqual ignored -> new RangeQuery(source(), keyedName, null, false, value, true, null, null);
+            default -> throw new QlIllegalArgumentException(
                 "Unexpected comparison [{}] for field_extract range pushdown",
                 this.getClass().getSimpleName()
             );
-        }
-        return new SingleValueQuery(inner, keyedName, false);
+        };
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
@@ -44,7 +44,6 @@ import org.elasticsearch.xpack.esql.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
-import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
@@ -513,7 +512,9 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
             return Translatable.YES;
         }
         if (value instanceof FieldExtract fe && fe.tryAsKeyedSubfieldName(pushdownPredicates).isPresent()) {
-            return Translatable.YES;
+            // Candidate terms query against the keyed sub-field; RECHECK keeps the predicate in the
+            // FilterOperator to null out multi-valued documents the candidate matched.
+            return Translatable.RECHECK;
         }
         return Translatable.NO;
     }
@@ -564,14 +565,15 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
     }
 
     /**
-     * Translate {@code field_extract(<flattened root>, "<key>") IN (<literals>)} into a
+     * Translate {@code field_extract(<flattened root>, "<key>") IN (<literals>)} into a candidate
      * {@link TermsQuery} against the keyed sub-field. The data node's {@code FieldTypeLookup}
      * resolves {@code <root>.<key>} to a {@code KeyedFlattenedFieldType} which prefixes each term
      * with the key separator at search time.
      * <p>
-     *     The result is wrapped in {@link SingleValueQuery} to preserve ES|QL's single-value-only
-     *     comparison semantics for multi-valued sub-keys (consistent with {@code field_extract}
-     *     used inside {@code Equals}/{@code NotEquals}).
+     *     The terms query is not wrapped in a {@code SingleValueQuery}: {@link #translatable} reports
+     *     {@code RECHECK} (consistent with {@code field_extract} used inside {@code Equals}/{@code NotEquals}),
+     *     so the FilterOperator re-applies the {@code IN} on the extracted keyword column and nulls out
+     *     multi-valued documents the candidate matched.
      * </p>
      */
     private Query translateFieldExtractIn(String keyedName) {
@@ -593,7 +595,7 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
             // an IN to a constant false beforehand, so this branch is defensive.
             throw new EsqlIllegalArgumentException("field_extract IN with all-null list cannot be translated to a query");
         }
-        return new SingleValueQuery(new TermsQuery(source(), keyedName, terms), keyedName, false);
+        return new TermsQuery(source(), keyedName, terms);
     }
 
     private static boolean needsTypeSpecificValueHandling(DataType fieldType) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEquals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEquals.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtra
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.EsqlArithmeticOperation;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
-import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 
 import java.time.ZoneId;
 import java.util.Collection;
@@ -239,8 +238,10 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
                         value = br.utf8ToString();
                     }
                     TermQuery termQuery = new TermQuery(source(), kn, value);
-
-                    return new SingleValueQuery(new NotQuery(source(), termQuery), kn, false);
+                    // Candidate query: documents not carrying this key/value are a superset of the true
+                    // "!=" matches. The optimizer marks this RECHECK so the FilterOperator restores exact
+                    // single-value semantics (multi-valued and missing-key documents null out).
+                    return new NotQuery(source(), termQuery);
                 }).orElseThrow();
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.PhysicalNames;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
@@ -43,11 +42,8 @@ import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 
 import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
@@ -416,7 +412,7 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
         LucenePushdownPredicates pushdownPredicates,
         AttributeMap<Attribute> aliasReplacedBy
     ) {
-        List<Expression> conjuncts = combineFieldExtractRangePairs(splitAnd(condition), pushdownPredicates, aliasReplacedBy);
+        List<Expression> conjuncts = splitAnd(condition);
 
         List<Expression> pushable = new ArrayList<>();
         List<Expression> nonPushable = new ArrayList<>();
@@ -434,99 +430,5 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
             }
         }
         return new PushdownClassification(pushable, nonPushable);
-    }
-
-    /**
-     * Pre-combines pairs of {@code field_extract(root, "key") >|>= lo} and
-     * {@code field_extract(root, "key") <|<= hi} conjuncts into a single {@link Range} node so
-     * the closed range can push to a {@code RangeQuery} on the keyed sub-field {@code root.key}.
-     * Single-sided ranges over {@code field_extract} are left untouched: the underlying
-     * {@code KeyedFlattenedFieldType.rangeQuery} requires both bounds, so an open range cannot
-     * be safely pushed.
-     * <p>
-     * Two {@code field_extract} expressions are considered the same LHS when
-     * {@link FieldExtract#tryAsKeyedSubfieldName} returns the same synthetic field name for
-     * both. {@code aliasReplacedBy} is applied to each conjunct before the inspection so the
-     * {@code | EVAL e = field_extract(F, "k") | WHERE e >= "a" AND e <= "z"} shape is folded
-     * identically to writing the {@code field_extract} call inline.
-     * <p>
-     * Runs <em>before</em> classification because the individual halves are not pushable in
-     * isolation; the mirror combiner {@link #combineEligiblePushableToRange} runs <em>after</em>
-     * classification because for indexed {@link Attribute} LHS the individual comparisons are
-     * already pushable.
-     * <p>
-     * Package-private so the unit tests in {@code PushFiltersToSourceTests} can drive it
-     * directly (same pattern as {@link #referencesAnyColumn}).
-     */
-    static List<Expression> combineFieldExtractRangePairs(
-        List<Expression> conjuncts,
-        LucenePushdownPredicates pushdownPredicates,
-        AttributeMap<Attribute> aliasReplacedBy
-    ) {
-        // Holds the BC in its alias-resolved form (so the produced Range references the
-        // underlying field_extract directly, never a ReferenceAttribute alias).
-        record Half(int conjunctIndex, EsqlBinaryComparison resolvedBc) {}
-
-        Map<String, Half> lowerByKeyedName = new LinkedHashMap<>();
-        Map<String, Half> upperByKeyedName = new LinkedHashMap<>();
-
-        for (int i = 0; i < conjuncts.size(); i++) {
-            Expression resolved = aliasReplacedBy.isEmpty()
-                ? conjuncts.get(i)
-                : conjuncts.get(i).transformUp(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
-
-            if (resolved instanceof EsqlBinaryComparison bc && bc.right().foldable() && bc.left() instanceof FieldExtract fe) {
-                Optional<String> keyedName = fe.tryAsKeyedSubfieldName(pushdownPredicates);
-                if (keyedName.isEmpty()) {
-                    continue;
-                }
-                String name = keyedName.get();
-                if (bc instanceof GreaterThan || bc instanceof GreaterThanOrEqual) {
-                    lowerByKeyedName.putIfAbsent(name, new Half(i, bc));
-                } else if (bc instanceof LessThan || bc instanceof LessThanOrEqual) {
-                    upperByKeyedName.putIfAbsent(name, new Half(i, bc));
-                }
-            }
-        }
-
-        if (lowerByKeyedName.isEmpty() || upperByKeyedName.isEmpty()) {
-            return conjuncts;
-        }
-
-        BitSet consumed = new BitSet(conjuncts.size());
-        List<Expression> additions = new ArrayList<>();
-        for (Map.Entry<String, Half> entry : lowerByKeyedName.entrySet()) {
-            Half lower = entry.getValue();
-            Half upper = upperByKeyedName.get(entry.getKey());
-            if (upper == null) {
-                continue;
-            }
-            consumed.set(lower.conjunctIndex);
-            consumed.set(upper.conjunctIndex);
-            additions.add(
-                new Range(
-                    lower.resolvedBc.source(),
-                    lower.resolvedBc.left(),
-                    lower.resolvedBc.right(),
-                    lower.resolvedBc instanceof GreaterThanOrEqual,
-                    upper.resolvedBc.right(),
-                    upper.resolvedBc instanceof LessThanOrEqual,
-                    lower.resolvedBc.zoneId()
-                )
-            );
-        }
-
-        if (additions.isEmpty()) {
-            return conjuncts;
-        }
-
-        List<Expression> result = new ArrayList<>(conjuncts.size() - additions.size());
-        for (int i = 0; i < conjuncts.size(); i++) {
-            if (consumed.get(i) == false) {
-                result.add(conjuncts.get(i));
-            }
-        }
-        result.addAll(additions);
-        return result;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/TranslatorHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/TranslatorHandler.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 
@@ -42,6 +43,13 @@ public final class TranslatorHandler {
     private static Query wrapFunctionQuery(Expression field, Query query) {
         if (query instanceof SingleValueQuery) {
             // Already wrapped
+            return query;
+        }
+        if (field instanceof FieldExtract) {
+            // field_extract query pushdown produces a candidate (superset) query and always reports
+            // Translatable.RECHECK, so the retained FilterOperator restores single-value semantics. The
+            // value comes from a keyed flattened sub-field, not a FieldAttribute, so there is nothing to
+            // wrap in a SingleValueQuery; the candidate query is pushed as-is.
             return query;
         }
         if (field instanceof FieldAttribute fa) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractQueryPushdownTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractQueryPushdownTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Not
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
-import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.util.Collections;
@@ -50,9 +49,11 @@ import static org.hamcrest.Matchers.equalTo;
  * {@code field_extract(<flattened root>, "<key>")} appears on the left of {@code ==}, {@code !=},
  * {@code IN}, the range comparators ({@code >}, {@code >=}, {@code <}, {@code <=}), or the
  * {@link Range} expression (combined {@code >=}/{@code <=} closed range), the predicate is
- * translated into a Lucene {@code TermQuery}, {@code TermsQuery}, or {@code RangeQuery} against
- * the synthetic keyed sub-field name ({@code <root>.<key>}) and wrapped in
- * {@code SingleValueQuery}.
+ * translated into a bare candidate Lucene {@code TermQuery}, {@code TermsQuery}, or {@code RangeQuery}
+ * against the synthetic keyed sub-field name ({@code <root>.<key>}). The comparison reports
+ * {@link TranslationAware.Translatable#RECHECK}, so the FilterOperator re-applies the predicate on the
+ * extracted keyword column to restore ES|QL single-value semantics instead of wrapping the query in a
+ * {@code SingleValueQuery}. Pushdown only fires when the flattened root is indexed.
  * <p>
  *     The {@link FieldExtract#tryAsKeyedSubfieldName(LucenePushdownPredicates)} helper drives the
  *     recognition. The translation lives inside {@code EsqlBinaryComparison.asQuery} (for
@@ -221,7 +222,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
         assertThat(eq.translatable(mappedKeyPredicates()), equalTo(TranslationAware.Translatable.NO));
     }
 
-    public void testEqualsTranslatableYesForFieldExtractOnFlattened() {
+    public void testEqualsTranslatableRecheckForFieldExtractOnFlattened() {
         assumeQueryPushdownEnabled();
         Equals eq = new Equals(
             Source.EMPTY,
@@ -229,10 +230,11 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             Literal.keyword(Source.EMPTY, "node-a")
         );
 
-        assertThat(eq.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        // field_extract pushes a candidate query and rechecks single-value equality in the compute engine.
+        assertThat(eq.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
-    public void testNotEqualsTranslatableYesForFieldExtractOnFlattened() {
+    public void testNotEqualsTranslatableRecheckForFieldExtractOnFlattened() {
         assumeQueryPushdownEnabled();
         NotEquals neq = new NotEquals(
             Source.EMPTY,
@@ -240,7 +242,22 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             Literal.keyword(Source.EMPTY, "node-a")
         );
 
-        assertThat(neq.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(neq.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
+    }
+
+    /**
+     * A doc-values-only flattened root (not indexed) must not push: the keyed term query would degrade to a
+     * full doc-values scan. The predicate stays in the FilterExec instead.
+     */
+    public void testEqualsTranslatableNoWhenRootNotIndexed() {
+        assumeQueryPushdownEnabled();
+        Equals eq = new Equals(
+            Source.EMPTY,
+            new FieldExtract(Source.EMPTY, flattenedField(FLATTENED_ROOT_NAME), Literal.keyword(Source.EMPTY, "host.name")),
+            Literal.keyword(Source.EMPTY, "node-a")
+        );
+
+        assertThat(eq.translatable(docValuesOnlyKeyPredicates()), equalTo(TranslationAware.Translatable.NO));
     }
 
     /**
@@ -257,7 +274,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             Literal.keyword(Source.EMPTY, "node-a")
         );
 
-        assertThat(gt.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(gt.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
     public void testGreaterThanOrEqualTranslatableYesForFieldExtractOnFlattened() {
@@ -268,7 +285,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             Literal.keyword(Source.EMPTY, "node-a")
         );
 
-        assertThat(gte.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(gte.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
     public void testLessThanTranslatableYesForFieldExtractOnFlattened() {
@@ -279,7 +296,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             Literal.keyword(Source.EMPTY, "node-a")
         );
 
-        assertThat(lt.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(lt.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
     public void testLessThanOrEqualTranslatableYesForFieldExtractOnFlattened() {
@@ -290,7 +307,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             Literal.keyword(Source.EMPTY, "node-a")
         );
 
-        assertThat(lte.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(lte.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
     /**
@@ -346,7 +363,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             null
         );
 
-        assertThat(range.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(range.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
     /**
@@ -401,11 +418,11 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
     }
 
     /**
-     * The translated query must be a {@code RangeQuery} on the synthetic {@code root.key} field
-     * name wrapped in {@code SingleValueQuery}, mirroring how {@code Equals}/{@code NotEquals}/
-     * {@code In} on the same LHS wrap their term queries.
+     * The translated query must be a bare {@code RangeQuery} on the synthetic {@code root.key} field
+     * name, mirroring how {@code Equals}/{@code NotEquals}/{@code In} on the same LHS push bare candidate
+     * queries. Exact single-value semantics come from the RECHECK filter, not a {@code SingleValueQuery}.
      */
-    public void testRangeAsQueryProducesSingleValueWrappedRangeQueryAgainstKeyedSubfield() {
+    public void testRangeAsQueryProducesBareRangeQueryAgainstKeyedSubfield() {
         assumeQueryPushdownEnabled();
         String keyedName = "resource.attributes.host.name";
         Range range = new Range(
@@ -420,15 +437,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = range.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        // SingleValueQuery wrapping is mandatory for the same reason it is on Equals/NotEquals/In: a
-        // multi-valued sub-key would otherwise let any of its values satisfy the range,
-        // which contradicts ES|QL's "multi-value compares to null" rule.
-        assertThat(
-            query,
-            equalTo(
-                new SingleValueQuery(new RangeQuery(Source.EMPTY, keyedName, "node-a", true, "node-z", true, null, null), keyedName, false)
-            )
-        );
+        assertThat(query, equalTo(new RangeQuery(Source.EMPTY, keyedName, "node-a", true, "node-z", true, null, null)));
     }
 
     /**
@@ -458,13 +467,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
                 assertThat(
                     "for (includeLower=" + includeLower + ", includeUpper=" + includeUpper + ")",
                     query,
-                    equalTo(
-                        new SingleValueQuery(
-                            new RangeQuery(Source.EMPTY, keyedName, "node-a", includeLower, "node-z", includeUpper, null, null),
-                            keyedName,
-                            false
-                        )
-                    )
+                    equalTo(new RangeQuery(Source.EMPTY, keyedName, "node-a", includeLower, "node-z", includeUpper, null, null))
                 );
             }
         }
@@ -474,9 +477,8 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
      * The translated query for {@code field_extract(...) > "lo"} is a {@code RangeQuery} with the
      * literal on the lower side, exclusive, and a {@code null} upper side. The keyed flattened
      * mapper expands the open upper into the {@code key\1} sentinel on the data node so the
-     * resulting Lucene range stays inside this key's slice of the term namespace. The query is
-     * wrapped in {@code SingleValueQuery} for the same multi-value safety reason as the other
-     * comparators.
+     * resulting Lucene range stays inside this key's slice of the term namespace. The query is a bare
+     * candidate range; RECHECK restores exact single-value semantics in the FilterOperator.
      */
     public void testGreaterThanAsQueryProducesLowerOnlyExclusiveRangeQuery() {
         assumeQueryPushdownEnabled();
@@ -489,12 +491,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = gt.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(
-            query,
-            equalTo(
-                new SingleValueQuery(new RangeQuery(Source.EMPTY, keyedName, "node-a", false, null, false, null, null), keyedName, false)
-            )
-        );
+        assertThat(query, equalTo(new RangeQuery(Source.EMPTY, keyedName, "node-a", false, null, false, null, null)));
     }
 
     /**
@@ -513,12 +510,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = gte.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(
-            query,
-            equalTo(
-                new SingleValueQuery(new RangeQuery(Source.EMPTY, keyedName, "node-a", true, null, false, null, null), keyedName, false)
-            )
-        );
+        assertThat(query, equalTo(new RangeQuery(Source.EMPTY, keyedName, "node-a", true, null, false, null, null)));
     }
 
     /**
@@ -538,12 +530,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = lt.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(
-            query,
-            equalTo(
-                new SingleValueQuery(new RangeQuery(Source.EMPTY, keyedName, null, false, "node-z", false, null, null), keyedName, false)
-            )
-        );
+        assertThat(query, equalTo(new RangeQuery(Source.EMPTY, keyedName, null, false, "node-z", false, null, null)));
     }
 
     /**
@@ -562,12 +549,7 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = lte.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(
-            query,
-            equalTo(
-                new SingleValueQuery(new RangeQuery(Source.EMPTY, keyedName, null, false, "node-z", true, null, null), keyedName, false)
-            )
-        );
+        assertThat(query, equalTo(new RangeQuery(Source.EMPTY, keyedName, null, false, "node-z", true, null, null)));
     }
 
     /**
@@ -601,10 +583,10 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
             List.of(Literal.keyword(Source.EMPTY, "node-a"), Literal.keyword(Source.EMPTY, "node-b"))
         );
 
-        assertThat(in.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.YES));
+        assertThat(in.translatable(UNMAPPED_KEY_PREDICATES), equalTo(TranslationAware.Translatable.RECHECK));
     }
 
-    public void testEqualsAsQueryProducesSingleValueWrappedTermQueryAgainstKeyedSubfield() {
+    public void testEqualsAsQueryProducesBareTermQueryAgainstKeyedSubfield() {
         assumeQueryPushdownEnabled();
         String keyedName = "resource.attributes.host.name";
         Equals eq = new Equals(
@@ -615,12 +597,12 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = eq.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        // SVQ wrapping is mandatory: a multi-valued sub-key would otherwise let any of its values
-        // satisfy the term match, which contradicts ES|QL's "multi-value compares to null" rule.
-        assertThat(query, equalTo(new SingleValueQuery(new TermQuery(Source.EMPTY, keyedName, "node-a"), keyedName, false)));
+        // Bare candidate term query: the comparison reports RECHECK, so single-value equality is restored by
+        // the FilterOperator rechecking the extracted keyword column, not by a SingleValueQuery wrapper.
+        assertThat(query, equalTo(new TermQuery(Source.EMPTY, keyedName, "node-a")));
     }
 
-    public void testNotEqualsAsQueryProducesSingleValueWrappedNotTermQuery() {
+    public void testNotEqualsAsQueryProducesBareNotTermQuery() {
         assumeQueryPushdownEnabled();
         String keyedName = "resource.attributes.host.name";
         NotEquals neq = new NotEquals(
@@ -631,13 +613,11 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
 
         Query query = neq.asQuery(UNMAPPED_KEY_PREDICATES, TranslatorHandler.TRANSLATOR_HANDLER);
 
-        assertThat(
-            query,
-            equalTo(new SingleValueQuery(new NotQuery(Source.EMPTY, new TermQuery(Source.EMPTY, keyedName, "node-a")), keyedName, false))
-        );
+        // Bare candidate NotQuery; RECHECK restores exact "!=" semantics in the FilterOperator.
+        assertThat(query, equalTo(new NotQuery(Source.EMPTY, new TermQuery(Source.EMPTY, keyedName, "node-a"))));
     }
 
-    public void testInAsQueryProducesSingleValueWrappedTermsQuery() {
+    public void testInAsQueryProducesBareTermsQuery() {
         assumeQueryPushdownEnabled();
         String keyedName = "resource.attributes.host.name";
         In in = new In(
@@ -653,7 +633,8 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
         LinkedHashSet<Object> expectedTerms = new LinkedHashSet<>();
         expectedTerms.add("node-a");
         expectedTerms.add("node-b");
-        assertThat(query, equalTo(new SingleValueQuery(new TermsQuery(Source.EMPTY, keyedName, expectedTerms), keyedName, false)));
+        // Bare candidate terms query; RECHECK restores exact IN semantics in the FilterOperator.
+        assertThat(query, equalTo(new TermsQuery(Source.EMPTY, keyedName, expectedTerms)));
     }
 
     public void testInAsQueryThrowsForAllNullList() {
@@ -690,6 +671,20 @@ public class FieldExtractQueryPushdownTests extends ESTestCase {
      */
     private static LucenePushdownPredicates mappedKeyPredicates() {
         return LucenePushdownPredicates.from(new EsqlTestUtils.TestSearchStats(false), new EsqlFlags(true));
+    }
+
+    /**
+     * A predicate whose {@code SearchStats} reports the flattened root as having doc values but not being
+     * indexed, mirroring a columnar flattened field without a postings index. Query pushdown must decline
+     * so the predicate stays in the {@code FilterExec} rather than pushing a full doc-values scan.
+     */
+    private static LucenePushdownPredicates docValuesOnlyKeyPredicates() {
+        return LucenePushdownPredicates.from(new EsqlTestUtils.TestSearchStats() {
+            @Override
+            public boolean isIndexed(FieldAttribute.FieldName field) {
+                return false;
+            }
+        }, new EsqlFlags(true));
     }
 
     private static void assumeQueryPushdownEnabled() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSourceTests.java
@@ -8,34 +8,18 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
-import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
-import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
-import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 
 /**
  * Verifies that {@link PushFiltersToSource#resolveFormatName} delegates to
@@ -88,206 +72,7 @@ public class PushFiltersToSourceTests extends ESTestCase {
         assertFalse(PushFiltersToSource.referencesAnyColumn(lit, Set.of("lang")));
     }
 
-    /**
-     * The happy path: a single conjunction of one {@code >=} and one {@code <=} on the same
-     * {@code field_extract(root, "k")} folds into one inclusive {@code Range}. The plan run
-     * by {@code PushFiltersToSource} must therefore land a {@code RangeQuery} on the keyed
-     * sub-field, with no {@code FilterExec} left behind.
-     */
-    public void testCombinesGreaterThanOrEqualAndLessThanOrEqualOnFieldExtractIntoRange() {
-        assumeQueryPushdownEnabled();
-        FieldAttribute root = flattenedRoot("resource.attributes");
-        FieldExtract fe = fieldExtract(root, "host.name");
-        Expression lower = new GreaterThanOrEqual(SRC, fe, Literal.keyword(SRC, "node-a"));
-        Expression upper = new LessThanOrEqual(SRC, fe, Literal.keyword(SRC, "node-z"));
-
-        List<Expression> result = PushFiltersToSource.combineFieldExtractRangePairs(
-            List.of(lower, upper),
-            UNMAPPED_KEY_PREDICATES,
-            AttributeMap.emptyAttributeMap()
-        );
-
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0), instanceOf(Range.class));
-        Range range = (Range) result.get(0);
-        assertThat(range.value(), equalTo(fe));
-        assertThat(range.lower(), equalTo(Literal.keyword(SRC, "node-a")));
-        assertThat(range.upper(), equalTo(Literal.keyword(SRC, "node-z")));
-        assertThat(range.includeLower(), equalTo(true));
-        assertThat(range.includeUpper(), equalTo(true));
-    }
-
-    /**
-     * The combine must respect the strictness of each half independently: {@code >} folds to
-     * an exclusive lower bound, {@code <} folds to an exclusive upper bound. Verifies the
-     * boundary flags from the original BCs land on the produced {@code Range}.
-     */
-    public void testCombinesGreaterThanAndLessThanOnFieldExtractIntoExclusiveRange() {
-        assumeQueryPushdownEnabled();
-        FieldAttribute root = flattenedRoot("resource.attributes");
-        FieldExtract fe = fieldExtract(root, "host.name");
-        Expression lower = new GreaterThan(SRC, fe, Literal.keyword(SRC, "node-a"));
-        Expression upper = new LessThan(SRC, fe, Literal.keyword(SRC, "node-z"));
-
-        List<Expression> result = PushFiltersToSource.combineFieldExtractRangePairs(
-            List.of(lower, upper),
-            UNMAPPED_KEY_PREDICATES,
-            AttributeMap.emptyAttributeMap()
-        );
-
-        assertThat(result, hasSize(1));
-        Range range = (Range) result.get(0);
-        assertThat(range.includeLower(), equalTo(false));
-        assertThat(range.includeUpper(), equalTo(false));
-    }
-
-    /**
-     * A lone {@code >=} or {@code <=} on {@code field_extract} must <em>not</em> be turned into
-     * a {@code Range} by the combiner. Single-sided ranges now have their own direct pushdown
-     * path on {@code EsqlBinaryComparison}, so the unpaired half stays as a binary comparison
-     * and is translated against the keyed flattened mapper's single-sided range support. The
-     * combiner only ever folds matching {@code (lower, upper)} pairs.
-     */
-    public void testDoesNotCombineSingleSidedRangeOnFieldExtract() {
-        assumeQueryPushdownEnabled();
-        FieldAttribute root = flattenedRoot("resource.attributes");
-        FieldExtract fe = fieldExtract(root, "host.name");
-        Expression lower = new GreaterThanOrEqual(SRC, fe, Literal.keyword(SRC, "node-a"));
-
-        List<Expression> conjuncts = List.of(lower);
-        List<Expression> result = PushFiltersToSource.combineFieldExtractRangePairs(
-            conjuncts,
-            UNMAPPED_KEY_PREDICATES,
-            AttributeMap.emptyAttributeMap()
-        );
-
-        // Same reference: with no matching upper, the combiner short-circuits and returns the
-        // original list rather than constructing a new one. The binary comparison itself is
-        // independently pushable through the {@code FieldExtract} branch on
-        // {@link EsqlBinaryComparison#translatable}, so the surrounding classification picks it
-        // up directly.
-        assertThat(result, equalTo(conjuncts));
-    }
-
-    /**
-     * Pairs across different flattened roots or different literal keys must stay separate.
-     * Two halves only fold together when {@code FieldExtract#tryAsKeyedSubfieldName} returns
-     * the same synthetic data-node field name for both.
-     */
-    public void testDoesNotCombineWhenFieldExtractRootsDiffer() {
-        assumeQueryPushdownEnabled();
-        FieldAttribute root = flattenedRoot("resource.attributes");
-        // Two field_extract calls on the same root but for different literal sub-keys produce
-        // different synthetic field names (root.host.name vs root.agent.id), so the combiner
-        // groups them into separate buckets and finds no pair.
-        FieldExtract hostExtract = fieldExtract(root, "host.name");
-        FieldExtract agentExtract = fieldExtract(root, "agent.id");
-        Expression lower = new GreaterThanOrEqual(SRC, hostExtract, Literal.keyword(SRC, "node-a"));
-        Expression upper = new LessThanOrEqual(SRC, agentExtract, Literal.keyword(SRC, "id-z"));
-
-        List<Expression> conjuncts = List.of(lower, upper);
-        List<Expression> result = PushFiltersToSource.combineFieldExtractRangePairs(
-            conjuncts,
-            UNMAPPED_KEY_PREDICATES,
-            AttributeMap.emptyAttributeMap()
-        );
-
-        assertThat(result, equalTo(conjuncts));
-    }
-
-    /**
-     * The combiner resolves {@code ReferenceAttribute}s through {@code aliasReplacedBy} before
-     * the {@code FieldExtract}-shape check. The applicable shape is an EVAL or RENAME that
-     * aliases the <em>flattened root</em> (e.g. {@code | EVAL my_root = real_root | WHERE
-     * field_extract(my_root, "k") >= "a" AND field_extract(my_root, "k") <= "z"}); after
-     * resolution the two halves point at the same underlying root and fold into a single
-     * {@code Range}.
-     */
-    public void testCombinesFieldExtractRangePairsOnAliasResolvedConjuncts() {
-        assumeQueryPushdownEnabled();
-        FieldAttribute realRoot = flattenedRoot("real_root");
-        // The alias map records a ReferenceAttribute "my_root" pointing at the real flattened
-        // attribute. The conjuncts below address the alias; only after alias resolution does
-        // the field_extract see a true FieldAttribute and become eligible for the keyed-name
-        // lookup.
-        ReferenceAttribute aliasAttr = new ReferenceAttribute(SRC, "my_root", DataType.FLATTENED);
-        AttributeMap.Builder<Attribute> aliasBuilder = AttributeMap.builder();
-        aliasBuilder.put(aliasAttr, realRoot);
-        AttributeMap<Attribute> aliasReplacedBy = aliasBuilder.build();
-
-        FieldExtract aliasedExtract = new FieldExtract(SRC, aliasAttr, Literal.keyword(SRC, "host.name"));
-        Expression lower = new GreaterThanOrEqual(SRC, aliasedExtract, Literal.keyword(SRC, "node-a"));
-        Expression upper = new LessThanOrEqual(SRC, aliasedExtract, Literal.keyword(SRC, "node-z"));
-
-        List<Expression> result = PushFiltersToSource.combineFieldExtractRangePairs(
-            List.of(lower, upper),
-            UNMAPPED_KEY_PREDICATES,
-            aliasReplacedBy
-        );
-
-        assertThat(result, hasSize(1));
-        Range range = (Range) result.get(0);
-        // The produced Range references the resolved field_extract (the one whose field is the
-        // real FieldAttribute), not the original aliased one. The classification loop's later
-        // alias-resolution pass would therefore be a no-op for this Range.
-        Expression rangeValue = range.value();
-        assertThat(rangeValue, instanceOf(FieldExtract.class));
-        assertThat(((FieldExtract) rangeValue).children().get(0), equalTo(realRoot));
-    }
-
-    /**
-     * Combining must not affect {@link FieldAttribute} LHS: those are still handled by the
-     * existing post-classification {@code combineEligiblePushableToRange} step. This test
-     * pins down that the new pre-pass is additive, not a replacement.
-     */
-    public void testFieldAttributeRangePairsAreNotCombinedByPrePass() {
-        FieldAttribute keyword = new FieldAttribute(
-            SRC,
-            "host.name",
-            new EsField("host.name", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
-        );
-        Expression lower = new GreaterThanOrEqual(SRC, keyword, Literal.keyword(SRC, "node-a"));
-        Expression upper = new LessThanOrEqual(SRC, keyword, Literal.keyword(SRC, "node-z"));
-
-        List<Expression> conjuncts = List.of(lower, upper);
-        List<Expression> result = PushFiltersToSource.combineFieldExtractRangePairs(
-            conjuncts,
-            UNMAPPED_KEY_PREDICATES,
-            AttributeMap.emptyAttributeMap()
-        );
-
-        // FieldAttribute LHS never enters the field_extract bucket. The pre-pass is a no-op
-        // and returns the original list; the post-classification combineEligiblePushableToRange
-        // continues to own this case.
-        assertThat(result, equalTo(conjuncts));
-    }
-
-    private static FieldAttribute flattenedRoot(String name) {
-        return new FieldAttribute(SRC, name, new EsField(name, DataType.FLATTENED, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
-    }
-
-    private static FieldExtract fieldExtract(FieldAttribute root, String key) {
-        return new FieldExtract(SRC, root, Literal.keyword(SRC, key));
-    }
-
-    private static void assumeQueryPushdownEnabled() {
-        assumeTrue("fn_field_extract must be enabled for this test path", FieldExtract.isFnFieldExtractCapabilityMet());
-    }
-
     private static final Source SRC = Source.EMPTY;
-
-    /**
-     * A stats-backed predicate whose {@code SearchStats} reports the {@code field_extract} loader config as
-     * supported (i.e. the sub-key is an unmapped keyed sub-field, so it stays pushable) while relying on the
-     * attribute's aggregatable flag for indexed/doc-values. The stats-less
-     * {@link LucenePushdownPredicates#DEFAULT} now conservatively reports no loader config as supported
-     * (can_match has no mapping access), so these recognition tests use this predicate to exercise the
-     * pushable (unmapped) path that local physical planning sees with real {@code SearchStats}.
-     */
-    private static final LucenePushdownPredicates UNMAPPED_KEY_PREDICATES = LucenePushdownPredicates.from(
-        new EsqlTestUtils.TestSearchStats(),
-        new EsqlFlags(true)
-    );
 
     private static FieldAttribute fieldAttr(String name) {
         return new FieldAttribute(SRC, name, new EsField(name, DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE));


### PR DESCRIPTION
## Backport

This will backport the following commits from main to 9.5: https://github.com/elastic/elasticsearch/pull/154135

field_extract pushdown over flattened fields regressed at scale when
the flattened root was not indexed. The candidate query fell back to
a per-document binary doc-values scan, so cost grew with the corpus
instead of the match count.

Two changes fix this:
- Gate pushdown on the flattened root being indexed. When it is not
  indexed, tryAsKeyedSubfieldName returns empty, the comparison
  reports Translatable.NO, and the predicate stays in the compute
  layer. That path decodes each document once through the columnar
  block loader, which scales better than the doc-values candidate
  scan.

- When the root is indexed, push a bare candidate query (TermQuery,
  TermsQuery, RangeQuery, NotQuery) and report Translatable.RECHECK
  instead of wrapping it in SingleValueQuery. The postings lookup
  returns a superset, and the retained FilterOperator re-applies the
  predicate to restore single-value semantics, nulling out
  multi-valued documents.

Small changes:
- TranslatorHandler.wrapFunctionQuery leaves field_extract queries
  unwrapped, since RECHECK handles single-value semantics.
- Remove the combineFieldExtractRangePairs pre-pass from
  PushFiltersToSource. It produced a planner-only Range node that the
  FilterOperator cannot evaluate during recheck. With bare candidate
  queries, single-sided ranges are independently pushable and
  evaluatable, so the pre-pass is both unnecessary.
- Equals, NotEquals, In, and the range comparators in
  EsqlBinaryComparison now follow the RECHECK contract.
