### PR TITLE
[Test] Increase timeout for RestClientSingleHostIntegTests

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -283,7 +283,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 httpGet.abort();
                 Future<HttpResponse> future = client.execute(httpHost, httpGet, null);
                 try {
-                    future.get(5, TimeUnit.SECONDS);
+                    future.get(10, TimeUnit.SECONDS);
                     fail("expected cancellation exception");
                 } catch (CancellationException e) {
                     // expected
@@ -298,7 +298,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 assertTrue(httpGet.isAborted());
                 try {
                     assertTrue(future.isDone());
-                    future.get(5, TimeUnit.SECONDS);
+                    future.get(10, TimeUnit.SECONDS);
                 } catch (CancellationException e) {
                     // expected sometimes - if the future was cancelled before executing successfully
                 }
@@ -308,7 +308,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 assertFalse(httpGet.isAborted());
                 Future<HttpResponse> future = client.execute(httpHost, httpGet, null);
                 assertFalse(httpGet.isAborted());
-                assertEquals(200, future.get(5, TimeUnit.SECONDS).getStatusLine().getStatusCode());
+                assertEquals(200, future.get(10, TimeUnit.SECONDS).getStatusLine().getStatusCode());
                 assertFalse(future.isCancelled());
             }
         }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -556,9 +556,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testClusterDetailsAfterCCSWithFailuresOnOneClusterOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
   issue: https://github.com/elastic/elasticsearch/issues/155173
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
-  method: testExplainApi
-  issue: https://github.com/elastic/elasticsearch/issues/155193
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/155155

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -556,9 +556,9 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testClusterDetailsAfterCCSWithFailuresOnOneClusterOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
   issue: https://github.com/elastic/elasticsearch/issues/155173
-- class: org.elasticsearch.client.RestClientSingleHostIntegTests
-  method: testRequestResetAndAbort
-  issue: https://github.com/elastic/elasticsearch/issues/155213
+- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
+  method: testExplainApi
+  issue: https://github.com/elastic/elasticsearch/issues/155193
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/155155


### PR DESCRIPTION
Closes #155213. RestClient unit test `testRequestResetAndAbort()` had a CI failure where one of the `future.get()` calls didn't complete before the timeout. Couldn't replicate locally, assuming it's an issue the test not running fast enough in CI, making the test less flaky by increasing the timout for the `future.get()`calls from 5s to 10s. 
