### PR TITLE
Unmute 7 ES|QL test failures tracked on Jul 27 2026

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -733,15 +733,33 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:spatial.centroidFromAirportsFilteredCountry}
   issue: https://github.com/elastic/elasticsearch/issues/155030
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
+  method: testRemoteFailureSkipUnavailableTrue
+  issue: https://github.com/elastic/elasticsearch/issues/155120
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
+  method: testCCSExecutionOnSearchesWithLimit0
+  issue: https://github.com/elastic/elasticsearch/issues/155121
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
+  method: testExplainCCS
+  issue: https://github.com/elastic/elasticsearch/issues/155122
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
+  method: testNoBothIncludeCcsMetadataAndIncludeExecutionMetadata
+  issue: https://github.com/elastic/elasticsearch/issues/155123
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/154157
 - class: org.elasticsearch.indices.ShardLimitValidatorTests
   method: testValidateShardLimitOpenIndices
   issue: https://github.com/elastic/elasticsearch/issues/154859
+- class: org.elasticsearch.xpack.esql.action.CrossClusterLookupJoinFailuresIT
+  method: testLookupDisconnect
+  issue: https://github.com/elastic/elasticsearch/issues/155185
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFuseIT
   method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
   issue: https://github.com/elastic/elasticsearch/issues/153902
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecApproximationIT
+  method: test {csv-spec:approximation.Rename stats group key}
+  issue: https://github.com/elastic/elasticsearch/issues/155194
 - class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
   method: testContinuousEvents
   issue: https://github.com/elastic/elasticsearch/issues/153782

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -733,36 +733,15 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:spatial.centroidFromAirportsFilteredCountry}
   issue: https://github.com/elastic/elasticsearch/issues/155030
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:change_point.nulls in groups}
-  issue: https://github.com/elastic/elasticsearch/issues/155111
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testRemoteFailureSkipUnavailableTrue
-  issue: https://github.com/elastic/elasticsearch/issues/155120
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testCCSExecutionOnSearchesWithLimit0
-  issue: https://github.com/elastic/elasticsearch/issues/155121
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testExplainCCS
-  issue: https://github.com/elastic/elasticsearch/issues/155122
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testNoBothIncludeCcsMetadataAndIncludeExecutionMetadata
-  issue: https://github.com/elastic/elasticsearch/issues/155123
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/154157
 - class: org.elasticsearch.indices.ShardLimitValidatorTests
   method: testValidateShardLimitOpenIndices
   issue: https://github.com/elastic/elasticsearch/issues/154859
-- class: org.elasticsearch.xpack.esql.action.CrossClusterLookupJoinFailuresIT
-  method: testLookupDisconnect
-  issue: https://github.com/elastic/elasticsearch/issues/155185
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFuseIT
   method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
   issue: https://github.com/elastic/elasticsearch/issues/153902
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecApproximationIT
-  method: test {csv-spec:approximation.Rename stats group key}
-  issue: https://github.com/elastic/elasticsearch/issues/155194
 - class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
   method: testContinuousEvents
   issue: https://github.com/elastic/elasticsearch/issues/153782


### PR DESCRIPTION
Removes 7 muted-test entries from `muted-tests.yml` on `9.5` — all corresponding to CI failures filed on 2026-07-27 with labels `>test-failure`, `:Analytics/ES|QL`, and `Team:Analytics`.

They were caused by change : https://github.com/elastic/elasticsearch/pull/154941, which we have reverted now.

Issues removed:  #155111