### PR TITLE
[9.5] Adding a hardcoded limit on nesting retrievers during parsing (#154814)

### DIFF
--- a/docs/changelog/154814.yaml
+++ b/docs/changelog/154814.yaml
@@ -1,0 +1,5 @@
+area: Ranking
+issues: []
+pr: 154814
+summary: Adding a hardcoded limit on nesting retrievers
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -56,6 +56,13 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
 
     public static final ParseField NAME_FIELD = new ParseField("_name");
 
+    /**
+     * The maximum depth to which retrievers may be nested within one another when parsing a search request. This is a hardcoded
+     * limit that guards against {@link StackOverflowError}s that would otherwise be thrown while recursively parsing a deeply
+     * nested retriever tree.This is also bound by the max_rewrite_rounds available.
+     */
+    public static final int MAX_NESTED_DEPTH = MAX_REWRITE_ROUNDS;
+
     protected static void declareBaseParserFields(AbstractObjectParser<? extends RetrieverBuilder, RetrieverParserContext> parser) {
         parser.declareObjectArray(
             (r, v) -> r.preFilterQueryBuilders = new ArrayList<>(v),
@@ -79,13 +86,40 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
     public static RetrieverBuilder parseTopLevelRetrieverBuilder(XContentParser parser, RetrieverParserContext context) throws IOException {
         parser = new FilterXContentParserWrapper(parser) {
 
+            int nestedDepth;
+
             @Override
             public <T> T namedObject(Class<T> categoryClass, String name, Object context) throws IOException {
-                return getXContentRegistry().parseNamedObject(categoryClass, name, this, context);
+                if (categoryClass.equals(RetrieverBuilder.class)) {
+                    nestedDepth++;
+                    if (nestedDepth > MAX_NESTED_DEPTH) {
+                        throw new RetrieverNestingDepthExceededException(
+                            "The nested depth of the [retriever] exceeds the maximum nested depth of ["
+                                + MAX_NESTED_DEPTH
+                                + "] for retrievers"
+                        );
+                    }
+                }
+                T namedObject = getXContentRegistry().parseNamedObject(categoryClass, name, this, context);
+                if (categoryClass.equals(RetrieverBuilder.class)) {
+                    nestedDepth--;
+                }
+                return namedObject;
             }
         };
 
-        return parseInnerRetrieverBuilder(parser, context);
+        try {
+            return parseInnerRetrieverBuilder(parser, context);
+        } catch (RuntimeException e) {
+            // each nested retriever parser re-wraps failures in a ParsingException;
+            // if a depth-limit is present, surface it as a single, clean IllegalArgumentException at the top level
+            for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+                if (cause instanceof RetrieverNestingDepthExceededException depthError) {
+                    throw depthError;
+                }
+            }
+            throw e;
+        }
     }
 
     protected static RetrieverBuilder parseInnerRetrieverBuilder(XContentParser parser, RetrieverParserContext context) throws IOException {
@@ -252,6 +286,12 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
      */
     public Set<String> getExtendedUsageFields() {
         return Set.of();
+    }
+
+    private static final class RetrieverNestingDepthExceededException extends IllegalArgumentException {
+        RetrieverNestingDepthExceededException(String message) {
+            super(message);
+        }
     }
 
     // ---- FOR TESTING XCONTENT PARSING ----

--- a/server/src/test/java/org/elasticsearch/search/retriever/RescorerRetrieverBuilderParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/RescorerRetrieverBuilderParsingTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.usage.SearchUsage;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.containsString;
 
 public class RescorerRetrieverBuilderParsingTests extends AbstractXContentTestCase<RescorerRetrieverBuilder> {
     private static List<NamedXContentRegistry.Entry> xContentRegistryEntries;
@@ -60,6 +62,39 @@ public class RescorerRetrieverBuilderParsingTests extends AbstractXContentTestCa
     @Override
     protected boolean supportsUnknownFields() {
         return false;
+    }
+
+    public void testMaxNestedDepth() throws IOException {
+
+        parseRetriever(nestedRescorerRetriever(RetrieverBuilder.MAX_NESTED_DEPTH));
+        String expectedMessage = "The nested depth of the [retriever] exceeds the maximum nested depth of ["
+            + RetrieverBuilder.MAX_NESTED_DEPTH
+            + "] for retrievers";
+        var exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> parseRetriever(nestedRescorerRetriever(RetrieverBuilder.MAX_NESTED_DEPTH + 10))
+        );
+        assertThat(exception.getMessage(), containsString(expectedMessage));
+    }
+
+    private RetrieverBuilder parseRetriever(String json) throws IOException {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            return RetrieverBuilder.parseTopLevelRetrieverBuilder(parser, new RetrieverParserContext(new SearchUsage(), n -> true));
+        }
+    }
+
+    /**
+     * Builds a JSON retriever tree made of {@code depth} nested retrievers: {@code depth - 1} {@code rescorer}
+     * retrievers wrapping a single innermost {@code standard} retriever.
+     */
+    private static String nestedRescorerRetriever(int depth) {
+        StringBuilder open = new StringBuilder();
+        StringBuilder close = new StringBuilder();
+        for (int i = 0; i < depth - 1; i++) {
+            open.append("{\"rescorer\":{\"retriever\":");
+            close.append(",\"rescore\":{\"query\":{\"rescore_query\":{\"match_all\":{}}}}}}");
+        }
+        return open + "{\"standard\":{\"query\":{\"match_all\":{}}}}" + close;
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Adding a hardcoded limit on nesting retrievers during parsing (#154814)