### PR TITLE
Unmute 39 ES|QL test failures tracked on Jul 27 2026

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -621,141 +621,24 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=search/350_point_in_time/delete invalid PIT returns error}
   issue: https://github.com/elastic/elasticsearch/issues/155066
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats_first_last.Test retrieval of first long by timestamp}
-  issue: https://github.com/elastic/elasticsearch/issues/155108
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats_earliest_latest.latest long by timestamp}
-  issue: https://github.com/elastic/elasticsearch/issues/155109
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:dense_vector_aggs.sumDenseVectorOverflow}
-  issue: https://github.com/elastic/elasticsearch/issues/155118
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
-  method: test {csv-spec:change_point.values int column with all nulls}
-  issue: https://github.com/elastic/elasticsearch/issues/155124
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecSpatialIT
-  method: test {csv-spec:spatial.convertCartesianFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/155125
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecLookupJoinIT
-  method: test {csv-spec:lookup-join.mvKeywordExpressionJoinWarningsFromLeftSide}
-  issue: https://github.com/elastic/elasticsearch/issues/155129
 - class: org.elasticsearch.xpack.stateless.objectstore.gc.StaleTranslogsGCIT
   method: testIsolatedNodeDoesNotDeleteTranslogs
   issue: https://github.com/elastic/elasticsearch/issues/155130
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordExpressionJoinWarningsFromLeftSide}
-  issue: https://github.com/elastic/elasticsearch/issues/155132
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:spatial_shapes.convertCartesianShapeFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/155133
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats_earliest_latest.retrieve earliest long by timestamp}
-  issue: https://github.com/elastic/elasticsearch/issues/155134
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
-  issue: https://github.com/elastic/elasticsearch/issues/155135
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
-  issue: https://github.com/elastic/elasticsearch/issues/155136
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordExpressionJoinWarningsFromRightSide}
-  issue: https://github.com/elastic/elasticsearch/issues/155138
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsFirstLastIT
   method: test {csv-spec:stats_first_last.Test aggregating on integers from row}
   issue: https://github.com/elastic/elasticsearch/issues/153700
-- class: org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT
-  method: test {csv-spec:folding.version_GreaterThan_MultiValueConstant}
-  issue: https://github.com/elastic/elasticsearch/issues/155141
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats.weightedAvgWeightMvWarning}
-  issue: https://github.com/elastic/elasticsearch/issues/155142
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:folding.mvBoolean_NotEquals_MultiValueConstant}
-  issue: https://github.com/elastic/elasticsearch/issues/155143
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
-  method: test {csv-spec:stats.weightedAvgWithOverflowRow}
-  issue: https://github.com/elastic/elasticsearch/issues/155144
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
-  method: test {csv-spec:stats.sumWithOverflowRow}
-  issue: https://github.com/elastic/elasticsearch/issues/155145
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats.sumWithOverflowGrouping}
-  issue: https://github.com/elastic/elasticsearch/issues/155146
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:change_point.not enough buckets per group}
-  issue: https://github.com/elastic/elasticsearch/issues/155147
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:string.mvStringNotEqualsMultiValueConstant}
-  issue: https://github.com/elastic/elasticsearch/issues/155148
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordExpressionJoinWarningsFromRightSideWhenNotKept}
-  issue: https://github.com/elastic/elasticsearch/issues/155149
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
   method: testReshardWithDisruption
   issue: https://github.com/elastic/elasticsearch/issues/155150
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
-  method: test {csv-spec:change_point.values null column}
-  issue: https://github.com/elastic/elasticsearch/issues/155152
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingStatsIT
-  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
-  issue: https://github.com/elastic/elasticsearch/issues/155153
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsEarliestLatestIT
-  method: test {csv-spec:stats_earliest_latest.retrieve earliest long by timestamp}
-  issue: https://github.com/elastic/elasticsearch/issues/155154
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
-  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
-  issue: https://github.com/elastic/elasticsearch/issues/155155
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:string.locateWarnings}
-  issue: https://github.com/elastic/elasticsearch/issues/155156
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
-  method: test {csv-spec:change_point.multivalued in groups}
-  issue: https://github.com/elastic/elasticsearch/issues/155158
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSideWhenNotKept}
-  issue: https://github.com/elastic/elasticsearch/issues/155159
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
-  issue: https://github.com/elastic/elasticsearch/issues/155162
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:folding.computedBoolean_NotEquals_MultiValueConstant}
-  issue: https://github.com/elastic/elasticsearch/issues/155163
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:ip.conditional}
-  issue: https://github.com/elastic/elasticsearch/issues/155164
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecDenseVectorAggsIT
-  method: test {csv-spec:dense_vector_aggs.sumDenseVectorOverflow}
-  issue: https://github.com/elastic/elasticsearch/issues/155167
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/153434
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:unmapped-type-conflicts.typeConflictLongDateUnmappedNonExistentCastToDouble}
-  issue: https://github.com/elastic/elasticsearch/issues/155168
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:stats_first_last.Test retrieval of last long by timestamp}
-  issue: https://github.com/elastic/elasticsearch/issues/155169
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSideWhenNotKept}
-  issue: https://github.com/elastic/elasticsearch/issues/155170
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
   method: test {csv-spec:change_point.values int column with all nulls}
   issue: https://github.com/elastic/elasticsearch/issues/153656
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testClusterDetailsAfterCCSWithFailuresOnOneClusterOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
   issue: https://github.com/elastic/elasticsearch/issues/155173
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsFirstLastIT
-  method: test {csv-spec:stats_first_last.Test aggregating on integers from row}
-  issue: https://github.com/elastic/elasticsearch/issues/155174
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecSpatialShapesIT
-  method: test {csv-spec:spatial_shapes.convertCartesianShapeFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/155177
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvJoinKeyFromRowExpanded}
-  issue: https://github.com/elastic/elasticsearch/issues/155184
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromRightSide}
-  issue: https://github.com/elastic/elasticsearch/issues/155190
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testExplainApi
   issue: https://github.com/elastic/elasticsearch/issues/155193


### PR DESCRIPTION
Removes 39 muted-test entries from `muted-tests.yml` on `main` — all corresponding to CI failures filed on 2026-07-27 with labels `>test-failure`, `:Analytics/ES|QL`, and `Team:Analytics`.
They were caused by change : https://github.com/elastic/elasticsearch/pull/154941, which we have reverted now.
Each entry is confirmed present in this branch's `muted-tests.yml` by searching for its issue URL directly.

Issues removed: #155190 #155184 #155177 #155174 #155170 #155169 #155168 #155167 #155164 #155163 #155162 #155159 #155158 #155156 #155155 #155154 #155153 #155152 #155149 #155148 #155147 #155146 #155145 #155144 #155143 #155142 #155141 #155138 #155136 #155135 #155134 #155133 #155132 #155129 #155125 #155124 #155118 #155109 #155108