### PR TITLE
address #153024

### DIFF
--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -80,22 +80,7 @@ public class KeyRotationIT extends SecurityIntegTestCase {
         for (String nodeName : internalCluster().getNodeNames()) {
             internalCluster().getInstance(KeyRotationCoordinator.class, nodeName).close();
         }
-        assertBusy(
-            () -> assertThat(
-                client().execute(TransportPendingClusterTasksAction.TYPE, new PendingClusterTasksRequest(TEST_REQUEST_TIMEOUT))
-                    .get()
-                    .pendingTasks()
-                    .stream()
-                    .filter(t -> {
-                        String src = t.getSource().string();
-                        return src.contains("project-encryption-key") || src.startsWith("re-encrypt-");
-                    })
-                    .toList(),
-                empty()
-            ),
-            30,
-            TimeUnit.SECONDS
-        );
+        waitNoPendingTasksOnAll();
     }
 
     @Override

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -7,8 +7,6 @@
 package org.elasticsearch.xpack.encryption;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksRequest;
-import org.elasticsearch.action.admin.cluster.tasks.TransportPendingClusterTasksAction;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -51,7 +49,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;


### PR DESCRIPTION
See #153024

I still can't reproduce the issue locally, but the GPT diagnosis is that active PEK tasks can still be running after `close` is called, but `stopKeyRotationCoordinators` only checks for pending tasks. 

If an active PEK task takes long enough to complete, it will block cluster shutdown and trigger the `safeGet: listener was not completed within the timeout` test failure.

`waitNoPendingTasksOnAll` submits a health check task at `LANGUID` priority, which will be blocked behind any PEK tasks, as these have `NORMAL` priority.

The test is currently only muted on 9.5, so I'll either need to introduce the unmute into the backport, or raise a follow-up PR against 9.5