### PR TITLE
[8.19] Forward Windows env vars and capture keystore stderr in test clusters (#154122)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -105,6 +105,9 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
     protected abstract H createHandle(Path baseWorkingDir, S spec);
 
     public static class Node {
+        private static final int TOOL_SCRIPT_RETRY_TIMES = OS.current() == WINDOWS ? 15 : 0;
+        private static final int TOOL_SCRIPT_RETRY_DELAY_MS = OS.current() == WINDOWS ? 500 : 0;
+
         private final ObjectMapper objectMapper;
         private final Path baseWorkingDir;
         private final DistributionResolver distributionResolver;
@@ -877,6 +880,20 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
             // Windows requires this as it defaults to `c:\windows` despite ES_TMPDIR
             environment.put("TMP", workingDir.resolve("tmp").toString());
 
+            if (OS.current() == WINDOWS) {
+                // cmd.exe needs SystemRoot to locate system32 DLLs, and Path so that batch scripts
+                // can resolve executables. ProcessUtils.exec() clears the inherited environment and
+                // repopulates it from this map, so these variables must be forwarded explicitly;
+                // without them elasticsearch-keystore.bat (and similar tools) fail with exit code 1.
+                Map<String, String> parentEnv = System.getenv();
+                for (String key : List.of("SystemRoot", "SYSTEMROOT", "SystemDrive", "ComSpec", "Path", "PATH")) {
+                    String value = parentEnv.get(key);
+                    if (value != null) {
+                        environment.putIfAbsent(key, value);
+                    }
+                }
+            }
+
             environment = environment.entrySet()
                 .stream()
                 .map(p -> Map.entry(p.getKey(), p.getValue().replace("${ES_PATH_CONF}", configDir.toString())))
@@ -972,22 +989,54 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
         }
 
         private void runToolScript(String tool, String input, String... args) {
-            try {
-                int exit = ProcessUtils.exec(
-                    input,
-                    distributionDir,
-                    distributionDir.resolve("bin")
-                        .resolve(OS.<String>conditional(c -> c.onWindows(() -> tool + ".bat").onUnix(() -> tool))),
-                    getEnvironmentVariables(),
-                    false,
-                    args
-                ).waitFor();
+            int attempt = 0;
+            while (true) {
+                try {
+                    ProcessUtils.Result result = ProcessUtils.execAndCapture(
+                        input,
+                        distributionDir,
+                        distributionDir.resolve("bin")
+                            .resolve(OS.<String>conditional(c -> c.onWindows(() -> tool + ".bat").onUnix(() -> tool))),
+                        getEnvironmentVariables(),
+                        args
+                    );
 
-                if (exit != 0) {
-                    throw new RuntimeException("Execution of " + tool + " failed with exit code " + exit);
+                    if (result.exitCode() == 0) {
+                        return;
+                    }
+
+                    if (attempt >= TOOL_SCRIPT_RETRY_TIMES) {
+                        String argsDesc = "[" + String.join(", ", args) + "]";
+                        String stderrDesc = result.stderr().isEmpty()
+                            ? "<no output>"
+                            : String.join(System.lineSeparator(), result.stderr());
+                        throw new RuntimeException(
+                            "Execution of "
+                                + tool
+                                + " failed with exit code "
+                                + result.exitCode()
+                                + "; tool='"
+                                + tool
+                                + "', args='"
+                                + argsDesc
+                                + "', stderr output:"
+                                + System.lineSeparator()
+                                + stderrDesc
+                        );
+                    }
+
+                    attempt++;
+                    LOGGER.warn(
+                        "Execution of {} failed with exit code {}, retrying ({}/{})",
+                        tool,
+                        result.exitCode(),
+                        attempt,
+                        TOOL_SCRIPT_RETRY_TIMES
+                    );
+                    Thread.sleep(TOOL_SCRIPT_RETRY_DELAY_MS);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
                 }
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
         }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
@@ -36,6 +36,12 @@ public final class ProcessUtils {
 
     private ProcessUtils() {}
 
+    /**
+     * The result of a captured tool process execution, containing the exit code and all lines
+     * written to stderr by the process.
+     */
+    public record Result(int exitCode, List<String> stderr) {}
+
     public static Process exec(Path workingDir, Path executable, Map<String, String> environment, boolean inheritIO, String... args) {
         return exec(null, workingDir, executable, environment, inheritIO, args);
     }
@@ -94,6 +100,74 @@ public final class ProcessUtils {
         }
 
         return process;
+    }
+
+    /**
+     * Executes a short-lived tool process and captures all stderr output for diagnostic purposes.
+     * Standard output is logged asynchronously via the process logger. This method blocks until
+     * the process exits and its entire stderr stream has been drained, so the returned
+     * {@link Result#stderr()} list is guaranteed to be complete on return.
+     *
+     * @param input      optional text to write to the process's stdin, or {@code null}
+     * @param workingDir the working directory for the process
+     * @param executable the executable to run
+     * @param environment the explicit environment for the process (parent environment is cleared)
+     * @param args       additional command-line arguments
+     * @return a {@link Result} with the process exit code and all captured stderr lines
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    public static Result execAndCapture(String input, Path workingDir, Path executable, Map<String, String> environment, String... args)
+        throws InterruptedException {
+        if (Files.exists(executable) == false) {
+            throw new IllegalArgumentException("Can't run executable: `" + executable + "` does not exist.");
+        }
+
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        List<String> command = new ArrayList<>();
+        command.addAll(
+            OS.conditional(
+                c -> c.onWindows(() -> List.of("cmd", "/c", workingDir.relativize(executable).toString()))
+                    .onUnix(() -> List.of(workingDir.relativize(executable).toString()))
+            )
+        );
+        command.addAll(Arrays.asList(args));
+
+        processBuilder.command(command);
+        processBuilder.directory(workingDir.toFile());
+        processBuilder.environment().clear();
+        processBuilder.environment().putAll(environment);
+
+        Process process;
+        List<String> stderrLines = new ArrayList<>();
+        Thread stderrThread;
+        try {
+            process = processBuilder.start();
+
+            // Drain stdout asynchronously — we do not need to capture it.
+            startLoggingThread(process.getInputStream(), PROCESS_LOGGER::info, executable.getFileName().toString());
+
+            // Drain stderr asynchronously while also collecting every line so that
+            // callers can include the output in diagnostic error messages.
+            stderrThread = startLoggingThread(process.getErrorStream(), line -> {
+                PROCESS_LOGGER.error(line);
+                stderrLines.add(line);
+            }, executable.getFileName().toString());
+
+            if (input != null) {
+                try (BufferedWriter writer = process.outputWriter()) {
+                    writer.write(input);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error executing process: " + executable.getFileName(), e);
+        }
+
+        int exit = process.waitFor();
+        // Join the stderr thread so that all lines are guaranteed to be in stderrLines
+        // before we return the Result to the caller.
+        stderrThread.join();
+
+        return new Result(exit, List.copyOf(stderrLines));
     }
 
     public static void stopHandle(ProcessHandle processHandle, boolean forcibly) {
@@ -158,8 +232,8 @@ public final class ProcessUtils {
         }
     }
 
-    private static void startLoggingThread(InputStream is, Consumer<String> logAppender, String name) {
-        new Thread(() -> {
+    private static Thread startLoggingThread(InputStream is, Consumer<String> logAppender, String name) {
+        Thread thread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -168,6 +242,8 @@ public final class ProcessUtils {
             } catch (IOException e) {
                 throw new UncheckedIOException("Error reading output from process.", e);
             }
-        }, name + "-log-forwarder").start();
+        }, name + "-log-forwarder");
+        thread.start();
+        return thread;
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Forward Windows env vars and capture keystore stderr in test clusters (#154122)](https://github.com/elastic/elasticsearch/pull/154122)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)