### PR TITLE
[9.5] Retry bc/pr upgrade test jobs on exit code 47 (preempted) (#154808)

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -66,6 +66,11 @@ steps:
       - label: "bc-upgrade-tests-part{{matrix.PART}}"
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=${BC_VERSION} -Dtests.bwc.refspec.main=${BC_COMMIT_HASH} bcUpgradeTestPart{{matrix.PART}}
         timeout_in_minutes: 300
+        retry:
+          automatic:
+            - exit_status: 47
+              limit: 3
+              signal_reason: none
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -32,6 +32,11 @@ steps:
         - label: "pr-upgrade-part-{{matrix.PART}}"
           command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=${VERSION}-SNAPSHOT -Dtests.bwc.refspec.main=${BASE_COMMIT} bcUpgradeTestPart{{matrix.PART}}
           timeout_in_minutes: 300
+          retry:
+            automatic:
+              - exit_status: 47
+                limit: 3
+                signal_reason: none
           agents:
             provider: gcp
             image: family/elasticsearch-ubuntu-2404


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Retry bc/pr upgrade test jobs on exit code 47 (preempted) (#154808)