### PR TITLE
[9.5] Fix error caused by empty reranker results (#155099)

### DIFF
--- a/docs/changelog/155099.yaml
+++ b/docs/changelog/155099.yaml
@@ -1,0 +1,5 @@
+area: Ranking
+issues: []
+pr: 155099
+summary: Fix error caused by empty reranker results
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -164,7 +164,8 @@ public class InferenceFeatures implements FeatureSpecification {
                 SEMANTIC_TEXT_PREVENT_LEGACY_FORMAT_NEW_INDICES,
                 SEMANTIC_TEXT_EMBEDDING_TASK,
                 SemanticTextFieldMapper.SEMANTIC_TEXT_ORIGINAL_VALUES_DOC_VALUES,
-                SemanticFieldMapper.SEMANTIC_FIELD_MAPPER
+                SemanticFieldMapper.SEMANTIC_FIELD_MAPPER,
+                TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_EMPTY_RESULT_FIX
             )
         );
         testFeatures.addAll(getFeatures());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -49,6 +49,9 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
     );
     public static final NodeFeature TEXT_SIMILARITY_RERANKER_MINSCORE_FIX = new NodeFeature("text_similarity_reranker_minscore_fix");
     public static final NodeFeature TEXT_SIMILARITY_RERANKER_SNIPPETS = new NodeFeature("text_similarity_reranker_snippets");
+    public static final NodeFeature TEXT_SIMILARITY_RERANKER_EMPTY_RESULT_FIX = new NodeFeature(
+        "text_similarity_reranker_empty_result_fix"
+    );
 
     public static final ParseField RETRIEVER_FIELD = new ParseField("retriever");
     public static final ParseField INFERENCE_ID_FIELD = new ParseField("inference_id");
@@ -303,6 +306,10 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
 
     @Override
     protected SearchSourceBuilder finalizeSourceBuilder(SearchSourceBuilder sourceBuilder) {
+        if (sourceBuilder.size() == 0) {
+            // Short-circuit when there are no candidate documents to return
+            return sourceBuilder;
+        }
         sourceBuilder.rankBuilder(
             new TextSimilarityRankBuilder(
                 field,

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -1175,7 +1175,7 @@ setup:
 ---
 "Test chunk rescorer with partial chunking_settings auto-completes remaining fields":
   - requires:
-      test_runner_features: [contains]
+      test_runner_features: [ contains ]
       cluster_features: "text_similarity_reranker_inference_id_chunking"
       reason: Auto-resolve chunking from inference endpoint introduced in 9.3.0
 
@@ -1239,6 +1239,41 @@ setup:
   - match: { hits.total.value: 3 }
   - contains: { profile.shards.0.searches.0.query.0.description: "chunkScorerConfig=ChunkScorerConfig{size=1" }
   - contains: { profile.shards.0.searches.0.query.0.description: "\"max_chunk_size\":333" }
+
+---
+"Text similarity reranker over a compound retriever with no matching documents returns empty results":
+
+  - requires:
+      cluster_features: "text_similarity_reranker_empty_result_fix"
+      reason: Bugfix failing validation on empty compound reranker results fixed in 9.4.6
+
+  - do:
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          fields: [ "text", "topic" ]
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                text_similarity_reranker:
+                  retriever:
+                    standard:
+                      query:
+                        term:
+                          topic: "asdfasdf"
+                  rank_window_size: 10
+                  inference_id: my-rerank-model
+                  inference_text: "How often does the moon hide the sun?"
+                  field: inference_text_field
+              rank_window_size: 10
+              inference_id: my-rerank-model
+              inference_text: "How often does the moon hide the sun?"
+              field: inference_text_field
+          size: 10
+
+  - match: { hits.total.value: 0 }
+  - length: { hits.hits: 0 }
 
 ---
 "Text similarity rank retriever with a rerank service that sets top_n":


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix error caused by empty reranker results (#155099)