### PR TITLE
[9.4] Addressing a concurrency issue in InferenceOperator#pollNextRequest in case of a failed response (#154972)

### DIFF
--- a/docs/changelog/154972.yaml
+++ b/docs/changelog/154972.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 154866
+pr: 154972
+summary: Fixing a concurrency issue in InferenceOperator#pollNextRequest in case of a failed response
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceOperator.java
@@ -362,7 +362,10 @@ public abstract class InferenceOperator extends AsyncOperator<InferenceOperator.
             }
 
             synchronized (checkpoint) {
-                if (requestItemIterator.hasNext() == false) {
+                // Re-check under the lock: completeIfFinished() releases the request iterator (and its backing block) while holding
+                // this lock when a failure occurs. Without re-checking, a concurrent poller that passed the guard above could invoke
+                // requestItemIterator.next() on an already-released block.
+                if (hasFailure() || completed.get() || requestItemIterator.hasNext() == false) {
                     return null;
                 }
 
@@ -406,6 +409,9 @@ public abstract class InferenceOperator extends AsyncOperator<InferenceOperator.
          */
         public void completeIfFinished() {
             synchronized (checkpoint) {
+                if (completed.get()) {
+                    return;
+                }
                 if (hasFailure() && completed.compareAndSet(false, true)) {
                     // An exception occurred during execution.
                     // Fail the operation.


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Addressing a concurrency issue in InferenceOperator#pollNextRequest in case of a failed response (#154972)