### PR TITLE
ES|QL: Add block loader and CSV tests for double_range

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryRangeUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryRangeUtil.java
@@ -91,7 +91,7 @@ public enum BinaryRangeUtil {
         return out.bytes().toBytesRef();
     }
 
-    static List<RangeFieldMapper.Range> decodeDoubleRanges(BytesRef encodedRanges) throws IOException {
+    public static List<RangeFieldMapper.Range> decodeDoubleRanges(BytesRef encodedRanges) throws IOException {
         return decodeRanges(encodedRanges, RangeType.DOUBLE, BinaryRangeUtil::decodeDouble);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.plain.BinaryIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.DateRangeDocValuesLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.DoubleRangeDocValuesLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
@@ -358,10 +359,13 @@ public class RangeFieldMapper extends FieldMapper {
             if (hasDocValues() == false) {
                 return ConstantNull.INSTANCE;
             }
-            if (rangeType != RangeType.DATE) {
-                throw new UnsupportedOperationException("loading blocks is only supported for date fields");
-            }
-            return new DateRangeDocValuesLoader(name());
+            return switch (rangeType) {
+                case DATE -> new DateRangeDocValuesLoader(name());
+                case DOUBLE -> new DoubleRangeDocValuesLoader(name());
+                case INTEGER, LONG, FLOAT, IP -> throw new UnsupportedOperationException(
+                    "loading blocks is not supported for [" + rangeType.typeName() + "] fields"
+                );
+            };
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DoubleRangeDocValuesLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DoubleRangeDocValuesLoader.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License, v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.blockloader.docvalues;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryRangeUtil;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.blockloader.ConstantNull;
+import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingBinaryDocValues;
+
+import java.io.IOException;
+
+/**
+ * Loads double range binary doc values into paired double blocks, converting Lucene's inclusive
+ * upper bound to the half-open representation used by ES|QL.
+ */
+public class DoubleRangeDocValuesLoader extends BlockDocValuesReader.DocValuesBlockLoader {
+    private final String fieldName;
+
+    public DoubleRangeDocValuesLoader(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public Builder builder(BlockFactory factory, int expectedCount) {
+        return factory.doubleRangeBuilder(expectedCount);
+    }
+
+    @Override
+    public ColumnAtATimeReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
+        TrackingBinaryDocValues dv = TrackingBinaryDocValues.get(breaker, context, fieldName);
+        if (dv == null) {
+            return ConstantNull.COLUMN_READER;
+        }
+        return new DoubleRangeDocValuesReader(dv);
+    }
+
+    private class DoubleRangeDocValuesReader extends BlockDocValuesReader {
+        private final TrackingBinaryDocValues docValues;
+        private int docId = -1;
+
+        DoubleRangeDocValuesReader(TrackingBinaryDocValues docValues) {
+            super(null);
+            this.docValues = docValues;
+        }
+
+        @Override
+        protected int docId() {
+            return docId;
+        }
+
+        @Override
+        public String toString() {
+            return "BlockDocValuesReader.DoubleRangeDocValuesReader";
+        }
+
+        @Override
+        public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
+            throws IOException {
+            try (BlockLoader.DoubleRangeBuilder builder = factory.doubleRangeBuilder(docs.count() - offset)) {
+                int lastDoc = -1;
+                for (int i = offset; i < docs.count(); i++) {
+                    int doc = docs.get(i);
+                    if (doc < lastDoc) {
+                        throw new IllegalStateException("docs within same block must be in order");
+                    }
+                    lastDoc = doc;
+                    docId = doc;
+                    if (docValues.docValues().advanceExact(doc) == false) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    BytesRef ref = docValues.docValues().binaryValue();
+                    var ranges = BinaryRangeUtil.decodeDoubleRanges(ref);
+                    if (ranges.isEmpty()) {
+                        builder.appendNull();
+                    } else if (ranges.size() == 1) {
+                        var range = ranges.get(0);
+                        builder.from().appendDouble((double) range.getFrom());
+                        // convert inclusive to exclusive bound
+                        builder.to().appendDouble(Math.nextUp((double) range.getTo()));
+                    } else {
+                        builder.from().beginPositionEntry();
+                        builder.to().beginPositionEntry();
+                        for (var range : ranges) {
+                            builder.from().appendDouble((double) range.getFrom());
+                            // convert inclusive to exclusive bound
+                            builder.to().appendDouble(Math.nextUp((double) range.getTo()));
+                        }
+                        builder.from().endPositionEntry();
+                        builder.to().endPositionEntry();
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        @Override
+        public void close() {
+            docValues.close();
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleRangeDocValuesLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleRangeDocValuesLoaderTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License, v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.mapper.blockloader.docvalues.DoubleRangeDocValuesLoader;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Tests loading double range binary doc values into ES|QL's half-open range representation.
+ */
+public class DoubleRangeDocValuesLoaderTests extends ESTestCase {
+
+    private static final String FIELD_NAME = "test_double_range";
+
+    public void testLoadsSingleAndMultipleRanges() throws IOException {
+        var singleRange = BinaryRangeUtil.encodeDoubleRanges(
+            Set.of(new RangeFieldMapper.Range(RangeType.DOUBLE, 1.5, Math.nextDown(2.0), true, true))
+        );
+        var multipleRanges = BinaryRangeUtil.encodeDoubleRanges(
+            Set.of(
+                new RangeFieldMapper.Range(RangeType.DOUBLE, 10.0, Math.nextDown(20.0), true, true),
+                new RangeFieldMapper.Range(RangeType.DOUBLE, 30.0, Math.nextDown(40.0), true, true)
+            )
+        );
+
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, singleRange)));
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, multipleRanges)));
+            iw.forceMerge(1);
+
+            try (DirectoryReader dr = iw.getReader()) {
+                var context = getOnlyLeafReader(dr).getContext();
+                var loader = new DoubleRangeDocValuesLoader(FIELD_NAME);
+                try (var reader = loader.columnAtATimeReader(context).apply(newLimitedBreaker(ByteSizeValue.ofMb(1)))) {
+                    var block = (TestBlock) reader.read(TestBlock.factory(), TestBlock.docs(0, 1), 0, false);
+
+                    assertThat(block.size(), equalTo(2));
+                    assertThat(List.of(block.get(0), block.get(1)), hasItem(List.of(List.of(10.0, 30.0), List.of(20.0, 40.0))));
+                    assertThat(List.of(block.get(0), block.get(1)), hasItem(List.of(1.5, 2.0)));
+                }
+            }
+        }
+    }
+
+    public void testEmptyAndMissingRangesAppendNull() throws IOException {
+        var oneRange = BinaryRangeUtil.encodeDoubleRanges(
+            Set.of(new RangeFieldMapper.Range(RangeType.DOUBLE, 1.0, Math.nextDown(2.0), true, true))
+        );
+        var emptyRanges = BinaryRangeUtil.encodeDoubleRanges(Set.of());
+
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, oneRange)));
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, emptyRanges)));
+            iw.addDocument(List.of());
+            iw.forceMerge(1);
+
+            try (DirectoryReader dr = iw.getReader()) {
+                var context = getOnlyLeafReader(dr).getContext();
+                var loader = new DoubleRangeDocValuesLoader(FIELD_NAME);
+                try (var reader = loader.columnAtATimeReader(context).apply(newLimitedBreaker(ByteSizeValue.ofMb(1)))) {
+                    var block = (TestBlock) reader.read(TestBlock.factory(), TestBlock.docs(0, 1, 2), 0, false);
+
+                    assertThat(block.size(), equalTo(3));
+                    List<Object> values = Arrays.asList(block.get(0), block.get(1), block.get(2));
+                    assertThat(values, hasItem(List.of(1.0, 2.0)));
+                    assertThat(values.stream().filter(Objects::isNull).count(), equalTo(2L));
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Types;
@@ -601,6 +602,11 @@ public final class CsvAssert {
                 expectedValue,
                 LongRangeBlockBuilder.LongRange.class,
                 x -> EsqlDataTypeConverter.dateRangeToString((LongRangeBlockBuilder.LongRange) x)
+            );
+            case DOUBLE_RANGE -> rebuildExpected(
+                expectedValue,
+                DoubleRangeBlockBuilder.DoubleRange.class,
+                x -> EsqlDataTypeConverter.doubleRangeToString((DoubleRangeBlockBuilder.DoubleRange) x)
             );
             case INTEGER, LONG, DOUBLE, FLOAT, HALF_FLOAT, SCALED_FLOAT, KEYWORD, TEXT, SEMANTIC_TEXT, IP_RANGE, JSON, NULL, BOOLEAN,
                 DENSE_VECTOR, TDIGEST, UNSUPPORTED, FLATTENED -> expectedValue;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -24,6 +24,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.BlockUtils.BuilderWrapper;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.Page;
@@ -728,6 +729,7 @@ public final class CsvTestUtils {
         JSON(s -> s == null ? null : new BytesRef(s), BytesRef.class),
         // DATE_RANGE literals are parsed in UTC only; TODO: support other zones in CSV specs (similar to DATETIME).
         DATE_RANGE(s -> EsqlDataTypeConverter.parseDateRange(s, ZoneOffset.UTC), LongRangeBlockBuilder.LongRange.class),
+        DOUBLE_RANGE(EsqlDataTypeConverter::parseDoubleRange, DoubleRangeBlockBuilder.DoubleRange.class),
         VERSION(v -> new org.elasticsearch.xpack.versionfield.Version(v).toBytesRef(), BytesRef.class),
         NULL(s -> s, Void.class),
         DATETIME(
@@ -863,7 +865,7 @@ public final class CsvTestUtils {
                 case EXPONENTIAL_HISTOGRAM -> EXPONENTIAL_HISTOGRAM;
                 case TDIGEST -> TDIGEST;
                 case LONG_RANGE -> DATE_RANGE;
-                case DOUBLE_RANGE -> throw new IllegalArgumentException("DOUBLE_RANGE not yet supported in csv tests");
+                case DOUBLE_RANGE -> DOUBLE_RANGE;
                 case UNKNOWN -> throw new IllegalArgumentException("Unknown block types cannot be handled");
             };
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
@@ -1,0 +1,16 @@
+doubleRangeBlockLoader
+required_capability: double_range_field_type_development_v2
+
+FROM heights
+| WHERE height_range IS NOT NULL
+| KEEP height_range, description
+| SORT description
+;
+
+height_range:double_range | description:keyword
+1.6..1.8                 | Medium Height
+1.5..1.6                 | Short
+1.8..2.0                 | Tall
+0.0..1.5                 | Very Short
+2.0..5.0                 | Very Tall
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2103,7 +2103,7 @@ public class EsqlCapabilities {
         /**
          * Support for the DOUBLE_RANGE field type.
          */
-        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V1(Build.current().isSnapshot()),
+        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V2(Build.current().isSnapshot()),
 
         /**
          * Network direction function.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
 import org.elasticsearch.compute.data.ExponentialHistogramBlock;
 import org.elasticsearch.compute.data.ExponentialHistogramScratch;
 import org.elasticsearch.compute.data.FloatBlock;
@@ -39,6 +40,7 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.DEFAULT_DA
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.DEFAULT_DATE_TIME_FORMATTER;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.aggregateMetricDoubleBlockToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateRangeToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.doubleRangeToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.geoGridToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.histogramBlockToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.ipToString;
@@ -218,6 +220,15 @@ public abstract class PositionToXContent {
                     return builder.value(dateRangeToString(from, to));
                 }
             };
+            case DOUBLE_RANGE -> new PositionToXContent(block) {
+                @Override
+                protected XContentBuilder valueToXContent(XContentBuilder builder, ToXContent.Params params, int valueIndex)
+                    throws IOException {
+                    var from = ((DoubleRangeBlock) block).getDoubleFromBlock().getDouble(valueIndex);
+                    var to = ((DoubleRangeBlock) block).getDoubleToBlock().getDouble(valueIndex);
+                    return builder.value(doubleRangeToString(from, to));
+                }
+            };
             case NULL -> new PositionToXContent(block) {
                 @Override
                 protected XContentBuilder valueToXContent(XContentBuilder builder, ToXContent.Params params, int valueIndex)
@@ -258,8 +269,8 @@ public abstract class PositionToXContent {
                     return builder.value(TimeSeriesIdFieldMapper.encodeTsid(bytesRef));
                 }
             };
-            case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, SHORT, BYTE, OBJECT, FLOAT, HALF_FLOAT, SCALED_FLOAT, PARTIAL_AGG,
-                DOUBLE_RANGE -> throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
+            case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, SHORT, BYTE, OBJECT, FLOAT, HALF_FLOAT, SCALED_FLOAT, PARTIAL_AGG ->
+                throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
 import org.elasticsearch.compute.data.ExponentialHistogramBlock;
 import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntBlock;
@@ -44,6 +45,7 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.DEFAULT_DA
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.aggregateMetricDoubleBlockToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateRangeToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.doubleRangeToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.exponentialHistogramBlockToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.geoGridToString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.ipToString;
@@ -182,6 +184,11 @@ public final class ResponseValueUtils {
                 var to = ((LongRangeBlock) block).getToBlock().getLong(offset);
                 return dateRangeToString(from, to);
             };
+            case DOUBLE_RANGE -> (block, offset, scratch) -> {
+                var from = ((DoubleRangeBlock) block).getDoubleFromBlock().getDouble(offset);
+                var to = ((DoubleRangeBlock) block).getDoubleToBlock().getDouble(offset);
+                return doubleRangeToString(from, to);
+            };
             case TDIGEST -> (block, offset, scratch) -> ((TDigestBlock) block).getTDigestHolder(offset, new TDigestHolder());
             case HISTOGRAM -> (block, offset, scratch) -> EsqlDataTypeConverter.histogramToString(
                 ((BytesRefBlock) block).getBytesRef(offset, scratch)
@@ -204,8 +211,8 @@ public final class ResponseValueUtils {
             case DENSE_VECTOR -> (block, offset, scratch) -> ((FloatBlock) block).getFloat(offset);
             case FLATTENED -> (block, offset, scratch) -> ((BytesRefBlock) block).getBytesRef(offset, scratch).utf8ToString();
             case NULL, UNSUPPORTED -> (block, offset, scratch) -> null;
-            case SHORT, BYTE, FLOAT, HALF_FLOAT, SCALED_FLOAT, OBJECT, DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, PARTIAL_AGG,
-                DOUBLE_RANGE -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
+            case SHORT, BYTE, FLOAT, HALF_FLOAT, SCALED_FLOAT, OBJECT, DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, PARTIAL_AGG ->
+                throw EsqlIllegalArgumentException.illegalDataType(dataType);
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -22,6 +22,7 @@ import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder.Metric;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.ExponentialHistogramBlock;
 import org.elasticsearch.compute.data.ExponentialHistogramScratch;
 import org.elasticsearch.compute.data.IntBlock;
@@ -749,6 +750,36 @@ public class EsqlDataTypeConverter {
     /** Formats a half-open [from, to) range using the block's stored millis for both bounds. */
     public static String dateRangeToString(long from, long to, DateFormatter formatter) {
         return dateTimeToString(from, formatter) + ".." + dateTimeToString(to, formatter);
+    }
+
+    /**
+     * Parses the string representation used for double range response values.
+     */
+    public static DoubleRangeBlockBuilder.DoubleRange parseDoubleRange(String value) {
+        String[] bounds = value.split("\\.\\.", -1);
+        if (bounds.length != 2) {
+            throw new IllegalArgumentException("expected double range in the form 'from..to', got [" + value + "]");
+        }
+        double from = Double.parseDouble(bounds[0]);
+        double to = Double.parseDouble(bounds[1]);
+        if (Double.isNaN(from) || Double.isNaN(to) || from >= to) {
+            throw new IllegalArgumentException("double range 'from' [" + bounds[0] + "] must be less than 'to' [" + bounds[1] + "]");
+        }
+        return new DoubleRangeBlockBuilder.DoubleRange(from, to);
+    }
+
+    /**
+     * Formats a half-open double range for response serialization.
+     */
+    public static String doubleRangeToString(DoubleRangeBlockBuilder.DoubleRange range) {
+        return doubleRangeToString(range.from(), range.to());
+    }
+
+    /**
+     * Formats half-open double range bounds for response serialization.
+     */
+    public static String doubleRangeToString(double from, double to) {
+        return Double.toString(from) + ".." + Double.toString(to);
     }
 
     public static BytesRef numericBooleanToString(Object field) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -110,6 +110,7 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateNanosT
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToLong;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.longToUnsignedLong;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.parseDateRange;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.parseDoubleRange;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToGeo;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToIP;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToSpatial;
@@ -229,7 +230,6 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 || t == DataType.AGGREGATE_METRIC_DOUBLE
                 || t == DataType.TSID_DATA_TYPE
                 || t == DataType.DATE_RANGE
-                || t == DataType.DOUBLE_RANGE
                 || t == DataType.PARTIAL_AGG,
             () -> randomFrom(DataType.types())
         ).widenSmallNumeric();
@@ -349,6 +349,16 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                         randomDoubles(valueCount).toArray()
                     );
                     expBuilder.append(histo);
+                }
+                case DOUBLE_RANGE -> {
+                    double first = randomDouble();
+                    double second;
+                    do {
+                        second = randomDouble();
+                    } while (first == second);
+                    BlockLoader.DoubleRangeBuilder rangeBuilder = (BlockLoader.DoubleRangeBuilder) builder;
+                    rangeBuilder.from().appendDouble(Math.min(first, second));
+                    rangeBuilder.to().appendDouble(Math.max(first, second));
                 }
                 case TDIGEST -> ((TDigestBlockBuilder) builder).appendTDigest(EsqlTestUtils.randomTDigest());
                 case HISTOGRAM -> ((BytesRefBlock.Builder) builder).appendBytesRef(EsqlTestUtils.randomHistogram());
@@ -1727,6 +1737,12 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                         var ll = parseDateRange(value.toString(), ZoneOffset.UTC);
                         b.from().appendLong(ll.from());
                         b.to().appendLong(ll.to());
+                    }
+                    case DOUBLE_RANGE -> {
+                        BlockLoader.DoubleRangeBuilder b = (BlockLoader.DoubleRangeBuilder) builder;
+                        var range = parseDoubleRange(value.toString());
+                        b.from().appendDouble(range.from());
+                        b.to().appendDouble(range.to());
                     }
                     case TDIGEST -> {
                         TDigestBlockBuilder tDigestBlockBuilder = (TDigestBlockBuilder) builder;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1628,7 +1628,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testDoubleRangeUnsupportedOperations() {
-        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V1.isEnabled());
+        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V2.isEnabled());
         analyzer().addIndex("heights", "mapping-heights.json")
             .stripErrorPrefix(true)
             .error("FROM heights | SORT height_range", containsString("cannot sort on double_range"));


### PR DESCRIPTION
Part of #154463

## Summary
- load `double_range` binary doc values into ES|QL range blocks
- serialize double ranges in JSON and CSV responses
- add block loader unit coverage and a CSV-spec test using the existing heights dataset