### PR TITLE
Revert "[9.3] ESQL: Fixes other possible causes of losing warnings (#154941)"

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkHandler.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkHandler.java
@@ -8,9 +8,7 @@
 package org.elasticsearch.compute.operator.exchange;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.IsBlockedResult;
@@ -119,14 +117,10 @@ public final class ExchangeSinkHandler {
 
     /**
      * Add a listener, which will be notified when this exchange sink handler is completed. An exchange sink
-     * handler is considered completed when all associated sinks are completed and the output pages are fetched.
-     * <p>
-     * The {@code threadContext} is captured at this call site. When the listener fires — potentially on a
-     * transport thread that has stashed its context — it is restored to the context captured here, ensuring
-     * that any response headers (e.g. warnings) written by the listener end up in the correct context.
+     * handler is consider completed when all associated sinks are completed and the output pages are fetched.
      */
-    public void addCompletionListener(ActionListener<Void> listener, ThreadContext threadContext) {
-        completionFuture.addListener(ContextPreservingActionListener.wrapPreservingContext(listener, threadContext));
+    public void addCompletionListener(ActionListener<Void> listener) {
+        completionFuture.addListener(listener);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -654,7 +654,7 @@ public class ExchangeServiceTests extends ESTestCase {
             assertNotNull(cause);
             assertThat(cause.getMessage(), equalTo("page is too large"));
             PlainActionFuture<Void> sinkCompletionFuture = new PlainActionFuture<>();
-            sinkHandler.addCompletionListener(sinkCompletionFuture, threadPool.getThreadContext());
+            sinkHandler.addCompletionListener(sinkCompletionFuture);
             safeGet(sinkCompletionFuture);
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -260,10 +260,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
         parentTask.addListener(
             () -> exchangeService.finishSinkHandler(globalSessionId, new TaskCancelledException(parentTask.getReasonCancelled()))
         );
-        exchangeSink.addCompletionListener(
-            ActionListener.running(() -> exchangeService.finishSinkHandler(globalSessionId, null)),
-            transportService.getThreadPool().getThreadContext()
-        );
+        exchangeSink.addCompletionListener(ActionListener.running(() -> exchangeService.finishSinkHandler(globalSessionId, null)));
         final String localSessionId = clusterAlias + ":" + globalSessionId;
         ReductionPlan reductionPlan = ComputeService.reductionPlan(
             computeService.plannerSettings(),
@@ -290,7 +287,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                 transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
             );
             try (Releasable ignored = exchangeSource.addEmptySink()) {
-                exchangeSink.addCompletionListener(computeListener.acquireAvoid(), transportService.getThreadPool().getThreadContext());
+                exchangeSink.addCompletionListener(computeListener.acquireAvoid());
                 computeService.runCompute(
                     parentTask,
                     new ComputeContext(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.plugin;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.compute.EsqlRefCountingListener;
 import org.elasticsearch.compute.operator.DriverCompletionInfo;
@@ -33,15 +32,10 @@ final class ComputeListener implements Releasable {
         this.runOnFailure = runOnFailure;
         this.responseHeaders = new ResponseHeadersCollector(threadPool.getThreadContext());
         // listener that executes after all the sub-listeners refs (created via acquireCompute) have completed
-        // ContextPreservingActionListener ensures finish() and the root delegate always fire on the
-        // construction-time thread context, even when the last ref drains on a transport response thread
-        // with a blank ThreadContext (e.g. ExchangeSourceHandler.RemoteSinkFetcher completing via transport).
-        this.refs = new EsqlRefCountingListener(
-            ContextPreservingActionListener.wrapPreservingContext(delegate.delegateFailure((l, ignored) -> {
-                responseHeaders.finish();
-                delegate.onResponse(completionInfoAccumulator.finish());
-            }), threadPool.getThreadContext())
-        );
+        this.refs = new EsqlRefCountingListener(delegate.delegateFailure((l, ignored) -> {
+            responseHeaders.finish();
+            delegate.onResponse(completionInfoAccumulator.finish());
+        }));
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -333,8 +333,7 @@ public class ComputeService {
                         "subplan-" + i,
                         ActionListener.wrap(result -> {
                             exchangeSink.addCompletionListener(
-                                ActionListener.running(() -> { exchangeService.finishSinkHandler(childSessionId, null); }),
-                                transportService.getThreadPool().getThreadContext()
+                                ActionListener.running(() -> { exchangeService.finishSinkHandler(childSessionId, null); })
                             );
                             subPlanListener.onResponse(result.completionInfo());
                         }, e -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.project.ProjectResolver;
@@ -464,8 +465,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 // don't return until all pages are fetched
                 var completionListener = computeListener.acquireAvoid();
                 exchangeSink.addCompletionListener(
-                    ActionListener.runAfter(completionListener, () -> exchangeService.finishSinkHandler(request.sessionId(), null)),
-                    threadPool.getThreadContext()
+                    ActionListener.runAfter(completionListener, () -> exchangeService.finishSinkHandler(request.sessionId(), null))
                 );
                 blockingSink.finish();
             }
@@ -551,11 +551,15 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     LocalPhysicalOptimization.DISABLED,
                     planTimeProfile,
                     ActionListener.wrap(resp -> {
-                        // don't return until all pages are fetched
-                        externalSink.addCompletionListener(ActionListener.running(() -> {
-                            exchangeService.finishSinkHandler(externalId, null);
-                            reductionListener.onResponse(resp);
-                        }), threadPool.getThreadContext());
+                        // don't return until all pages are fetched; preserve the current thread context (which holds the
+                        // reduction driver's warnings) because the completion listener may fire on a different thread
+                        // (the transport thread that processes the coordinator's fetchPageAsync call)
+                        externalSink.addCompletionListener(
+                            ContextPreservingActionListener.wrapPreservingContext(ActionListener.running(() -> {
+                                exchangeService.finishSinkHandler(externalId, null);
+                                reductionListener.onResponse(resp);
+                            }), threadPool.getThreadContext())
+                        );
                     }, e -> {
                         LOGGER.debug("Error in node-level reduction", e);
                         exchangeService.finishSinkHandler(externalId, e);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.operator.DriverCompletionInfo;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.DriverSleeps;
@@ -37,10 +36,8 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -258,79 +255,5 @@ public class ComputeListenerTests extends ESTestCase {
         }
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         assertThat(onFailure.get(), equalTo(0));
-    }
-
-    /**
-     * Regression test: the root delegate must fire in the {@link ComputeListener} construction-time
-     * context even when the last ref is an avoid listener that fires on a transport thread with a
-     * stashed (blank) context, as happens in {@code ExchangeSourceHandler.RemoteSinkFetcher}.
-     * <p>
-     * A sentinel request header placed in the construction-time context lets the root listener
-     * detect which context it is running in. The sentinel is absent in a blank stash, so the test
-     * fails without the {@link org.elasticsearch.action.support.ContextPreservingActionListener}
-     * wrapping in {@link ComputeListener} and passes with it.
-     */
-    public void testCollectWarningsWhenLastRefIsAvoidOnBlankContext() throws Exception {
-        // Mark the construction-time context with a sentinel request header so the root listener
-        // can verify it fires in that context rather than in the blank stash.
-        final String sentinelKey = "x-construction-time-sentinel";
-        final String sentinelValue = "present";
-        threadPool.getThreadContext().putHeader(sentinelKey, sentinelValue);
-
-        final String warningKey = "warning-key";
-        final String warningValue = "warning-value";
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicBoolean firedInSearchContext = new AtomicBoolean();
-        AtomicReference<Map<String, List<String>>> capturedHeaders = new AtomicReference<>();
-
-        ActionListener<DriverCompletionInfo> rootListener = new ActionListener<>() {
-            @Override
-            public void onResponse(DriverCompletionInfo result) {
-                firedInSearchContext.set(sentinelValue.equals(threadPool.getThreadContext().getHeader(sentinelKey)));
-                capturedHeaders.set(threadPool.getThreadContext().getResponseHeaders());
-                latch.countDown();
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                throw new AssertionError(e);
-            }
-        };
-
-        final ActionListener<DriverCompletionInfo> computeSubListener;
-        final ActionListener<Void> avoidSubListener;
-        try (var computeListener = new ComputeListener(threadPool, () -> {}, rootListener)) {
-            computeSubListener = computeListener.acquireCompute();
-            avoidSubListener = computeListener.acquireAvoid();
-        }
-
-        // Emit a warning from the compute sub-listener and wait for it to finish, so the avoid
-        // listener is guaranteed to be the last ref.
-        CountDownLatch computeDone = new CountDownLatch(1);
-        threadPool.executor(ThreadPool.Names.GENERIC).execute(() -> {
-            threadPool.getThreadContext().addResponseHeader(warningKey, warningValue);
-            computeSubListener.onResponse(randomCompletionInfo());
-            computeDone.countDown();
-        });
-        assertTrue(computeDone.await(10, TimeUnit.SECONDS));
-
-        // Fire the avoid sub-listener on a thread with a blank (stashed) context, mimicking a
-        // transport response thread. Without the fix the root delegate fires inside the blank stash
-        // and the sentinel is absent.
-        threadPool.executor(ThreadPool.Names.GENERIC).execute(() -> {
-            try (ThreadContext.StoredContext ignored = threadPool.getThreadContext().stashContext()) {
-                avoidSubListener.onResponse(null);
-            }
-        });
-
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-        assertTrue(
-            "rootListener must fire in the construction-time context (ContextPreservingActionListener fix not applied)",
-            firedInSearchContext.get()
-        );
-        assertNotNull(capturedHeaders.get());
-        Map<String, Set<String>> actual = new HashMap<>();
-        capturedHeaders.get().forEach((k, vs) -> actual.put(k, new HashSet<>(vs)));
-        assertThat(actual, equalTo(Map.of(warningKey, Set.of(warningValue))));
     }
 }


### PR DESCRIPTION
Reverts #155092 on the `9.3` branch.

There was a rash of CI failures related to warnings and leftover exchanges after merging #154941 on `main` and its backports. The `main` revert is tracked in #155139.

This revert restores `9.3` to its state before the backport.