### PR TITLE
Report finalizing snapshots' status as incomplete

### DIFF
--- a/docs/changelog/155241.yaml
+++ b/docs/changelog/155241.yaml
@@ -1,0 +1,6 @@
+area: Snapshot/Restore
+issues:
+ - 155212
+pr: 155241
+summary: Report finalizing snapshots' status as incomplete
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -294,7 +294,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                 builder.add(
                     new SnapshotStatus(
                         entry.snapshot(),
-                        entry.state(),
+                        convertStateIfFinalizing(entry.state()),
                         Collections.unmodifiableList(shardStatusBuilder),
                         entry.includeGlobalState(),
                         entry.startTime(),
@@ -310,6 +310,12 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
         } else {
             listener.onResponse(new SnapshotsStatusResponse(Collections.unmodifiableList(builder)));
         }
+    }
+
+    /// [SnapshotsInProgress] entries have state `SUCCESS` as soon as all shard snapshots complete, but it's still in progress (awaiting
+    /// finalization) so reporting `SUCCESS` in this API doesn't make sense to users. Keep it at `STARTED` until it's really complete.
+    private static SnapshotsInProgress.State convertStateIfFinalizing(SnapshotsInProgress.State state) {
+        return state == SnapshotsInProgress.State.SUCCESS ? SnapshotsInProgress.State.STARTED : state;
     }
 
     // Visible for testing

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusActionTests.java
@@ -443,7 +443,8 @@ public class TransportSnapshotsStatusActionTests extends ESTestCase {
 
     /**
      * This tests whether the {@code SnapshotStatus} API reports {@link SnapshotIndexShardStage#DONE} for
-     * {@link SnapshotsInProgress.ShardState#SUCCESS}. No other API fields are validated for correctness in this test
+     * {@link SnapshotsInProgress.ShardState#SUCCESS} and {@link SnapshotsInProgress.State#STARTED} for a completed snapshot that
+     * is still awaiting finalization. No other API fields are validated for correctness in this test
      */
     public void testSuccessfulSnapshotInProgressShardState() {
         final var snapshot = new Snapshot(ProjectId.DEFAULT, "test-repo", new SnapshotId("snapshot", "uuid"));
@@ -473,7 +474,7 @@ public class TransportSnapshotsStatusActionTests extends ESTestCase {
                 Map.of(),
                 IndexVersion.current()
             ),
-            SnapshotsInProgress.State.SUCCESS,
+            SnapshotsInProgress.State.STARTED,
             SnapshotIndexShardStage.DONE
         );
     }


### PR DESCRIPTION
Today a finalizing snapshot is reported in state `SUCCESS` in the
snapshot status API, but this is a consequence of how the internal state
machine works and is misleading to users. With this change we report
them as `STARTED` until they're really complete.

Closes #155212