### PR TITLE
Reshard: cancel clone if source is relocating

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -3260,6 +3260,78 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         assertHitCount(prepareSearchAll(indexName), 100);
     }
 
+    // Test that when the source shard is relocated while cloning to the target shard, the clone task is cancelled
+    // and relocation completes promptly. The clone task holds a permit, so if it is not cancelled it will block relocation from
+    // acquiring all permits when it is about to hand off.
+    public void testSourceRelocationCancelsClone() throws Exception {
+        var copyStarted = new CountDownLatch(1);
+        var copyBlock = new CountDownLatch(1);
+        var copyBlockStrategy = new StatelessMockRepositoryStrategy() {
+            @Override
+            public void blobContainerCopyBlob(
+                CheckedRunnable<IOException> originalRunnable,
+                OperationPurpose purpose,
+                BlobContainer sourceBlobContainer,
+                String sourceBlobName,
+                String blobName,
+                long blobSize
+            ) throws IOException {
+                copyStarted.countDown();
+                safeAwait(copyBlock);
+                super.blobContainerCopyBlob(originalRunnable, purpose, sourceBlobContainer, sourceBlobName, blobName, blobSize);
+            }
+        };
+
+        startMasterOnlyNode();
+        var sourceNode = startIndexNode(
+            Settings.builder().put(ObjectStoreService.TYPE_SETTING.getKey(), ObjectStoreService.ObjectStoreType.MOCK).build()
+        );
+        setNodeRepositoryStrategy(sourceNode, copyBlockStrategy);
+
+        MockTransportService.getInstance(sourceNode)
+            .addRequestHandlingBehavior(TransportReshardSplitAction.START_SPLIT_ACTION_NAME, (handler, request, channel, task) -> {
+                ((CancellableTask) task).addListener(() -> {
+                    logger.info("split task cancelled, unblocking copy: {}", task);
+                    copyBlock.countDown();
+                });
+                handler.messageReceived(request, channel, task);
+            });
+
+        var targetNode = startIndexNode();
+        ensureStableCluster(3);
+
+        updateClusterSettings(
+            Settings.builder()
+                .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), "none")
+                .put(IndexBalanceConstraintSettings.INDEX_BALANCE_DECIDER_ENABLED_SETTING.getKey(), false)
+                .put("cluster.routing.allocation.exclude._name", targetNode)
+        );
+
+        final var indexName = randomIndexName();
+        createIndex(indexName, 1, 0);
+        ensureGreen(indexName);
+
+        // allow placement on target node after shard 0 has been placed on source node
+        updateClusterSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", "null"));
+
+        // with one commit, copyShard won't throw, it will unblock on relocation and succeed the copy.
+        // With two it should throw. Test both cases.
+        for (var i = 0; i < randomIntBetween(1, 2); i++) {
+            indexDocs(indexName, 100);
+            refresh(indexName);
+        }
+
+        logger.info("starting reshard");
+        safeGet(client().execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)));
+
+        // once copy has started, relocate source shard. This should cause the split task to be cancelled and unblock relocation
+        safeAwait(copyStarted);
+        ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand(indexName, 0, sourceNode, targetNode));
+
+        waitForReshardCompletion(indexName);
+        ensureGreen(indexName);
+    }
+
     public void testMismatchedSourceAndTargetPrimaryTerm() {
         String indexNode = startMasterAndIndexNode();
         String indexNodeB = startIndexNode();

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
@@ -312,6 +312,7 @@ public class SplitSourceService {
                 try (Releasable ignore = permit) {
                     objectStoreService.copyShard(task, sourceShardId, targetShardId, sourcePrimaryTerm);
                 }
+                task.ensureNotCancelled();
                 prepareForHandoff(l, sourceShard, targetShardId);
             })
             .addListener(listener.delegateResponse((l, e) -> {
@@ -727,6 +728,10 @@ public class SplitSourceService {
         // we can bump the refcount instead of waiting for them to be released and then reacquiring.
         // This speeds up handoff when multiple target shards enter handoff concurrently.
         final RefCountedAcquirer permitAcquirer;
+        // once we have begun acquiring, we should not cancel on relocation because it is difficult to reason about whether
+        // we will need to wait for handoff before releasing them, e.g., if we've submitted a handoff request but then
+        // relocation begins.
+        final AtomicBoolean acquiring = new AtomicBoolean(false);
 
         Split(IndexShard sourceShard) {
             // XXX figure out what to do with the timeout on acquiring the permit. I would guess that we're blocking any new requests that
@@ -735,9 +740,12 @@ public class SplitSourceService {
             permitAcquirer = new RefCountedAcquirer(
                 releasableListener -> sourceShard.acquireAllPrimaryOperationsPermits(releasableListener, TimeValue.ONE_MINUTE),
                 SplitSourceService.this.indicesService.clusterService().threadPool().relativeTimeInMillisSupplier(),
-                acquiredDuration -> SplitSourceService.this.reshardIndexService.getReshardMetrics()
-                    .indexingBlockedDurationHistogram()
-                    .record(acquiredDuration)
+                acquiredDuration -> {
+                    SplitSourceService.this.reshardIndexService.getReshardMetrics()
+                        .indexingBlockedDurationHistogram()
+                        .record(acquiredDuration);
+                    acquiring.set(false);
+                }
             );
         }
 
@@ -750,7 +758,18 @@ public class SplitSourceService {
          * @param listener a listener to call when permits have been acquired
          */
         public void withPermits(ActionListener<Releasable> listener) {
-            permitAcquirer.acquire(listener);
+            acquiring.set(true);
+            permitAcquirer.acquire(listener.delegateResponse((l, e) -> {
+                acquiring.set(false);
+                l.onFailure(e);
+            }));
+        }
+
+        /**
+         * @return true if the acquirer has started trying to acquire permits or is already holding them
+         */
+        public boolean isAcquiring() {
+            return acquiring.get();
         }
     }
 
@@ -919,6 +938,15 @@ public class SplitSourceService {
                         return true;
                     }
 
+                    // if the source shard has been marked for relocation, exit early so that the clone step releases its permit
+                    // and doesn't block relocation. But don't exit early once we've started acquiring permits, to avoid racing
+                    // with relocation while trying to enter handoff.
+                    if (indexShard.routingEntry().relocating() && split().isAcquiring() == false) {
+                        logger.info("cancelling split from {} because it is relocating", indexShard.shardId());
+                        cancel();
+                        return true;
+                    }
+
                     if (indexShard.state() != IndexShardState.STARTED) {
                         // State can be POST_RECOVERY here because split progress tracking is set up during recovery.
                         // It's possible that the very first cluster state we observe has all targets in DONE but the recovery hasn't
@@ -945,6 +973,15 @@ public class SplitSourceService {
                     @Override
                     public void onNewClusterState(ClusterState state) {
                         if (cancelled.get() || indexShard.state() == IndexShardState.CLOSED) {
+                            final var currentSplit = activeTargetRequests.get(indexShard);
+                            if (currentSplit != null) {
+                                taskManager.cancelTaskAndDescendants(
+                                    currentSplit.task(),
+                                    "source relocating",
+                                    false,
+                                    ActionListener.noop()
+                                );
+                            }
                             return;
                         }
 


### PR DESCRIPTION
Clone takes a permit while it copies the source shard to the target. This is to synchronize with relocation, but clone can take a while if the shard is large, and we don't want to block relocation for a long time. This change causes relocation to cancel the split task if relocation has started, which will cause clone to exit early and release permits to relocation. It only cancels split up to the point where it is about to enter handoff itself. After that point it is tricky to be sure wheter we need to wait for handoff to complete before releasing permits, so we drive split to completion first.