### PR TITLE
[9.3] Fix flaky ShardLimitValidatorTests.testValidateShardLimitOpenIndices

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -358,9 +358,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testOneRemoteClusterPartial
   issue: https://github.com/elastic/elasticsearch/issues/154916
-- class: org.elasticsearch.indices.ShardLimitValidatorTests
-  method: testValidateShardLimitOpenIndices
-  issue: https://github.com/elastic/elasticsearch/issues/154859
 - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
   method: test {yaml=search/161_exists_query_within_nested_query/Test exists query within nested query on mapped geo_point field}
   issue: https://github.com/elastic/elasticsearch/issues/155025

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -143,6 +143,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
             counts.getFirstIndexReplicas(),
             counts.getFailingIndexShards(),
             counts.getFailingIndexReplicas(),
+            counts.getShardsPerNode(),
             group
         );
 
@@ -317,15 +318,21 @@ public class ShardLimitValidatorTests extends ESTestCase {
         return ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).nodes(nodes).build();
     }
 
-    public static ClusterState createClusterForShardLimitTest(
+    private static ClusterState createClusterForShardLimitTest(
         int nodesInCluster,
         int openIndexShards,
         int openIndexReplicas,
         int closedIndexShards,
         int closedIndexReplicas,
+        int shardsPerNode,
         LimitGroup group
     ) {
-        DiscoveryNodes nodes = createDiscoveryNodes(nodesInCluster, group);
+        // Index shard capacity is checked before search shard capacity and fails fast. For tests that expect the search shard capacity
+        // to be exceeded, this ensures there are enough index nodes that opening the closed index does not trip the index tier validation
+        final int minIndexNodesForSearch = group == LimitGroup.SEARCH
+            ? (openIndexShards + closedIndexShards + shardsPerNode - 1) / shardsPerNode
+            : 0;
+        DiscoveryNodes nodes = createDiscoveryNodes(nodesInCluster, group, minIndexNodesForSearch);
 
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
         state = addOpenedIndex(Metadata.DEFAULT_PROJECT_ID, randomAlphaOfLengthBetween(5, 15), openIndexShards, openIndexReplicas, state);
@@ -350,6 +357,10 @@ public class ShardLimitValidatorTests extends ESTestCase {
     }
 
     public static DiscoveryNodes createDiscoveryNodes(int nodesInCluster, LimitGroup group) {
+        return createDiscoveryNodes(nodesInCluster, group, 0);
+    }
+
+    private static DiscoveryNodes createDiscoveryNodes(int nodesInCluster, LimitGroup group, int minIndexNodesForSearch) {
         DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
         for (int i = 0; i < nodesInCluster; i++) {
             Set<DiscoveryNodeRole> roles;
@@ -380,8 +391,11 @@ public class ShardLimitValidatorTests extends ESTestCase {
                     )
                 );
         } else if (group == LimitGroup.SEARCH) {
-            // Also add index nodes for search limit group and they should not affect the result of the search group
-            IntStream.range(0, nodesInCluster + 1)
+            // Stateless validation checks shard capacity on index nodes before search nodes and fails fast on the first limit that
+            // is exceeded. Opening a closed index adds primary shards to index nodes and replica shards to search nodes. For tests that
+            // expect the closed index to overflow search nodes, so we must give the index tier enough nodes that its limit still has room
+            int indexNodes = Math.max(nodesInCluster + 1, minIndexNodesForSearch);
+            IntStream.range(0, indexNodes)
                 .forEach(
                     i -> builder.add(
                         DiscoveryNodeUtils.builder(randomAlphaOfLength(16) + i).roles(Set.of(DiscoveryNodeRole.INDEX_ROLE)).build()


### PR DESCRIPTION
For search open shard capacity tests, size the index-node count so index open shard capacity is not exceeded when the closed index is opened. Otherwise the index tier fails validation first and the assertion expects the wrong error message.

Backport of https://github.com/elastic/elasticsearch/pull/155082

Relates #154859
