### PR TITLE
Unmute OpenAiServiceUpgradeIT{upgradedNodes=2}

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -676,9 +676,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT
   method: test {csv-spec:k8s-timeseries.firstAndLastWithNullSort}
   issue: https://github.com/elastic/elasticsearch/issues/153638
-- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
-  method: testOpenAiEmbeddings {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/154172
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.renameDerivedGroupingPrune [ndjson.bz/HTTP]}
   issue: https://github.com/elastic/elasticsearch/issues/154238


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/154172

Removed OpenAiServiceUpgradeIT test case from muted tests.

We chatted with the es-delivery team and believe the issue is from the smart retries. We're unmuting to see if the issue persists and we'll readdress it if so.