### PR TITLE
[ES|QL] Fix IndexNotFoundException when view is explicitly included+excluded

### DIFF
--- a/docs/changelog/155157.yaml
+++ b/docs/changelog/155157.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 147863
+pr: 155157
+summary: Fix `IndexNotFoundException` when view is explicitly included+excluded
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
@@ -745,6 +745,47 @@ at_least_one:boolean
 true
 ;
 
+concreteViewIncludeAndConcreteExcludeAlongsideIndex
+required_capability: views_with_no_branching
+required_capability: views_crud_as_index_actions
+required_capability: views_explicit_include_exclude_fix
+
+// Reproduces https://github.com/elastic/elasticsearch/issues/147863
+// FROM airports, employees_rehired, -employees_rehired should return only airports data.
+// Before the fix, stripValidConcreteViewExclusions removed -employees_rehired but left the
+// literal view name employees_rehired in the pattern. That literal then leaked into
+// EsRelation#originalIndices and caused IndexNotFoundException at search-shards time because
+// the strict search-shards options (resolveViews=false, ignoreUnavailable=false) cannot
+// resolve a view name as a concrete index.
+FROM airports, employees_rehired, -employees_rehired
+| STATS total = COUNT(*)
+| EVAL at_least_one = total > 0
+| KEEP at_least_one
+;
+
+at_least_one:boolean
+true
+;
+
+concreteViewIncludeAndWildcardExcludeAlongsideIndex
+required_capability: views_with_no_branching
+required_capability: views_crud_as_index_actions
+required_capability: views_explicit_include_exclude_fix
+
+// Reproduces https://github.com/elastic/elasticsearch/issues/147863 (wildcard-exclusion variant).
+// FROM airports, employees_rehired, -employees_* should return only airports data.
+// The wildcard -employees_* matched and excluded the view employees_rehired, but before the fix
+// the positive view-name literal stayed in the pattern and caused the same IndexNotFoundException.
+FROM airports, employees_rehired, -employees_*
+| STATS total = COUNT(*)
+| EVAL at_least_one = total > 0
+| KEEP at_least_one
+;
+
+at_least_one:boolean
+true
+;
+
 viewWithInnerSubqueryComposedWithSibling
 required_capability: views_with_branching
 required_capability: views_crud_as_index_actions

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1524,6 +1524,16 @@ public class EsqlCapabilities {
          * See https://github.com/elastic/elasticsearch/issues/146208
          */
         VIEWS_FALSE_CIRCULAR_REFERENCE_FIX,
+        /**
+         * Fixed a bug where explicitly including a view and then explicitly excluding it (either by its
+         * concrete name or by a wildcard that matches it) alongside another concrete index caused an
+         * {@code IndexNotFoundException("no such index [view-name]")} at search-shards time. The view
+         * resolver stripped the exclusion token but left the positive view-name literal in the pattern,
+         * which then leaked into {@code EsRelation#originalIndices} and reached the data-node
+         * search-shards request with options that cannot resolve view names.
+         * See https://github.com/elastic/elasticsearch/issues/147863
+         */
+        VIEWS_EXPLICIT_INCLUDE_EXCLUDE_FIX,
 
         /**
          * Fixes two related bugs where mixing TS-mode and standard sources caused the optimizer to

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -744,15 +744,54 @@ public class ViewResolver {
     }
 
     /**
-     * Returns a copy of the unresolved relation with concrete view exclusions removed from its pattern.
-     * Used in the early return path when no views were resolved, to prevent valid view exclusions from
-     * reaching field caps where they would fail.
+     * Returns a copy of the unresolved relation with concrete view exclusions — and their paired
+     * positive view inclusions — removed from its pattern.
+     * <p>
+     * Used in the early return path when no views were resolved, to prevent view-related tokens
+     * from reaching field caps or the data-node search-shards layer where they would fail.
+     * <p>
+     * When a pattern list contains both a positive view inclusion ({@code view-name}) and a
+     * concrete exclusion ({@code -view-name}) or a wildcard exclusion ({@code -view-*}) that
+     * covers that view, the view was effectively included-then-excluded. The concrete exclusion
+     * is harmless to remove (it targets only a view, invisible to field caps). The positive
+     * inclusion, however, is dangerous: if left in the pattern it leaks the literal view name
+     * into {@code EsRelation#originalIndices}, and the data-node search-shards request later
+     * fails with {@code IndexNotFoundException("no such index [view-name]")} because the
+     * strict search-shards options ({@code resolveViews=false, ignoreUnavailable=false}) cannot
+     * resolve a view name as a concrete index.
+     * <p>
+     * Fix: first identify every view name that is excluded by any local exclusion pattern
+     * (concrete or wildcard), then strip both the concrete exclusions and the paired positive
+     * view-name inclusions. Wildcard exclusions that are not concrete view exclusions are
+     * preserved because they may also match ordinary concrete indices.
      */
     private UnresolvedRelation stripValidConcreteViewExclusions(UnresolvedRelation ur, String[] patterns) {
         var viewNames = getMetadata().views();
-        var filtered = Arrays.stream(patterns)
-            .filter(p -> isConcreteViewExclusion(p, viewNames::containsKey) == false)
-            .toArray(String[]::new);
+
+        // Collect view names cancelled by any local (non-cluster-scoped) exclusion pattern.
+        Set<String> excludedViewNames = new HashSet<>();
+        for (String pattern : patterns) {
+            if (patternIsExclusion(pattern) && pattern.contains(":") == false) {
+                String target = pattern.substring(1);
+                for (String viewName : viewNames.keySet()) {
+                    if (Regex.simpleMatch(target, viewName)) {
+                        excludedViewNames.add(viewName);
+                    }
+                }
+            }
+        }
+
+        var filtered = Arrays.stream(patterns).filter(p -> {
+            // Remove concrete view exclusions (-viewname where viewname is a known view)
+            if (isConcreteViewExclusion(p, viewNames::containsKey)) {
+                return false;
+            }
+            // Remove positive view-name inclusions cancelled by any exclusion in the pattern list
+            if (patternIsExclusion(p) == false && viewNames.containsKey(p) && excludedViewNames.contains(p)) {
+                return false;
+            }
+            return true;
+        }).toArray(String[]::new);
         if (filtered.length == patterns.length) {
             return ur;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -138,6 +138,33 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(plan), matchesPlan(query("FROM emp1")));
     }
 
+    /**
+     * Reproduces <a href="https://github.com/elastic/elasticsearch/issues/147863">#147863</a>.
+     * A view that is explicitly included and then explicitly excluded alongside another concrete
+     * index must not leak the literal view name into the downstream pattern. Before the fix,
+     * {@code stripValidConcreteViewExclusions} removed {@code -view-x} but left {@code view-x}
+     * in the pattern, causing an {@code IndexNotFoundException("no such index [view-x]")} at
+     * search-shards time because the strict options there cannot resolve a view name.
+     */
+    public void testViewIncludeAndExcludeAlongsideConcreteIndex() {
+        addView("view-x", "FROM emp1");
+        LogicalPlan plan = query("FROM emp2,view-x,-view-x");
+        assertThat(replaceViews(plan), matchesPlan(query("FROM emp2")));
+    }
+
+    /**
+     * Reproduces <a href="https://github.com/elastic/elasticsearch/issues/147863">#147863</a>
+     * (wildcard-exclusion variant). A view that is explicitly included and then excluded via a
+     * wildcard alongside another concrete index must not leak the literal view name downstream.
+     * The wildcard exclusion {@code -view-*} is preserved because it may also match concrete
+     * indices; only the positive view-name inclusion is removed.
+     */
+    public void testViewIncludeAndWildcardExcludeAlongsideConcreteIndex() {
+        addView("view-x", "FROM emp1");
+        LogicalPlan plan = query("FROM emp2,view-x,-view-*");
+        assertThat(replaceViews(plan), matchesPlan(query("FROM emp2,-view-*")));
+    }
+
     public void testExclusionWithRemainingIndexMatch() {
         addView("logs-nginx", "FROM logs-1 | WHERE logs.type == nginx");
         addIndex("logs-1");


### PR DESCRIPTION
As described in https://github.com/elastic/elasticsearch/issues/147863

`FROM index,view,-view` and `FROM index,view,-view-*` failed with `IndexNotFoundException("no such index [view]")` even though the view existed.

stripValidConcreteViewExclusions removed the -view exclusion token but left the positive view-name literal in the pattern. That literal leaked into EsRelation#originalIndices and reached the data-node search-shards request, whose strict options (resolveViews=false, ignoreUnavailable=false) cannot resolve a view name as a concrete index.

Fix: before filtering, collect every view name cancelled by any local exclusion pattern (concrete -view-name or wildcard -view-*). Then strip both the concrete view exclusions and the paired positive view-name inclusions. Wildcard exclusions that are not concrete view exclusions are preserved because they may also match ordinary concrete indices.

Closes #147863
