### PR TITLE
[8.19] Fix packaging test HttpServer thread leak (#154502)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/HttpServerThreadsFilter.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/HttpServerThreadsFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.packaging.test;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+
+/**
+ * The JDK's {@link com.sun.net.httpserver.HttpServer} (used by our {@code MockWebServer}) eagerly starts daemon
+ * {@link java.util.Timer} threads in {@code sun.net.httpserver.ServerImpl}, named {@code idle-timeout-task} and
+ * {@code req-rsp-timeout-task}. Stopping the server cancels these timers but does not join their threads, so they
+ * can still be terminating when per-test thread leak detection runs, producing a spurious {@code ThreadLeakError}.
+ * Filter them out since we can't deterministically wait for the JDK to finish tearing them down.
+ */
+public class HttpServerThreadsFilter implements ThreadFilter {
+    @Override
+    public boolean reject(Thread t) {
+        final String name = t.getName();
+        return name.equals("idle-timeout-task") || name.equals("req-rsp-timeout-task");
+    }
+}

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagesSecurityAutoConfigurationTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagesSecurityAutoConfigurationTests.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.packaging.test;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ssl.PemKeyConfig;
@@ -54,6 +56,9 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeTrue;
 
+// This test creates a MockWebServer backed by the JDK's HttpServer, which leaves daemon timer threads that cannot
+// be deterministically joined on close; filter them out so they aren't reported as leaked threads.
+@ThreadLeakFilters(defaultFilters = true, filters = { HttpServerThreadsFilter.class })
 public class PackagesSecurityAutoConfigurationTests extends PackagingTestCase {
 
     private static final String AUTOCONFIG_DIRNAME = "certs";


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix packaging test HttpServer thread leak (#154502)